### PR TITLE
Make terminal placement canonical and host PTYs in resilient per-terminal processes

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.119",
 ]
 
@@ -140,6 +140,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+dependencies = [
+ "find-msvc-tools",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -224,11 +234,13 @@ dependencies = [
  "anyhow",
  "base64",
  "cmux-tui-cdp",
+ "fs4",
  "getrandom 0.3.4",
  "ghostty-vt",
  "libc",
  "portable-pty",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "tungstenite",
@@ -451,6 +463,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +536,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "futures-core"
@@ -751,6 +791,17 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "line-clipping"
@@ -1079,6 +1130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1401,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rusqlite"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1571,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1882,6 +1958,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tungstenite",
  "uds_windows",
 ]

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -46,6 +46,8 @@ regex = "1"
 bindgen = "0.72"
 smallvec = "1"
 getrandom = "0.3"
+rusqlite = { version = "0.40.1", default-features = false, features = ["bundled"] }
+fs4 = "1.1.0"
 
 [profile.release]
 lto = "thin"

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -48,6 +48,7 @@ smallvec = "1"
 getrandom = "0.3"
 rusqlite = { version = "0.40.1", default-features = false, features = ["bundled"] }
 fs4 = "1.1.0"
+sha2 = "0.10"
 
 [profile.release]
 lto = "thin"

--- a/cmux-tui/bindings/typescript/src/client.ts
+++ b/cmux-tui/bindings/typescript/src/client.ts
@@ -41,6 +41,7 @@ import type {
   ReloadConfigResult,
   ResizeSurfaceResult,
   ReportAgentResult,
+  ResolveTerminalResult,
   RunResult,
   RenderAttachEvent,
   SidebarPluginResult,
@@ -57,6 +58,7 @@ import type {
   ZoomPaneResult,
   AgentReportSource,
   AgentState,
+  CloseTerminalResult,
   DeclarativeLayout,
   FocusDirectionResult,
 } from "./protocol/index.js";
@@ -445,6 +447,15 @@ export class CmuxClient {
     return this.request("sidebar-plugin", { cols, rows, relaunch });
   }
   vtState(surface: Id): Promise<VtStateResult> { return this.request("vt-state", { surface }); }
+  resolveTerminal(terminalId: string): Promise<ResolveTerminalResult> {
+    return this.request("resolve-terminal", { terminal_id: terminalId });
+  }
+  closeTerminal(terminalId: string, terminalIncarnation: string): Promise<CloseTerminalResult> {
+    return this.request("close-terminal", {
+      terminal_id: terminalId,
+      terminal_incarnation: terminalIncarnation,
+    });
+  }
   newTab(options: NewTabOptions = {}): Promise<SurfaceResult> { return this.request("new-tab", options); }
   newBrowserTab(url: string, options: NewBrowserTabOptions = {}): Promise<SurfaceResult> {
     return this.request("new-browser-tab", { url, ...options });

--- a/cmux-tui/bindings/typescript/src/client.ts
+++ b/cmux-tui/bindings/typescript/src/client.ts
@@ -30,6 +30,8 @@ import type {
   JsonObject,
   ListAgentsResult,
   ListClientsResult,
+  ListTerminalsResult,
+  MoveTerminalResult,
   NotificationLevel,
   NotifyResult,
   PaneDirection,
@@ -49,6 +51,7 @@ import type {
   SubscribeEvent,
   SurfaceResult,
   TerminalPlacement,
+  TerminalEventsResult,
   Tree,
   WorkspacePlacement,
   WorkspaceMutation,
@@ -84,6 +87,10 @@ export type NewBrowserTabOptions = Omit<CmuxRequestParams<"new-browser-tab">, "u
 export type NewWorkspaceOptions = CmuxRequestParams<"new-workspace">;
 export type CreateWorkspaceOptions = CmuxRequestParams<"create-workspace">;
 export type CreateTerminalOptions = CmuxRequestParams<"create-terminal">;
+export type CloseTerminalOptions = Omit<
+  CmuxRequestParams<"close-terminal">,
+  "terminal_id" | "terminal_incarnation"
+>;
 export type CloseWorkspaceOptions = CmuxRequestParams<"close-workspace">;
 export type RenameWorkspaceOptions = CmuxRequestParams<"rename-workspace">;
 export type MoveWorkspaceOptions = CmuxRequestParams<"move-workspace">;
@@ -428,6 +435,10 @@ export class CmuxClient {
   setWindowTitle(title: string): Promise<EmptyResult> { return this.request("set-window-title", { title }); }
   clearWindowTitle(): Promise<EmptyResult> { return this.request("clear-window-title"); }
   listWorkspaces(): Promise<Tree> { return this.request("list-workspaces"); }
+  listTerminals(): Promise<ListTerminalsResult> { return this.request("list-terminals"); }
+  terminalEvents(afterRevision = 0): Promise<TerminalEventsResult> {
+    return this.request("terminal-events", { after_revision: afterRevision });
+  }
   exportLayout(screen?: Id | null): Promise<ExportLayoutResult> { return this.request("export-layout", { screen }); }
   applyLayout(layout: DeclarativeLayout, options: Omit<CmuxRequestParams<"apply-layout">, "layout"> = {}): Promise<ApplyLayoutResult> {
     return this.request("apply-layout", { ...options, layout });
@@ -450,8 +461,13 @@ export class CmuxClient {
   resolveTerminal(terminalId: string): Promise<ResolveTerminalResult> {
     return this.request("resolve-terminal", { terminal_id: terminalId });
   }
-  closeTerminal(terminalId: string, terminalIncarnation: string): Promise<CloseTerminalResult> {
+  closeTerminal(
+    terminalId: string,
+    terminalIncarnation?: string | null,
+    options: CloseTerminalOptions = {},
+  ): Promise<CloseTerminalResult> {
     return this.request("close-terminal", {
+      ...options,
       terminal_id: terminalId,
       terminal_incarnation: terminalIncarnation,
     });
@@ -466,6 +482,20 @@ export class CmuxClient {
   }
   createTerminal(options: CreateTerminalOptions): Promise<TerminalPlacement> {
     return this.request("create-terminal", options);
+  }
+  moveTerminal(
+    terminalId: string,
+    workspaceKey: string,
+    options: Omit<
+      CmuxRequestParams<"move-terminal">,
+      "terminal_id" | "workspace_key"
+    > = {},
+  ): Promise<MoveTerminalResult> {
+    return this.request("move-terminal", {
+      ...options,
+      terminal_id: terminalId,
+      workspace_key: workspaceKey,
+    });
   }
   newScreen(options: NewScreenOptions = {}): Promise<SurfaceResult> { return this.request("new-screen", options); }
   split(pane: Id, dir: SplitDirection, options: SplitOptions = {}): Promise<SurfaceResult> {

--- a/cmux-tui/bindings/typescript/src/protocol/commands.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/commands.ts
@@ -8,6 +8,7 @@ import type {
   EmptyResult,
   Id,
   IdRef,
+  Json,
   NotificationLevel,
   PaneDirection,
   SplitDirection,
@@ -16,7 +17,17 @@ import type { DeclarativeLayout, Layout, Tree } from "./tree.js";
 import type { RenderRow } from "./render.js";
 
 export interface IdentifyRequest extends CmuxRequestBase { cmd: "identify" }
-export interface IdentifyResult { app: "cmux-tui"; version: string; protocol: number; session: string; pid: number }
+export interface IdentifyResult {
+  app: "cmux-tui";
+  version: string;
+  protocol: number;
+  session: string;
+  pid: number;
+  registry_id: string;
+  generation: string;
+  workspace_revision: number;
+  terminal_revision: number;
+}
 
 export interface PingRequest extends CmuxRequestBase { cmd: "ping" }
 export interface PingResult { ok: true; version: string; protocol: number }
@@ -46,6 +57,42 @@ export interface ClientInfo {
   size_participating: boolean;
 }
 export type ListClientsResult = ClientInfo[];
+
+export type TerminalLifecycle = "launching" | "adopting" | "running" | "exited" | "tombstoned";
+export interface TerminalRecord {
+  terminal_id: string;
+  workspace_key: string;
+  terminal_incarnation: string | null;
+  lifecycle: TerminalLifecycle;
+  launch_spec: Json;
+  exit: Json | null;
+}
+export interface ListTerminalsRequest extends CmuxRequestBase { cmd: "list-terminals" }
+export interface ListTerminalsResult {
+  registry_id: string;
+  generation: string;
+  terminal_revision: number;
+  terminals: TerminalRecord[];
+}
+export interface TerminalEventsRequest extends CmuxRequestBase {
+  cmd: "terminal-events";
+  after_revision?: number;
+}
+export interface TerminalRegistryEvent {
+  terminal_revision: number;
+  kind: string;
+  terminal_id: string;
+  workspace_key: string;
+  origin: string;
+  mutation_id: string;
+  result: Json;
+}
+export interface TerminalEventsResult {
+  registry_id: string;
+  generation: string;
+  terminal_revision: number;
+  events: TerminalRegistryEvent[];
+}
 
 export interface DetachClientRequest extends CmuxRequestBase { cmd: "detach-client"; client: Id }
 export interface SetClientSizingRequest extends CmuxRequestBase {
@@ -125,17 +172,37 @@ export interface ResolveTerminalRequest extends CmuxRequestBase {
   terminal_id: string;
 }
 export interface ResolveTerminalResult {
-  surface: Id;
+  surface: Id | null;
   terminal_id: string;
-  terminal_incarnation: string;
+  terminal_incarnation: string | null;
+  workspace_key: string;
+  lifecycle: TerminalLifecycle;
+  launch_spec: Json;
+  exit: Json | null;
+  registry_id: string;
+  generation: string;
+  terminal_revision: number;
 }
 
 export interface CloseTerminalRequest extends CmuxRequestBase {
   cmd: "close-terminal";
   terminal_id: string;
-  terminal_incarnation: string;
+  terminal_incarnation?: string | null;
+  origin?: string;
+  mutation_id?: string;
+  expected_generation?: string | null;
+  expected_terminal_revision?: number | null;
 }
-export type CloseTerminalResult = ResolveTerminalResult;
+export interface CloseTerminalResult {
+  surface: Id | null;
+  terminal_id: string;
+  terminal_incarnation: string | null;
+  closed: true;
+  already_closed: boolean;
+  registry_id: string;
+  generation: string;
+  terminal_revision: number;
+}
 
 export interface NewTabRequest extends CmuxRequestBase {
   cmd: "new-tab";
@@ -185,6 +252,11 @@ export interface CreateTerminalRequest extends CmuxRequestBase {
   name?: string | null;
   cols?: number | null;
   rows?: number | null;
+  terminal_id?: string | null;
+  origin?: string;
+  mutation_id?: string;
+  expected_generation?: string | null;
+  expected_terminal_revision?: number | null;
 }
 
 export interface TerminalPlacement {
@@ -193,6 +265,13 @@ export interface TerminalPlacement {
   screen: Id;
   workspace: Id;
   key: string;
+  terminal_id: string | null;
+  terminal_incarnation: string | null;
+  lifecycle: "running" | null;
+  terminal_revision: number;
+  replayed: boolean;
+  registry_id: string;
+  generation: string;
 }
 
 export interface NewScreenRequest extends CmuxRequestBase {
@@ -318,6 +397,32 @@ export interface SelectWorkspaceRequest extends CmuxRequestBase {
   delta?: number | null;
 }
 
+export interface MoveTerminalRequest extends CmuxRequestBase {
+  cmd: "move-terminal";
+  terminal_id: string;
+  workspace_key: string;
+  terminal_incarnation?: string | null;
+  origin?: string;
+  mutation_id?: string;
+  expected_generation?: string | null;
+  expected_terminal_revision?: number | null;
+}
+export interface MoveTerminalResult {
+  surface: Id | null;
+  pane: Id | null;
+  screen: Id | null;
+  workspace: Id | null;
+  terminal_id: string;
+  terminal_incarnation: string | null;
+  workspace_key: string;
+  lifecycle: TerminalLifecycle;
+  changed: boolean;
+  replayed: boolean;
+  terminal_revision: number;
+  registry_id: string;
+  generation: string;
+}
+
 export interface MoveTabRequest extends CmuxRequestBase { cmd: "move-tab"; surface: Id; pane: Id; index: number }
 export interface MoveWorkspaceRequest extends CmuxRequestBase {
   cmd: "move-workspace";
@@ -412,6 +517,8 @@ export type CmuxRequest =
   | PingRequest
   | SetClientInfoRequest
   | ListClientsRequest
+  | ListTerminalsRequest
+  | TerminalEventsRequest
   | DetachClientRequest
   | SetClientSizingRequest
   | ReloadConfigRequest
@@ -455,6 +562,7 @@ export type CmuxRequest =
   | SelectTabRequest
   | SelectScreenRequest
   | SelectWorkspaceRequest
+  | MoveTerminalRequest
   | MoveTabRequest
   | MoveWorkspaceRequest
   | ScrollSurfaceRequest
@@ -475,6 +583,8 @@ export interface CmuxResponseDataMap {
   ping: PingResult;
   "set-client-info": EmptyResult;
   "list-clients": ListClientsResult;
+  "list-terminals": ListTerminalsResult;
+  "terminal-events": TerminalEventsResult;
   "detach-client": EmptyResult;
   "set-client-sizing": EmptyResult;
   "reload-config": ReloadConfigResult;
@@ -518,6 +628,7 @@ export interface CmuxResponseDataMap {
   "select-tab": EmptyResult;
   "select-screen": EmptyResult;
   "select-workspace": EmptyResult;
+  "move-terminal": MoveTerminalResult;
   "move-tab": EmptyResult;
   "move-workspace": WorkspaceMutation;
   "scroll-surface": EmptyResult;

--- a/cmux-tui/bindings/typescript/src/protocol/commands.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/commands.ts
@@ -119,6 +119,24 @@ export interface SidebarPluginResult {
 export interface VtStateRequest extends CmuxRequestBase { cmd: "vt-state"; surface: Id }
 export interface VtStateResult { cols: number; rows: number; data: Base64 }
 
+export interface ResolveTerminalRequest extends CmuxRequestBase {
+  cmd: "resolve-terminal";
+  /** Stable 16-byte terminal UUID encoded as exactly 32 lowercase hex characters. */
+  terminal_id: string;
+}
+export interface ResolveTerminalResult {
+  surface: Id;
+  terminal_id: string;
+  terminal_incarnation: string;
+}
+
+export interface CloseTerminalRequest extends CmuxRequestBase {
+  cmd: "close-terminal";
+  terminal_id: string;
+  terminal_incarnation: string;
+}
+export type CloseTerminalResult = ResolveTerminalResult;
+
 export interface NewTabRequest extends CmuxRequestBase {
   cmd: "new-tab";
   pane?: Id | null;
@@ -192,7 +210,12 @@ export interface SplitRequest extends CmuxRequestBase {
   rows?: number | null;
 }
 
-export interface SurfaceResult { surface: Id }
+export interface SurfaceResult {
+  surface: Id;
+  /** Present for process-hosted terminal creation, absent for browser surfaces. */
+  terminal_id?: string | null;
+  terminal_incarnation?: string | null;
+}
 
 export interface SetRatioRequest extends CmuxRequestBase {
   cmd: "set-ratio";
@@ -402,6 +425,8 @@ export type CmuxRequest =
   | ReadScrollbackRequest
   | SidebarPluginRequest
   | VtStateRequest
+  | ResolveTerminalRequest
+  | CloseTerminalRequest
   | NewTabRequest
   | NewBrowserTabRequest
   | NewWorkspaceRequest
@@ -463,6 +488,8 @@ export interface CmuxResponseDataMap {
   "read-scrollback": ReadScrollbackResult;
   "sidebar-plugin": SidebarPluginResult;
   "vt-state": VtStateResult;
+  "resolve-terminal": ResolveTerminalResult;
+  "close-terminal": CloseTerminalResult;
   "new-tab": SurfaceResult;
   "new-browser-tab": SurfaceResult;
   "new-workspace": SurfaceResult;

--- a/cmux-tui/bindings/typescript/src/protocol/events.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/events.ts
@@ -61,6 +61,13 @@ export interface ClientChangedEvent {
   kind: string | null;
 }
 export interface ClientDetachedEvent { event: "client-detached"; client: Id }
+export interface TerminalRegistryChangedEvent {
+  event: "terminal-registry-changed";
+  registry_id: string;
+  generation: string;
+  terminal_revision: number;
+  refetch: "terminal-events-or-list-terminals";
+}
 export interface EmptyEvent { event: "empty" }
 
 export interface WorkspaceAddedEvent {
@@ -299,6 +306,7 @@ export type KnownSubscribeEvent =
   | ClientAttachedEvent
   | ClientChangedEvent
   | ClientDetachedEvent
+  | TerminalRegistryChangedEvent
   | EmptyEvent
   | OverflowEvent;
 

--- a/cmux-tui/bindings/typescript/src/protocol/events.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/events.ts
@@ -179,6 +179,8 @@ export interface TerminalColors {
   cursor_style?: "block" | "underline" | "bar" | null;
   /** Protocol v6 additive extension. Older servers omit this field. */
   cursor_blink?: boolean | null;
+  /** Protocol v7 sparse application-authored OSC 4 overrides by palette index. */
+  palette?: Record<string, ColorHex>;
 }
 
 /** Initial base64 VT replay for an attached PTY surface. */
@@ -193,13 +195,21 @@ export interface VtStateEvent {
 }
 
 /** Live base64 PTY bytes after the attach snapshot. */
-export interface OutputEvent { event: "output"; surface: Id; data: Base64 }
+export interface OutputEvent {
+  event: "output";
+  surface: Id;
+  data: Base64;
+  /** Present when output and its complete color state are one transition. */
+  colors?: TerminalColors;
+}
 
 interface ResizedEventBase {
   event: "resized";
   surface: Id;
   cols: number;
   rows: number;
+  /** Present when the theme-portable replay and colors are one transition. */
+  colors?: TerminalColors;
 }
 
 /** A replacement replay using the protocol-v7 field or protocol-v6 compatibility field. */

--- a/cmux-tui/bindings/typescript/test/client.test.ts
+++ b/cmux-tui/bindings/typescript/test/client.test.ts
@@ -157,7 +157,59 @@ test("resize response preserves reservation identity", async () => {
   await client.close();
 });
 
+test("stable terminal resolve and close serialize process identity", async () => {
+  const terminalId = "0123456789abcdef0123456789abcdef";
+  const incarnation = "fedcba9876543210fedcba9876543210";
+  const transport = new ScriptedTransport((request, connection) => {
+    if (request.cmd === "resolve-terminal") {
+      assert.deepEqual(request, {
+        id: 1,
+        cmd: "resolve-terminal",
+        terminal_id: terminalId,
+      });
+    } else {
+      assert.deepEqual(request, {
+        id: 2,
+        cmd: "close-terminal",
+        terminal_id: terminalId,
+        terminal_incarnation: incarnation,
+      });
+    }
+    connection.emit({
+      id: request.id,
+      ok: true,
+      data: {
+        surface: 7,
+        terminal_id: terminalId,
+        terminal_incarnation: incarnation,
+      },
+    });
+  });
+  const client = new CmuxClient({ transport, timeoutMs: 100 });
+
+  assert.deepEqual(await client.resolveTerminal(terminalId), {
+    surface: 7,
+    terminal_id: terminalId,
+    terminal_incarnation: incarnation,
+  });
+  assert.deepEqual(await client.closeTerminal(terminalId, incarnation), {
+    surface: 7,
+    terminal_id: terminalId,
+    terminal_incarnation: incarnation,
+  });
+  await client.close();
+});
+
 test("attachSurface decodes VT colors, output, and resized payloads", async () => {
+  const atomicColors = {
+    fg: "#010203",
+    bg: "#040506",
+    cursor: null,
+    selection_bg: null,
+    selection_fg: null,
+    cursor_style: null,
+    cursor_blink: null,
+  };
   const main = new ScriptedTransport((request, transport) => {
     assert.equal(request.cmd, "identify");
     transport.emit({ id: request.id, ok: true, data: { app: "cmux-tui", version: "0.1.2", protocol: 6, session: "main", pid: 1 } });
@@ -181,8 +233,15 @@ test("attachSurface decodes VT colors, output, and resized payloads", async () =
       },
     });
     transport.emit({ id: request.id, ok: true, data: {} });
-    transport.emit({ event: "output", surface: 7, data: "aGk=" });
-    transport.emit({ event: "resized", surface: 7, cols: 100, rows: 30, data: "AQID" });
+    transport.emit({ event: "output", surface: 7, data: "aGk=", colors: atomicColors });
+    transport.emit({
+      event: "resized",
+      surface: 7,
+      cols: 100,
+      rows: 30,
+      data: "AQID",
+      colors: atomicColors,
+    });
   });
   const client = new CmuxClient({
     transport: main,
@@ -208,11 +267,15 @@ test("attachSurface decodes VT colors, output, and resized payloads", async () =
     });
   }
   assert.equal(output.event, "output");
-  if (output.event === "output") assert.deepEqual(output.data, Uint8Array.from([104, 105]));
+  if (output.event === "output") {
+    assert.deepEqual(output.data, Uint8Array.from([104, 105]));
+    assert.deepEqual(output.colors, atomicColors);
+  }
   assert.equal(resized.event, "resized");
   if (resized.event === "resized") {
     assert.deepEqual(resized.data, Uint8Array.from([1, 2, 3]));
     assert.deepEqual(resized.replay, resized.data);
+    assert.deepEqual(resized.colors, atomicColors);
   }
   stream.close();
   await client.close();

--- a/cmux-tui/bindings/typescript/test/protocol-types.ts
+++ b/cmux-tui/bindings/typescript/test/protocol-types.ts
@@ -76,7 +76,17 @@ const requests = [
 ] satisfies CmuxRequest[];
 
 type IdentifyData = CmuxResponseData<(typeof requests)[0]>;
-const identify: IdentifyData = { app: "cmux-tui", version: "0.1.2", protocol: 6, session: "main", pid: 1 };
+const identify: IdentifyData = {
+  app: "cmux-tui",
+  version: "0.1.2",
+  protocol: 7,
+  session: "main",
+  pid: 1,
+  registry_id: "registry",
+  generation: "generation",
+  workspace_revision: 1,
+  terminal_revision: 2,
+};
 void identify;
 
 function surfaceFromKnownEvent(event: KnownCmuxEvent): number | undefined {

--- a/cmux-tui/crates/cmux-tui-core/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui-core/Cargo.toml
@@ -22,6 +22,8 @@ libc.workspace = true
 regex.workspace = true
 tungstenite.workspace = true
 getrandom.workspace = true
+rusqlite.workspace = true
+fs4.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 uds_windows.workspace = true

--- a/cmux-tui/crates/cmux-tui-core/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui-core/Cargo.toml
@@ -24,6 +24,7 @@ tungstenite.workspace = true
 getrandom.workspace = true
 rusqlite.workspace = true
 fs4.workspace = true
+sha2.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 uds_windows.workspace = true

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod platform;
 pub mod server;
 pub mod terminal_host;
 pub mod terminal_host_protocol;
+pub mod terminal_host_runtime;
 
 pub use browser::{TRANSPORT_SAFE_CAPTURE_MEGAPIXELS, normalize_url};
 pub use event_bus::{MuxEventBroadcaster, MuxEventReceiver};

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -15,6 +15,7 @@ mod mux;
 mod pairing;
 mod short_id;
 mod surface;
+mod workspace_registry;
 
 pub mod layout;
 pub mod platform;
@@ -31,8 +32,8 @@ pub use mux::{
     AgentRecord, AgentSource, AgentState, AppliedLayout, AppliedPane, CellPixelUpdate,
     CellPixelUpdateFailure, Direction, LayoutLeafSpec, LayoutSpec, Mux, MuxEvent,
     NotificationEvent, NotificationLevel, RunPlacement, SidebarPluginOptions, SidebarPluginStatus,
-    SurfaceNotification, SurfaceResizeReporter, TreeDelta, TreeDeltaKind, WorkspacePlacement,
-    ZoomMode, ZoomState,
+    SurfaceNotification, SurfaceResizeReporter, TreeDelta, TreeDeltaKind, WorkspaceMutationResult,
+    WorkspacePlacement, ZoomMode, ZoomState,
 };
 pub use pairing::{PairingChallenge, PairingDecision, PairingError};
 pub use short_id::assign_short_ids;
@@ -40,6 +41,10 @@ pub use surface::{
     AttachFrame, AttachFrameReceiver, AttachStream, BrowserAttachState, BrowserFrame,
     BrowserFrameStream, BrowserSource, BrowserStatus, DefaultColors, RenderAttachFrame,
     RenderAttachStream, Surface, SurfaceKind, SurfaceOptions, SurfaceRenderFrame, TerminalColors,
+};
+pub use workspace_registry::{
+    FrontendProjection, ProjectionCommit, RegistryCommit, RegistryEvent, RegistrySnapshot,
+    RegistryWorkspace, WorkspaceMutation, WorkspaceRegistry,
 };
 
 pub use cmux_tui_cdp::BrowserMode;

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -20,6 +20,8 @@ mod workspace_registry;
 pub mod layout;
 pub mod platform;
 pub mod server;
+pub mod terminal_host;
+pub mod terminal_host_protocol;
 
 pub use browser::{TRANSPORT_SAFE_CAPTURE_MEGAPIXELS, normalize_url};
 pub use event_bus::{MuxEventBroadcaster, MuxEventReceiver};

--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -44,6 +44,7 @@ pub use surface::{
     AttachFrame, AttachFrameReceiver, AttachStream, BrowserAttachState, BrowserFrame,
     BrowserFrameStream, BrowserSource, BrowserStatus, DefaultColors, RenderAttachFrame,
     RenderAttachStream, Surface, SurfaceKind, SurfaceOptions, SurfaceRenderFrame, TerminalColors,
+    TerminalHostConnectionState,
 };
 pub use workspace_registry::{
     FrontendProjection, ProjectionCommit, RegistryCommit, RegistryEvent, RegistrySnapshot,

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -20,6 +20,8 @@ use crate::pairing::PairingBroker;
 use crate::surface::{DefaultColors, Surface, SurfaceOptions};
 use crate::terminal_host::TerminalId;
 use crate::terminal_host_runtime::TerminalHostIdentity;
+#[cfg(unix)]
+use crate::terminal_host_runtime::TerminalHostLiveness;
 use crate::workspace_registry::{
     FrontendProjection, ProjectionCommit, RegistryCommit, RegistryTerminal, RegistryWorkspace,
     TerminalLifecycle, TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
@@ -70,8 +72,9 @@ pub enum MuxEvent {
         retry_after_ms: Option<u64>,
         reservation_id: Option<u64>,
     },
-    /// A surface's child exited. The mux has already reaped it from the
-    /// tree (a tree-changed follows) by the time this arrives.
+    /// A surface's child exited. Hosted terminals remain in the tree as an
+    /// addressable Exited tab until an explicit close tombstones them; local
+    /// terminals have already been reaped when this arrives.
     SurfaceExited(SurfaceId),
     TitleChanged {
         surface: SurfaceId,
@@ -516,6 +519,8 @@ pub struct Mux {
     client_sizing: Mutex<ClientSizingState>,
     #[cfg(test)]
     client_resize_before_apply: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    #[cfg(test)]
+    terminal_move_before_projection: Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
     browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
     cell_pixels: Mutex<(u16, u16)>,
     default_colors: Mutex<DefaultColors>,
@@ -603,6 +608,8 @@ impl Mux {
             client_sizing: Mutex::new(ClientSizingState::default()),
             #[cfg(test)]
             client_resize_before_apply: Mutex::new(None),
+            #[cfg(test)]
+            terminal_move_before_projection: Mutex::new(None),
             browser_runtime: Mutex::new(None),
             cell_pixels: Mutex::new((8, 16)),
             default_colors: Mutex::new(DefaultColors::default()),
@@ -625,19 +632,13 @@ impl Mux {
     #[cfg(unix)]
     fn adopt_terminal_hosts(self: &Arc<Self>) -> anyhow::Result<()> {
         let options = self.surface_options.lock().unwrap().clone();
-        let Some(root) = options.terminal_host_root.clone() else {
-            return Ok(());
+        let records = match options.terminal_host_root.as_deref() {
+            Some(root) => crate::terminal_host_runtime::load_terminal_host_records(root)?,
+            None => Vec::new(),
         };
-        let records = crate::terminal_host_runtime::load_terminal_host_records(&root)?;
-        let mut retained_records = HashSet::new();
+        let mut handled_terminals = HashSet::new();
         for (record_path, record) in records {
             let terminal_id = record.terminal_id.clone();
-            if TerminalId::from_hex(&terminal_id).is_none()
-                || TerminalId::from_hex(&record.incarnation).is_none()
-            {
-                crate::terminal_host_runtime::remove_terminal_host_record(&record_path);
-                continue;
-            }
             let mut terminal =
                 self.workspace_registry.lock().unwrap().terminal_record(&terminal_id)?;
             if terminal.is_none() {
@@ -665,67 +666,121 @@ impl Mux {
                     self.emit_terminal_registry_changed(&registry, revision);
                     terminal = Some(imported);
                 } else {
-                    terminate_host_record(record, record_path);
+                    if !cleanup_terminal_host_record(&record, &record_path) {
+                        self.schedule_terminal_adoption(options.clone(), record, record_path);
+                    }
                     continue;
                 }
             }
             let terminal = terminal.expect("terminal imported or loaded");
-            if matches!(
-                terminal.lifecycle,
-                TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
-            ) {
-                terminate_host_record(record, record_path);
+            if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+                if !cleanup_terminal_host_record(&record, &record_path) {
+                    self.schedule_terminal_adoption(options.clone(), record, record_path);
+                }
+                continue;
+            }
+            if terminal.lifecycle == TerminalLifecycle::Exited {
+                self.materialize_exited_terminal(&terminal.terminal_id, &options)?;
+                handled_terminals.insert(terminal_id.clone());
+                if !cleanup_terminal_host_record(&record, &record_path) {
+                    self.schedule_terminal_adoption(options.clone(), record, record_path);
+                }
                 continue;
             }
             if terminal.incarnation.as_deref().is_some_and(|value| value != record.incarnation) {
-                terminate_host_record(record, record_path);
-                let _ = self.transition_terminal_lifecycle(
-                    "terminal-exited",
-                    "terminal-incarnation-mismatch",
+                self.mark_terminal_exited_and_materialize(
                     &terminal_id,
-                    TerminalLifecycle::Exited,
-                    terminal.incarnation.as_deref(),
-                    Some(serde_json::json!({"reason":"host-incarnation-mismatch"})),
-                );
+                    "terminal-incarnation-mismatch",
+                    "host-incarnation-mismatch",
+                    &options,
+                )?;
+                handled_terminals.insert(terminal_id.clone());
+                if !cleanup_terminal_host_record(&record, &record_path) {
+                    self.schedule_terminal_adoption(options.clone(), record, record_path);
+                }
                 continue;
             }
-            self.transition_terminal_lifecycle(
+            if let Err(error) = self.transition_terminal_lifecycle(
                 "terminal-adopting",
                 "adopt-terminal",
                 &terminal_id,
                 TerminalLifecycle::Adopting,
                 Some(&record.incarnation),
                 None,
-            )?;
-            let id = self.next_id();
-            let mut adopted = None;
-            for attempt in 0..3 {
-                match Surface::adopt_hosted(
-                    id,
-                    options.clone(),
-                    Arc::downgrade(self),
-                    record.clone(),
-                    record_path.clone(),
-                ) {
-                    Ok(surface) => {
-                        adopted = Some(surface);
-                        break;
+            ) {
+                let current =
+                    self.workspace_registry.lock().unwrap().terminal_record(&terminal_id)?;
+                if current.as_ref().is_some_and(|terminal| {
+                    matches!(
+                        terminal.lifecycle,
+                        TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
+                    )
+                }) {
+                    if current
+                        .as_ref()
+                        .is_some_and(|terminal| terminal.lifecycle == TerminalLifecycle::Exited)
+                    {
+                        self.materialize_exited_terminal(&terminal_id, &options)?;
                     }
-                    Err(_) if attempt < 2 => {
-                        std::thread::sleep(Duration::from_millis(25 * (1 << attempt)));
+                    handled_terminals.insert(terminal_id.clone());
+                    if !cleanup_terminal_host_record(&record, &record_path) {
+                        self.schedule_terminal_adoption(options.clone(), record, record_path);
                     }
-                    Err(_) => {}
+                    continue;
                 }
+                return Err(error);
             }
+            if terminal_host_record_liveness(&record_path, &record) == TerminalHostLiveness::Dead {
+                let _ = crate::terminal_host_runtime::remove_stale_terminal_host_record(
+                    &record_path,
+                    &record,
+                );
+                self.mark_terminal_exited_and_materialize(
+                    &terminal_id,
+                    "terminal-host-proven-dead",
+                    "host-process-ended-before-adoption",
+                    &options,
+                )?;
+                handled_terminals.insert(terminal_id.clone());
+                continue;
+            }
+            let id = self.next_id();
+            // Bound startup head-of-line blocking per host. One handshake is
+            // enough for healthy hosts; live or indeterminate failures
+            // continue on the asynchronous adoption loop instead of retrying
+            // serially ahead of every later terminal.
+            let adopted = Surface::adopt_hosted(
+                id,
+                options.clone(),
+                Arc::downgrade(self),
+                record.clone(),
+                record_path.clone(),
+            )
+            .ok();
             let surface = match adopted {
                 Some(surface) => surface,
-                // A failed connection can be a transient host startup or
-                // descriptor-pressure failure. The host owns cleanup of its
-                // record on exit; deleting the capability here would turn a
-                // retryable interruption into permanent terminal loss.
                 None => {
-                    retained_records.insert(terminal_id.clone());
-                    self.schedule_terminal_adoption(options.clone(), record, record_path);
+                    if terminal_host_record_liveness(&record_path, &record)
+                        == TerminalHostLiveness::Dead
+                    {
+                        let _ = crate::terminal_host_runtime::remove_stale_terminal_host_record(
+                            &record_path,
+                            &record,
+                        );
+                        self.mark_terminal_exited_and_materialize(
+                            &terminal_id,
+                            "terminal-host-proven-dead",
+                            "host-process-ended-before-adoption",
+                            &options,
+                        )?;
+                        handled_terminals.insert(terminal_id.clone());
+                    } else {
+                        // Socket loss and descriptor pressure are not process
+                        // death proof. Keep the capability and retry the same
+                        // host rather than spawning a replacement shell.
+                        handled_terminals.insert(terminal_id.clone());
+                        self.schedule_terminal_adoption(options.clone(), record, record_path);
+                    }
                     continue;
                 }
             };
@@ -734,9 +789,19 @@ impl Mux {
                 .is_err()
             {
                 surface.kill();
+                self.mark_terminal_exited_and_materialize(
+                    &terminal_id,
+                    "terminal-adoption-failed",
+                    "host-adoption-topology-failed",
+                    &options,
+                )?;
+                handled_terminals.insert(terminal_id.clone());
+                if !cleanup_terminal_host_record(&record, &record_path) {
+                    self.schedule_terminal_adoption(options.clone(), record, record_path);
+                }
                 continue;
             }
-            retained_records.insert(terminal_id);
+            handled_terminals.insert(terminal_id);
             self.reap_if_dead(&surface);
         }
 
@@ -745,20 +810,160 @@ impl Mux {
         // window, not permission to spawn a replacement shell.
         let snapshot = self.workspace_registry.lock().unwrap().terminal_snapshot()?;
         for terminal in snapshot.terminals {
-            if retained_records.contains(&terminal.terminal_id)
-                || terminal.lifecycle == TerminalLifecycle::Exited
+            if terminal.lifecycle == TerminalLifecycle::Tombstoned
+                || handled_terminals.contains(&terminal.terminal_id)
             {
                 continue;
             }
-            let _ = self.transition_terminal_lifecycle(
-                "terminal-exited",
-                "terminal-record-missing",
+            if terminal.lifecycle == TerminalLifecycle::Exited {
+                self.materialize_exited_terminal(&terminal.terminal_id, &options)?;
+                continue;
+            }
+            self.mark_terminal_exited_and_materialize(
                 &terminal.terminal_id,
+                "terminal-record-missing",
+                "missing-host-record",
+                &options,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Project durable Exited state into the normal topology. The placeholder
+    /// owns no PTY and can never respawn a shell, but it retains the stable
+    /// terminal/incarnation identity until an explicit close tombstones it.
+    /// Re-reading under registry -> state makes a concurrent move or close
+    /// authoritative.
+    #[cfg(unix)]
+    fn materialize_exited_terminal(
+        self: &Arc<Self>,
+        terminal_id: &str,
+        options: &SurfaceOptions,
+    ) -> anyhow::Result<Option<RunPlacement>> {
+        let terminal = self.workspace_registry.lock().unwrap().terminal_record(terminal_id)?;
+        let Some(terminal) = terminal.filter(|terminal| {
+            terminal.lifecycle == TerminalLifecycle::Exited && terminal.incarnation.is_some()
+        }) else {
+            return Ok(None);
+        };
+        let identity = TerminalHostIdentity {
+            terminal_id: terminal.terminal_id,
+            incarnation: terminal.incarnation.expect("filtered Exited incarnation"),
+        };
+        let existing_projection = {
+            let registry = self.workspace_registry.lock().unwrap();
+            let Some(current) = registry.terminal_record(terminal_id)? else {
+                return Ok(None);
+            };
+            if current.lifecycle != TerminalLifecycle::Exited
+                || current.incarnation.as_deref() != Some(identity.incarnation.as_str())
+            {
+                return Ok(None);
+            }
+            let mut state = self.state.lock().unwrap();
+            let existing = unique_terminal_match(
+                terminal_id,
+                state.surfaces.values().filter_map(|surface| {
+                    surface.terminal_host_identity().map(|identity| (surface.id, identity))
+                }),
+            )?;
+            if existing.is_some() {
+                Some(self.project_terminal_to_workspace_in_state(
+                    &mut state,
+                    terminal_id,
+                    &current.workspace_key,
+                )?)
+            } else {
+                None
+            }
+        };
+        if let Some((placement, changed)) = existing_projection {
+            if changed {
+                self.emit(MuxEvent::TreeChanged);
+            }
+            return Ok(placement);
+        }
+        let placeholder = Surface::exited_terminal_placeholder(
+            self.next_id(),
+            options.clone(),
+            Arc::downgrade(self),
+            identity.clone(),
+        )?;
+
+        let (placement, changed) = {
+            let registry = self.workspace_registry.lock().unwrap();
+            let Some(current) = registry.terminal_record(terminal_id)? else {
+                return Ok(None);
+            };
+            if current.lifecycle != TerminalLifecycle::Exited
+                || current.incarnation.as_deref() != Some(identity.incarnation.as_str())
+            {
+                return Ok(None);
+            }
+            let mut state = self.state.lock().unwrap();
+            let existing = unique_terminal_match(
+                terminal_id,
+                state.surfaces.values().filter_map(|surface| {
+                    surface.terminal_host_identity().map(|identity| (surface.id, identity))
+                }),
+            )?;
+            if existing.is_none() {
+                insert_surface_checked(&mut state, placeholder.clone())?;
+            }
+            match self.project_terminal_to_workspace_in_state(
+                &mut state,
+                terminal_id,
+                &current.workspace_key,
+            ) {
+                Ok(result) => result,
+                Err(error) => {
+                    if existing.is_none() {
+                        state.surfaces.remove(&placeholder.id);
+                    }
+                    return Err(error);
+                }
+            }
+        };
+        if changed {
+            self.emit(MuxEvent::TreeChanged);
+        }
+        Ok(placement)
+    }
+
+    #[cfg(unix)]
+    fn mark_terminal_exited_and_materialize(
+        self: &Arc<Self>,
+        terminal_id: &str,
+        operation: &str,
+        reason: &str,
+        options: &SurfaceOptions,
+    ) -> anyhow::Result<()> {
+        let terminal = self.workspace_registry.lock().unwrap().terminal_record(terminal_id)?;
+        let Some(terminal) = terminal else { return Ok(()) };
+        if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+            return Ok(());
+        }
+        if terminal.lifecycle != TerminalLifecycle::Exited
+            && let Err(error) = self.transition_terminal_lifecycle(
+                "terminal-exited",
+                operation,
+                terminal_id,
                 TerminalLifecycle::Exited,
                 terminal.incarnation.as_deref(),
-                Some(serde_json::json!({"reason":"missing-host-record"})),
-            );
+                Some(serde_json::json!({"reason":reason})),
+            )
+        {
+            let current = self.workspace_registry.lock().unwrap().terminal_record(terminal_id)?;
+            if !current.as_ref().is_some_and(|terminal| {
+                matches!(
+                    terminal.lifecycle,
+                    TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
+                )
+            }) {
+                return Err(error);
+            }
         }
+        self.materialize_exited_terminal(terminal_id, options)?;
         Ok(())
     }
 
@@ -876,35 +1081,42 @@ impl Mux {
                         .terminal_record(&terminal_id)
                         .ok()
                         .flatten();
-                    let Some(terminal) = terminal else { break };
-                    if terminal.lifecycle == TerminalLifecycle::Tombstoned {
-                        if terminate_host_record(record.clone(), record_path.clone()) {
+                    let Some(terminal) = terminal else {
+                        if cleanup_terminal_host_record(&record, &record_path) {
                             break;
                         }
                         delay = (delay * 2).min(Duration::from_secs(5));
                         continue;
-                    }
-                    if terminal.lifecycle == TerminalLifecycle::Exited {
-                        break;
+                    };
+                    if matches!(
+                        terminal.lifecycle,
+                        TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
+                    ) {
+                        if terminal.lifecycle == TerminalLifecycle::Exited {
+                            let _ = mux.materialize_exited_terminal(&terminal_id, &options);
+                        }
+                        if cleanup_terminal_host_record(&record, &record_path) {
+                            break;
+                        }
+                        delay = (delay * 2).min(Duration::from_secs(5));
+                        continue;
                     }
                     if terminal
                         .incarnation
                         .as_deref()
                         .is_some_and(|incarnation| incarnation != record.incarnation)
                     {
-                        terminate_host_record(record.clone(), record_path.clone());
-                        break;
-                    }
-                    if !record_path.exists() {
-                        let _ = mux.transition_terminal_lifecycle(
-                            "terminal-exited",
-                            "terminal-record-disappeared",
+                        let _ = mux.mark_terminal_exited_and_materialize(
                             &terminal_id,
-                            TerminalLifecycle::Exited,
-                            terminal.incarnation.as_deref(),
-                            Some(serde_json::json!({"reason":"missing-host-record"})),
+                            "terminal-incarnation-mismatch",
+                            "host-incarnation-mismatch",
+                            &options,
                         );
-                        break;
+                        if cleanup_terminal_host_record(&record, &record_path) {
+                            break;
+                        }
+                        delay = (delay * 2).min(Duration::from_secs(5));
+                        continue;
                     }
                     if terminal.lifecycle == TerminalLifecycle::Running {
                         let already_live = mux
@@ -929,6 +1141,21 @@ impl Mux {
                             break;
                         }
                     }
+                    if terminal_host_record_liveness(&record_path, &record)
+                        == TerminalHostLiveness::Dead
+                    {
+                        let _ = crate::terminal_host_runtime::remove_stale_terminal_host_record(
+                            &record_path,
+                            &record,
+                        );
+                        let _ = mux.mark_terminal_exited_and_materialize(
+                            &terminal_id,
+                            "terminal-host-proven-dead",
+                            "host-process-ended-before-adoption",
+                            &options,
+                        );
+                        break;
+                    }
                     let id = mux.next_id();
                     if let Ok(surface) = Surface::adopt_hosted(
                         id,
@@ -949,6 +1176,14 @@ impl Mux {
                             break;
                         }
                         surface.kill();
+                        let _ = mux.mark_terminal_exited_and_materialize(
+                            &terminal_id,
+                            "terminal-adoption-failed",
+                            "host-adoption-topology-failed",
+                            &options,
+                        );
+                        delay = (delay * 2).min(Duration::from_secs(5));
+                        continue;
                     }
                     delay = (delay * 2).min(Duration::from_secs(5));
                 }
@@ -1034,11 +1269,20 @@ impl Mux {
         self.workspace_registry.lock().unwrap().terminal_snapshot()
     }
 
-    pub fn terminal_registry_events_after(
+    pub fn terminal_registry_events_page(
         &self,
         revision: u64,
-    ) -> anyhow::Result<Vec<crate::workspace_registry::TerminalRegistryEvent>> {
-        self.workspace_registry.lock().unwrap().terminal_events_after(revision)
+    ) -> anyhow::Result<(
+        TerminalRegistrySnapshot,
+        Vec<crate::workspace_registry::TerminalRegistryEvent>,
+    )> {
+        // One writer guard is the read transaction boundary exposed to a
+        // frontend. Otherwise a commit between snapshot and event queries can
+        // return an event whose revision is newer than terminal_revision.
+        let registry = self.workspace_registry.lock().unwrap();
+        let snapshot = registry.terminal_snapshot()?;
+        let events = registry.terminal_events_after(revision)?;
+        Ok((snapshot, events))
     }
 
     pub fn workspace_registry_event(
@@ -1145,6 +1389,121 @@ impl Mux {
         )?;
         self.emit_terminal_registry_changed(&registry, result.1);
         Ok(result)
+    }
+
+    /// A broken admin stream is not evidence that the per-terminal process
+    /// died. The surface keeps its tab and reconnects the same incarnation;
+    /// this callback only exposes the transient lifecycle to frontends.
+    pub(crate) fn terminal_host_connection_lost(
+        &self,
+        surface_id: SurfaceId,
+        identity: &TerminalHostIdentity,
+    ) -> bool {
+        if self.shutting_down.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let state = self.state.lock().unwrap();
+        let identity_matches = state
+            .surfaces
+            .get(&surface_id)
+            .and_then(|surface| surface.terminal_host_identity())
+            .is_some_and(|current| current == *identity);
+        drop(state);
+        if !identity_matches {
+            return false;
+        }
+        let Ok(Some(terminal)) = registry.terminal_record(&identity.terminal_id) else {
+            return false;
+        };
+        if terminal.incarnation.as_deref() != Some(identity.incarnation.as_str())
+            || matches!(
+                terminal.lifecycle,
+                TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
+            )
+        {
+            return false;
+        }
+        if terminal.lifecycle == TerminalLifecycle::Adopting {
+            return true;
+        }
+        match commit_terminal_lifecycle(
+            &mut registry,
+            "terminal-adopting",
+            "terminal-admin-stream-lost",
+            &identity.terminal_id,
+            TerminalLifecycle::Adopting,
+            Some(&identity.incarnation),
+            None,
+        ) {
+            Ok((_, revision)) => {
+                self.emit_terminal_registry_changed(&registry, revision);
+                true
+            }
+            Err(error) => {
+                self.emit(MuxEvent::Status(format!(
+                    "could not persist terminal {} reconnect state: {error}",
+                    identity.terminal_id
+                )));
+                false
+            }
+        }
+    }
+
+    pub(crate) fn terminal_host_reconnected(
+        &self,
+        surface_id: SurfaceId,
+        identity: &TerminalHostIdentity,
+    ) -> bool {
+        if self.shutting_down.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let state = self.state.lock().unwrap();
+        let identity_matches = state
+            .surfaces
+            .get(&surface_id)
+            .and_then(|surface| surface.terminal_host_identity())
+            .is_some_and(|current| current == *identity);
+        drop(state);
+        if !identity_matches {
+            return false;
+        }
+        let Ok(Some(terminal)) = registry.terminal_record(&identity.terminal_id) else {
+            return false;
+        };
+        if terminal.incarnation.as_deref() != Some(identity.incarnation.as_str())
+            || matches!(
+                terminal.lifecycle,
+                TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
+            )
+        {
+            return false;
+        }
+        if terminal.lifecycle == TerminalLifecycle::Running {
+            return true;
+        }
+        match commit_terminal_lifecycle(
+            &mut registry,
+            "terminal-ready",
+            "terminal-admin-stream-reconnected",
+            &identity.terminal_id,
+            TerminalLifecycle::Running,
+            Some(&identity.incarnation),
+            None,
+        ) {
+            Ok((_, revision)) => {
+                self.emit_terminal_registry_changed(&registry, revision);
+                true
+            }
+            Err(error) => {
+                self.emit(MuxEvent::Status(format!(
+                    "could not persist terminal {} reconnect completion: {error}",
+                    identity.terminal_id
+                )));
+                false
+            }
+        }
     }
 
     pub(crate) fn lock_client_sizing_lifecycle(&self) -> MutexGuard<'_, ()> {
@@ -1821,6 +2180,11 @@ impl Mux {
         *self.client_resize_before_apply.lock().unwrap() = hook;
     }
 
+    #[cfg(test)]
+    fn set_terminal_move_before_projection(&self, hook: Option<Arc<dyn Fn() + Send + Sync>>) {
+        *self.terminal_move_before_projection.lock().unwrap() = hook;
+    }
+
     fn browser_runtime(&self) -> anyhow::Result<Arc<BrowserRuntime>> {
         let mut runtime = self.browser_runtime.lock().unwrap();
         if let Some(existing) = runtime.as_ref().filter(|existing| !existing.is_closed()) {
@@ -1899,7 +2263,7 @@ impl Mux {
         let state = self.state.lock().unwrap();
         let surface = unique_terminal_match(
             terminal_id,
-            state.surfaces.values().filter(|surface| !surface.is_dead()).filter_map(|surface| {
+            state.surfaces.values().filter_map(|surface| {
                 surface.terminal_host_identity().map(|identity| (surface.id, identity))
             }),
         )?
@@ -1957,11 +2321,9 @@ impl Mux {
             let mut state = self.state.lock().unwrap();
             let target = unique_terminal_match(
                 terminal_id,
-                state.surfaces.values().filter(|surface| !surface.is_dead()).filter_map(
-                    |surface| {
-                        surface.terminal_host_identity().map(|identity| (surface.id, identity))
-                    },
-                ),
+                state.surfaces.values().filter_map(|surface| {
+                    surface.terminal_host_identity().map(|identity| (surface.id, identity))
+                }),
             )?
             .map(|(surface, _)| surface);
             let changed_screen = target.and_then(|target| surface_screen_id(&state, target));
@@ -2620,14 +2982,22 @@ impl Mux {
         let (placement, delta) = {
             let mut state = self.state.lock().unwrap();
             let Some((wi, si)) = state.screen_of(target) else {
-                state.surfaces.remove(&surface.id);
-                surface.kill();
-                anyhow::bail!("pane disappeared while creating tab");
+                drop(state);
+                self.fail_hosted_terminal_attachment(
+                    &surface,
+                    "terminal-run-attach-failed",
+                    "pane-disappeared-before-attach",
+                )?;
+                anyhow::bail!("pane disappeared while creating tab")
             };
             let Some(pane) = state.panes.get_mut(&target) else {
-                state.surfaces.remove(&surface.id);
-                surface.kill();
-                anyhow::bail!("pane disappeared while creating tab");
+                drop(state);
+                self.fail_hosted_terminal_attachment(
+                    &surface,
+                    "terminal-run-attach-failed",
+                    "pane-disappeared-before-attach",
+                )?;
+                anyhow::bail!("pane disappeared while creating tab")
             };
             pane.tabs.push(surface.id);
             pane.active_tab = pane.tabs.len() - 1;
@@ -2740,14 +3110,15 @@ impl Mux {
                         workspace_revision: None,
                     })
                 }
-                None => {
-                    state.surfaces.remove(&surface.id);
-                    None
-                }
+                None => None,
             }
         };
         let Some(delta) = attached else {
-            surface.kill();
+            self.fail_hosted_terminal_attachment(
+                &surface,
+                "terminal-screen-attach-failed",
+                "workspace-disappeared-before-attach",
+            )?;
             anyhow::bail!("workspace disappeared while creating screen");
         };
         self.emit(MuxEvent::TreeDelta(delta));
@@ -2829,13 +3200,16 @@ impl Mux {
                 }
                 None => {
                     // Pane disappeared between validation and attach.
-                    state.surfaces.remove(&surface.id);
                     None
                 }
             }
         };
         let Some(delta) = attached else {
-            surface.kill();
+            self.fail_hosted_terminal_attachment(
+                &surface,
+                "terminal-tab-attach-failed",
+                "pane-disappeared-before-attach",
+            )?;
             anyhow::bail!("pane disappeared while creating tab");
         };
         self.emit(MuxEvent::TreeDelta(delta));
@@ -2990,35 +3364,12 @@ impl Mux {
         if let Some(name) = name {
             surface.set_name(Some(name));
         }
-        if let Some(identity) = surface.terminal_host_identity() {
+        if surface.terminal_host_identity().is_some() {
             // Launch/Ready intentionally releases the registry lock around
             // process startup. Re-read canonical placement after Ready and
             // hold registry -> state through the binding so a move committed
             // during launch is projected instead of the stale request target.
-            let projected = (|| -> anyhow::Result<(RunPlacement, String, bool)> {
-                let registry = self.workspace_registry.lock().unwrap();
-                let terminal = registry
-                    .terminal_record(&identity.terminal_id)?
-                    .ok_or_else(|| anyhow::anyhow!("created terminal has no registry row"))?;
-                if terminal.lifecycle != TerminalLifecycle::Running {
-                    anyhow::bail!(
-                        "created terminal is {} before topology binding",
-                        terminal_lifecycle_name(terminal.lifecycle)
-                    );
-                }
-                let mut state = self.state.lock().unwrap();
-                if !state.surfaces.contains_key(&surface.id) {
-                    anyhow::bail!("terminal closed while its topology binding was being created");
-                }
-                let (placement, changed) = self.project_terminal_to_workspace_in_state(
-                    &mut state,
-                    &identity.terminal_id,
-                    &terminal.workspace_key,
-                )?;
-                let placement = placement
-                    .ok_or_else(|| anyhow::anyhow!("created terminal has no live surface"))?;
-                Ok((placement, terminal.workspace_key, changed))
-            })();
+            let projected = self.bind_running_terminal_to_canonical_workspace(&surface);
             let (placement, canonical_workspace, changed) = match projected {
                 Ok(projected) => projected,
                 Err(error) => {
@@ -3128,6 +3479,40 @@ impl Mux {
         self.emit(MuxEvent::TreeDelta(attached.1));
         self.reap_if_dead(&surface);
         Ok(attached.0)
+    }
+
+    /// Bind a just-launched hosted surface using the latest durable row, not
+    /// the workspace requested before process launch. Holding registry ->
+    /// state through projection is the create/move serialization fence.
+    fn bind_running_terminal_to_canonical_workspace(
+        &self,
+        surface: &Arc<Surface>,
+    ) -> anyhow::Result<(RunPlacement, String, bool)> {
+        let identity = surface
+            .terminal_host_identity()
+            .ok_or_else(|| anyhow::anyhow!("created terminal has no host identity"))?;
+        let registry = self.workspace_registry.lock().unwrap();
+        let terminal = registry
+            .terminal_record(&identity.terminal_id)?
+            .ok_or_else(|| anyhow::anyhow!("created terminal has no registry row"))?;
+        if terminal.lifecycle != TerminalLifecycle::Running {
+            anyhow::bail!(
+                "created terminal is {} before topology binding",
+                terminal_lifecycle_name(terminal.lifecycle)
+            );
+        }
+        let mut state = self.state.lock().unwrap();
+        if !state.surfaces.contains_key(&surface.id) {
+            anyhow::bail!("terminal closed while its topology binding was being created");
+        }
+        let (placement, changed) = self.project_terminal_to_workspace_in_state(
+            &mut state,
+            &identity.terminal_id,
+            &terminal.workspace_key,
+        )?;
+        let placement =
+            placement.ok_or_else(|| anyhow::anyhow!("created terminal has no live surface"))?;
+        Ok((placement, terminal.workspace_key, changed))
     }
 
     /// Create a browser tab in a pane (default: the active pane). When
@@ -3538,12 +3923,14 @@ impl Mux {
                     entity,
                     workspace_revision: None,
                 });
-            } else {
-                state.surfaces.remove(&surface.id);
             }
         }
         if !done {
-            surface.kill();
+            self.fail_hosted_terminal_attachment(
+                &surface,
+                "terminal-split-attach-failed",
+                "pane-disappeared-before-attach",
+            )?;
             anyhow::bail!("pane {target} not found");
         }
         self.emit(MuxEvent::TreeDelta(delta.expect("successful split has a tree delta")));
@@ -3601,21 +3988,27 @@ impl Mux {
     /// Close every surface in `tabs` (helper for pane/screen/workspace
     /// close). Emits events outside the lock.
     fn close_surfaces(&self, tabs: Vec<SurfaceId>, delta: TreeDelta) {
-        let surfaces = {
-            let state = self.state.lock().unwrap();
-            tabs.iter().filter_map(|id| state.surfaces.get(id).cloned()).collect::<Vec<_>>()
-        };
-        for surface in &surfaces {
-            if let Err(error) = self.tombstone_hosted_surface(surface) {
-                self.emit(MuxEvent::Status(format!(
-                    "could not close terminal {}: {error}",
-                    surface.id
-                )));
-                return;
-            }
-        }
-        let (removed, changed_screens, empty) = {
+        let mutation = WorkspaceMutation::local("cmux-tui");
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let (removed, changed_screens, empty, batch) = {
             let mut state = self.state.lock().unwrap();
+            let hosted = tabs
+                .iter()
+                .filter_map(|id| state.surfaces.get(id))
+                .filter_map(|surface| surface.terminal_host_identity())
+                .map(|identity| (identity.terminal_id, Some(identity.incarnation)))
+                .collect::<Vec<_>>();
+            let batch = match registry.close_terminals_atomically(&mutation, &hosted) {
+                Ok(batch) => batch,
+                Err(error) => {
+                    drop(state);
+                    drop(registry);
+                    self.emit(MuxEvent::Status(format!(
+                        "could not atomically close terminal topology: {error}"
+                    )));
+                    return;
+                }
+            };
             let changed_screens = unique_screen_ids(
                 tabs.iter().filter_map(|surface| surface_screen_id(&state, *surface)),
             );
@@ -3625,8 +4018,12 @@ impl Mux {
                     removed.push(surface);
                 }
             }
-            (removed, changed_screens, state.workspaces.is_empty())
+            (removed, changed_screens, state.workspaces.is_empty(), batch)
         };
+        if batch.closed != 0 {
+            self.emit_terminal_registry_changed(&registry, batch.revision);
+        }
+        drop(registry);
         if !removed.is_empty() {
             for surface in removed {
                 self.purge_surface_side_tables(surface.id);
@@ -3980,19 +4377,24 @@ impl Mux {
         true
     }
 
-    /// Reap a surface whose child exited before its tree insert completed.
-    /// The exit handler sets the dead flag before calling `surface_exited`,
-    /// whose `close_surface` finds nothing to remove in that window; the
-    /// creator re-checks after the insert (a harmless no-op otherwise).
+    /// Reconcile a surface whose child exited before its tree insert
+    /// completed. Hosted terminals retain their binding as Exited tabs;
+    /// local terminals are reaped after the creator closes the insert race.
     fn reap_if_dead(&self, surface: &Arc<Surface>) {
         if surface.is_dead() {
-            if let Err(error) =
-                self.mark_hosted_surface_exited(surface, "host-exited-before-attach")
-            {
-                self.emit(MuxEvent::Status(format!(
-                    "could not persist terminal {} exit: {error}",
-                    surface.id
-                )));
+            if surface.terminal_host_identity().is_some() {
+                if let Err(error) =
+                    self.mark_hosted_surface_exited(surface, "host-exited-before-attach")
+                {
+                    self.emit(MuxEvent::Status(format!(
+                        "could not persist terminal {} exit: {error}",
+                        surface.id
+                    )));
+                    return;
+                }
+                // Hosted exits remain addressable/renderable placeholders
+                // until an explicit close mutation tombstones the terminal.
+                self.emit(MuxEvent::TreeChanged);
                 return;
             }
             self.remove_surface_after_registry(surface.id);
@@ -4013,18 +4415,25 @@ impl Mux {
         }
     }
 
-    /// Called by a surface's reader thread when its child exits. The mux
-    /// reaps the surface out of the tree itself, so frontends only need to
-    /// drop their render state.
+    /// Called by a surface's reader thread when its child exits. Hosted
+    /// terminals remain stable, renderable Exited tabs until an explicit
+    /// close; local surfaces are removed immediately.
     pub fn surface_exited(&self, id: SurfaceId) {
         if self.sidebar_surface_exited(id) {
             self.emit(MuxEvent::SurfaceExited(id));
             return;
         }
         if let Some(surface) = self.surface(id)
-            && let Err(error) = self.mark_hosted_surface_exited(&surface, "host-exited")
+            && surface.terminal_host_identity().is_some()
         {
-            self.emit(MuxEvent::Status(format!("could not persist terminal {id} exit: {error}")));
+            if let Err(error) = self.mark_hosted_surface_exited(&surface, "host-exited") {
+                self.emit(MuxEvent::Status(format!(
+                    "could not persist terminal {id} exit: {error}"
+                )));
+                return;
+            }
+            self.emit(MuxEvent::TreeChanged);
+            self.emit(MuxEvent::SurfaceExited(id));
             return;
         }
         self.remove_surface_after_registry(id);
@@ -4330,15 +4739,68 @@ impl Mux {
         if spawned.is_empty() {
             return;
         }
-        for surface in &spawned {
-            if let Err(error) = self.tombstone_hosted_surface(surface) {
+        let hosted = spawned
+            .iter()
+            .filter_map(|surface| surface.terminal_host_identity())
+            .map(|identity| (identity.terminal_id, Some(identity.incarnation)))
+            .collect::<Vec<_>>();
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let batch = match registry.close_terminals_atomically(
+            &WorkspaceMutation::local("cmux-tui-layout-discard"),
+            &hosted,
+        ) {
+            Ok(batch) => batch,
+            Err(error) => {
+                // The transaction rolled back, so killing or dropping these
+                // surfaces would leave durable Running rows unreachable. Put
+                // every still-canonical terminal into its registry workspace
+                // while the same registry -> state writer fence is held.
+                let mut topology_changed = false;
+                let mut projection_errors = Vec::new();
+                {
+                    let mut state = self.state.lock().unwrap();
+                    for (terminal_id, _) in &hosted {
+                        let terminal = match registry.terminal_record(terminal_id) {
+                            Ok(Some(terminal))
+                                if terminal.lifecycle != TerminalLifecycle::Tombstoned =>
+                            {
+                                terminal
+                            }
+                            Ok(_) => continue,
+                            Err(projection_error) => {
+                                projection_errors.push(format!(
+                                    "{terminal_id}: could not read canonical placement: {projection_error}"
+                                ));
+                                continue;
+                            }
+                        };
+                        match self.project_terminal_to_workspace_in_state(
+                            &mut state,
+                            terminal_id,
+                            &terminal.workspace_key,
+                        ) {
+                            Ok((_, changed)) => topology_changed |= changed,
+                            Err(projection_error) => projection_errors.push(format!(
+                                "{terminal_id}: could not restore topology: {projection_error}"
+                            )),
+                        }
+                    }
+                }
+                drop(registry);
+                let projection_errors = if projection_errors.is_empty() {
+                    String::new()
+                } else {
+                    format!("; {}", projection_errors.join("; "))
+                };
                 self.emit(MuxEvent::Status(format!(
-                    "could not close discarded terminal {}: {error}",
-                    surface.id
+                    "could not atomically close discarded terminals: {error}{projection_errors}"
                 )));
+                if topology_changed {
+                    self.emit(MuxEvent::TreeChanged);
+                }
                 return;
             }
-        }
+        };
         let ids = spawned.iter().map(|surface| surface.id).collect::<Vec<_>>();
         {
             let mut state = self.state.lock().unwrap();
@@ -4346,6 +4808,10 @@ impl Mux {
                 state.surfaces.remove(id);
             }
         }
+        if batch.closed != 0 {
+            self.emit_terminal_registry_changed(&registry, batch.revision);
+        }
+        drop(registry);
         for surface in spawned {
             surface.kill();
         }
@@ -4382,7 +4848,12 @@ impl Mux {
                 let terminal = registry
                     .terminal_record(terminal_id)?
                     .ok_or_else(|| anyhow::anyhow!("unknown terminal {terminal_id}"))?;
+                let current_revision = registry.terminal_snapshot()?.revision;
                 let changed = replay.result["changed"].as_bool().unwrap_or(true);
+                #[cfg(test)]
+                if let Some(hook) = self.terminal_move_before_projection.lock().unwrap().clone() {
+                    hook();
+                }
                 let (placement, topology_changed) =
                     if terminal.lifecycle == TerminalLifecycle::Tombstoned {
                         (None, false)
@@ -4393,7 +4864,7 @@ impl Mux {
                             &terminal.workspace_key,
                         )?
                     };
-                (terminal, replay.revision, true, changed, placement, topology_changed)
+                (terminal, current_revision, true, changed, placement, topology_changed)
             } else {
                 let snapshot = registry.terminal_snapshot()?;
                 let mut terminal = registry
@@ -4425,6 +4896,10 @@ impl Mux {
                     }),
                 )?;
                 self.emit_terminal_registry_changed(&registry, commit.revision);
+                #[cfg(test)]
+                if let Some(hook) = self.terminal_move_before_projection.lock().unwrap().clone() {
+                    hook();
+                }
                 let (placement, topology_changed) = self.project_terminal_to_workspace_in_state(
                     &mut state,
                     terminal_id,
@@ -5000,6 +5475,44 @@ fn terminate_host_record(
     }
 }
 
+#[cfg(unix)]
+fn terminal_host_record_liveness(
+    record_path: &Path,
+    record: &crate::terminal_host_runtime::TerminalHostRecord,
+) -> TerminalHostLiveness {
+    crate::terminal_host_runtime::terminal_host_record_liveness(record_path, record)
+        .unwrap_or(TerminalHostLiveness::Indeterminate)
+}
+
+/// Ask a host to terminate first; if its admin socket is unavailable, remove
+/// discovery artifacts only when the process-start nonce positively proves
+/// this exact incarnation is dead. `false` means the live/ambiguous record is
+/// deliberately retained for a later retry.
+#[cfg(unix)]
+fn cleanup_terminal_host_record(
+    record: &crate::terminal_host_runtime::TerminalHostRecord,
+    record_path: &Path,
+) -> bool {
+    match terminal_host_record_liveness(record_path, record) {
+        TerminalHostLiveness::Dead => {
+            match crate::terminal_host_runtime::remove_stale_terminal_host_record(
+                record_path,
+                record,
+            ) {
+                Ok(removed) => removed,
+                // Positive nonce/PID death proof remains authoritative when
+                // the host already removed its own record between probe and
+                // compare-delete.
+                Err(_) if !record_path.exists() => true,
+                Err(_) => false,
+            }
+        }
+        TerminalHostLiveness::Live | TerminalHostLiveness::Indeterminate => {
+            terminate_host_record(record.clone(), record_path.to_path_buf())
+        }
+    }
+}
+
 fn insert_surface_checked(state: &mut State, surface: Arc<Surface>) -> anyhow::Result<()> {
     if state.surfaces.contains_key(&surface.id) {
         anyhow::bail!("duplicate_surface_id");
@@ -5448,16 +5961,46 @@ mod tests {
         Mux::new_for_test("test", SurfaceOptions::default())
     }
 
+    #[cfg(unix)]
+    fn insert_terminal_identity_surface(
+        mux: &Arc<Mux>,
+        terminal_id: &str,
+        incarnation: &str,
+        workspace_key: &str,
+    ) -> Arc<Surface> {
+        let surface = Surface::exited_terminal_placeholder(
+            mux.next_id(),
+            mux.surface_options.lock().unwrap().clone(),
+            Arc::downgrade(mux),
+            TerminalHostIdentity {
+                terminal_id: terminal_id.to_string(),
+                incarnation: incarnation.to_string(),
+            },
+        )
+        .unwrap();
+        let _registry = mux.workspace_registry.lock().unwrap();
+        let mut state = mux.state.lock().unwrap();
+        insert_surface_checked(&mut state, surface.clone()).unwrap();
+        let (placement, changed) = mux
+            .project_terminal_to_workspace_in_state(&mut state, terminal_id, workspace_key)
+            .unwrap();
+        assert!(changed);
+        assert_eq!(placement.unwrap().surface, surface.id);
+        surface
+    }
+
     #[test]
     fn terminal_registry_launch_spec_never_persists_environment_secrets() {
         let sentinel = "cmux-secret-sentinel-do-not-persist";
-        let mut options = SurfaceOptions::default();
-        options.command = Some(vec!["/bin/sh".into(), "-c".into(), sentinel.into()]);
-        options.cwd = Some(format!("/tmp/{sentinel}"));
-        options.extra_env = vec![
-            ("API_BEARER_TOKEN".into(), sentinel.into()),
-            ("CMUX_TUI_SOCKET".into(), "/tmp/cmux.sock".into()),
-        ];
+        let options = SurfaceOptions {
+            command: Some(vec!["/bin/sh".into(), "-c".into(), sentinel.into()]),
+            cwd: Some(format!("/tmp/{sentinel}")),
+            extra_env: vec![
+                ("API_BEARER_TOKEN".into(), sentinel.into()),
+                ("CMUX_TUI_SOCKET".into(), "/tmp/cmux.sock".into()),
+            ],
+            ..SurfaceOptions::default()
+        };
         let encoded = serde_json::to_string(&terminal_launch_spec(&options)).unwrap();
         assert!(!encoded.contains(sentinel));
         assert!(!encoded.contains("API_BEARER_TOKEN"));
@@ -6799,9 +7342,13 @@ mod tests {
                 )
                 .unwrap();
         }
-        let mut options = SurfaceOptions::default();
-        options.terminal_host_root =
-            Some(crate::terminal_host_runtime::terminal_host_root(&root, "recover-terminal"));
+        let options = SurfaceOptions {
+            terminal_host_root: Some(crate::terminal_host_runtime::terminal_host_root(
+                &root,
+                "recover-terminal",
+            )),
+            ..SurfaceOptions::default()
+        };
         let mux = Mux::open_persistent("recover-terminal", options, &root).unwrap();
         let resolved = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
         assert_eq!(resolved.surface, None);
@@ -6811,6 +7358,175 @@ mod tests {
         mux.shutdown();
         drop(mux);
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restart_materializes_exited_terminal_until_explicit_close() {
+        const TERMINAL: &str = "0000000000004000800000000000000c";
+        const INCARNATION: &str = "1000000000004000800000000000000c";
+        let root = std::env::temp_dir().join(format!(
+            "cmux-mux-exited-placeholder-{}",
+            crate::workspace_registry::new_uuid_v4()
+        ));
+        {
+            let mut registry = WorkspaceRegistry::open(&root, "recover-exited").unwrap();
+            registry
+                .commit(
+                    &WorkspaceMutation::new("workspace", "test").unwrap(),
+                    &serde_json::json!({"op":"create-workspace"}),
+                    None,
+                    Some(0),
+                    "workspace-added",
+                    "workspace-one",
+                    &[RegistryWorkspace {
+                        id: 1,
+                        key: "workspace-one".into(),
+                        name: "One".into(),
+                        group_key: "recover-exited".into(),
+                    }],
+                    &serde_json::json!({"workspace":1,"key":"workspace-one"}),
+                )
+                .unwrap();
+            let reserved = RegistryTerminal {
+                terminal_id: TERMINAL.into(),
+                workspace_key: "workspace-one".into(),
+                incarnation: None,
+                lifecycle: TerminalLifecycle::Launching,
+                launch_spec: serde_json::json!({}),
+                exit: None,
+            };
+            commit_terminal_transition(
+                &mut registry,
+                "terminal-reserved",
+                "reserve-terminal",
+                &reserved,
+            )
+            .unwrap();
+            commit_terminal_lifecycle(
+                &mut registry,
+                "terminal-exited",
+                "host-exited",
+                TERMINAL,
+                TerminalLifecycle::Exited,
+                Some(INCARNATION),
+                Some(serde_json::json!({"reason":"persisted-exit"})),
+            )
+            .unwrap();
+        }
+        let options = SurfaceOptions {
+            terminal_host_root: Some(crate::terminal_host_runtime::terminal_host_root(
+                &root,
+                "recover-exited",
+            )),
+            ..SurfaceOptions::default()
+        };
+        let mux = Mux::open_persistent("recover-exited", options.clone(), &root).unwrap();
+        let resolved = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(resolved.terminal.lifecycle, TerminalLifecycle::Exited);
+        assert_eq!(resolved.terminal.exit.as_ref().unwrap()["reason"], "persisted-exit");
+        let surface = resolved.surface.expect("Exited terminal remains addressable");
+        let placement = mux
+            .with_state(|state| run_placement_for_surface(state, surface))
+            .expect("Exited terminal remains in topology");
+        assert_eq!(placement.workspace, 1);
+
+        // Duplicate exit observations preserve both the tab and first exit
+        // metadata. Only an explicit close removes it and burns the UUID.
+        mux.surface_exited(surface);
+        let after_exit = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(after_exit.surface, Some(surface));
+        assert_eq!(after_exit.terminal.exit.unwrap()["reason"], "persisted-exit");
+        let closed = mux.close_terminal(TERMINAL, INCARNATION).unwrap();
+        assert_eq!(closed.surface, Some(surface));
+        let closed = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(closed.surface, None);
+        assert_eq!(closed.terminal.lifecycle, TerminalLifecycle::Tombstoned);
+        mux.shutdown();
+        drop(mux);
+
+        let reopened = Mux::open_persistent("recover-exited", options, &root).unwrap();
+        let closed = reopened.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(closed.surface, None);
+        assert_eq!(closed.terminal.lifecycle, TerminalLifecycle::Tombstoned);
+        reopened.shutdown();
+        drop(reopened);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_move_during_launch_binds_only_latest_canonical_workspace() {
+        const TERMINAL: &str = "0000000000004000800000000000000d";
+        const INCARNATION: &str = "1000000000004000800000000000000d";
+        let mux = test_mux();
+        let first = mux.create_empty_workspace(None, Some("launch-a".into()), None).unwrap();
+        let second = mux.create_empty_workspace(None, Some("launch-b".into()), None).unwrap();
+        commit_terminal_transition(
+            &mut mux.workspace_registry.lock().unwrap(),
+            "terminal-reserved",
+            "reserve-terminal",
+            &RegistryTerminal {
+                terminal_id: TERMINAL.into(),
+                workspace_key: first.key,
+                incarnation: None,
+                lifecycle: TerminalLifecycle::Launching,
+                launch_spec: serde_json::json!({}),
+                exit: None,
+            },
+        )
+        .unwrap();
+
+        // The GUI move commits while process launch has released the writer
+        // lock and before the daemon-local surface exists.
+        let moved = mux
+            .move_terminal_with_mutation(
+                TERMINAL,
+                &second.key,
+                None,
+                None,
+                Some(1),
+                &WorkspaceMutation::new("move-during-launch", "browser").unwrap(),
+            )
+            .unwrap();
+        assert_eq!(moved.placement, None);
+        let (_, ready_revision) = commit_terminal_lifecycle(
+            &mut mux.workspace_registry.lock().unwrap(),
+            "terminal-ready",
+            "terminal-ready",
+            TERMINAL,
+            TerminalLifecycle::Running,
+            Some(INCARNATION),
+            None,
+        )
+        .unwrap();
+        assert_eq!(ready_revision, 3);
+
+        let surface = Surface::exited_terminal_placeholder(
+            mux.next_id(),
+            mux.surface_options.lock().unwrap().clone(),
+            Arc::downgrade(&mux),
+            TerminalHostIdentity { terminal_id: TERMINAL.into(), incarnation: INCARNATION.into() },
+        )
+        .unwrap();
+        insert_surface_checked(&mut mux.state.lock().unwrap(), surface.clone()).unwrap();
+        let (placement, canonical_workspace, changed) =
+            mux.bind_running_terminal_to_canonical_workspace(&surface).unwrap();
+        assert!(changed);
+        assert_eq!(canonical_workspace, second.key);
+        assert_eq!(placement.workspace, second.workspace);
+        mux.with_state(|state| {
+            assert_eq!(state.pane_of(surface.id), Some(placement.pane));
+            assert_eq!(
+                state
+                    .surfaces
+                    .values()
+                    .filter_map(|surface| surface.terminal_host_identity())
+                    .filter(|identity| identity.terminal_id == TERMINAL)
+                    .count(),
+                1
+            );
+        });
     }
 
     #[test]
@@ -6917,6 +7633,171 @@ mod tests {
             mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal.workspace_key,
             third.key
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn concurrent_terminal_moves_cannot_project_out_of_commit_order() {
+        const TERMINAL: &str = "0000000000004000800000000000000a";
+        const INCARNATION: &str = "1000000000004000800000000000000a";
+        let mux = test_mux();
+        let first = mux.create_empty_workspace(None, Some("race-a".into()), None).unwrap();
+        let second = mux.create_empty_workspace(None, Some("race-b".into()), None).unwrap();
+        let third = mux.create_empty_workspace(None, Some("race-c".into()), None).unwrap();
+        commit_terminal_transition(
+            &mut mux.workspace_registry.lock().unwrap(),
+            "terminal-reserved",
+            "reserve-terminal",
+            &RegistryTerminal {
+                terminal_id: TERMINAL.into(),
+                workspace_key: first.key.clone(),
+                incarnation: None,
+                lifecycle: TerminalLifecycle::Launching,
+                launch_spec: serde_json::json!({}),
+                exit: None,
+            },
+        )
+        .unwrap();
+        let surface = insert_terminal_identity_surface(&mux, TERMINAL, INCARNATION, &first.key);
+
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        mux.set_terminal_move_before_projection(Some(Arc::new(move || {
+            if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                entered_tx.send(()).unwrap();
+                release_rx.lock().unwrap().recv().unwrap();
+            }
+        })));
+
+        let moving_to_second = {
+            let mux = mux.clone();
+            let key = second.key.clone();
+            std::thread::spawn(move || {
+                mux.move_terminal_with_mutation(
+                    TERMINAL,
+                    &key,
+                    None,
+                    None,
+                    Some(1),
+                    &WorkspaceMutation::new("move-race-one", "browser").unwrap(),
+                )
+            })
+        };
+        entered_rx.recv().unwrap();
+        let (second_attempted_tx, second_attempted_rx) = std::sync::mpsc::channel();
+        let (second_done_tx, second_done_rx) = std::sync::mpsc::channel();
+        let moving_to_third = {
+            let mux = mux.clone();
+            let key = third.key.clone();
+            std::thread::spawn(move || {
+                second_attempted_tx.send(()).unwrap();
+                let result = mux.move_terminal_with_mutation(
+                    TERMINAL,
+                    &key,
+                    None,
+                    None,
+                    None,
+                    &WorkspaceMutation::new("move-race-two", "browser").unwrap(),
+                );
+                second_done_tx.send(result).unwrap();
+            })
+        };
+        second_attempted_rx.recv().unwrap();
+        assert!(second_done_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        release_tx.send(()).unwrap();
+        assert_eq!(moving_to_second.join().unwrap().unwrap().terminal.workspace_key, second.key);
+        assert_eq!(second_done_rx.recv().unwrap().unwrap().terminal.workspace_key, third.key);
+        moving_to_third.join().unwrap();
+        mux.set_terminal_move_before_projection(None);
+        assert_eq!(
+            mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal.workspace_key,
+            third.key
+        );
+        let placement = mux
+            .with_state(|state| run_placement_for_surface(state, surface.id))
+            .expect("terminal has one final topology binding");
+        assert_eq!(placement.workspace, third.workspace);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminal_move_and_destination_close_have_one_registry_topology_order() {
+        const TERMINAL: &str = "0000000000004000800000000000000b";
+        const INCARNATION: &str = "1000000000004000800000000000000b";
+        let mux = test_mux();
+        let first = mux.create_empty_workspace(None, Some("close-race-a".into()), None).unwrap();
+        let second = mux.create_empty_workspace(None, Some("close-race-b".into()), None).unwrap();
+        commit_terminal_transition(
+            &mut mux.workspace_registry.lock().unwrap(),
+            "terminal-reserved",
+            "reserve-terminal",
+            &RegistryTerminal {
+                terminal_id: TERMINAL.into(),
+                workspace_key: first.key.clone(),
+                incarnation: None,
+                lifecycle: TerminalLifecycle::Launching,
+                launch_spec: serde_json::json!({}),
+                exit: None,
+            },
+        )
+        .unwrap();
+        let surface = insert_terminal_identity_surface(&mux, TERMINAL, INCARNATION, &first.key);
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        mux.set_terminal_move_before_projection(Some(Arc::new(move || {
+            entered_tx.send(()).unwrap();
+            release_rx.lock().unwrap().recv().unwrap();
+        })));
+        let move_thread = {
+            let mux = mux.clone();
+            let key = second.key.clone();
+            std::thread::spawn(move || {
+                mux.move_terminal_with_mutation(
+                    TERMINAL,
+                    &key,
+                    None,
+                    None,
+                    Some(1),
+                    &WorkspaceMutation::new("move-before-close", "browser").unwrap(),
+                )
+            })
+        };
+        entered_rx.recv().unwrap();
+        let (close_attempted_tx, close_attempted_rx) = std::sync::mpsc::channel();
+        let (close_done_tx, close_done_rx) = std::sync::mpsc::channel();
+        let close_thread = {
+            let mux = mux.clone();
+            std::thread::spawn(move || {
+                close_attempted_tx.send(()).unwrap();
+                close_done_tx
+                    .send(mux.close_workspace_at_revision(second.workspace, Some(2)))
+                    .unwrap();
+            })
+        };
+        close_attempted_rx.recv().unwrap();
+        assert!(close_done_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        release_tx.send(()).unwrap();
+        assert_eq!(move_thread.join().unwrap().unwrap().terminal.workspace_key, second.key);
+        assert_eq!(close_done_rx.recv().unwrap().unwrap(), Some(3));
+        close_thread.join().unwrap();
+        mux.set_terminal_move_before_projection(None);
+        assert_eq!(
+            mux.workspace_registry
+                .lock()
+                .unwrap()
+                .terminal_record(TERMINAL)
+                .unwrap()
+                .unwrap()
+                .lifecycle,
+            TerminalLifecycle::Tombstoned
+        );
+        assert!(mux.with_state(|state| state.workspace_by_key(&second.key).is_none()));
+        assert_eq!(mux.resolve_terminal(TERMINAL).unwrap().unwrap().surface, None);
+        assert!(mux.surface(surface.id).is_none());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2,6 +2,7 @@
 //! and broadcasts [`MuxEvent`]s to subscribed frontends.
 
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 #[cfg(test)]
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -9,6 +10,7 @@ use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use anyhow::Context;
 use serde_json::Value;
 
 use crate::browser::{self, BrowserBootstrap, BrowserRuntime};
@@ -17,6 +19,10 @@ use crate::layout::{Rect, layout_screen};
 use crate::model::{Node, Pane, Screen, State, Workspace};
 use crate::pairing::PairingBroker;
 use crate::surface::{DefaultColors, Surface, SurfaceOptions};
+use crate::workspace_registry::{
+    FrontendProjection, ProjectionCommit, RegistryCommit, RegistryWorkspace, WorkspaceMutation,
+    WorkspaceRegistry,
+};
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SurfaceId,
     WorkspaceId,
@@ -89,6 +95,14 @@ pub enum MuxEvent {
     /// One protocol-v7 lifecycle mutation. Coarse subscribers project this
     /// back to the legacy `tree-changed` event.
     TreeDelta(TreeDelta),
+    FrontendProjectionChanged {
+        frontend: String,
+        scope: String,
+        subject_key: String,
+        projection_revision: u64,
+        origin: String,
+        mutation_id: String,
+    },
     /// A screen's pane geometry changed. Clients should re-fetch layout.
     LayoutChanged(ScreenId),
     /// A control connection attached its first surface.
@@ -300,6 +314,17 @@ pub struct WorkspacePlacement {
     pub key: String,
     pub index: usize,
     pub revision: u64,
+    pub replayed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceMutationResult {
+    pub workspace: Option<WorkspaceId>,
+    pub key: String,
+    pub index: Option<usize>,
+    pub revision: u64,
+    pub replayed: bool,
+    pub changed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -426,6 +451,9 @@ impl ClientSizingState {
 
 /// The multiplexer. Shared by frontends and the control socket server.
 pub struct Mux {
+    /// Serializes durable workspace commits and their in-memory/event
+    /// projection. Lock order is always registry, then state.
+    workspace_registry: Mutex<WorkspaceRegistry>,
     state: Mutex<State>,
     subscribers: MuxEventBroadcaster,
     next_id: AtomicU64,
@@ -461,20 +489,71 @@ impl Mux {
         #[cfg_attr(not(test), allow(unused_variables))] test_surface_runtime: bool,
     ) -> Arc<Self> {
         let session = session.into();
-        let mut surface_options = surface_options;
+        let registry = WorkspaceRegistry::in_memory(&session)
+            .expect("in-memory workspace registry must initialize");
+        Self::from_workspace_registry(session, surface_options, registry, test_surface_runtime)
+            .expect("in-memory workspace registry must load")
+    }
+
+    pub fn open_persistent(
+        session: impl Into<String>,
+        surface_options: SurfaceOptions,
+        state_root: &Path,
+    ) -> anyhow::Result<Arc<Self>> {
+        let session = session.into();
+        let registry = WorkspaceRegistry::open(state_root, &session)?;
+        Self::from_workspace_registry(session, surface_options, registry, false)
+    }
+
+    fn from_workspace_registry(
+        session: String,
+        mut surface_options: SurfaceOptions,
+        registry: WorkspaceRegistry,
+        #[cfg_attr(not(test), allow(unused_variables))] test_surface_runtime: bool,
+    ) -> anyhow::Result<Arc<Self>> {
+        let snapshot = registry.snapshot()?;
+        let next_id = snapshot
+            .workspaces
+            .iter()
+            .map(|workspace| workspace.id)
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("workspace id space exhausted"))?;
+        let workspaces = snapshot
+            .workspaces
+            .into_iter()
+            .map(|workspace| Workspace {
+                id: workspace.id,
+                key: workspace.key,
+                name: workspace.name,
+                screens: Vec::new(),
+                active_screen: 0,
+            })
+            .collect::<Vec<_>>();
+        let workspace_index_by_id = workspaces
+            .iter()
+            .enumerate()
+            .map(|(index, workspace)| (workspace.id, index))
+            .collect();
+        let workspace_id_by_key = workspaces
+            .iter()
+            .map(|workspace| (workspace.key.clone(), workspace.id))
+            .collect();
         surface_options.browser_session_name = session.clone();
-        Arc::new(Mux {
+        Ok(Arc::new(Mux {
+            workspace_registry: Mutex::new(registry),
             state: Mutex::new(State {
-                workspaces: Vec::new(),
-                workspace_index_by_id: HashMap::new(),
-                workspace_id_by_key: HashMap::new(),
-                workspace_revision: 0,
+                workspaces,
+                workspace_index_by_id,
+                workspace_id_by_key,
+                workspace_revision: snapshot.revision,
                 active_workspace: 0,
                 panes: HashMap::new(),
                 surfaces: HashMap::new(),
             }),
             subscribers: MuxEventBroadcaster::default(),
-            next_id: AtomicU64::new(1),
+            next_id: AtomicU64::new(next_id),
             next_notification_id: AtomicU64::new(1),
             next_active_at: AtomicU64::new(1),
             surface_options: Mutex::new(surface_options),
@@ -494,7 +573,7 @@ impl Mux {
             #[cfg(test)]
             test_surface_runtime,
             session,
-        })
+        }))
     }
 
     #[cfg(test)]
@@ -550,16 +629,85 @@ impl Mux {
         ))
     }
 
-    fn require_workspace_revision(state: &State, expected: Option<u64>) -> anyhow::Result<()> {
-        if let Some(expected) = expected
-            && expected != state.workspace_revision
-        {
-            anyhow::bail!(
-                "workspace revision conflict: expected {expected}, current {}",
-                state.workspace_revision
-            );
+    fn registry_projection(&self, state: &State) -> Vec<RegistryWorkspace> {
+        state
+            .workspaces
+            .iter()
+            .map(|workspace| RegistryWorkspace {
+                id: workspace.id,
+                key: workspace.key.clone(),
+                name: workspace.name.clone(),
+                group_key: self.session.clone(),
+            })
+            .collect()
+    }
+
+    pub fn registry_identity(&self) -> (String, String) {
+        let registry = self.workspace_registry.lock().unwrap();
+        (registry.registry_id().to_string(), registry.generation().to_string())
+    }
+
+    pub fn workspace_registry_event(
+        &self,
+        revision: u64,
+    ) -> anyhow::Result<Option<crate::workspace_registry::RegistryEvent>> {
+        if revision == 0 {
+            return Ok(None);
         }
-        Ok(())
+        Ok(self
+            .workspace_registry
+            .lock()
+            .unwrap()
+            .events_after(revision - 1)?
+            .into_iter()
+            .find(|event| event.revision == revision))
+    }
+
+    pub fn get_frontend_projection(
+        &self,
+        frontend: &str,
+        scope: &str,
+        subject_key: &str,
+    ) -> anyhow::Result<Option<FrontendProjection>> {
+        self.workspace_registry.lock().unwrap().get_frontend_projection(
+            frontend,
+            scope,
+            subject_key,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn put_frontend_projection(
+        &self,
+        mutation: &WorkspaceMutation,
+        frontend: &str,
+        scope: &str,
+        subject_key: &str,
+        schema_version: u32,
+        expected_projection_revision: Option<u64>,
+        projection: &Value,
+    ) -> anyhow::Result<ProjectionCommit> {
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let commit = registry.put_frontend_projection(
+            mutation,
+            frontend,
+            scope,
+            subject_key,
+            schema_version,
+            expected_projection_revision,
+            projection,
+        )?;
+        if !commit.replayed {
+            self.emit(MuxEvent::FrontendProjectionChanged {
+                frontend: frontend.to_string(),
+                scope: scope.to_string(),
+                subject_key: subject_key.to_string(),
+                projection_revision: commit.projection.projection_revision,
+                origin: mutation.origin.clone(),
+                mutation_id: mutation.id.clone(),
+            });
+        }
+        Ok(commit)
     }
 
     pub fn subscribe(&self) -> MuxEventReceiver {
@@ -1491,9 +1639,46 @@ impl Mux {
         let screen_id = self.next_id();
         let ws_id = self.next_id();
         let notifications = self.surface_notifications();
+        let mutation = WorkspaceMutation::local("cmux-tui");
+        let mut registry = self.workspace_registry.lock().unwrap();
         let delta = {
             let mut state = self.state.lock().unwrap();
             let name = name.unwrap_or_else(|| format!("{}", state.workspaces.len() + 1));
+            let index = state.workspaces.len();
+            let mut desired = self.registry_projection(&state);
+            desired.push(RegistryWorkspace {
+                id: ws_id,
+                key: workspace_key.clone(),
+                name: name.clone(),
+                group_key: self.session.clone(),
+            });
+            let commit = match registry.commit(
+                &mutation,
+                &serde_json::json!({
+                    "op": "new-workspace",
+                    "workspace": ws_id,
+                    "key": workspace_key.clone(),
+                    "name": name.clone(),
+                }),
+                None,
+                None,
+                "workspace-added",
+                &workspace_key,
+                &desired,
+                &serde_json::json!({
+                    "workspace": ws_id,
+                    "key": workspace_key.clone(),
+                    "index": index
+                }),
+            ) {
+                Ok(commit) => commit,
+                Err(error) => {
+                    drop(state);
+                    drop(registry);
+                    self.discard_spawned(vec![surface.clone()]);
+                    return Err(error);
+                }
+            };
             state.panes.insert(pane_id, pane);
             state.push_workspace(Workspace {
                 id: ws_id,
@@ -1509,9 +1694,8 @@ impl Mux {
                 active_screen: 0,
             });
             state.active_workspace = state.workspaces.len() - 1;
-            state.workspace_revision = state.workspace_revision.saturating_add(1);
-            let workspace_revision = state.workspace_revision;
-            let index = state.workspaces.len() - 1;
+            state.workspace_revision = commit.revision;
+            let workspace_revision = commit.revision;
             let entity = crate::server::tree_entity_json(
                 &state,
                 &notifications,
@@ -1544,20 +1728,77 @@ impl Mux {
         key: Option<String>,
         expected_revision: Option<u64>,
     ) -> anyhow::Result<WorkspacePlacement> {
-        let key = match key {
+        let mutation = WorkspaceMutation::local("cmux-tui");
+        self.create_empty_workspace_with_mutation(name, key, None, expected_revision, &mutation)
+    }
+
+    pub fn create_empty_workspace_with_mutation(
+        &self,
+        name: Option<String>,
+        requested_key: Option<String>,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<WorkspacePlacement> {
+        let key = match requested_key.as_ref() {
             Some(key) if key.trim().is_empty() => anyhow::bail!("workspace key cannot be empty"),
-            Some(key) => key,
+            Some(key) => key.clone(),
             None => Self::new_workspace_key()?,
         };
+        let requested_name = name.clone();
         let ws_id = self.next_id();
         let notifications = self.surface_notifications();
+        let mut registry = self.workspace_registry.lock().unwrap();
         let (placement, delta) = {
             let mut state = self.state.lock().unwrap();
-            Self::require_workspace_revision(&state, expected_revision)?;
-            if state.workspace_by_key(&key).is_some() {
-                anyhow::bail!("workspace key already exists: {key}");
-            }
             let name = name.unwrap_or_else(|| format!("{}", state.workspaces.len() + 1));
+            let index = state.workspaces.len();
+            let mut desired = self.registry_projection(&state);
+            desired.push(RegistryWorkspace {
+                id: ws_id,
+                key: key.clone(),
+                name: name.clone(),
+                group_key: self.session.clone(),
+            });
+            let result = serde_json::json!({
+                "workspace": ws_id,
+                "key": key.clone(),
+                "index": index,
+            });
+            let commit = registry.commit(
+                mutation,
+                &serde_json::json!({
+                    "op": "create-workspace",
+                    "name": requested_name,
+                    "requested_key": requested_key.clone(),
+                }),
+                expected_generation,
+                expected_revision,
+                "workspace-added",
+                &key,
+                &desired,
+                &result,
+            )?;
+            let committed_workspace = commit.result["workspace"]
+                .as_u64()
+                .ok_or_else(|| anyhow::anyhow!("stored create result is missing workspace"))?;
+            let committed_key = commit.result["key"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("stored create result is missing key"))?
+                .to_string();
+            let committed_index = commit.result["index"]
+                .as_u64()
+                .and_then(|value| usize::try_from(value).ok())
+                .ok_or_else(|| anyhow::anyhow!("stored create result is missing index"))?;
+            if commit.replayed {
+                return Ok(WorkspacePlacement {
+                    workspace: committed_workspace,
+                    key: committed_key,
+                    index: committed_index,
+                    revision: commit.revision,
+                    replayed: true,
+                });
+            }
             state.push_workspace(Workspace {
                 id: ws_id,
                 key: key.clone(),
@@ -1566,9 +1807,8 @@ impl Mux {
                 active_screen: 0,
             });
             state.active_workspace = state.workspaces.len() - 1;
-            state.workspace_revision = state.workspace_revision.saturating_add(1);
-            let index = state.workspaces.len() - 1;
-            let revision = state.workspace_revision;
+            state.workspace_revision = commit.revision;
+            let revision = commit.revision;
             let entity = crate::server::tree_entity_json(
                 &state,
                 &notifications,
@@ -1577,7 +1817,7 @@ impl Mux {
             )
             .expect("new empty workspace is present in tree snapshot");
             (
-                WorkspacePlacement { workspace: ws_id, key, index, revision },
+                WorkspacePlacement { workspace: ws_id, key, index, revision, replayed: false },
                 TreeDelta {
                     kind: TreeDeltaKind::WorkspaceAdded,
                     workspace: ws_id,
@@ -1613,10 +1853,47 @@ impl Mux {
             let screen_id = self.next_id();
             let ws_id = self.next_id();
             let notifications = self.surface_notifications();
+            let mutation = WorkspaceMutation::local("cmux-tui");
+            let mut registry = self.workspace_registry.lock().unwrap();
             let delta = {
                 let mut state = self.state.lock().unwrap();
                 let workspace_name =
                     name.unwrap_or_else(|| format!("{}", state.workspaces.len() + 1));
+                let index = state.workspaces.len();
+                let mut desired = self.registry_projection(&state);
+                desired.push(RegistryWorkspace {
+                    id: ws_id,
+                    key: workspace_key.clone(),
+                    name: workspace_name.clone(),
+                    group_key: self.session.clone(),
+                });
+                let commit = match registry.commit(
+                    &mutation,
+                    &serde_json::json!({
+                        "op": "run-new-workspace",
+                        "workspace": ws_id,
+                        "key": workspace_key.clone(),
+                        "name": workspace_name.clone(),
+                    }),
+                    None,
+                    None,
+                    "workspace-added",
+                    &workspace_key,
+                    &desired,
+                    &serde_json::json!({
+                        "workspace": ws_id,
+                        "key": workspace_key.clone(),
+                        "index": index,
+                    }),
+                ) {
+                    Ok(commit) => commit,
+                    Err(error) => {
+                        drop(state);
+                        drop(registry);
+                        self.discard_spawned(vec![surface.clone()]);
+                        return Err(error);
+                    }
+                };
                 state.panes.insert(pane_id, pane);
                 state.push_workspace(Workspace {
                     id: ws_id,
@@ -1632,9 +1909,8 @@ impl Mux {
                     active_screen: 0,
                 });
                 state.active_workspace = state.workspaces.len() - 1;
-                state.workspace_revision = state.workspace_revision.saturating_add(1);
-                let workspace_revision = state.workspace_revision;
-                let index = state.workspaces.len() - 1;
+                state.workspace_revision = commit.revision;
+                let workspace_revision = commit.revision;
                 let entity = crate::server::tree_entity_json(
                     &state,
                     &notifications,
@@ -2110,9 +2386,87 @@ impl Mux {
             let screen_id = self.next_id();
             let ws_id = self.next_id();
             let notifications = self.surface_notifications();
+            if let Some(workspace_id) = empty_workspace {
+                let delta = {
+                    let mut state = self.state.lock().unwrap();
+                    let Some(workspace_index) =
+                        state.workspaces.iter().position(|workspace| workspace.id == workspace_id)
+                    else {
+                        state.surfaces.remove(&surface.id);
+                        surface.kill();
+                        anyhow::bail!("workspace disappeared while creating browser tab");
+                    };
+                    state.panes.insert(pane_id, pane);
+                    state.workspaces[workspace_index].screens.push(Screen {
+                        id: screen_id,
+                        name: None,
+                        root: Node::Leaf(pane_id),
+                        active_pane: pane_id,
+                        zoomed_pane: None,
+                    });
+                    state.workspaces[workspace_index].active_screen = 0;
+                    let entity = crate::server::tree_entity_json(
+                        &state,
+                        &notifications,
+                        TreeDeltaKind::ScreenAdded,
+                        screen_id,
+                    )
+                    .expect("first workspace screen is present in tree snapshot");
+                    TreeDelta {
+                        kind: TreeDeltaKind::ScreenAdded,
+                        workspace: workspace_id,
+                        screen: Some(screen_id),
+                        pane: None,
+                        surface: None,
+                        index: Some(0),
+                        entity,
+                        workspace_revision: None,
+                    }
+                };
+                self.emit(MuxEvent::TreeDelta(delta));
+                self.reap_if_dead(&surface);
+                return Ok(surface);
+            }
+            let mutation = WorkspaceMutation::local("cmux-tui");
+            let mut registry = self.workspace_registry.lock().unwrap();
             let delta = {
                 let mut state = self.state.lock().unwrap();
                 let name = format!("{}", state.workspaces.len() + 1);
+                let index = state.workspaces.len();
+                let mut desired = self.registry_projection(&state);
+                desired.push(RegistryWorkspace {
+                    id: ws_id,
+                    key: workspace_key.clone(),
+                    name: name.clone(),
+                    group_key: self.session.clone(),
+                });
+                let commit = match registry.commit(
+                    &mutation,
+                    &serde_json::json!({
+                        "op": "new-browser-workspace",
+                        "workspace": ws_id,
+                        "key": workspace_key.clone(),
+                        "name": name.clone(),
+                    }),
+                    None,
+                    None,
+                    "workspace-added",
+                    &workspace_key,
+                    &desired,
+                    &serde_json::json!({
+                        "workspace": ws_id,
+                        "key": workspace_key.clone(),
+                        "index": index,
+                    }),
+                ) {
+                    Ok(commit) => commit,
+                    Err(error) => {
+                        drop(state);
+                        drop(registry);
+                        self.discard_spawned(vec![surface.clone()]);
+                        return Err(error);
+                    }
+                };
                 state.panes.insert(pane_id, pane);
                 state.push_workspace(Workspace {
                     id: ws_id,
@@ -2128,9 +2482,8 @@ impl Mux {
                     active_screen: 0,
                 });
                 state.active_workspace = state.workspaces.len() - 1;
-                state.workspace_revision = state.workspace_revision.saturating_add(1);
-                let workspace_revision = state.workspace_revision;
-                let index = state.workspaces.len() - 1;
+                state.workspace_revision = commit.revision;
+                let workspace_revision = commit.revision;
                 let entity = crate::server::tree_entity_json(
                     &state,
                     &notifications,
@@ -2369,25 +2722,15 @@ impl Mux {
     }
 
     /// Close one tab. When it was the pane's last tab, the pane collapses
-    /// out of its split tree (and emptied screens/workspaces are removed).
+    /// out of its split tree. Empty workspace containers remain durable;
+    /// only an explicit close-workspace mutation removes a workspace.
     pub fn close_surface(&self, target: SurfaceId) {
         let notifications = self.surface_notifications();
         let (removed, changed_screens, empty, delta) = {
             let mut state = self.state.lock().unwrap();
             let changed_screen = surface_screen_id(&state, target);
-            let mut delta = close_surface_delta(&state, &notifications, target);
+            let delta = close_surface_delta(&state, &notifications, target);
             let removed = remove_surface(&mut state, target);
-            if removed.is_some()
-                && matches!(
-                    delta.as_ref().map(|delta| delta.kind),
-                    Some(TreeDeltaKind::WorkspaceClosed)
-                )
-            {
-                state.workspace_revision = state.workspace_revision.saturating_add(1);
-                if let Some(delta) = delta.as_mut() {
-                    delta.workspace_revision = Some(state.workspace_revision);
-                }
-            }
             (
                 removed,
                 changed_screen.into_iter().collect::<Vec<_>>(),
@@ -2414,7 +2757,7 @@ impl Mux {
 
     /// Close every surface in `tabs` (helper for pane/screen/workspace
     /// close). Emits events outside the lock.
-    fn close_surfaces(&self, tabs: Vec<SurfaceId>, mut delta: TreeDelta) {
+    fn close_surfaces(&self, tabs: Vec<SurfaceId>, delta: TreeDelta) {
         let (removed, changed_screens, empty) = {
             let mut state = self.state.lock().unwrap();
             let changed_screens = unique_screen_ids(
@@ -2425,10 +2768,6 @@ impl Mux {
                 if let Some(surface) = remove_surface(&mut state, surface) {
                     removed.push(surface);
                 }
-            }
-            if !removed.is_empty() && delta.kind == TreeDeltaKind::WorkspaceClosed {
-                state.workspace_revision = state.workspace_revision.saturating_add(1);
-                delta.workspace_revision = Some(state.workspace_revision);
             }
             (removed, changed_screens, state.workspaces.is_empty())
         };
@@ -2499,14 +2838,59 @@ impl Mux {
         target: WorkspaceId,
         expected_revision: Option<u64>,
     ) -> anyhow::Result<Option<u64>> {
+        let mutation = WorkspaceMutation::local("cmux-tui");
+        let result = self.close_workspace_with_mutation(
+            Some(target),
+            None,
+            None,
+            expected_revision,
+            &mutation,
+        )?;
+        Ok(Some(result.revision))
+    }
+
+    pub fn close_workspace_with_mutation(
+        &self,
+        target: Option<WorkspaceId>,
+        requested_key: Option<&str>,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<WorkspaceMutationResult> {
+        let fingerprint = serde_json::json!({
+            "op": "close-workspace",
+            "workspace": target,
+            "key": requested_key,
+        });
         let notifications = self.surface_notifications();
-        let (removed, delta, empty, revision) = {
+        let mut registry = self.workspace_registry.lock().unwrap();
+        if let Some(commit) = registry.replay(mutation, &fingerprint)? {
+            return workspace_mutation_result(&commit);
+        }
+        let (removed, delta, empty, result) = {
             let mut state = self.state.lock().unwrap();
-            Self::require_workspace_revision(&state, expected_revision)?;
-            let Some(index) = state.workspace_index(target) else {
-                return Ok(None);
-            };
-            let mut delta = close_workspace_delta(&state, &notifications, target)
+            let index = resolve_workspace_index(&state, target, requested_key)?;
+            let workspace_id = state.workspaces[index].id;
+            let key = state.workspaces[index].key.clone();
+            let mut desired = self.registry_projection(&state);
+            desired.remove(index);
+            let committed_result = serde_json::json!({
+                "workspace": workspace_id,
+                "key": key,
+                "index": index,
+                "changed": true,
+            });
+            let commit = registry.commit(
+                mutation,
+                &fingerprint,
+                expected_generation,
+                expected_revision,
+                "workspace-closed",
+                &key,
+                &desired,
+                &committed_result,
+            )?;
+            let mut delta = close_workspace_delta(&state, &notifications, workspace_id)
                 .expect("live workspace has a close delta");
             let active_id =
                 state.workspaces.get(state.active_workspace).map(|workspace| workspace.id);
@@ -2528,10 +2912,10 @@ impl Mux {
             state.active_workspace = active_id
                 .and_then(|id| state.workspace_index(id))
                 .unwrap_or_else(|| state.workspaces.len().saturating_sub(1));
-            state.workspace_revision = state.workspace_revision.saturating_add(1);
-            let revision = state.workspace_revision;
-            delta.workspace_revision = Some(revision);
-            (removed, delta, state.workspaces.is_empty(), revision)
+            state.workspace_revision = commit.revision;
+            delta.workspace_revision = Some(commit.revision);
+            let result = workspace_mutation_result(&commit)?;
+            (removed, delta, state.workspaces.is_empty(), result)
         };
         for surface in removed {
             self.purge_surface_side_tables(surface.id);
@@ -2541,7 +2925,7 @@ impl Mux {
         if empty {
             self.emit(MuxEvent::Empty);
         }
-        Ok(Some(revision))
+        Ok(result)
     }
 
     pub fn rename_workspace(&self, target: WorkspaceId, name: String) -> bool {
@@ -2556,27 +2940,76 @@ impl Mux {
         name: String,
         expected_revision: Option<u64>,
     ) -> anyhow::Result<Option<u64>> {
+        let mutation = WorkspaceMutation::local("cmux-tui");
+        let result = self.rename_workspace_with_mutation(
+            Some(target),
+            None,
+            name,
+            None,
+            expected_revision,
+            &mutation,
+        )?;
+        Ok(Some(result.revision))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn rename_workspace_with_mutation(
+        &self,
+        target: Option<WorkspaceId>,
+        requested_key: Option<&str>,
+        name: String,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<WorkspaceMutationResult> {
+        let fingerprint = serde_json::json!({
+            "op": "rename-workspace",
+            "workspace": target,
+            "key": requested_key,
+            "name": name.clone(),
+        });
         let notifications = self.surface_notifications();
-        let renamed = {
+        let mut registry = self.workspace_registry.lock().unwrap();
+        if let Some(commit) = registry.replay(mutation, &fingerprint)? {
+            return workspace_mutation_result(&commit);
+        }
+        let (renamed, result) = {
             let mut state = self.state.lock().unwrap();
-            Self::require_workspace_revision(&state, expected_revision)?;
-            let Some(index) = state.workspace_index(target) else {
-                return Ok(None);
-            };
+            let index = resolve_workspace_index(&state, target, requested_key)?;
+            let workspace_id = state.workspaces[index].id;
+            let key = state.workspaces[index].key.clone();
+            let changed = state.workspaces[index].name != name;
+            let mut desired = self.registry_projection(&state);
+            desired[index].name = name.clone();
+            let commit = registry.commit(
+                mutation,
+                &fingerprint,
+                expected_generation,
+                expected_revision,
+                "workspace-renamed",
+                &key,
+                &desired,
+                &serde_json::json!({
+                    "workspace": workspace_id,
+                    "key": key.clone(),
+                    "index": index,
+                    "changed": changed,
+                }),
+            )?;
             state.workspaces[index].name = name;
-            state.workspace_revision = state.workspace_revision.saturating_add(1);
-            let workspace_revision = state.workspace_revision;
+            state.workspace_revision = commit.revision;
+            let workspace_revision = commit.revision;
             let entity = crate::server::tree_entity_json(
                 &state,
                 &notifications,
                 TreeDeltaKind::WorkspaceRenamed,
-                target,
+                workspace_id,
             )
             .expect("renamed workspace is present in tree snapshot");
             (
                 TreeDelta {
                     kind: TreeDeltaKind::WorkspaceRenamed,
-                    workspace: target,
+                    workspace: workspace_id,
                     screen: None,
                     pane: None,
                     surface: None,
@@ -2584,11 +3017,11 @@ impl Mux {
                     entity,
                     workspace_revision: Some(workspace_revision),
                 },
-                workspace_revision,
+                workspace_mutation_result(&commit)?,
             )
         };
-        self.emit(MuxEvent::TreeDelta(renamed.0));
-        Ok(Some(renamed.1))
+        self.emit(MuxEvent::TreeDelta(renamed));
+        Ok(result)
     }
 
     /// Set a pane's user-visible name. An empty name clears it (the pane
@@ -2844,6 +3277,7 @@ impl Mux {
         layout: &LayoutSpec,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<AppliedLayout> {
+        let new_workspace_key = Self::new_workspace_key()?;
         {
             let state = self.state.lock().unwrap();
             if let Some(id) = workspace
@@ -2869,9 +3303,50 @@ impl Mux {
             anyhow::bail!("layout must contain at least one leaf");
         };
         let screen_id = self.next_id();
+        let new_workspace_id = self.next_id();
         let notifications = self.surface_notifications();
+        let mutation = WorkspaceMutation::local("cmux-tui");
+        let mut registry = self.workspace_registry.lock().unwrap();
         let delta = {
             let mut state = self.state.lock().unwrap();
+            let created_revision = if workspace.is_none() && state.workspaces.is_empty() {
+                let mut desired = self.registry_projection(&state);
+                desired.push(RegistryWorkspace {
+                    id: new_workspace_id,
+                    key: new_workspace_key.clone(),
+                    name: "1".into(),
+                    group_key: self.session.clone(),
+                });
+                let commit = match registry.commit(
+                    &mutation,
+                    &serde_json::json!({
+                        "op": "apply-layout-new-workspace",
+                        "workspace": new_workspace_id,
+                        "key": new_workspace_key.clone(),
+                    }),
+                    None,
+                    None,
+                    "workspace-added",
+                    &new_workspace_key,
+                    &desired,
+                    &serde_json::json!({
+                        "workspace": new_workspace_id,
+                        "key": new_workspace_key.clone(),
+                        "index": 0,
+                    }),
+                ) {
+                    Ok(commit) => commit,
+                    Err(error) => {
+                        drop(state);
+                        drop(registry);
+                        self.discard_spawned(spawned);
+                        return Err(error);
+                    }
+                };
+                Some(commit.revision)
+            } else {
+                None
+            };
             for (pane_id, pane) in panes {
                 state.panes.insert(pane_id, pane);
             }
@@ -2886,19 +3361,18 @@ impl Mux {
                     id
                 }
                 None if state.workspaces.is_empty() => {
-                    let new_workspace_key = Self::new_workspace_key()?;
-                    let ws_id = self.next_id();
                     state.push_workspace(Workspace {
-                        id: ws_id,
+                        id: new_workspace_id,
                         key: new_workspace_key,
                         name: "1".into(),
                         screens: vec![screen],
                         active_screen: 0,
                     });
                     state.active_workspace = 0;
-                    state.workspace_revision = state.workspace_revision.saturating_add(1);
-                    created_workspace = Some(ws_id);
-                    ws_id
+                    state.workspace_revision =
+                        created_revision.expect("empty workspace registry commit exists");
+                    created_workspace = Some(new_workspace_id);
+                    new_workspace_id
                 }
                 None => {
                     let active = state.active_workspace;
@@ -3014,13 +3488,9 @@ impl Mux {
         let active_at = self.next_active_at();
         let moved = {
             let mut state = self.state.lock().unwrap();
-            let workspace_count = state.workspaces.len();
             let moved = move_tab_in_state(&mut state, surface, pane, index);
             if moved {
                 stamp_pane(&mut state, pane, active_at);
-                if state.workspaces.len() != workspace_count {
-                    state.workspace_revision = state.workspace_revision.saturating_add(1);
-                }
             }
             moved
         };
@@ -3043,35 +3513,83 @@ impl Mux {
         index: usize,
         expected_revision: Option<u64>,
     ) -> anyhow::Result<Option<(u64, bool)>> {
+        let mutation = WorkspaceMutation::local("cmux-tui");
+        let result = self.move_workspace_with_mutation(
+            Some(workspace),
+            None,
+            index,
+            None,
+            expected_revision,
+            &mutation,
+        )?;
+        Ok(Some((result.revision, result.changed)))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn move_workspace_with_mutation(
+        &self,
+        workspace: Option<WorkspaceId>,
+        requested_key: Option<&str>,
+        index: usize,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<WorkspaceMutationResult> {
+        let fingerprint = serde_json::json!({
+            "op": "move-workspace",
+            "workspace": workspace,
+            "key": requested_key,
+            "index": index,
+        });
         let notifications = self.surface_notifications();
-        let delta = {
+        let mut registry = self.workspace_registry.lock().unwrap();
+        if let Some(commit) = registry.replay(mutation, &fingerprint)? {
+            return workspace_mutation_result(&commit);
+        }
+        let (delta, result) = {
             let mut state = self.state.lock().unwrap();
-            Self::require_workspace_revision(&state, expected_revision)?;
-            let Some(old_idx) = state.workspace_index(workspace) else {
-                return Ok(None);
-            };
-            let new_idx = index.min(state.workspaces.len().saturating_sub(1));
-            if new_idx == old_idx {
-                return Ok(Some((state.workspace_revision, false)));
-            }
+            let old_idx = resolve_workspace_index(&state, workspace, requested_key)?;
+            let workspace_id = state.workspaces[old_idx].id;
+            let key = state.workspaces[old_idx].key.clone();
+            let new_idx = if index > old_idx { index.saturating_sub(1) } else { index };
+            let new_idx = new_idx.min(state.workspaces.len().saturating_sub(1));
+            let changed = new_idx != old_idx;
+            let mut desired = self.registry_projection(&state);
+            let desired_workspace = desired.remove(old_idx);
+            desired.insert(new_idx, desired_workspace);
+            let commit = registry.commit(
+                mutation,
+                &fingerprint,
+                expected_generation,
+                expected_revision,
+                "workspace-moved",
+                &key,
+                &desired,
+                &serde_json::json!({
+                    "workspace": workspace_id,
+                    "key": key.clone(),
+                    "index": new_idx,
+                    "changed": changed,
+                }),
+            )?;
             let active_id = state.workspaces.get(state.active_workspace).map(|ws| ws.id);
             state.move_workspace(old_idx, new_idx);
             state.active_workspace = active_id
                 .and_then(|id| state.workspace_index(id))
                 .unwrap_or_else(|| state.workspaces.len().saturating_sub(1));
-            state.workspace_revision = state.workspace_revision.saturating_add(1);
-            let workspace_revision = state.workspace_revision;
+            state.workspace_revision = commit.revision;
+            let workspace_revision = commit.revision;
             let entity = crate::server::tree_entity_json(
                 &state,
                 &notifications,
                 TreeDeltaKind::WorkspaceMoved,
-                workspace,
+                workspace_id,
             )
             .expect("moved workspace is present in tree snapshot");
-            Some((
+            (
                 TreeDelta {
                     kind: TreeDeltaKind::WorkspaceMoved,
-                    workspace,
+                    workspace: workspace_id,
                     screen: None,
                     pane: None,
                     surface: None,
@@ -3079,15 +3597,11 @@ impl Mux {
                     entity,
                     workspace_revision: Some(workspace_revision),
                 },
-                workspace_revision,
-            ))
+                workspace_mutation_result(&commit)?,
+            )
         };
-        if let Some((delta, revision)) = delta {
-            self.emit(MuxEvent::TreeDelta(delta));
-            Ok(Some((revision, true)))
-        } else {
-            Ok(None)
-        }
+        self.emit(MuxEvent::TreeDelta(delta));
+        Ok(result)
     }
 
     /// Select a tab within a pane (default: the active pane) by index or
@@ -3248,6 +3762,50 @@ fn surface_screen_id(state: &State, surface: SurfaceId) -> Option<ScreenId> {
     Some(state.workspaces[wi].screens[si].id)
 }
 
+fn resolve_workspace_index(
+    state: &State,
+    id: Option<WorkspaceId>,
+    key: Option<&str>,
+) -> anyhow::Result<usize> {
+    if id.is_none() && key.is_none() {
+        anyhow::bail!("workspace or key is required");
+    }
+    let by_id = id.and_then(|id| state.workspaces.iter().position(|workspace| workspace.id == id));
+    let by_key =
+        key.and_then(|key| state.workspaces.iter().position(|workspace| workspace.key == key));
+    match (id, key, by_id, by_key) {
+        (Some(id), _, None, _) => anyhow::bail!("unknown workspace {id}"),
+        (_, Some(key), _, None) => anyhow::bail!("unknown workspace key {key}"),
+        (Some(_), Some(_), Some(left), Some(right)) if left != right => {
+            anyhow::bail!("workspace and key identify different workspaces")
+        }
+        (_, _, Some(index), _) | (_, _, _, Some(index)) => Ok(index),
+        _ => anyhow::bail!("unknown workspace"),
+    }
+}
+
+fn workspace_mutation_result(commit: &RegistryCommit) -> anyhow::Result<WorkspaceMutationResult> {
+    let workspace = commit.result["workspace"].as_u64();
+    let key = commit.result["key"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("stored workspace mutation result is missing key"))?
+        .to_string();
+    let index = commit.result["index"]
+        .as_u64()
+        .map(usize::try_from)
+        .transpose()
+        .context("stored workspace mutation index is invalid")?;
+    let changed = commit.result["changed"].as_bool().unwrap_or(true);
+    Ok(WorkspaceMutationResult {
+        workspace,
+        key,
+        index,
+        revision: commit.revision,
+        replayed: commit.replayed,
+        changed,
+    })
+}
+
 fn screen_pane_index(state: &State, screen: ScreenId, pane: PaneId) -> usize {
     state
         .workspaces
@@ -3330,25 +3888,18 @@ fn close_screen_delta(
         workspace.screens.iter().position(|candidate| candidate.id == screen).map(|si| (wi, si))
     })?;
     let workspace = &state.workspaces[wi];
-    if workspace.screens.len() > 1 {
-        let entity = crate::server::tree_entity_json(
-            state,
-            notifications,
-            TreeDeltaKind::ScreenClosed,
-            screen,
-        )?;
-        return Some(TreeDelta {
-            kind: TreeDeltaKind::ScreenClosed,
-            workspace: workspace.id,
-            screen: Some(screen),
-            pane: None,
-            surface: None,
-            index: Some(si),
-            entity,
-            workspace_revision: None,
-        });
-    }
-    close_workspace_delta(state, notifications, workspace.id)
+    let entity =
+        crate::server::tree_entity_json(state, notifications, TreeDeltaKind::ScreenClosed, screen)?;
+    Some(TreeDelta {
+        kind: TreeDeltaKind::ScreenClosed,
+        workspace: workspace.id,
+        screen: Some(screen),
+        pane: None,
+        surface: None,
+        index: Some(si),
+        entity,
+        workspace_revision: None,
+    })
 }
 
 fn close_workspace_delta(
@@ -3376,7 +3927,8 @@ fn close_workspace_delta(
 }
 
 /// Remove one surface from the state: detach it from its
-/// pane, and collapse emptied panes/screens/workspaces. Returns whether
+/// pane, and collapse emptied panes/screens. Empty workspaces remain as
+/// canonical registry entries. Returns whether
 /// anything was removed. Runs under the state lock.
 fn remove_surface(state: &mut State, target: SurfaceId) -> Option<Arc<Surface>> {
     let removed = state.surfaces.remove(&target);
@@ -3434,12 +3986,6 @@ fn remove_surface(state: &mut State, target: SurfaceId) -> Option<Arc<Surface>> 
         }
     }
 
-    // Workspace emptied too: drop it, keeping the active selection stable.
-    let active_id = state.workspaces.get(state.active_workspace).map(|w| w.id);
-    state.remove_workspace(wi);
-    state.active_workspace = active_id
-        .and_then(|id| state.workspace_index(id))
-        .unwrap_or_else(|| state.workspaces.len().saturating_sub(1));
     removed
 }
 
@@ -3476,14 +4022,6 @@ fn collapse_empty_pane(state: &mut State, pane_id: PaneId) {
             let ws = &mut state.workspaces[wi];
             ws.screens.remove(si);
             ws.active_screen = ws.active_screen.min(ws.screens.len().saturating_sub(1));
-            if !ws.screens.is_empty() {
-                return;
-            }
-            let active_id = state.workspaces.get(state.active_workspace).map(|w| w.id);
-            state.remove_workspace(wi);
-            state.active_workspace = active_id
-                .and_then(|id| state.workspace_index(id))
-                .unwrap_or_else(|| state.workspaces.len().saturating_sub(1));
         }
     }
 }
@@ -4374,7 +4912,11 @@ mod tests {
         mux.close_pane(p1);
         mux.close_pane(p3);
         assert_eq!(mux.surface_count(), 0);
-        mux.with_state(|s| assert!(s.workspaces.is_empty()));
+        mux.with_state(|s| {
+            assert_eq!(s.workspaces.len(), 1);
+            assert!(s.workspaces[0].screens.is_empty());
+            assert_eq!(s.workspace_revision, 1);
+        });
     }
 
     #[test]
@@ -4441,9 +4983,14 @@ mod tests {
             assert_eq!(s.workspaces.len(), 1);
         });
 
-        // Closing the last tab collapses the pane, screen, and workspace.
+        // Closing the last tab collapses the pane and screen, while the
+        // canonical workspace remains until an explicit close-workspace.
         mux.close_surface(s1.id);
-        mux.with_state(|s| assert!(s.workspaces.is_empty()));
+        mux.with_state(|s| {
+            assert_eq!(s.workspaces.len(), 1);
+            assert!(s.workspaces[0].screens.is_empty());
+            assert_eq!(s.workspace_revision, 1);
+        });
     }
 
     #[test]
@@ -4686,6 +5233,46 @@ mod tests {
         assert_eq!(closed.kind, TreeDeltaKind::WorkspaceClosed);
         assert_eq!(closed.workspace_revision, Some(3));
         assert!(matches!(events.recv().expect("empty event"), MuxEvent::Empty));
+    }
+
+    #[test]
+    fn persistent_workspace_registry_recovers_exact_identity_order_and_revision() {
+        let root = std::env::temp_dir()
+            .join(format!("cmux-mux-persistent-{}", crate::workspace_registry::new_uuid_v4()));
+        let (registry_id, generation) = {
+            let mux = Mux::open_persistent("recover", SurfaceOptions::default(), &root).unwrap();
+            let first = mux
+                .create_empty_workspace(Some("one".into()), Some("stable-one".into()), Some(0))
+                .unwrap();
+            let second = mux
+                .create_empty_workspace(Some("two".into()), Some("stable-two".into()), Some(1))
+                .unwrap();
+            assert_eq!(
+                mux.rename_workspace_at_revision(second.workspace, "renamed".into(), Some(2))
+                    .unwrap(),
+                Some(3)
+            );
+            assert_eq!(
+                mux.move_workspace_at_revision(second.workspace, 0, Some(3)).unwrap(),
+                Some((4, true))
+            );
+            assert_eq!(first.workspace, 1);
+            mux.registry_identity()
+        };
+
+        let recovered = Mux::open_persistent("recover", SurfaceOptions::default(), &root).unwrap();
+        let (recovered_registry_id, recovered_generation) = recovered.registry_identity();
+        assert_eq!(recovered_registry_id, registry_id);
+        assert_ne!(recovered_generation, generation);
+        recovered.with_state(|state| {
+            assert_eq!(state.workspace_revision, 4);
+            assert_eq!(state.workspaces.len(), 2);
+            assert_eq!(state.workspaces[0].key, "stable-two");
+            assert_eq!(state.workspaces[0].name, "renamed");
+            assert_eq!(state.workspaces[1].key, "stable-one");
+            assert!(state.workspaces.iter().all(|workspace| workspace.screens.is_empty()));
+        });
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -512,14 +512,7 @@ impl Mux {
         #[cfg_attr(not(test), allow(unused_variables))] test_surface_runtime: bool,
     ) -> anyhow::Result<Arc<Self>> {
         let snapshot = registry.snapshot()?;
-        let next_id = snapshot
-            .workspaces
-            .iter()
-            .map(|workspace| workspace.id)
-            .max()
-            .unwrap_or(0)
-            .checked_add(1)
-            .ok_or_else(|| anyhow::anyhow!("workspace id space exhausted"))?;
+        let next_id = snapshot.next_numeric_id;
         let workspaces = snapshot
             .workspaces
             .into_iter()
@@ -531,15 +524,10 @@ impl Mux {
                 active_screen: 0,
             })
             .collect::<Vec<_>>();
-        let workspace_index_by_id = workspaces
-            .iter()
-            .enumerate()
-            .map(|(index, workspace)| (workspace.id, index))
-            .collect();
-        let workspace_id_by_key = workspaces
-            .iter()
-            .map(|workspace| (workspace.key.clone(), workspace.id))
-            .collect();
+        let workspace_index_by_id =
+            workspaces.iter().enumerate().map(|(index, workspace)| (workspace.id, index)).collect();
+        let workspace_id_by_key =
+            workspaces.iter().map(|workspace| (workspace.key.clone(), workspace.id)).collect();
         surface_options.browser_session_name = session.clone();
         Ok(Arc::new(Mux {
             workspace_registry: Mutex::new(registry),
@@ -1658,7 +1646,7 @@ impl Mux {
                     "op": "new-workspace",
                     "workspace": ws_id,
                     "key": workspace_key.clone(),
-                    "name": name.clone(),
+                    "name": name,
                 }),
                 None,
                 None,
@@ -1675,7 +1663,7 @@ impl Mux {
                 Err(error) => {
                     drop(state);
                     drop(registry);
-                    self.discard_spawned(vec![surface.clone()]);
+                    self.discard_spawned(vec![surface]);
                     return Err(error);
                 }
             };
@@ -1762,7 +1750,7 @@ impl Mux {
             });
             let result = serde_json::json!({
                 "workspace": ws_id,
-                "key": key.clone(),
+                "key": key,
                 "index": index,
             });
             let commit = registry.commit(
@@ -1770,7 +1758,7 @@ impl Mux {
                 &serde_json::json!({
                     "op": "create-workspace",
                     "name": requested_name,
-                    "requested_key": requested_key.clone(),
+                    "requested_key": requested_key,
                 }),
                 expected_generation,
                 expected_revision,
@@ -1873,7 +1861,7 @@ impl Mux {
                         "op": "run-new-workspace",
                         "workspace": ws_id,
                         "key": workspace_key.clone(),
-                        "name": workspace_name.clone(),
+                        "name": workspace_name,
                     }),
                     None,
                     None,
@@ -1890,7 +1878,7 @@ impl Mux {
                     Err(error) => {
                         drop(state);
                         drop(registry);
-                        self.discard_spawned(vec![surface.clone()]);
+                        self.discard_spawned(vec![surface]);
                         return Err(error);
                     }
                 };
@@ -2446,7 +2434,7 @@ impl Mux {
                         "op": "new-browser-workspace",
                         "workspace": ws_id,
                         "key": workspace_key.clone(),
-                        "name": name.clone(),
+                        "name": name,
                     }),
                     None,
                     None,
@@ -2463,7 +2451,7 @@ impl Mux {
                     Err(error) => {
                         drop(state);
                         drop(registry);
-                        self.discard_spawned(vec![surface.clone()]);
+                        self.discard_spawned(vec![surface]);
                         return Err(error);
                     }
                 };
@@ -2966,7 +2954,7 @@ impl Mux {
             "op": "rename-workspace",
             "workspace": target,
             "key": requested_key,
-            "name": name.clone(),
+            "name": name,
         });
         let notifications = self.surface_notifications();
         let mut registry = self.workspace_registry.lock().unwrap();
@@ -5273,6 +5261,40 @@ mod tests {
             assert!(state.workspaces.iter().all(|workspace| workspace.screens.is_empty()));
         });
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn concurrent_workspace_commits_publish_in_exact_revision_order() {
+        let mux = test_mux();
+        let events = mux.subscribe();
+        let mut workers = Vec::new();
+        for index in 0..16 {
+            let mux = mux.clone();
+            workers.push(std::thread::spawn(move || {
+                mux.create_empty_workspace(
+                    Some(format!("workspace-{index}")),
+                    Some(format!("stable-{index}")),
+                    None,
+                )
+                .unwrap()
+            }));
+        }
+        let mut committed =
+            workers.into_iter().map(|worker| worker.join().unwrap().revision).collect::<Vec<_>>();
+        committed.sort_unstable();
+        assert_eq!(committed, (1..=16).collect::<Vec<_>>());
+
+        let published = (1..=16)
+            .map(|_| match events.recv().unwrap() {
+                MuxEvent::TreeDelta(delta) => delta.workspace_revision.unwrap(),
+                event => panic!("unexpected event: {event:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(published, (1..=16).collect::<Vec<_>>());
+        mux.with_state(|state| {
+            assert_eq!(state.workspace_revision, 16);
+            assert_eq!(state.workspaces.len(), 16);
+        });
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -5124,8 +5124,7 @@ impl Mux {
                     state.workspace_revision
                 );
             }
-            let new_index = if index > old_index { index.saturating_sub(1) } else { index }
-                .min(state.workspaces.len().saturating_sub(1));
+            let new_index = index.min(state.workspaces.len().saturating_sub(1));
             if new_index == old_index {
                 return Ok(Some((state.workspace_revision, false)));
             }
@@ -5168,8 +5167,7 @@ impl Mux {
             let old_idx = resolve_workspace_index(&state, workspace, requested_key)?;
             let workspace_id = state.workspaces[old_idx].id;
             let key = state.workspaces[old_idx].key.clone();
-            let new_idx = if index > old_idx { index.saturating_sub(1) } else { index };
-            let new_idx = new_idx.min(state.workspaces.len().saturating_sub(1));
+            let new_idx = index.min(state.workspaces.len().saturating_sub(1));
             let changed = new_idx != old_idx;
             let mut desired = self.registry_projection(&state);
             let desired_workspace = desired.remove(old_idx);

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -19,6 +19,7 @@ use crate::layout::{Rect, layout_screen};
 use crate::model::{Node, Pane, Screen, State, Workspace};
 use crate::pairing::PairingBroker;
 use crate::surface::{DefaultColors, Surface, SurfaceOptions};
+use crate::terminal_host_runtime::TerminalHostIdentity;
 use crate::workspace_registry::{
     FrontendProjection, ProjectionCommit, RegistryCommit, RegistryWorkspace, WorkspaceMutation,
     WorkspaceRegistry,
@@ -529,7 +530,7 @@ impl Mux {
         let workspace_id_by_key =
             workspaces.iter().map(|workspace| (workspace.key.clone(), workspace.id)).collect();
         surface_options.browser_session_name = session.clone();
-        Ok(Arc::new(Mux {
+        let mux = Arc::new(Mux {
             workspace_registry: Mutex::new(registry),
             state: Mutex::new(State {
                 workspaces,
@@ -561,7 +562,67 @@ impl Mux {
             #[cfg(test)]
             test_surface_runtime,
             session,
-        }))
+        });
+        #[cfg(unix)]
+        mux.adopt_terminal_hosts()?;
+        Ok(mux)
+    }
+
+    #[cfg(unix)]
+    fn adopt_terminal_hosts(self: &Arc<Self>) -> anyhow::Result<()> {
+        let options = self.surface_options.lock().unwrap().clone();
+        let Some(root) = options.terminal_host_root.clone() else {
+            return Ok(());
+        };
+        for (record_path, record) in
+            crate::terminal_host_runtime::load_terminal_host_records(&root)?
+        {
+            if record.workspace_key.is_empty() {
+                continue;
+            }
+            let workspace_id = self.state.lock().unwrap().workspaces.iter().find_map(|workspace| {
+                (workspace.key == record.workspace_key).then_some(workspace.id)
+            });
+            let Some(workspace_id) = workspace_id else { continue };
+            let id = self.next_id();
+            let surface = match Surface::adopt_hosted(
+                id,
+                options.clone(),
+                Arc::downgrade(self),
+                record,
+                record_path.clone(),
+            ) {
+                Ok(surface) => surface,
+                // A failed connection can be a transient host startup or
+                // descriptor-pressure failure. The host owns cleanup of its
+                // record on exit; deleting the capability here would turn a
+                // retryable interruption into permanent terminal loss.
+                Err(_) => continue,
+            };
+            let (pane_id, pane) = self.make_pane(surface.id);
+            let screen_id = self.next_id();
+            {
+                let mut state = self.state.lock().unwrap();
+                let Some(workspace) =
+                    state.workspaces.iter_mut().find(|workspace| workspace.id == workspace_id)
+                else {
+                    surface.disconnect_for_daemon_shutdown();
+                    continue;
+                };
+                workspace.screens.push(Screen {
+                    id: screen_id,
+                    name: None,
+                    root: Node::Leaf(pane_id),
+                    active_pane: pane_id,
+                    zoomed_pane: None,
+                });
+                workspace.active_screen = workspace.screens.len() - 1;
+                state.panes.insert(pane_id, pane);
+                insert_surface_checked(&mut state, surface.clone())?;
+            }
+            self.reap_if_dead(&surface);
+        }
+        Ok(())
     }
 
     #[cfg(test)]
@@ -782,7 +843,7 @@ impl Mux {
         };
         #[cfg(not(test))]
         let surface = Surface::spawn(id, opts, Arc::downgrade(self))?;
-        self.state.lock().unwrap().surfaces.insert(id, surface.clone());
+        insert_surface_checked(&mut self.state.lock().unwrap(), surface.clone())?;
         Ok(surface)
     }
 
@@ -817,7 +878,7 @@ impl Mux {
         };
         #[cfg(not(test))]
         let surface = Surface::spawn(id, opts, Arc::downgrade(self))?;
-        self.state.lock().unwrap().surfaces.insert(id, surface.clone());
+        insert_surface_checked(&mut self.state.lock().unwrap(), surface.clone())?;
         Ok(surface)
     }
 
@@ -1299,6 +1360,79 @@ impl Mux {
         self.state.lock().unwrap().surfaces.get(&id).cloned()
     }
 
+    /// Resolve a process-stable terminal UUID to this daemon generation's
+    /// local surface id. This is lookup-only: absence during startup adoption
+    /// is retryable and never creates a replacement shell.
+    pub fn resolve_terminal(
+        &self,
+        terminal_id: &str,
+    ) -> anyhow::Result<Option<(SurfaceId, TerminalHostIdentity)>> {
+        validate_terminal_hex(terminal_id, "invalid_terminal_id")?;
+        let state = self.state.lock().unwrap();
+        unique_terminal_match(
+            terminal_id,
+            state.surfaces.values().filter(|surface| !surface.is_dead()).filter_map(|surface| {
+                surface.terminal_host_identity().map(|identity| (surface.id, identity))
+            }),
+        )
+    }
+
+    /// Atomically resolve, incarnation-check, and remove a hosted terminal by
+    /// process-stable identity. The host is terminated only after the state
+    /// lock has made the removal authoritative for this daemon generation.
+    pub fn close_terminal(
+        &self,
+        terminal_id: &str,
+        terminal_incarnation: &str,
+    ) -> anyhow::Result<Option<SurfaceId>> {
+        validate_terminal_hex(terminal_id, "invalid_terminal_id")?;
+        validate_terminal_hex(terminal_incarnation, "invalid_terminal_incarnation")?;
+        let notifications = self.surface_notifications();
+        let (target, removed, changed_screens, empty, delta) = {
+            let mut state = self.state.lock().unwrap();
+            let Some((target, identity)) = unique_terminal_match(
+                terminal_id,
+                state.surfaces.values().filter(|surface| !surface.is_dead()).filter_map(
+                    |surface| {
+                        surface.terminal_host_identity().map(|identity| (surface.id, identity))
+                    },
+                ),
+            )?
+            else {
+                return Ok(None);
+            };
+            if identity.incarnation != terminal_incarnation {
+                anyhow::bail!("terminal_incarnation_mismatch");
+            }
+            let changed_screen = surface_screen_id(&state, target);
+            let delta = close_surface_delta(&state, &notifications, target);
+            let removed = remove_surface(&mut state, target);
+            (
+                target,
+                removed,
+                changed_screen.into_iter().collect::<Vec<_>>(),
+                state.workspaces.is_empty(),
+                delta,
+            )
+        };
+        if let Some(surface) = removed {
+            self.purge_surface_side_tables(surface.id);
+            surface.kill();
+            if let Some(delta) = delta {
+                self.emit(MuxEvent::TreeDelta(delta));
+            } else {
+                self.emit(MuxEvent::TreeChanged);
+            }
+            for screen in changed_screens {
+                self.emit(MuxEvent::LayoutChanged(screen));
+            }
+        }
+        if empty {
+            self.emit(MuxEvent::Empty);
+        }
+        Ok(Some(target))
+    }
+
     /// Run `f` with the session state.
     ///
     /// The state lock is held for the duration of `f`; do not call back
@@ -1423,7 +1557,7 @@ impl Mux {
     pub fn shutdown(&self) {
         let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();
         for surface in surfaces {
-            surface.kill();
+            surface.disconnect_for_daemon_shutdown();
         }
         if let Some(runtime) = self.browser_runtime.lock().unwrap().take() {
             runtime.shutdown();
@@ -1604,8 +1738,12 @@ impl Mux {
                 surface.resize_reporting_acceptance(cols, rows, Box::new(|_| {}))?;
             return Ok((reservation_id.is_some(), reservation_id));
         }
+        let reports_asynchronously = surface.resize_reports_asynchronously();
         if !surface.resize(cols, rows)? {
             return Ok((false, None));
+        }
+        if reports_asynchronously {
+            return Ok((true, None));
         }
         let (cols, rows) = surface.size();
         self.emit(MuxEvent::SurfaceResized { surface: id, cols, rows, reservation_id: None });
@@ -3108,6 +3246,20 @@ impl Mux {
     fn reap_if_dead(&self, surface: &Arc<Surface>) {
         if surface.is_dead() {
             self.close_surface(surface.id);
+            return;
+        }
+        let workspace_key = {
+            let state = self.state.lock().unwrap();
+            state.workspaces.iter().find_map(|workspace| {
+                workspace
+                    .screens
+                    .iter()
+                    .any(|screen| screen_tabs(&state, screen).contains(&surface.id))
+                    .then(|| workspace.key.clone())
+            })
+        };
+        if let Some(workspace_key) = workspace_key {
+            let _ = surface.persist_host_workspace(&workspace_key);
         }
     }
 
@@ -3678,6 +3830,51 @@ impl Mux {
     }
 }
 
+fn insert_surface_checked(state: &mut State, surface: Arc<Surface>) -> anyhow::Result<()> {
+    if state.surfaces.contains_key(&surface.id) {
+        anyhow::bail!("duplicate_surface_id");
+    }
+    if let Some(identity) = surface.terminal_host_identity()
+        && unique_terminal_match(
+            &identity.terminal_id,
+            state.surfaces.values().filter_map(|surface| {
+                surface.terminal_host_identity().map(|identity| (surface.id, identity))
+            }),
+        )?
+        .is_some()
+    {
+        anyhow::bail!("duplicate_terminal_id");
+    }
+    state.surfaces.insert(surface.id, surface);
+    Ok(())
+}
+
+fn validate_terminal_hex(value: &str, error: &'static str) -> anyhow::Result<()> {
+    if value.len() != crate::terminal_host::TERMINAL_ID_LEN * 2
+        || !value.bytes().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        anyhow::bail!(error);
+    }
+    Ok(())
+}
+
+fn unique_terminal_match(
+    terminal_id: &str,
+    identities: impl IntoIterator<Item = (SurfaceId, TerminalHostIdentity)>,
+) -> anyhow::Result<Option<(SurfaceId, TerminalHostIdentity)>> {
+    let mut found = None;
+    for (surface, identity) in identities {
+        if identity.terminal_id != terminal_id {
+            continue;
+        }
+        if found.is_some() {
+            anyhow::bail!("duplicate_terminal_id");
+        }
+        found = Some((surface, identity));
+    }
+    Ok(found)
+}
+
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -3694,7 +3891,7 @@ impl Drop for Mux {
     fn drop(&mut self) {
         if let Ok(state) = self.state.get_mut() {
             for surface in state.surfaces.values() {
-                surface.kill();
+                surface.disconnect_for_daemon_shutdown();
             }
         }
         if let Ok(runtime) = self.browser_runtime.get_mut()
@@ -4081,6 +4278,35 @@ mod tests {
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())
+    }
+
+    #[test]
+    fn stable_terminal_lookup_never_chooses_between_duplicate_ids() {
+        let terminal_id = "00112233445566778899aabbccddeeff";
+        let identities = vec![
+            (
+                10,
+                TerminalHostIdentity {
+                    terminal_id: terminal_id.into(),
+                    incarnation: "11111111111111111111111111111111".into(),
+                },
+            ),
+            (
+                20,
+                TerminalHostIdentity {
+                    terminal_id: terminal_id.into(),
+                    incarnation: "22222222222222222222222222222222".into(),
+                },
+            ),
+        ];
+
+        assert_eq!(
+            unique_terminal_match(terminal_id, identities.clone()).unwrap_err().to_string(),
+            "duplicate_terminal_id"
+        );
+        let unique =
+            unique_terminal_match(terminal_id, identities.into_iter().take(1)).unwrap().unwrap();
+        assert_eq!(unique.0, 10);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2864,9 +2864,9 @@ impl Mux {
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
         let workspace = self.create_empty_workspace(name, None, None)?.workspace;
-        let placement = self.create_terminal_in_workspace(workspace, None, None, None, size)?;
-        self.surface(placement.surface)
-            .ok_or_else(|| anyhow::anyhow!("new terminal disappeared after creation"))
+        let (_, surface) =
+            self.create_terminal_in_workspace_impl(workspace, None, None, None, size, None)?;
+        Ok(surface)
     }
 
     /// Add an ordered workspace-registry entry without creating a PTY,
@@ -3286,7 +3286,9 @@ impl Mux {
         name: Option<String>,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<RunPlacement> {
-        self.create_terminal_in_workspace_impl(workspace, argv, cwd, name, size, None)
+        let (placement, _) =
+            self.create_terminal_in_workspace_impl(workspace, argv, cwd, name, size, None)?;
+        Ok(placement)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -3339,7 +3341,7 @@ impl Mux {
             expected_generation: expected_generation.map(str::to_string),
             expected_revision,
         };
-        let placement = self.create_terminal_in_workspace_impl(
+        let (placement, surface) = self.create_terminal_in_workspace_impl(
             workspace,
             argv,
             cwd,
@@ -3347,9 +3349,8 @@ impl Mux {
             size,
             Some(reservation),
         )?;
-        let identity = self
-            .surface(placement.surface)
-            .and_then(|surface| surface.terminal_host_identity())
+        let identity = surface
+            .terminal_host_identity()
             .ok_or_else(|| anyhow::anyhow!("created terminal has no host identity"))?;
         let snapshot = self.workspace_registry.lock().unwrap().terminal_snapshot()?;
         Ok(TerminalPlacementResult {
@@ -3396,7 +3397,7 @@ impl Mux {
         name: Option<String>,
         size: Option<(u16, u16)>,
         reservation: Option<TerminalReservationRequest>,
-    ) -> anyhow::Result<RunPlacement> {
+    ) -> anyhow::Result<(RunPlacement, Arc<Surface>)> {
         let (workspace_key, inherited_pane) = {
             let state = self.state.lock().unwrap();
             let Some(workspace) = state.workspace_by_id(workspace) else {
@@ -3442,7 +3443,7 @@ impl Mux {
                 self.emit(MuxEvent::TreeChanged);
             }
             self.reap_if_dead(&surface);
-            return Ok(placement);
+            return Ok((placement, surface));
         }
         let notifications = self.surface_notifications();
         let active_at = self.next_active_at();
@@ -3534,7 +3535,7 @@ impl Mux {
         };
         self.emit(MuxEvent::TreeDelta(attached.1));
         self.reap_if_dead(&surface);
-        Ok(attached.0)
+        Ok((attached.0, surface))
     }
 
     /// Bind a just-launched hosted surface using the latest durable row, not

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2185,6 +2185,62 @@ impl Mux {
         *self.terminal_move_before_projection.lock().unwrap() = hook;
     }
 
+    #[cfg(all(test, unix))]
+    pub(crate) fn seed_running_terminal_for_test(
+        self: &Arc<Self>,
+        terminal_id: &str,
+        incarnation: &str,
+        workspace_key: &str,
+    ) -> anyhow::Result<SurfaceId> {
+        let mut registry = self.workspace_registry.lock().unwrap();
+        commit_terminal_transition(
+            &mut registry,
+            "terminal-reserved",
+            "seed-terminal-reservation",
+            &RegistryTerminal {
+                terminal_id: terminal_id.to_string(),
+                workspace_key: workspace_key.to_string(),
+                incarnation: None,
+                lifecycle: TerminalLifecycle::Launching,
+                launch_spec: serde_json::json!({}),
+                exit: None,
+            },
+        )?;
+        commit_terminal_lifecycle(
+            &mut registry,
+            "terminal-ready",
+            "seed-running-terminal",
+            terminal_id,
+            TerminalLifecycle::Running,
+            Some(incarnation),
+            None,
+        )?;
+        let surface = Surface::exited_terminal_placeholder(
+            self.next_id(),
+            self.surface_options.lock().unwrap().clone(),
+            Arc::downgrade(self),
+            TerminalHostIdentity {
+                terminal_id: terminal_id.to_string(),
+                incarnation: incarnation.to_string(),
+            },
+        )?;
+        let mut state = self.state.lock().unwrap();
+        insert_surface_checked(&mut state, surface.clone())?;
+        let (placement, changed) =
+            self.project_terminal_to_workspace_in_state(&mut state, terminal_id, workspace_key)?;
+        anyhow::ensure!(changed, "seeded terminal did not change topology");
+        anyhow::ensure!(
+            placement.is_some_and(|placement| placement.surface == surface.id),
+            "seeded terminal projection returned the wrong surface"
+        );
+        Ok(surface.id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_terminal_close_failure_for_test(&self, enabled: bool) -> anyhow::Result<()> {
+        self.workspace_registry.lock().unwrap().set_terminal_close_failure(enabled)
+    }
+
     fn browser_runtime(&self) -> anyhow::Result<Arc<BrowserRuntime>> {
         let mut runtime = self.browser_runtime.lock().unwrap();
         if let Some(existing) = runtime.as_ref().filter(|existing| !existing.is_closed()) {
@@ -3944,17 +4000,16 @@ impl Mux {
     /// Close one tab. When it was the pane's last tab, the pane collapses
     /// out of its split tree. Empty workspace containers remain durable;
     /// only an explicit close-workspace mutation removes a workspace.
-    pub fn close_surface(&self, target: SurfaceId) {
+    pub fn close_surface(&self, target: SurfaceId) -> anyhow::Result<bool> {
         if let Some(surface) = self.surface(target)
             && let Err(error) = self.tombstone_hosted_surface(&surface)
         {
-            self.emit(MuxEvent::Status(format!("could not close terminal {target}: {error}")));
-            return;
+            return Err(error);
         }
-        self.remove_surface_after_registry(target);
+        Ok(self.remove_surface_after_registry(target))
     }
 
-    fn remove_surface_after_registry(&self, target: SurfaceId) {
+    fn remove_surface_after_registry(&self, target: SurfaceId) -> bool {
         let notifications = self.surface_notifications();
         let (removed, changed_screens, empty, delta) = {
             let mut state = self.state.lock().unwrap();
@@ -3968,7 +4023,7 @@ impl Mux {
                 delta,
             )
         };
-        if let Some(surface) = removed {
+        let removed = if let Some(surface) = removed {
             self.purge_surface_side_tables(surface.id);
             surface.kill();
             if let Some(delta) = delta {
@@ -3979,15 +4034,19 @@ impl Mux {
             for screen in changed_screens {
                 self.emit(MuxEvent::LayoutChanged(screen));
             }
-        }
+            true
+        } else {
+            false
+        };
         if empty {
             self.emit(MuxEvent::Empty);
         }
+        removed
     }
 
     /// Close every surface in `tabs` (helper for pane/screen/workspace
     /// close). Emits events outside the lock.
-    fn close_surfaces(&self, tabs: Vec<SurfaceId>, delta: TreeDelta) {
+    fn close_surfaces(&self, tabs: Vec<SurfaceId>, delta: TreeDelta) -> anyhow::Result<()> {
         let mutation = WorkspaceMutation::local("cmux-tui");
         let mut registry = self.workspace_registry.lock().unwrap();
         let (removed, changed_screens, empty, batch) = {
@@ -3998,17 +4057,7 @@ impl Mux {
                 .filter_map(|surface| surface.terminal_host_identity())
                 .map(|identity| (identity.terminal_id, Some(identity.incarnation)))
                 .collect::<Vec<_>>();
-            let batch = match registry.close_terminals_atomically(&mutation, &hosted) {
-                Ok(batch) => batch,
-                Err(error) => {
-                    drop(state);
-                    drop(registry);
-                    self.emit(MuxEvent::Status(format!(
-                        "could not atomically close terminal topology: {error}"
-                    )));
-                    return;
-                }
-            };
+            let batch = registry.close_terminals_atomically(&mutation, &hosted)?;
             let changed_screens = unique_screen_ids(
                 tabs.iter().filter_map(|surface| surface_screen_id(&state, *surface)),
             );
@@ -4037,10 +4086,11 @@ impl Mux {
         if empty {
             self.emit(MuxEvent::Empty);
         }
+        Ok(())
     }
 
     /// Close a pane and every tab in it.
-    pub fn close_pane(&self, target: PaneId) {
+    pub fn close_pane(&self, target: PaneId) -> anyhow::Result<bool> {
         let notifications = self.surface_notifications();
         let (tabs, delta) = {
             let state = self.state.lock().unwrap();
@@ -4050,21 +4100,22 @@ impl Mux {
                     close_pane_delta(&state, &notifications, target)
                         .expect("live pane has a close delta"),
                 ),
-                None => return,
+                None => return Ok(false),
             }
         };
-        self.close_surfaces(tabs, delta);
+        self.close_surfaces(tabs, delta).with_context(|| format!("close pane {target}"))?;
+        Ok(true)
     }
 
     /// Close a screen and every pane/tab in it.
-    pub fn close_screen(&self, target: ScreenId) -> bool {
+    pub fn close_screen(&self, target: ScreenId) -> anyhow::Result<bool> {
         let notifications = self.surface_notifications();
         let (tabs, delta) = {
             let state = self.state.lock().unwrap();
             let Some(screen) =
                 state.workspaces.iter().flat_map(|ws| ws.screens.iter()).find(|s| s.id == target)
             else {
-                return false;
+                return Ok(false);
             };
             (
                 screen_tabs(&state, screen),
@@ -4072,8 +4123,8 @@ impl Mux {
                     .expect("live screen has a close delta"),
             )
         };
-        self.close_surfaces(tabs, delta);
-        true
+        self.close_surfaces(tabs, delta).with_context(|| format!("close screen {target}"))?;
+        Ok(true)
     }
 
     /// Close a workspace and every screen/pane/tab in it.
@@ -5989,6 +6040,18 @@ mod tests {
         surface
     }
 
+    #[cfg(unix)]
+    fn insert_running_terminal_identity_surface(
+        mux: &Arc<Mux>,
+        terminal_id: &str,
+        incarnation: &str,
+        workspace_key: &str,
+    ) -> Arc<Surface> {
+        let surface =
+            mux.seed_running_terminal_for_test(terminal_id, incarnation, workspace_key).unwrap();
+        mux.surface(surface).unwrap()
+    }
+
     #[test]
     fn terminal_registry_launch_spec_never_persists_environment_secrets() {
         let sentinel = "cmux-secret-sentinel-do-not-persist";
@@ -6578,7 +6641,7 @@ mod tests {
         assert_eq!(mux.list_agents(Some(first.id), None).len(), 1);
         assert!(mux.surface_notification(first.id).is_some());
 
-        mux.close_surface(first.id);
+        mux.close_surface(first.id).unwrap();
 
         // The dead surface must not linger in either side table.
         assert!(mux.list_agents(Some(first.id), None).is_empty());
@@ -6923,21 +6986,110 @@ mod tests {
             assert_eq!(ids, vec![p1, p2, p3]);
         });
 
-        mux.close_pane(p2);
+        mux.close_pane(p2).unwrap();
         mux.with_state(|s| {
             let mut ids = Vec::new();
             s.workspaces[0].screens[0].root.pane_ids(&mut ids);
             assert_eq!(ids, vec![p1, p3]);
         });
 
-        mux.close_pane(p1);
-        mux.close_pane(p3);
+        mux.close_pane(p1).unwrap();
+        mux.close_pane(p3).unwrap();
         assert_eq!(mux.surface_count(), 0);
         mux.with_state(|s| {
             assert_eq!(s.workspaces.len(), 1);
             assert!(s.workspaces[0].screens.is_empty());
             assert_eq!(s.workspace_revision, 1);
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_pane_reports_registry_failure_without_mutating_topology() {
+        const TERMINAL: &str = "00000000000040008000000000000010";
+        const INCARNATION: &str = "10000000000040008000000000000010";
+        let mux = test_mux();
+        let workspace = mux.create_empty_workspace(None, Some("close-pane".into()), None).unwrap();
+        let surface =
+            insert_running_terminal_identity_surface(&mux, TERMINAL, INCARNATION, &workspace.key);
+        let pane = mux.with_state(|state| state.pane_of(surface.id).unwrap());
+        let events = mux.subscribe();
+        mux.workspace_registry.lock().unwrap().set_terminal_close_failure(true).unwrap();
+
+        let error = mux.close_pane(pane).unwrap_err();
+        assert!(error.to_string().contains("close pane"));
+        assert!(format!("{error:#}").contains("forced terminal close failure"));
+        assert_eq!(mux.with_state(|state| state.pane_of(surface.id)), Some(pane));
+        assert!(mux.surface(surface.id).is_some());
+        assert_eq!(
+            mux.workspace_registry
+                .lock()
+                .unwrap()
+                .terminal_record(TERMINAL)
+                .unwrap()
+                .unwrap()
+                .lifecycle,
+            TerminalLifecycle::Running
+        );
+        assert!(events.recv_timeout(Duration::from_millis(25)).is_err());
+
+        mux.workspace_registry.lock().unwrap().set_terminal_close_failure(false).unwrap();
+        assert!(mux.close_pane(pane).unwrap());
+        assert!(mux.surface(surface.id).is_none());
+        assert_eq!(
+            mux.workspace_registry
+                .lock()
+                .unwrap()
+                .terminal_record(TERMINAL)
+                .unwrap()
+                .unwrap()
+                .lifecycle,
+            TerminalLifecycle::Tombstoned
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_screen_reports_registry_failure_without_mutating_topology() {
+        const TERMINAL: &str = "00000000000040008000000000000011";
+        const INCARNATION: &str = "10000000000040008000000000000011";
+        let mux = test_mux();
+        let workspace =
+            mux.create_empty_workspace(None, Some("close-screen".into()), None).unwrap();
+        let surface =
+            insert_running_terminal_identity_surface(&mux, TERMINAL, INCARNATION, &workspace.key);
+        let screen = mux.with_state(|state| surface_screen_id(state, surface.id).unwrap());
+        mux.workspace_registry.lock().unwrap().set_terminal_close_failure(true).unwrap();
+
+        let error = mux.close_screen(screen).unwrap_err();
+        assert!(error.to_string().contains("close screen"));
+        assert!(format!("{error:#}").contains("forced terminal close failure"));
+        assert_eq!(mux.with_state(|state| surface_screen_id(state, surface.id)), Some(screen));
+        assert!(mux.surface(surface.id).is_some());
+        assert_eq!(
+            mux.workspace_registry
+                .lock()
+                .unwrap()
+                .terminal_record(TERMINAL)
+                .unwrap()
+                .unwrap()
+                .lifecycle,
+            TerminalLifecycle::Running
+        );
+
+        mux.workspace_registry.lock().unwrap().set_terminal_close_failure(false).unwrap();
+        assert!(mux.close_screen(screen).unwrap());
+        assert!(mux.surface(surface.id).is_none());
+        assert_eq!(
+            mux.workspace_registry
+                .lock()
+                .unwrap()
+                .terminal_record(TERMINAL)
+                .unwrap()
+                .unwrap()
+                .lifecycle,
+            TerminalLifecycle::Tombstoned
+        );
     }
 
     #[test]
@@ -6974,7 +7126,7 @@ mod tests {
 
         assert!(mux.focus_pane(p1));
         assert!(mux.focus_pane(p3));
-        mux.close_pane(p3);
+        mux.close_pane(p3).unwrap();
 
         mux.with_state(|s| {
             assert_eq!(s.workspaces[0].screens[0].active_pane, p1);
@@ -6996,7 +7148,7 @@ mod tests {
         });
 
         // Closing the active tab activates the previous one; the pane stays.
-        mux.close_surface(s2.id);
+        mux.close_surface(s2.id).unwrap();
         mux.with_state(|s| {
             let p = &s.panes[&pane];
             assert_eq!(p.tabs, vec![s1.id]);
@@ -7006,7 +7158,7 @@ mod tests {
 
         // Closing the last tab collapses the pane and screen, while the
         // canonical workspace remains until an explicit close-workspace.
-        mux.close_surface(s1.id);
+        mux.close_surface(s1.id).unwrap();
         mux.with_state(|s| {
             assert_eq!(s.workspaces.len(), 1);
             assert!(s.workspaces[0].screens.is_empty());
@@ -7148,7 +7300,7 @@ mod tests {
         mux.with_state(|s| assert_eq!(s.workspaces[0].active_screen, 1));
 
         // Closing screen 2 keeps the workspace with screen 1.
-        assert!(mux.close_screen(screen2));
+        assert!(mux.close_screen(screen2).unwrap());
         mux.with_state(|s| {
             let ws = &s.workspaces[0];
             assert_eq!(ws.screens.len(), 1);

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -3,15 +3,14 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-#[cfg(test)]
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::browser::{self, BrowserBootstrap, BrowserRuntime};
 use crate::event_bus::{MuxEventBroadcaster, MuxEventReceiver};
@@ -19,10 +18,11 @@ use crate::layout::{Rect, layout_screen};
 use crate::model::{Node, Pane, Screen, State, Workspace};
 use crate::pairing::PairingBroker;
 use crate::surface::{DefaultColors, Surface, SurfaceOptions};
+use crate::terminal_host::TerminalId;
 use crate::terminal_host_runtime::TerminalHostIdentity;
 use crate::workspace_registry::{
-    FrontendProjection, ProjectionCommit, RegistryCommit, RegistryWorkspace, WorkspaceMutation,
-    WorkspaceRegistry,
+    FrontendProjection, ProjectionCommit, RegistryCommit, RegistryTerminal, RegistryWorkspace,
+    TerminalLifecycle, TerminalRegistrySnapshot, WorkspaceMutation, WorkspaceRegistry,
 };
 use crate::{
     PairingChallenge, PairingDecision, PairingError, PaneId, ScreenId, SplitDir, SurfaceId,
@@ -103,6 +103,13 @@ pub enum MuxEvent {
         projection_revision: u64,
         origin: String,
         mutation_id: String,
+    },
+    /// A durable terminal-registry mutation committed. Consumers use this as
+    /// a barrier, then fetch `terminal-events` or a fresh snapshot.
+    TerminalRegistryChanged {
+        registry_id: String,
+        generation: String,
+        terminal_revision: u64,
     },
     /// A screen's pane geometry changed. Clients should re-fetch layout.
     LayoutChanged(ScreenId),
@@ -301,12 +308,55 @@ pub struct SurfaceNotification {
     pub unread: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RunPlacement {
     pub surface: SurfaceId,
     pub pane: PaneId,
     pub screen: ScreenId,
     pub workspace: WorkspaceId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalCloseResult {
+    pub surface: Option<SurfaceId>,
+    pub terminal_id: String,
+    pub terminal_incarnation: Option<String>,
+    pub already_closed: bool,
+    pub terminal_revision: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TerminalResolution {
+    pub surface: Option<SurfaceId>,
+    pub terminal: RegistryTerminal,
+    pub terminal_revision: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalPlacementResult {
+    pub placement: RunPlacement,
+    pub terminal_id: String,
+    pub terminal_incarnation: Option<String>,
+    pub terminal_revision: u64,
+    pub replayed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TerminalMoveResult {
+    pub placement: Option<RunPlacement>,
+    pub terminal: RegistryTerminal,
+    pub terminal_revision: u64,
+    pub replayed: bool,
+    pub changed: bool,
+}
+
+#[derive(Debug, Clone)]
+struct TerminalReservationRequest {
+    terminal_id: TerminalId,
+    mutation: WorkspaceMutation,
+    fingerprint: Value,
+    expected_generation: Option<String>,
+    expected_revision: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -472,6 +522,8 @@ pub struct Mux {
     sidebar_plugin: Mutex<SidebarPluginRuntime>,
     agent_records: Mutex<HashMap<SurfaceId, AgentRecord>>,
     surface_notifications: Mutex<HashMap<SurfaceId, SurfaceNotification>>,
+    terminal_adoptions: Mutex<HashSet<String>>,
+    shutting_down: AtomicBool,
     pub(crate) control_clients: crate::server::ClientRegistry,
     pairing: PairingBroker,
     #[cfg(test)]
@@ -557,6 +609,8 @@ impl Mux {
             sidebar_plugin: Mutex::new(SidebarPluginRuntime::default()),
             agent_records: Mutex::new(HashMap::new()),
             surface_notifications: Mutex::new(HashMap::new()),
+            terminal_adoptions: Mutex::new(HashSet::new()),
+            shutting_down: AtomicBool::new(false),
             control_clients: crate::server::ClientRegistry::new(),
             pairing: PairingBroker::new(),
             #[cfg(test)]
@@ -574,55 +628,335 @@ impl Mux {
         let Some(root) = options.terminal_host_root.clone() else {
             return Ok(());
         };
-        for (record_path, record) in
-            crate::terminal_host_runtime::load_terminal_host_records(&root)?
-        {
-            if record.workspace_key.is_empty() {
+        let records = crate::terminal_host_runtime::load_terminal_host_records(&root)?;
+        let mut retained_records = HashSet::new();
+        for (record_path, record) in records {
+            let terminal_id = record.terminal_id.clone();
+            if TerminalId::from_hex(&terminal_id).is_none()
+                || TerminalId::from_hex(&record.incarnation).is_none()
+            {
+                crate::terminal_host_runtime::remove_terminal_host_record(&record_path);
                 continue;
             }
-            let workspace_id = self.state.lock().unwrap().workspaces.iter().find_map(|workspace| {
-                (workspace.key == record.workspace_key).then_some(workspace.id)
-            });
-            let Some(workspace_id) = workspace_id else { continue };
-            let id = self.next_id();
-            let surface = match Surface::adopt_hosted(
-                id,
-                options.clone(),
-                Arc::downgrade(self),
-                record,
-                record_path.clone(),
+            let mut terminal =
+                self.workspace_registry.lock().unwrap().terminal_record(&terminal_id)?;
+            if terminal.is_none() {
+                // One-release migration path for hosts launched before SQLite
+                // became placement authority. Never trust the JSON hint when
+                // its workspace no longer exists.
+                let can_import = !record.workspace_key.is_empty()
+                    && self.state.lock().unwrap().workspace_by_key(&record.workspace_key).is_some();
+                if can_import {
+                    let imported = RegistryTerminal {
+                        terminal_id: terminal_id.clone(),
+                        workspace_key: record.workspace_key.clone(),
+                        incarnation: None,
+                        lifecycle: TerminalLifecycle::Launching,
+                        launch_spec: serde_json::json!({"legacy_import":true}),
+                        exit: None,
+                    };
+                    let mut registry = self.workspace_registry.lock().unwrap();
+                    let revision = commit_terminal_transition(
+                        &mut registry,
+                        "terminal-imported",
+                        "import-legacy-terminal",
+                        &imported,
+                    )?;
+                    self.emit_terminal_registry_changed(&registry, revision);
+                    terminal = Some(imported);
+                } else {
+                    terminate_host_record(record, record_path);
+                    continue;
+                }
+            }
+            let terminal = terminal.expect("terminal imported or loaded");
+            if matches!(
+                terminal.lifecycle,
+                TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned
             ) {
-                Ok(surface) => surface,
+                terminate_host_record(record, record_path);
+                continue;
+            }
+            if terminal.incarnation.as_deref().is_some_and(|value| value != record.incarnation) {
+                terminate_host_record(record, record_path);
+                let _ = self.transition_terminal_lifecycle(
+                    "terminal-exited",
+                    "terminal-incarnation-mismatch",
+                    &terminal_id,
+                    TerminalLifecycle::Exited,
+                    terminal.incarnation.as_deref(),
+                    Some(serde_json::json!({"reason":"host-incarnation-mismatch"})),
+                );
+                continue;
+            }
+            self.transition_terminal_lifecycle(
+                "terminal-adopting",
+                "adopt-terminal",
+                &terminal_id,
+                TerminalLifecycle::Adopting,
+                Some(&record.incarnation),
+                None,
+            )?;
+            let id = self.next_id();
+            let mut adopted = None;
+            for attempt in 0..3 {
+                match Surface::adopt_hosted(
+                    id,
+                    options.clone(),
+                    Arc::downgrade(self),
+                    record.clone(),
+                    record_path.clone(),
+                ) {
+                    Ok(surface) => {
+                        adopted = Some(surface);
+                        break;
+                    }
+                    Err(_) if attempt < 2 => {
+                        std::thread::sleep(Duration::from_millis(25 * (1 << attempt)));
+                    }
+                    Err(_) => {}
+                }
+            }
+            let surface = match adopted {
+                Some(surface) => surface,
                 // A failed connection can be a transient host startup or
                 // descriptor-pressure failure. The host owns cleanup of its
                 // record on exit; deleting the capability here would turn a
                 // retryable interruption into permanent terminal loss.
-                Err(_) => continue,
-            };
-            let (pane_id, pane) = self.make_pane(surface.id);
-            let screen_id = self.next_id();
-            {
-                let mut state = self.state.lock().unwrap();
-                let Some(workspace) =
-                    state.workspaces.iter_mut().find(|workspace| workspace.id == workspace_id)
-                else {
-                    surface.disconnect_for_daemon_shutdown();
+                None => {
+                    retained_records.insert(terminal_id.clone());
+                    self.schedule_terminal_adoption(options.clone(), record, record_path);
                     continue;
-                };
-                workspace.screens.push(Screen {
-                    id: screen_id,
-                    name: None,
-                    root: Node::Leaf(pane_id),
-                    active_pane: pane_id,
-                    zoomed_pane: None,
-                });
-                workspace.active_screen = workspace.screens.len() - 1;
-                state.panes.insert(pane_id, pane);
-                insert_surface_checked(&mut state, surface.clone())?;
+                }
+            };
+            if self
+                .finish_terminal_adoption(&terminal_id, &record.incarnation, surface.clone())
+                .is_err()
+            {
+                surface.kill();
+                continue;
             }
+            retained_records.insert(terminal_id);
             self.reap_if_dead(&surface);
         }
+
+        // No launcher survives a daemon restart. A durable lifecycle row
+        // without a host-owned record therefore represents a closed crash
+        // window, not permission to spawn a replacement shell.
+        let snapshot = self.workspace_registry.lock().unwrap().terminal_snapshot()?;
+        for terminal in snapshot.terminals {
+            if retained_records.contains(&terminal.terminal_id)
+                || terminal.lifecycle == TerminalLifecycle::Exited
+            {
+                continue;
+            }
+            let _ = self.transition_terminal_lifecycle(
+                "terminal-exited",
+                "terminal-record-missing",
+                &terminal.terminal_id,
+                TerminalLifecycle::Exited,
+                terminal.incarnation.as_deref(),
+                Some(serde_json::json!({"reason":"missing-host-record"})),
+            );
+        }
         Ok(())
+    }
+
+    #[cfg(unix)]
+    fn finish_terminal_adoption(
+        &self,
+        terminal_id: &str,
+        incarnation: &str,
+        surface: Arc<Surface>,
+    ) -> anyhow::Result<()> {
+        if surface.is_dead() {
+            self.transition_terminal_lifecycle(
+                "terminal-exited",
+                "terminal-died-during-adoption",
+                terminal_id,
+                TerminalLifecycle::Exited,
+                Some(incarnation),
+                Some(serde_json::json!({"reason":"host-exited-during-adoption"})),
+            )?;
+            anyhow::bail!("terminal host exited during adoption");
+        }
+        let (pane_id, pane) = self.make_pane(surface.id);
+        let screen_id = self.next_id();
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let (terminal, revision) = commit_terminal_lifecycle(
+            &mut registry,
+            "terminal-ready",
+            "terminal-adopted",
+            terminal_id,
+            TerminalLifecycle::Running,
+            Some(incarnation),
+            None,
+        )?;
+        self.emit_terminal_registry_changed(&registry, revision);
+        let mut state = self.state.lock().unwrap();
+        let Some(workspace_index) =
+            state.workspaces.iter().position(|workspace| workspace.key == terminal.workspace_key)
+        else {
+            drop(state);
+            if let Ok((_, revision)) = commit_terminal_lifecycle(
+                &mut registry,
+                "terminal-exited",
+                "terminal-adoption-workspace-missing",
+                terminal_id,
+                TerminalLifecycle::Exited,
+                Some(incarnation),
+                Some(serde_json::json!({"reason":"workspace-missing-during-adoption"})),
+            ) {
+                self.emit_terminal_registry_changed(&registry, revision);
+            }
+            anyhow::bail!("terminal workspace disappeared during adoption");
+        };
+        if let Err(error) = insert_surface_checked(&mut state, surface) {
+            drop(state);
+            if let Ok((_, revision)) = commit_terminal_lifecycle(
+                &mut registry,
+                "terminal-exited",
+                "terminal-adoption-insert-failed",
+                terminal_id,
+                TerminalLifecycle::Exited,
+                Some(incarnation),
+                Some(serde_json::json!({
+                    "reason":"surface-insert-failed",
+                    "error":error.to_string(),
+                })),
+            ) {
+                self.emit_terminal_registry_changed(&registry, revision);
+            }
+            return Err(error);
+        }
+        {
+            let workspace = &mut state.workspaces[workspace_index];
+            workspace.screens.push(Screen {
+                id: screen_id,
+                name: None,
+                root: Node::Leaf(pane_id),
+                active_pane: pane_id,
+                zoomed_pane: None,
+            });
+            workspace.active_screen = workspace.screens.len() - 1;
+        }
+        state.panes.insert(pane_id, pane);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn schedule_terminal_adoption(
+        self: &Arc<Self>,
+        options: SurfaceOptions,
+        record: crate::terminal_host_runtime::TerminalHostRecord,
+        record_path: std::path::PathBuf,
+    ) {
+        let terminal_id = record.terminal_id.clone();
+        if !self.terminal_adoptions.lock().unwrap().insert(terminal_id.clone()) {
+            return;
+        }
+        let cleanup_id = terminal_id.clone();
+        let mux = self.clone();
+        let spawn_result = std::thread::Builder::new()
+            .name(format!("terminal-adopt-{terminal_id}"))
+            .spawn(move || {
+                let mut delay = Duration::from_millis(100);
+                loop {
+                    if mux.shutting_down.load(Ordering::Acquire) {
+                        break;
+                    }
+                    std::thread::sleep(delay);
+                    if mux.shutting_down.load(Ordering::Acquire) {
+                        break;
+                    }
+                    let terminal = mux
+                        .workspace_registry
+                        .lock()
+                        .unwrap()
+                        .terminal_record(&terminal_id)
+                        .ok()
+                        .flatten();
+                    let Some(terminal) = terminal else { break };
+                    if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+                        if terminate_host_record(record.clone(), record_path.clone()) {
+                            break;
+                        }
+                        delay = (delay * 2).min(Duration::from_secs(5));
+                        continue;
+                    }
+                    if terminal.lifecycle == TerminalLifecycle::Exited {
+                        break;
+                    }
+                    if terminal
+                        .incarnation
+                        .as_deref()
+                        .is_some_and(|incarnation| incarnation != record.incarnation)
+                    {
+                        terminate_host_record(record.clone(), record_path.clone());
+                        break;
+                    }
+                    if !record_path.exists() {
+                        let _ = mux.transition_terminal_lifecycle(
+                            "terminal-exited",
+                            "terminal-record-disappeared",
+                            &terminal_id,
+                            TerminalLifecycle::Exited,
+                            terminal.incarnation.as_deref(),
+                            Some(serde_json::json!({"reason":"missing-host-record"})),
+                        );
+                        break;
+                    }
+                    if terminal.lifecycle == TerminalLifecycle::Running {
+                        let already_live = mux
+                            .resolve_terminal(&terminal_id)
+                            .ok()
+                            .flatten()
+                            .is_some_and(|resolution| resolution.surface.is_some());
+                        if already_live {
+                            break;
+                        }
+                        if mux
+                            .transition_terminal_lifecycle(
+                                "terminal-adopting",
+                                "retry-terminal-adoption",
+                                &terminal_id,
+                                TerminalLifecycle::Adopting,
+                                Some(&record.incarnation),
+                                None,
+                            )
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    let id = mux.next_id();
+                    if let Ok(surface) = Surface::adopt_hosted(
+                        id,
+                        options.clone(),
+                        Arc::downgrade(&mux),
+                        record.clone(),
+                        record_path.clone(),
+                    ) {
+                        if mux
+                            .finish_terminal_adoption(
+                                &terminal_id,
+                                &record.incarnation,
+                                surface.clone(),
+                            )
+                            .is_ok()
+                        {
+                            mux.reap_if_dead(&surface);
+                            break;
+                        }
+                        surface.kill();
+                    }
+                    delay = (delay * 2).min(Duration::from_secs(5));
+                }
+                mux.terminal_adoptions.lock().unwrap().remove(&terminal_id);
+            });
+        if spawn_result.is_err() {
+            self.terminal_adoptions.lock().unwrap().remove(&cleanup_id);
+        }
     }
 
     #[cfg(test)]
@@ -694,6 +1028,17 @@ impl Mux {
     pub fn registry_identity(&self) -> (String, String) {
         let registry = self.workspace_registry.lock().unwrap();
         (registry.registry_id().to_string(), registry.generation().to_string())
+    }
+
+    pub fn terminal_registry_snapshot(&self) -> anyhow::Result<TerminalRegistrySnapshot> {
+        self.workspace_registry.lock().unwrap().terminal_snapshot()
+    }
+
+    pub fn terminal_registry_events_after(
+        &self,
+        revision: u64,
+    ) -> anyhow::Result<Vec<crate::workspace_registry::TerminalRegistryEvent>> {
+        self.workspace_registry.lock().unwrap().terminal_events_after(revision)
     }
 
     pub fn workspace_registry_event(
@@ -771,6 +1116,37 @@ impl Mux {
         self.subscribers.emit(event);
     }
 
+    fn emit_terminal_registry_changed(&self, registry: &WorkspaceRegistry, terminal_revision: u64) {
+        self.emit(MuxEvent::TerminalRegistryChanged {
+            registry_id: registry.registry_id().to_string(),
+            generation: registry.generation().to_string(),
+            terminal_revision,
+        });
+    }
+
+    fn transition_terminal_lifecycle(
+        &self,
+        event_kind: &str,
+        operation: &str,
+        terminal_id: &str,
+        lifecycle: TerminalLifecycle,
+        incarnation: Option<&str>,
+        exit: Option<Value>,
+    ) -> anyhow::Result<(RegistryTerminal, u64)> {
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let result = commit_terminal_lifecycle(
+            &mut registry,
+            event_kind,
+            operation,
+            terminal_id,
+            lifecycle,
+            incarnation,
+            exit,
+        )?;
+        self.emit_terminal_registry_changed(&registry, result.1);
+        Ok(result)
+    }
+
     pub(crate) fn lock_client_sizing_lifecycle(&self) -> MutexGuard<'_, ()> {
         self.client_sizing_lifecycle.lock().unwrap()
     }
@@ -806,13 +1182,25 @@ impl Mux {
         self.pairing.pending()
     }
 
-    fn spawn_surface_with_command(
+    fn spawn_surface_in_workspace(
         self: &Arc<Self>,
+        workspace_key: &str,
         cwd: Option<String>,
         size: Option<(u16, u16)>,
         command: Option<Vec<String>>,
     ) -> anyhow::Result<Arc<Surface>> {
-        self.spawn_surface_with(cwd, command, size)
+        self.spawn_surface_with(cwd, command, size, Some(workspace_key), None)
+    }
+
+    fn spawn_surface_in_workspace_reserved(
+        self: &Arc<Self>,
+        workspace_key: &str,
+        cwd: Option<String>,
+        size: Option<(u16, u16)>,
+        command: Option<Vec<String>>,
+        reservation: TerminalReservationRequest,
+    ) -> anyhow::Result<Arc<Surface>> {
+        self.spawn_surface_with(cwd, command, size, Some(workspace_key), Some(reservation))
     }
 
     fn spawn_surface_with(
@@ -820,6 +1208,8 @@ impl Mux {
         cwd: Option<String>,
         command: Option<Vec<String>>,
         size: Option<(u16, u16)>,
+        workspace_key: Option<&str>,
+        reservation: Option<TerminalReservationRequest>,
     ) -> anyhow::Result<Arc<Surface>> {
         let id = self.next_id();
         let mut opts = self.surface_options.lock().unwrap().clone();
@@ -835,6 +1225,144 @@ impl Mux {
         let (cols, rows) = self.resolve_client_size(size, (opts.cols, opts.rows));
         opts.cols = cols;
         opts.rows = rows;
+        #[cfg(all(test, unix))]
+        let use_host_runtime = !self.test_surface_runtime;
+        #[cfg(all(not(test), unix))]
+        let use_host_runtime = true;
+        #[cfg(unix)]
+        if let (Some(_), Some(workspace_key), true) =
+            (opts.terminal_host_root.as_ref(), workspace_key, use_host_runtime)
+        {
+            let terminal_id = reservation
+                .as_ref()
+                .map(|reservation| reservation.terminal_id)
+                .map(Ok)
+                .unwrap_or_else(TerminalId::random)?;
+            let terminal_hex = terminal_id.to_hex();
+            let launch_spec = terminal_launch_spec(&opts);
+            let terminal = RegistryTerminal {
+                terminal_id: terminal_hex.clone(),
+                workspace_key: workspace_key.to_string(),
+                incarnation: None,
+                lifecycle: TerminalLifecycle::Launching,
+                launch_spec,
+                exit: None,
+            };
+            let reserve_replayed = {
+                let mut registry = self.workspace_registry.lock().unwrap();
+                let (replayed, revision) = if let Some(reservation) = reservation.as_ref() {
+                    let commit = registry.commit_terminal(
+                        &reservation.mutation,
+                        &reservation.fingerprint,
+                        reservation.expected_generation.as_deref(),
+                        reservation.expected_revision,
+                        "terminal-reserved",
+                        &terminal,
+                        &serde_json::json!({
+                            "terminal_id":terminal_hex,
+                            "workspace_key":workspace_key,
+                            "state":"launching",
+                        }),
+                    )?;
+                    (commit.replayed, commit.revision)
+                } else {
+                    let revision = commit_terminal_transition(
+                        &mut registry,
+                        "terminal-reserved",
+                        "reserve-terminal",
+                        &terminal,
+                    )?;
+                    (false, revision)
+                };
+                if !replayed {
+                    self.emit_terminal_registry_changed(&registry, revision);
+                }
+                replayed
+            };
+            if reserve_replayed {
+                anyhow::bail!("terminal_create_replayed");
+            }
+            let surface = match Surface::spawn_with_terminal_id(
+                id,
+                opts,
+                Arc::downgrade(self),
+                Some(terminal_id),
+            ) {
+                Ok(surface) => surface,
+                Err(error) => {
+                    let _ = self.transition_terminal_lifecycle(
+                        "terminal-exited",
+                        "terminal-launch-failed",
+                        &terminal_hex,
+                        TerminalLifecycle::Exited,
+                        None,
+                        Some(serde_json::json!({
+                            "reason": "launch-failed",
+                            "error": error.to_string(),
+                        })),
+                    );
+                    return Err(error);
+                }
+            };
+            let identity = surface
+                .terminal_host_identity()
+                .ok_or_else(|| anyhow::anyhow!("reserved terminal did not return host identity"))?;
+            if identity.terminal_id != terminal_hex {
+                let _ = self.transition_terminal_lifecycle(
+                    "terminal-exited",
+                    "terminal-identity-mismatch",
+                    &terminal_hex,
+                    TerminalLifecycle::Exited,
+                    None,
+                    Some(serde_json::json!({"reason":"host-identity-mismatch"})),
+                );
+                surface.kill();
+                anyhow::bail!("terminal host changed registry-reserved identity");
+            }
+            {
+                let mut registry = self.workspace_registry.lock().unwrap();
+                let ready = commit_terminal_lifecycle(
+                    &mut registry,
+                    "terminal-ready",
+                    "terminal-ready",
+                    &terminal_hex,
+                    TerminalLifecycle::Running,
+                    Some(&identity.incarnation),
+                    None,
+                );
+                let (_, ready_revision) = match ready {
+                    Ok(ready) => ready,
+                    Err(error) => {
+                        surface.kill();
+                        return Err(error);
+                    }
+                };
+                self.emit_terminal_registry_changed(&registry, ready_revision);
+                if let Err(error) =
+                    insert_surface_checked(&mut self.state.lock().unwrap(), surface.clone())
+                {
+                    if let Ok((_, revision)) = commit_terminal_lifecycle(
+                        &mut registry,
+                        "terminal-exited",
+                        "terminal-surface-insert-failed",
+                        &terminal_hex,
+                        TerminalLifecycle::Exited,
+                        Some(&identity.incarnation),
+                        Some(serde_json::json!({"reason":"surface-insert-failed"})),
+                    ) {
+                        self.emit_terminal_registry_changed(&registry, revision);
+                    }
+                    surface.kill();
+                    return Err(error);
+                }
+            }
+            // Deprecated recovery mirror only; SQLite is placement authority.
+            let _ = surface.persist_host_workspace(workspace_key);
+            return Ok(surface);
+        }
+        if reservation.is_some() {
+            anyhow::bail!("canonical terminal reservation requires terminal host runtime");
+        }
         #[cfg(test)]
         let surface = if self.test_surface_runtime {
             Surface::spawn_for_test(id, opts, Arc::downgrade(self))?
@@ -845,14 +1373,6 @@ impl Mux {
         let surface = Surface::spawn(id, opts, Arc::downgrade(self))?;
         insert_surface_checked(&mut self.state.lock().unwrap(), surface.clone())?;
         Ok(surface)
-    }
-
-    fn spawn_surface(
-        self: &Arc<Self>,
-        cwd: Option<String>,
-        size: Option<(u16, u16)>,
-    ) -> anyhow::Result<Arc<Surface>> {
-        self.spawn_surface_with_command(cwd, size, None)
     }
 
     fn spawn_sidebar_plugin_surface(
@@ -1366,15 +1886,25 @@ impl Mux {
     pub fn resolve_terminal(
         &self,
         terminal_id: &str,
-    ) -> anyhow::Result<Option<(SurfaceId, TerminalHostIdentity)>> {
+    ) -> anyhow::Result<Option<TerminalResolution>> {
         validate_terminal_hex(terminal_id, "invalid_terminal_id")?;
+        let (terminal, terminal_revision) = {
+            let registry = self.workspace_registry.lock().unwrap();
+            let snapshot = registry.terminal_snapshot()?;
+            (registry.terminal_record(terminal_id)?, snapshot.revision)
+        };
+        let Some(terminal) = terminal else {
+            return Ok(None);
+        };
         let state = self.state.lock().unwrap();
-        unique_terminal_match(
+        let surface = unique_terminal_match(
             terminal_id,
             state.surfaces.values().filter(|surface| !surface.is_dead()).filter_map(|surface| {
                 surface.terminal_host_identity().map(|identity| (surface.id, identity))
             }),
-        )
+        )?
+        .map(|(surface, _)| surface);
+        Ok(Some(TerminalResolution { surface, terminal, terminal_revision }))
     }
 
     /// Atomically resolve, incarnation-check, and remove a hosted terminal by
@@ -1384,13 +1914,48 @@ impl Mux {
         &self,
         terminal_id: &str,
         terminal_incarnation: &str,
-    ) -> anyhow::Result<Option<SurfaceId>> {
+    ) -> anyhow::Result<TerminalCloseResult> {
+        self.close_terminal_with_mutation(
+            terminal_id,
+            Some(terminal_incarnation),
+            None,
+            None,
+            &WorkspaceMutation::local("cmux-tui"),
+        )
+    }
+
+    pub fn close_terminal_with_mutation(
+        &self,
+        terminal_id: &str,
+        terminal_incarnation: Option<&str>,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<TerminalCloseResult> {
         validate_terminal_hex(terminal_id, "invalid_terminal_id")?;
-        validate_terminal_hex(terminal_incarnation, "invalid_terminal_incarnation")?;
+        if let Some(incarnation) = terminal_incarnation {
+            validate_terminal_hex(incarnation, "invalid_terminal_incarnation")?;
+        }
+        let (commit, terminal_incarnation) = {
+            let mut registry = self.workspace_registry.lock().unwrap();
+            let commit = registry.close_terminal(
+                mutation,
+                expected_generation,
+                expected_revision,
+                terminal_id,
+                terminal_incarnation,
+            )?;
+            if !commit.replayed && !commit.result["already_closed"].as_bool().unwrap_or(false) {
+                self.emit_terminal_registry_changed(&registry, commit.revision);
+            }
+            let incarnation =
+                registry.terminal_record(terminal_id)?.and_then(|terminal| terminal.incarnation);
+            (commit, incarnation)
+        };
         let notifications = self.surface_notifications();
         let (target, removed, changed_screens, empty, delta) = {
             let mut state = self.state.lock().unwrap();
-            let Some((target, identity)) = unique_terminal_match(
+            let target = unique_terminal_match(
                 terminal_id,
                 state.surfaces.values().filter(|surface| !surface.is_dead()).filter_map(
                     |surface| {
@@ -1398,15 +1963,11 @@ impl Mux {
                     },
                 ),
             )?
-            else {
-                return Ok(None);
-            };
-            if identity.incarnation != terminal_incarnation {
-                anyhow::bail!("terminal_incarnation_mismatch");
-            }
-            let changed_screen = surface_screen_id(&state, target);
-            let delta = close_surface_delta(&state, &notifications, target);
-            let removed = remove_surface(&mut state, target);
+            .map(|(surface, _)| surface);
+            let changed_screen = target.and_then(|target| surface_screen_id(&state, target));
+            let delta =
+                target.and_then(|target| close_surface_delta(&state, &notifications, target));
+            let removed = target.and_then(|target| remove_surface(&mut state, target));
             (
                 target,
                 removed,
@@ -1427,10 +1988,134 @@ impl Mux {
                 self.emit(MuxEvent::LayoutChanged(screen));
             }
         }
+        self.terminate_discovered_terminal_host(terminal_id, terminal_incarnation.as_deref());
         if empty {
             self.emit(MuxEvent::Empty);
         }
-        Ok(Some(target))
+        Ok(TerminalCloseResult {
+            surface: target,
+            terminal_id: terminal_id.to_string(),
+            terminal_incarnation,
+            already_closed: commit.result["already_closed"].as_bool().unwrap_or(commit.replayed),
+            terminal_revision: commit.revision,
+        })
+    }
+
+    fn tombstone_hosted_surface(&self, surface: &Arc<Surface>) -> anyhow::Result<()> {
+        let Some(identity) = surface.terminal_host_identity() else {
+            return Ok(());
+        };
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let commit = registry.close_terminal(
+            &WorkspaceMutation::local("cmux-tui"),
+            None,
+            None,
+            &identity.terminal_id,
+            Some(&identity.incarnation),
+        )?;
+        if !commit.replayed && !commit.result["already_closed"].as_bool().unwrap_or(false) {
+            self.emit_terminal_registry_changed(&registry, commit.revision);
+        }
+        Ok(())
+    }
+
+    /// A host can become Running before its topology binding is built. Keep
+    /// the durable lifecycle transition ahead of in-memory removal so a crash
+    /// at any point cannot resurrect an unbound Running terminal on restart.
+    fn fail_hosted_terminal_attachment(
+        &self,
+        surface: &Arc<Surface>,
+        operation: &str,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let Some(identity) = surface.terminal_host_identity() else {
+            let removed = self.state.lock().unwrap().surfaces.remove(&surface.id);
+            if removed.is_some() {
+                surface.kill();
+            }
+            return Ok(());
+        };
+        let mut registry = self.workspace_registry.lock().unwrap();
+        let terminal = registry.terminal_record(&identity.terminal_id)?.ok_or_else(|| {
+            anyhow::anyhow!("missing registry row for terminal {}", identity.terminal_id)
+        })?;
+        if !matches!(terminal.lifecycle, TerminalLifecycle::Exited | TerminalLifecycle::Tombstoned)
+        {
+            let (_, revision) = commit_terminal_lifecycle(
+                &mut registry,
+                "terminal-exited",
+                operation,
+                &identity.terminal_id,
+                TerminalLifecycle::Exited,
+                Some(&identity.incarnation),
+                Some(serde_json::json!({"reason":reason})),
+            )?;
+            self.emit_terminal_registry_changed(&registry, revision);
+        }
+        let removed = {
+            let mut state = self.state.lock().unwrap();
+            remove_surface(&mut state, surface.id).or_else(|| state.surfaces.remove(&surface.id))
+        };
+        drop(registry);
+        if removed.is_some() {
+            self.purge_surface_side_tables(surface.id);
+            surface.kill();
+        }
+        Ok(())
+    }
+
+    fn terminate_discovered_terminal_host(&self, terminal_id: &str, incarnation: Option<&str>) {
+        #[cfg(unix)]
+        {
+            let root = self.surface_options.lock().unwrap().terminal_host_root.clone();
+            let Some(root) = root else { return };
+            let Ok(records) = crate::terminal_host_runtime::load_terminal_host_records(&root)
+            else {
+                return;
+            };
+            for (path, record) in records {
+                if record.terminal_id == terminal_id
+                    && incarnation.is_none_or(|expected| record.incarnation == expected)
+                {
+                    terminate_host_record(record, path);
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = (terminal_id, incarnation);
+    }
+
+    fn terminate_tombstoned_workspace_hosts(&self, workspace_key: &str) {
+        #[cfg(unix)]
+        {
+            let root = self.surface_options.lock().unwrap().terminal_host_root.clone();
+            let Some(root) = root else { return };
+            let Ok(records) = crate::terminal_host_runtime::load_terminal_host_records(&root)
+            else {
+                return;
+            };
+            for (path, record) in records {
+                let terminal = self
+                    .workspace_registry
+                    .lock()
+                    .unwrap()
+                    .terminal_record(&record.terminal_id)
+                    .ok()
+                    .flatten();
+                if terminal.as_ref().is_some_and(|terminal| {
+                    terminal.workspace_key == workspace_key
+                        && terminal.lifecycle == TerminalLifecycle::Tombstoned
+                        && terminal
+                            .incarnation
+                            .as_deref()
+                            .is_none_or(|expected| expected == record.incarnation)
+                }) {
+                    terminate_host_record(record, path);
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = workspace_key;
     }
 
     /// Run `f` with the session state.
@@ -1555,6 +2240,7 @@ impl Mux {
     }
 
     pub fn shutdown(&self) {
+        self.shutting_down.store(true, Ordering::Release);
         let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();
         for surface in surfaces {
             surface.disconnect_for_daemon_shutdown();
@@ -1759,90 +2445,10 @@ impl Mux {
         name: Option<String>,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
-        let workspace_key = Self::new_workspace_key()?;
-        let surface = self.spawn_surface(None, size)?;
-        let (pane_id, pane) = self.make_pane(surface.id);
-        let screen_id = self.next_id();
-        let ws_id = self.next_id();
-        let notifications = self.surface_notifications();
-        let mutation = WorkspaceMutation::local("cmux-tui");
-        let mut registry = self.workspace_registry.lock().unwrap();
-        let delta = {
-            let mut state = self.state.lock().unwrap();
-            let name = name.unwrap_or_else(|| format!("{}", state.workspaces.len() + 1));
-            let index = state.workspaces.len();
-            let mut desired = self.registry_projection(&state);
-            desired.push(RegistryWorkspace {
-                id: ws_id,
-                key: workspace_key.clone(),
-                name: name.clone(),
-                group_key: self.session.clone(),
-            });
-            let commit = match registry.commit(
-                &mutation,
-                &serde_json::json!({
-                    "op": "new-workspace",
-                    "workspace": ws_id,
-                    "key": workspace_key.clone(),
-                    "name": name,
-                }),
-                None,
-                None,
-                "workspace-added",
-                &workspace_key,
-                &desired,
-                &serde_json::json!({
-                    "workspace": ws_id,
-                    "key": workspace_key.clone(),
-                    "index": index
-                }),
-            ) {
-                Ok(commit) => commit,
-                Err(error) => {
-                    drop(state);
-                    drop(registry);
-                    self.discard_spawned(vec![surface]);
-                    return Err(error);
-                }
-            };
-            state.panes.insert(pane_id, pane);
-            state.push_workspace(Workspace {
-                id: ws_id,
-                key: workspace_key,
-                name,
-                screens: vec![Screen {
-                    id: screen_id,
-                    name: None,
-                    root: Node::Leaf(pane_id),
-                    active_pane: pane_id,
-                    zoomed_pane: None,
-                }],
-                active_screen: 0,
-            });
-            state.active_workspace = state.workspaces.len() - 1;
-            state.workspace_revision = commit.revision;
-            let workspace_revision = commit.revision;
-            let entity = crate::server::tree_entity_json(
-                &state,
-                &notifications,
-                TreeDeltaKind::WorkspaceAdded,
-                ws_id,
-            )
-            .expect("new workspace is present in tree snapshot");
-            TreeDelta {
-                kind: TreeDeltaKind::WorkspaceAdded,
-                workspace: ws_id,
-                screen: None,
-                pane: None,
-                surface: None,
-                index: Some(index),
-                entity,
-                workspace_revision: Some(workspace_revision),
-            }
-        };
-        self.emit(MuxEvent::TreeDelta(delta));
-        self.reap_if_dead(&surface);
-        Ok(surface)
+        let workspace = self.create_empty_workspace(name, None, None)?.workspace;
+        let placement = self.create_terminal_in_workspace(workspace, None, None, None, size)?;
+        self.surface(placement.surface)
+            .ok_or_else(|| anyhow::anyhow!("new terminal disappeared after creation"))
     }
 
     /// Add an ordered workspace-registry entry without creating a PTY,
@@ -1970,99 +2576,8 @@ impl Mux {
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<RunPlacement> {
         if new_workspace {
-            let workspace_key = Self::new_workspace_key()?;
-            let surface = self.spawn_surface_with_command(cwd, size, Some(argv))?;
-            if let Some(name) = name.as_ref() {
-                surface.set_name(Some(name.clone()));
-            }
-            let (pane_id, pane) = self.make_pane(surface.id);
-            let screen_id = self.next_id();
-            let ws_id = self.next_id();
-            let notifications = self.surface_notifications();
-            let mutation = WorkspaceMutation::local("cmux-tui");
-            let mut registry = self.workspace_registry.lock().unwrap();
-            let delta = {
-                let mut state = self.state.lock().unwrap();
-                let workspace_name =
-                    name.unwrap_or_else(|| format!("{}", state.workspaces.len() + 1));
-                let index = state.workspaces.len();
-                let mut desired = self.registry_projection(&state);
-                desired.push(RegistryWorkspace {
-                    id: ws_id,
-                    key: workspace_key.clone(),
-                    name: workspace_name.clone(),
-                    group_key: self.session.clone(),
-                });
-                let commit = match registry.commit(
-                    &mutation,
-                    &serde_json::json!({
-                        "op": "run-new-workspace",
-                        "workspace": ws_id,
-                        "key": workspace_key.clone(),
-                        "name": workspace_name,
-                    }),
-                    None,
-                    None,
-                    "workspace-added",
-                    &workspace_key,
-                    &desired,
-                    &serde_json::json!({
-                        "workspace": ws_id,
-                        "key": workspace_key.clone(),
-                        "index": index,
-                    }),
-                ) {
-                    Ok(commit) => commit,
-                    Err(error) => {
-                        drop(state);
-                        drop(registry);
-                        self.discard_spawned(vec![surface]);
-                        return Err(error);
-                    }
-                };
-                state.panes.insert(pane_id, pane);
-                state.push_workspace(Workspace {
-                    id: ws_id,
-                    key: workspace_key,
-                    name: workspace_name,
-                    screens: vec![Screen {
-                        id: screen_id,
-                        name: None,
-                        root: Node::Leaf(pane_id),
-                        active_pane: pane_id,
-                        zoomed_pane: None,
-                    }],
-                    active_screen: 0,
-                });
-                state.active_workspace = state.workspaces.len() - 1;
-                state.workspace_revision = commit.revision;
-                let workspace_revision = commit.revision;
-                let entity = crate::server::tree_entity_json(
-                    &state,
-                    &notifications,
-                    TreeDeltaKind::WorkspaceAdded,
-                    ws_id,
-                )
-                .expect("new workspace is present in tree snapshot");
-                TreeDelta {
-                    kind: TreeDeltaKind::WorkspaceAdded,
-                    workspace: ws_id,
-                    screen: None,
-                    pane: None,
-                    surface: None,
-                    index: Some(index),
-                    entity,
-                    workspace_revision: Some(workspace_revision),
-                }
-            };
-            self.emit(MuxEvent::TreeDelta(delta));
-            self.reap_if_dead(&surface);
-            return Ok(RunPlacement {
-                surface: surface.id,
-                pane: pane_id,
-                screen: screen_id,
-                workspace: ws_id,
-            });
+            let workspace = self.create_empty_workspace(name.clone(), None, None)?.workspace;
+            return self.create_terminal_in_workspace(workspace, Some(argv), cwd, name, size);
         }
 
         let (target, empty_workspace) = {
@@ -2093,7 +2608,10 @@ impl Mux {
         };
 
         let cwd = cwd.or_else(|| self.pane_cwd(target));
-        let surface = self.spawn_surface_with_command(cwd, size, Some(argv))?;
+        let workspace_key = self
+            .workspace_key_for_pane(target)
+            .ok_or_else(|| anyhow::anyhow!("pane {target} has no workspace"))?;
+        let surface = self.spawn_surface_in_workspace(&workspace_key, cwd, size, Some(argv))?;
         if let Some(name) = name {
             surface.set_name(Some(name));
         }
@@ -2162,7 +2680,7 @@ impl Mux {
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
         // Validate the target before spawning a child.
-        {
+        let workspace_key = {
             let state = self.state.lock().unwrap();
             match workspace {
                 Some(id) if !state.workspaces.iter().any(|w| w.id == id) => {
@@ -2172,10 +2690,15 @@ impl Mux {
                     drop(state);
                     return self.new_workspace(None, size);
                 }
-                _ => {}
+                Some(id) => state.workspace_by_id(id).map(|workspace| workspace.key.clone()),
+                None => state
+                    .workspaces
+                    .get(state.active_workspace)
+                    .map(|workspace| workspace.key.clone()),
             }
         }
-        let surface = self.spawn_surface(cwd, size)?;
+        .ok_or_else(|| anyhow::anyhow!("workspace disappeared before terminal spawn"))?;
+        let surface = self.spawn_surface_in_workspace(&workspace_key, cwd, size, None)?;
         let (pane_id, pane) = self.make_pane(surface.id);
         let screen_id = self.next_id();
         let notifications = self.surface_notifications();
@@ -2269,7 +2792,10 @@ impl Mux {
         };
 
         let cwd = cwd.or_else(|| self.pane_cwd(target));
-        let surface = self.spawn_surface(cwd, size)?;
+        let workspace_key = self
+            .workspace_key_for_pane(target)
+            .ok_or_else(|| anyhow::anyhow!("pane {target} has no workspace"))?;
+        let surface = self.spawn_surface_in_workspace(&workspace_key, cwd, size, None)?;
         let active_at = self.next_active_at();
         let notifications = self.surface_notifications();
         let attached = {
@@ -2330,22 +2856,194 @@ impl Mux {
         name: Option<String>,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<RunPlacement> {
-        let inherited_cwd = {
+        self.create_terminal_in_workspace_impl(workspace, argv, cwd, name, size, None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_terminal_in_workspace_with_mutation(
+        self: &Arc<Self>,
+        workspace: WorkspaceId,
+        argv: Option<Vec<String>>,
+        cwd: Option<String>,
+        name: Option<String>,
+        size: Option<(u16, u16)>,
+        requested_terminal_id: Option<&str>,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<TerminalPlacementResult> {
+        let workspace_key = self
+            .state
+            .lock()
+            .unwrap()
+            .workspace_by_id(workspace)
+            .map(|workspace| workspace.key.clone())
+            .ok_or_else(|| anyhow::anyhow!("unknown workspace {workspace}"))?;
+        if let Some(terminal_id) = requested_terminal_id {
+            validate_terminal_hex(terminal_id, "invalid_terminal_id")?;
+        }
+        let fingerprint = terminal_create_fingerprint(
+            &workspace_key,
+            requested_terminal_id,
+            argv.as_deref(),
+            cwd.as_deref(),
+            name.as_deref(),
+            size,
+        )?;
+        let replay =
+            { self.workspace_registry.lock().unwrap().replay_terminal(mutation, &fingerprint)? };
+        if let Some(replay) = replay {
+            let terminal_id = replay.result["terminal_id"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("stored terminal create result is missing id"))?;
+            return self.replayed_terminal_placement(terminal_id);
+        }
+        let terminal_id = match requested_terminal_id {
+            Some(value) => TerminalId::from_hex(value).expect("validated terminal UUID"),
+            None => TerminalId::random()?,
+        };
+        let reservation = TerminalReservationRequest {
+            terminal_id,
+            mutation: mutation.clone(),
+            fingerprint,
+            expected_generation: expected_generation.map(str::to_string),
+            expected_revision,
+        };
+        let placement = self.create_terminal_in_workspace_impl(
+            workspace,
+            argv,
+            cwd,
+            name,
+            size,
+            Some(reservation),
+        )?;
+        let identity = self
+            .surface(placement.surface)
+            .and_then(|surface| surface.terminal_host_identity())
+            .ok_or_else(|| anyhow::anyhow!("created terminal has no host identity"))?;
+        let snapshot = self.workspace_registry.lock().unwrap().terminal_snapshot()?;
+        Ok(TerminalPlacementResult {
+            placement,
+            terminal_id: identity.terminal_id,
+            terminal_incarnation: Some(identity.incarnation),
+            terminal_revision: snapshot.revision,
+            replayed: false,
+        })
+    }
+
+    fn replayed_terminal_placement(
+        &self,
+        terminal_id: &str,
+    ) -> anyhow::Result<TerminalPlacementResult> {
+        let resolution = self
+            .resolve_terminal(terminal_id)?
+            .ok_or_else(|| anyhow::anyhow!("stored terminal create result has no registry row"))?;
+        let surface = resolution.surface.ok_or_else(|| {
+            anyhow::anyhow!(
+                "terminal_create_pending:{}",
+                terminal_lifecycle_name(resolution.terminal.lifecycle)
+            )
+        })?;
+        let placement = {
+            let state = self.state.lock().unwrap();
+            run_placement_for_surface(&state, surface)
+        }
+        .ok_or_else(|| anyhow::anyhow!("terminal_create_pending:binding"))?;
+        Ok(TerminalPlacementResult {
+            placement,
+            terminal_id: resolution.terminal.terminal_id,
+            terminal_incarnation: resolution.terminal.incarnation,
+            terminal_revision: resolution.terminal_revision,
+            replayed: true,
+        })
+    }
+
+    fn create_terminal_in_workspace_impl(
+        self: &Arc<Self>,
+        workspace: WorkspaceId,
+        argv: Option<Vec<String>>,
+        cwd: Option<String>,
+        name: Option<String>,
+        size: Option<(u16, u16)>,
+        reservation: Option<TerminalReservationRequest>,
+    ) -> anyhow::Result<RunPlacement> {
+        let (workspace_key, inherited_pane) = {
             let state = self.state.lock().unwrap();
             let Some(workspace) = state.workspace_by_id(workspace) else {
                 anyhow::bail!("unknown workspace {workspace}");
             };
-            workspace.active_screen_ref().map(|screen| screen.active_pane)
-        }
-        .and_then(|pane| self.pane_cwd(pane));
-        let surface = self.spawn_surface_with_command(cwd.or(inherited_cwd), size, argv)?;
+            (workspace.key.clone(), workspace.active_screen_ref().map(|screen| screen.active_pane))
+        };
+        let inherited_cwd = inherited_pane.and_then(|pane| self.pane_cwd(pane));
+        let surface = match reservation {
+            Some(reservation) => self.spawn_surface_in_workspace_reserved(
+                &workspace_key,
+                cwd.or(inherited_cwd),
+                size,
+                argv,
+                reservation,
+            )?,
+            None => {
+                self.spawn_surface_in_workspace(&workspace_key, cwd.or(inherited_cwd), size, argv)?
+            }
+        };
         if let Some(name) = name {
             surface.set_name(Some(name));
+        }
+        if let Some(identity) = surface.terminal_host_identity() {
+            // Launch/Ready intentionally releases the registry lock around
+            // process startup. Re-read canonical placement after Ready and
+            // hold registry -> state through the binding so a move committed
+            // during launch is projected instead of the stale request target.
+            let projected = (|| -> anyhow::Result<(RunPlacement, String, bool)> {
+                let registry = self.workspace_registry.lock().unwrap();
+                let terminal = registry
+                    .terminal_record(&identity.terminal_id)?
+                    .ok_or_else(|| anyhow::anyhow!("created terminal has no registry row"))?;
+                if terminal.lifecycle != TerminalLifecycle::Running {
+                    anyhow::bail!(
+                        "created terminal is {} before topology binding",
+                        terminal_lifecycle_name(terminal.lifecycle)
+                    );
+                }
+                let mut state = self.state.lock().unwrap();
+                if !state.surfaces.contains_key(&surface.id) {
+                    anyhow::bail!("terminal closed while its topology binding was being created");
+                }
+                let (placement, changed) = self.project_terminal_to_workspace_in_state(
+                    &mut state,
+                    &identity.terminal_id,
+                    &terminal.workspace_key,
+                )?;
+                let placement = placement
+                    .ok_or_else(|| anyhow::anyhow!("created terminal has no live surface"))?;
+                Ok((placement, terminal.workspace_key, changed))
+            })();
+            let (placement, canonical_workspace, changed) = match projected {
+                Ok(projected) => projected,
+                Err(error) => {
+                    self.fail_hosted_terminal_attachment(
+                        &surface,
+                        "terminal-topology-attach-failed",
+                        "topology-attach-failed",
+                    )?;
+                    return Err(error);
+                }
+            };
+            let _ = surface.persist_host_workspace(&canonical_workspace);
+            if changed {
+                self.emit(MuxEvent::TreeChanged);
+            }
+            self.reap_if_dead(&surface);
+            return Ok(placement);
         }
         let notifications = self.surface_notifications();
         let active_at = self.next_active_at();
         let attached = {
             let mut state = self.state.lock().unwrap();
+            if !state.surfaces.contains_key(&surface.id) {
+                anyhow::bail!("terminal closed while its topology binding was being created");
+            }
             let Some(wi) = state.workspace_index(workspace) else {
                 state.surfaces.remove(&surface.id);
                 surface.kill();
@@ -2772,6 +3470,12 @@ impl Mux {
         surface.and_then(|s| s.pwd())
     }
 
+    fn workspace_key_for_pane(&self, pane: PaneId) -> Option<String> {
+        let state = self.state.lock().unwrap();
+        let (workspace, _) = state.screen_of(pane)?;
+        Some(state.workspaces[workspace].key.clone())
+    }
+
     /// Split the screen containing `target`, putting a new single-tab
     /// pane after it. Returns the new pane's surface. `size` is the
     /// expected content size of the new pane, when the caller knows it.
@@ -2782,7 +3486,10 @@ impl Mux {
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
         let cwd = self.pane_cwd(target);
-        let surface = self.spawn_surface(cwd, size)?;
+        let workspace_key = self
+            .workspace_key_for_pane(target)
+            .ok_or_else(|| anyhow::anyhow!("pane {target} has no workspace"))?;
+        let surface = self.spawn_surface_in_workspace(&workspace_key, cwd, size, None)?;
         let pane_id = self.next_id();
         let active_at = self.next_active_at();
         let mut done = false;
@@ -2851,6 +3558,16 @@ impl Mux {
     /// out of its split tree. Empty workspace containers remain durable;
     /// only an explicit close-workspace mutation removes a workspace.
     pub fn close_surface(&self, target: SurfaceId) {
+        if let Some(surface) = self.surface(target)
+            && let Err(error) = self.tombstone_hosted_surface(&surface)
+        {
+            self.emit(MuxEvent::Status(format!("could not close terminal {target}: {error}")));
+            return;
+        }
+        self.remove_surface_after_registry(target);
+    }
+
+    fn remove_surface_after_registry(&self, target: SurfaceId) {
         let notifications = self.surface_notifications();
         let (removed, changed_screens, empty, delta) = {
             let mut state = self.state.lock().unwrap();
@@ -2884,6 +3601,19 @@ impl Mux {
     /// Close every surface in `tabs` (helper for pane/screen/workspace
     /// close). Emits events outside the lock.
     fn close_surfaces(&self, tabs: Vec<SurfaceId>, delta: TreeDelta) {
+        let surfaces = {
+            let state = self.state.lock().unwrap();
+            tabs.iter().filter_map(|id| state.surfaces.get(id).cloned()).collect::<Vec<_>>()
+        };
+        for surface in &surfaces {
+            if let Err(error) = self.tombstone_hosted_surface(surface) {
+                self.emit(MuxEvent::Status(format!(
+                    "could not close terminal {}: {error}",
+                    surface.id
+                )));
+                return;
+            }
+        }
         let (removed, changed_screens, empty) = {
             let mut state = self.state.lock().unwrap();
             let changed_screens = unique_screen_ids(
@@ -2991,9 +3721,14 @@ impl Mux {
         let notifications = self.surface_notifications();
         let mut registry = self.workspace_registry.lock().unwrap();
         if let Some(commit) = registry.replay(mutation, &fingerprint)? {
-            return workspace_mutation_result(&commit);
+            let result = workspace_mutation_result(&commit)?;
+            let key = result.key.clone();
+            drop(registry);
+            self.terminate_tombstoned_workspace_hosts(&key);
+            return Ok(result);
         }
-        let (removed, delta, empty, result) = {
+        let terminal_revision_before = registry.terminal_snapshot()?.revision;
+        let (removed, delta, empty, result, closed_workspace_key) = {
             let mut state = self.state.lock().unwrap();
             let index = resolve_workspace_index(&state, target, requested_key)?;
             let workspace_id = state.workspaces[index].id;
@@ -3041,12 +3776,18 @@ impl Mux {
             state.workspace_revision = commit.revision;
             delta.workspace_revision = Some(commit.revision);
             let result = workspace_mutation_result(&commit)?;
-            (removed, delta, state.workspaces.is_empty(), result)
+            (removed, delta, state.workspaces.is_empty(), result, key)
         };
+        let terminal_revision_after = registry.terminal_snapshot()?.revision;
+        if terminal_revision_after != terminal_revision_before {
+            self.emit_terminal_registry_changed(&registry, terminal_revision_after);
+        }
+        drop(registry);
         for surface in removed {
             self.purge_surface_side_tables(surface.id);
             surface.kill();
         }
+        self.terminate_tombstoned_workspace_hosts(&closed_workspace_key);
         self.emit(MuxEvent::TreeDelta(delta));
         if empty {
             self.emit(MuxEvent::Empty);
@@ -3245,7 +3986,16 @@ impl Mux {
     /// creator re-checks after the insert (a harmless no-op otherwise).
     fn reap_if_dead(&self, surface: &Arc<Surface>) {
         if surface.is_dead() {
-            self.close_surface(surface.id);
+            if let Err(error) =
+                self.mark_hosted_surface_exited(surface, "host-exited-before-attach")
+            {
+                self.emit(MuxEvent::Status(format!(
+                    "could not persist terminal {} exit: {error}",
+                    surface.id
+                )));
+                return;
+            }
+            self.remove_surface_after_registry(surface.id);
             return;
         }
         let workspace_key = {
@@ -3271,8 +4021,33 @@ impl Mux {
             self.emit(MuxEvent::SurfaceExited(id));
             return;
         }
-        self.close_surface(id);
+        if let Some(surface) = self.surface(id)
+            && let Err(error) = self.mark_hosted_surface_exited(&surface, "host-exited")
+        {
+            self.emit(MuxEvent::Status(format!("could not persist terminal {id} exit: {error}")));
+            return;
+        }
+        self.remove_surface_after_registry(id);
         self.emit(MuxEvent::SurfaceExited(id));
+    }
+
+    fn mark_hosted_surface_exited(
+        &self,
+        surface: &Arc<Surface>,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        let Some(identity) = surface.terminal_host_identity() else {
+            return Ok(());
+        };
+        self.transition_terminal_lifecycle(
+            "terminal-exited",
+            "terminal-host-exited",
+            &identity.terminal_id,
+            TerminalLifecycle::Exited,
+            Some(&identity.incarnation),
+            Some(serde_json::json!({"reason":reason})),
+        )?;
+        Ok(())
     }
 
     fn sidebar_surface_exited(&self, id: SurfaceId) -> bool {
@@ -3417,154 +4192,81 @@ impl Mux {
         layout: &LayoutSpec,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<AppliedLayout> {
-        let new_workspace_key = Self::new_workspace_key()?;
-        {
+        let target_workspace = {
             let state = self.state.lock().unwrap();
             if let Some(id) = workspace
                 && !state.workspaces.iter().any(|ws| ws.id == id)
             {
                 anyhow::bail!("unknown workspace {id}");
             }
-        }
+            workspace.or_else(|| state.workspaces.get(state.active_workspace).map(|ws| ws.id))
+        };
+        let target_workspace = match target_workspace {
+            Some(workspace) => workspace,
+            None => self.create_empty_workspace(None, None, None)?.workspace,
+        };
+        let workspace_key = self
+            .state
+            .lock()
+            .unwrap()
+            .workspace_by_id(target_workspace)
+            .map(|workspace| workspace.key.clone())
+            .ok_or_else(|| anyhow::anyhow!("layout workspace disappeared"))?;
 
         let mut created = Vec::new();
         let mut panes = Vec::new();
         let mut spawned = Vec::new();
-        let root =
-            match self.instantiate_layout(layout, size, &mut panes, &mut created, &mut spawned) {
-                Ok(root) => root,
-                Err(err) => {
-                    self.discard_spawned(spawned);
-                    return Err(err);
-                }
-            };
+        let root = match self.instantiate_layout(
+            layout,
+            size,
+            &workspace_key,
+            &mut panes,
+            &mut created,
+            &mut spawned,
+        ) {
+            Ok(root) => root,
+            Err(err) => {
+                self.discard_spawned(spawned);
+                return Err(err);
+            }
+        };
         let Some(active_pane) = created.first().map(|pane| pane.pane) else {
             self.discard_spawned(spawned);
             anyhow::bail!("layout must contain at least one leaf");
         };
         let screen_id = self.next_id();
-        let new_workspace_id = self.next_id();
         let notifications = self.surface_notifications();
-        let mutation = WorkspaceMutation::local("cmux-tui");
-        let mut registry = self.workspace_registry.lock().unwrap();
         let delta = {
             let mut state = self.state.lock().unwrap();
-            let created_revision = if workspace.is_none() && state.workspaces.is_empty() {
-                let mut desired = self.registry_projection(&state);
-                desired.push(RegistryWorkspace {
-                    id: new_workspace_id,
-                    key: new_workspace_key.clone(),
-                    name: "1".into(),
-                    group_key: self.session.clone(),
-                });
-                let commit = match registry.commit(
-                    &mutation,
-                    &serde_json::json!({
-                        "op": "apply-layout-new-workspace",
-                        "workspace": new_workspace_id,
-                        "key": new_workspace_key.clone(),
-                    }),
-                    None,
-                    None,
-                    "workspace-added",
-                    &new_workspace_key,
-                    &desired,
-                    &serde_json::json!({
-                        "workspace": new_workspace_id,
-                        "key": new_workspace_key.clone(),
-                        "index": 0,
-                    }),
-                ) {
-                    Ok(commit) => commit,
-                    Err(error) => {
-                        drop(state);
-                        drop(registry);
-                        self.discard_spawned(spawned);
-                        return Err(error);
-                    }
-                };
-                Some(commit.revision)
-            } else {
-                None
+            let Some(workspace_index) = state.workspace_index(target_workspace) else {
+                drop(state);
+                self.discard_spawned(spawned);
+                anyhow::bail!("layout workspace disappeared");
             };
             for (pane_id, pane) in panes {
                 state.panes.insert(pane_id, pane);
             }
             let screen = Screen { id: screen_id, name, root, active_pane, zoomed_pane: None };
-            let mut created_workspace = None;
-            let workspace_id = match workspace {
-                Some(id) => {
-                    let workspace_index =
-                        state.workspace_index(id).expect("workspace validated before spawning");
-                    let ws = &mut state.workspaces[workspace_index];
-                    ws.screens.push(screen);
-                    id
-                }
-                None if state.workspaces.is_empty() => {
-                    state.push_workspace(Workspace {
-                        id: new_workspace_id,
-                        key: new_workspace_key,
-                        name: "1".into(),
-                        screens: vec![screen],
-                        active_screen: 0,
-                    });
-                    state.active_workspace = 0;
-                    state.workspace_revision =
-                        created_revision.expect("empty workspace registry commit exists");
-                    created_workspace = Some(new_workspace_id);
-                    new_workspace_id
-                }
-                None => {
-                    let active = state.active_workspace;
-                    let ws =
-                        state.workspaces.get_mut(active).expect("active workspace index valid");
-                    ws.screens.push(screen);
-                    ws.id
-                }
-            };
-            if let Some(workspace_id) = created_workspace {
-                let index = state.workspace_index(workspace_id).expect("new workspace index");
-                let entity = crate::server::tree_entity_json(
-                    &state,
-                    &notifications,
-                    TreeDeltaKind::WorkspaceAdded,
-                    workspace_id,
-                )
-                .expect("applied workspace is present in tree snapshot");
-                TreeDelta {
-                    kind: TreeDeltaKind::WorkspaceAdded,
-                    workspace: workspace_id,
-                    screen: None,
-                    pane: None,
-                    surface: None,
-                    index: Some(index),
-                    entity,
-                    workspace_revision: Some(state.workspace_revision),
-                }
-            } else {
-                let index = state
-                    .workspace_by_id(workspace_id)
-                    .and_then(|workspace| {
-                        workspace.screens.iter().position(|screen| screen.id == screen_id)
-                    })
-                    .expect("new screen index");
-                let entity = crate::server::tree_entity_json(
-                    &state,
-                    &notifications,
-                    TreeDeltaKind::ScreenAdded,
-                    screen_id,
-                )
-                .expect("applied screen is present in tree snapshot");
-                TreeDelta {
-                    kind: TreeDeltaKind::ScreenAdded,
-                    workspace: workspace_id,
-                    screen: Some(screen_id),
-                    pane: None,
-                    surface: None,
-                    index: Some(index),
-                    entity,
-                    workspace_revision: None,
-                }
+            let ws = &mut state.workspaces[workspace_index];
+            ws.screens.push(screen);
+            ws.active_screen = ws.screens.len().saturating_sub(1);
+            let index = ws.active_screen;
+            let entity = crate::server::tree_entity_json(
+                &state,
+                &notifications,
+                TreeDeltaKind::ScreenAdded,
+                screen_id,
+            )
+            .expect("applied screen is present in tree snapshot");
+            TreeDelta {
+                kind: TreeDeltaKind::ScreenAdded,
+                workspace: target_workspace,
+                screen: Some(screen_id),
+                pane: None,
+                surface: None,
+                index: Some(index),
+                entity,
+                workspace_revision: None,
             }
         };
         self.emit(MuxEvent::TreeDelta(delta));
@@ -3579,6 +4281,7 @@ impl Mux {
         self: &Arc<Self>,
         layout: &LayoutSpec,
         size: Option<(u16, u16)>,
+        workspace_key: &str,
         panes: &mut Vec<(PaneId, Pane)>,
         created: &mut Vec<AppliedPane>,
         spawned: &mut Vec<Arc<Surface>>,
@@ -3588,8 +4291,12 @@ impl Mux {
                 if spec.command.as_ref().is_some_and(|argv| argv.is_empty()) {
                     anyhow::bail!("leaf command must not be empty");
                 }
-                let surface =
-                    self.spawn_surface_with(spec.cwd.clone(), spec.command.clone(), size)?;
+                let surface = self.spawn_surface_in_workspace(
+                    workspace_key,
+                    spec.cwd.clone(),
+                    size,
+                    spec.command.clone(),
+                )?;
                 let (pane_id, pane) = self.make_pane(surface.id);
                 created.push(AppliedPane { pane: pane_id, surface: surface.id });
                 panes.push((pane_id, pane));
@@ -3599,8 +4306,22 @@ impl Mux {
             LayoutSpec::Split { dir, ratio, a, b } => Ok(Node::Split {
                 dir: *dir,
                 ratio: clamp_split_ratio(*ratio),
-                a: Box::new(self.instantiate_layout(a, size, panes, created, spawned)?),
-                b: Box::new(self.instantiate_layout(b, size, panes, created, spawned)?),
+                a: Box::new(self.instantiate_layout(
+                    a,
+                    size,
+                    workspace_key,
+                    panes,
+                    created,
+                    spawned,
+                )?),
+                b: Box::new(self.instantiate_layout(
+                    b,
+                    size,
+                    workspace_key,
+                    panes,
+                    created,
+                    spawned,
+                )?),
             }),
         }
     }
@@ -3608,6 +4329,15 @@ impl Mux {
     fn discard_spawned(&self, spawned: Vec<Arc<Surface>>) {
         if spawned.is_empty() {
             return;
+        }
+        for surface in &spawned {
+            if let Err(error) = self.tombstone_hosted_surface(surface) {
+                self.emit(MuxEvent::Status(format!(
+                    "could not close discarded terminal {}: {error}",
+                    surface.id
+                )));
+                return;
+            }
         }
         let ids = spawned.iter().map(|surface| surface.id).collect::<Vec<_>>();
         {
@@ -3621,13 +4351,210 @@ impl Mux {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn move_terminal_with_mutation(
+        &self,
+        terminal_id: &str,
+        workspace_key: &str,
+        expected_incarnation: Option<&str>,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        mutation: &WorkspaceMutation,
+    ) -> anyhow::Result<TerminalMoveResult> {
+        validate_terminal_hex(terminal_id, "invalid_terminal_id")?;
+        if let Some(incarnation) = expected_incarnation {
+            validate_terminal_hex(incarnation, "invalid_terminal_incarnation")?;
+        }
+        let fingerprint = serde_json::json!({
+            "op":"move-terminal",
+            "terminal_id":terminal_id,
+            "workspace_key":workspace_key,
+            "incarnation":expected_incarnation,
+        });
+        let (terminal, terminal_revision, replayed, changed, placement, topology_changed) = {
+            let mut registry = self.workspace_registry.lock().unwrap();
+            // Registry -> state is the global writer order. Holding both from
+            // canonical commit through projection prevents move B / move C
+            // from projecting C and then stale B, and serializes moves with a
+            // concurrent workspace close.
+            let mut state = self.state.lock().unwrap();
+            if let Some(replay) = registry.replay_terminal(mutation, &fingerprint)? {
+                let terminal = registry
+                    .terminal_record(terminal_id)?
+                    .ok_or_else(|| anyhow::anyhow!("unknown terminal {terminal_id}"))?;
+                let changed = replay.result["changed"].as_bool().unwrap_or(true);
+                let (placement, topology_changed) =
+                    if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+                        (None, false)
+                    } else {
+                        self.project_terminal_to_workspace_in_state(
+                            &mut state,
+                            terminal_id,
+                            &terminal.workspace_key,
+                        )?
+                    };
+                (terminal, replay.revision, true, changed, placement, topology_changed)
+            } else {
+                let snapshot = registry.terminal_snapshot()?;
+                let mut terminal = registry
+                    .terminal_record(terminal_id)?
+                    .ok_or_else(|| anyhow::anyhow!("unknown terminal {terminal_id}"))?;
+                if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+                    anyhow::bail!("terminal is already closed");
+                }
+                if let Some(expected) = expected_incarnation
+                    && terminal.incarnation.as_deref() != Some(expected)
+                {
+                    anyhow::bail!("terminal_incarnation_mismatch");
+                }
+                let changed = terminal.workspace_key != workspace_key;
+                terminal.workspace_key = workspace_key.to_string();
+                let commit = registry.commit_terminal(
+                    mutation,
+                    &fingerprint,
+                    expected_generation,
+                    expected_revision.or(Some(snapshot.revision)),
+                    "terminal-moved",
+                    &terminal,
+                    &serde_json::json!({
+                        "terminal_id":terminal_id,
+                        "workspace_key":workspace_key,
+                        "incarnation":terminal.incarnation,
+                        "state":terminal.lifecycle,
+                        "changed":changed,
+                    }),
+                )?;
+                self.emit_terminal_registry_changed(&registry, commit.revision);
+                let (placement, topology_changed) = self.project_terminal_to_workspace_in_state(
+                    &mut state,
+                    terminal_id,
+                    &terminal.workspace_key,
+                )?;
+                (terminal, commit.revision, false, changed, placement, topology_changed)
+            }
+        };
+        if placement.is_some()
+            && let Some(surface) = placement.and_then(|placement| self.surface(placement.surface))
+        {
+            let _ = surface.persist_host_workspace(&terminal.workspace_key);
+        }
+        if topology_changed {
+            self.emit(MuxEvent::TreeChanged);
+        }
+        Ok(TerminalMoveResult { placement, terminal, terminal_revision, replayed, changed })
+    }
+
+    fn project_terminal_to_workspace_in_state(
+        &self,
+        state: &mut State,
+        terminal_id: &str,
+        workspace_key: &str,
+    ) -> anyhow::Result<(Option<RunPlacement>, bool)> {
+        let identity = unique_terminal_match(
+            terminal_id,
+            state.surfaces.values().filter_map(|surface| {
+                surface.terminal_host_identity().map(|identity| (surface.id, identity))
+            }),
+        )?;
+        let Some((surface, _)) = identity else {
+            // Still validate the in-memory projection while both writer locks
+            // are held; a missing destination indicates registry/state drift.
+            if state.workspaces.iter().all(|workspace| workspace.key != workspace_key) {
+                anyhow::bail!("unknown workspace key {workspace_key}");
+            }
+            return Ok((None, false));
+        };
+        let active_at = self.next_active_at();
+        let preserved_focus = current_focus_identity(state);
+        let destination = state
+            .workspaces
+            .iter()
+            .position(|workspace| workspace.key == workspace_key)
+            .ok_or_else(|| anyhow::anyhow!("unknown workspace key {workspace_key}"))?;
+        if let Some(current) = run_placement_for_surface(state, surface)
+            && current.workspace == state.workspaces[destination].id
+        {
+            return Ok((Some(current), false));
+        }
+        let target_pane = state.workspaces[destination]
+            .active_screen_ref()
+            .map(|screen| screen.active_pane)
+            .unwrap_or_else(|| {
+                let pane = self.next_id();
+                let screen = self.next_id();
+                state.panes.insert(
+                    pane,
+                    Pane { id: pane, name: None, tabs: Vec::new(), active_tab: 0, active_at },
+                );
+                state.workspaces[destination].screens.push(Screen {
+                    id: screen,
+                    name: None,
+                    root: Node::Leaf(pane),
+                    active_pane: pane,
+                    zoomed_pane: None,
+                });
+                state.workspaces[destination].active_screen = 0;
+                pane
+            });
+        if state.pane_of(surface).is_some() {
+            if !move_tab_in_state(state, surface, target_pane, usize::MAX) {
+                anyhow::bail!("terminal topology changed during move");
+            }
+        } else {
+            let pane = state
+                .panes
+                .get_mut(&target_pane)
+                .ok_or_else(|| anyhow::anyhow!("destination pane disappeared"))?;
+            pane.tabs.push(surface);
+            pane.active_tab = pane.tabs.len() - 1;
+            pane.active_at = active_at;
+        }
+        restore_focus_identity(state, preserved_focus);
+        let placement = run_placement_for_surface(state, surface)
+            .ok_or_else(|| anyhow::anyhow!("terminal move did not produce a binding"))?;
+        Ok((Some(placement), true))
+    }
+
     /// Move an existing tab to `index` in `pane`. The surface is kept
     /// alive; if moving it empties the source pane, that pane collapses
     /// out of its split tree.
     pub fn move_tab(&self, surface: SurfaceId, pane: PaneId, index: usize) -> bool {
         let active_at = self.next_active_at();
+        let hosted_identity =
+            self.surface(surface).and_then(|surface| surface.terminal_host_identity());
+        let mut registry =
+            hosted_identity.as_ref().map(|_| self.workspace_registry.lock().unwrap());
         let moved = {
             let mut state = self.state.lock().unwrap();
+            let source_workspace_key = state.pane_of(surface).and_then(|source| {
+                state.screen_of(source).map(|(wi, _)| state.workspaces[wi].key.clone())
+            });
+            let target_workspace_key =
+                state.screen_of(pane).map(|(wi, _)| state.workspaces[wi].key.clone());
+            let (Some(source_workspace_key), Some(target_workspace_key)) =
+                (source_workspace_key, target_workspace_key)
+            else {
+                return false;
+            };
+            if source_workspace_key != target_workspace_key
+                && let (Some(identity), Some(registry)) =
+                    (hosted_identity.as_ref(), registry.as_deref_mut())
+            {
+                match commit_terminal_workspace(
+                    registry,
+                    &identity.terminal_id,
+                    &target_workspace_key,
+                ) {
+                    Ok(revision) => self.emit_terminal_registry_changed(registry, revision),
+                    Err(error) => {
+                        self.emit(MuxEvent::Status(format!(
+                            "could not move terminal {}: {error}",
+                            identity.terminal_id
+                        )));
+                        return false;
+                    }
+                }
+            }
             let moved = move_tab_in_state(&mut state, surface, pane, index);
             if moved {
                 stamp_pane(&mut state, pane, active_at);
@@ -3635,6 +4562,11 @@ impl Mux {
             moved
         };
         if moved {
+            if let Some(surface) = self.surface(surface)
+                && let Some(workspace_key) = self.workspace_key_for_pane(pane)
+            {
+                let _ = surface.persist_host_workspace(&workspace_key);
+            }
             self.emit(MuxEvent::TreeChanged);
         }
         moved
@@ -3653,6 +4585,25 @@ impl Mux {
         index: usize,
         expected_revision: Option<u64>,
     ) -> anyhow::Result<Option<(u64, bool)>> {
+        {
+            let state = self.state.lock().unwrap();
+            let Some(old_index) = state.workspace_index(workspace) else {
+                return Ok(None);
+            };
+            if let Some(expected) = expected_revision
+                && expected != state.workspace_revision
+            {
+                anyhow::bail!(
+                    "workspace revision conflict: expected {expected}, current {}",
+                    state.workspace_revision
+                );
+            }
+            let new_index = if index > old_index { index.saturating_sub(1) } else { index }
+                .min(state.workspaces.len().saturating_sub(1));
+            if new_index == old_index {
+                return Ok(Some((state.workspace_revision, false)));
+            }
+        }
         let mutation = WorkspaceMutation::local("cmux-tui");
         let result = self.move_workspace_with_mutation(
             Some(workspace),
@@ -3830,6 +4781,225 @@ impl Mux {
     }
 }
 
+fn terminal_launch_spec(options: &SurfaceOptions) -> Value {
+    let cmux_env = options
+        .extra_env
+        .iter()
+        .map(|(key, _)| key.as_str())
+        .filter(|key| matches!(*key, "CMUX_TUI_SOCKET" | "CMUX_MUX_SOCKET" | "CMUX_SIDEBAR"))
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        // This is diagnostic shape, not a respawn recipe. argv and cwd can
+        // both contain credentials and missing hosts are never recreated.
+        "command_present": options.command.is_some(),
+        "cwd_present": options.cwd.is_some(),
+        "term": options.term,
+        "cols": options.cols,
+        "rows": options.rows,
+        "scrollback": options.scrollback,
+        // Values are deliberately absent: launch environments routinely
+        // contain bearer credentials and SQLite is durable frontend state,
+        // not a secret store or a shell-respawn recipe.
+        "cmux_env": cmux_env,
+    })
+}
+
+/// Durable exactly-once metadata must distinguish retries without turning the
+/// workspace registry into a second secret store. Command arguments, cwd, and
+/// user-provided names can all contain credentials, so only their digest is
+/// persisted alongside the non-secret routing identity.
+fn terminal_create_fingerprint(
+    workspace_key: &str,
+    terminal_id: Option<&str>,
+    argv: Option<&[String]>,
+    cwd: Option<&str>,
+    name: Option<&str>,
+    size: Option<(u16, u16)>,
+) -> anyhow::Result<Value> {
+    let request = serde_json::json!({
+        "argv": argv,
+        "cwd": cwd,
+        "name": name,
+        "size": size,
+    });
+    let digest = Sha256::digest(serde_json::to_vec(&request)?);
+    let request_sha256 = digest.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    Ok(serde_json::json!({
+        "op": "create-terminal",
+        "workspace_key": workspace_key,
+        "terminal_id": terminal_id,
+        "request_sha256": request_sha256,
+    }))
+}
+
+fn terminal_lifecycle_name(lifecycle: TerminalLifecycle) -> &'static str {
+    match lifecycle {
+        TerminalLifecycle::Launching => "launching",
+        TerminalLifecycle::Adopting => "adopting",
+        TerminalLifecycle::Running => "running",
+        TerminalLifecycle::Exited => "exited",
+        TerminalLifecycle::Tombstoned => "tombstoned",
+    }
+}
+
+fn run_placement_for_surface(state: &State, surface: SurfaceId) -> Option<RunPlacement> {
+    let pane = state.pane_of(surface)?;
+    let (workspace_index, screen_index) = state.screen_of(pane)?;
+    Some(RunPlacement {
+        surface,
+        pane,
+        screen: state.workspaces[workspace_index].screens[screen_index].id,
+        workspace: state.workspaces[workspace_index].id,
+    })
+}
+
+type FocusIdentity = (WorkspaceId, ScreenId, PaneId);
+
+fn current_focus_identity(state: &State) -> Option<FocusIdentity> {
+    let workspace = state.workspaces.get(state.active_workspace)?;
+    let screen = workspace.active_screen_ref()?;
+    Some((workspace.id, screen.id, screen.active_pane))
+}
+
+fn restore_focus_identity(state: &mut State, focus: Option<FocusIdentity>) {
+    let Some((workspace_id, screen_id, pane_id)) = focus else { return };
+    let Some(workspace_index) = state.workspace_index(workspace_id) else { return };
+    state.active_workspace = workspace_index;
+    let Some(screen_index) =
+        state.workspaces[workspace_index].screens.iter().position(|screen| screen.id == screen_id)
+    else {
+        return;
+    };
+    state.workspaces[workspace_index].active_screen = screen_index;
+    if state.workspaces[workspace_index].screens[screen_index].root.contains(pane_id) {
+        state.workspaces[workspace_index].screens[screen_index].active_pane = pane_id;
+    }
+}
+
+fn commit_terminal_transition(
+    registry: &mut WorkspaceRegistry,
+    event_kind: &str,
+    operation: &str,
+    terminal: &RegistryTerminal,
+) -> anyhow::Result<u64> {
+    let mutation = WorkspaceMutation::local("cmux-tui-runtime");
+    let commit = registry.commit_terminal(
+        &mutation,
+        &serde_json::json!({
+            "op": operation,
+            "terminal_id": terminal.terminal_id,
+            "workspace_key": terminal.workspace_key,
+            "incarnation": terminal.incarnation,
+            "lifecycle": terminal.lifecycle,
+        }),
+        None,
+        None,
+        event_kind,
+        terminal,
+        &serde_json::json!({
+            "terminal_id": terminal.terminal_id,
+            "workspace_key": terminal.workspace_key,
+            "incarnation": terminal.incarnation,
+            "state": terminal.lifecycle,
+        }),
+    )?;
+    Ok(commit.revision)
+}
+
+/// Advance only renderer lifecycle fields from the latest durable row. This
+/// deliberately re-reads under the registry writer mutex and uses the
+/// terminal revision as a CAS: a GUI move committed while a host launch or
+/// adoption was in flight can never be overwritten by a stale row clone.
+fn commit_terminal_lifecycle(
+    registry: &mut WorkspaceRegistry,
+    event_kind: &str,
+    operation: &str,
+    terminal_id: &str,
+    lifecycle: TerminalLifecycle,
+    incarnation: Option<&str>,
+    exit: Option<Value>,
+) -> anyhow::Result<(RegistryTerminal, u64)> {
+    let snapshot = registry.terminal_snapshot()?;
+    let mut terminal = registry
+        .terminal_record(terminal_id)?
+        .ok_or_else(|| anyhow::anyhow!("unknown terminal {terminal_id}"))?;
+    terminal.lifecycle = lifecycle;
+    if let Some(incarnation) = incarnation {
+        terminal.incarnation = Some(incarnation.to_string());
+    }
+    terminal.exit = exit;
+    let mutation = WorkspaceMutation::local("cmux-tui-runtime");
+    let commit = registry.commit_terminal(
+        &mutation,
+        &serde_json::json!({
+            "op": operation,
+            "terminal_id": terminal.terminal_id,
+            "incarnation": terminal.incarnation,
+            "lifecycle": terminal.lifecycle,
+        }),
+        Some(&snapshot.generation),
+        Some(snapshot.revision),
+        event_kind,
+        &terminal,
+        &serde_json::json!({
+            "terminal_id": terminal.terminal_id,
+            "workspace_key": terminal.workspace_key,
+            "incarnation": terminal.incarnation,
+            "state": terminal.lifecycle,
+        }),
+    )?;
+    Ok((terminal, commit.revision))
+}
+
+fn commit_terminal_workspace(
+    registry: &mut WorkspaceRegistry,
+    terminal_id: &str,
+    workspace_key: &str,
+) -> anyhow::Result<u64> {
+    let snapshot = registry.terminal_snapshot()?;
+    let mut terminal = registry
+        .terminal_record(terminal_id)?
+        .ok_or_else(|| anyhow::anyhow!("unknown terminal {terminal_id}"))?;
+    if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+        anyhow::bail!("terminal is already closed");
+    }
+    terminal.workspace_key = workspace_key.to_string();
+    let mutation = WorkspaceMutation::local("cmux-tui-runtime");
+    let commit = registry.commit_terminal(
+        &mutation,
+        &serde_json::json!({
+            "op":"move-terminal",
+            "terminal_id":terminal_id,
+            "workspace_key":workspace_key,
+        }),
+        Some(&snapshot.generation),
+        Some(snapshot.revision),
+        "terminal-moved",
+        &terminal,
+        &serde_json::json!({
+            "terminal_id":terminal_id,
+            "workspace_key":workspace_key,
+            "incarnation":terminal.incarnation,
+            "state":terminal.lifecycle,
+        }),
+    )?;
+    Ok(commit.revision)
+}
+
+#[cfg(unix)]
+fn terminate_host_record(
+    record: crate::terminal_host_runtime::TerminalHostRecord,
+    record_path: std::path::PathBuf,
+) -> bool {
+    if let Ok(host) = crate::terminal_host_runtime::adopt_terminal_host(record, record_path) {
+        let terminated = host.terminate().is_ok();
+        host.disconnect();
+        terminated
+    } else {
+        false
+    }
+}
+
 fn insert_surface_checked(state: &mut State, surface: Arc<Surface>) -> anyhow::Result<()> {
     if state.surfaces.contains_key(&surface.id) {
         anyhow::bail!("duplicate_surface_id");
@@ -3850,9 +5020,7 @@ fn insert_surface_checked(state: &mut State, surface: Arc<Surface>) -> anyhow::R
 }
 
 fn validate_terminal_hex(value: &str, error: &'static str) -> anyhow::Result<()> {
-    if value.len() != crate::terminal_host::TERMINAL_ID_LEN * 2
-        || !value.bytes().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
-    {
+    if TerminalId::from_hex(value).is_none() {
         anyhow::bail!(error);
     }
     Ok(())
@@ -4278,6 +5446,102 @@ mod tests {
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())
+    }
+
+    #[test]
+    fn terminal_registry_launch_spec_never_persists_environment_secrets() {
+        let sentinel = "cmux-secret-sentinel-do-not-persist";
+        let mut options = SurfaceOptions::default();
+        options.command = Some(vec!["/bin/sh".into(), "-c".into(), sentinel.into()]);
+        options.cwd = Some(format!("/tmp/{sentinel}"));
+        options.extra_env = vec![
+            ("API_BEARER_TOKEN".into(), sentinel.into()),
+            ("CMUX_TUI_SOCKET".into(), "/tmp/cmux.sock".into()),
+        ];
+        let encoded = serde_json::to_string(&terminal_launch_spec(&options)).unwrap();
+        assert!(!encoded.contains(sentinel));
+        assert!(!encoded.contains("API_BEARER_TOKEN"));
+        assert!(!encoded.contains("/tmp/cmux.sock"));
+        assert!(!encoded.contains("/bin/sh"));
+        assert!(encoded.contains("CMUX_TUI_SOCKET"));
+    }
+
+    #[test]
+    fn terminal_create_mutation_persists_only_a_secret_free_digest() {
+        const TERMINAL: &str = "00000000000040008000000000000009";
+        let sentinel = "cmux-create-secret-sentinel-do-not-persist";
+        let root = std::env::temp_dir()
+            .join(format!("cmux-create-fingerprint-{}", crate::workspace_registry::new_uuid_v4()));
+        let argv = vec!["/bin/sh".to_string(), "-c".to_string(), sentinel.to_string()];
+        let cwd = format!("/tmp/{sentinel}");
+        let name = format!("terminal-{sentinel}");
+        let fingerprint = terminal_create_fingerprint(
+            "workspace-one",
+            Some(TERMINAL),
+            Some(&argv),
+            Some(&cwd),
+            Some(&name),
+            Some((80, 24)),
+        )
+        .unwrap();
+        assert!(!serde_json::to_string(&fingerprint).unwrap().contains(sentinel));
+
+        {
+            let mut registry = WorkspaceRegistry::open(&root, "secret-test").unwrap();
+            registry
+                .commit(
+                    &WorkspaceMutation::new("workspace", "test").unwrap(),
+                    &serde_json::json!({"op":"create-workspace"}),
+                    None,
+                    Some(0),
+                    "workspace-added",
+                    "workspace-one",
+                    &[RegistryWorkspace {
+                        id: 1,
+                        key: "workspace-one".into(),
+                        name: "One".into(),
+                        group_key: "secret-test".into(),
+                    }],
+                    &serde_json::json!({"workspace":1,"key":"workspace-one"}),
+                )
+                .unwrap();
+            registry
+                .commit_terminal(
+                    &WorkspaceMutation::new("create", "browser").unwrap(),
+                    &fingerprint,
+                    None,
+                    Some(0),
+                    "terminal-reserved",
+                    &RegistryTerminal {
+                        terminal_id: TERMINAL.into(),
+                        workspace_key: "workspace-one".into(),
+                        incarnation: None,
+                        lifecycle: TerminalLifecycle::Launching,
+                        launch_spec: serde_json::json!({"command_present":true}),
+                        exit: None,
+                    },
+                    &serde_json::json!({"terminal_id":TERMINAL}),
+                )
+                .unwrap();
+        }
+
+        fn assert_tree_does_not_contain(path: &Path, needle: &[u8]) {
+            for entry in std::fs::read_dir(path).unwrap() {
+                let path = entry.unwrap().path();
+                if path.is_dir() {
+                    assert_tree_does_not_contain(&path, needle);
+                } else {
+                    let bytes = std::fs::read(&path).unwrap();
+                    assert!(
+                        !bytes.windows(needle.len()).any(|window| window == needle),
+                        "secret persisted in {}",
+                        path.display()
+                    );
+                }
+            }
+        }
+        assert_tree_does_not_contain(&root, sentinel.as_bytes());
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
@@ -5487,6 +6751,232 @@ mod tests {
             assert!(state.workspaces.iter().all(|workspace| workspace.screens.is_empty()));
         });
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restart_marks_reserved_terminal_without_host_record_exited_without_respawn() {
+        const TERMINAL: &str = "00000000000040008000000000000001";
+        let root = std::env::temp_dir().join(format!(
+            "cmux-mux-terminal-crash-window-{}",
+            crate::workspace_registry::new_uuid_v4()
+        ));
+        {
+            let mut registry = WorkspaceRegistry::open(&root, "recover-terminal").unwrap();
+            registry
+                .commit(
+                    &WorkspaceMutation::new("workspace", "test").unwrap(),
+                    &serde_json::json!({"op":"create-workspace"}),
+                    None,
+                    Some(0),
+                    "workspace-added",
+                    "workspace-one",
+                    &[RegistryWorkspace {
+                        id: 1,
+                        key: "workspace-one".into(),
+                        name: "One".into(),
+                        group_key: "recover-terminal".into(),
+                    }],
+                    &serde_json::json!({"workspace":1,"key":"workspace-one"}),
+                )
+                .unwrap();
+            registry
+                .commit_terminal(
+                    &WorkspaceMutation::new("reserve", "test").unwrap(),
+                    &serde_json::json!({"op":"create-terminal","terminal_id":TERMINAL}),
+                    None,
+                    Some(0),
+                    "terminal-reserved",
+                    &RegistryTerminal {
+                        terminal_id: TERMINAL.into(),
+                        workspace_key: "workspace-one".into(),
+                        incarnation: None,
+                        lifecycle: TerminalLifecycle::Launching,
+                        launch_spec: serde_json::json!({"command_present":true}),
+                        exit: None,
+                    },
+                    &serde_json::json!({"terminal_id":TERMINAL}),
+                )
+                .unwrap();
+        }
+        let mut options = SurfaceOptions::default();
+        options.terminal_host_root =
+            Some(crate::terminal_host_runtime::terminal_host_root(&root, "recover-terminal"));
+        let mux = Mux::open_persistent("recover-terminal", options, &root).unwrap();
+        let resolved = mux.resolve_terminal(TERMINAL).unwrap().unwrap();
+        assert_eq!(resolved.surface, None);
+        assert_eq!(resolved.terminal.lifecycle, TerminalLifecycle::Exited);
+        assert_eq!(resolved.terminal.exit.unwrap()["reason"], "missing-host-record");
+        assert_eq!(resolved.terminal_revision, 2);
+        mux.shutdown();
+        drop(mux);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn late_lifecycle_transition_preserves_latest_canonical_workspace_move() {
+        const TERMINAL: &str = "00000000000040008000000000000002";
+        const INCARNATION: &str = "10000000000040008000000000000001";
+        let mux = test_mux();
+        let first = mux.create_empty_workspace(None, Some("first".into()), None).unwrap();
+        let second = mux.create_empty_workspace(None, Some("second".into()), None).unwrap();
+        {
+            let mut registry = mux.workspace_registry.lock().unwrap();
+            let reserved = RegistryTerminal {
+                terminal_id: TERMINAL.into(),
+                workspace_key: first.key,
+                incarnation: None,
+                lifecycle: TerminalLifecycle::Launching,
+                launch_spec: serde_json::json!({"command_present":true}),
+                exit: None,
+            };
+            commit_terminal_transition(
+                &mut registry,
+                "terminal-reserved",
+                "reserve-terminal",
+                &reserved,
+            )
+            .unwrap();
+            commit_terminal_lifecycle(
+                &mut registry,
+                "terminal-ready",
+                "terminal-ready",
+                TERMINAL,
+                TerminalLifecycle::Running,
+                Some(INCARNATION),
+                None,
+            )
+            .unwrap();
+            commit_terminal_workspace(&mut registry, TERMINAL, &second.key).unwrap();
+        }
+        mux.transition_terminal_lifecycle(
+            "terminal-exited",
+            "host-exited",
+            TERMINAL,
+            TerminalLifecycle::Exited,
+            Some(INCARNATION),
+            Some(serde_json::json!({"reason":"test"})),
+        )
+        .unwrap();
+        let terminal = mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal;
+        assert_eq!(terminal.workspace_key, second.key);
+        assert_eq!(terminal.lifecycle, TerminalLifecycle::Exited);
+        assert_eq!(terminal.launch_spec, serde_json::json!({"command_present":true}));
+    }
+
+    #[test]
+    fn stale_move_replay_projects_the_latest_canonical_workspace() {
+        const TERMINAL: &str = "00000000000040008000000000000003";
+        let mux = test_mux();
+        let first = mux.create_empty_workspace(None, Some("move-a".into()), None).unwrap();
+        let second = mux.create_empty_workspace(None, Some("move-b".into()), None).unwrap();
+        let third = mux.create_empty_workspace(None, Some("move-c".into()), None).unwrap();
+        {
+            let mut registry = mux.workspace_registry.lock().unwrap();
+            commit_terminal_transition(
+                &mut registry,
+                "terminal-reserved",
+                "reserve-terminal",
+                &RegistryTerminal {
+                    terminal_id: TERMINAL.into(),
+                    workspace_key: first.key,
+                    incarnation: None,
+                    lifecycle: TerminalLifecycle::Launching,
+                    launch_spec: serde_json::json!({"command_present":true}),
+                    exit: None,
+                },
+            )
+            .unwrap();
+        }
+        let events = mux.subscribe();
+        let first_move = WorkspaceMutation::new("move-one", "browser").unwrap();
+        let moved = mux
+            .move_terminal_with_mutation(TERMINAL, &second.key, None, None, Some(1), &first_move)
+            .unwrap();
+        assert_eq!(moved.terminal.workspace_key, second.key);
+        let MuxEvent::TerminalRegistryChanged { terminal_revision, .. } = events.recv().unwrap()
+        else {
+            panic!("expected terminal registry barrier");
+        };
+        assert_eq!(terminal_revision, 2);
+        mux.move_terminal_with_mutation(
+            TERMINAL,
+            &third.key,
+            None,
+            None,
+            Some(2),
+            &WorkspaceMutation::new("move-two", "browser").unwrap(),
+        )
+        .unwrap();
+        let replay = mux
+            .move_terminal_with_mutation(TERMINAL, &second.key, None, None, Some(1), &first_move)
+            .unwrap();
+        assert!(replay.replayed);
+        assert_eq!(replay.terminal.workspace_key, third.key);
+        assert_eq!(
+            mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal.workspace_key,
+            third.key
+        );
+    }
+
+    #[test]
+    fn move_terminal_to_missing_workspace_fails_without_changing_placement() {
+        const TERMINAL: &str = "00000000000040008000000000000004";
+        let mux = test_mux();
+        let first = mux.create_empty_workspace(None, Some("move-live".into()), None).unwrap();
+        {
+            let mut registry = mux.workspace_registry.lock().unwrap();
+            commit_terminal_transition(
+                &mut registry,
+                "terminal-reserved",
+                "reserve-terminal",
+                &RegistryTerminal {
+                    terminal_id: TERMINAL.into(),
+                    workspace_key: first.key.clone(),
+                    incarnation: None,
+                    lifecycle: TerminalLifecycle::Launching,
+                    launch_spec: serde_json::json!({}),
+                    exit: None,
+                },
+            )
+            .unwrap();
+        }
+        let error = mux
+            .move_terminal_with_mutation(
+                TERMINAL,
+                "missing-workspace",
+                None,
+                None,
+                Some(1),
+                &WorkspaceMutation::new("move-missing", "browser").unwrap(),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("workspace is missing or closed"));
+        assert_eq!(
+            mux.resolve_terminal(TERMINAL).unwrap().unwrap().terminal.workspace_key,
+            first.key
+        );
+    }
+
+    #[test]
+    fn remote_terminal_projection_restores_unrelated_tui_focus() {
+        let mux = test_mux();
+        let moving = mux.new_workspace(Some("source".into()), None).unwrap();
+        let destination = mux.new_workspace(Some("destination".into()), None).unwrap();
+        let focused = mux.new_workspace(Some("focused".into()), None).unwrap();
+        let (destination_pane, focused_pane) = mux.with_state(|state| {
+            (state.pane_of(destination.id).unwrap(), state.pane_of(focused.id).unwrap())
+        });
+        assert!(mux.focus_pane(focused_pane));
+        let before = mux.with_state(current_focus_identity);
+        {
+            let mut state = mux.state.lock().unwrap();
+            let preserved = current_focus_identity(&state);
+            assert!(move_tab_in_state(&mut state, moving.id, destination_pane, usize::MAX));
+            restore_focus_identity(&mut state, preserved);
+        }
+        assert_eq!(mux.with_state(current_focus_identity), before);
+        assert_eq!(mux.with_state(|state| state.pane_of(moving.id)), Some(destination_pane));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -133,6 +133,43 @@ pub fn runtime_dir() -> PathBuf {
     runtime_base_dir().join(format!("cmux-tui-{}", user_id_component()))
 }
 
+/// Default root for durable workspace/session state. Runtime sockets stay in
+/// the short-lived runtime directory; canonical identities and mutation
+/// ledgers live here across daemon and machine reboots.
+pub fn workspace_state_dir() -> Option<PathBuf> {
+    if let Some(path) = env_path("CMUX_TUI_STATE_DIR") {
+        return Some(path);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return home_dir().map(|home| {
+            home.join("Library").join("Application Support").join("cmux-tui").join("sessions")
+        });
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return env_path("XDG_STATE_HOME")
+            .map(|state| state.join("cmux-tui").join("sessions"))
+            .or_else(|| {
+                home_dir()
+                    .map(|home| home.join(".local").join("state").join("cmux-tui").join("sessions"))
+            });
+    }
+    #[cfg(windows)]
+    {
+        return env_path("LOCALAPPDATA").map(|dir| dir.join("cmux-tui").join("sessions"));
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "linux"), not(windows)))]
+    {
+        env_path("XDG_STATE_HOME").map(|state| state.join("cmux-tui").join("sessions")).or_else(
+            || {
+                home_dir()
+                    .map(|home| home.join(".local").join("state").join("cmux-tui").join("sessions"))
+            },
+        )
+    }
+}
+
 /// User config file path, honoring explicit env overrides before the default
 /// cmux config directory. `cmux-tui.json` is preferred, with `mux.json`
 /// retained as a compatibility fallback for existing installs.

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -142,9 +142,9 @@ pub fn workspace_state_dir() -> Option<PathBuf> {
     }
     #[cfg(target_os = "macos")]
     {
-        return home_dir().map(|home| {
+        home_dir().map(|home| {
             home.join("Library").join("Application Support").join("cmux-tui").join("sessions")
-        });
+        })
     }
     #[cfg(target_os = "linux")]
     {

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -77,6 +77,13 @@ enum Command {
         kind: Option<String>,
     },
     ListClients,
+    /// Canonical non-tombstoned terminal placement/lifecycle snapshot.
+    ListTerminals,
+    /// Durable ordered terminal mutations after `terminal_revision`.
+    TerminalEvents {
+        #[serde(default)]
+        after_revision: u64,
+    },
     SetClientSizing {
         #[serde(default)]
         client: Option<u64>,
@@ -229,7 +236,10 @@ enum Command {
     /// generations; the incarnation guard prevents a stale close request.
     CloseTerminal {
         terminal_id: String,
-        terminal_incarnation: String,
+        #[serde(default)]
+        terminal_incarnation: Option<String>,
+        #[serde(flatten)]
+        mutation: MutationRequest,
     },
     /// New tab in a pane (default: the active pane).
     NewTab {
@@ -349,6 +359,12 @@ enum Command {
         cols: Option<u16>,
         #[serde(default)]
         rows: Option<u16>,
+        /// Optional frontend-reserved canonical UUID. Supplying it with a
+        /// mutation id makes a lost-response retry exactly once.
+        #[serde(default)]
+        terminal_id: Option<String>,
+        #[serde(flatten)]
+        mutation: MutationRequest,
     },
     /// New screen in a workspace (default: the active one).
     NewScreen {
@@ -398,6 +414,14 @@ enum Command {
     },
     ProcessInfo {
         surface: SurfaceId,
+    },
+    MoveTerminal {
+        terminal_id: String,
+        workspace_key: String,
+        #[serde(default)]
+        terminal_incarnation: Option<String>,
+        #[serde(flatten)]
+        mutation: MutationRequest,
     },
     MoveTab {
         surface: SurfaceId,
@@ -530,7 +554,7 @@ struct MutationRequest {
     mutation_id: Option<String>,
     #[serde(default)]
     expected_generation: Option<String>,
-    #[serde(default)]
+    #[serde(default, alias = "expected_terminal_revision")]
     expected_revision: Option<u64>,
 }
 
@@ -2479,6 +2503,7 @@ fn handle_command(
                 "registry_id": registry_id,
                 "generation": generation,
                 "workspace_revision": mux.with_state(|state| state.workspace_revision),
+                "terminal_revision": mux.terminal_registry_snapshot()?.revision,
             });
             if let Some(commit) =
                 option_env!("CMUX_TUI_BUILD_COMMIT").or(option_env!("CMUX_MUX_BUILD_COMMIT"))
@@ -2501,6 +2526,53 @@ fn handle_command(
             Ok(json!({}))
         }
         Command::ListClients => Ok(mux.control_clients_json(client)),
+        Command::ListTerminals => {
+            let snapshot = mux.terminal_registry_snapshot()?;
+            let terminals = snapshot
+                .terminals
+                .into_iter()
+                .map(|terminal| {
+                    json!({
+                        "terminal_id":terminal.terminal_id,
+                        "workspace_key":terminal.workspace_key,
+                        "terminal_incarnation":terminal.incarnation,
+                        "lifecycle":terminal.lifecycle,
+                        "launch_spec":terminal.launch_spec,
+                        "exit":terminal.exit,
+                    })
+                })
+                .collect::<Vec<_>>();
+            Ok(json!({
+                "registry_id":snapshot.registry_id,
+                "generation":snapshot.generation,
+                "terminal_revision":snapshot.revision,
+                "terminals":terminals,
+            }))
+        }
+        Command::TerminalEvents { after_revision } => {
+            let snapshot = mux.terminal_registry_snapshot()?;
+            let events = mux
+                .terminal_registry_events_after(after_revision)?
+                .into_iter()
+                .map(|event| {
+                    json!({
+                        "terminal_revision":event.revision,
+                        "kind":event.kind,
+                        "terminal_id":event.terminal_id,
+                        "workspace_key":event.workspace_key,
+                        "origin":event.origin,
+                        "mutation_id":event.mutation_id,
+                        "result":event.result,
+                    })
+                })
+                .collect::<Vec<_>>();
+            Ok(json!({
+                "registry_id":snapshot.registry_id,
+                "generation":snapshot.generation,
+                "terminal_revision":snapshot.revision,
+                "events":events,
+            }))
+        }
         Command::SetClientSizing { client: target, enabled, exclusive } => {
             if exclusive && !enabled {
                 anyhow::bail!("exclusive client sizing must be enabled");
@@ -2560,6 +2632,7 @@ fn handle_command(
             let (registry_id, generation) = mux.registry_identity();
             workspaces["registry_id"] = json!(registry_id);
             workspaces["generation"] = json!(generation);
+            workspaces["terminal_revision"] = json!(mux.terminal_registry_snapshot()?.revision);
             Ok(workspaces)
         }
         Command::GetFrontendProjection { frontend, scope, subject_key } => {
@@ -2850,23 +2923,42 @@ fn handle_command(
             }))
         }
         Command::ResolveTerminal { terminal_id } => {
-            let Some((surface, identity)) = mux.resolve_terminal(&terminal_id)? else {
+            let Some(resolution) = mux.resolve_terminal(&terminal_id)? else {
                 anyhow::bail!("terminal_not_found");
             };
+            let (registry_id, generation) = mux.registry_identity();
             Ok(json!({
-                "surface": surface,
-                "terminal_id": identity.terminal_id,
-                "terminal_incarnation": identity.incarnation,
+                "surface": resolution.surface,
+                "terminal_id": resolution.terminal.terminal_id,
+                "terminal_incarnation": resolution.terminal.incarnation,
+                "workspace_key": resolution.terminal.workspace_key,
+                "lifecycle": resolution.terminal.lifecycle,
+                "launch_spec": resolution.terminal.launch_spec,
+                "exit": resolution.terminal.exit,
+                "terminal_revision": resolution.terminal_revision,
+                "registry_id": registry_id,
+                "generation": generation,
             }))
         }
-        Command::CloseTerminal { terminal_id, terminal_incarnation } => {
-            let Some(surface) = mux.close_terminal(&terminal_id, &terminal_incarnation)? else {
-                anyhow::bail!("terminal_not_found");
-            };
+        Command::CloseTerminal { terminal_id, terminal_incarnation, mutation } => {
+            let workspace_mutation = workspace_mutation(&mutation)?;
+            let result = mux.close_terminal_with_mutation(
+                &terminal_id,
+                terminal_incarnation.as_deref(),
+                mutation.expected_generation.as_deref(),
+                mutation.expected_revision,
+                &workspace_mutation,
+            )?;
+            let (registry_id, generation) = mux.registry_identity();
             Ok(json!({
-                "surface": surface,
-                "terminal_id": terminal_id,
-                "terminal_incarnation": terminal_incarnation,
+                "surface": result.surface,
+                "terminal_id": result.terminal_id,
+                "terminal_incarnation": result.terminal_incarnation,
+                "already_closed": result.already_closed,
+                "closed": true,
+                "terminal_revision": result.terminal_revision,
+                "registry_id": registry_id,
+                "generation": generation,
             }))
         }
         Command::NewTab { pane, cwd, cols, rows } => {
@@ -3014,7 +3106,18 @@ fn handle_command(
                 "generation": generation,
             }))
         }
-        Command::CreateTerminal { workspace, key, argv, command, cwd, name, cols, rows } => {
+        Command::CreateTerminal {
+            workspace,
+            key,
+            argv,
+            command,
+            cwd,
+            name,
+            cols,
+            rows,
+            terminal_id,
+            mutation,
+        } => {
             if argv.is_some() && command.is_some() {
                 anyhow::bail!("argv and command are mutually exclusive");
             }
@@ -3027,26 +3130,62 @@ fn handle_command(
                 _ => anyhow::bail!("argv or command must be non-empty when provided"),
             };
             let (workspace, key) = resolve_workspace(mux, workspace, key.as_deref())?;
-            let placement = mux.create_terminal_in_workspace(
-                workspace,
-                argv,
-                cwd,
-                name,
-                optional_surface_size(cols, rows),
-            )?;
-            let terminal_identity =
-                mux.surface(placement.surface).and_then(|surface| surface.terminal_host_identity());
-            Ok(json!({
-                "surface": placement.surface,
-                "terminal_id": terminal_identity.as_ref().map(|identity| &identity.terminal_id),
-                "terminal_incarnation": terminal_identity
-                    .as_ref()
-                    .map(|identity| &identity.incarnation),
-                "pane": placement.pane,
-                "screen": placement.screen,
-                "workspace": placement.workspace,
-                "key": key,
-            }))
+            let (registry_id, generation) = mux.registry_identity();
+            if terminal_id.is_some() || mutation.mutation_id.is_some() {
+                let workspace_mutation = workspace_mutation(&mutation)?;
+                let result = mux.create_terminal_in_workspace_with_mutation(
+                    workspace,
+                    argv,
+                    cwd,
+                    name,
+                    optional_surface_size(cols, rows),
+                    terminal_id.as_deref(),
+                    mutation.expected_generation.as_deref(),
+                    mutation.expected_revision,
+                    &workspace_mutation,
+                )?;
+                let placement = result.placement;
+                Ok(json!({
+                    "surface": placement.surface,
+                    "terminal_id": result.terminal_id,
+                    "terminal_incarnation": result.terminal_incarnation,
+                    "pane": placement.pane,
+                    "screen": placement.screen,
+                    "workspace": placement.workspace,
+                    "key": key,
+                    "lifecycle": "running",
+                    "terminal_revision": result.terminal_revision,
+                    "replayed": result.replayed,
+                    "registry_id": registry_id,
+                    "generation": generation,
+                }))
+            } else {
+                let placement = mux.create_terminal_in_workspace(
+                    workspace,
+                    argv,
+                    cwd,
+                    name,
+                    optional_surface_size(cols, rows),
+                )?;
+                let identity = mux
+                    .surface(placement.surface)
+                    .and_then(|surface| surface.terminal_host_identity());
+                let terminal_revision = mux.terminal_registry_snapshot()?.revision;
+                Ok(json!({
+                    "surface": placement.surface,
+                    "terminal_id": identity.as_ref().map(|identity| &identity.terminal_id),
+                    "terminal_incarnation": identity.as_ref().map(|identity| &identity.incarnation),
+                    "pane": placement.pane,
+                    "screen": placement.screen,
+                    "workspace": placement.workspace,
+                    "key": key,
+                    "lifecycle": identity.as_ref().map(|_| "running"),
+                    "terminal_revision": terminal_revision,
+                    "replayed": false,
+                    "registry_id": registry_id,
+                    "generation": generation,
+                }))
+            }
         }
         Command::NewScreen { workspace, cols, rows } => {
             let surface = mux.new_screen(workspace, optional_surface_size(cols, rows))?;
@@ -3105,6 +3244,33 @@ fn handle_command(
                 "pid": surface.process_id(),
                 "command": surface.spawn_command(),
                 "cwd": surface.pwd().or_else(|| surface.spawn_cwd()),
+            }))
+        }
+        Command::MoveTerminal { terminal_id, workspace_key, terminal_incarnation, mutation } => {
+            let workspace_mutation = workspace_mutation(&mutation)?;
+            let result = mux.move_terminal_with_mutation(
+                &terminal_id,
+                &workspace_key,
+                terminal_incarnation.as_deref(),
+                mutation.expected_generation.as_deref(),
+                mutation.expected_revision,
+                &workspace_mutation,
+            )?;
+            let (registry_id, generation) = mux.registry_identity();
+            Ok(json!({
+                "surface":result.placement.as_ref().map(|placement| placement.surface),
+                "pane":result.placement.as_ref().map(|placement| placement.pane),
+                "screen":result.placement.as_ref().map(|placement| placement.screen),
+                "workspace":result.placement.as_ref().map(|placement| placement.workspace),
+                "terminal_id":result.terminal.terminal_id,
+                "terminal_incarnation":result.terminal.incarnation,
+                "workspace_key":result.terminal.workspace_key,
+                "lifecycle":result.terminal.lifecycle,
+                "changed":result.changed,
+                "replayed":result.replayed,
+                "terminal_revision":result.terminal_revision,
+                "registry_id":registry_id,
+                "generation":generation,
             }))
         }
         Command::MoveTab { surface, pane, index } => {
@@ -3744,6 +3910,13 @@ fn subscribed_event_json(event: &MuxEvent) -> Value {
             "projection_revision": projection_revision,
             "origin": origin,
             "mutation_id": mutation_id,
+        }),
+        MuxEvent::TerminalRegistryChanged { registry_id, generation, terminal_revision } => json!({
+            "event":"terminal-registry-changed",
+            "registry_id":registry_id,
+            "generation":generation,
+            "terminal_revision":terminal_revision,
+            "refetch":"terminal-events-or-list-terminals",
         }),
         MuxEvent::LayoutChanged(screen) => json!({"event": "layout-changed", "screen": screen}),
         MuxEvent::ClientAttached { client, transport, name, kind } => json!({

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -3324,18 +3324,19 @@ fn handle_command(
         }
         Command::CloseSurface { surface } => {
             get_surface(mux, surface)?;
-            mux.close_surface(surface);
+            if !mux.close_surface(surface)? {
+                anyhow::bail!("unknown surface {surface}");
+            }
             Ok(json!({}))
         }
         Command::ClosePane { pane } => {
-            if !mux.with_state(|s| s.panes.contains_key(&pane)) {
+            if !mux.close_pane(pane)? {
                 anyhow::bail!("unknown pane {pane}");
             }
-            mux.close_pane(pane);
             Ok(json!({}))
         }
         Command::CloseScreen { screen } => {
-            if !mux.close_screen(screen) {
+            if !mux.close_screen(screen)? {
                 anyhow::bail!("unknown screen {screen}");
             }
             Ok(json!({}))
@@ -4301,6 +4302,37 @@ mod tests {
         assert_eq!(data["ok"].as_bool(), Some(true));
         assert_eq!(data["version"].as_str(), Some(env!("CARGO_PKG_VERSION")));
         assert_eq!(data["protocol"].as_u64(), Some(PROTOCOL_VERSION as u64));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pane_and_screen_close_publish_errors_until_registry_commit_succeeds() {
+        const TERMINAL: &str = "00000000000040008000000000000012";
+        const INCARNATION: &str = "10000000000040008000000000000012";
+        let mux = test_mux();
+        let workspace =
+            mux.create_empty_workspace(None, Some("server-close".into()), None).unwrap();
+        let surface =
+            mux.seed_running_terminal_for_test(TERMINAL, INCARNATION, &workspace.key).unwrap();
+        let (pane, screen) = mux.with_state(|state| {
+            let pane = state.pane_of(surface).unwrap();
+            let (workspace, screen) = state.screen_of(pane).unwrap();
+            (pane, state.workspaces[workspace].screens[screen].id)
+        });
+        mux.set_terminal_close_failure_for_test(true).unwrap();
+
+        let pane_error =
+            handle_command(&mux, 0, Command::ClosePane { pane }, &test_writer()).unwrap_err();
+        assert!(format!("{pane_error:#}").contains("forced terminal close failure"));
+        let screen_error =
+            handle_command(&mux, 0, Command::CloseScreen { screen }, &test_writer()).unwrap_err();
+        assert!(format!("{screen_error:#}").contains("forced terminal close failure"));
+        assert!(mux.surface(surface).is_some());
+        assert_eq!(mux.with_state(|state| state.pane_of(surface)), Some(pane));
+
+        mux.set_terminal_close_failure_for_test(false).unwrap();
+        handle_command(&mux, 0, Command::CloseScreen { screen }, &test_writer()).unwrap();
+        assert!(mux.surface(surface).is_none());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -47,8 +47,8 @@ use crate::{
     AgentRecord, AgentSource, AgentState, AttachFrame, DefaultColors, Direction, LayoutLeafSpec,
     LayoutSpec, Mux, MuxEvent, Node, NotificationLevel, PairingDecision, PaneId, RenderAttachFrame,
     Rgb, ScreenId, SidebarPluginStatus, SplitDir, SurfaceId, SurfaceKind, SurfaceNotification,
-    SurfaceRenderFrame, TerminalColors, TreeDelta, TreeDeltaKind, WorkspaceId, ZoomMode,
-    assign_short_ids,
+    SurfaceRenderFrame, TerminalColors, TreeDelta, TreeDeltaKind, WorkspaceId, WorkspaceMutation,
+    ZoomMode, assign_short_ids,
 };
 
 pub const PROTOCOL_VERSION: u32 = 7;
@@ -97,6 +97,22 @@ enum Command {
     },
     ClearWindowTitle,
     ListWorkspaces,
+    GetFrontendProjection {
+        frontend: String,
+        scope: String,
+        subject_key: String,
+    },
+    PutFrontendProjection {
+        frontend: String,
+        scope: String,
+        subject_key: String,
+        schema_version: u32,
+        #[serde(default)]
+        expected_projection_revision: Option<u64>,
+        projection: Value,
+        #[serde(flatten)]
+        mutation: MutationRequest,
+    },
     ExportLayout {
         #[serde(default)]
         screen: Option<ScreenId>,
@@ -293,9 +309,8 @@ enum Command {
         /// generates a UUIDv4 key and returns it.
         #[serde(default)]
         key: Option<String>,
-        /// Compare-and-swap guard for the ordered registry.
-        #[serde(default)]
-        expected_revision: Option<u64>,
+        #[serde(flatten)]
+        mutation: MutationRequest,
     },
     /// Create a terminal inside an existing workspace selected by stable key
     /// or legacy numeric id.
@@ -377,8 +392,8 @@ enum Command {
         #[serde(default)]
         key: Option<String>,
         index: usize,
-        #[serde(default)]
-        expected_revision: Option<u64>,
+        #[serde(flatten)]
+        mutation: MutationRequest,
     },
     SetDefaultColors {
         #[serde(default)]
@@ -402,8 +417,8 @@ enum Command {
         workspace: Option<WorkspaceId>,
         #[serde(default)]
         key: Option<String>,
-        #[serde(default)]
-        expected_revision: Option<u64>,
+        #[serde(flatten)]
+        mutation: MutationRequest,
     },
     RenamePane {
         pane: PaneId,
@@ -426,8 +441,8 @@ enum Command {
         #[serde(default)]
         key: Option<String>,
         name: String,
-        #[serde(default)]
-        expected_revision: Option<u64>,
+        #[serde(flatten)]
+        mutation: MutationRequest,
     },
     ResizeSurface {
         surface: SurfaceId,
@@ -487,6 +502,18 @@ enum Command {
         surface: SurfaceId,
         delta: isize,
     },
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct MutationRequest {
+    #[serde(default)]
+    origin: Option<String>,
+    #[serde(default)]
+    mutation_id: Option<String>,
+    #[serde(default)]
+    expected_generation: Option<String>,
+    #[serde(default)]
+    expected_revision: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -1692,6 +1719,14 @@ fn optional_surface_size(cols: Option<u16>, rows: Option<u16>) -> Option<(u16, u
     cols.zip(rows).map(|(cols, rows)| (cols.max(1), rows.max(1)))
 }
 
+fn workspace_mutation(request: &MutationRequest) -> anyhow::Result<WorkspaceMutation> {
+    match (&request.mutation_id, &request.origin) {
+        (Some(id), Some(origin)) => WorkspaceMutation::new(id.clone(), origin.clone()),
+        (None, None) => Ok(WorkspaceMutation::local("legacy-control")),
+        _ => anyhow::bail!("origin and mutation_id must be provided together"),
+    }
+}
+
 fn parse_direction(dir: &str) -> anyhow::Result<Direction> {
     match dir {
         "left" => Ok(Direction::Left),
@@ -1916,7 +1951,7 @@ pub(crate) fn tree_entity_json(
     }
 }
 
-fn tree_delta_json(delta: &TreeDelta) -> Value {
+fn tree_delta_json(delta: &TreeDelta, mux: &Mux) -> Value {
     let mut value = json!({
         "event": delta.kind.as_str(),
         "workspace": delta.workspace,
@@ -1936,6 +1971,13 @@ fn tree_delta_json(delta: &TreeDelta) -> Value {
     }
     if let Some(revision) = delta.workspace_revision {
         value["workspace_revision"] = json!(revision);
+        if let Ok(Some(event)) = mux.workspace_registry_event(revision) {
+            value["origin"] = json!(event.origin);
+            value["mutation_id"] = json!(event.mutation_id);
+        }
+        let (registry_id, generation) = mux.registry_identity();
+        value["registry_id"] = json!(registry_id);
+        value["generation"] = json!(generation);
     }
     value
 }
@@ -2391,12 +2433,16 @@ fn handle_command(
 ) -> anyhow::Result<Value> {
     match cmd {
         Command::Identify => {
+            let (registry_id, generation) = mux.registry_identity();
             let mut identity = json!({
                 "app": "cmux-tui",
                 "version": env!("CARGO_PKG_VERSION"),
                 "protocol": PROTOCOL_VERSION,
                 "session": mux.session,
                 "pid": std::process::id(),
+                "registry_id": registry_id,
+                "generation": generation,
+                "workspace_revision": mux.with_state(|state| state.workspace_revision),
             });
             if let Some(commit) =
                 option_env!("CMUX_TUI_BUILD_COMMIT").or(option_env!("CMUX_MUX_BUILD_COMMIT"))
@@ -2474,7 +2520,48 @@ fn handle_command(
         }
         Command::ListWorkspaces => {
             let notifications = mux.surface_notifications();
-            Ok(mux.with_state(|state| workspaces_json(state, &notifications)))
+            let mut workspaces = mux.with_state(|state| workspaces_json(state, &notifications));
+            let (registry_id, generation) = mux.registry_identity();
+            workspaces["registry_id"] = json!(registry_id);
+            workspaces["generation"] = json!(generation);
+            Ok(workspaces)
+        }
+        Command::GetFrontendProjection { frontend, scope, subject_key } => {
+            let projection = mux.get_frontend_projection(&frontend, &scope, &subject_key)?;
+            Ok(match projection {
+                Some(projection) => serde_json::to_value(projection)?,
+                None => json!({
+                    "frontend": frontend,
+                    "scope": scope,
+                    "subject_key": subject_key,
+                    "schema_version": 0,
+                    "projection_revision": 0,
+                    "projection": null,
+                }),
+            })
+        }
+        Command::PutFrontendProjection {
+            frontend,
+            scope,
+            subject_key,
+            schema_version,
+            expected_projection_revision,
+            projection,
+            mutation,
+        } => {
+            let workspace_mutation = workspace_mutation(&mutation)?;
+            let commit = mux.put_frontend_projection(
+                &workspace_mutation,
+                &frontend,
+                &scope,
+                &subject_key,
+                schema_version,
+                expected_projection_revision,
+                &projection,
+            )?;
+            let mut value = serde_json::to_value(commit.projection)?;
+            value["replayed"] = json!(commit.replayed);
+            Ok(value)
         }
         Command::ExportLayout { screen } => {
             mux.with_state(|state| export_layout_json(state, screen))
@@ -2825,13 +2912,24 @@ fn handle_command(
             let surface = mux.new_workspace(name, optional_surface_size(cols, rows))?;
             Ok(json!({ "surface": surface.id }))
         }
-        Command::CreateWorkspace { name, key, expected_revision } => {
-            let placement = mux.create_empty_workspace(name, key, expected_revision)?;
+        Command::CreateWorkspace { name, key, mutation } => {
+            let workspace_mutation = workspace_mutation(&mutation)?;
+            let placement = mux.create_empty_workspace_with_mutation(
+                name,
+                key,
+                mutation.expected_generation.as_deref(),
+                mutation.expected_revision,
+                &workspace_mutation,
+            )?;
+            let (registry_id, generation) = mux.registry_identity();
             Ok(json!({
                 "workspace": placement.workspace,
                 "key": placement.key,
                 "index": placement.index,
                 "workspace_revision": placement.revision,
+                "replayed": placement.replayed,
+                "registry_id": registry_id,
+                "generation": generation,
             }))
         }
         Command::CreateTerminal { workspace, key, argv, command, cwd, name, cols, rows } => {
@@ -2933,14 +3031,27 @@ fn handle_command(
             mux.move_tab(surface, pane, index);
             Ok(json!({}))
         }
-        Command::MoveWorkspace { workspace, key, index, expected_revision } => {
-            let (workspace, key) = resolve_workspace(mux, workspace, key.as_deref())?;
-            let Some((revision, _)) =
-                mux.move_workspace_at_revision(workspace, index, expected_revision)?
-            else {
-                anyhow::bail!("unknown workspace {workspace}");
-            };
-            Ok(json!({"workspace": workspace, "key": key, "workspace_revision": revision}))
+        Command::MoveWorkspace { workspace, key, index, mutation } => {
+            let workspace_mutation = workspace_mutation(&mutation)?;
+            let result = mux.move_workspace_with_mutation(
+                workspace,
+                key.as_deref(),
+                index,
+                mutation.expected_generation.as_deref(),
+                mutation.expected_revision,
+                &workspace_mutation,
+            )?;
+            let (registry_id, generation) = mux.registry_identity();
+            Ok(json!({
+                "workspace": result.workspace,
+                "key": result.key,
+                "index": result.index,
+                "workspace_revision": result.revision,
+                "changed": result.changed,
+                "replayed": result.replayed,
+                "registry_id": registry_id,
+                "generation": generation,
+            }))
         }
         Command::SetDefaultColors { fg, bg } => {
             let current = mux.default_colors();
@@ -2976,13 +3087,26 @@ fn handle_command(
             }
             Ok(json!({}))
         }
-        Command::CloseWorkspace { workspace, key, expected_revision } => {
-            let (workspace, key) = resolve_workspace(mux, workspace, key.as_deref())?;
-            let Some(revision) = mux.close_workspace_at_revision(workspace, expected_revision)?
-            else {
-                anyhow::bail!("unknown workspace {workspace}");
-            };
-            Ok(json!({"workspace": workspace, "key": key, "workspace_revision": revision}))
+        Command::CloseWorkspace { workspace, key, mutation } => {
+            let workspace_mutation = workspace_mutation(&mutation)?;
+            let result = mux.close_workspace_with_mutation(
+                workspace,
+                key.as_deref(),
+                mutation.expected_generation.as_deref(),
+                mutation.expected_revision,
+                &workspace_mutation,
+            )?;
+            let (registry_id, generation) = mux.registry_identity();
+            Ok(json!({
+                "workspace": result.workspace,
+                "key": result.key,
+                "index": result.index,
+                "workspace_revision": result.revision,
+                "changed": result.changed,
+                "replayed": result.replayed,
+                "registry_id": registry_id,
+                "generation": generation,
+            }))
         }
         Command::RenamePane { pane, name } => {
             if !mux.rename_pane(pane, name) {
@@ -3002,14 +3126,27 @@ fn handle_command(
             }
             Ok(json!({}))
         }
-        Command::RenameWorkspace { workspace, key, name, expected_revision } => {
-            let (workspace, key) = resolve_workspace(mux, workspace, key.as_deref())?;
-            let Some(revision) =
-                mux.rename_workspace_at_revision(workspace, name, expected_revision)?
-            else {
-                anyhow::bail!("unknown workspace {workspace}");
-            };
-            Ok(json!({"workspace": workspace, "key": key, "workspace_revision": revision}))
+        Command::RenameWorkspace { workspace, key, name, mutation } => {
+            let workspace_mutation = workspace_mutation(&mutation)?;
+            let result = mux.rename_workspace_with_mutation(
+                workspace,
+                key.as_deref(),
+                name,
+                mutation.expected_generation.as_deref(),
+                mutation.expected_revision,
+                &workspace_mutation,
+            )?;
+            let (registry_id, generation) = mux.registry_identity();
+            Ok(json!({
+                "workspace": result.workspace,
+                "key": result.key,
+                "index": result.index,
+                "workspace_revision": result.revision,
+                "changed": result.changed,
+                "replayed": result.replayed,
+                "registry_id": registry_id,
+                "generation": generation,
+            }))
         }
         Command::ResizeSurface { surface, cols, rows } => {
             let (cols, rows) = clamp_terminal_size(cols, rows);
@@ -3072,6 +3209,7 @@ fn handle_command(
                 other => anyhow::bail!("bad request: unsupported tree_events {other:?}"),
             };
             let events = mux.subscribe();
+            let event_mux = mux.clone();
             let trusted_pairing_client = mux.control_clients.is_unix(client);
             let pending_pairings =
                 if trusted_pairing_client { mux.pending_pairings() } else { Vec::new() };
@@ -3115,7 +3253,9 @@ fn handle_command(
                             "event": "pairing-resolved",
                             "request": request,
                         }),
-                        MuxEvent::TreeDelta(delta) if tree_deltas => tree_delta_json(delta),
+                        MuxEvent::TreeDelta(delta) if tree_deltas => {
+                            tree_delta_json(delta, &event_mux)
+                        }
                         MuxEvent::TreeDelta(_) => json!({"event": "tree-changed"}),
                         _ => subscribed_event_json(&event),
                     };
@@ -3487,6 +3627,22 @@ fn subscribed_event_json(event: &MuxEvent) -> Value {
         }),
         MuxEvent::TreeChanged => json!({"event": "tree-changed"}),
         MuxEvent::TreeDelta(_) => json!({"event": "tree-changed"}),
+        MuxEvent::FrontendProjectionChanged {
+            frontend,
+            scope,
+            subject_key,
+            projection_revision,
+            origin,
+            mutation_id,
+        } => json!({
+            "event": "frontend-projection-changed",
+            "frontend": frontend,
+            "scope": scope,
+            "subject_key": subject_key,
+            "projection_revision": projection_revision,
+            "origin": origin,
+            "mutation_id": mutation_id,
+        }),
         MuxEvent::LayoutChanged(screen) => json!({"event": "layout-changed", "screen": screen}),
         MuxEvent::ClientAttached { client, transport, name, kind } => json!({
             "event": "client-attached",

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -213,6 +213,24 @@ enum Command {
     VtState {
         surface: SurfaceId,
     },
+    /// Mint a one-use direct renderer credential without exposing the
+    /// daemon's durable owner capability.
+    MintTerminalRenderer {
+        surface: SurfaceId,
+        #[serde(default = "default_renderer_capability_ttl_ms")]
+        ttl_ms: u64,
+    },
+    /// Resolve a process-stable hosted terminal UUID to this daemon
+    /// generation's local surface handle without creating anything.
+    ResolveTerminal {
+        terminal_id: String,
+    },
+    /// Close a hosted terminal by stable identity. This is safe across daemon
+    /// generations; the incarnation guard prevents a stale close request.
+    CloseTerminal {
+        terminal_id: String,
+        terminal_incarnation: String,
+    },
     /// New tab in a pane (default: the active pane).
     NewTab {
         #[serde(default)]
@@ -1719,6 +1737,10 @@ fn optional_surface_size(cols: Option<u16>, rows: Option<u16>) -> Option<(u16, u
     cols.zip(rows).map(|(cols, rows)| (cols.max(1), rows.max(1)))
 }
 
+fn default_renderer_capability_ttl_ms() -> u64 {
+    30_000
+}
+
 fn workspace_mutation(request: &MutationRequest) -> anyhow::Result<WorkspaceMutation> {
     match (&request.mutation_id, &request.origin) {
         (Some(id), Some(origin)) => WorkspaceMutation::new(id.clone(), origin.clone()),
@@ -1791,8 +1813,13 @@ fn pane_json(
         "active_tab": pane.active_tab,
         "tabs": pane.tabs.iter().map(|sid| {
             let surface = state.surfaces.get(sid);
+            let terminal_identity = surface.and_then(|surface| surface.terminal_host_identity());
             json!({
                 "surface": sid,
+                "terminal_id": terminal_identity.as_ref().map(|identity| &identity.terminal_id),
+                "terminal_incarnation": terminal_identity
+                    .as_ref()
+                    .map(|identity| &identity.incarnation),
                 "short_id": short_ids.get(sid).cloned().unwrap_or_default(),
                 "kind": surface.map(|s| s.kind().as_str()).unwrap_or("pty"),
                 "browser_source": surface.and_then(|s| s.browser_source().map(|source| source.as_str())),
@@ -2136,6 +2163,14 @@ fn terminal_colors_json(colors: TerminalColors) -> Value {
         ghostty_vt::CursorShape::Underline => "underline",
         ghostty_vt::CursorShape::Block | ghostty_vt::CursorShape::BlockHollow => "block",
     });
+    let palette = colors
+        .palette
+        .iter()
+        .enumerate()
+        .filter_map(|(index, color)| {
+            color.map(|color| (index.to_string(), Value::String(rgb_hex(color))))
+        })
+        .collect::<serde_json::Map<_, _>>();
     json!({
         "fg": color_hex(colors.fg),
         "bg": color_hex(colors.bg),
@@ -2144,6 +2179,7 @@ fn terminal_colors_json(colors: TerminalColors) -> Value {
         "selection_fg": color_hex(colors.selection_fg),
         "cursor_style": cursor_style,
         "cursor_blink": colors.cursor_blink,
+        "palette": palette,
     })
 }
 
@@ -2703,8 +2739,14 @@ fn handle_command(
                 name,
                 optional_surface_size(cols, rows),
             )?;
+            let terminal_identity =
+                mux.surface(placement.surface).and_then(|surface| surface.terminal_host_identity());
             Ok(json!({
                 "surface": placement.surface,
+                "terminal_id": terminal_identity.as_ref().map(|identity| &identity.terminal_id),
+                "terminal_incarnation": terminal_identity
+                    .as_ref()
+                    .map(|identity| &identity.incarnation),
                 "pane": placement.pane,
                 "screen": placement.screen,
                 "workspace": placement.workspace,
@@ -2794,9 +2836,49 @@ fn handle_command(
                 "data": base64::engine::general_purpose::STANDARD.encode(replay),
             }))
         }
+        Command::MintTerminalRenderer { surface, ttl_ms } => {
+            let surface = get_surface(mux, surface)?;
+            require_pty(&surface)?;
+            let grant = surface.mint_renderer_grant(Duration::from_millis(ttl_ms))?;
+            Ok(json!({
+                "endpoint": grant.endpoint,
+                "terminal_id": grant.terminal_id,
+                "incarnation": grant.incarnation,
+                "token": grant.token,
+                "rights": grant.rights.bits(),
+                "ttl_ms": ttl_ms,
+            }))
+        }
+        Command::ResolveTerminal { terminal_id } => {
+            let Some((surface, identity)) = mux.resolve_terminal(&terminal_id)? else {
+                anyhow::bail!("terminal_not_found");
+            };
+            Ok(json!({
+                "surface": surface,
+                "terminal_id": identity.terminal_id,
+                "terminal_incarnation": identity.incarnation,
+            }))
+        }
+        Command::CloseTerminal { terminal_id, terminal_incarnation } => {
+            let Some(surface) = mux.close_terminal(&terminal_id, &terminal_incarnation)? else {
+                anyhow::bail!("terminal_not_found");
+            };
+            Ok(json!({
+                "surface": surface,
+                "terminal_id": terminal_id,
+                "terminal_incarnation": terminal_incarnation,
+            }))
+        }
         Command::NewTab { pane, cwd, cols, rows } => {
             let surface = mux.new_tab(pane, cwd, optional_surface_size(cols, rows))?;
-            Ok(json!({ "surface": surface.id }))
+            let terminal_identity = surface.terminal_host_identity();
+            Ok(json!({
+                "surface": surface.id,
+                "terminal_id": terminal_identity.as_ref().map(|identity| &identity.terminal_id),
+                "terminal_incarnation": terminal_identity
+                    .as_ref()
+                    .map(|identity| &identity.incarnation),
+            }))
         }
         Command::NewBrowserTab { url, pane, cols, rows } => {
             let surface = mux.new_browser_tab(url, pane, optional_surface_size(cols, rows))?;
@@ -2952,8 +3034,14 @@ fn handle_command(
                 name,
                 optional_surface_size(cols, rows),
             )?;
+            let terminal_identity =
+                mux.surface(placement.surface).and_then(|surface| surface.terminal_host_identity());
             Ok(json!({
                 "surface": placement.surface,
+                "terminal_id": terminal_identity.as_ref().map(|identity| &identity.terminal_id),
+                "terminal_incarnation": terminal_identity
+                    .as_ref()
+                    .map(|identity| &identity.incarnation),
                 "pane": placement.pane,
                 "screen": placement.screen,
                 "workspace": placement.workspace,
@@ -3535,6 +3623,12 @@ fn handle_command(
                                 "surface": surface_id,
                                 "data": base64::engine::general_purpose::STANDARD.encode(chunk),
                             }),
+                            AttachFrame::OutputWithColors { output, colors } => json!({
+                                "event": "output",
+                                "surface": surface_id,
+                                "data": base64::engine::general_purpose::STANDARD.encode(output),
+                                "colors": terminal_colors_json(*colors),
+                            }),
                             AttachFrame::Resized { cols, rows, replay } => json!({
                                 "event": "resized",
                                 "surface": surface_id,
@@ -3542,8 +3636,16 @@ fn handle_command(
                                 "rows": rows,
                                 "replay": base64::engine::general_purpose::STANDARD.encode(replay),
                             }),
+                            AttachFrame::ResizedWithColors { cols, rows, replay, colors } => json!({
+                                "event": "resized",
+                                "surface": surface_id,
+                                "cols": cols,
+                                "rows": rows,
+                                "replay": base64::engine::general_purpose::STANDARD.encode(replay),
+                                "colors": terminal_colors_json(*colors),
+                            }),
                             AttachFrame::ColorsChanged(colors) => {
-                                let mut value = terminal_colors_json(colors);
+                                let mut value = terminal_colors_json(*colors);
                                 value["event"] = json!("colors-changed");
                                 value["surface"] = json!(surface_id);
                                 value

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -2550,9 +2550,8 @@ fn handle_command(
             }))
         }
         Command::TerminalEvents { after_revision } => {
-            let snapshot = mux.terminal_registry_snapshot()?;
-            let events = mux
-                .terminal_registry_events_after(after_revision)?
+            let (snapshot, events) = mux.terminal_registry_events_page(after_revision)?;
+            let events = events
                 .into_iter()
                 .map(|event| {
                     json!({

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -9,7 +9,7 @@ use std::io::{Read, Write};
 use std::mem::size_of;
 use std::ops::Deref;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{
     Receiver, RecvError, RecvTimeoutError, SyncSender, TryRecvError, TrySendError, sync_channel,
 };
@@ -288,11 +288,17 @@ impl HostedFrameStager {
                 _ => Err("unknown Output flags"),
             },
             MessageKind::Resized => {
-                if frame.flags != FLAG_COLORS_FOLLOW || frame.payload.len() < 4 {
+                if frame.flags != FLAG_COLORS_FOLLOW
+                    || frame.payload.len() < 4
+                    || frame.payload.len() - 4 > VT_REPLAY_MAX_BYTES
+                {
                     return Err("invalid Resized frame");
                 }
-                let cols = u16::from_le_bytes([frame.payload[0], frame.payload[1]]).max(1);
-                let rows = u16::from_le_bytes([frame.payload[2], frame.payload[3]]).max(1);
+                let (cols, rows) = crate::terminal_host_runtime::normalize_terminal_geometry(
+                    u16::from_le_bytes([frame.payload[0], frame.payload[1]]),
+                    u16::from_le_bytes([frame.payload[2], frame.payload[3]]),
+                )
+                .map_err(|_| "invalid Resized geometry")?;
                 self.pending = Some(PendingHostedTransition::Resized {
                     cols,
                     rows,
@@ -478,6 +484,24 @@ pub enum SurfaceKind {
     Browser,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TerminalHostConnectionState {
+    Connected = 0,
+    Reconnecting = 1,
+    Exited = 2,
+}
+
+impl TerminalHostConnectionState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Reconnecting,
+            2 => Self::Exited,
+            _ => Self::Connected,
+        }
+    }
+}
+
 impl SurfaceKind {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -521,6 +545,7 @@ pub struct PtySurface {
     term: Mutex<Terminal>,
     mouse_encoders: Mutex<MouseEncoders>,
     runtime: Mutex<PtyRuntime>,
+    host_identity: Option<crate::terminal_host_runtime::TerminalHostIdentity>,
     pid: Option<u32>,
     command: Vec<String>,
     cwd: Option<String>,
@@ -530,7 +555,7 @@ pub struct PtySurface {
     owner_detaching: AtomicBool,
     /// The host socket ended without a sequenced Exit. Closing this proxy
     /// must retain the host record so a fresh snapshot can recover it.
-    host_connection_lost: AtomicBool,
+    host_connection_state: AtomicU8,
     /// Set when output arrived since the last render; cleared by the
     /// frontend when it draws.
     dirty: AtomicBool,
@@ -559,6 +584,8 @@ enum PtyRuntime {
     },
     #[cfg(unix)]
     Hosted(Box<crate::terminal_host_runtime::HostAttachment>),
+    #[cfg(unix)]
+    ExitedHosted,
 }
 
 #[cfg(unix)]
@@ -580,6 +607,24 @@ fn hosted_terminal_callbacks(
                 mux.emit(MuxEvent::Bell(id));
             }
         })),
+    }
+}
+
+#[cfg(unix)]
+fn mark_hosted_runtime_exited(
+    pty: &PtySurface,
+    identity: &crate::terminal_host_runtime::TerminalHostIdentity,
+) {
+    let mut runtime = pty.runtime.lock().unwrap();
+    let matches = match &*runtime {
+        PtyRuntime::Hosted(host) => host.identity() == *identity,
+        PtyRuntime::ExitedHosted | PtyRuntime::Local { .. } => false,
+    };
+    if matches {
+        if let PtyRuntime::Hosted(host) = &*runtime {
+            host.disconnect();
+        }
+        *runtime = PtyRuntime::ExitedHosted;
     }
 }
 
@@ -700,12 +745,13 @@ impl Surface {
             term: Mutex::new(term),
             mouse_encoders: Mutex::new(mouse_encoders),
             runtime: Mutex::new(PtyRuntime::Local { writer, master: pty.master, killer }),
+            host_identity: None,
             pid,
             command: argv,
             cwd,
             dead: AtomicBool::new(false),
             owner_detaching: AtomicBool::new(false),
-            host_connection_lost: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
             dirty: AtomicBool::new(false),
             title: Mutex::new(String::new()),
             pwd: Mutex::new(None),
@@ -810,7 +856,7 @@ impl Surface {
         mut attachment: crate::terminal_host_runtime::HostAttachment,
     ) -> anyhow::Result<Arc<Surface>> {
         let mut reader = attachment.take_reader()?;
-        let capability_responses = attachment.capability_responses();
+        let mut capability_responses = attachment.capability_responses();
         let snapshot = attachment.snapshot.clone();
         let mut applied_color_overrides = snapshot.colors.clone();
         let pending_responses: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
@@ -842,6 +888,7 @@ impl Surface {
         let mut mouse_encoders = MouseEncoders::new()?;
         mouse_encoders.sync_from_terminal(&term);
         let sequence_boundary = snapshot.sequence_boundary;
+        let host_identity = attachment.identity();
         let render_state = RenderState::new()?;
         let (frame_requests, frame_rx) = sync_channel(1);
         let surface = Arc::new(Surface::Pty(PtySurface {
@@ -849,12 +896,13 @@ impl Surface {
             term: Mutex::new(term),
             mouse_encoders: Mutex::new(mouse_encoders),
             runtime: Mutex::new(PtyRuntime::Hosted(Box::new(attachment))),
+            host_identity: Some(host_identity),
             pid: snapshot.pid,
             command: snapshot.command,
             cwd: snapshot.cwd,
             dead: AtomicBool::new(false),
             owner_detaching: AtomicBool::new(false),
-            host_connection_lost: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
             dirty: AtomicBool::new(true),
             title: Mutex::new(title),
             pwd: Mutex::new(pwd),
@@ -876,215 +924,397 @@ impl Surface {
             let surface = surface.clone();
             let scrollback = opts.scrollback;
             move || {
-                let mut stager = HostedFrameStager::new(sequence_boundary);
-                let mut received_exit = false;
-                'host_stream: while let Ok(Some(frame)) = crate::terminal_host_protocol::read_frame(
-                    &mut reader,
-                    crate::terminal_host_protocol::MAX_FRAME_PAYLOAD,
-                ) {
-                    let Some(pty) = surface.as_pty() else { break };
-                    if frame.kind == MessageKind::Capability && frame.request_id != 0 {
-                        if frame.version != PROTOCOL_VERSION
-                            || frame.flags != 0
-                            || frame.sequence != 0
-                        {
-                            break;
-                        }
-                        capability_responses.resolve(&frame);
-                        continue;
-                    }
-                    let Ok(transition) = stager.push(frame) else {
-                        break;
-                    };
-                    let Some(transition) = transition else { continue };
-                    match transition {
-                        transition @ (HostedTransition::Output(_)
-                        | HostedTransition::OutputWithColors { .. }) => {
-                            let (output, colors) = match transition {
-                                HostedTransition::Output(output) => (output, None),
-                                HostedTransition::OutputWithColors { output, colors } => {
-                                    (output, Some(colors))
-                                }
-                                _ => unreachable!(),
-                            };
-                            let mut scroll_changed = None;
-                            let mut title_update = None;
-                            let defaults =
-                                mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
-                            let generation = {
-                                let mut term = pty.term.lock().unwrap();
-                                let before = terminal_scroll_position(&term);
-                                term.vt_write(&output);
-                                if let Some(colors) = colors.as_ref() {
-                                    let delta = terminal_color_override_delta(
-                                        &applied_color_overrides,
-                                        colors,
-                                    );
-                                    if !delta.is_empty() {
-                                        term.vt_write(&delta);
-                                    }
-                                    applied_color_overrides = colors.clone();
-                                } else if term.color_overrides() != applied_color_overrides {
-                                    // An unflagged Output that changed colors
-                                    // violated the producer's iff contract.
-                                    break 'host_stream;
-                                }
-                                pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
-                                let after = terminal_scroll_position(&term);
-                                // The parser already contains the complete
-                                // coupled state before any attach observer can
-                                // see the Output or ColorsChanged callback.
-                                if colors.is_some() {
-                                    pty.broadcast_attach_frame(AttachFrame::OutputWithColors {
-                                        output,
-                                        colors: Box::new(TerminalColors::from_terminal(
-                                            &mut term, defaults,
-                                        )),
-                                    });
-                                } else {
-                                    pty.broadcast_attach_output(&output);
-                                }
-                                if title_changed.swap(false, Ordering::Relaxed) {
-                                    let title = term.title().unwrap_or_default();
-                                    *pty.title.lock().unwrap() = title.clone();
-                                    title_update = Some(title);
-                                }
-                                if let Some(pwd) = term.pwd() {
-                                    *pty.pwd.lock().unwrap() = Some(pwd);
-                                }
-                                if before != after {
-                                    scroll_changed = Some(after);
-                                    broadcast_render_scroll_locked(pty, after);
-                                }
-                                pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
-                            };
-                            pty.request_frame(generation);
-                            if let Some(title) = title_update
-                                && let Some(mux) = mux.upgrade()
+                let mut sequence_boundary = sequence_boundary;
+                'connection: loop {
+                    let mut stager = HostedFrameStager::new(sequence_boundary);
+                    let mut received_exit = false;
+                    'host_stream: while let Ok(Some(frame)) =
+                        crate::terminal_host_protocol::read_frame(
+                            &mut reader,
+                            crate::terminal_host_protocol::MAX_FRAME_PAYLOAD,
+                        )
+                    {
+                        let Some(pty) = surface.as_pty() else { break };
+                        if frame.kind == MessageKind::Capability && frame.request_id != 0 {
+                            if frame.version != PROTOCOL_VERSION
+                                || frame.flags != 0
+                                || frame.sequence != 0
                             {
-                                mux.emit(MuxEvent::TitleChanged {
-                                    surface: surface.id,
-                                    title: title.into(),
-                                });
-                            }
-                            if let Some((offset, at_bottom)) = scroll_changed
-                                && let Some(mux) = mux.upgrade()
-                            {
-                                mux.emit(MuxEvent::ScrollChanged {
-                                    surface: surface.id,
-                                    offset,
-                                    at_bottom,
-                                });
-                            }
-                            let responses = std::mem::take(&mut *pending_responses.lock().unwrap());
-                            if !responses.is_empty() {
-                                let _ = surface.write_bytes(&responses);
-                            }
-                        }
-                        HostedTransition::ResizedWithColors { cols, rows, replay, colors } => {
-                            let defaults =
-                                mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
-                            let callbacks = hosted_terminal_callbacks(
-                                id,
-                                mux.clone(),
-                                pending_responses.clone(),
-                                title_changed.clone(),
-                            );
-                            let Ok(mut replacement) =
-                                Terminal::new(cols, rows, scrollback, callbacks)
-                            else {
                                 break;
-                            };
-                            replacement.set_default_colors(
-                                defaults.fg,
-                                defaults.bg,
-                                defaults.cursor,
-                            );
-                            replacement.set_default_palette(&defaults.palette);
-                            replacement
-                                .set_default_cursor(defaults.cursor_style, defaults.cursor_blink);
-                            replacement.vt_write(&replay);
-                            let delta = terminal_color_override_delta(&Default::default(), &colors);
-                            if !delta.is_empty() {
-                                replacement.vt_write(&delta);
                             }
-                            // Replay query responses were already answered by
-                            // the host; never send them again from the mirror.
-                            pending_responses.lock().unwrap().clear();
-                            title_changed.store(false, Ordering::Relaxed);
-                            let title = replacement.title().unwrap_or_default();
-                            let pwd = replacement.pwd();
-                            let mut scroll_changed = None;
-                            let generation = {
-                                let mut term = pty.term.lock().unwrap();
-                                let before = terminal_scroll_position(&term);
-                                *term = replacement;
-                                pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
-                                *pty.size.lock().unwrap() = (cols, rows);
-                                *pty.title.lock().unwrap() = title.clone();
-                                *pty.pwd.lock().unwrap() = pwd;
-                                applied_color_overrides = colors;
-                                let after = terminal_scroll_position(&term);
-                                if before != after {
-                                    scroll_changed = Some(after);
-                                    broadcast_render_scroll_locked(pty, after);
+                            capability_responses.resolve(&frame);
+                            continue;
+                        }
+                        let Ok(transition) = stager.push(frame) else {
+                            break;
+                        };
+                        let Some(transition) = transition else { continue };
+                        match transition {
+                            transition @ (HostedTransition::Output(_)
+                            | HostedTransition::OutputWithColors { .. }) => {
+                                let (output, colors) = match transition {
+                                    HostedTransition::Output(output) => (output, None),
+                                    HostedTransition::OutputWithColors { output, colors } => {
+                                        (output, Some(colors))
+                                    }
+                                    _ => unreachable!(),
+                                };
+                                let mut scroll_changed = None;
+                                let mut title_update = None;
+                                let defaults = mux
+                                    .upgrade()
+                                    .map(|mux| mux.default_colors())
+                                    .unwrap_or_default();
+                                let generation = {
+                                    let mut term = pty.term.lock().unwrap();
+                                    let before = terminal_scroll_position(&term);
+                                    term.vt_write(&output);
+                                    if let Some(colors) = colors.as_ref() {
+                                        let delta = terminal_color_override_delta(
+                                            &applied_color_overrides,
+                                            colors,
+                                        );
+                                        if !delta.is_empty() {
+                                            term.vt_write(&delta);
+                                        }
+                                        applied_color_overrides = colors.clone();
+                                    } else if term.color_overrides() != applied_color_overrides {
+                                        // An unflagged Output that changed colors
+                                        // violated the producer's iff contract.
+                                        break 'host_stream;
+                                    }
+                                    pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+                                    let after = terminal_scroll_position(&term);
+                                    // The parser already contains the complete
+                                    // coupled state before any attach observer can
+                                    // see the Output or ColorsChanged callback.
+                                    if colors.is_some() {
+                                        pty.broadcast_attach_frame(AttachFrame::OutputWithColors {
+                                            output,
+                                            colors: Box::new(TerminalColors::from_terminal(
+                                                &mut term, defaults,
+                                            )),
+                                        });
+                                    } else {
+                                        pty.broadcast_attach_output(&output);
+                                    }
+                                    if title_changed.swap(false, Ordering::Relaxed) {
+                                        let title = term.title().unwrap_or_default();
+                                        *pty.title.lock().unwrap() = title.clone();
+                                        title_update = Some(title);
+                                    }
+                                    if let Some(pwd) = term.pwd() {
+                                        *pty.pwd.lock().unwrap() = Some(pwd);
+                                    }
+                                    if before != after {
+                                        scroll_changed = Some(after);
+                                        broadcast_render_scroll_locked(pty, after);
+                                    }
+                                    pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
+                                };
+                                pty.request_frame(generation);
+                                if let Some(title) = title_update
+                                    && let Some(mux) = mux.upgrade()
+                                {
+                                    mux.emit(MuxEvent::TitleChanged {
+                                        surface: surface.id,
+                                        title: title.into(),
+                                    });
                                 }
-                                // Both attach notifications are queued only
-                                // after the authoritative replay and complete
-                                // color state have replaced the old parser.
-                                pty.broadcast_attach_frame(AttachFrame::ResizedWithColors {
-                                    cols,
-                                    rows,
-                                    replay,
-                                    colors: Box::new(TerminalColors::from_terminal(
-                                        &mut term, defaults,
-                                    )),
-                                });
-                                pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
-                            };
-                            pty.request_frame(generation);
-                            if let Some(mux) = mux.upgrade() {
-                                mux.emit(MuxEvent::TitleChanged {
-                                    surface: surface.id,
-                                    title: title.into(),
-                                });
-                                mux.emit(MuxEvent::SurfaceResized {
-                                    surface: surface.id,
-                                    cols,
-                                    rows,
-                                    reservation_id: None,
-                                });
-                                if let Some((offset, at_bottom)) = scroll_changed {
+                                if let Some((offset, at_bottom)) = scroll_changed
+                                    && let Some(mux) = mux.upgrade()
+                                {
                                     mux.emit(MuxEvent::ScrollChanged {
                                         surface: surface.id,
                                         offset,
                                         at_bottom,
                                     });
                                 }
+                                let responses =
+                                    std::mem::take(&mut *pending_responses.lock().unwrap());
+                                if !responses.is_empty() {
+                                    let _ = surface.write_bytes(&responses);
+                                }
+                            }
+                            HostedTransition::ResizedWithColors { cols, rows, replay, colors } => {
+                                let defaults = mux
+                                    .upgrade()
+                                    .map(|mux| mux.default_colors())
+                                    .unwrap_or_default();
+                                let callbacks = hosted_terminal_callbacks(
+                                    id,
+                                    mux.clone(),
+                                    pending_responses.clone(),
+                                    title_changed.clone(),
+                                );
+                                let Ok(mut replacement) =
+                                    Terminal::new(cols, rows, scrollback, callbacks)
+                                else {
+                                    break;
+                                };
+                                replacement.set_default_colors(
+                                    defaults.fg,
+                                    defaults.bg,
+                                    defaults.cursor,
+                                );
+                                replacement.set_default_palette(&defaults.palette);
+                                replacement.set_default_cursor(
+                                    defaults.cursor_style,
+                                    defaults.cursor_blink,
+                                );
+                                replacement.vt_write(&replay);
+                                let delta =
+                                    terminal_color_override_delta(&Default::default(), &colors);
+                                if !delta.is_empty() {
+                                    replacement.vt_write(&delta);
+                                }
+                                // Replay query responses were already answered by
+                                // the host; never send them again from the mirror.
+                                pending_responses.lock().unwrap().clear();
+                                title_changed.store(false, Ordering::Relaxed);
+                                let title = replacement.title().unwrap_or_default();
+                                let pwd = replacement.pwd();
+                                let mut scroll_changed = None;
+                                let generation = {
+                                    let mut term = pty.term.lock().unwrap();
+                                    let before = terminal_scroll_position(&term);
+                                    *term = replacement;
+                                    pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+                                    *pty.size.lock().unwrap() = (cols, rows);
+                                    *pty.title.lock().unwrap() = title.clone();
+                                    *pty.pwd.lock().unwrap() = pwd;
+                                    applied_color_overrides = colors;
+                                    let after = terminal_scroll_position(&term);
+                                    if before != after {
+                                        scroll_changed = Some(after);
+                                        broadcast_render_scroll_locked(pty, after);
+                                    }
+                                    // Both attach notifications are queued only
+                                    // after the authoritative replay and complete
+                                    // color state have replaced the old parser.
+                                    pty.broadcast_attach_frame(AttachFrame::ResizedWithColors {
+                                        cols,
+                                        rows,
+                                        replay,
+                                        colors: Box::new(TerminalColors::from_terminal(
+                                            &mut term, defaults,
+                                        )),
+                                    });
+                                    pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
+                                };
+                                pty.request_frame(generation);
+                                if let Some(mux) = mux.upgrade() {
+                                    mux.emit(MuxEvent::TitleChanged {
+                                        surface: surface.id,
+                                        title: title.into(),
+                                    });
+                                    mux.emit(MuxEvent::SurfaceResized {
+                                        surface: surface.id,
+                                        cols,
+                                        rows,
+                                        reservation_id: None,
+                                    });
+                                    if let Some((offset, at_bottom)) = scroll_changed {
+                                        mux.emit(MuxEvent::ScrollChanged {
+                                            surface: surface.id,
+                                            offset,
+                                            at_bottom,
+                                        });
+                                    }
+                                }
+                            }
+                            // The mirror derives these from the preceding Output;
+                            // the sequenced metadata frames are still consumed so
+                            // they cannot hide a stream gap.
+                            HostedTransition::Metadata(_kind) => {}
+                            HostedTransition::Exit => {
+                                received_exit = true;
+                                break;
+                            }
+                            HostedTransition::ResyncRequired => break,
+                        }
+                    }
+                    let Some(pty) = surface.as_pty() else { return };
+                    if pty.owner_detaching.load(Ordering::Acquire) {
+                        return;
+                    }
+                    let Some(identity) = pty.host_identity.clone() else { return };
+                    if received_exit {
+                        mark_hosted_runtime_exited(pty, &identity);
+                        pty.host_connection_state
+                            .store(TerminalHostConnectionState::Exited as u8, Ordering::Release);
+                        pty.dead.store(true, Ordering::Release);
+                        if let Some(mux) = mux.upgrade() {
+                            mux.surface_exited(surface.id);
+                        }
+                        return;
+                    }
+
+                    let first_loss = pty
+                        .host_connection_state
+                        .swap(TerminalHostConnectionState::Reconnecting as u8, Ordering::AcqRel)
+                        != TerminalHostConnectionState::Reconnecting as u8;
+                    if first_loss
+                        && let Some(mux) = mux.upgrade()
+                        && !mux.terminal_host_connection_lost(surface.id, &identity)
+                    {
+                        return;
+                    }
+
+                    let mut retry_delay = Duration::from_millis(25);
+                    loop {
+                        if pty.owner_detaching.load(Ordering::Acquire) {
+                            return;
+                        }
+                        let discovery = {
+                            let runtime = pty.runtime.lock().unwrap();
+                            match &*runtime {
+                                PtyRuntime::Hosted(host) => Some(host.discovery_record()),
+                                PtyRuntime::ExitedHosted | PtyRuntime::Local { .. } => None,
+                            }
+                        };
+                        let Some((record, record_path)) = discovery else { return };
+                        match crate::terminal_host_runtime::terminal_host_record_liveness(
+                            &record_path,
+                            &record,
+                        ) {
+                            Ok(crate::terminal_host_runtime::TerminalHostLiveness::Dead) => {
+                                mark_hosted_runtime_exited(pty, &identity);
+                                pty.host_connection_state.store(
+                                    TerminalHostConnectionState::Exited as u8,
+                                    Ordering::Release,
+                                );
+                                pty.dead.store(true, Ordering::Release);
+                                if let Some(mux) = mux.upgrade() {
+                                    mux.surface_exited(surface.id);
+                                }
+                                return;
+                            }
+                            Ok(crate::terminal_host_runtime::TerminalHostLiveness::Live)
+                            | Ok(
+                                crate::terminal_host_runtime::TerminalHostLiveness::Indeterminate,
+                            )
+                            | Err(_) => {}
+                        }
+
+                        let mut replacement =
+                            match crate::terminal_host_runtime::adopt_terminal_host(
+                                record,
+                                record_path,
+                            ) {
+                                Ok(replacement) if replacement.identity() == identity => {
+                                    replacement
+                                }
+                                Ok(_) | Err(_) => {
+                                    std::thread::sleep(retry_delay);
+                                    retry_delay = (retry_delay * 2).min(Duration::from_secs(1));
+                                    continue;
+                                }
+                            };
+                        let replacement_snapshot = replacement.snapshot.clone();
+                        let replacement_capabilities = replacement.capability_responses();
+                        let replacement_reader = match replacement.take_reader() {
+                            Ok(reader) => reader,
+                            Err(_) => {
+                                std::thread::sleep(retry_delay);
+                                continue;
+                            }
+                        };
+                        {
+                            let mut runtime = pty.runtime.lock().unwrap();
+                            if pty.owner_detaching.load(Ordering::Acquire) {
+                                replacement.disconnect();
+                                return;
+                            }
+                            match &*runtime {
+                                PtyRuntime::Hosted(current) if current.identity() == identity => {
+                                    *runtime = PtyRuntime::Hosted(Box::new(replacement));
+                                }
+                                PtyRuntime::Hosted(_)
+                                | PtyRuntime::ExitedHosted
+                                | PtyRuntime::Local { .. } => return,
                             }
                         }
-                        // The mirror derives these from the preceding Output;
-                        // the sequenced metadata frames are still consumed so
-                        // they cannot hide a stream gap.
-                        HostedTransition::Metadata(_kind) => {}
-                        HostedTransition::Exit => {
-                            received_exit = true;
-                            break;
+
+                        let defaults =
+                            mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
+                        let callbacks = hosted_terminal_callbacks(
+                            id,
+                            mux.clone(),
+                            pending_responses.clone(),
+                            title_changed.clone(),
+                        );
+                        let Ok(mut replacement_term) = Terminal::new(
+                            replacement_snapshot.cols,
+                            replacement_snapshot.rows,
+                            scrollback,
+                            callbacks,
+                        ) else {
+                            std::thread::sleep(retry_delay);
+                            continue;
+                        };
+                        replacement_term.set_default_colors(
+                            defaults.fg,
+                            defaults.bg,
+                            defaults.cursor,
+                        );
+                        replacement_term.set_default_palette(&defaults.palette);
+                        replacement_term
+                            .set_default_cursor(defaults.cursor_style, defaults.cursor_blink);
+                        replacement_term.vt_write(&replacement_snapshot.replay);
+                        let color_delta = terminal_color_override_delta(
+                            &Default::default(),
+                            &replacement_snapshot.colors,
+                        );
+                        if !color_delta.is_empty() {
+                            replacement_term.vt_write(&color_delta);
                         }
-                        HostedTransition::ResyncRequired => break,
+                        pending_responses.lock().unwrap().clear();
+                        title_changed.store(false, Ordering::Relaxed);
+                        let title = replacement_term.title().unwrap_or_default();
+                        let pwd = replacement_term.pwd();
+                        let generation = {
+                            let mut term = pty.term.lock().unwrap();
+                            *term = replacement_term;
+                            pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+                            *pty.size.lock().unwrap() =
+                                (replacement_snapshot.cols, replacement_snapshot.rows);
+                            *pty.title.lock().unwrap() = title.clone();
+                            *pty.pwd.lock().unwrap() = pwd;
+                            applied_color_overrides = replacement_snapshot.colors;
+                            pty.broadcast_attach_frame(AttachFrame::ResizedWithColors {
+                                cols: replacement_snapshot.cols,
+                                rows: replacement_snapshot.rows,
+                                replay: replacement_snapshot.replay,
+                                colors: Box::new(TerminalColors::from_terminal(
+                                    &mut term, defaults,
+                                )),
+                            });
+                            pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
+                        };
+                        pty.request_frame(generation);
+                        reader = replacement_reader;
+                        capability_responses = replacement_capabilities;
+                        sequence_boundary = replacement_snapshot.sequence_boundary;
+                        pty.host_connection_state
+                            .store(TerminalHostConnectionState::Connected as u8, Ordering::Release);
+                        if let Some(mux) = mux.upgrade() {
+                            mux.emit(MuxEvent::TitleChanged {
+                                surface: surface.id,
+                                title: title.into(),
+                            });
+                            mux.emit(MuxEvent::SurfaceResized {
+                                surface: surface.id,
+                                cols: replacement_snapshot.cols,
+                                rows: replacement_snapshot.rows,
+                                reservation_id: None,
+                            });
+                            if !mux.terminal_host_reconnected(surface.id, &identity) {
+                                return;
+                            }
+                        }
+                        continue 'connection;
                     }
-                }
-                if surface.as_pty().is_some_and(|pty| pty.owner_detaching.load(Ordering::Acquire)) {
-                    return;
-                }
-                if let Some(pty) = surface.as_pty() {
-                    if !received_exit {
-                        pty.host_connection_lost.store(true, Ordering::Release);
-                    }
-                    pty.dead.store(true, Ordering::Release);
-                }
-                if let Some(mux) = mux.upgrade() {
-                    mux.surface_exited(surface.id);
                 }
             }
         })?;
@@ -1101,6 +1331,69 @@ impl Surface {
     ) -> anyhow::Result<Arc<Surface>> {
         let attachment = crate::terminal_host_runtime::adopt_terminal_host(record, record_path)?;
         Self::spawn_hosted(id, opts, mux, attachment)
+    }
+
+    /// Materialize canonical Exited registry state without inventing a live
+    /// host connection. The stable identity stays queryable so later
+    /// placement mutations operate on the same terminal object rather than a
+    /// daemon-local surrogate.
+    #[cfg(unix)]
+    pub(crate) fn exited_terminal_placeholder(
+        id: SurfaceId,
+        opts: SurfaceOptions,
+        mux: Weak<Mux>,
+        identity: crate::terminal_host_runtime::TerminalHostIdentity,
+    ) -> anyhow::Result<Arc<Surface>> {
+        let pending_responses = Arc::new(Mutex::new(Vec::new()));
+        let title_changed = Arc::new(AtomicBool::new(false));
+        let callbacks =
+            hosted_terminal_callbacks(id, mux.clone(), pending_responses, title_changed);
+        let (cols, rows) = (opts.cols.max(1), opts.rows.max(1));
+        let mut term = Terminal::new(cols, rows, opts.scrollback, callbacks)?;
+        if let Some(mux) = mux.upgrade() {
+            let colors = mux.default_colors();
+            term.set_default_colors(colors.fg, colors.bg, colors.cursor);
+            term.set_default_palette(&colors.palette);
+            term.set_default_cursor(colors.cursor_style, colors.cursor_blink);
+        }
+        let mut mouse_encoders = MouseEncoders::new()?;
+        mouse_encoders.sync_from_terminal(&term);
+        let render_state = RenderState::new()?;
+        let (frame_requests, frame_rx) = sync_channel(1);
+        let command = opts
+            .command
+            .clone()
+            .filter(|command| !command.is_empty())
+            .unwrap_or_else(|| vec![platform::default_shell()]);
+        let surface = Arc::new(Surface::Pty(PtySurface {
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
+            term: Mutex::new(term),
+            mouse_encoders: Mutex::new(mouse_encoders),
+            runtime: Mutex::new(PtyRuntime::ExitedHosted),
+            host_identity: Some(identity),
+            pid: None,
+            command,
+            cwd: opts.cwd,
+            dead: AtomicBool::new(true),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Exited as u8),
+            dirty: AtomicBool::new(true),
+            title: Mutex::new(String::new()),
+            pwd: Mutex::new(None),
+            size: Mutex::new((cols, rows)),
+            mux,
+            taps: Mutex::new(Vec::new()),
+            render: Mutex::new(RenderHub {
+                state: Box::new(render_state),
+                built_generation: 0,
+                latest: None,
+                taps: Vec::new(),
+            }),
+            render_generation: AtomicU64::new(1),
+            frame_requests,
+        }));
+        spawn_frame_producer(&surface, frame_rx)?;
+        Ok(surface)
     }
 
     #[cfg(test)]
@@ -1150,12 +1443,13 @@ impl Surface {
                 }),
                 killer: Box::new(TestChildKiller),
             }),
+            host_identity: None,
             pid: Some(id as u32),
             command: opts.command.unwrap_or_else(|| vec![platform::default_shell()]),
             cwd: opts.cwd,
             dead: AtomicBool::new(false),
             owner_detaching: AtomicBool::new(false),
-            host_connection_lost: AtomicBool::new(false),
+            host_connection_state: AtomicU8::new(TerminalHostConnectionState::Connected as u8),
             dirty: AtomicBool::new(false),
             title: Mutex::new(String::new()),
             pwd: Mutex::new(None),
@@ -1210,6 +1504,10 @@ impl Surface {
             }
             #[cfg(unix)]
             PtyRuntime::Hosted(host) => host.send(MessageKind::Input, bytes),
+            #[cfg(unix)]
+            PtyRuntime::ExitedHosted => {
+                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "terminal host has exited"))
+            }
         }
     }
 
@@ -1230,6 +1528,12 @@ impl Surface {
             let runtime = pty.runtime.lock().unwrap();
             if let PtyRuntime::Hosted(host) = &*runtime {
                 return host.send(MessageKind::Paste, bytes);
+            }
+            if matches!(&*runtime, PtyRuntime::ExitedHosted) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "terminal host has exited",
+                ));
             }
         }
         let bracketed = {
@@ -1537,13 +1841,15 @@ impl Surface {
     pub fn terminal_host_identity(
         &self,
     ) -> Option<crate::terminal_host_runtime::TerminalHostIdentity> {
-        #[cfg(unix)]
-        if let Some(pty) = self.as_pty()
-            && let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap()
-        {
-            return Some(host.identity());
-        }
-        None
+        self.as_pty().and_then(|pty| pty.host_identity.clone())
+    }
+
+    pub fn terminal_host_connection_state(&self) -> Option<TerminalHostConnectionState> {
+        let pty = self.as_pty()?;
+        pty.host_identity.as_ref()?;
+        Some(TerminalHostConnectionState::from_u8(
+            pty.host_connection_state.load(Ordering::Acquire),
+        ))
     }
 
     /// Ask the host to mint a one-use renderer credential. The durable owner
@@ -1643,16 +1949,14 @@ impl Surface {
                     }
                     #[cfg(unix)]
                     PtyRuntime::Hosted(host) => {
-                        if pty.host_connection_lost.load(Ordering::Acquire) {
-                            host.disconnect();
-                            return;
-                        }
                         // The host owns record cleanup and removes it only
                         // after the PTY process has actually exited. Unlinking
                         // here would make a failed Terminate write turn a live
                         // shell into an undiscoverable orphan.
                         let _ = host.terminate();
                     }
+                    #[cfg(unix)]
+                    PtyRuntime::ExitedHosted => {}
                 }
             }
             Surface::Browser(browser) => browser.kill(),
@@ -1666,6 +1970,9 @@ impl Surface {
                 if let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap() {
                     pty.owner_detaching.store(true, Ordering::Release);
                     host.disconnect();
+                    return;
+                }
+                if matches!(&*pty.runtime.lock().unwrap(), PtyRuntime::ExitedHosted) {
                     return;
                 }
                 self.kill();
@@ -1943,6 +2250,8 @@ impl PtySurface {
                 }
                 #[cfg(unix)]
                 PtyRuntime::Hosted(_) => unreachable!("hosted resize returned above"),
+                #[cfg(unix)]
+                PtyRuntime::ExitedHosted => return false,
             }
         }
         // Nominal cell metrics; only pixel size reports observe these.
@@ -2172,6 +2481,34 @@ mod tests {
         let mut exit = Frame::new(MessageKind::Exit, vec![]);
         exit.sequence = 2;
         assert!(stager.push(exit).is_err(), "a coupled frame requires Colors exactly next");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_host_placeholder_preserves_identity_and_rejects_input() {
+        let mux = Mux::new_for_test("exited-host-placeholder", SurfaceOptions::default());
+        let identity = crate::terminal_host_runtime::TerminalHostIdentity {
+            terminal_id: crate::terminal_host::TerminalId::random().unwrap().to_hex(),
+            incarnation: crate::terminal_host::HostIncarnation::random().unwrap().to_hex(),
+        };
+        let surface = Surface::exited_terminal_placeholder(
+            91,
+            SurfaceOptions::default(),
+            Arc::downgrade(&mux),
+            identity.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(surface.terminal_host_identity(), Some(identity));
+        assert_eq!(
+            surface.terminal_host_connection_state(),
+            Some(TerminalHostConnectionState::Exited)
+        );
+        assert!(surface.is_dead());
+        assert_eq!(
+            surface.write_bytes(b"must not reach a dead host").unwrap_err().kind(),
+            std::io::ErrorKind::BrokenPipe
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -667,7 +667,7 @@ impl Surface {
                     default_colors,
                 )?,
             };
-            return Self::spawn_hosted(id, opts, mux, attachment);
+            return Self::spawn_hosted(id, opts, mux, attachment, true);
         }
         let _ = terminal_id;
         let pty = native_pty_system().openpty(PtySize {
@@ -854,8 +854,15 @@ impl Surface {
         opts: SurfaceOptions,
         mux: Weak<Mux>,
         mut attachment: crate::terminal_host_runtime::HostAttachment,
+        terminate_on_error: bool,
     ) -> anyhow::Result<Arc<Surface>> {
         let mut reader = attachment.take_reader()?;
+        if let Ok(delay_ms) = std::env::var("CMUX_TUI_TEST_HOSTED_SPAWN_FAIL_AFTER_CONNECT")
+            && let Ok(delay_ms) = delay_ms.parse::<u64>()
+        {
+            std::thread::sleep(Duration::from_millis(delay_ms));
+            anyhow::bail!("injected hosted surface setup failure after attachment");
+        }
         let mut capability_responses = attachment.capability_responses();
         let snapshot = attachment.snapshot.clone();
         let mut applied_color_overrides = snapshot.colors.clone();
@@ -920,6 +927,10 @@ impl Surface {
         }));
         spawn_frame_producer(&surface, frame_rx)?;
 
+        // Keep exact-child rollback ownership armed through the final thread
+        // spawn. If Builder::spawn fails, dropping the closure clone and
+        // function-local Surface drops the still-armed attachment, so no
+        // control-write failure can convert this Err into a live orphan.
         std::thread::Builder::new().name(format!("surface-{id}-host")).spawn({
             let surface = surface.clone();
             let scrollback = opts.scrollback;
@@ -1318,6 +1329,12 @@ impl Surface {
                 }
             }
         })?;
+        if terminate_on_error
+            && let Some(pty) = surface.as_pty()
+            && let PtyRuntime::Hosted(host) = &mut *pty.runtime.lock().unwrap()
+        {
+            host.commit_launched_host();
+        }
         Ok(surface)
     }
 
@@ -1330,7 +1347,7 @@ impl Surface {
         record_path: PathBuf,
     ) -> anyhow::Result<Arc<Surface>> {
         let attachment = crate::terminal_host_runtime::adopt_terminal_host(record, record_path)?;
-        Self::spawn_hosted(id, opts, mux, attachment)
+        Self::spawn_hosted(id, opts, mux, attachment, false)
     }
 
     /// Materialize canonical Exited registry state without inventing a live

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -595,13 +595,36 @@ impl Surface {
         opts: SurfaceOptions,
         mux: Weak<Mux>,
     ) -> anyhow::Result<Arc<Surface>> {
+        Self::spawn_with_terminal_id(id, opts, mux, None)
+    }
+
+    pub(crate) fn spawn_with_terminal_id(
+        id: SurfaceId,
+        opts: SurfaceOptions,
+        mux: Weak<Mux>,
+        terminal_id: Option<crate::terminal_host::TerminalId>,
+    ) -> anyhow::Result<Arc<Surface>> {
         #[cfg(unix)]
         if let Some(root) = opts.terminal_host_root.clone() {
             let default_colors = mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
-            let attachment =
-                crate::terminal_host_runtime::launch_terminal_host(&opts, &root, default_colors)?;
+            let attachment = match terminal_id {
+                Some(terminal_id) => {
+                    crate::terminal_host_runtime::launch_terminal_host_with_identity(
+                        &opts,
+                        &root,
+                        default_colors,
+                        terminal_id,
+                    )?
+                }
+                None => crate::terminal_host_runtime::launch_terminal_host(
+                    &opts,
+                    &root,
+                    default_colors,
+                )?,
+            };
             return Self::spawn_hosted(id, opts, mux, attachment);
         }
+        let _ = terminal_id;
         let pty = native_pty_system().openpty(PtySize {
             rows: opts.rows,
             cols: opts.cols,
@@ -1624,10 +1647,11 @@ impl Surface {
                             host.disconnect();
                             return;
                         }
+                        // The host owns record cleanup and removes it only
+                        // after the PTY process has actually exited. Unlinking
+                        // here would make a failed Terminate write turn a live
+                        // shell into an undiscoverable orphan.
                         let _ = host.terminate();
-                        crate::terminal_host_runtime::remove_terminal_host_record(
-                            &host.record_path,
-                        );
                     }
                 }
             }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8,6 +8,7 @@
 use std::io::{Read, Write};
 use std::mem::size_of;
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{
     Receiver, RecvError, RecvTimeoutError, SyncSender, TryRecvError, TrySendError, sync_channel,
@@ -17,6 +18,7 @@ use std::time::{Duration, Instant};
 
 use ghostty_vt::{
     Callbacks, CursorShape, MouseEncoders, MouseInput, RenderFrame, RenderState, Rgb, Terminal,
+    TerminalColorOverrides,
 };
 use portable_pty::{ChildKiller, CommandBuilder, MasterPty, PtySize, native_pty_system};
 
@@ -27,6 +29,8 @@ use crate::browser::BrowserSurface;
 pub use crate::browser::{
     BrowserAttachState, BrowserFrame, BrowserFrameStream, BrowserSource, BrowserStatus,
 };
+#[cfg(unix)]
+use crate::terminal_host_protocol::{FLAG_COLORS_FOLLOW, Frame, MessageKind, PROTOCOL_VERSION};
 use cmux_tui_cdp::BrowserMode;
 
 /// How to spawn surface children.
@@ -63,6 +67,9 @@ pub struct SurfaceOptions {
     pub browser_max_capture_megapixels: f64,
     /// Optional maximum browser capture scale, further reduced to honor the megapixel cap.
     pub browser_capture_scale: Option<f64>,
+    /// Durable per-terminal host records. When set, PTYs are created in a
+    /// dedicated process and this surface becomes an adoptable mirror.
+    pub terminal_host_root: Option<PathBuf>,
 }
 
 impl Default for SurfaceOptions {
@@ -87,6 +94,7 @@ impl Default for SurfaceOptions {
             browser_ephemeral: false,
             browser_max_capture_megapixels: crate::browser::TRANSPORT_SAFE_CAPTURE_MEGAPIXELS,
             browser_capture_scale: None,
+            terminal_host_root: None,
         }
     }
 }
@@ -119,7 +127,7 @@ impl Default for DefaultColors {
 }
 
 /// Effective colors exposed to attached terminal clients.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TerminalColors {
     pub fg: Option<Rgb>,
     pub bg: Option<Rgb>,
@@ -128,11 +136,30 @@ pub struct TerminalColors {
     pub selection_fg: Option<Rgb>,
     pub cursor_style: Option<CursorShape>,
     pub cursor_blink: Option<bool>,
+    /// Complete sparse application-authored OSC 4 state. Missing entries
+    /// mean reset to the receiving frontend's palette defaults.
+    pub palette: [Option<Rgb>; 256],
+}
+
+impl Default for TerminalColors {
+    fn default() -> Self {
+        Self {
+            fg: None,
+            bg: None,
+            cursor: None,
+            selection_bg: None,
+            selection_fg: None,
+            cursor_style: None,
+            cursor_blink: None,
+            palette: [None; 256],
+        }
+    }
 }
 
 impl TerminalColors {
     fn from_terminal(term: &mut Terminal, defaults: DefaultColors) -> Self {
         let (fg, bg, cursor) = term.effective_colors();
+        let palette = term.color_overrides().palette;
         let cursor_visual = term.cursor_overridden().then(|| {
             RenderState::new()
                 .and_then(|mut state| {
@@ -150,6 +177,7 @@ impl TerminalColors {
             selection_fg: defaults.selection_fg,
             cursor_style: cursor_visual.map(|(style, _)| style).or(defaults.cursor_style),
             cursor_blink: cursor_visual.map(|(_, blink)| blink).or(defaults.cursor_blink),
+            palette,
         }
     }
 }
@@ -169,8 +197,121 @@ pub struct AttachStream {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AttachFrame {
     Output(Vec<u8>),
+    /// One parser transition: consumers must apply `output` and replace the
+    /// complete color state before rendering or notifying observers.
+    OutputWithColors {
+        output: Vec<u8>,
+        colors: Box<TerminalColors>,
+    },
+    Resized {
+        cols: u16,
+        rows: u16,
+        replay: Vec<u8>,
+    },
+    /// One parser transition: `replay` is theme-portable, so `colors` is part
+    /// of the same replacement snapshot rather than a subsequent callback.
+    ResizedWithColors {
+        cols: u16,
+        rows: u16,
+        replay: Vec<u8>,
+        colors: Box<TerminalColors>,
+    },
+    ColorsChanged(Box<TerminalColors>),
+}
+
+/// A host frame is not actionable until its wire-level atomicity contract is
+/// satisfied. In particular, a renderer must never expose output or a resize
+/// whose authoritative color state is still sitting in the socket.
+#[cfg(unix)]
+#[derive(Debug)]
+enum HostedTransition {
+    Output(Vec<u8>),
+    OutputWithColors { output: Vec<u8>, colors: TerminalColorOverrides },
+    ResizedWithColors { cols: u16, rows: u16, replay: Vec<u8>, colors: TerminalColorOverrides },
+    Metadata(MessageKind),
+    Exit,
+    ResyncRequired,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+enum PendingHostedTransition {
+    Output(Vec<u8>),
     Resized { cols: u16, rows: u16, replay: Vec<u8> },
-    ColorsChanged(TerminalColors),
+}
+
+#[cfg(unix)]
+struct HostedFrameStager {
+    expected_sequence: u64,
+    pending: Option<PendingHostedTransition>,
+}
+
+#[cfg(unix)]
+impl HostedFrameStager {
+    fn new(sequence_boundary: u64) -> Self {
+        Self { expected_sequence: sequence_boundary.wrapping_add(1), pending: None }
+    }
+
+    fn push(&mut self, frame: Frame) -> Result<Option<HostedTransition>, &'static str> {
+        if frame.version != PROTOCOL_VERSION || frame.request_id != 0 {
+            return Err("invalid live-frame envelope");
+        }
+        if frame.sequence != self.expected_sequence {
+            return Err("non-contiguous live-frame sequence");
+        }
+        self.expected_sequence = self.expected_sequence.wrapping_add(1);
+
+        if let Some(pending) = self.pending.take() {
+            if frame.kind != MessageKind::Colors || frame.flags != 0 {
+                return Err("coupled frame was not followed by Colors");
+            }
+            let colors =
+                crate::terminal_host_runtime::decode_terminal_color_overrides(&frame.payload)
+                    .map_err(|_| "invalid Colors payload")?;
+            return Ok(Some(match pending {
+                PendingHostedTransition::Output(output) => {
+                    HostedTransition::OutputWithColors { output, colors }
+                }
+                PendingHostedTransition::Resized { cols, rows, replay } => {
+                    HostedTransition::ResizedWithColors { cols, rows, replay, colors }
+                }
+            }));
+        }
+
+        match frame.kind {
+            MessageKind::Output => match frame.flags {
+                0 => Ok(Some(HostedTransition::Output(frame.payload))),
+                FLAG_COLORS_FOLLOW => {
+                    self.pending = Some(PendingHostedTransition::Output(frame.payload));
+                    Ok(None)
+                }
+                _ => Err("unknown Output flags"),
+            },
+            MessageKind::Resized => {
+                if frame.flags != FLAG_COLORS_FOLLOW || frame.payload.len() < 4 {
+                    return Err("invalid Resized frame");
+                }
+                let cols = u16::from_le_bytes([frame.payload[0], frame.payload[1]]).max(1);
+                let rows = u16::from_le_bytes([frame.payload[2], frame.payload[3]]).max(1);
+                self.pending = Some(PendingHostedTransition::Resized {
+                    cols,
+                    rows,
+                    replay: frame.payload[4..].to_vec(),
+                });
+                Ok(None)
+            }
+            MessageKind::Title | MessageKind::Pwd | MessageKind::Bell if frame.flags == 0 => {
+                Ok(Some(HostedTransition::Metadata(frame.kind)))
+            }
+            MessageKind::Exit if frame.flags == 0 => Ok(Some(HostedTransition::Exit)),
+            MessageKind::ResyncRequired if frame.flags == 0 => {
+                Ok(Some(HostedTransition::ResyncRequired))
+            }
+            MessageKind::Colors => Err("unpaired Colors frame"),
+            _ if frame.flags != 0 => Err("flags are not valid for this message kind"),
+            _ => Err("message kind is not valid on the live stream"),
+        }
+    }
 }
 
 const ATTACH_STREAM_CAPACITY: usize = 256;
@@ -211,8 +352,14 @@ impl AttachFrame {
         size_of::<Self>()
             + match self {
                 Self::Output(bytes) => bytes.capacity(),
+                Self::OutputWithColors { output, .. } => {
+                    output.capacity() + size_of::<TerminalColors>()
+                }
                 Self::Resized { replay, .. } => replay.capacity(),
-                Self::ColorsChanged(_) => 0,
+                Self::ResizedWithColors { replay, .. } => {
+                    replay.capacity() + size_of::<TerminalColors>()
+                }
+                Self::ColorsChanged(_) => size_of::<TerminalColors>(),
             }
     }
 }
@@ -373,13 +520,17 @@ pub struct PtySurface {
     pub(crate) meta: SurfaceMeta,
     term: Mutex<Terminal>,
     mouse_encoders: Mutex<MouseEncoders>,
-    writer: Mutex<Box<dyn Write + Send>>,
-    master: Mutex<Box<dyn MasterPty + Send>>,
-    killer: Mutex<Box<dyn ChildKiller + Send>>,
+    runtime: Mutex<PtyRuntime>,
     pid: Option<u32>,
     command: Vec<String>,
     cwd: Option<String>,
     dead: AtomicBool,
+    /// The daemon is intentionally dropping its compatibility proxy while
+    /// leaving the terminal host alive for a later daemon to adopt.
+    owner_detaching: AtomicBool,
+    /// The host socket ended without a sequenced Exit. Closing this proxy
+    /// must retain the host record so a fresh snapshot can recover it.
+    host_connection_lost: AtomicBool,
     /// Set when output arrived since the last render; cleared by the
     /// frontend when it draws.
     dirty: AtomicBool,
@@ -400,6 +551,38 @@ pub struct PtySurface {
     frame_requests: SyncSender<u64>,
 }
 
+enum PtyRuntime {
+    Local {
+        writer: Box<dyn Write + Send>,
+        master: Box<dyn MasterPty + Send>,
+        killer: Box<dyn ChildKiller + Send>,
+    },
+    #[cfg(unix)]
+    Hosted(Box<crate::terminal_host_runtime::HostAttachment>),
+}
+
+#[cfg(unix)]
+fn hosted_terminal_callbacks(
+    id: SurfaceId,
+    mux: Weak<Mux>,
+    pending_responses: Arc<Mutex<Vec<u8>>>,
+    title_changed: Arc<AtomicBool>,
+) -> Callbacks {
+    Callbacks {
+        on_pty_write: Some(Box::new(move |bytes| {
+            pending_responses.lock().unwrap().extend_from_slice(bytes);
+        })),
+        on_title_changed: Some(Box::new(move || {
+            title_changed.store(true, Ordering::Relaxed);
+        })),
+        on_bell: Some(Box::new(move || {
+            if let Some(mux) = mux.upgrade() {
+                mux.emit(MuxEvent::Bell(id));
+            }
+        })),
+    }
+}
+
 impl std::fmt::Debug for Surface {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Surface").field("id", &self.id).field("kind", &self.kind()).finish()
@@ -412,6 +595,13 @@ impl Surface {
         opts: SurfaceOptions,
         mux: Weak<Mux>,
     ) -> anyhow::Result<Arc<Surface>> {
+        #[cfg(unix)]
+        if let Some(root) = opts.terminal_host_root.clone() {
+            let default_colors = mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
+            let attachment =
+                crate::terminal_host_runtime::launch_terminal_host(&opts, &root, default_colors)?;
+            return Self::spawn_hosted(id, opts, mux, attachment);
+        }
         let pty = native_pty_system().openpty(PtySize {
             rows: opts.rows,
             cols: opts.cols,
@@ -486,13 +676,13 @@ impl Surface {
             meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
             term: Mutex::new(term),
             mouse_encoders: Mutex::new(mouse_encoders),
-            writer: Mutex::new(writer),
-            master: Mutex::new(pty.master),
-            killer: Mutex::new(killer),
+            runtime: Mutex::new(PtyRuntime::Local { writer, master: pty.master, killer }),
             pid,
             command: argv,
             cwd,
             dead: AtomicBool::new(false),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_lost: AtomicBool::new(false),
             dirty: AtomicBool::new(false),
             title: Mutex::new(String::new()),
             pwd: Mutex::new(None),
@@ -523,13 +713,21 @@ impl Surface {
                     };
                     let pty = surface.as_pty().expect("surface reader got non-pty surface");
                     let mut scroll_changed = None;
+                    let defaults =
+                        mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
                     let generation = {
                         let mut term = pty.term.lock().unwrap();
                         let before = terminal_scroll_position(&term);
+                        let colors_before = term.color_overrides();
                         term.vt_write(&buf[..n]);
                         pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
                         let after = terminal_scroll_position(&term);
                         pty.broadcast_attach_output(&buf[..n]);
+                        if term.color_overrides() != colors_before {
+                            pty.broadcast_attach_frame(AttachFrame::ColorsChanged(Box::new(
+                                TerminalColors::from_terminal(&mut term, defaults),
+                            )));
+                        }
                         if title_changed.swap(false, Ordering::Relaxed) {
                             let title = term.title().unwrap_or_default();
                             *pty.title.lock().unwrap() = title.clone();
@@ -581,6 +779,307 @@ impl Surface {
         Ok(surface)
     }
 
+    #[cfg(unix)]
+    fn spawn_hosted(
+        id: SurfaceId,
+        opts: SurfaceOptions,
+        mux: Weak<Mux>,
+        mut attachment: crate::terminal_host_runtime::HostAttachment,
+    ) -> anyhow::Result<Arc<Surface>> {
+        let mut reader = attachment.take_reader()?;
+        let capability_responses = attachment.capability_responses();
+        let snapshot = attachment.snapshot.clone();
+        let mut applied_color_overrides = snapshot.colors.clone();
+        let pending_responses: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let title_changed = Arc::new(AtomicBool::new(false));
+        let callbacks = hosted_terminal_callbacks(
+            id,
+            mux.clone(),
+            pending_responses.clone(),
+            title_changed.clone(),
+        );
+        let mut term = Terminal::new(snapshot.cols, snapshot.rows, opts.scrollback, callbacks)?;
+        if let Some(mux) = mux.upgrade() {
+            let colors = mux.default_colors();
+            term.set_default_colors(colors.fg, colors.bg, colors.cursor);
+            term.set_default_palette(&colors.palette);
+            term.set_default_cursor(colors.cursor_style, colors.cursor_blink);
+        }
+        term.vt_write(&snapshot.replay);
+        let initial_color_delta =
+            terminal_color_override_delta(&Default::default(), &snapshot.colors);
+        if !initial_color_delta.is_empty() {
+            term.vt_write(&initial_color_delta);
+        }
+        // Query replies represented in a replay have already been answered by
+        // the authoritative host; never send them a second time on adoption.
+        pending_responses.lock().unwrap().clear();
+        let title = term.title().unwrap_or_default();
+        let pwd = term.pwd();
+        let mut mouse_encoders = MouseEncoders::new()?;
+        mouse_encoders.sync_from_terminal(&term);
+        let sequence_boundary = snapshot.sequence_boundary;
+        let render_state = RenderState::new()?;
+        let (frame_requests, frame_rx) = sync_channel(1);
+        let surface = Arc::new(Surface::Pty(PtySurface {
+            meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
+            term: Mutex::new(term),
+            mouse_encoders: Mutex::new(mouse_encoders),
+            runtime: Mutex::new(PtyRuntime::Hosted(Box::new(attachment))),
+            pid: snapshot.pid,
+            command: snapshot.command,
+            cwd: snapshot.cwd,
+            dead: AtomicBool::new(false),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_lost: AtomicBool::new(false),
+            dirty: AtomicBool::new(true),
+            title: Mutex::new(title),
+            pwd: Mutex::new(pwd),
+            size: Mutex::new((snapshot.cols, snapshot.rows)),
+            mux: mux.clone(),
+            taps: Mutex::new(Vec::new()),
+            render: Mutex::new(RenderHub {
+                state: Box::new(render_state),
+                built_generation: 0,
+                latest: None,
+                taps: Vec::new(),
+            }),
+            render_generation: AtomicU64::new(1),
+            frame_requests,
+        }));
+        spawn_frame_producer(&surface, frame_rx)?;
+
+        std::thread::Builder::new().name(format!("surface-{id}-host")).spawn({
+            let surface = surface.clone();
+            let scrollback = opts.scrollback;
+            move || {
+                let mut stager = HostedFrameStager::new(sequence_boundary);
+                let mut received_exit = false;
+                'host_stream: while let Ok(Some(frame)) = crate::terminal_host_protocol::read_frame(
+                    &mut reader,
+                    crate::terminal_host_protocol::MAX_FRAME_PAYLOAD,
+                ) {
+                    let Some(pty) = surface.as_pty() else { break };
+                    if frame.kind == MessageKind::Capability && frame.request_id != 0 {
+                        if frame.version != PROTOCOL_VERSION
+                            || frame.flags != 0
+                            || frame.sequence != 0
+                        {
+                            break;
+                        }
+                        capability_responses.resolve(&frame);
+                        continue;
+                    }
+                    let Ok(transition) = stager.push(frame) else {
+                        break;
+                    };
+                    let Some(transition) = transition else { continue };
+                    match transition {
+                        transition @ (HostedTransition::Output(_)
+                        | HostedTransition::OutputWithColors { .. }) => {
+                            let (output, colors) = match transition {
+                                HostedTransition::Output(output) => (output, None),
+                                HostedTransition::OutputWithColors { output, colors } => {
+                                    (output, Some(colors))
+                                }
+                                _ => unreachable!(),
+                            };
+                            let mut scroll_changed = None;
+                            let mut title_update = None;
+                            let defaults =
+                                mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
+                            let generation = {
+                                let mut term = pty.term.lock().unwrap();
+                                let before = terminal_scroll_position(&term);
+                                term.vt_write(&output);
+                                if let Some(colors) = colors.as_ref() {
+                                    let delta = terminal_color_override_delta(
+                                        &applied_color_overrides,
+                                        colors,
+                                    );
+                                    if !delta.is_empty() {
+                                        term.vt_write(&delta);
+                                    }
+                                    applied_color_overrides = colors.clone();
+                                } else if term.color_overrides() != applied_color_overrides {
+                                    // An unflagged Output that changed colors
+                                    // violated the producer's iff contract.
+                                    break 'host_stream;
+                                }
+                                pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+                                let after = terminal_scroll_position(&term);
+                                // The parser already contains the complete
+                                // coupled state before any attach observer can
+                                // see the Output or ColorsChanged callback.
+                                if colors.is_some() {
+                                    pty.broadcast_attach_frame(AttachFrame::OutputWithColors {
+                                        output,
+                                        colors: Box::new(TerminalColors::from_terminal(
+                                            &mut term, defaults,
+                                        )),
+                                    });
+                                } else {
+                                    pty.broadcast_attach_output(&output);
+                                }
+                                if title_changed.swap(false, Ordering::Relaxed) {
+                                    let title = term.title().unwrap_or_default();
+                                    *pty.title.lock().unwrap() = title.clone();
+                                    title_update = Some(title);
+                                }
+                                if let Some(pwd) = term.pwd() {
+                                    *pty.pwd.lock().unwrap() = Some(pwd);
+                                }
+                                if before != after {
+                                    scroll_changed = Some(after);
+                                    broadcast_render_scroll_locked(pty, after);
+                                }
+                                pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
+                            };
+                            pty.request_frame(generation);
+                            if let Some(title) = title_update
+                                && let Some(mux) = mux.upgrade()
+                            {
+                                mux.emit(MuxEvent::TitleChanged {
+                                    surface: surface.id,
+                                    title: title.into(),
+                                });
+                            }
+                            if let Some((offset, at_bottom)) = scroll_changed
+                                && let Some(mux) = mux.upgrade()
+                            {
+                                mux.emit(MuxEvent::ScrollChanged {
+                                    surface: surface.id,
+                                    offset,
+                                    at_bottom,
+                                });
+                            }
+                            let responses = std::mem::take(&mut *pending_responses.lock().unwrap());
+                            if !responses.is_empty() {
+                                let _ = surface.write_bytes(&responses);
+                            }
+                        }
+                        HostedTransition::ResizedWithColors { cols, rows, replay, colors } => {
+                            let defaults =
+                                mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
+                            let callbacks = hosted_terminal_callbacks(
+                                id,
+                                mux.clone(),
+                                pending_responses.clone(),
+                                title_changed.clone(),
+                            );
+                            let Ok(mut replacement) =
+                                Terminal::new(cols, rows, scrollback, callbacks)
+                            else {
+                                break;
+                            };
+                            replacement.set_default_colors(
+                                defaults.fg,
+                                defaults.bg,
+                                defaults.cursor,
+                            );
+                            replacement.set_default_palette(&defaults.palette);
+                            replacement
+                                .set_default_cursor(defaults.cursor_style, defaults.cursor_blink);
+                            replacement.vt_write(&replay);
+                            let delta = terminal_color_override_delta(&Default::default(), &colors);
+                            if !delta.is_empty() {
+                                replacement.vt_write(&delta);
+                            }
+                            // Replay query responses were already answered by
+                            // the host; never send them again from the mirror.
+                            pending_responses.lock().unwrap().clear();
+                            title_changed.store(false, Ordering::Relaxed);
+                            let title = replacement.title().unwrap_or_default();
+                            let pwd = replacement.pwd();
+                            let mut scroll_changed = None;
+                            let generation = {
+                                let mut term = pty.term.lock().unwrap();
+                                let before = terminal_scroll_position(&term);
+                                *term = replacement;
+                                pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+                                *pty.size.lock().unwrap() = (cols, rows);
+                                *pty.title.lock().unwrap() = title.clone();
+                                *pty.pwd.lock().unwrap() = pwd;
+                                applied_color_overrides = colors;
+                                let after = terminal_scroll_position(&term);
+                                if before != after {
+                                    scroll_changed = Some(after);
+                                    broadcast_render_scroll_locked(pty, after);
+                                }
+                                // Both attach notifications are queued only
+                                // after the authoritative replay and complete
+                                // color state have replaced the old parser.
+                                pty.broadcast_attach_frame(AttachFrame::ResizedWithColors {
+                                    cols,
+                                    rows,
+                                    replay,
+                                    colors: Box::new(TerminalColors::from_terminal(
+                                        &mut term, defaults,
+                                    )),
+                                });
+                                pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1
+                            };
+                            pty.request_frame(generation);
+                            if let Some(mux) = mux.upgrade() {
+                                mux.emit(MuxEvent::TitleChanged {
+                                    surface: surface.id,
+                                    title: title.into(),
+                                });
+                                mux.emit(MuxEvent::SurfaceResized {
+                                    surface: surface.id,
+                                    cols,
+                                    rows,
+                                    reservation_id: None,
+                                });
+                                if let Some((offset, at_bottom)) = scroll_changed {
+                                    mux.emit(MuxEvent::ScrollChanged {
+                                        surface: surface.id,
+                                        offset,
+                                        at_bottom,
+                                    });
+                                }
+                            }
+                        }
+                        // The mirror derives these from the preceding Output;
+                        // the sequenced metadata frames are still consumed so
+                        // they cannot hide a stream gap.
+                        HostedTransition::Metadata(_kind) => {}
+                        HostedTransition::Exit => {
+                            received_exit = true;
+                            break;
+                        }
+                        HostedTransition::ResyncRequired => break,
+                    }
+                }
+                if surface.as_pty().is_some_and(|pty| pty.owner_detaching.load(Ordering::Acquire)) {
+                    return;
+                }
+                if let Some(pty) = surface.as_pty() {
+                    if !received_exit {
+                        pty.host_connection_lost.store(true, Ordering::Release);
+                    }
+                    pty.dead.store(true, Ordering::Release);
+                }
+                if let Some(mux) = mux.upgrade() {
+                    mux.surface_exited(surface.id);
+                }
+            }
+        })?;
+        Ok(surface)
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn adopt_hosted(
+        id: SurfaceId,
+        opts: SurfaceOptions,
+        mux: Weak<Mux>,
+        record: crate::terminal_host_runtime::TerminalHostRecord,
+        record_path: PathBuf,
+    ) -> anyhow::Result<Arc<Surface>> {
+        let attachment = crate::terminal_host_runtime::adopt_terminal_host(record, record_path)?;
+        Self::spawn_hosted(id, opts, mux, attachment)
+    }
+
     #[cfg(test)]
     pub(crate) fn spawn_for_test(
         id: SurfaceId,
@@ -616,20 +1115,24 @@ impl Surface {
             meta: SurfaceMeta { id, name: Mutex::new(None), selection: Mutex::new(None) },
             term: Mutex::new(term),
             mouse_encoders: Mutex::new(mouse_encoders),
-            writer: Mutex::new(Box::new(std::io::sink())),
-            master: Mutex::new(Box::new(TestMasterPty {
-                size: Mutex::new(PtySize {
-                    rows: opts.rows,
-                    cols: opts.cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
+            runtime: Mutex::new(PtyRuntime::Local {
+                writer: Box::new(std::io::sink()),
+                master: Box::new(TestMasterPty {
+                    size: Mutex::new(PtySize {
+                        rows: opts.rows,
+                        cols: opts.cols,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    }),
                 }),
-            })),
-            killer: Mutex::new(Box::new(TestChildKiller)),
+                killer: Box::new(TestChildKiller),
+            }),
             pid: Some(id as u32),
             command: opts.command.unwrap_or_else(|| vec![platform::default_shell()]),
             cwd: opts.cwd,
             dead: AtomicBool::new(false),
+            owner_detaching: AtomicBool::new(false),
+            host_connection_lost: AtomicBool::new(false),
             dirty: AtomicBool::new(false),
             title: Mutex::new(String::new()),
             pwd: Mutex::new(None),
@@ -676,9 +1179,15 @@ impl Surface {
                 "browser surface does not accept PTY bytes",
             ));
         };
-        let mut writer = pty.writer.lock().unwrap();
-        writer.write_all(bytes)?;
-        writer.flush()
+        let mut runtime = pty.runtime.lock().unwrap();
+        match &mut *runtime {
+            PtyRuntime::Local { writer, .. } => {
+                writer.write_all(bytes)?;
+                writer.flush()
+            }
+            #[cfg(unix)]
+            PtyRuntime::Hosted(host) => host.send(MessageKind::Input, bytes),
+        }
     }
 
     /// Write a protocol input payload, conditionally applying bracketed-paste
@@ -693,11 +1202,21 @@ impl Surface {
         if bytes.is_empty() {
             return Ok(());
         }
+        #[cfg(unix)]
+        {
+            let runtime = pty.runtime.lock().unwrap();
+            if let PtyRuntime::Hosted(host) = &*runtime {
+                return host.send(MessageKind::Paste, bytes);
+            }
+        }
         let bracketed = {
             let term = pty.term.lock().unwrap();
             term.mode(2004, false)
         };
-        let mut writer = pty.writer.lock().unwrap();
+        let mut runtime = pty.runtime.lock().unwrap();
+        let PtyRuntime::Local { writer, .. } = &mut *runtime else {
+            unreachable!("hosted paste returned above")
+        };
         if bracketed {
             writer.write_all(b"\x1b[200~")?;
         }
@@ -843,7 +1362,7 @@ impl Surface {
             let colors = TerminalColors::from_terminal(&mut term, colors);
             let mut taps = pty.taps.lock().unwrap();
             if !taps.is_empty() {
-                taps.retain(|tap| tap.try_send(AttachFrame::ColorsChanged(colors)));
+                taps.retain(|tap| tap.try_send(AttachFrame::ColorsChanged(Box::new(colors))));
             }
             drop(taps);
             let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
@@ -896,6 +1415,24 @@ impl Surface {
         match self {
             Surface::Pty(pty) => Ok(pty.resize(cols, rows)),
             Surface::Browser(browser) => browser.resize(cols, rows),
+        }
+    }
+
+    /// Hosted PTYs acknowledge a resize with an authoritative replay/color
+    /// pair. The mux must wait for that pair before publishing the new grid.
+    pub(crate) fn resize_reports_asynchronously(&self) -> bool {
+        match self {
+            Surface::Pty(pty) => {
+                #[cfg(unix)]
+                {
+                    matches!(&*pty.runtime.lock().unwrap(), PtyRuntime::Hosted(_))
+                }
+                #[cfg(not(unix))]
+                {
+                    false
+                }
+            }
+            Surface::Browser(_) => true,
         }
     }
 
@@ -972,6 +1509,36 @@ impl Surface {
         self.as_pty().and_then(|pty| pty.cwd.clone())
     }
 
+    /// Process-stable identity for hosted terminals. Surface ids remain
+    /// daemon-local compatibility handles and may change after adoption.
+    pub fn terminal_host_identity(
+        &self,
+    ) -> Option<crate::terminal_host_runtime::TerminalHostIdentity> {
+        #[cfg(unix)]
+        if let Some(pty) = self.as_pty()
+            && let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap()
+        {
+            return Some(host.identity());
+        }
+        None
+    }
+
+    /// Ask the host to mint a one-use renderer credential. The durable owner
+    /// secret remains confined to the daemon and its private state record.
+    pub fn mint_renderer_grant(
+        &self,
+        ttl: Duration,
+    ) -> anyhow::Result<crate::terminal_host_runtime::RendererGrant> {
+        #[cfg(unix)]
+        if let Some(pty) = self.as_pty()
+            && let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap()
+        {
+            return host.mint_renderer_grant(ttl);
+        }
+        let _ = ttl;
+        anyhow::bail!("surface is not backed by a terminal host")
+    }
+
     pub fn is_dead(&self) -> bool {
         match self {
             Surface::Pty(pty) => pty.dead.load(Ordering::Acquire),
@@ -1046,10 +1613,53 @@ impl Surface {
     pub fn kill(&self) {
         match self {
             Surface::Pty(pty) => {
-                let _ = pty.killer.lock().unwrap().kill();
+                let mut runtime = pty.runtime.lock().unwrap();
+                match &mut *runtime {
+                    PtyRuntime::Local { killer, .. } => {
+                        let _ = killer.kill();
+                    }
+                    #[cfg(unix)]
+                    PtyRuntime::Hosted(host) => {
+                        if pty.host_connection_lost.load(Ordering::Acquire) {
+                            host.disconnect();
+                            return;
+                        }
+                        let _ = host.terminate();
+                        crate::terminal_host_runtime::remove_terminal_host_record(
+                            &host.record_path,
+                        );
+                    }
+                }
             }
             Surface::Browser(browser) => browser.kill(),
         }
+    }
+
+    pub(crate) fn disconnect_for_daemon_shutdown(&self) {
+        match self {
+            #[cfg(unix)]
+            Surface::Pty(pty) => {
+                if let PtyRuntime::Hosted(host) = &*pty.runtime.lock().unwrap() {
+                    pty.owner_detaching.store(true, Ordering::Release);
+                    host.disconnect();
+                    return;
+                }
+                self.kill();
+            }
+            #[cfg(not(unix))]
+            Surface::Pty(_) => self.kill(),
+            Surface::Browser(browser) => browser.kill(),
+        }
+    }
+
+    pub(crate) fn persist_host_workspace(&self, workspace_key: &str) -> anyhow::Result<()> {
+        #[cfg(unix)]
+        if let Some(pty) = self.as_pty()
+            && let PtyRuntime::Hosted(host) = &mut *pty.runtime.lock().unwrap()
+        {
+            return host.persist_workspace(workspace_key);
+        }
+        Ok(())
     }
 
     pub fn browser_frame(&self) -> Option<BrowserFrame> {
@@ -1193,7 +1803,7 @@ impl MasterPty for TestMasterPty {
     }
 
     #[cfg(unix)]
-    fn tty_name(&self) -> Option<std::path::PathBuf> {
+    fn tty_name(&self) -> Option<PathBuf> {
         None
     }
 }
@@ -1277,6 +1887,19 @@ impl PtySurface {
     /// final clamped size actually changed.
     fn resize(&self, cols: u16, rows: u16) -> bool {
         let (cols, rows) = (cols.max(1), rows.max(1));
+        #[cfg(unix)]
+        {
+            let runtime = self.runtime.lock().unwrap();
+            if let PtyRuntime::Hosted(host) = &*runtime {
+                if *self.size.lock().unwrap() == (cols, rows) {
+                    return false;
+                }
+                // Do not speculatively reflow the mirror. The host returns a
+                // Resized+Colors pair containing the canonical post-resize
+                // replay, which the reader installs as one transition.
+                return host.send_viewer_size(cols, rows).is_ok();
+            }
+        }
         {
             let mut size = self.size.lock().unwrap();
             if *size == (cols, rows) {
@@ -1288,12 +1911,16 @@ impl PtySurface {
         // attach marker, so attach mirrors observe bytes and resizes in
         // the exact order the server terminal applied them.
         let mut term = self.term.lock().unwrap();
-        let _ = self.master.lock().unwrap().resize(PtySize {
-            rows,
-            cols,
-            pixel_width: 0,
-            pixel_height: 0,
-        });
+        {
+            let mut runtime = self.runtime.lock().unwrap();
+            match &mut *runtime {
+                PtyRuntime::Local { master, .. } => {
+                    let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
+                }
+                #[cfg(unix)]
+                PtyRuntime::Hosted(_) => unreachable!("hosted resize returned above"),
+            }
+        }
         // Nominal cell metrics; only pixel size reports observe these.
         let _ = term.resize(cols, rows, 8, 16);
         let replay = term.vt_replay_bounded(VT_REPLAY_MAX_BYTES).unwrap_or_default();
@@ -1302,6 +1929,48 @@ impl PtySurface {
         let _ = self.build_frame_locked(&mut term, generation, false);
         true
     }
+}
+
+fn terminal_color_override_delta(
+    previous: &TerminalColorOverrides,
+    next: &TerminalColorOverrides,
+) -> Vec<u8> {
+    fn dynamic_color(output: &mut Vec<u8>, set_code: u16, reset_code: u16, color: Option<Rgb>) {
+        match color {
+            Some(color) => output.extend_from_slice(
+                format!(
+                    "\x1b]{set_code};rgb:{:02x}/{:02x}/{:02x}\x1b\\",
+                    color.r, color.g, color.b
+                )
+                .as_bytes(),
+            ),
+            None => output.extend_from_slice(format!("\x1b]{reset_code}\x1b\\").as_bytes()),
+        }
+    }
+
+    let mut output = Vec::new();
+    if previous.foreground != next.foreground {
+        dynamic_color(&mut output, 10, 110, next.foreground);
+    }
+    if previous.background != next.background {
+        dynamic_color(&mut output, 11, 111, next.background);
+    }
+    if previous.cursor != next.cursor {
+        dynamic_color(&mut output, 12, 112, next.cursor);
+    }
+    for index in 0..256 {
+        if previous.palette[index] == next.palette[index] {
+            continue;
+        }
+        match next.palette[index] {
+            Some(color) => output.extend_from_slice(
+                format!("\x1b]4;{index};rgb:{:02x}/{:02x}/{:02x}\x1b\\", color.r, color.g, color.b)
+                    .as_bytes(),
+            ),
+            None => output.extend_from_slice(format!("\x1b]104;{index}\x1b\\").as_bytes()),
+        }
+    }
+    output
 }
 
 const RENDER_FRAME_CADENCE: Duration = Duration::from_millis(8);
@@ -1356,6 +2025,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn terminal_color_override_delta_sets_and_resets_sparse_state() {
+        let mut colors = TerminalColorOverrides {
+            foreground: Some(Rgb { r: 1, g: 2, b: 3 }),
+            background: Some(Rgb { r: 4, g: 5, b: 6 }),
+            cursor: Some(Rgb { r: 7, g: 8, b: 9 }),
+            ..Default::default()
+        };
+        colors.palette[42] = Some(Rgb { r: 10, g: 11, b: 12 });
+        let mut terminal = Terminal::new(10, 2, 0, Callbacks::default()).unwrap();
+        terminal.vt_write(&terminal_color_override_delta(&Default::default(), &colors));
+        assert_eq!(terminal.color_overrides(), colors);
+
+        terminal.vt_write(&terminal_color_override_delta(&colors, &Default::default()));
+        assert_eq!(terminal.color_overrides(), Default::default());
+    }
+
+    #[test]
     fn attach_tap_overflow_cancels_the_shared_lifecycle_once() {
         let lifecycle = AttachLifecycle::default();
         let (sender, _receiver) = sync_channel(1);
@@ -1389,6 +2075,79 @@ mod tests {
         assert!(tap.try_send(AttachFrame::Output(vec![1])));
         assert!(!tap.try_send(AttachFrame::Output(vec![2])));
         assert!(lifecycle.overflowed());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hosted_stager_exposes_coupled_state_only_after_colors() {
+        let mut stager = HostedFrameStager::new(40);
+        let mut resize = Frame::new(MessageKind::Resized, {
+            let mut payload = Vec::from([101, 0, 37, 0]);
+            payload.extend_from_slice(b"authoritative replay");
+            payload
+        });
+        resize.flags = FLAG_COLORS_FOLLOW;
+        resize.sequence = 41;
+
+        // A delayed Colors frame cannot expose a resize attach callback or a
+        // renderable transition with the old theme.
+        assert!(stager.push(resize).unwrap().is_none());
+
+        let colors = TerminalColorOverrides {
+            foreground: Some(Rgb { r: 1, g: 2, b: 3 }),
+            ..Default::default()
+        };
+        let mut colors_frame = Frame::new(
+            MessageKind::Colors,
+            crate::terminal_host_runtime::encode_terminal_color_overrides(&colors),
+        );
+        colors_frame.sequence = 42;
+        match stager.push(colors_frame).unwrap().unwrap() {
+            HostedTransition::ResizedWithColors { cols, rows, replay, colors: received } => {
+                assert_eq!((cols, rows), (101, 37));
+                assert_eq!(replay, b"authoritative replay");
+                assert_eq!(received, colors);
+            }
+            other => panic!("unexpected staged transition: {other:?}"),
+        }
+
+        let mut output = Frame::new(MessageKind::Output, b"\x1b]10;red\x1b\\".to_vec());
+        output.flags = FLAG_COLORS_FOLLOW;
+        output.sequence = 43;
+        assert!(stager.push(output).unwrap().is_none());
+        let mut colors_frame = Frame::new(
+            MessageKind::Colors,
+            crate::terminal_host_runtime::encode_terminal_color_overrides(&colors),
+        );
+        colors_frame.sequence = 44;
+        assert!(matches!(
+            stager.push(colors_frame).unwrap(),
+            Some(HostedTransition::OutputWithColors { .. })
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hosted_stager_fails_closed_on_invalid_flags_and_pairing() {
+        let mut stager = HostedFrameStager::new(0);
+        let mut resized = Frame::new(MessageKind::Resized, vec![80, 0, 24, 0]);
+        resized.sequence = 1;
+        assert!(stager.push(resized).is_err(), "Resized must declare Colors follow");
+
+        let mut stager = HostedFrameStager::new(0);
+        let mut output = Frame::new(MessageKind::Output, vec![]);
+        output.flags = FLAG_COLORS_FOLLOW | (1 << 7);
+        output.sequence = 1;
+        assert!(stager.push(output).is_err(), "unknown flags must fail closed");
+
+        let mut stager = HostedFrameStager::new(0);
+        let mut output = Frame::new(MessageKind::Output, vec![]);
+        output.flags = FLAG_COLORS_FOLLOW;
+        output.sequence = 1;
+        assert!(stager.push(output).unwrap().is_none());
+        let mut exit = Frame::new(MessageKind::Exit, vec![]);
+        exit.sequence = 2;
+        assert!(stager.push(exit).is_err(), "a coupled frame requires Colors exactly next");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
@@ -37,6 +37,42 @@ impl TerminalId {
     pub const fn as_bytes(&self) -> &[u8; TERMINAL_ID_LEN] {
         &self.0
     }
+
+    /// Parse the canonical registry representation: lowercase UUIDv4 bytes
+    /// without dashes. Keeping this strict prevents one terminal from being
+    /// addressable by multiple spellings across process boundaries.
+    pub fn from_hex(value: &str) -> Option<Self> {
+        if value.len() != TERMINAL_ID_LEN * 2
+            || !value.bytes().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+            || value.as_bytes()[12] != b'4'
+            || !matches!(value.as_bytes()[16], b'8'..=b'b')
+        {
+            return None;
+        }
+        let mut bytes = [0u8; TERMINAL_ID_LEN];
+        for (index, pair) in value.as_bytes().chunks_exact(2).enumerate() {
+            bytes[index] = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
+        }
+        Some(Self(bytes))
+    }
+
+    pub fn to_hex(self) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut output = String::with_capacity(TERMINAL_ID_LEN * 2);
+        for byte in self.0 {
+            output.push(HEX[(byte >> 4) as usize] as char);
+            output.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        output
+    }
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
 }
 
 impl fmt::Debug for TerminalId {
@@ -656,6 +692,16 @@ mod tests {
 
     fn terminal(byte: u8) -> TerminalId {
         TerminalId::from_bytes([byte; TERMINAL_ID_LEN])
+    }
+
+    #[test]
+    fn canonical_terminal_hex_requires_lowercase_uuid_v4() {
+        let canonical = "00000000000040008000000000000001";
+        assert_eq!(TerminalId::from_hex(canonical).unwrap().to_hex(), canonical);
+        assert!(TerminalId::from_hex("00000000000030008000000000000001").is_none());
+        assert!(TerminalId::from_hex("00000000000040007000000000000001").is_none());
+        assert!(TerminalId::from_hex("0000000000004000800000000000000A").is_none());
+        assert!(TerminalId::from_hex("short").is_none());
     }
 
     fn token(byte: u8) -> CapabilityToken {

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
@@ -1,0 +1,863 @@
+//! Terminal-host identities, capability handshakes, and process bootstrap.
+//!
+//! This module intentionally does not own workspace state or spawn a PTY yet.
+//! It is the separable security and process-mode foundation for moving each
+//! PTY into an independently adoptable host.
+
+use std::fmt;
+use std::io::{Read, Write};
+use std::ops::{BitOr, RangeInclusive};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::terminal_host_protocol::{
+    Frame, MessageKind, PROTOCOL_VERSION, ProtocolError, read_frame, write_frame,
+};
+
+pub const CAPABILITY_TOKEN_LEN: usize = 32;
+pub const TERMINAL_ID_LEN: usize = 16;
+const CLIENT_HELLO_LEN: usize = 60;
+const HOST_HELLO_LEN: usize = 40;
+const BOOTSTRAP_LEN: usize = 52;
+const READY_LEN: usize = 34;
+const MAX_HANDSHAKE_PAYLOAD: usize = 4096;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TerminalId([u8; TERMINAL_ID_LEN]);
+
+impl TerminalId {
+    pub fn random() -> Result<Self, HostHandshakeError> {
+        Ok(Self(random_uuid_v4()?))
+    }
+
+    pub const fn from_bytes(bytes: [u8; TERMINAL_ID_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; TERMINAL_ID_LEN] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for TerminalId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "TerminalId({:02x}{:02x}{:02x}{:02x}-...)",
+            self.0[0], self.0[1], self.0[2], self.0[3]
+        )
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HostIncarnation([u8; TERMINAL_ID_LEN]);
+
+impl HostIncarnation {
+    pub fn random() -> Result<Self, HostHandshakeError> {
+        Ok(Self(random_uuid_v4()?))
+    }
+
+    pub const fn from_bytes(bytes: [u8; TERMINAL_ID_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; TERMINAL_ID_LEN] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for HostIncarnation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "HostIncarnation({:02x}{:02x}{:02x}{:02x}-...)",
+            self.0[0], self.0[1], self.0[2], self.0[3]
+        )
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CapabilityToken([u8; CAPABILITY_TOKEN_LEN]);
+
+impl CapabilityToken {
+    pub fn random() -> Result<Self, HostHandshakeError> {
+        let mut bytes = [0u8; CAPABILITY_TOKEN_LEN];
+        getrandom::fill(&mut bytes).map_err(|_| HostHandshakeError::RandomnessUnavailable)?;
+        Ok(Self(bytes))
+    }
+
+    pub const fn from_bytes(bytes: [u8; CAPABILITY_TOKEN_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(&self) -> &[u8; CAPABILITY_TOKEN_LEN] {
+        &self.0
+    }
+
+    fn constant_time_eq(&self, other: &Self) -> bool {
+        let mut difference = 0u8;
+        for index in 0..CAPABILITY_TOKEN_LEN {
+            difference |= self.0[index] ^ other.0[index];
+        }
+        difference == 0
+    }
+
+    fn is_zero(&self) -> bool {
+        let mut combined = 0u8;
+        for byte in self.0 {
+            combined |= byte;
+        }
+        combined == 0
+    }
+}
+
+impl fmt::Debug for CapabilityToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CapabilityToken([REDACTED])")
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CapabilityRights(u32);
+
+impl CapabilityRights {
+    pub const READ: Self = Self(1 << 0);
+    pub const INPUT: Self = Self(1 << 1);
+    pub const RESIZE: Self = Self(1 << 2);
+    pub const TERMINATE: Self = Self(1 << 3);
+    pub const MINT_CAPABILITY: Self = Self(1 << 4);
+    pub const ADMIN: Self = Self(
+        Self::READ.0 | Self::INPUT.0 | Self::RESIZE.0 | Self::TERMINATE.0 | Self::MINT_CAPABILITY.0,
+    );
+    const KNOWN_BITS: u32 = Self::ADMIN.0;
+
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    pub const fn from_bits(bits: u32) -> Option<Self> {
+        if bits & !Self::KNOWN_BITS == 0 { Some(Self(bits)) } else { None }
+    }
+
+    pub const fn contains(self, requested: Self) -> bool {
+        self.0 & requested.0 == requested.0
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl BitOr for CapabilityRights {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl fmt::Debug for CapabilityRights {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut names = Vec::new();
+        for (right, name) in [
+            (Self::READ, "read"),
+            (Self::INPUT, "input"),
+            (Self::RESIZE, "resize"),
+            (Self::TERMINATE, "terminate"),
+            (Self::MINT_CAPABILITY, "mint-capability"),
+        ] {
+            if self.contains(right) {
+                names.push(name);
+            }
+        }
+        f.debug_tuple("CapabilityRights").field(&names.join("|")).finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ClientRole {
+    DaemonMirror = 1,
+    Renderer = 2,
+    Admin = 3,
+}
+
+impl ClientRole {
+    fn allowed_rights(self) -> CapabilityRights {
+        match self {
+            Self::DaemonMirror => CapabilityRights::READ,
+            Self::Renderer => {
+                CapabilityRights::READ | CapabilityRights::INPUT | CapabilityRights::RESIZE
+            }
+            Self::Admin => CapabilityRights::ADMIN,
+        }
+    }
+}
+
+impl TryFrom<u8> for ClientRole {
+    type Error = HostHandshakeError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::DaemonMirror),
+            2 => Ok(Self::Renderer),
+            3 => Ok(Self::Admin),
+            _ => Err(HostHandshakeError::MalformedPayload("unknown client role")),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ClientHello {
+    pub min_version: u16,
+    pub max_version: u16,
+    pub role: ClientRole,
+    pub requested_rights: CapabilityRights,
+    pub terminal_id: TerminalId,
+    pub token: CapabilityToken,
+}
+
+impl fmt::Debug for ClientHello {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClientHello")
+            .field("min_version", &self.min_version)
+            .field("max_version", &self.max_version)
+            .field("role", &self.role)
+            .field("requested_rights", &self.requested_rights)
+            .field("terminal_id", &self.terminal_id)
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl ClientHello {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(CLIENT_HELLO_LEN);
+        payload.extend_from_slice(&self.min_version.to_le_bytes());
+        payload.extend_from_slice(&self.max_version.to_le_bytes());
+        payload.push(self.role as u8);
+        payload.extend_from_slice(&[0; 3]);
+        payload.extend_from_slice(&self.requested_rights.bits().to_le_bytes());
+        payload.extend_from_slice(self.terminal_id.as_bytes());
+        payload.extend_from_slice(self.token.as_bytes());
+        payload
+    }
+
+    pub fn decode(payload: &[u8]) -> Result<Self, HostHandshakeError> {
+        if payload.len() != CLIENT_HELLO_LEN {
+            return Err(HostHandshakeError::MalformedPayload("bad client hello length"));
+        }
+        if payload[5..8] != [0; 3] {
+            return Err(HostHandshakeError::MalformedPayload(
+                "nonzero client hello reserved bytes",
+            ));
+        }
+        let requested_rights = CapabilityRights::from_bits(u32::from_le_bytes(
+            payload[8..12].try_into().expect("fixed rights slice"),
+        ))
+        .ok_or(HostHandshakeError::MalformedPayload("unknown capability rights"))?;
+        Ok(Self {
+            min_version: u16::from_le_bytes(payload[0..2].try_into().expect("fixed min slice")),
+            max_version: u16::from_le_bytes(payload[2..4].try_into().expect("fixed max slice")),
+            role: ClientRole::try_from(payload[4])?,
+            requested_rights,
+            terminal_id: TerminalId::from_bytes(
+                payload[12..28].try_into().expect("fixed terminal-id slice"),
+            ),
+            token: CapabilityToken::from_bytes(
+                payload[28..60].try_into().expect("fixed capability-token slice"),
+            ),
+        })
+    }
+
+    pub fn into_frame(self, request_id: u64) -> Frame {
+        let mut frame = Frame::new(MessageKind::ClientHello, self.encode());
+        frame.request_id = request_id;
+        frame
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostHello {
+    pub selected_version: u16,
+    pub granted_rights: CapabilityRights,
+    pub terminal_id: TerminalId,
+    pub incarnation: HostIncarnation,
+}
+
+impl HostHello {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(HOST_HELLO_LEN);
+        payload.extend_from_slice(&self.selected_version.to_le_bytes());
+        payload.extend_from_slice(&[0; 2]);
+        payload.extend_from_slice(&self.granted_rights.bits().to_le_bytes());
+        payload.extend_from_slice(self.terminal_id.as_bytes());
+        payload.extend_from_slice(self.incarnation.as_bytes());
+        payload
+    }
+
+    pub fn decode(payload: &[u8]) -> Result<Self, HostHandshakeError> {
+        if payload.len() != HOST_HELLO_LEN {
+            return Err(HostHandshakeError::MalformedPayload("bad host hello length"));
+        }
+        if payload[2..4] != [0; 2] {
+            return Err(HostHandshakeError::MalformedPayload("nonzero host hello reserved bytes"));
+        }
+        Ok(Self {
+            selected_version: u16::from_le_bytes(
+                payload[0..2].try_into().expect("fixed version slice"),
+            ),
+            granted_rights: CapabilityRights::from_bits(u32::from_le_bytes(
+                payload[4..8].try_into().expect("fixed rights slice"),
+            ))
+            .ok_or(HostHandshakeError::MalformedPayload("unknown capability rights"))?,
+            terminal_id: TerminalId::from_bytes(
+                payload[8..24].try_into().expect("fixed terminal-id slice"),
+            ),
+            incarnation: HostIncarnation::from_bytes(
+                payload[24..40].try_into().expect("fixed incarnation slice"),
+            ),
+        })
+    }
+}
+
+struct CapabilityGrant {
+    token: CapabilityToken,
+    terminal_id: TerminalId,
+    rights: CapabilityRights,
+    expires_at: Instant,
+}
+
+pub struct CapabilityStore {
+    grants: Mutex<Vec<CapabilityGrant>>,
+    max_grants: usize,
+}
+
+impl CapabilityStore {
+    pub fn new(max_grants: usize) -> Self {
+        Self { grants: Mutex::new(Vec::new()), max_grants }
+    }
+
+    pub fn mint(
+        &self,
+        terminal_id: TerminalId,
+        rights: CapabilityRights,
+        ttl: Duration,
+    ) -> Result<CapabilityToken, HostHandshakeError> {
+        if rights.is_empty() {
+            return Err(HostHandshakeError::CapabilityDenied);
+        }
+        let now = Instant::now();
+        let mut grants = self.grants.lock().unwrap();
+        grants.retain(|grant| grant.expires_at > now);
+        if grants.len() >= self.max_grants {
+            return Err(HostHandshakeError::CapabilityCapacity);
+        }
+        let token = loop {
+            let candidate = CapabilityToken::random()?;
+            if !grants.iter().any(|grant| grant.token.constant_time_eq(&candidate)) {
+                break candidate;
+            }
+        };
+        grants.push(CapabilityGrant {
+            token,
+            terminal_id,
+            rights,
+            expires_at: now.checked_add(ttl).unwrap_or(now),
+        });
+        Ok(token)
+    }
+
+    /// Consume a one-use capability and negotiate the highest common version.
+    /// A matching token is removed before checking terminal, role, or rights,
+    /// so a failed authorization cannot be probed and then reused differently.
+    pub fn accept(
+        &self,
+        hello: &ClientHello,
+        supported_versions: RangeInclusive<u16>,
+        incarnation: HostIncarnation,
+    ) -> Result<HostHello, HostHandshakeError> {
+        let selected_version =
+            negotiate_version(hello.min_version, hello.max_version, supported_versions)?;
+        let now = Instant::now();
+        let grant = {
+            let mut grants = self.grants.lock().unwrap();
+            grants.retain(|grant| grant.expires_at > now);
+            let Some(index) =
+                grants.iter().position(|grant| grant.token.constant_time_eq(&hello.token))
+            else {
+                return Err(HostHandshakeError::CapabilityDenied);
+            };
+            grants.remove(index)
+        };
+        if hello.requested_rights.is_empty()
+            || !hello.role.allowed_rights().contains(hello.requested_rights)
+            || grant.terminal_id != hello.terminal_id
+            || !grant.rights.contains(hello.requested_rights)
+        {
+            return Err(HostHandshakeError::CapabilityDenied);
+        }
+        Ok(HostHello {
+            selected_version,
+            granted_rights: hello.requested_rights,
+            terminal_id: hello.terminal_id,
+            incarnation,
+        })
+    }
+
+    pub fn active_grants(&self) -> usize {
+        let now = Instant::now();
+        let mut grants = self.grants.lock().unwrap();
+        grants.retain(|grant| grant.expires_at > now);
+        grants.len()
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct HostBootstrap {
+    pub min_version: u16,
+    pub max_version: u16,
+    pub terminal_id: TerminalId,
+    pub owner_token: CapabilityToken,
+}
+
+impl fmt::Debug for HostBootstrap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HostBootstrap")
+            .field("min_version", &self.min_version)
+            .field("max_version", &self.max_version)
+            .field("terminal_id", &self.terminal_id)
+            .field("owner_token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl HostBootstrap {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(BOOTSTRAP_LEN);
+        payload.extend_from_slice(&self.min_version.to_le_bytes());
+        payload.extend_from_slice(&self.max_version.to_le_bytes());
+        payload.extend_from_slice(self.terminal_id.as_bytes());
+        payload.extend_from_slice(self.owner_token.as_bytes());
+        payload
+    }
+
+    pub fn decode(payload: &[u8]) -> Result<Self, HostHandshakeError> {
+        if payload.len() != BOOTSTRAP_LEN {
+            return Err(HostHandshakeError::MalformedPayload("bad bootstrap length"));
+        }
+        let owner_token = CapabilityToken::from_bytes(
+            payload[20..52].try_into().expect("fixed owner-token slice"),
+        );
+        if owner_token.is_zero() {
+            return Err(HostHandshakeError::MalformedPayload("zero owner token"));
+        }
+        Ok(Self {
+            min_version: u16::from_le_bytes(payload[0..2].try_into().expect("fixed min slice")),
+            max_version: u16::from_le_bytes(payload[2..4].try_into().expect("fixed max slice")),
+            terminal_id: TerminalId::from_bytes(
+                payload[4..20].try_into().expect("fixed terminal-id slice"),
+            ),
+            owner_token,
+        })
+    }
+
+    pub fn into_frame(self, request_id: u64) -> Frame {
+        let mut frame = Frame::new(MessageKind::Bootstrap, self.encode());
+        frame.request_id = request_id;
+        frame
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostReady {
+    pub selected_version: u16,
+    pub terminal_id: TerminalId,
+    pub incarnation: HostIncarnation,
+}
+
+impl HostReady {
+    pub fn encode(&self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(READY_LEN);
+        payload.extend_from_slice(&self.selected_version.to_le_bytes());
+        payload.extend_from_slice(self.terminal_id.as_bytes());
+        payload.extend_from_slice(self.incarnation.as_bytes());
+        payload
+    }
+
+    pub fn decode(payload: &[u8]) -> Result<Self, HostHandshakeError> {
+        if payload.len() != READY_LEN {
+            return Err(HostHandshakeError::MalformedPayload("bad ready length"));
+        }
+        Ok(Self {
+            selected_version: u16::from_le_bytes(
+                payload[0..2].try_into().expect("fixed version slice"),
+            ),
+            terminal_id: TerminalId::from_bytes(
+                payload[2..18].try_into().expect("fixed terminal-id slice"),
+            ),
+            incarnation: HostIncarnation::from_bytes(
+                payload[18..34].try_into().expect("fixed incarnation slice"),
+            ),
+        })
+    }
+}
+
+/// State established through the private parent-to-host bootstrap pipe.
+/// The token is retained for the future owner/admin loop and is never echoed
+/// in the ready response.
+pub struct BootstrappedHost {
+    pub terminal_id: TerminalId,
+    pub incarnation: HostIncarnation,
+    owner_token: CapabilityToken,
+}
+
+impl BootstrappedHost {
+    pub fn owner_token(&self) -> CapabilityToken {
+        self.owner_token
+    }
+}
+
+impl fmt::Debug for BootstrappedHost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BootstrappedHost")
+            .field("terminal_id", &self.terminal_id)
+            .field("incarnation", &self.incarnation)
+            .field("owner_token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Perform the private, one-frame process bootstrap used by the hidden
+/// `__terminal-host --bootstrap-stdio` mode. PTY ownership and the long-lived
+/// admin/data socket loop will be layered on the returned state.
+pub fn bootstrap_stdio_once(
+    reader: &mut impl Read,
+    writer: &mut impl Write,
+) -> Result<BootstrappedHost, HostHandshakeError> {
+    let frame = read_frame(reader, MAX_HANDSHAKE_PAYLOAD)?
+        .ok_or(HostHandshakeError::MalformedPayload("missing bootstrap frame"))?;
+    if frame.kind != MessageKind::Bootstrap {
+        return Err(HostHandshakeError::UnexpectedMessage {
+            expected: MessageKind::Bootstrap,
+            actual: frame.kind,
+        });
+    }
+    let bootstrap = HostBootstrap::decode(&frame.payload)?;
+    let selected_version = negotiate_version(
+        bootstrap.min_version,
+        bootstrap.max_version,
+        PROTOCOL_VERSION..=PROTOCOL_VERSION,
+    )?;
+    if frame.version != selected_version {
+        return Err(HostHandshakeError::UnsupportedVersion {
+            client_min: frame.version,
+            client_max: frame.version,
+            host_min: selected_version,
+            host_max: selected_version,
+        });
+    }
+    let incarnation = HostIncarnation::random()?;
+    let ready = HostReady { selected_version, terminal_id: bootstrap.terminal_id, incarnation };
+    let mut response = Frame::new(MessageKind::Ready, ready.encode());
+    response.version = selected_version;
+    response.request_id = frame.request_id;
+    write_frame(writer, &response)?;
+    Ok(BootstrappedHost {
+        terminal_id: bootstrap.terminal_id,
+        incarnation,
+        owner_token: bootstrap.owner_token,
+    })
+}
+
+fn negotiate_version(
+    client_min: u16,
+    client_max: u16,
+    host_versions: RangeInclusive<u16>,
+) -> Result<u16, HostHandshakeError> {
+    let host_min = *host_versions.start();
+    let host_max = *host_versions.end();
+    if client_min == 0
+        || host_min == 0
+        || client_min > client_max
+        || host_min > host_max
+        || client_max < host_min
+        || host_max < client_min
+    {
+        return Err(HostHandshakeError::UnsupportedVersion {
+            client_min,
+            client_max,
+            host_min,
+            host_max,
+        });
+    }
+    Ok(client_max.min(host_max))
+}
+
+fn random_uuid_v4() -> Result<[u8; TERMINAL_ID_LEN], HostHandshakeError> {
+    let mut bytes = [0u8; TERMINAL_ID_LEN];
+    getrandom::fill(&mut bytes).map_err(|_| HostHandshakeError::RandomnessUnavailable)?;
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Ok(bytes)
+}
+
+#[derive(Debug)]
+pub enum HostHandshakeError {
+    Protocol(ProtocolError),
+    RandomnessUnavailable,
+    MalformedPayload(&'static str),
+    UnexpectedMessage { expected: MessageKind, actual: MessageKind },
+    UnsupportedVersion { client_min: u16, client_max: u16, host_min: u16, host_max: u16 },
+    CapabilityDenied,
+    CapabilityCapacity,
+}
+
+impl fmt::Display for HostHandshakeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Protocol(error) => error.fmt(f),
+            Self::RandomnessUnavailable => f.write_str("operating system randomness unavailable"),
+            Self::MalformedPayload(reason) => {
+                write!(f, "malformed terminal-host payload: {reason}")
+            }
+            Self::UnexpectedMessage { expected, actual } => {
+                write!(f, "expected terminal-host {expected:?}, received {actual:?}")
+            }
+            Self::UnsupportedVersion { client_min, client_max, host_min, host_max } => write!(
+                f,
+                "no common terminal-host protocol version (client {client_min}..={client_max}, host {host_min}..={host_max})"
+            ),
+            Self::CapabilityDenied => f.write_str("terminal-host capability denied"),
+            Self::CapabilityCapacity => f.write_str("terminal-host capability limit reached"),
+        }
+    }
+}
+
+impl std::error::Error for HostHandshakeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Protocol(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<ProtocolError> for HostHandshakeError {
+    fn from(value: ProtocolError) -> Self {
+        Self::Protocol(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal_host_protocol::{encode_frame, read_frame};
+
+    fn terminal(byte: u8) -> TerminalId {
+        TerminalId::from_bytes([byte; TERMINAL_ID_LEN])
+    }
+
+    fn token(byte: u8) -> CapabilityToken {
+        CapabilityToken::from_bytes([byte; CAPABILITY_TOKEN_LEN])
+    }
+
+    fn hello(
+        terminal_id: TerminalId,
+        token: CapabilityToken,
+        role: ClientRole,
+        rights: CapabilityRights,
+    ) -> ClientHello {
+        ClientHello {
+            min_version: 1,
+            max_version: 3,
+            role,
+            requested_rights: rights,
+            terminal_id,
+            token,
+        }
+    }
+
+    #[test]
+    fn hello_payloads_are_fixed_width_little_endian_and_redact_tokens() {
+        let hello = ClientHello {
+            min_version: 1,
+            max_version: 0x0203,
+            role: ClientRole::Renderer,
+            requested_rights: CapabilityRights::READ | CapabilityRights::INPUT,
+            terminal_id: terminal(0x44),
+            token: token(0xa5),
+        };
+        let encoded = hello.encode();
+        assert_eq!(encoded.len(), CLIENT_HELLO_LEN);
+        assert_eq!(&encoded[0..4], &[1, 0, 3, 2]);
+        assert_eq!(ClientHello::decode(&encoded).unwrap(), hello);
+        assert!(!format!("{hello:?}").contains("a5a5"));
+        assert_eq!(format!("{:?}", hello.token), "CapabilityToken([REDACTED])");
+
+        let response = HostHello {
+            selected_version: 2,
+            granted_rights: CapabilityRights::READ,
+            terminal_id: hello.terminal_id,
+            incarnation: HostIncarnation::from_bytes([7; TERMINAL_ID_LEN]),
+        };
+        assert_eq!(HostHello::decode(&response.encode()).unwrap(), response);
+    }
+
+    #[test]
+    fn one_use_capability_is_bound_to_terminal_role_and_rights() {
+        let store = CapabilityStore::new(8);
+        let terminal_id = terminal(1);
+        let minted = store
+            .mint(
+                terminal_id,
+                CapabilityRights::READ | CapabilityRights::INPUT,
+                Duration::from_secs(60),
+            )
+            .unwrap();
+        let request = hello(
+            terminal_id,
+            minted,
+            ClientRole::Renderer,
+            CapabilityRights::READ | CapabilityRights::INPUT,
+        );
+        let incarnation = HostIncarnation::from_bytes([2; TERMINAL_ID_LEN]);
+        let accepted = store.accept(&request, 1..=2, incarnation).unwrap();
+        assert_eq!(accepted.selected_version, 2);
+        assert_eq!(accepted.granted_rights, request.requested_rights);
+        assert_eq!(store.active_grants(), 0);
+        assert!(matches!(
+            store.accept(&request, 1..=2, incarnation),
+            Err(HostHandshakeError::CapabilityDenied)
+        ));
+    }
+
+    #[test]
+    fn failed_binding_check_consumes_the_matching_token() {
+        let store = CapabilityStore::new(8);
+        let minted =
+            store.mint(terminal(1), CapabilityRights::READ, Duration::from_secs(60)).unwrap();
+        let wrong_terminal =
+            hello(terminal(2), minted, ClientRole::Renderer, CapabilityRights::READ);
+        let incarnation = HostIncarnation::from_bytes([3; TERMINAL_ID_LEN]);
+        assert!(matches!(
+            store.accept(&wrong_terminal, 1..=1, incarnation),
+            Err(HostHandshakeError::CapabilityDenied)
+        ));
+        let corrected = hello(terminal(1), minted, ClientRole::Renderer, CapabilityRights::READ);
+        assert!(matches!(
+            store.accept(&corrected, 1..=1, incarnation),
+            Err(HostHandshakeError::CapabilityDenied)
+        ));
+    }
+
+    #[test]
+    fn role_violation_consumes_even_a_broad_matching_token() {
+        let store = CapabilityStore::new(8);
+        let minted =
+            store.mint(terminal(1), CapabilityRights::ADMIN, Duration::from_secs(60)).unwrap();
+        let request = hello(terminal(1), minted, ClientRole::Renderer, CapabilityRights::TERMINATE);
+        assert!(matches!(
+            store.accept(&request, 1..=1, HostIncarnation::from_bytes([4; 16])),
+            Err(HostHandshakeError::CapabilityDenied)
+        ));
+        // Any matching token is one-use even when its role or requested
+        // rights are invalid, so rejected handshakes cannot probe and retry.
+        let admin = hello(terminal(1), minted, ClientRole::Admin, CapabilityRights::TERMINATE);
+        assert!(matches!(
+            store.accept(&admin, 1..=1, HostIncarnation::from_bytes([4; 16])),
+            Err(HostHandshakeError::CapabilityDenied)
+        ));
+    }
+
+    #[test]
+    fn expired_grants_are_denied_and_do_not_consume_capacity() {
+        let store = CapabilityStore::new(1);
+        let expired = store.mint(terminal(1), CapabilityRights::READ, Duration::ZERO).unwrap();
+        assert_eq!(store.active_grants(), 0);
+        let replacement =
+            store.mint(terminal(1), CapabilityRights::READ, Duration::from_secs(60)).unwrap();
+        assert_ne!(expired, replacement);
+        assert!(matches!(
+            store.accept(
+                &hello(terminal(1), expired, ClientRole::Renderer, CapabilityRights::READ,),
+                1..=1,
+                HostIncarnation::from_bytes([5; 16]),
+            ),
+            Err(HostHandshakeError::CapabilityDenied)
+        ));
+        assert!(matches!(
+            store.mint(terminal(1), CapabilityRights::READ, Duration::from_secs(60)),
+            Err(HostHandshakeError::CapabilityCapacity)
+        ));
+    }
+
+    #[test]
+    fn malformed_reserved_and_unknown_rights_are_rejected() {
+        let mut encoded =
+            hello(terminal(1), token(2), ClientRole::Renderer, CapabilityRights::READ).encode();
+        encoded[5] = 1;
+        assert!(matches!(
+            ClientHello::decode(&encoded),
+            Err(HostHandshakeError::MalformedPayload(_))
+        ));
+        encoded[5] = 0;
+        encoded[8..12].copy_from_slice(&(1u32 << 31).to_le_bytes());
+        assert!(matches!(
+            ClientHello::decode(&encoded),
+            Err(HostHandshakeError::MalformedPayload(_))
+        ));
+    }
+
+    #[test]
+    fn version_negotiation_selects_highest_common_version() {
+        assert_eq!(negotiate_version(1, 4, 2..=3).unwrap(), 3);
+        assert!(matches!(
+            negotiate_version(4, 5, 1..=3),
+            Err(HostHandshakeError::UnsupportedVersion { .. })
+        ));
+        assert!(matches!(
+            negotiate_version(3, 2, 1..=3),
+            Err(HostHandshakeError::UnsupportedVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn stdio_bootstrap_echoes_identity_not_owner_secret() {
+        let bootstrap = HostBootstrap {
+            min_version: PROTOCOL_VERSION,
+            max_version: PROTOCOL_VERSION,
+            terminal_id: terminal(0x42),
+            owner_token: token(0xa5),
+        };
+        let input = encode_frame(&bootstrap.into_frame(77)).unwrap();
+        let mut output = Vec::new();
+        let state = bootstrap_stdio_once(&mut input.as_slice(), &mut output).unwrap();
+        assert_eq!(state.terminal_id, terminal(0x42));
+        assert_eq!(state.owner_token(), token(0xa5));
+        assert!(!output.windows(CAPABILITY_TOKEN_LEN).any(|window| window == [0xa5; 32]));
+
+        let frame = read_frame(&mut output.as_slice(), MAX_HANDSHAKE_PAYLOAD).unwrap().unwrap();
+        assert_eq!(frame.kind, MessageKind::Ready);
+        assert_eq!(frame.request_id, 77);
+        let ready = HostReady::decode(&frame.payload).unwrap();
+        assert_eq!(ready.terminal_id, terminal(0x42));
+        assert_eq!(ready.incarnation, state.incarnation);
+    }
+
+    #[test]
+    fn stdio_bootstrap_requires_the_bootstrap_message_kind() {
+        let input = encode_frame(&Frame::new(MessageKind::Input, vec![])).unwrap();
+        assert!(matches!(
+            bootstrap_stdio_once(&mut input.as_slice(), &mut Vec::new()),
+            Err(HostHandshakeError::UnexpectedMessage {
+                expected: MessageKind::Bootstrap,
+                actual: MessageKind::Input,
+            })
+        ));
+    }
+}

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
@@ -1,8 +1,8 @@
 //! Terminal-host identities, capability handshakes, and process bootstrap.
 //!
-//! This module intentionally does not own workspace state or spawn a PTY yet.
-//! It is the separable security and process-mode foundation for moving each
-//! PTY into an independently adoptable host.
+//! This module intentionally does not own workspace state or PTYs. It is the
+//! separable security foundation used by `terminal_host_runtime`, where each
+//! PTY lives in an independently adoptable process.
 
 use std::fmt;
 use std::io::{Read, Write};
@@ -126,9 +126,8 @@ impl CapabilityRights {
     pub const RESIZE: Self = Self(1 << 2);
     pub const TERMINATE: Self = Self(1 << 3);
     pub const MINT_CAPABILITY: Self = Self(1 << 4);
-    pub const ADMIN: Self = Self(
-        Self::READ.0 | Self::INPUT.0 | Self::RESIZE.0 | Self::TERMINATE.0 | Self::MINT_CAPABILITY.0,
-    );
+    pub const RENDERER: Self = Self(Self::READ.0 | Self::INPUT.0 | Self::RESIZE.0);
+    pub const ADMIN: Self = Self(Self::RENDERER.0 | Self::TERMINATE.0 | Self::MINT_CAPABILITY.0);
     const KNOWN_BITS: u32 = Self::ADMIN.0;
 
     pub const fn empty() -> Self {
@@ -190,9 +189,7 @@ impl ClientRole {
     fn allowed_rights(self) -> CapabilityRights {
         match self {
             Self::DaemonMirror => CapabilityRights::READ,
-            Self::Renderer => {
-                CapabilityRights::READ | CapabilityRights::INPUT | CapabilityRights::RESIZE
-            }
+            Self::Renderer => CapabilityRights::RENDERER,
             Self::Admin => CapabilityRights::ADMIN,
         }
     }
@@ -507,9 +504,8 @@ impl HostReady {
     }
 }
 
-/// State established through the private parent-to-host bootstrap pipe.
-/// The token is retained for the future owner/admin loop and is never echoed
-/// in the ready response.
+/// State established through the private parent-to-host bootstrap pipe. The
+/// token is retained for the owner/admin loop and never echoed in Ready.
 pub struct BootstrappedHost {
     pub terminal_id: TerminalId,
     pub incarnation: HostIncarnation,
@@ -533,8 +529,8 @@ impl fmt::Debug for BootstrappedHost {
 }
 
 /// Perform the private, one-frame process bootstrap used by the hidden
-/// `__terminal-host --bootstrap-stdio` mode. PTY ownership and the long-lived
-/// admin/data socket loop will be layered on the returned state.
+/// `__terminal-host --bootstrap-stdio` mode. The runtime layers PTY ownership
+/// and the long-lived admin/data socket loop on the returned state.
 pub fn bootstrap_stdio_once(
     reader: &mut impl Read,
     writer: &mut impl Write,

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
@@ -100,6 +100,18 @@ impl HostIncarnation {
     pub const fn as_bytes(&self) -> &[u8; TERMINAL_ID_LEN] {
         &self.0
     }
+
+    /// Parse the canonical registry representation: lowercase UUIDv4 bytes
+    /// without dashes. Incarnations use the same strict spelling and UUID
+    /// invariants as terminal ids so records cannot be duplicated through
+    /// alternate encodings.
+    pub fn from_hex(value: &str) -> Option<Self> {
+        TerminalId::from_hex(value).map(|id| Self::from_bytes(*id.as_bytes()))
+    }
+
+    pub fn to_hex(self) -> String {
+        TerminalId::from_bytes(self.0).to_hex()
+    }
 }
 
 impl fmt::Debug for HostIncarnation {

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -1,0 +1,470 @@
+//! Binary framing for the local terminal-host data plane.
+//!
+//! The public cmux-tui control protocol remains JSON. This framing is for
+//! bounded, local Unix-socket streams between a terminal host, its daemon,
+//! and disposable renderers. The header is deliberately fixed-width and
+//! little-endian so non-Rust clients can implement it without sharing a
+//! serializer or ABI.
+
+use std::fmt;
+use std::io::{self, Read, Write};
+
+pub const MAGIC: [u8; 4] = *b"CMTH";
+pub const HEADER_LEN: usize = 32;
+pub const PROTOCOL_VERSION: u16 = 1;
+pub const MAX_FRAME_PAYLOAD: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MessageKind {
+    Bootstrap = 1,
+    Ready = 2,
+    ClientHello = 3,
+    HostHello = 4,
+    Snapshot = 5,
+    Output = 6,
+    Resized = 7,
+    Colors = 8,
+    Title = 9,
+    Pwd = 10,
+    Bell = 11,
+    Exit = 12,
+    ResyncRequired = 13,
+    Input = 100,
+    Paste = 101,
+    ViewerSize = 102,
+    ReleaseViewer = 103,
+    Terminate = 104,
+}
+
+impl TryFrom<u16> for MessageKind {
+    type Error = ProtocolError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Bootstrap),
+            2 => Ok(Self::Ready),
+            3 => Ok(Self::ClientHello),
+            4 => Ok(Self::HostHello),
+            5 => Ok(Self::Snapshot),
+            6 => Ok(Self::Output),
+            7 => Ok(Self::Resized),
+            8 => Ok(Self::Colors),
+            9 => Ok(Self::Title),
+            10 => Ok(Self::Pwd),
+            11 => Ok(Self::Bell),
+            12 => Ok(Self::Exit),
+            13 => Ok(Self::ResyncRequired),
+            100 => Ok(Self::Input),
+            101 => Ok(Self::Paste),
+            102 => Ok(Self::ViewerSize),
+            103 => Ok(Self::ReleaseViewer),
+            104 => Ok(Self::Terminate),
+            other => Err(ProtocolError::UnknownMessageKind(other)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Frame {
+    pub version: u16,
+    pub kind: MessageKind,
+    pub flags: u32,
+    pub request_id: u64,
+    pub sequence: u64,
+    pub payload: Vec<u8>,
+}
+
+impl Frame {
+    pub fn new(kind: MessageKind, payload: Vec<u8>) -> Self {
+        Self { version: PROTOCOL_VERSION, kind, flags: 0, request_id: 0, sequence: 0, payload }
+    }
+}
+
+#[derive(Debug)]
+pub enum ProtocolError {
+    Io(io::Error),
+    InvalidMagic([u8; 4]),
+    InvalidVersion(u16),
+    UnknownMessageKind(u16),
+    PayloadTooLarge { len: usize, max: usize },
+    Truncated { expected: usize, actual: usize },
+    DecoderFailed,
+}
+
+impl fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(f, "terminal-host protocol I/O failed: {error}"),
+            Self::InvalidMagic(actual) => {
+                write!(f, "bad terminal-host protocol magic {actual:?}")
+            }
+            Self::InvalidVersion(version) => {
+                write!(f, "bad terminal-host protocol version {version}")
+            }
+            Self::UnknownMessageKind(kind) => {
+                write!(f, "unknown terminal-host message kind {kind}")
+            }
+            Self::PayloadTooLarge { len, max } => {
+                write!(f, "terminal-host payload is {len} bytes; maximum is {max}")
+            }
+            Self::Truncated { expected, actual } => {
+                write!(f, "truncated terminal-host frame: expected {expected} bytes, got {actual}")
+            }
+            Self::DecoderFailed => write!(f, "terminal-host decoder is unusable after an error"),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for ProtocolError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Header {
+    version: u16,
+    kind: MessageKind,
+    flags: u32,
+    payload_len: usize,
+    request_id: u64,
+    sequence: u64,
+}
+
+fn parse_header(bytes: &[u8], max_payload: usize) -> Result<Header, ProtocolError> {
+    debug_assert_eq!(bytes.len(), HEADER_LEN);
+    let magic = <[u8; 4]>::try_from(&bytes[0..4]).expect("fixed header magic slice");
+    if magic != MAGIC {
+        return Err(ProtocolError::InvalidMagic(magic));
+    }
+    let version = u16::from_le_bytes([bytes[4], bytes[5]]);
+    if version == 0 {
+        return Err(ProtocolError::InvalidVersion(version));
+    }
+    let kind = MessageKind::try_from(u16::from_le_bytes([bytes[6], bytes[7]]))?;
+    let flags = u32::from_le_bytes(bytes[8..12].try_into().expect("fixed flags slice"));
+    let payload_len =
+        u32::from_le_bytes(bytes[12..16].try_into().expect("fixed payload-length slice")) as usize;
+    if payload_len > max_payload {
+        return Err(ProtocolError::PayloadTooLarge { len: payload_len, max: max_payload });
+    }
+    let request_id = u64::from_le_bytes(bytes[16..24].try_into().expect("fixed request-id slice"));
+    let sequence = u64::from_le_bytes(bytes[24..32].try_into().expect("fixed sequence slice"));
+    Ok(Header { version, kind, flags, payload_len, request_id, sequence })
+}
+
+fn encode_header(frame: &Frame, max_payload: usize) -> Result<[u8; HEADER_LEN], ProtocolError> {
+    if frame.version == 0 {
+        return Err(ProtocolError::InvalidVersion(frame.version));
+    }
+    if frame.payload.len() > max_payload {
+        return Err(ProtocolError::PayloadTooLarge { len: frame.payload.len(), max: max_payload });
+    }
+    let payload_len = u32::try_from(frame.payload.len()).map_err(|_| {
+        ProtocolError::PayloadTooLarge { len: frame.payload.len(), max: max_payload }
+    })?;
+    let mut header = [0u8; HEADER_LEN];
+    header[0..4].copy_from_slice(&MAGIC);
+    header[4..6].copy_from_slice(&frame.version.to_le_bytes());
+    header[6..8].copy_from_slice(&(frame.kind as u16).to_le_bytes());
+    header[8..12].copy_from_slice(&frame.flags.to_le_bytes());
+    header[12..16].copy_from_slice(&payload_len.to_le_bytes());
+    header[16..24].copy_from_slice(&frame.request_id.to_le_bytes());
+    header[24..32].copy_from_slice(&frame.sequence.to_le_bytes());
+    Ok(header)
+}
+
+pub fn write_frame(writer: &mut impl Write, frame: &Frame) -> Result<(), ProtocolError> {
+    let header = encode_header(frame, MAX_FRAME_PAYLOAD)?;
+    writer.write_all(&header)?;
+    writer.write_all(&frame.payload)?;
+    writer.flush()?;
+    Ok(())
+}
+
+pub fn encode_frame(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
+    let mut bytes = Vec::with_capacity(HEADER_LEN.saturating_add(frame.payload.len()));
+    write_frame(&mut bytes, frame)?;
+    Ok(bytes)
+}
+
+/// Read one complete frame. Clean EOF before a header returns `None`; EOF
+/// after any part of a frame is a truncation error.
+pub fn read_frame(
+    reader: &mut impl Read,
+    max_payload: usize,
+) -> Result<Option<Frame>, ProtocolError> {
+    let max_payload = max_payload.min(MAX_FRAME_PAYLOAD);
+    let mut header_bytes = [0u8; HEADER_LEN];
+    let mut header_read = 0;
+    while header_read < HEADER_LEN {
+        match reader.read(&mut header_bytes[header_read..]) {
+            Ok(0) if header_read == 0 => return Ok(None),
+            Ok(0) => {
+                return Err(ProtocolError::Truncated { expected: HEADER_LEN, actual: header_read });
+            }
+            Ok(count) => header_read += count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    let header = parse_header(&header_bytes, max_payload)?;
+    let mut payload = vec![0u8; header.payload_len];
+    let mut payload_read = 0;
+    while payload_read < payload.len() {
+        match reader.read(&mut payload[payload_read..]) {
+            Ok(0) => {
+                return Err(ProtocolError::Truncated {
+                    expected: HEADER_LEN + payload.len(),
+                    actual: HEADER_LEN + payload_read,
+                });
+            }
+            Ok(count) => payload_read += count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(Some(Frame {
+        version: header.version,
+        kind: header.kind,
+        flags: header.flags,
+        request_id: header.request_id,
+        sequence: header.sequence,
+        payload,
+    }))
+}
+
+/// Incremental decoder for nonblocking or callback-driven stream readers.
+/// It parses and validates the header before retaining any payload bytes, so
+/// an advertised oversized frame cannot force a correspondingly large
+/// allocation.
+pub struct FrameDecoder {
+    buffer: Vec<u8>,
+    expected_total: Option<usize>,
+    max_payload: usize,
+    failed: bool,
+}
+
+impl FrameDecoder {
+    pub fn new(max_payload: usize) -> Self {
+        Self {
+            buffer: Vec::with_capacity(HEADER_LEN),
+            expected_total: None,
+            max_payload: max_payload.min(MAX_FRAME_PAYLOAD),
+            failed: false,
+        }
+    }
+
+    pub fn push(&mut self, mut input: &[u8]) -> Result<Vec<Frame>, ProtocolError> {
+        if self.failed {
+            return Err(ProtocolError::DecoderFailed);
+        }
+        let result = self.push_inner(&mut input);
+        if result.is_err() {
+            self.failed = true;
+        }
+        result
+    }
+
+    fn push_inner(&mut self, input: &mut &[u8]) -> Result<Vec<Frame>, ProtocolError> {
+        let mut frames = Vec::new();
+        loop {
+            if self.expected_total.is_none() {
+                if self.buffer.len() < HEADER_LEN {
+                    if input.is_empty() {
+                        break;
+                    }
+                    let count = (HEADER_LEN - self.buffer.len()).min(input.len());
+                    self.buffer.extend_from_slice(&input[..count]);
+                    *input = &input[count..];
+                    if self.buffer.len() < HEADER_LEN {
+                        break;
+                    }
+                }
+                let header = parse_header(&self.buffer[..HEADER_LEN], self.max_payload)?;
+                self.expected_total = Some(HEADER_LEN + header.payload_len);
+                self.buffer.reserve(header.payload_len);
+            }
+
+            let expected_total = self.expected_total.expect("set after a valid header");
+            if self.buffer.len() < expected_total {
+                if input.is_empty() {
+                    break;
+                }
+                let count = (expected_total - self.buffer.len()).min(input.len());
+                self.buffer.extend_from_slice(&input[..count]);
+                *input = &input[count..];
+                if self.buffer.len() < expected_total {
+                    break;
+                }
+            }
+
+            let header = parse_header(&self.buffer[..HEADER_LEN], self.max_payload)?;
+            self.buffer.drain(..HEADER_LEN);
+            let payload = std::mem::take(&mut self.buffer);
+            self.buffer = Vec::with_capacity(HEADER_LEN);
+            self.expected_total = None;
+            frames.push(Frame {
+                version: header.version,
+                kind: header.kind,
+                flags: header.flags,
+                request_id: header.request_id,
+                sequence: header.sequence,
+                payload,
+            });
+        }
+        Ok(frames)
+    }
+
+    pub fn finish(&self) -> Result<(), ProtocolError> {
+        if self.failed {
+            return Err(ProtocolError::DecoderFailed);
+        }
+        if self.buffer.is_empty() && self.expected_total.is_none() {
+            return Ok(());
+        }
+        Err(ProtocolError::Truncated {
+            expected: self.expected_total.unwrap_or(HEADER_LEN),
+            actual: self.buffer.len(),
+        })
+    }
+
+    pub fn buffered_len(&self) -> usize {
+        self.buffer.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_frame() -> Frame {
+        Frame {
+            version: PROTOCOL_VERSION,
+            kind: MessageKind::Output,
+            flags: 0x1122_3344,
+            request_id: 0x0102_0304_0506_0708,
+            sequence: 0x1112_1314_1516_1718,
+            payload: vec![0xaa, 0xbb, 0xcc],
+        }
+    }
+
+    #[test]
+    fn golden_frame_is_explicit_little_endian() {
+        let encoded = encode_frame(&sample_frame()).unwrap();
+        assert_eq!(
+            encoded,
+            vec![
+                b'C', b'M', b'T', b'H', // magic
+                0x01, 0x00, // version
+                0x06, 0x00, // output
+                0x44, 0x33, 0x22, 0x11, // flags
+                0x03, 0x00, 0x00, 0x00, // payload length
+                0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, // request id
+                0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11, // sequence
+                0xaa, 0xbb, 0xcc,
+            ]
+        );
+        let decoded = read_frame(&mut encoded.as_slice(), MAX_FRAME_PAYLOAD).unwrap().unwrap();
+        assert_eq!(decoded, sample_frame());
+    }
+
+    #[test]
+    fn fragmented_and_coalesced_frames_decode_without_boundary_assumptions() {
+        let first = sample_frame();
+        let mut second = Frame::new(MessageKind::ViewerSize, vec![80, 0, 24, 0]);
+        second.request_id = 9;
+        let mut stream = encode_frame(&first).unwrap();
+        stream.extend_from_slice(&encode_frame(&second).unwrap());
+
+        let mut decoder = FrameDecoder::new(1024);
+        let mut decoded = Vec::new();
+        for byte in &stream {
+            decoded.extend(decoder.push(std::slice::from_ref(byte)).unwrap());
+        }
+        decoder.finish().unwrap();
+        assert_eq!(decoded, vec![first.clone(), second.clone()]);
+
+        let mut decoder = FrameDecoder::new(1024);
+        assert_eq!(decoder.push(&stream).unwrap(), vec![first, second]);
+        decoder.finish().unwrap();
+    }
+
+    #[test]
+    fn malformed_headers_poison_the_incremental_decoder() {
+        let mut bad_magic = encode_frame(&sample_frame()).unwrap();
+        bad_magic[0] = b'X';
+        let mut decoder = FrameDecoder::new(1024);
+        assert!(matches!(decoder.push(&bad_magic), Err(ProtocolError::InvalidMagic(_))));
+        assert!(matches!(decoder.push(&[]), Err(ProtocolError::DecoderFailed)));
+
+        let mut unknown_kind = encode_frame(&sample_frame()).unwrap();
+        unknown_kind[6..8].copy_from_slice(&999u16.to_le_bytes());
+        let mut decoder = FrameDecoder::new(1024);
+        assert!(matches!(decoder.push(&unknown_kind), Err(ProtocolError::UnknownMessageKind(999))));
+
+        let mut zero_version = encode_frame(&sample_frame()).unwrap();
+        zero_version[4..6].copy_from_slice(&0u16.to_le_bytes());
+        let mut decoder = FrameDecoder::new(1024);
+        assert!(matches!(decoder.push(&zero_version), Err(ProtocolError::InvalidVersion(0))));
+    }
+
+    #[test]
+    fn oversized_length_is_rejected_before_payload_is_buffered() {
+        let mut encoded = encode_frame(&sample_frame()).unwrap();
+        encoded[12..16].copy_from_slice(&65u32.to_le_bytes());
+        encoded.truncate(HEADER_LEN);
+        let mut decoder = FrameDecoder::new(64);
+        assert!(matches!(
+            decoder.push(&encoded),
+            Err(ProtocolError::PayloadTooLarge { len: 65, max: 64 })
+        ));
+        assert_eq!(decoder.buffered_len(), HEADER_LEN);
+    }
+
+    #[test]
+    fn incomplete_header_and_payload_are_reported_as_truncated() {
+        let encoded = encode_frame(&sample_frame()).unwrap();
+        let mut decoder = FrameDecoder::new(1024);
+        decoder.push(&encoded[..8]).unwrap();
+        assert!(matches!(
+            decoder.finish(),
+            Err(ProtocolError::Truncated { expected: HEADER_LEN, actual: 8 })
+        ));
+
+        let mut decoder = FrameDecoder::new(1024);
+        decoder.push(&encoded[..HEADER_LEN + 1]).unwrap();
+        assert!(matches!(
+            decoder.finish(),
+            Err(ProtocolError::Truncated { expected, actual })
+                if expected == HEADER_LEN + 3 && actual == HEADER_LEN + 1
+        ));
+
+        let error = read_frame(&mut &encoded[..HEADER_LEN + 2], 1024).unwrap_err();
+        assert!(matches!(
+            error,
+            ProtocolError::Truncated { expected, actual }
+                if expected == HEADER_LEN + 3 && actual == HEADER_LEN + 2
+        ));
+    }
+
+    #[test]
+    fn encoder_enforces_the_global_payload_budget() {
+        let frame = Frame::new(MessageKind::Input, vec![0; MAX_FRAME_PAYLOAD + 1]);
+        assert!(matches!(
+            encode_frame(&frame),
+            Err(ProtocolError::PayloadTooLarge { len, max })
+                if len == MAX_FRAME_PAYLOAD + 1 && max == MAX_FRAME_PAYLOAD
+        ));
+    }
+}

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -13,6 +13,11 @@ pub const MAGIC: [u8; 4] = *b"CMTH";
 pub const HEADER_LEN: usize = 32;
 pub const PROTOCOL_VERSION: u16 = 1;
 pub const MAX_FRAME_PAYLOAD: usize = 16 * 1024 * 1024;
+/// The live Output or Resized payload is not independently renderable. Its
+/// immediately following sequenced frame must be Colors, and consumers must
+/// apply both before publishing terminal state. No other flag bits are
+/// currently defined.
+pub const FLAG_COLORS_FOLLOW: u32 = 1 << 0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u16)]
@@ -30,11 +35,16 @@ pub enum MessageKind {
     Bell = 11,
     Exit = 12,
     ResyncRequired = 13,
+    Launch = 14,
+    /// Response to `MintCapability`; payload is one 32-byte capability.
+    Capability = 15,
     Input = 100,
     Paste = 101,
     ViewerSize = 102,
     ReleaseViewer = 103,
     Terminate = 104,
+    /// Admin request: little-endian rights:u32 + ttl_ms:u32.
+    MintCapability = 105,
 }
 
 impl TryFrom<u16> for MessageKind {
@@ -55,11 +65,14 @@ impl TryFrom<u16> for MessageKind {
             11 => Ok(Self::Bell),
             12 => Ok(Self::Exit),
             13 => Ok(Self::ResyncRequired),
+            14 => Ok(Self::Launch),
+            15 => Ok(Self::Capability),
             100 => Ok(Self::Input),
             101 => Ok(Self::Paste),
             102 => Ok(Self::ViewerSize),
             103 => Ok(Self::ReleaseViewer),
             104 => Ok(Self::Terminate),
+            105 => Ok(Self::MintCapability),
             other => Err(ProtocolError::UnknownMessageKind(other)),
         }
     }
@@ -71,6 +84,26 @@ pub struct Frame {
     pub kind: MessageKind,
     pub flags: u32,
     pub request_id: u64,
+    /// Host-to-client live-stream position.
+    ///
+    /// Snapshot and its immediately following full-state Colors frame carry
+    /// the same boundary and consume no sequence numbers. Every subsequent
+    /// live Output, Colors, Resized, Title, Pwd, Bell, Exit, or
+    /// ResyncRequired frame consumes exactly one contiguous number. Control
+    /// request/response frames have a nonzero `request_id`, carry sequence
+    /// zero, and are outside that ordered stream. A client that sees a gap or
+    /// duplicate must disconnect and take a new Snapshot; continuing would
+    /// silently corrupt its terminal mirror.
+    ///
+    /// When Output changes application-authored colors it carries
+    /// [`FLAG_COLORS_FOLLOW`], and its full-state Colors frame is exactly the
+    /// next sequence. Resized always carries that flag and likewise has its
+    /// complete Colors state exactly next. Producers publish each pair
+    /// atomically; consumers stage the first frame and expose only the paired
+    /// state. Snapshot keeps flags zero: its same-boundary Colors frame is a
+    /// mandatory bootstrap rule rather than a live-stream transition.
+    /// Unknown flags, flags on Colors or other message kinds, an unflagged
+    /// Resized, and a flagged frame not followed by Colors are protocol errors.
     pub sequence: u64,
     pub payload: Vec<u8>,
 }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -1,0 +1,1741 @@
+//! Long-lived per-terminal process runtime.
+//!
+//! A terminal host owns the PTY master, child, authoritative Ghostty parser,
+//! replay snapshot, and viewer-size arbitration.  The mux process only keeps
+//! an authenticated mirror connection.  Host records contain no daemon-local
+//! ids, so a replacement mux can adopt the same shell after a crash.
+
+use std::path::{Path, PathBuf};
+
+use ghostty_vt::{Rgb, TerminalColorOverrides};
+use serde::{Deserialize, Serialize};
+
+use crate::surface::{DefaultColors, SurfaceOptions};
+use crate::terminal_host::{
+    CapabilityRights, CapabilityStore, CapabilityToken, ClientHello, ClientRole, HostBootstrap,
+    HostHello, HostIncarnation, HostReady, TerminalId,
+};
+use crate::terminal_host_protocol::{
+    FLAG_COLORS_FOLLOW, Frame, MAX_FRAME_PAYLOAD, MessageKind, PROTOCOL_VERSION, read_frame,
+    write_frame,
+};
+
+const HOST_RECORD_VERSION: u32 = 1;
+const MAX_LAUNCH_PAYLOAD: usize = 1024 * 1024;
+const MAX_STRING: usize = 256 * 1024;
+const MAX_BLOB: usize = 8 * 1024 * 1024;
+const MAX_ARGV: usize = 256;
+const MAX_ENV: usize = 1024;
+const MAX_RENDERER_CAPABILITY_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+const CAPABILITY_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const MAX_HOST_CLIENT_QUEUED_BYTES: usize = 8 * 1024 * 1024;
+pub const TERMINAL_COLORS_WIRE_VERSION: u16 = 1;
+pub const MAX_TERMINAL_COLORS_PAYLOAD: usize = 8 + 3 * 3 + 256 * 4;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TerminalHostRecord {
+    pub record_version: u32,
+    pub terminal_id: String,
+    pub incarnation: String,
+    pub endpoint: String,
+    pub owner_token: String,
+    /// Deprecated compatibility placement hint. Discovery authority is the
+    /// stable terminal identity + endpoint capability; the canonical
+    /// workspace registry owns placement in the stacked follow-up.
+    #[serde(default)]
+    pub workspace_key: String,
+}
+
+impl TerminalHostRecord {
+    pub fn record_path(&self, root: &Path) -> PathBuf {
+        root.join(format!("{}.json", self.terminal_id))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HostSnapshot {
+    pub cols: u16,
+    pub rows: u16,
+    pub replay: Vec<u8>,
+    /// Global live-stream sequence at the atomic Snapshot/Colors boundary.
+    pub sequence_boundary: u64,
+    /// Complete application-authored color state at `sequence_boundary`.
+    pub colors: TerminalColorOverrides,
+    pub pid: Option<u32>,
+    pub command: Vec<String>,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalHostIdentity {
+    pub terminal_id: String,
+    pub incarnation: String,
+}
+
+/// A short-lived, one-use credential that can open the terminal host socket
+/// directly without receiving the durable owner/admin secret.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RendererGrant {
+    pub endpoint: String,
+    pub terminal_id: String,
+    pub incarnation: String,
+    pub token: String,
+    pub rights: CapabilityRights,
+}
+
+impl std::fmt::Debug for RendererGrant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RendererGrant")
+            .field("endpoint", &self.endpoint)
+            .field("terminal_id", &self.terminal_id)
+            .field("incarnation", &self.incarnation)
+            .field("token", &"[REDACTED]")
+            .field("rights", &self.rights)
+            .finish()
+    }
+}
+
+/// Encode a complete sparse application-color state.
+///
+/// Wire layout is little-endian: schema_version:u16, flags:u16 (foreground,
+/// background, cursor), palette_count:u16, reserved:u16, each flagged RGB in
+/// that order, then palette_count repetitions of index:u8 + RGB. Missing
+/// fields and palette indices mean "reset to the receiving renderer's theme",
+/// not "retain the previous override".
+pub fn encode_terminal_color_overrides(colors: &TerminalColorOverrides) -> Vec<u8> {
+    let mut flags = 0u16;
+    flags |= colors.foreground.is_some() as u16;
+    flags |= (colors.background.is_some() as u16) << 1;
+    flags |= (colors.cursor.is_some() as u16) << 2;
+    let palette_count = colors.palette.iter().filter(|color| color.is_some()).count() as u16;
+    let mut payload =
+        Vec::with_capacity(8 + flags.count_ones() as usize * 3 + usize::from(palette_count) * 4);
+    payload.extend_from_slice(&TERMINAL_COLORS_WIRE_VERSION.to_le_bytes());
+    payload.extend_from_slice(&flags.to_le_bytes());
+    payload.extend_from_slice(&palette_count.to_le_bytes());
+    payload.extend_from_slice(&0u16.to_le_bytes());
+    for color in [colors.foreground, colors.background, colors.cursor].into_iter().flatten() {
+        payload.extend_from_slice(&[color.r, color.g, color.b]);
+    }
+    for (index, color) in colors.palette.iter().enumerate() {
+        if let Some(color) = color {
+            payload.extend_from_slice(&[index as u8, color.r, color.g, color.b]);
+        }
+    }
+    debug_assert!(payload.len() <= MAX_TERMINAL_COLORS_PAYLOAD);
+    payload
+}
+
+pub fn decode_terminal_color_overrides(payload: &[u8]) -> anyhow::Result<TerminalColorOverrides> {
+    if payload.len() < 8 || payload.len() > MAX_TERMINAL_COLORS_PAYLOAD {
+        anyhow::bail!("terminal-host Colors payload length is out of range");
+    }
+    let version = u16::from_le_bytes(payload[0..2].try_into().unwrap());
+    let flags = u16::from_le_bytes(payload[2..4].try_into().unwrap());
+    let palette_count = u16::from_le_bytes(payload[4..6].try_into().unwrap()) as usize;
+    let reserved = u16::from_le_bytes(payload[6..8].try_into().unwrap());
+    if version != TERMINAL_COLORS_WIRE_VERSION || flags & !0b111 != 0 || reserved != 0 {
+        anyhow::bail!("unsupported terminal-host Colors payload header");
+    }
+    if palette_count > 256 {
+        anyhow::bail!("terminal-host Colors palette count is out of range");
+    }
+    let expected = 8 + flags.count_ones() as usize * 3 + palette_count * 4;
+    if payload.len() != expected {
+        anyhow::bail!("malformed terminal-host Colors payload");
+    }
+    fn take_rgb(payload: &[u8], offset: &mut usize) -> Rgb {
+        let color = Rgb { r: payload[*offset], g: payload[*offset + 1], b: payload[*offset + 2] };
+        *offset += 3;
+        color
+    }
+    let mut offset = 8;
+    let foreground = (flags & 1 != 0).then(|| take_rgb(payload, &mut offset));
+    let background = (flags & 2 != 0).then(|| take_rgb(payload, &mut offset));
+    let cursor = (flags & 4 != 0).then(|| take_rgb(payload, &mut offset));
+    let mut palette = [None; 256];
+    for _ in 0..palette_count {
+        let index = payload[offset] as usize;
+        if palette[index].is_some() {
+            anyhow::bail!("duplicate terminal-host Colors palette index");
+        }
+        palette[index] =
+            Some(Rgb { r: payload[offset + 1], g: payload[offset + 2], b: payload[offset + 3] });
+        offset += 4;
+    }
+    Ok(TerminalColorOverrides { foreground, background, cursor, palette })
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::collections::HashMap;
+    use std::fs::{self, OpenOptions};
+    use std::io::{Read, Write};
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::process::{Command, Stdio};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+    use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+
+    use anyhow::Context;
+    use ghostty_vt::{Callbacks, CursorShape, Terminal};
+    use portable_pty::{ChildKiller, CommandBuilder, MasterPty, PtySize, native_pty_system};
+
+    use super::*;
+
+    static RECORD_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+    #[derive(Debug)]
+    struct HostLaunch {
+        endpoint: String,
+        record_path: String,
+        term: String,
+        cols: u16,
+        rows: u16,
+        scrollback: usize,
+        cwd: Option<String>,
+        command: Vec<String>,
+        extra_env: Vec<(String, String)>,
+        default_colors: DefaultColors,
+    }
+
+    impl HostLaunch {
+        fn encode(&self) -> anyhow::Result<Vec<u8>> {
+            if self.command.is_empty() || self.command.len() > MAX_ARGV {
+                anyhow::bail!("terminal-host command count is out of range");
+            }
+            if self.extra_env.len() > MAX_ENV {
+                anyhow::bail!("terminal-host environment count is out of range");
+            }
+            let mut output = Vec::new();
+            put_string(&mut output, &self.endpoint)?;
+            put_string(&mut output, &self.record_path)?;
+            put_string(&mut output, &self.term)?;
+            output.extend_from_slice(&self.cols.max(1).to_le_bytes());
+            output.extend_from_slice(&self.rows.max(1).to_le_bytes());
+            output.extend_from_slice(
+                &u32::try_from(self.scrollback)
+                    .map_err(|_| anyhow::anyhow!("terminal-host scrollback is too large"))?
+                    .to_le_bytes(),
+            );
+            put_optional_string(&mut output, self.cwd.as_deref())?;
+            output.extend_from_slice(&(self.command.len() as u16).to_le_bytes());
+            for argument in &self.command {
+                put_string(&mut output, argument)?;
+            }
+            output.extend_from_slice(&(self.extra_env.len() as u16).to_le_bytes());
+            for (key, value) in &self.extra_env {
+                put_string(&mut output, key)?;
+                put_string(&mut output, value)?;
+            }
+            encode_default_colors(&mut output, self.default_colors);
+            if output.len() > MAX_LAUNCH_PAYLOAD {
+                anyhow::bail!("terminal-host launch payload is too large");
+            }
+            Ok(output)
+        }
+
+        fn decode(payload: &[u8]) -> anyhow::Result<Self> {
+            let mut decoder = PayloadDecoder::new(payload);
+            let endpoint = decoder.string()?;
+            let record_path = decoder.string()?;
+            let term = decoder.string()?;
+            let cols = decoder.u16()?.max(1);
+            let rows = decoder.u16()?.max(1);
+            let scrollback = decoder.u32()? as usize;
+            let cwd = decoder.optional_string()?;
+            let argc = decoder.u16()? as usize;
+            if argc == 0 || argc > MAX_ARGV {
+                anyhow::bail!("terminal-host command count is out of range");
+            }
+            let mut command = Vec::with_capacity(argc);
+            for _ in 0..argc {
+                command.push(decoder.string()?);
+            }
+            let envc = decoder.u16()? as usize;
+            if envc > MAX_ENV {
+                anyhow::bail!("terminal-host environment count is out of range");
+            }
+            let mut extra_env = Vec::with_capacity(envc);
+            for _ in 0..envc {
+                extra_env.push((decoder.string()?, decoder.string()?));
+            }
+            let default_colors = decode_default_colors(&mut decoder)?;
+            decoder.finish()?;
+            Ok(Self {
+                endpoint,
+                record_path,
+                term,
+                cols,
+                rows,
+                scrollback,
+                cwd,
+                command,
+                extra_env,
+                default_colors,
+            })
+        }
+    }
+
+    fn encode_default_colors(output: &mut Vec<u8>, colors: DefaultColors) {
+        let mut flags = 0u8;
+        flags |= colors.fg.is_some() as u8;
+        flags |= (colors.bg.is_some() as u8) << 1;
+        flags |= (colors.cursor.is_some() as u8) << 2;
+        flags |= (colors.cursor_style.is_some() as u8) << 3;
+        flags |= (colors.cursor_blink.is_some() as u8) << 4;
+        output.push(flags);
+        for color in [colors.fg, colors.bg, colors.cursor].into_iter().flatten() {
+            output.extend_from_slice(&[color.r, color.g, color.b]);
+        }
+        if let Some(style) = colors.cursor_style {
+            output.push(match style {
+                CursorShape::Block => 1,
+                CursorShape::BlockHollow => 2,
+                CursorShape::Bar => 3,
+                CursorShape::Underline => 4,
+            });
+        }
+        if let Some(blink) = colors.cursor_blink {
+            output.push(blink as u8);
+        }
+        let palette_count = colors.palette.iter().filter(|color| color.is_some()).count() as u16;
+        output.extend_from_slice(&palette_count.to_le_bytes());
+        for (index, color) in colors.palette.iter().enumerate() {
+            if let Some(color) = color {
+                output.extend_from_slice(&[index as u8, color.r, color.g, color.b]);
+            }
+        }
+    }
+
+    fn decode_default_colors(decoder: &mut PayloadDecoder<'_>) -> anyhow::Result<DefaultColors> {
+        let flags = decoder.u8()?;
+        if flags & !0b1_1111 != 0 {
+            anyhow::bail!("terminal-host default-color flags are out of range");
+        }
+        let fg = if flags & 1 != 0 { Some(decoder.rgb()?) } else { None };
+        let bg = if flags & 2 != 0 { Some(decoder.rgb()?) } else { None };
+        let cursor = if flags & 4 != 0 { Some(decoder.rgb()?) } else { None };
+        let cursor_style = if flags & 8 != 0 {
+            Some(match decoder.u8()? {
+                1 => CursorShape::Block,
+                2 => CursorShape::BlockHollow,
+                3 => CursorShape::Bar,
+                4 => CursorShape::Underline,
+                _ => anyhow::bail!("terminal-host default cursor style is out of range"),
+            })
+        } else {
+            None
+        };
+        let cursor_blink = if flags & 16 != 0 {
+            Some(match decoder.u8()? {
+                0 => false,
+                1 => true,
+                _ => anyhow::bail!("terminal-host default cursor blink is out of range"),
+            })
+        } else {
+            None
+        };
+        let palette_count = decoder.u16()? as usize;
+        if palette_count > 256 {
+            anyhow::bail!("terminal-host default palette count is out of range");
+        }
+        let mut palette = [None; 256];
+        for _ in 0..palette_count {
+            let index = decoder.u8()? as usize;
+            if palette[index].is_some() {
+                anyhow::bail!("duplicate terminal-host default palette index");
+            }
+            palette[index] = Some(decoder.rgb()?);
+        }
+        Ok(DefaultColors {
+            fg,
+            bg,
+            cursor,
+            selection_bg: None,
+            selection_fg: None,
+            cursor_style,
+            cursor_blink,
+            palette,
+        })
+    }
+
+    pub(crate) struct CapabilityResponses {
+        waiters: Mutex<HashMap<u64, SyncSender<Vec<u8>>>>,
+    }
+
+    impl CapabilityResponses {
+        pub(crate) fn resolve(&self, frame: &Frame) {
+            if let Some(waiter) = self.waiters.lock().unwrap().remove(&frame.request_id) {
+                let _ = waiter.try_send(frame.payload.clone());
+            }
+        }
+    }
+
+    pub struct HostAttachment {
+        pub record: TerminalHostRecord,
+        pub record_path: PathBuf,
+        pub snapshot: HostSnapshot,
+        reader: Option<UnixStream>,
+        writer: Arc<Mutex<UnixStream>>,
+        capability_responses: Arc<CapabilityResponses>,
+        next_request: AtomicU64,
+    }
+
+    impl std::fmt::Debug for HostAttachment {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("HostAttachment")
+                .field("terminal_id", &self.record.terminal_id)
+                .field("incarnation", &self.record.incarnation)
+                .field("endpoint", &self.record.endpoint)
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl HostAttachment {
+        pub fn take_reader(&mut self) -> anyhow::Result<UnixStream> {
+            self.reader.take().ok_or_else(|| anyhow::anyhow!("terminal-host reader already taken"))
+        }
+
+        pub fn send(&self, kind: MessageKind, payload: &[u8]) -> std::io::Result<()> {
+            let mut writer = self.writer.lock().unwrap();
+            let frame = Frame::new(kind, payload.to_vec());
+            write_frame(&mut *writer, &frame).map_err(protocol_io_error)
+        }
+
+        pub fn send_viewer_size(&self, cols: u16, rows: u16) -> std::io::Result<()> {
+            let mut payload = Vec::with_capacity(4);
+            payload.extend_from_slice(&cols.max(1).to_le_bytes());
+            payload.extend_from_slice(&rows.max(1).to_le_bytes());
+            self.send(MessageKind::ViewerSize, &payload)
+        }
+
+        pub fn terminate(&self) -> std::io::Result<()> {
+            self.send(MessageKind::Terminate, &[])
+        }
+
+        pub fn disconnect(&self) {
+            let _ = self.writer.lock().unwrap().shutdown(std::net::Shutdown::Both);
+        }
+
+        pub fn identity(&self) -> TerminalHostIdentity {
+            TerminalHostIdentity {
+                terminal_id: self.record.terminal_id.clone(),
+                incarnation: self.record.incarnation.clone(),
+            }
+        }
+
+        pub(crate) fn capability_responses(&self) -> Arc<CapabilityResponses> {
+            self.capability_responses.clone()
+        }
+
+        pub fn mint_renderer_grant(&self, ttl: Duration) -> anyhow::Result<RendererGrant> {
+            if ttl.is_zero() || ttl > MAX_RENDERER_CAPABILITY_TTL {
+                anyhow::bail!("renderer capability TTL must be between 1ms and 60s");
+            }
+            let ttl_ms = u32::try_from(ttl.as_millis())
+                .map_err(|_| anyhow::anyhow!("renderer capability TTL is too large"))?;
+            let request_id = self.next_request.fetch_add(1, Ordering::Relaxed);
+            let (sender, receiver) = sync_channel(1);
+            self.capability_responses.waiters.lock().unwrap().insert(request_id, sender);
+            let mut payload = Vec::with_capacity(8);
+            payload.extend_from_slice(&CapabilityRights::RENDERER.bits().to_le_bytes());
+            payload.extend_from_slice(&ttl_ms.to_le_bytes());
+            let mut frame = Frame::new(MessageKind::MintCapability, payload);
+            frame.request_id = request_id;
+            let write_result = {
+                let mut writer = self.writer.lock().unwrap();
+                write_frame(&mut *writer, &frame).map_err(protocol_io_error)
+            };
+            if let Err(error) = write_result {
+                self.capability_responses.waiters.lock().unwrap().remove(&request_id);
+                return Err(error.into());
+            }
+            let payload = match receiver.recv_timeout(CAPABILITY_RESPONSE_TIMEOUT) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    self.capability_responses.waiters.lock().unwrap().remove(&request_id);
+                    return Err(anyhow::anyhow!(
+                        "terminal host did not mint renderer grant: {error}"
+                    ));
+                }
+            };
+            if payload.len() != crate::terminal_host::CAPABILITY_TOKEN_LEN {
+                anyhow::bail!("terminal host returned a malformed renderer capability");
+            }
+            Ok(RendererGrant {
+                endpoint: self.record.endpoint.clone(),
+                terminal_id: self.record.terminal_id.clone(),
+                incarnation: self.record.incarnation.clone(),
+                token: encode_hex(&payload),
+                rights: CapabilityRights::RENDERER,
+            })
+        }
+
+        pub fn persist_workspace(&mut self, workspace_key: &str) -> anyhow::Result<()> {
+            if self.record.workspace_key == workspace_key {
+                return Ok(());
+            }
+            self.record.workspace_key = workspace_key.to_string();
+            write_record(&self.record_path, &self.record)
+        }
+    }
+
+    pub fn terminal_host_root(state_root: &Path, session: &str) -> PathBuf {
+        state_root.join(format!("terminal-hosts-{}", stable_token(session)))
+    }
+
+    pub fn launch_terminal_host(
+        options: &SurfaceOptions,
+        root: &Path,
+        default_colors: DefaultColors,
+    ) -> anyhow::Result<HostAttachment> {
+        let terminal_id = TerminalId::random()?;
+        launch_terminal_host_with_identity(options, root, default_colors, terminal_id)
+    }
+
+    /// Launch using a registry-reserved stable UUID. The workspace registry
+    /// can commit identity/placement before process creation, eliminating the
+    /// launch-window orphan race without changing the host wire protocol.
+    pub fn launch_terminal_host_with_identity(
+        options: &SurfaceOptions,
+        root: &Path,
+        default_colors: DefaultColors,
+        terminal_id: TerminalId,
+    ) -> anyhow::Result<HostAttachment> {
+        prepare_private_dir(root)?;
+        let owner_token = CapabilityToken::random()?;
+        let terminal_hex = encode_hex(terminal_id.as_bytes());
+        // macOS limits sockaddr_un paths to roughly one hundred bytes and
+        // TMPDIR is commonly already longer than that. Keep the transport
+        // endpoint short; the private durable record still carries its full
+        // canonical identity and owner capability.
+        let uid = fs::metadata(root)?.uid();
+        let endpoint_root = PathBuf::from("/tmp").join(format!("cmux-th-{uid}"));
+        prepare_private_dir(&endpoint_root)?;
+        let endpoint = endpoint_root.join(format!("{terminal_hex}.sock"));
+        let record_path = root.join(format!("{terminal_hex}.json"));
+        if record_path.exists() || endpoint.exists() {
+            anyhow::bail!("terminal host identity already exists");
+        }
+        let command = options
+            .command
+            .clone()
+            .filter(|command| !command.is_empty())
+            .unwrap_or_else(|| vec![crate::platform::default_shell()]);
+        let launch = HostLaunch {
+            endpoint: endpoint.to_string_lossy().into_owned(),
+            record_path: record_path.to_string_lossy().into_owned(),
+            term: options.term.clone(),
+            cols: options.cols,
+            rows: options.rows,
+            scrollback: options.scrollback,
+            cwd: options.cwd.clone().or_else(|| {
+                crate::platform::home_dir().map(|path| path.to_string_lossy().into_owned())
+            }),
+            command,
+            extra_env: options.extra_env.clone(),
+            default_colors,
+        };
+
+        let binary = std::env::current_exe().context("resolve cmux-tui terminal-host binary")?;
+        let mut child = Command::new(binary)
+            .args(["__terminal-host", "--bootstrap-stdio"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // A host outlives its daemon, so it must not retain a daemon log
+            // pipe whose EOF is itself used as a lifecycle signal.
+            .stderr(Stdio::null())
+            .spawn()
+            .context("spawn terminal-host process")?;
+        let mut stdin = child.stdin.take().context("open terminal-host bootstrap stdin")?;
+        let mut stdout = child.stdout.take().context("open terminal-host bootstrap stdout")?;
+
+        let bootstrap = HostBootstrap {
+            min_version: PROTOCOL_VERSION,
+            max_version: PROTOCOL_VERSION,
+            terminal_id,
+            owner_token,
+        };
+        write_frame(&mut stdin, &bootstrap.into_frame(1))?;
+        let ready_frame = read_required_frame(&mut stdout, "bootstrap ready")?;
+        if ready_frame.kind != MessageKind::Ready {
+            anyhow::bail!("terminal host returned {:?} instead of Ready", ready_frame.kind);
+        }
+        let ready = HostReady::decode(&ready_frame.payload)?;
+        if ready.terminal_id != terminal_id {
+            anyhow::bail!("terminal host changed terminal identity during bootstrap");
+        }
+
+        let mut launch_frame = Frame::new(MessageKind::Launch, launch.encode()?);
+        launch_frame.request_id = 2;
+        write_frame(&mut stdin, &launch_frame)?;
+        let launched_frame = read_required_frame(&mut stdout, "launch ready")?;
+        if launched_frame.kind != MessageKind::Ready || launched_frame.request_id != 2 {
+            anyhow::bail!("terminal host did not acknowledge launch");
+        }
+        let launched = HostReady::decode(&launched_frame.payload)?;
+        if launched.terminal_id != terminal_id || launched.incarnation != ready.incarnation {
+            anyhow::bail!("terminal host identity changed while launching PTY");
+        }
+        drop(stdin);
+        drop(stdout);
+        thread::Builder::new().name("terminal-host-reaper".into()).spawn(move || {
+            let _ = child.wait();
+        })?;
+
+        let record = TerminalHostRecord {
+            record_version: HOST_RECORD_VERSION,
+            terminal_id: terminal_hex,
+            incarnation: encode_hex(ready.incarnation.as_bytes()),
+            endpoint: endpoint.to_string_lossy().into_owned(),
+            owner_token: encode_hex(owner_token.as_bytes()),
+            workspace_key: String::new(),
+        };
+        connect_record(record, record_path)
+    }
+
+    pub fn adopt_terminal_host(
+        record: TerminalHostRecord,
+        record_path: PathBuf,
+    ) -> anyhow::Result<HostAttachment> {
+        if record.record_version != HOST_RECORD_VERSION {
+            anyhow::bail!("unsupported terminal-host record version {}", record.record_version);
+        }
+        connect_record(record, record_path)
+    }
+
+    pub fn load_terminal_host_records(
+        root: &Path,
+    ) -> anyhow::Result<Vec<(PathBuf, TerminalHostRecord)>> {
+        let mut records = Vec::new();
+        let entries = match fs::read_dir(root) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(records),
+            Err(error) => return Err(error.into()),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes = match fs::read(&path) {
+                Ok(bytes) => bytes,
+                Err(_) => continue,
+            };
+            let Ok(record) = serde_json::from_slice::<TerminalHostRecord>(&bytes) else {
+                continue;
+            };
+            records.push((path, record));
+        }
+        records.sort_by(|left, right| left.0.cmp(&right.0));
+        Ok(records)
+    }
+
+    pub fn remove_terminal_host_record(path: &Path) {
+        let _ = fs::remove_file(path);
+    }
+
+    fn connect_record(
+        record: TerminalHostRecord,
+        record_path: PathBuf,
+    ) -> anyhow::Result<HostAttachment> {
+        let terminal_id = TerminalId::from_bytes(decode_hex_array(&record.terminal_id)?);
+        let incarnation = HostIncarnation::from_bytes(decode_hex_array(&record.incarnation)?);
+        let owner_token = CapabilityToken::from_bytes(decode_hex_array(&record.owner_token)?);
+        let mut stream = connect_with_retry(Path::new(&record.endpoint))?;
+        let hello = ClientHello {
+            min_version: PROTOCOL_VERSION,
+            max_version: PROTOCOL_VERSION,
+            role: ClientRole::Admin,
+            requested_rights: CapabilityRights::ADMIN,
+            terminal_id,
+            token: owner_token,
+        };
+        write_frame(&mut stream, &hello.into_frame(1))?;
+        let hello_frame = read_required_frame(&mut stream, "host hello")?;
+        if hello_frame.kind != MessageKind::HostHello {
+            anyhow::bail!("terminal host rejected owner handshake");
+        }
+        let host_hello = HostHello::decode(&hello_frame.payload)?;
+        if host_hello.terminal_id != terminal_id || host_hello.incarnation != incarnation {
+            anyhow::bail!("terminal-host record identity does not match live host");
+        }
+        let snapshot_frame = read_required_frame(&mut stream, "terminal snapshot")?;
+        if snapshot_frame.kind != MessageKind::Snapshot
+            || snapshot_frame.flags != 0
+            || snapshot_frame.request_id != 0
+        {
+            anyhow::bail!("terminal host did not send an initial snapshot");
+        }
+        let mut snapshot = decode_snapshot(&snapshot_frame.payload)?;
+        let colors_frame = read_required_frame(&mut stream, "terminal color state")?;
+        if colors_frame.kind != MessageKind::Colors
+            || colors_frame.flags != 0
+            || colors_frame.sequence != snapshot_frame.sequence
+            || colors_frame.request_id != 0
+        {
+            anyhow::bail!("terminal host did not send Colors at the snapshot sequence boundary");
+        }
+        snapshot.sequence_boundary = snapshot_frame.sequence;
+        snapshot.colors = decode_terminal_color_overrides(&colors_frame.payload)?;
+        let reader = stream.try_clone()?;
+        let attachment = HostAttachment {
+            record,
+            record_path,
+            snapshot,
+            reader: Some(reader),
+            writer: Arc::new(Mutex::new(stream)),
+            capability_responses: Arc::new(CapabilityResponses {
+                waiters: Mutex::new(HashMap::new()),
+            }),
+            next_request: AtomicU64::new(2),
+        };
+        attachment.send_viewer_size(attachment.snapshot.cols, attachment.snapshot.rows)?;
+        Ok(attachment)
+    }
+
+    fn connect_with_retry(path: &Path) -> anyhow::Result<UnixStream> {
+        let mut last_error = None;
+        for _ in 0..100 {
+            match UnixStream::connect(path) {
+                Ok(stream) => return Ok(stream),
+                Err(error) => {
+                    last_error = Some(error);
+                    thread::sleep(Duration::from_millis(10));
+                }
+            }
+        }
+        Err(last_error
+            .unwrap_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "host missing"))
+            .into())
+    }
+
+    fn read_required_frame(reader: &mut impl Read, context: &str) -> anyhow::Result<Frame> {
+        read_frame(reader, MAX_FRAME_PAYLOAD)?
+            .ok_or_else(|| anyhow::anyhow!("terminal host closed before {context}"))
+    }
+
+    fn write_record(path: &Path, record: &TerminalHostRecord) -> anyhow::Result<()> {
+        if let Some(parent) = path.parent() {
+            prepare_private_dir(parent)?;
+        }
+        let temporary = path.with_extension(format!(
+            "tmp-{}-{}",
+            std::process::id(),
+            RECORD_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let bytes = serde_json::to_vec(record)?;
+        let result = (|| -> anyhow::Result<()> {
+            let mut file =
+                OpenOptions::new().write(true).create_new(true).mode(0o600).open(&temporary)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+            fs::rename(&temporary, path)?;
+            Ok(())
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        result
+    }
+
+    fn prepare_private_dir(path: &Path) -> anyhow::Result<()> {
+        fs::create_dir_all(path)?;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+        Ok(())
+    }
+
+    #[derive(Clone)]
+    struct HostTap {
+        sender: SyncSender<Frame>,
+        queued_bytes: Arc<AtomicUsize>,
+        shutdown: Arc<UnixStream>,
+        max_queued_bytes: usize,
+    }
+
+    impl HostTap {
+        fn try_send(&self, frame: Frame) -> bool {
+            let retained =
+                crate::terminal_host_protocol::HEADER_LEN.saturating_add(frame.payload.len());
+            let mut queued = self.queued_bytes.load(Ordering::Acquire);
+            loop {
+                let Some(next) = queued.checked_add(retained) else {
+                    self.close();
+                    return false;
+                };
+                if next > self.max_queued_bytes {
+                    self.close();
+                    return false;
+                }
+                match self.queued_bytes.compare_exchange_weak(
+                    queued,
+                    next,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(actual) => queued = actual,
+                }
+            }
+            match self.sender.try_send(frame) {
+                Ok(()) => true,
+                Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => {
+                    self.queued_bytes.fetch_sub(retained, Ordering::AcqRel);
+                    self.close();
+                    false
+                }
+            }
+        }
+
+        fn release(&self, frame: &Frame) {
+            let retained =
+                crate::terminal_host_protocol::HEADER_LEN.saturating_add(frame.payload.len());
+            self.queued_bytes.fetch_sub(retained, Ordering::AcqRel);
+        }
+
+        fn close(&self) {
+            let _ = self.shutdown.shutdown(std::net::Shutdown::Both);
+        }
+    }
+
+    struct HostShared {
+        terminal_id: TerminalId,
+        incarnation: HostIncarnation,
+        owner_token: CapabilityToken,
+        capabilities: CapabilityStore,
+        term: Mutex<Terminal>,
+        writer: Mutex<Box<dyn Write + Send>>,
+        master: Mutex<Box<dyn MasterPty + Send>>,
+        killer: Mutex<Box<dyn ChildKiller + Send>>,
+        pid: Option<u32>,
+        command: Vec<String>,
+        cwd: Option<String>,
+        size: Mutex<(u16, u16)>,
+        viewer_sizes: Mutex<HashMap<u64, (u16, u16)>>,
+        taps: Mutex<HashMap<u64, HostTap>>,
+        broadcast_lock: Mutex<()>,
+        sequence: AtomicU64,
+        next_client: AtomicU64,
+        dead: AtomicBool,
+    }
+
+    fn publish_host_frames(
+        broadcast_lock: &Mutex<()>,
+        sequence: &AtomicU64,
+        taps: &Mutex<HashMap<u64, HostTap>>,
+        frames: impl IntoIterator<Item = Frame>,
+    ) {
+        // Sequence allocation and publication are one critical section;
+        // otherwise concurrent output/resize/exit producers could mint N
+        // then publish N+1 first, or split a coupled Output/Colors pair.
+        let _broadcast = broadcast_lock.lock().unwrap();
+        let mut taps = taps.lock().unwrap();
+        for mut frame in frames {
+            let sequence = sequence.fetch_add(1, Ordering::AcqRel) + 1;
+            frame.sequence = sequence;
+            taps.retain(|_, tap| tap.try_send(frame.clone()));
+        }
+    }
+
+    impl HostShared {
+        fn broadcast(&self, kind: MessageKind, payload: Vec<u8>) {
+            self.broadcast_frames([Frame::new(kind, payload)]);
+        }
+
+        fn broadcast_frames(&self, frames: impl IntoIterator<Item = Frame>) {
+            publish_host_frames(&self.broadcast_lock, &self.sequence, &self.taps, frames);
+        }
+
+        fn broadcast_with_colors(&self, kind: MessageKind, payload: Vec<u8>, colors: Vec<u8>) {
+            debug_assert!(matches!(kind, MessageKind::Output | MessageKind::Resized));
+            let mut first = Frame::new(kind, payload);
+            first.flags = FLAG_COLORS_FOLLOW;
+            self.broadcast_frames([first, Frame::new(MessageKind::Colors, colors)]);
+        }
+
+        fn remove_client(&self, client: u64) {
+            self.taps.lock().unwrap().remove(&client);
+            self.viewer_sizes.lock().unwrap().remove(&client);
+            self.apply_viewer_minimum();
+        }
+
+        fn set_viewer_size(&self, client: u64, cols: u16, rows: u16) {
+            self.viewer_sizes.lock().unwrap().insert(client, (cols.max(1), rows.max(1)));
+            self.apply_viewer_minimum();
+        }
+
+        fn apply_viewer_minimum(&self) {
+            let desired = self
+                .viewer_sizes
+                .lock()
+                .unwrap()
+                .values()
+                .copied()
+                .reduce(|left, right| (left.0.min(right.0), left.1.min(right.1)));
+            let Some((cols, rows)) = desired else { return };
+            {
+                let mut size = self.size.lock().unwrap();
+                if *size == (cols, rows) {
+                    return;
+                }
+                *size = (cols, rows);
+            }
+            let mut term = self.term.lock().unwrap();
+            let _ = self.master.lock().unwrap().resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            });
+            let _ = term.resize(cols, rows, 8, 16);
+            let replay = term
+                .vt_replay_bounded_theme_portable(crate::surface::VT_REPLAY_MAX_BYTES)
+                .unwrap_or_default();
+            let colors = term.color_overrides();
+            // Keep the parser lock through sequence publication so output
+            // parsed at the new size cannot overtake the Resized marker.
+            self.broadcast_with_colors(
+                MessageKind::Resized,
+                encode_resize(cols, rows, &replay),
+                encode_terminal_color_overrides(&colors),
+            );
+        }
+    }
+
+    pub fn serve_terminal_host_stdio(
+        args: &[String],
+        reader: &mut impl Read,
+        writer: &mut impl Write,
+    ) -> anyhow::Result<()> {
+        if args.iter().map(String::as_str).ne(["--bootstrap-stdio"]) {
+            anyhow::bail!("hidden mode requires --bootstrap-stdio");
+        }
+        let bootstrapped = crate::terminal_host::bootstrap_stdio_once(reader, writer)?;
+        let Some(launch_frame) = read_frame(reader, MAX_LAUNCH_PAYLOAD)? else {
+            // Keep the one-frame bootstrap probe useful for compatibility and
+            // packaging diagnostics. Production launchers always follow it
+            // with Launch on the same private pipe.
+            return Ok(());
+        };
+        if launch_frame.kind != MessageKind::Launch {
+            anyhow::bail!("expected terminal-host Launch, received {:?}", launch_frame.kind);
+        }
+        let launch = HostLaunch::decode(&launch_frame.payload)?;
+        let shared = spawn_host_runtime(&launch, &bootstrapped)?;
+
+        let endpoint = PathBuf::from(&launch.endpoint);
+        let _ = fs::remove_file(&endpoint);
+        if let Some(parent) = endpoint.parent() {
+            prepare_private_dir(parent)?;
+        }
+        let listener = UnixListener::bind(&endpoint)?;
+        fs::set_permissions(&endpoint, fs::Permissions::from_mode(0o600))?;
+        listener.set_nonblocking(true)?;
+
+        // The PTY owner publishes its own adoption record before Ready. A
+        // daemon killed immediately after launch acknowledgement can never
+        // leave behind an undiscoverable terminal process.
+        let record = TerminalHostRecord {
+            record_version: HOST_RECORD_VERSION,
+            terminal_id: encode_hex(bootstrapped.terminal_id.as_bytes()),
+            incarnation: encode_hex(bootstrapped.incarnation.as_bytes()),
+            endpoint: launch.endpoint.clone(),
+            owner_token: encode_hex(bootstrapped.owner_token().as_bytes()),
+            workspace_key: String::new(),
+        };
+        write_record(Path::new(&launch.record_path), &record)?;
+
+        let ready = HostReady {
+            selected_version: PROTOCOL_VERSION,
+            terminal_id: bootstrapped.terminal_id,
+            incarnation: bootstrapped.incarnation,
+        };
+        let mut response = Frame::new(MessageKind::Ready, ready.encode());
+        response.request_id = launch_frame.request_id;
+        write_frame(writer, &response)?;
+
+        while !shared.dead.load(Ordering::Acquire) {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    // Accepted sockets inherit O_NONBLOCK from the listener
+                    // on macOS. Client protocol threads use blocking framed
+                    // reads, so normalize the accepted descriptor here.
+                    stream.set_nonblocking(false)?;
+                    let host = shared.clone();
+                    thread::Builder::new().name("terminal-host-client".into()).spawn(
+                        move || {
+                            let _ = serve_client(host, stream);
+                        },
+                    )?;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(20));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        shared.broadcast(MessageKind::Exit, Vec::new());
+        thread::sleep(Duration::from_millis(20));
+        let _ = fs::remove_file(&endpoint);
+        let _ = fs::remove_file(&launch.record_path);
+        Ok(())
+    }
+
+    fn spawn_host_runtime(
+        launch: &HostLaunch,
+        bootstrapped: &crate::terminal_host::BootstrappedHost,
+    ) -> anyhow::Result<Arc<HostShared>> {
+        let pty = native_pty_system().openpty(PtySize {
+            rows: launch.rows,
+            cols: launch.cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+        let mut command = CommandBuilder::new(&launch.command[0]);
+        command.args(&launch.command[1..]);
+        command.env("TERM", &launch.term);
+        for (key, value) in &launch.extra_env {
+            command.env(key, value);
+        }
+        if let Some(cwd) = launch.cwd.as_deref() {
+            command.cwd(cwd);
+        }
+        let mut child = pty.slave.spawn_command(command)?;
+        let pid = child.process_id();
+        drop(pty.slave);
+        let killer = child.clone_killer();
+        let mut pty_reader = pty.master.try_clone_reader()?;
+        let pty_writer = pty.master.take_writer()?;
+
+        let pending_responses = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let title_changed = Arc::new(AtomicBool::new(false));
+        let bell = Arc::new(AtomicBool::new(false));
+        let callbacks = Callbacks {
+            on_pty_write: Some(Box::new({
+                let pending = pending_responses.clone();
+                move |bytes| pending.lock().unwrap().extend_from_slice(bytes)
+            })),
+            on_title_changed: Some(Box::new({
+                let title_changed = title_changed.clone();
+                move || title_changed.store(true, Ordering::Release)
+            })),
+            on_bell: Some(Box::new({
+                let bell = bell.clone();
+                move || bell.store(true, Ordering::Release)
+            })),
+        };
+        let mut term = Terminal::new(launch.cols, launch.rows, launch.scrollback, callbacks)?;
+        term.set_default_colors(
+            launch.default_colors.fg,
+            launch.default_colors.bg,
+            launch.default_colors.cursor,
+        );
+        term.set_default_palette(&launch.default_colors.palette);
+        term.set_default_cursor(
+            launch.default_colors.cursor_style,
+            launch.default_colors.cursor_blink,
+        );
+        let shared = Arc::new(HostShared {
+            terminal_id: bootstrapped.terminal_id,
+            incarnation: bootstrapped.incarnation,
+            owner_token: bootstrapped.owner_token(),
+            capabilities: CapabilityStore::new(64),
+            term: Mutex::new(term),
+            writer: Mutex::new(pty_writer),
+            master: Mutex::new(pty.master),
+            killer: Mutex::new(killer),
+            pid,
+            command: launch.command.clone(),
+            cwd: launch.cwd.clone(),
+            size: Mutex::new((launch.cols, launch.rows)),
+            viewer_sizes: Mutex::new(HashMap::new()),
+            taps: Mutex::new(HashMap::new()),
+            broadcast_lock: Mutex::new(()),
+            sequence: AtomicU64::new(0),
+            next_client: AtomicU64::new(1),
+            dead: AtomicBool::new(false),
+        });
+
+        let reader_host = shared.clone();
+        thread::Builder::new().name("terminal-host-pty".into()).spawn(move || {
+            let mut buffer = [0u8; 64 * 1024];
+            let mut last_colors = TerminalColorOverrides::default();
+            loop {
+                let count = match pty_reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(count) => count,
+                    Err(_) => break,
+                };
+                let bytes = &buffer[..count];
+                let (title, pwd) = {
+                    let mut term = reader_host.term.lock().unwrap();
+                    term.vt_write(bytes);
+                    let title = title_changed
+                        .swap(false, Ordering::AcqRel)
+                        .then(|| term.title().unwrap_or_default());
+                    let pwd = term.pwd();
+                    // Snapshot registration takes the same parser lock. By
+                    // publishing before releasing it, replay + live output is
+                    // an atomic handoff with neither gaps nor duplicates.
+                    let colors = term.color_overrides();
+                    if colors != last_colors {
+                        reader_host.broadcast_with_colors(
+                            MessageKind::Output,
+                            bytes.to_vec(),
+                            encode_terminal_color_overrides(&colors),
+                        );
+                        last_colors = colors;
+                    } else {
+                        reader_host.broadcast(MessageKind::Output, bytes.to_vec());
+                    }
+                    (title, pwd)
+                };
+                if let Some(title) = title {
+                    reader_host.broadcast(MessageKind::Title, title.into_bytes());
+                }
+                if let Some(pwd) = pwd {
+                    reader_host.broadcast(MessageKind::Pwd, pwd.into_bytes());
+                }
+                if bell.swap(false, Ordering::AcqRel) {
+                    reader_host.broadcast(MessageKind::Bell, Vec::new());
+                }
+                let responses = std::mem::take(&mut *pending_responses.lock().unwrap());
+                if !responses.is_empty() {
+                    let mut writer = reader_host.writer.lock().unwrap();
+                    let _ = writer.write_all(&responses);
+                    let _ = writer.flush();
+                }
+            }
+            reader_host.dead.store(true, Ordering::Release);
+            reader_host.broadcast(MessageKind::Exit, Vec::new());
+        })?;
+        thread::Builder::new().name("terminal-host-child".into()).spawn(move || {
+            let _ = child.wait();
+        })?;
+        Ok(shared)
+    }
+
+    fn serve_client(host: Arc<HostShared>, mut stream: UnixStream) -> anyhow::Result<()> {
+        let hello_frame = read_required_frame(&mut stream, "client hello")?;
+        if hello_frame.kind != MessageKind::ClientHello {
+            anyhow::bail!("terminal-host client did not send ClientHello");
+        }
+        let hello = ClientHello::decode(&hello_frame.payload)?;
+        let response = authenticate_client(&host, &hello)?;
+        if hello_frame.version != response.selected_version
+            || !response.granted_rights.contains(CapabilityRights::READ)
+        {
+            anyhow::bail!("terminal-host capability denied");
+        }
+        let granted_rights = response.granted_rights;
+        let mut hello_response = Frame::new(MessageKind::HostHello, response.encode());
+        hello_response.request_id = hello_frame.request_id;
+        write_frame(&mut stream, &hello_response)?;
+
+        let client = host.next_client.fetch_add(1, Ordering::Relaxed);
+        let (sender, receiver) = sync_channel(256);
+        let tap = HostTap {
+            sender,
+            queued_bytes: Arc::new(AtomicUsize::new(0)),
+            shutdown: Arc::new(stream.try_clone()?),
+            max_queued_bytes: MAX_HOST_CLIENT_QUEUED_BYTES,
+        };
+        let command_sender = tap.clone();
+        let (snapshot, colors, snapshot_sequence) = {
+            let mut term = host.term.lock().unwrap();
+            let replay =
+                term.vt_replay_bounded_theme_portable(crate::surface::VT_REPLAY_MAX_BYTES)?;
+            let colors = term.color_overrides();
+            let (cols, rows) = (term.cols(), term.rows());
+            let _broadcast = host.broadcast_lock.lock().unwrap();
+            if host.dead.load(Ordering::Acquire) {
+                anyhow::bail!("terminal host exited before snapshot");
+            }
+            host.viewer_sizes.lock().unwrap().insert(client, (cols, rows));
+            host.taps.lock().unwrap().insert(client, tap.clone());
+            (
+                HostSnapshot {
+                    cols,
+                    rows,
+                    replay,
+                    sequence_boundary: 0,
+                    colors: colors.clone(),
+                    pid: host.pid,
+                    command: host.command.clone(),
+                    cwd: host.cwd.clone(),
+                },
+                colors,
+                host.sequence.load(Ordering::Acquire),
+            )
+        };
+        let mut snapshot_frame = Frame::new(MessageKind::Snapshot, encode_snapshot(&snapshot)?);
+        snapshot_frame.sequence = snapshot_sequence;
+        if let Err(error) = write_frame(&mut stream, &snapshot_frame) {
+            host.remove_client(client);
+            return Err(error.into());
+        }
+        let mut colors_frame =
+            Frame::new(MessageKind::Colors, encode_terminal_color_overrides(&colors));
+        colors_frame.sequence = snapshot_sequence;
+        if let Err(error) = write_frame(&mut stream, &colors_frame) {
+            host.remove_client(client);
+            return Err(error.into());
+        }
+
+        let mut command_stream = stream.try_clone()?;
+        let command_host = host.clone();
+        thread::Builder::new().name("terminal-host-client-input".into()).spawn(move || {
+            while let Ok(Some(frame)) = read_frame(&mut command_stream, MAX_FRAME_PAYLOAD) {
+                // Client-to-host messages currently define no flags and never
+                // participate in the host live-stream sequence.
+                if frame.flags != 0 || frame.sequence != 0 {
+                    break;
+                }
+                match frame.kind {
+                    MessageKind::Input => {
+                        if !granted_rights.contains(CapabilityRights::INPUT) {
+                            break;
+                        }
+                        let mut writer = command_host.writer.lock().unwrap();
+                        let _ = writer.write_all(&frame.payload);
+                        let _ = writer.flush();
+                    }
+                    MessageKind::Paste => {
+                        if !granted_rights.contains(CapabilityRights::INPUT) {
+                            break;
+                        }
+                        let bracketed = command_host.term.lock().unwrap().mode(2004, false);
+                        let mut writer = command_host.writer.lock().unwrap();
+                        if bracketed {
+                            let _ = writer.write_all(b"\x1b[200~");
+                        }
+                        let _ = writer.write_all(&frame.payload);
+                        if bracketed {
+                            let _ = writer.write_all(b"\x1b[201~");
+                        }
+                        let _ = writer.flush();
+                    }
+                    MessageKind::ViewerSize if frame.payload.len() == 4 => {
+                        if !granted_rights.contains(CapabilityRights::RESIZE) {
+                            break;
+                        }
+                        let cols = u16::from_le_bytes([frame.payload[0], frame.payload[1]]);
+                        let rows = u16::from_le_bytes([frame.payload[2], frame.payload[3]]);
+                        command_host.set_viewer_size(client, cols, rows);
+                    }
+                    MessageKind::ReleaseViewer => {
+                        if !granted_rights.contains(CapabilityRights::RESIZE) {
+                            break;
+                        }
+                        command_host.viewer_sizes.lock().unwrap().remove(&client);
+                        command_host.apply_viewer_minimum();
+                    }
+                    MessageKind::Terminate => {
+                        if !granted_rights.contains(CapabilityRights::TERMINATE) {
+                            break;
+                        }
+                        let _ = command_host.killer.lock().unwrap().kill();
+                    }
+                    MessageKind::MintCapability => {
+                        if !granted_rights.contains(CapabilityRights::MINT_CAPABILITY) {
+                            break;
+                        }
+                        let Ok(token) = mint_renderer_capability(&command_host, &frame.payload)
+                        else {
+                            break;
+                        };
+                        let mut response =
+                            Frame::new(MessageKind::Capability, token.as_bytes().to_vec());
+                        response.request_id = frame.request_id;
+                        // Targeted control responses share the socket writer
+                        // with live frames. Serialize enqueueing with coupled
+                        // Output/Resized + Colors publication so even an admin
+                        // response cannot physically split an atomic pair.
+                        let _broadcast = command_host.broadcast_lock.lock().unwrap();
+                        if !command_sender.try_send(response) {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            command_host.remove_client(client);
+        })?;
+
+        while let Ok(frame) = receiver.recv() {
+            let write_result = write_frame(&mut stream, &frame);
+            tap.release(&frame);
+            if write_result.is_err() {
+                break;
+            }
+            if frame.kind == MessageKind::Exit {
+                break;
+            }
+        }
+        host.remove_client(client);
+        Ok(())
+    }
+
+    fn authenticate_client(host: &HostShared, hello: &ClientHello) -> anyhow::Result<HostHello> {
+        if hello.terminal_id != host.terminal_id {
+            anyhow::bail!("terminal-host capability denied");
+        }
+        if constant_time_equal(hello.token.as_bytes(), host.owner_token.as_bytes()) {
+            if hello.role != ClientRole::Admin
+                || hello.requested_rights.is_empty()
+                || !CapabilityRights::ADMIN.contains(hello.requested_rights)
+                || hello.min_version > PROTOCOL_VERSION
+                || hello.max_version < PROTOCOL_VERSION
+            {
+                anyhow::bail!("terminal-host owner capability denied");
+            }
+            return Ok(HostHello {
+                selected_version: PROTOCOL_VERSION,
+                granted_rights: hello.requested_rights,
+                terminal_id: host.terminal_id,
+                incarnation: host.incarnation,
+            });
+        }
+        Ok(host.capabilities.accept(
+            hello,
+            PROTOCOL_VERSION..=PROTOCOL_VERSION,
+            host.incarnation,
+        )?)
+    }
+
+    fn mint_renderer_capability(
+        host: &HostShared,
+        payload: &[u8],
+    ) -> anyhow::Result<CapabilityToken> {
+        if payload.len() != 8 {
+            anyhow::bail!("bad renderer capability request");
+        }
+        let rights = CapabilityRights::from_bits(u32::from_le_bytes(
+            payload[0..4].try_into().expect("fixed rights slice"),
+        ))
+        .ok_or_else(|| anyhow::anyhow!("unknown renderer capability rights"))?;
+        if !rights.contains(CapabilityRights::READ) || !CapabilityRights::RENDERER.contains(rights)
+        {
+            anyhow::bail!("renderer capability rights are out of range");
+        }
+        let ttl_ms = u32::from_le_bytes(payload[4..8].try_into().expect("fixed TTL slice"));
+        let ttl = Duration::from_millis(u64::from(ttl_ms));
+        if ttl.is_zero() || ttl > MAX_RENDERER_CAPABILITY_TTL {
+            anyhow::bail!("renderer capability TTL is out of range");
+        }
+        Ok(host.capabilities.mint(host.terminal_id, rights, ttl)?)
+    }
+
+    fn encode_snapshot(snapshot: &HostSnapshot) -> anyhow::Result<Vec<u8>> {
+        let mut output = Vec::new();
+        output.extend_from_slice(&snapshot.cols.to_le_bytes());
+        output.extend_from_slice(&snapshot.rows.to_le_bytes());
+        output.extend_from_slice(&snapshot.pid.unwrap_or(0).to_le_bytes());
+        put_blob(&mut output, &snapshot.replay)?;
+        put_optional_string(&mut output, snapshot.cwd.as_deref())?;
+        if snapshot.command.len() > MAX_ARGV {
+            anyhow::bail!("terminal-host snapshot command count is too large");
+        }
+        output.extend_from_slice(&(snapshot.command.len() as u16).to_le_bytes());
+        for argument in &snapshot.command {
+            put_string(&mut output, argument)?;
+        }
+        Ok(output)
+    }
+
+    fn decode_snapshot(payload: &[u8]) -> anyhow::Result<HostSnapshot> {
+        let mut decoder = PayloadDecoder::new(payload);
+        let cols = decoder.u16()?.max(1);
+        let rows = decoder.u16()?.max(1);
+        let pid = match decoder.u32()? {
+            0 => None,
+            pid => Some(pid),
+        };
+        let replay = decoder.blob()?.to_vec();
+        let cwd = decoder.optional_string()?;
+        let argc = decoder.u16()? as usize;
+        if argc > MAX_ARGV {
+            anyhow::bail!("terminal-host snapshot command count is too large");
+        }
+        let mut command = Vec::with_capacity(argc);
+        for _ in 0..argc {
+            command.push(decoder.string()?);
+        }
+        decoder.finish()?;
+        Ok(HostSnapshot {
+            cols,
+            rows,
+            replay,
+            sequence_boundary: 0,
+            colors: TerminalColorOverrides::default(),
+            pid,
+            command,
+            cwd,
+        })
+    }
+
+    fn encode_resize(cols: u16, rows: u16, replay: &[u8]) -> Vec<u8> {
+        let mut output = Vec::with_capacity(8 + replay.len());
+        output.extend_from_slice(&cols.to_le_bytes());
+        output.extend_from_slice(&rows.to_le_bytes());
+        output.extend_from_slice(&(replay.len() as u32).to_le_bytes());
+        output.extend_from_slice(replay);
+        output
+    }
+
+    fn protocol_io_error(error: crate::terminal_host_protocol::ProtocolError) -> std::io::Error {
+        match error {
+            crate::terminal_host_protocol::ProtocolError::Io(error) => error,
+            other => std::io::Error::new(std::io::ErrorKind::InvalidData, other),
+        }
+    }
+
+    fn stable_token(value: &str) -> String {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for byte in value.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100_0000_01b3);
+        }
+        format!("{hash:016x}")
+    }
+
+    fn constant_time_equal(left: &[u8], right: &[u8]) -> bool {
+        if left.len() != right.len() {
+            return false;
+        }
+        let mut difference = 0u8;
+        for (left, right) in left.iter().zip(right) {
+            difference |= left ^ right;
+        }
+        difference == 0
+    }
+
+    fn encode_hex(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut output = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            output.push(HEX[(byte >> 4) as usize] as char);
+            output.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        output
+    }
+
+    fn decode_hex_array<const N: usize>(text: &str) -> anyhow::Result<[u8; N]> {
+        if text.len() != N * 2 {
+            anyhow::bail!("terminal-host identity has the wrong length");
+        }
+        let mut bytes = [0u8; N];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            let start = index * 2;
+            *byte = u8::from_str_radix(&text[start..start + 2], 16)
+                .map_err(|_| anyhow::anyhow!("terminal-host identity is not hexadecimal"))?;
+        }
+        Ok(bytes)
+    }
+
+    struct PayloadDecoder<'a> {
+        payload: &'a [u8],
+        offset: usize,
+    }
+
+    impl<'a> PayloadDecoder<'a> {
+        fn new(payload: &'a [u8]) -> Self {
+            Self { payload, offset: 0 }
+        }
+
+        fn take(&mut self, length: usize) -> anyhow::Result<&'a [u8]> {
+            let end = self
+                .offset
+                .checked_add(length)
+                .filter(|end| *end <= self.payload.len())
+                .ok_or_else(|| anyhow::anyhow!("truncated terminal-host payload"))?;
+            let bytes = &self.payload[self.offset..end];
+            self.offset = end;
+            Ok(bytes)
+        }
+
+        fn u16(&mut self) -> anyhow::Result<u16> {
+            Ok(u16::from_le_bytes(self.take(2)?.try_into().unwrap()))
+        }
+
+        fn u8(&mut self) -> anyhow::Result<u8> {
+            Ok(self.take(1)?[0])
+        }
+
+        fn rgb(&mut self) -> anyhow::Result<Rgb> {
+            let bytes = self.take(3)?;
+            Ok(Rgb { r: bytes[0], g: bytes[1], b: bytes[2] })
+        }
+
+        fn u32(&mut self) -> anyhow::Result<u32> {
+            Ok(u32::from_le_bytes(self.take(4)?.try_into().unwrap()))
+        }
+
+        fn bytes_with_limit(&mut self, limit: usize) -> anyhow::Result<&'a [u8]> {
+            let length = self.u32()? as usize;
+            if length > limit {
+                anyhow::bail!("terminal-host payload field is too large");
+            }
+            self.take(length)
+        }
+
+        fn blob(&mut self) -> anyhow::Result<&'a [u8]> {
+            self.bytes_with_limit(MAX_BLOB)
+        }
+
+        fn string(&mut self) -> anyhow::Result<String> {
+            Ok(std::str::from_utf8(self.bytes_with_limit(MAX_STRING)?)?.to_string())
+        }
+
+        fn optional_string(&mut self) -> anyhow::Result<Option<String>> {
+            match self.take(1)?[0] {
+                0 => Ok(None),
+                1 => Ok(Some(self.string()?)),
+                _ => anyhow::bail!("bad terminal-host optional string tag"),
+            }
+        }
+
+        fn finish(&self) -> anyhow::Result<()> {
+            if self.offset != self.payload.len() {
+                anyhow::bail!("trailing terminal-host payload bytes");
+            }
+            Ok(())
+        }
+    }
+
+    fn put_bytes(output: &mut Vec<u8>, bytes: &[u8]) -> anyhow::Result<()> {
+        if bytes.len() > MAX_STRING {
+            anyhow::bail!("terminal-host payload field is too large");
+        }
+        output.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+        output.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    fn put_string(output: &mut Vec<u8>, value: &str) -> anyhow::Result<()> {
+        put_bytes(output, value.as_bytes())
+    }
+
+    fn put_blob(output: &mut Vec<u8>, value: &[u8]) -> anyhow::Result<()> {
+        if value.len() > MAX_BLOB {
+            anyhow::bail!("terminal-host payload blob is too large");
+        }
+        output.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        output.extend_from_slice(value);
+        Ok(())
+    }
+
+    fn put_optional_string(output: &mut Vec<u8>, value: Option<&str>) -> anyhow::Result<()> {
+        match value {
+            Some(value) => {
+                output.push(1);
+                put_string(output, value)
+            }
+            None => {
+                output.push(0);
+                Ok(())
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn launch_round_trip_preserves_ghostty_defaults() {
+            let mut default_colors = DefaultColors {
+                fg: Some(Rgb { r: 1, g: 2, b: 3 }),
+                bg: Some(Rgb { r: 4, g: 5, b: 6 }),
+                cursor: Some(Rgb { r: 7, g: 8, b: 9 }),
+                cursor_style: Some(CursorShape::Bar),
+                cursor_blink: Some(false),
+                ..Default::default()
+            };
+            default_colors.palette[0] = Some(Rgb { r: 10, g: 11, b: 12 });
+            default_colors.palette[255] = Some(Rgb { r: 13, g: 14, b: 15 });
+            let launch = HostLaunch {
+                endpoint: "/tmp/terminal.sock".into(),
+                record_path: "/tmp/terminal.json".into(),
+                term: "xterm-256color".into(),
+                cols: 80,
+                rows: 24,
+                scrollback: 10_000,
+                cwd: Some("/tmp".into()),
+                command: vec!["/bin/cat".into()],
+                extra_env: vec![("KEY".into(), "value".into())],
+                default_colors,
+            };
+
+            let decoded = HostLaunch::decode(&launch.encode().unwrap()).unwrap();
+            assert_eq!(decoded.default_colors, default_colors);
+            assert_eq!(decoded.command, launch.command);
+            assert_eq!(decoded.extra_env, launch.extra_env);
+        }
+
+        #[test]
+        fn host_tap_byte_overflow_closes_the_client_socket() {
+            let (host_socket, mut client_socket) = UnixStream::pair().unwrap();
+            client_socket.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+            let (sender, _receiver) = sync_channel(8);
+            let one_frame = crate::terminal_host_protocol::HEADER_LEN + 4;
+            let tap = HostTap {
+                sender,
+                queued_bytes: Arc::new(AtomicUsize::new(0)),
+                shutdown: Arc::new(host_socket),
+                max_queued_bytes: one_frame,
+            };
+
+            assert!(tap.try_send(Frame::new(MessageKind::Output, vec![1; 4])));
+            assert!(!tap.try_send(Frame::new(MessageKind::Output, vec![2])));
+            let mut byte = [0u8; 1];
+            assert_eq!(client_socket.read(&mut byte).unwrap(), 0);
+        }
+
+        #[test]
+        fn host_tap_channel_overflow_closes_the_client_socket() {
+            let (host_socket, mut client_socket) = UnixStream::pair().unwrap();
+            client_socket.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+            let (sender, _receiver) = sync_channel(1);
+            let tap = HostTap {
+                sender,
+                queued_bytes: Arc::new(AtomicUsize::new(0)),
+                shutdown: Arc::new(host_socket),
+                max_queued_bytes: usize::MAX,
+            };
+
+            assert!(tap.try_send(Frame::new(MessageKind::Output, vec![1])));
+            assert!(!tap.try_send(Frame::new(MessageKind::Output, vec![2])));
+            let mut byte = [0u8; 1];
+            assert_eq!(client_socket.read(&mut byte).unwrap(), 0);
+        }
+
+        #[test]
+        fn coupled_color_frames_stay_adjacent_under_concurrent_exit_and_resize() {
+            let (host_socket, _client_socket) = UnixStream::pair().unwrap();
+            let (sender, receiver) = sync_channel(8);
+            let tap = HostTap {
+                sender,
+                queued_bytes: Arc::new(AtomicUsize::new(0)),
+                shutdown: Arc::new(host_socket),
+                max_queued_bytes: usize::MAX,
+            };
+            let broadcast_lock = Mutex::new(());
+            let sequence = AtomicU64::new(0);
+            let taps = Mutex::new(HashMap::from([(1, tap)]));
+            let barrier = Arc::new(std::sync::Barrier::new(4));
+
+            thread::scope(|scope| {
+                let spawn = |frames| {
+                    let barrier = barrier.clone();
+                    let broadcast_lock = &broadcast_lock;
+                    let sequence = &sequence;
+                    let taps = &taps;
+                    scope.spawn(move || {
+                        barrier.wait();
+                        publish_host_frames(broadcast_lock, sequence, taps, frames);
+                    });
+                };
+                let paired = |kind, payload| {
+                    let mut first = Frame::new(kind, Vec::new());
+                    first.flags = FLAG_COLORS_FOLLOW;
+                    vec![first, Frame::new(MessageKind::Colors, payload)]
+                };
+                spawn(paired(MessageKind::Output, vec![1]));
+                spawn(paired(MessageKind::Resized, vec![2]));
+                spawn(vec![Frame::new(MessageKind::Exit, vec![])]);
+                barrier.wait();
+            });
+
+            let frames = receiver.try_iter().collect::<Vec<_>>();
+            assert_eq!(frames.len(), 5);
+            assert_eq!(
+                frames.iter().map(|frame| frame.sequence).collect::<Vec<_>>(),
+                vec![1, 2, 3, 4, 5]
+            );
+            let output = frames.iter().position(|frame| frame.kind == MessageKind::Output).unwrap();
+            assert_eq!(frames[output].flags, FLAG_COLORS_FOLLOW);
+            assert_eq!(frames[output + 1].kind, MessageKind::Colors);
+            assert_eq!(frames[output + 1].flags, 0);
+            assert_eq!(frames[output + 1].payload, vec![1]);
+            let resized =
+                frames.iter().position(|frame| frame.kind == MessageKind::Resized).unwrap();
+            assert_eq!(frames[resized].flags, FLAG_COLORS_FOLLOW);
+            assert_eq!(frames[resized + 1].kind, MessageKind::Colors);
+            assert_eq!(frames[resized + 1].flags, 0);
+            assert_eq!(frames[resized + 1].payload, vec![2]);
+        }
+    }
+}
+
+#[cfg(unix)]
+pub use unix::{
+    HostAttachment, adopt_terminal_host, launch_terminal_host, launch_terminal_host_with_identity,
+    load_terminal_host_records, remove_terminal_host_record, serve_terminal_host_stdio,
+    terminal_host_root,
+};
+
+#[cfg(not(unix))]
+pub fn terminal_host_root(state_root: &Path, session: &str) -> PathBuf {
+    state_root.join(format!("{session}.terminal-hosts"))
+}
+
+#[cfg(not(unix))]
+pub fn serve_terminal_host_stdio(
+    _args: &[String],
+    _reader: &mut impl std::io::Read,
+    _writer: &mut impl std::io::Write,
+) -> anyhow::Result<()> {
+    anyhow::bail!("per-terminal hosts are not implemented on this platform")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colors_payload_is_versioned_bounded_full_sparse_state() {
+        let mut colors = TerminalColorOverrides {
+            foreground: Some(Rgb { r: 1, g: 2, b: 3 }),
+            background: Some(Rgb { r: 4, g: 5, b: 6 }),
+            cursor: Some(Rgb { r: 7, g: 8, b: 9 }),
+            ..Default::default()
+        };
+        colors.palette[0] = Some(Rgb { r: 10, g: 11, b: 12 });
+        colors.palette[255] = Some(Rgb { r: 13, g: 14, b: 15 });
+        let payload = encode_terminal_color_overrides(&colors);
+        assert!(payload.len() <= MAX_TERMINAL_COLORS_PAYLOAD);
+        assert_eq!(decode_terminal_color_overrides(&payload).unwrap(), colors);
+
+        // An empty full-state frame explicitly clears every prior override.
+        let reset = encode_terminal_color_overrides(&Default::default());
+        assert_eq!(reset.len(), 8);
+        assert_eq!(decode_terminal_color_overrides(&reset).unwrap(), Default::default());
+    }
+
+    #[test]
+    fn colors_payload_rejects_unknown_versions_duplicates_and_trailing_bytes() {
+        let mut colors = TerminalColorOverrides::default();
+        colors.palette[1] = Some(Rgb { r: 1, g: 2, b: 3 });
+        colors.palette[2] = Some(Rgb { r: 4, g: 5, b: 6 });
+        let payload = encode_terminal_color_overrides(&colors);
+
+        let mut bad_version = payload.clone();
+        bad_version[0..2].copy_from_slice(&2u16.to_le_bytes());
+        assert!(decode_terminal_color_overrides(&bad_version).is_err());
+
+        let mut duplicate = payload.clone();
+        duplicate[12] = duplicate[8];
+        assert!(decode_terminal_color_overrides(&duplicate).is_err());
+
+        let mut trailing = payload;
+        trailing.push(0);
+        assert!(decode_terminal_color_overrides(&trailing).is_err());
+    }
+}

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -860,23 +860,36 @@ mod unix {
 
         fn remove_client(&self, client: u64) {
             self.taps.lock().unwrap().remove(&client);
-            self.viewer_sizes.lock().unwrap().remove(&client);
-            self.apply_viewer_minimum();
+            mutate_viewer_sizes(
+                &self.viewer_sizes,
+                |viewer_sizes| {
+                    viewer_sizes.remove(&client);
+                },
+                |desired| self.apply_viewer_minimum(desired),
+            );
         }
 
         fn set_viewer_size(&self, client: u64, cols: u16, rows: u16) {
-            self.viewer_sizes.lock().unwrap().insert(client, (cols.max(1), rows.max(1)));
-            self.apply_viewer_minimum();
+            mutate_viewer_sizes(
+                &self.viewer_sizes,
+                |viewer_sizes| {
+                    viewer_sizes.insert(client, (cols.max(1), rows.max(1)));
+                },
+                |desired| self.apply_viewer_minimum(desired),
+            );
         }
 
-        fn apply_viewer_minimum(&self) {
-            let desired = self
-                .viewer_sizes
-                .lock()
-                .unwrap()
-                .values()
-                .copied()
-                .reduce(|left, right| (left.0.min(right.0), left.1.min(right.1)));
+        fn remove_viewer_size(&self, client: u64) {
+            mutate_viewer_sizes(
+                &self.viewer_sizes,
+                |viewer_sizes| {
+                    viewer_sizes.remove(&client);
+                },
+                |desired| self.apply_viewer_minimum(desired),
+            );
+        }
+
+        fn apply_viewer_minimum(&self, desired: Option<(u16, u16)>) {
             let Some((cols, rows)) = desired else { return };
             {
                 let mut size = self.size.lock().unwrap();
@@ -905,6 +918,24 @@ mod unix {
                 encode_terminal_color_overrides(&colors),
             );
         }
+    }
+
+    /// Keep viewer mutation, minimum reduction, and the resulting PTY resize
+    /// in one critical section. If the guard were released after reduction,
+    /// an older large resize could run after a newer small resize and leave
+    /// the host at a size that no longer matches its viewer set.
+    fn mutate_viewer_sizes(
+        viewer_sizes: &Mutex<HashMap<u64, (u16, u16)>>,
+        mutation: impl FnOnce(&mut HashMap<u64, (u16, u16)>),
+        apply: impl FnOnce(Option<(u16, u16)>),
+    ) {
+        let mut viewer_sizes = viewer_sizes.lock().unwrap();
+        mutation(&mut viewer_sizes);
+        let desired = viewer_sizes
+            .values()
+            .copied()
+            .reduce(|left, right| (left.0.min(right.0), left.1.min(right.1)));
+        apply(desired);
     }
 
     pub fn serve_terminal_host_stdio(
@@ -1148,6 +1179,10 @@ mod unix {
         };
         let command_sender = tap.clone();
         let (snapshot, colors, snapshot_sequence) = {
+            // Viewer registration follows the same viewer -> parser ->
+            // broadcast lock order as resize application. This makes the
+            // initial snapshot an atomic member of size arbitration too.
+            let mut viewer_sizes = host.viewer_sizes.lock().unwrap();
             let mut term = host.term.lock().unwrap();
             let replay =
                 term.vt_replay_bounded_theme_portable(crate::surface::VT_REPLAY_MAX_BYTES)?;
@@ -1157,7 +1192,7 @@ mod unix {
             if host.dead.load(Ordering::Acquire) {
                 anyhow::bail!("terminal host exited before snapshot");
             }
-            host.viewer_sizes.lock().unwrap().insert(client, (cols, rows));
+            viewer_sizes.insert(client, (cols, rows));
             host.taps.lock().unwrap().insert(client, tap.clone());
             (
                 HostSnapshot {
@@ -1233,8 +1268,7 @@ mod unix {
                         if !granted_rights.contains(CapabilityRights::RESIZE) {
                             break;
                         }
-                        command_host.viewer_sizes.lock().unwrap().remove(&client);
-                        command_host.apply_viewer_minimum();
+                        command_host.remove_viewer_size(client);
                     }
                     MessageKind::Terminate => {
                         if !granted_rights.contains(CapabilityRights::TERMINATE) {
@@ -1614,6 +1648,67 @@ mod unix {
             assert!(!tap.try_send(Frame::new(MessageKind::Output, vec![2])));
             let mut byte = [0u8; 1];
             assert_eq!(client_socket.read(&mut byte).unwrap(), 0);
+        }
+
+        #[test]
+        fn viewer_resize_apply_order_cannot_invert_reduced_sizes() {
+            let viewer_sizes = Arc::new(Mutex::new(HashMap::new()));
+            let applied = Arc::new(Mutex::new(Vec::new()));
+            let (first_applying_tx, first_applying_rx) = std::sync::mpsc::channel();
+            let (release_first_tx, release_first_rx) = std::sync::mpsc::channel();
+
+            let first = {
+                let viewer_sizes = viewer_sizes.clone();
+                let applied = applied.clone();
+                thread::spawn(move || {
+                    mutate_viewer_sizes(
+                        &viewer_sizes,
+                        |sizes| {
+                            sizes.insert(1, (120, 40));
+                        },
+                        |desired| {
+                            first_applying_tx.send(()).unwrap();
+                            release_first_rx.recv().unwrap();
+                            applied.lock().unwrap().push(desired.unwrap());
+                        },
+                    );
+                })
+            };
+            first_applying_rx.recv().unwrap();
+
+            let (second_attempting_tx, second_attempting_rx) = std::sync::mpsc::channel();
+            let (second_mutating_tx, second_mutating_rx) = std::sync::mpsc::channel();
+            let second = {
+                let viewer_sizes = viewer_sizes.clone();
+                let applied = applied.clone();
+                thread::spawn(move || {
+                    second_attempting_tx.send(()).unwrap();
+                    mutate_viewer_sizes(
+                        &viewer_sizes,
+                        |sizes| {
+                            second_mutating_tx.send(()).unwrap();
+                            sizes.insert(2, (80, 24));
+                        },
+                        |desired| applied.lock().unwrap().push(desired.unwrap()),
+                    );
+                })
+            };
+            second_attempting_rx.recv().unwrap();
+            assert!(second_mutating_rx.try_recv().is_err());
+            release_first_tx.send(()).unwrap();
+            first.join().unwrap();
+            second.join().unwrap();
+
+            assert_eq!(*applied.lock().unwrap(), vec![(120, 40), (80, 24)]);
+            assert_eq!(
+                viewer_sizes
+                    .lock()
+                    .unwrap()
+                    .values()
+                    .copied()
+                    .reduce(|left, right| (left.0.min(right.0), left.1.min(right.1))),
+                Some((80, 24))
+            );
         }
 
         #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -223,15 +223,16 @@ mod unix {
     use std::collections::{HashMap, HashSet};
     use std::fs::{self, File, OpenOptions};
     use std::io::{Read, Write};
-    use std::os::fd::AsRawFd;
+    use std::os::fd::{AsRawFd, RawFd};
     use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
     use std::os::unix::net::{UnixListener, UnixStream};
+    use std::os::unix::process::CommandExt;
     use std::process::{Command, Stdio};
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
     use std::sync::{Arc, Condvar, Mutex};
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use anyhow::Context;
     use ghostty_vt::{Callbacks, CursorShape, Terminal};
@@ -240,6 +241,11 @@ mod unix {
     use super::*;
 
     static RECORD_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+    const HOST_TERMINATE_GRACE: Duration = Duration::from_millis(250);
+    const HOST_KILL_WAIT: Duration = Duration::from_secs(2);
+    const HOST_PTY_DRAIN_GRACE: Duration = Duration::from_millis(250);
+    const HOST_FORCED_DRAIN_WINDOW: Duration = Duration::from_millis(100);
+    const HOST_LAUNCH_ROLLBACK_WAIT: Duration = Duration::from_secs(4);
 
     struct SpawnedHostProcess {
         child: Option<std::process::Child>,
@@ -252,6 +258,23 @@ mod unix {
 
         fn into_child(mut self) -> std::process::Child {
             self.child.take().expect("terminal-host child is present")
+        }
+
+        fn wait_timeout(&mut self, timeout: Duration) -> bool {
+            let deadline = Instant::now() + timeout;
+            loop {
+                let Some(child) = self.child.as_mut() else { return true };
+                match child.try_wait() {
+                    Ok(Some(_)) => {
+                        self.child.take();
+                        return true;
+                    }
+                    Ok(None) if Instant::now() < deadline => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Ok(None) | Err(_) => return false,
+                }
+            }
         }
     }
 
@@ -459,6 +482,10 @@ mod unix {
         writer: Arc<Mutex<UnixStream>>,
         capability_responses: Arc<CapabilityResponses>,
         next_request: AtomicU64,
+        /// Exact process ownership retained only between a successful launch
+        /// handshake and complete Surface materialization. Adoption never
+        /// carries this guard.
+        launch_process: Option<SpawnedHostProcess>,
     }
 
     impl std::fmt::Debug for HostAttachment {
@@ -505,6 +532,20 @@ mod unix {
 
         pub fn disconnect(&self) {
             let _ = self.writer.lock().unwrap().shutdown(std::net::Shutdown::Both);
+        }
+
+        /// Commit the launch ownership handoff after every fallible Surface
+        /// setup step succeeds. Until then, dropping this attachment exact-
+        /// kills and waits the child process through SpawnedHostProcess.
+        pub(crate) fn commit_launched_host(&mut self) {
+            let Some(process) = self.launch_process.take() else { return };
+            let mut child = process.into_child();
+            // Reaping is housekeeping after the ownership handoff. Failure to
+            // create this helper cannot turn a committed live Surface into an
+            // error; dropping Child leaves the independent host running.
+            let _ = thread::Builder::new().name("terminal-host-reaper".into()).spawn(move || {
+                let _ = child.wait();
+            });
         }
 
         pub fn identity(&self) -> TerminalHostIdentity {
@@ -578,8 +619,71 @@ mod unix {
         }
     }
 
+    impl Drop for HostAttachment {
+        fn drop(&mut self) {
+            let Some(mut process) = self.launch_process.take() else { return };
+            // Surface setup failed after an authenticated launch. Ask the
+            // still-live host to perform its bounded PTY group shutdown and
+            // record cleanup, then wait on the exact owned host process. Only
+            // a wedged host that exceeds that bound is SIGKILLed by the
+            // SpawnedHostProcess fallback below.
+            let _ = self.terminate();
+            if process.wait_timeout(HOST_LAUNCH_ROLLBACK_WAIT) {
+                return;
+            }
+            drop(process);
+        }
+    }
+
     pub fn terminal_host_root(state_root: &Path, session: &str) -> PathBuf {
         state_root.join(format!("terminal-hosts-{}", stable_token(session)))
+    }
+
+    /// Strip every descriptor except the private bootstrap stdio before the
+    /// hidden host starts any threads or opens its endpoint. This runs inside
+    /// the freshly exec'd `__terminal-host`, so descriptor enumeration is
+    /// race-free and cannot affect the daemon's own open files.
+    pub fn isolate_terminal_host_process_fds() -> anyhow::Result<()> {
+        let mut last_error = None;
+        let mut inherited = None;
+        for directory in ["/proc/self/fd", "/dev/fd"] {
+            match fs::read_dir(directory) {
+                Ok(entries) => {
+                    let mut descriptors = entries
+                        .filter_map(Result::ok)
+                        .filter_map(|entry| entry.file_name().to_str()?.parse::<libc::c_int>().ok())
+                        .filter(|descriptor| *descriptor > libc::STDERR_FILENO)
+                        .collect::<Vec<_>>();
+                    descriptors.sort_unstable();
+                    descriptors.dedup();
+                    inherited = Some(descriptors);
+                    break;
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+        let descriptors = inherited.ok_or_else(|| {
+            anyhow::anyhow!(
+                "enumerate inherited terminal-host descriptors: {}",
+                last_error.unwrap_or_else(|| std::io::Error::other("no descriptor filesystem"))
+            )
+        })?;
+        for descriptor in descriptors {
+            // SAFETY: descriptors came from this single-threaded process's
+            // descriptor filesystem snapshot. stdio 0/1/2 is excluded.
+            if unsafe { libc::close(descriptor) } != 0 {
+                let error = std::io::Error::last_os_error();
+                if !matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::Interrupted
+                ) && error.raw_os_error() != Some(libc::EBADF)
+                {
+                    return Err(error)
+                        .context(format!("close inherited terminal-host descriptor {descriptor}"));
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn launch_terminal_host(
@@ -636,15 +740,26 @@ mod unix {
         };
 
         let binary = std::env::current_exe().context("resolve cmux-tui terminal-host binary")?;
-        let child = Command::new(binary)
+        let mut command = Command::new(binary);
+        command
             .args(["__terminal-host", "--bootstrap-stdio"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             // A host outlives its daemon, so it must not retain a daemon log
             // pipe whose EOF is itself used as a lifecycle signal.
-            .stderr(Stdio::null())
-            .spawn()
-            .context("spawn terminal-host process")?;
+            .stderr(Stdio::null());
+        // A durable host must not share the daemon's controlling terminal,
+        // session, or process group. Otherwise a shell hangup or group
+        // interrupt intended for the daemon can also kill every hosted PTY.
+        // SAFETY: setsid(2) is async-signal-safe and touches no Rust state in
+        // the post-fork child. A freshly forked child is not a process-group
+        // leader, so failure is an actual launch error and must be surfaced.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 { Err(std::io::Error::last_os_error()) } else { Ok(()) }
+            });
+        }
+        let child = command.spawn().context("spawn terminal-host process")?;
         let mut process = SpawnedHostProcess { child: Some(child) };
         let host_pid = process.child_mut().id();
         let mut stdin =
@@ -681,10 +796,6 @@ mod unix {
         }
         drop(stdin);
         drop(stdout);
-        let mut child = process.into_child();
-        thread::Builder::new().name("terminal-host-reaper".into()).spawn(move || {
-            let _ = child.wait();
-        })?;
 
         let record: TerminalHostRecord = serde_json::from_slice(
             &fs::read(&record_path).context("read terminal-host discovery record")?,
@@ -697,7 +808,13 @@ mod unix {
         {
             anyhow::bail!("terminal-host discovery record changed during launch");
         }
-        connect_record(record, record_path)
+        // Keep the exact-kill guard armed through record validation and a
+        // successful authenticated Snapshot. Returning Err after disarming it
+        // would leave a live published host while the mux marks its registry
+        // row Exited.
+        let mut attachment = connect_record(record, record_path)?;
+        attachment.launch_process = Some(process);
+        Ok(attachment)
     }
 
     pub fn adopt_terminal_host(
@@ -993,6 +1110,7 @@ mod unix {
                 waiters: Mutex::new(HashMap::new()),
             }),
             next_request: AtomicU64::new(2),
+            launch_process: None,
         };
         attachment.send_viewer_size(attachment.snapshot.cols, attachment.snapshot.rows)?;
         Ok(attachment)
@@ -1105,6 +1223,70 @@ mod unix {
         }
     }
 
+    fn wait_for_pty_readable_or_forced_drain(
+        pty_fd: RawFd,
+        drain_waiter: &mut UnixStream,
+        force_drain: &AtomicBool,
+        forced_at: &mut Option<Instant>,
+    ) -> std::io::Result<bool> {
+        loop {
+            if force_drain.load(Ordering::Acquire) {
+                let started = forced_at.get_or_insert_with(Instant::now);
+                if started.elapsed() >= HOST_FORCED_DRAIN_WINDOW {
+                    return Ok(false);
+                }
+            }
+            let mut poll_fds = [
+                libc::pollfd {
+                    fd: pty_fd,
+                    events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+                    revents: 0,
+                },
+                libc::pollfd {
+                    fd: drain_waiter.as_raw_fd(),
+                    events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+                    revents: 0,
+                },
+            ];
+            let timeout_ms = forced_at
+                .map(|started| {
+                    let remaining = HOST_FORCED_DRAIN_WINDOW.saturating_sub(started.elapsed());
+                    remaining.as_millis().clamp(1, i32::MAX as u128) as i32
+                })
+                .unwrap_or(-1);
+            // SAFETY: poll_fds points to two initialized values and both
+            // descriptors remain owned by the caller for this call.
+            let ready = unsafe {
+                libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as libc::nfds_t, timeout_ms)
+            };
+            if ready < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(error);
+            }
+            if poll_fds[0].revents & libc::POLLNVAL != 0 {
+                return Ok(false);
+            }
+            if poll_fds[1].revents & libc::POLLIN != 0 {
+                let mut wake = [0u8; 64];
+                let _ = drain_waiter.read(&mut wake);
+            }
+            if poll_fds[0].revents != 0 {
+                return Ok(true);
+            }
+            if poll_fds[1].revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL) != 0
+                && !force_drain.load(Ordering::Acquire)
+            {
+                return Ok(false);
+            }
+            // A wake transitions the next iteration into forced mode. While
+            // forced, an empty poll waits again until the remaining bounded
+            // window expires so late final bytes are still observed.
+        }
+    }
+
     struct HostShared {
         terminal_id: TerminalId,
         incarnation: HostIncarnation,
@@ -1125,6 +1307,15 @@ mod unix {
         next_client: AtomicU64,
         dead: AtomicBool,
         child_exit: (Mutex<bool>, Condvar),
+        child_waitable: AtomicBool,
+        pty_drained: AtomicBool,
+        exit_published: AtomicBool,
+        force_pty_drain: AtomicBool,
+        pty_drain_waker: Mutex<UnixStream>,
+        termination_started: AtomicBool,
+        child_signal_lock: Mutex<()>,
+        child_reaped: AtomicBool,
+        group_escalation_complete: AtomicBool,
     }
 
     fn publish_host_frames(
@@ -1168,7 +1359,7 @@ mod unix {
                 |viewer_sizes| {
                     viewer_sizes.remove(&client);
                 },
-                |desired| self.apply_viewer_minimum(desired),
+                |desired| self.apply_viewer_minimum(desired, false),
             );
         }
 
@@ -1179,7 +1370,11 @@ mod unix {
                 |viewer_sizes| {
                     viewer_sizes.insert(client, (cols, rows));
                 },
-                |desired| self.apply_viewer_minimum(desired),
+                // Every accepted ViewerSize is a request/ack round trip. Even
+                // when another smaller viewer keeps the canonical grid
+                // unchanged, renderers need a Resized+Colors replay to retire
+                // their in-flight physical resize without guessing.
+                |desired| self.apply_viewer_minimum(desired, true),
             )
         }
 
@@ -1189,46 +1384,57 @@ mod unix {
                 |viewer_sizes| {
                     viewer_sizes.remove(&client);
                 },
-                |desired| self.apply_viewer_minimum(desired),
+                |desired| self.apply_viewer_minimum(desired, false),
             );
         }
 
-        fn apply_viewer_minimum(&self, desired: Option<(u16, u16)>) -> anyhow::Result<()> {
+        fn apply_viewer_minimum(
+            &self,
+            desired: Option<(u16, u16)>,
+            acknowledge: bool,
+        ) -> anyhow::Result<()> {
             let Some((cols, rows)) = desired else { return Ok(()) };
             let (cols, rows) = normalize_terminal_geometry(cols, rows)?;
             let mut size = self.size.lock().unwrap();
-            if *size == (cols, rows) {
+            let changed = *size != (cols, rows);
+            if !changed && !acknowledge {
                 return Ok(());
             }
             let previous = *size;
             let mut term = self.term.lock().unwrap();
             let master = self.master.lock().unwrap();
-            master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })?;
-            if let Err(error) = term.resize(cols, rows, 8, 16) {
-                let _ = master.resize(PtySize {
-                    rows: previous.1,
-                    cols: previous.0,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                });
-                return Err(error.into());
+            if changed {
+                master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })?;
+                if let Err(error) = term.resize(cols, rows, 8, 16) {
+                    let _ = master.resize(PtySize {
+                        rows: previous.1,
+                        cols: previous.0,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    });
+                    return Err(error.into());
+                }
             }
             let replay =
                 match term.vt_replay_bounded_theme_portable(crate::surface::VT_REPLAY_MAX_BYTES) {
                     Ok(replay) => replay,
                     Err(error) => {
-                        let _ = term.resize(previous.0, previous.1, 8, 16);
-                        let _ = master.resize(PtySize {
-                            rows: previous.1,
-                            cols: previous.0,
-                            pixel_width: 0,
-                            pixel_height: 0,
-                        });
+                        if changed {
+                            let _ = term.resize(previous.0, previous.1, 8, 16);
+                            let _ = master.resize(PtySize {
+                                rows: previous.1,
+                                cols: previous.0,
+                                pixel_width: 0,
+                                pixel_height: 0,
+                            });
+                        }
                         return Err(error.into());
                     }
                 };
             let colors = term.color_overrides();
-            *size = (cols, rows);
+            if changed {
+                *size = (cols, rows);
+            }
             // Keep the parser lock through sequence publication so output
             // parsed at the new size cannot overtake the Resized marker.
             self.broadcast_with_colors(
@@ -1243,15 +1449,177 @@ mod unix {
             *self.child_exit.0.lock().unwrap()
         }
 
-        fn terminate_and_wait(&self) {
-            if !self.child_exited() {
-                let _ = self.killer.lock().unwrap().kill();
+        fn wait_for_child_exit(&self, timeout: Duration) -> bool {
+            let exited = self.child_exit.0.lock().unwrap();
+            if *exited {
+                return true;
             }
-            let mut exited = self.child_exit.0.lock().unwrap();
-            while !*exited {
-                exited = self.child_exit.1.wait(exited).unwrap();
+            let (exited, _) =
+                self.child_exit.1.wait_timeout_while(exited, timeout, |exited| !*exited).unwrap();
+            *exited
+        }
+
+        fn wait_for_child_waitable(&self, timeout: Duration) -> bool {
+            if self.child_waitable.load(Ordering::Acquire) {
+                return true;
+            }
+            let state = self.child_exit.0.lock().unwrap();
+            let (_state, _) = self
+                .child_exit
+                .1
+                .wait_timeout_while(state, timeout, |_| {
+                    !self.child_waitable.load(Ordering::Acquire)
+                })
+                .unwrap();
+            self.child_waitable.load(Ordering::Acquire)
+        }
+
+        fn wait_for_pty_drain(&self, timeout: Duration) -> bool {
+            if self.pty_drained.load(Ordering::Acquire) {
+                return true;
+            }
+            // The child-exit mutex is only a rendezvous guard here; the PTY
+            // reader notifies the same condition variable after publishing
+            // its final bytes and setting pty_drained.
+            let state = self.child_exit.0.lock().unwrap();
+            let (_state, _) = self
+                .child_exit
+                .1
+                .wait_timeout_while(state, timeout, |_| !self.pty_drained.load(Ordering::Acquire))
+                .unwrap();
+            self.pty_drained.load(Ordering::Acquire)
+        }
+
+        fn signal_terminal_process_groups(&self, signal: libc::c_int) {
+            let mut groups = Vec::with_capacity(2);
+            // The wait thread observes exit with WNOWAIT, then takes this lock
+            // before reaping. While we hold it, `!child_reaped` means the
+            // original PID/PGID is still kernel-reserved and cannot have been
+            // reused between validation and killpg.
+            let _signal = self.child_signal_lock.lock().unwrap();
+            let child_reserved = !self.child_reaped.load(Ordering::Acquire);
+            if child_reserved
+                && let Some(pid) = self.pid.and_then(|pid| libc::pid_t::try_from(pid).ok())
+            {
+                groups.push(pid);
+            }
+            // Query the PTY each time rather than trusting the original group:
+            // a foreground job or retained descendant may own a different
+            // group by the time explicit Terminate escalates.
+            if child_reserved
+                && let Some(foreground) = self.master.lock().unwrap().process_group_leader()
+            {
+                groups.push(foreground);
+            }
+            groups.sort_unstable();
+            groups.dedup();
+            // A portable-pty child starts as a new session/process-group
+            // leader. Signal both that durable group and any foreground job
+            // group, but never risk addressing the terminal-host's own group.
+            // SAFETY: getpgrp has no preconditions.
+            let host_group = unsafe { libc::getpgrp() };
+            for group in groups.into_iter().filter(|group| *group > 0 && *group != host_group) {
+                // SAFETY: validated positive process-group ids owned by this
+                // PTY session; signal is a platform constant from this module.
+                let _ = unsafe { libc::killpg(group, signal) };
             }
         }
+
+        fn request_forced_pty_drain(&self) {
+            self.force_pty_drain.store(true, Ordering::Release);
+            // Wake the otherwise blocking poll in the sole PTY reader. The
+            // byte has no protocol meaning; it only makes the wake fd ready.
+            let _ = self.pty_drain_waker.lock().unwrap().write_all(&[1]);
+        }
+
+        fn request_termination(self: &Arc<Self>) {
+            let already_started = {
+                // Serialize the ownership transition with WNOWAIT's final
+                // reap decision so an explicit Terminate cannot lose the
+                // original reserved PID/PGID in between.
+                let _signal = self.child_signal_lock.lock().unwrap();
+                self.termination_started.swap(true, Ordering::AcqRel)
+            };
+            if already_started {
+                return;
+            }
+            let worker = self.clone();
+            if thread::Builder::new()
+                .name("terminal-host-terminate".into())
+                .spawn(move || worker.terminate_and_wait())
+                .is_err()
+            {
+                // Bounded fallback: even thread exhaustion cannot turn an
+                // accepted Terminate into an unbounded or ignored request.
+                self.terminate_and_wait();
+            }
+        }
+
+        fn finish_group_escalation(&self) {
+            self.group_escalation_complete.store(true, Ordering::Release);
+            self.child_exit.1.notify_all();
+        }
+
+        fn publish_exit_if_drained(&self) {
+            if claim_host_exit_after_drain(
+                &self.child_exit.0,
+                &self.pty_drained,
+                &self.exit_published,
+            ) {
+                self.dead.store(true, Ordering::Release);
+                self.broadcast(MessageKind::Exit, Vec::new());
+            }
+        }
+
+        fn terminate_and_wait(&self) {
+            {
+                let _signal = self.child_signal_lock.lock().unwrap();
+                self.termination_started.store(true, Ordering::Release);
+            }
+            // ProcessSignaller only targets the direct child. Start with a
+            // graceful group hangup so foreground jobs and normal descendants
+            // can clean up too, then escalate after a strict bound.
+            self.signal_terminal_process_groups(libc::SIGHUP);
+            if !self.child_waitable.load(Ordering::Acquire) {
+                let _ = self.killer.lock().unwrap().kill();
+            }
+            let _ = self.wait_for_child_waitable(HOST_TERMINATE_GRACE);
+            let _ = self.wait_for_pty_drain(HOST_PTY_DRAIN_GRACE);
+
+            // The direct child may ignore SIGHUP, or it may already have
+            // exited while a descendant retains the PTY. Kill both the
+            // original session group and its current foreground job group.
+            // This escalation is mandatory even if Darwin reports PTY EOF as
+            // soon as the session leader exits: an HUP-ignoring descendant
+            // can still be alive in the now-invisible original group.
+            self.signal_terminal_process_groups(libc::SIGKILL);
+            self.finish_group_escalation();
+            let child_exited = self.wait_for_child_exit(HOST_KILL_WAIT);
+            if child_exited && self.wait_for_pty_drain(HOST_PTY_DRAIN_GRACE) {
+                return;
+            }
+
+            if child_exited {
+                // A process that escaped the PTY session can retain a slave
+                // descriptor forever. Do not let an explicit tombstone hang
+                // the durable host: wake the reader, drain bytes already
+                // readable for a short bounded window, then publish Exit.
+                self.request_forced_pty_drain();
+                let _ = self.wait_for_pty_drain(HOST_FORCED_DRAIN_WINDOW * 2);
+            }
+        }
+    }
+
+    fn claim_host_exit_after_drain(
+        child_exited: &Mutex<bool>,
+        pty_drained: &AtomicBool,
+        exit_published: &AtomicBool,
+    ) -> bool {
+        pty_drained.load(Ordering::Acquire)
+            && *child_exited.lock().unwrap()
+            && exit_published
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
     }
 
     /// Keep viewer mutation, minimum reduction, and the resulting PTY resize
@@ -1275,6 +1643,31 @@ mod unix {
             return Err(error);
         }
         Ok(())
+    }
+
+    fn wait_for_child_exit_without_reaping(pid: libc::pid_t) -> std::io::Result<()> {
+        loop {
+            let mut status = std::mem::MaybeUninit::<libc::siginfo_t>::uninit();
+            // SAFETY: status points to writable siginfo storage. WNOWAIT
+            // observes this owned child becoming waitable without releasing
+            // its PID/PGID for reuse; the portable Child handle reaps it after
+            // acquiring child_signal_lock.
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    pid as libc::id_t,
+                    status.as_mut_ptr(),
+                    libc::WEXITED | libc::WNOWAIT,
+                )
+            };
+            if result == 0 {
+                return Ok(());
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() != std::io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
     }
 
     struct HostLivenessLease {
@@ -1493,8 +1886,10 @@ mod unix {
         let pid = child.process_id();
         drop(pty.slave);
         let killer = child.clone_killer();
+        let pty_poll_fd = pty.master.as_raw_fd().context("open terminal-host PTY poll fd")?;
         let mut pty_reader = pty.master.try_clone_reader()?;
         let pty_writer = pty.master.take_writer()?;
+        let (pty_drain_waker, pty_drain_waiter) = UnixStream::pair()?;
 
         let pending_responses = Arc::new(Mutex::new(Vec::<u8>::new()));
         let title_changed = Arc::new(AtomicBool::new(false));
@@ -1544,13 +1939,29 @@ mod unix {
             next_client: AtomicU64::new(1),
             dead: AtomicBool::new(false),
             child_exit: (Mutex::new(false), Condvar::new()),
+            child_waitable: AtomicBool::new(false),
+            pty_drained: AtomicBool::new(false),
+            exit_published: AtomicBool::new(false),
+            force_pty_drain: AtomicBool::new(false),
+            pty_drain_waker: Mutex::new(pty_drain_waker),
+            termination_started: AtomicBool::new(false),
+            child_signal_lock: Mutex::new(()),
+            child_reaped: AtomicBool::new(false),
+            group_escalation_complete: AtomicBool::new(false),
         });
 
         let reader_host = shared.clone();
         thread::Builder::new().name("terminal-host-pty".into()).spawn(move || {
             let mut buffer = [0u8; 64 * 1024];
             let mut last_colors = TerminalColorOverrides::default();
-            loop {
+            let mut forced_at = None;
+            let mut pty_drain_waiter = pty_drain_waiter;
+            while let Ok(true) = wait_for_pty_readable_or_forced_drain(
+                pty_poll_fd,
+                &mut pty_drain_waiter,
+                &reader_host.force_pty_drain,
+                &mut forced_at,
+            ) {
                 let count = match pty_reader.read(&mut buffer) {
                     Ok(0) => break,
                     Ok(count) => count,
@@ -1596,17 +2007,63 @@ mod unix {
                     let _ = writer.flush();
                 }
             }
+            // The reader publishes every final PTY byte before declaring the
+            // stream drained. Exit is emitted only after this flag and the
+            // child wait rendezvous, so clients can safely stop at Exit.
+            reader_host.pty_drained.store(true, Ordering::Release);
+            reader_host.child_exit.1.notify_all();
+            reader_host.publish_exit_if_drained();
         })?;
         let child_host = shared.clone();
         thread::Builder::new().name("terminal-host-child".into()).spawn(move || {
-            let _ = child.wait();
-            {
+            let observed_without_reaping = child_host
+                .pid
+                .and_then(|pid| libc::pid_t::try_from(pid).ok())
+                .is_some_and(|pid| wait_for_child_exit_without_reaping(pid).is_ok());
+            if observed_without_reaping {
+                child_host.child_waitable.store(true, Ordering::Release);
+                child_host.child_exit.1.notify_all();
+                loop {
+                    let signal = child_host.child_signal_lock.lock().unwrap();
+                    let escalation_complete =
+                        child_host.group_escalation_complete.load(Ordering::Acquire);
+                    let termination_started =
+                        child_host.termination_started.load(Ordering::Acquire);
+                    let pty_drained = child_host.pty_drained.load(Ordering::Acquire);
+                    if escalation_complete || (!termination_started && pty_drained) {
+                        let _ = child.wait();
+                        child_host.child_reaped.store(true, Ordering::Release);
+                        drop(signal);
+                        break;
+                    }
+                    drop(signal);
+                    let state = child_host.child_exit.0.lock().unwrap();
+                    let _state = child_host
+                        .child_exit
+                        .1
+                        .wait_while(state, |_| {
+                            !child_host.group_escalation_complete.load(Ordering::Acquire)
+                                && (child_host.termination_started.load(Ordering::Acquire)
+                                    || !child_host.pty_drained.load(Ordering::Acquire))
+                        })
+                        .unwrap();
+                }
                 let mut exited = child_host.child_exit.0.lock().unwrap();
                 *exited = true;
+                drop(exited);
+                child_host.child_exit.1.notify_all();
+                child_host.publish_exit_if_drained();
+            } else {
+                // Native Unix PTYs always expose a PID and support waitid;
+                // retain a conservative fallback for alternate backends.
+                let _ = child.wait();
+                child_host.child_reaped.store(true, Ordering::Release);
+                child_host.child_waitable.store(true, Ordering::Release);
+                let mut exited = child_host.child_exit.0.lock().unwrap();
+                *exited = true;
+                child_host.child_exit.1.notify_all();
+                child_host.publish_exit_if_drained();
             }
-            child_host.dead.store(true, Ordering::Release);
-            child_host.broadcast(MessageKind::Exit, Vec::new());
-            child_host.child_exit.1.notify_all();
         })?;
         Ok(shared)
     }
@@ -1738,7 +2195,7 @@ mod unix {
                         if !granted_rights.contains(CapabilityRights::TERMINATE) {
                             break;
                         }
-                        let _ = command_host.killer.lock().unwrap().kill();
+                        command_host.request_termination();
                     }
                     MessageKind::MintCapability => {
                         if !granted_rights.contains(CapabilityRights::MINT_CAPABILITY) {
@@ -2234,7 +2691,7 @@ mod unix {
                 thread::sleep(Duration::from_millis(200));
             });
 
-            let started = std::time::Instant::now();
+            let started = Instant::now();
             assert!(
                 connect_record_with_timeout(
                     record.clone(),
@@ -2356,6 +2813,119 @@ mod unix {
         }
 
         #[test]
+        fn exit_waits_for_final_pty_output_in_either_completion_order() {
+            for child_first in [false, true] {
+                let (host_socket, _client_socket) = UnixStream::pair().unwrap();
+                let (sender, receiver) = sync_channel(8);
+                let tap = HostTap {
+                    sender,
+                    queued_bytes: Arc::new(AtomicUsize::new(0)),
+                    shutdown: Arc::new(host_socket),
+                    max_queued_bytes: usize::MAX,
+                };
+                let broadcast_lock = Mutex::new(());
+                let sequence = AtomicU64::new(0);
+                let taps = Mutex::new(HashMap::from([(1, tap)]));
+                let child_exited = Mutex::new(false);
+                let pty_drained = AtomicBool::new(false);
+                let exit_published = AtomicBool::new(false);
+
+                if child_first {
+                    *child_exited.lock().unwrap() = true;
+                    assert!(!claim_host_exit_after_drain(
+                        &child_exited,
+                        &pty_drained,
+                        &exit_published,
+                    ));
+                }
+
+                publish_host_frames(
+                    &broadcast_lock,
+                    &sequence,
+                    &taps,
+                    [Frame::new(MessageKind::Output, b"final-output".to_vec())],
+                );
+                pty_drained.store(true, Ordering::Release);
+
+                if !child_first {
+                    assert!(!claim_host_exit_after_drain(
+                        &child_exited,
+                        &pty_drained,
+                        &exit_published,
+                    ));
+                    *child_exited.lock().unwrap() = true;
+                }
+                assert!(claim_host_exit_after_drain(&child_exited, &pty_drained, &exit_published,));
+                publish_host_frames(
+                    &broadcast_lock,
+                    &sequence,
+                    &taps,
+                    [Frame::new(MessageKind::Exit, Vec::new())],
+                );
+                assert!(
+                    !claim_host_exit_after_drain(&child_exited, &pty_drained, &exit_published,)
+                );
+
+                let frames = receiver.try_iter().collect::<Vec<_>>();
+                assert_eq!(frames.len(), 2);
+                assert_eq!(frames[0].kind, MessageKind::Output);
+                assert_eq!(frames[0].payload, b"final-output");
+                assert_eq!(frames[0].sequence, 1);
+                assert_eq!(frames[1].kind, MessageKind::Exit);
+                assert_eq!(frames[1].sequence, 2);
+            }
+        }
+
+        #[test]
+        fn forced_drain_waits_for_late_bytes_then_exits_with_writer_still_open() {
+            let (mut pty_reader, mut retained_writer) = UnixStream::pair().unwrap();
+            let (mut drain_waiter, mut drain_waker) = UnixStream::pair().unwrap();
+            let force_drain = Arc::new(AtomicBool::new(false));
+            let worker_force = force_drain.clone();
+            let (written_tx, written_rx) = std::sync::mpsc::channel();
+            let (release_tx, release_rx) = std::sync::mpsc::channel();
+            let worker = thread::spawn(move || {
+                thread::sleep(Duration::from_millis(20));
+                worker_force.store(true, Ordering::Release);
+                drain_waker.write_all(&[1]).unwrap();
+                thread::sleep(Duration::from_millis(20));
+                retained_writer.write_all(b"late").unwrap();
+                written_tx.send(()).unwrap();
+                // Deliberately retain the write side beyond the forced drain
+                // bound. The helper must not confuse an open writer with more
+                // bytes becoming readable forever.
+                release_rx.recv().unwrap();
+            });
+
+            let mut forced_at = None;
+            assert!(
+                wait_for_pty_readable_or_forced_drain(
+                    pty_reader.as_raw_fd(),
+                    &mut drain_waiter,
+                    &force_drain,
+                    &mut forced_at,
+                )
+                .unwrap()
+            );
+            let mut late = [0u8; 4];
+            pty_reader.read_exact(&mut late).unwrap();
+            assert_eq!(&late, b"late");
+            written_rx.recv().unwrap();
+            assert!(
+                !wait_for_pty_readable_or_forced_drain(
+                    pty_reader.as_raw_fd(),
+                    &mut drain_waiter,
+                    &force_drain,
+                    &mut forced_at,
+                )
+                .unwrap()
+            );
+
+            release_tx.send(()).unwrap();
+            worker.join().unwrap();
+        }
+
+        #[test]
         fn coupled_color_frames_stay_adjacent_under_concurrent_exit_and_resize() {
             let (host_socket, _client_socket) = UnixStream::pair().unwrap();
             let (sender, receiver) = sync_channel(8);
@@ -2415,14 +2985,20 @@ mod unix {
 
 #[cfg(unix)]
 pub use unix::{
-    HostAttachment, adopt_terminal_host, launch_terminal_host, launch_terminal_host_with_identity,
-    load_terminal_host_records, remove_stale_terminal_host_record, serve_terminal_host_stdio,
-    terminal_host_record_liveness, terminal_host_root, validate_terminal_host_record,
+    HostAttachment, adopt_terminal_host, isolate_terminal_host_process_fds, launch_terminal_host,
+    launch_terminal_host_with_identity, load_terminal_host_records,
+    remove_stale_terminal_host_record, serve_terminal_host_stdio, terminal_host_record_liveness,
+    terminal_host_root, validate_terminal_host_record,
 };
 
 #[cfg(not(unix))]
 pub fn terminal_host_root(state_root: &Path, session: &str) -> PathBuf {
     state_root.join(format!("{session}.terminal-hosts"))
+}
+
+#[cfg(not(unix))]
+pub fn isolate_terminal_host_process_fds() -> anyhow::Result<()> {
+    Ok(())
 }
 
 #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -20,7 +20,7 @@ use crate::terminal_host_protocol::{
     write_frame,
 };
 
-const HOST_RECORD_VERSION: u32 = 1;
+const HOST_RECORD_VERSION: u32 = 2;
 const MAX_LAUNCH_PAYLOAD: usize = 1024 * 1024;
 const MAX_STRING: usize = 256 * 1024;
 const MAX_BLOB: usize = 8 * 1024 * 1024;
@@ -28,22 +28,62 @@ const MAX_ARGV: usize = 256;
 const MAX_ENV: usize = 1024;
 const MAX_RENDERER_CAPABILITY_TTL: std::time::Duration = std::time::Duration::from_secs(60);
 const CAPABILITY_RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const HOST_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 const MAX_HOST_CLIENT_QUEUED_BYTES: usize = 8 * 1024 * 1024;
+const HOST_START_NONCE_LEN: usize = 32;
+const TERMINAL_DIMENSION_MAX: u16 = 10_000;
+const TERMINAL_CELL_AREA_MAX: u64 = 4_000_000;
 pub const TERMINAL_COLORS_WIRE_VERSION: u16 = 1;
 pub const MAX_TERMINAL_COLORS_PAYLOAD: usize = 8 + 3 * 3 + 256 * 4;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) fn normalize_terminal_geometry(cols: u16, rows: u16) -> anyhow::Result<(u16, u16)> {
+    let cols = cols.clamp(1, TERMINAL_DIMENSION_MAX);
+    let rows = rows.clamp(1, TERMINAL_DIMENSION_MAX);
+    if u64::from(cols) * u64::from(rows) > TERMINAL_CELL_AREA_MAX {
+        anyhow::bail!(
+            "terminal geometry {cols}x{rows} exceeds the {TERMINAL_CELL_AREA_MAX}-cell limit"
+        );
+    }
+    Ok((cols, rows))
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TerminalHostRecord {
     pub record_version: u32,
     pub terminal_id: String,
     pub incarnation: String,
     pub endpoint: String,
     pub owner_token: String,
+    /// PID of the terminal-host process (not the child running inside its
+    /// PTY). A PID by itself is never sufficient proof of liveness because it
+    /// can be reused after a crash.
+    #[serde(default)]
+    pub host_pid: u32,
+    /// Random process-start nonce naming a file lock held for exactly this
+    /// host process lifetime. The PID + locked nonce gives cleanup code a
+    /// positive, PID-reuse-safe liveness proof.
+    #[serde(default)]
+    pub host_start_nonce: String,
     /// Deprecated compatibility placement hint. Discovery authority is the
     /// stable terminal identity + endpoint capability; the canonical
     /// workspace registry owns placement in the stacked follow-up.
     #[serde(default)]
     pub workspace_key: String,
+}
+
+impl std::fmt::Debug for TerminalHostRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TerminalHostRecord")
+            .field("record_version", &self.record_version)
+            .field("terminal_id", &self.terminal_id)
+            .field("incarnation", &self.incarnation)
+            .field("endpoint", &self.endpoint)
+            .field("owner_token", &"[REDACTED]")
+            .field("host_pid", &self.host_pid)
+            .field("host_start_nonce", &self.host_start_nonce)
+            .field("workspace_key", &self.workspace_key)
+            .finish()
+    }
 }
 
 impl TerminalHostRecord {
@@ -70,6 +110,18 @@ pub struct HostSnapshot {
 pub struct TerminalHostIdentity {
     pub terminal_id: String,
     pub incarnation: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalHostLiveness {
+    /// The exact process-start nonce is still locked by a host process.
+    Live,
+    /// The nonce lock is no longer held (or the recorded PID does not exist),
+    /// which positively proves that this exact host incarnation ended.
+    Dead,
+    /// The proof could not be inspected safely. Callers must retain the
+    /// record and retry; this state is never permission to reap a terminal.
+    Indeterminate,
 }
 
 /// A short-lived, one-use credential that can open the terminal host socket
@@ -168,15 +220,16 @@ pub fn decode_terminal_color_overrides(payload: &[u8]) -> anyhow::Result<Termina
 
 #[cfg(unix)]
 mod unix {
-    use std::collections::HashMap;
-    use std::fs::{self, OpenOptions};
+    use std::collections::{HashMap, HashSet};
+    use std::fs::{self, File, OpenOptions};
     use std::io::{Read, Write};
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
     use std::os::unix::net::{UnixListener, UnixStream};
     use std::process::{Command, Stdio};
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Condvar, Mutex};
     use std::thread;
     use std::time::Duration;
 
@@ -187,6 +240,29 @@ mod unix {
     use super::*;
 
     static RECORD_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+    struct SpawnedHostProcess {
+        child: Option<std::process::Child>,
+    }
+
+    impl SpawnedHostProcess {
+        fn child_mut(&mut self) -> &mut std::process::Child {
+            self.child.as_mut().expect("terminal-host child is present")
+        }
+
+        fn into_child(mut self) -> std::process::Child {
+            self.child.take().expect("terminal-host child is present")
+        }
+    }
+
+    impl Drop for SpawnedHostProcess {
+        fn drop(&mut self) {
+            if let Some(child) = self.child.as_mut() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+    }
 
     #[derive(Debug)]
     struct HostLaunch {
@@ -210,12 +286,13 @@ mod unix {
             if self.extra_env.len() > MAX_ENV {
                 anyhow::bail!("terminal-host environment count is out of range");
             }
+            let (cols, rows) = normalize_terminal_geometry(self.cols, self.rows)?;
             let mut output = Vec::new();
             put_string(&mut output, &self.endpoint)?;
             put_string(&mut output, &self.record_path)?;
             put_string(&mut output, &self.term)?;
-            output.extend_from_slice(&self.cols.max(1).to_le_bytes());
-            output.extend_from_slice(&self.rows.max(1).to_le_bytes());
+            output.extend_from_slice(&cols.to_le_bytes());
+            output.extend_from_slice(&rows.to_le_bytes());
             output.extend_from_slice(
                 &u32::try_from(self.scrollback)
                     .map_err(|_| anyhow::anyhow!("terminal-host scrollback is too large"))?
@@ -243,8 +320,7 @@ mod unix {
             let endpoint = decoder.string()?;
             let record_path = decoder.string()?;
             let term = decoder.string()?;
-            let cols = decoder.u16()?.max(1);
-            let rows = decoder.u16()?.max(1);
+            let (cols, rows) = normalize_terminal_geometry(decoder.u16()?, decoder.u16()?)?;
             let scrollback = decoder.u32()? as usize;
             let cwd = decoder.optional_string()?;
             let argc = decoder.u16()? as usize;
@@ -403,13 +479,23 @@ mod unix {
         pub fn send(&self, kind: MessageKind, payload: &[u8]) -> std::io::Result<()> {
             let mut writer = self.writer.lock().unwrap();
             let frame = Frame::new(kind, payload.to_vec());
-            write_frame(&mut *writer, &frame).map_err(protocol_io_error)
+            let result = write_frame(&mut *writer, &frame).map_err(protocol_io_error);
+            if result.is_err() {
+                // A timed-out write may have emitted only part of a frame.
+                // Poison this connection so the reader takes a fresh atomic
+                // Snapshot instead of ever appending to a corrupt stream.
+                let _ = writer.shutdown(std::net::Shutdown::Both);
+            }
+            result
         }
 
         pub fn send_viewer_size(&self, cols: u16, rows: u16) -> std::io::Result<()> {
+            let (cols, rows) = normalize_terminal_geometry(cols, rows).map_err(|error| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, error.to_string())
+            })?;
             let mut payload = Vec::with_capacity(4);
-            payload.extend_from_slice(&cols.max(1).to_le_bytes());
-            payload.extend_from_slice(&rows.max(1).to_le_bytes());
+            payload.extend_from_slice(&cols.to_le_bytes());
+            payload.extend_from_slice(&rows.to_le_bytes());
             self.send(MessageKind::ViewerSize, &payload)
         }
 
@@ -426,6 +512,10 @@ mod unix {
                 terminal_id: self.record.terminal_id.clone(),
                 incarnation: self.record.incarnation.clone(),
             }
+        }
+
+        pub(crate) fn discovery_record(&self) -> (TerminalHostRecord, PathBuf) {
+            (self.record.clone(), self.record_path.clone())
         }
 
         pub(crate) fn capability_responses(&self) -> Arc<CapabilityResponses> {
@@ -451,6 +541,7 @@ mod unix {
                 write_frame(&mut *writer, &frame).map_err(protocol_io_error)
             };
             if let Err(error) = write_result {
+                let _ = self.writer.lock().unwrap().shutdown(std::net::Shutdown::Both);
                 self.capability_responses.waiters.lock().unwrap().remove(&request_id);
                 return Err(error.into());
             }
@@ -479,8 +570,11 @@ mod unix {
             if self.record.workspace_key == workspace_key {
                 return Ok(());
             }
-            self.record.workspace_key = workspace_key.to_string();
-            write_record(&self.record_path, &self.record)
+            let mut updated = self.record.clone();
+            updated.workspace_key = workspace_key.to_string();
+            write_record(&self.record_path, &updated)?;
+            self.record = updated;
+            Ok(())
         }
     }
 
@@ -542,7 +636,7 @@ mod unix {
         };
 
         let binary = std::env::current_exe().context("resolve cmux-tui terminal-host binary")?;
-        let mut child = Command::new(binary)
+        let child = Command::new(binary)
             .args(["__terminal-host", "--bootstrap-stdio"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -551,8 +645,12 @@ mod unix {
             .stderr(Stdio::null())
             .spawn()
             .context("spawn terminal-host process")?;
-        let mut stdin = child.stdin.take().context("open terminal-host bootstrap stdin")?;
-        let mut stdout = child.stdout.take().context("open terminal-host bootstrap stdout")?;
+        let mut process = SpawnedHostProcess { child: Some(child) };
+        let host_pid = process.child_mut().id();
+        let mut stdin =
+            process.child_mut().stdin.take().context("open terminal-host bootstrap stdin")?;
+        let mut stdout =
+            process.child_mut().stdout.take().context("open terminal-host bootstrap stdout")?;
 
         let bootstrap = HostBootstrap {
             min_version: PROTOCOL_VERSION,
@@ -583,18 +681,22 @@ mod unix {
         }
         drop(stdin);
         drop(stdout);
+        let mut child = process.into_child();
         thread::Builder::new().name("terminal-host-reaper".into()).spawn(move || {
             let _ = child.wait();
         })?;
 
-        let record = TerminalHostRecord {
-            record_version: HOST_RECORD_VERSION,
-            terminal_id: terminal_hex,
-            incarnation: encode_hex(ready.incarnation.as_bytes()),
-            endpoint: endpoint.to_string_lossy().into_owned(),
-            owner_token: encode_hex(owner_token.as_bytes()),
-            workspace_key: String::new(),
-        };
+        let record: TerminalHostRecord = serde_json::from_slice(
+            &fs::read(&record_path).context("read terminal-host discovery record")?,
+        )?;
+        validate_terminal_host_record(&record_path, &record)?;
+        if record.terminal_id != terminal_hex
+            || record.incarnation != ready.incarnation.to_hex()
+            || record.owner_token != encode_hex(owner_token.as_bytes())
+            || record.host_pid != host_pid
+        {
+            anyhow::bail!("terminal-host discovery record changed during launch");
+        }
         connect_record(record, record_path)
     }
 
@@ -602,16 +704,196 @@ mod unix {
         record: TerminalHostRecord,
         record_path: PathBuf,
     ) -> anyhow::Result<HostAttachment> {
-        if record.record_version != HOST_RECORD_VERSION {
+        validate_terminal_host_record(&record_path, &record)?;
+        connect_record(record, record_path)
+    }
+
+    /// Validate a discovery record without trusting paths or alternate
+    /// identity spellings supplied by its JSON payload.
+    pub fn validate_terminal_host_record(
+        record_path: &Path,
+        record: &TerminalHostRecord,
+    ) -> anyhow::Result<TerminalHostIdentity> {
+        if !matches!(record.record_version, 1 | HOST_RECORD_VERSION) {
             anyhow::bail!("unsupported terminal-host record version {}", record.record_version);
         }
-        connect_record(record, record_path)
+        let terminal_id = TerminalId::from_hex(&record.terminal_id)
+            .ok_or_else(|| anyhow::anyhow!("terminal-host id is not a canonical UUIDv4"))?;
+        let incarnation = HostIncarnation::from_hex(&record.incarnation).ok_or_else(|| {
+            anyhow::anyhow!("terminal-host incarnation is not a canonical UUIDv4")
+        })?;
+        let owner = decode_lower_hex_array::<{ crate::terminal_host::CAPABILITY_TOKEN_LEN }>(
+            &record.owner_token,
+            "owner token",
+        )?;
+        if owner.iter().all(|byte| *byte == 0) {
+            anyhow::bail!("terminal-host owner token is zero");
+        }
+        if record.record_version == 1 {
+            if record.host_pid != 0 || !record.host_start_nonce.is_empty() {
+                anyhow::bail!("legacy terminal-host record has unexpected liveness fields");
+            }
+        } else {
+            let nonce = decode_lower_hex_array::<HOST_START_NONCE_LEN>(
+                &record.host_start_nonce,
+                "process-start nonce",
+            )?;
+            if nonce.iter().all(|byte| *byte == 0) {
+                anyhow::bail!("terminal-host process-start nonce is zero");
+            }
+            if record.host_pid == 0 {
+                anyhow::bail!("terminal-host PID is zero");
+            }
+        }
+        if record.workspace_key.len() > MAX_STRING || record.workspace_key.contains('\0') {
+            anyhow::bail!("terminal-host workspace hint is invalid");
+        }
+
+        let parent = record_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("terminal-host record has no parent directory"))?;
+        let expected_record = parent.join(format!("{}.json", record.terminal_id));
+        if record_path != expected_record {
+            anyhow::bail!("terminal-host record filename is not canonical");
+        }
+        let uid = fs::metadata(parent)?.uid();
+        let expected_endpoint = PathBuf::from("/tmp")
+            .join(format!("cmux-th-{uid}"))
+            .join(format!("{}.sock", record.terminal_id));
+        if Path::new(&record.endpoint) != expected_endpoint {
+            anyhow::bail!("terminal-host endpoint is not canonical");
+        }
+        if let Ok(metadata) = fs::symlink_metadata(record_path)
+            && (!metadata.file_type().is_file()
+                || metadata.uid() != uid
+                || metadata.mode() & 0o077 != 0)
+        {
+            anyhow::bail!("terminal-host record permissions or ownership are unsafe");
+        }
+        let _ = (terminal_id, incarnation);
+        Ok(TerminalHostIdentity {
+            terminal_id: record.terminal_id.clone(),
+            incarnation: record.incarnation.clone(),
+        })
+    }
+
+    fn liveness_path(record_path: &Path, record: &TerminalHostRecord) -> PathBuf {
+        record_path
+            .with_extension(format!("{}-{}.live", record.incarnation, record.host_start_nonce))
+    }
+
+    /// Probe the process-lifetime nonce lock. `Dead` is positive evidence
+    /// tied to this exact incarnation even if `host_pid` has since been
+    /// assigned to another process.
+    pub fn terminal_host_record_liveness(
+        record_path: &Path,
+        record: &TerminalHostRecord,
+    ) -> anyhow::Result<TerminalHostLiveness> {
+        validate_terminal_host_record(record_path, record)?;
+        if record.record_version == 1 {
+            // v1 predates process-bound liveness proof. Preserve and adopt a
+            // reachable legacy host, but never infer death from PID/socket
+            // observations that are vulnerable to reuse and startup races.
+            // A normal legacy Exit remains authoritative and removes its own
+            // record; an unclean v1 crash intentionally requires manual or
+            // version-aware migration rather than unsafe reaping.
+            return Ok(if !record_path.exists() && !Path::new(&record.endpoint).exists() {
+                TerminalHostLiveness::Dead
+            } else {
+                TerminalHostLiveness::Indeterminate
+            });
+        }
+        let path = liveness_path(record_path, record);
+        let file = match OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+            .open(&path)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let host_cleanup_complete = !record_path.exists()
+                    && !Path::new(&record.endpoint).exists()
+                    && !path.exists();
+                return Ok(
+                    if host_cleanup_complete || process_definitely_absent(record.host_pid) {
+                        TerminalHostLiveness::Dead
+                    } else {
+                        TerminalHostLiveness::Indeterminate
+                    },
+                );
+            }
+            Err(_) => return Ok(TerminalHostLiveness::Indeterminate),
+        };
+        let metadata = file.metadata()?;
+        let expected_uid = fs::metadata(record_path.parent().unwrap())?.uid();
+        if !metadata.file_type().is_file()
+            || metadata.uid() != expected_uid
+            || metadata.nlink() != 1
+            || metadata.mode() & 0o077 != 0
+        {
+            return Ok(TerminalHostLiveness::Indeterminate);
+        }
+        loop {
+            // SAFETY: flock only observes/changes the advisory lock associated
+            // with this valid, owned file descriptor.
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if result == 0 {
+                // SAFETY: same valid descriptor as above. Unlock before the
+                // temporary probe descriptor is closed.
+                let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+                return Ok(TerminalHostLiveness::Dead);
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Ok(
+                if error
+                    .raw_os_error()
+                    .is_some_and(|code| code == libc::EWOULDBLOCK || code == libc::EAGAIN)
+                {
+                    TerminalHostLiveness::Live
+                } else {
+                    TerminalHostLiveness::Indeterminate
+                },
+            );
+        }
+    }
+
+    /// Remove a discovery record only after the process-lifetime proof says
+    /// the exact recorded host is dead. A live or ambiguous record is always
+    /// retained for a later adoption attempt.
+    pub fn remove_stale_terminal_host_record(
+        record_path: &Path,
+        expected: &TerminalHostRecord,
+    ) -> anyhow::Result<bool> {
+        if terminal_host_record_liveness(record_path, expected)? != TerminalHostLiveness::Dead {
+            return Ok(false);
+        }
+        let current: TerminalHostRecord = serde_json::from_slice(&fs::read(record_path)?)?;
+        validate_terminal_host_record(record_path, &current)?;
+        if current.terminal_id != expected.terminal_id
+            || current.incarnation != expected.incarnation
+            || current.host_start_nonce != expected.host_start_nonce
+        {
+            return Ok(false);
+        }
+        let proof = liveness_path(record_path, &current);
+        let endpoint = PathBuf::from(&current.endpoint);
+        fs::remove_file(record_path)?;
+        let _ = fs::remove_file(proof);
+        if fs::symlink_metadata(&endpoint).is_ok_and(|metadata| metadata.file_type().is_socket()) {
+            let _ = fs::remove_file(endpoint);
+        }
+        Ok(true)
     }
 
     pub fn load_terminal_host_records(
         root: &Path,
     ) -> anyhow::Result<Vec<(PathBuf, TerminalHostRecord)>> {
         let mut records = Vec::new();
+        let mut identities = HashSet::new();
         let entries = match fs::read_dir(root) {
             Ok(entries) => entries,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(records),
@@ -630,24 +912,35 @@ mod unix {
             let Ok(record) = serde_json::from_slice::<TerminalHostRecord>(&bytes) else {
                 continue;
             };
+            if validate_terminal_host_record(&path, &record).is_err()
+                || !identities.insert((record.terminal_id.clone(), record.incarnation.clone()))
+            {
+                continue;
+            }
             records.push((path, record));
         }
         records.sort_by(|left, right| left.0.cmp(&right.0));
         Ok(records)
     }
 
-    pub fn remove_terminal_host_record(path: &Path) {
-        let _ = fs::remove_file(path);
-    }
-
     fn connect_record(
         record: TerminalHostRecord,
         record_path: PathBuf,
+    ) -> anyhow::Result<HostAttachment> {
+        connect_record_with_timeout(record, record_path, HOST_HANDSHAKE_TIMEOUT)
+    }
+
+    fn connect_record_with_timeout(
+        record: TerminalHostRecord,
+        record_path: PathBuf,
+        handshake_timeout: Duration,
     ) -> anyhow::Result<HostAttachment> {
         let terminal_id = TerminalId::from_bytes(decode_hex_array(&record.terminal_id)?);
         let incarnation = HostIncarnation::from_bytes(decode_hex_array(&record.incarnation)?);
         let owner_token = CapabilityToken::from_bytes(decode_hex_array(&record.owner_token)?);
         let mut stream = connect_with_retry(Path::new(&record.endpoint))?;
+        stream.set_read_timeout(Some(handshake_timeout))?;
+        stream.set_write_timeout(Some(handshake_timeout))?;
         let hello = ClientHello {
             min_version: PROTOCOL_VERSION,
             max_version: PROTOCOL_VERSION,
@@ -683,6 +976,12 @@ mod unix {
         }
         snapshot.sequence_boundary = snapshot_frame.sequence;
         snapshot.colors = decode_terminal_color_overrides(&colors_frame.payload)?;
+        stream.set_read_timeout(None)?;
+        // Keep bounded writes for the lifetime of the disposable admin
+        // mirror. A stopped or wedged host must not block a mux/control thread
+        // forever while it sends input, mouse, resize, or Terminate. Reads are
+        // unbounded because the dedicated reader thread is intentionally
+        // long-lived and reconnects on any eventual EOF/protocol failure.
         let reader = stream.try_clone()?;
         let attachment = HostAttachment {
             record,
@@ -736,6 +1035,9 @@ mod unix {
             file.write_all(&bytes)?;
             file.sync_all()?;
             fs::rename(&temporary, path)?;
+            if let Some(parent) = path.parent() {
+                File::open(parent)?.sync_all()?;
+            }
             Ok(())
         })();
         if result.is_err() {
@@ -822,6 +1124,7 @@ mod unix {
         sequence: AtomicU64,
         next_client: AtomicU64,
         dead: AtomicBool,
+        child_exit: (Mutex<bool>, Condvar),
     }
 
     fn publish_host_frames(
@@ -860,7 +1163,7 @@ mod unix {
 
         fn remove_client(&self, client: u64) {
             self.taps.lock().unwrap().remove(&client);
-            mutate_viewer_sizes(
+            let _ = mutate_viewer_sizes(
                 &self.viewer_sizes,
                 |viewer_sizes| {
                     viewer_sizes.remove(&client);
@@ -869,18 +1172,19 @@ mod unix {
             );
         }
 
-        fn set_viewer_size(&self, client: u64, cols: u16, rows: u16) {
+        fn set_viewer_size(&self, client: u64, cols: u16, rows: u16) -> anyhow::Result<()> {
+            let (cols, rows) = normalize_terminal_geometry(cols, rows)?;
             mutate_viewer_sizes(
                 &self.viewer_sizes,
                 |viewer_sizes| {
-                    viewer_sizes.insert(client, (cols.max(1), rows.max(1)));
+                    viewer_sizes.insert(client, (cols, rows));
                 },
                 |desired| self.apply_viewer_minimum(desired),
-            );
+            )
         }
 
         fn remove_viewer_size(&self, client: u64) {
-            mutate_viewer_sizes(
+            let _ = mutate_viewer_sizes(
                 &self.viewer_sizes,
                 |viewer_sizes| {
                     viewer_sizes.remove(&client);
@@ -889,27 +1193,42 @@ mod unix {
             );
         }
 
-        fn apply_viewer_minimum(&self, desired: Option<(u16, u16)>) {
-            let Some((cols, rows)) = desired else { return };
-            {
-                let mut size = self.size.lock().unwrap();
-                if *size == (cols, rows) {
-                    return;
-                }
-                *size = (cols, rows);
+        fn apply_viewer_minimum(&self, desired: Option<(u16, u16)>) -> anyhow::Result<()> {
+            let Some((cols, rows)) = desired else { return Ok(()) };
+            let (cols, rows) = normalize_terminal_geometry(cols, rows)?;
+            let mut size = self.size.lock().unwrap();
+            if *size == (cols, rows) {
+                return Ok(());
             }
+            let previous = *size;
             let mut term = self.term.lock().unwrap();
-            let _ = self.master.lock().unwrap().resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            });
-            let _ = term.resize(cols, rows, 8, 16);
-            let replay = term
-                .vt_replay_bounded_theme_portable(crate::surface::VT_REPLAY_MAX_BYTES)
-                .unwrap_or_default();
+            let master = self.master.lock().unwrap();
+            master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })?;
+            if let Err(error) = term.resize(cols, rows, 8, 16) {
+                let _ = master.resize(PtySize {
+                    rows: previous.1,
+                    cols: previous.0,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                });
+                return Err(error.into());
+            }
+            let replay =
+                match term.vt_replay_bounded_theme_portable(crate::surface::VT_REPLAY_MAX_BYTES) {
+                    Ok(replay) => replay,
+                    Err(error) => {
+                        let _ = term.resize(previous.0, previous.1, 8, 16);
+                        let _ = master.resize(PtySize {
+                            rows: previous.1,
+                            cols: previous.0,
+                            pixel_width: 0,
+                            pixel_height: 0,
+                        });
+                        return Err(error.into());
+                    }
+                };
             let colors = term.color_overrides();
+            *size = (cols, rows);
             // Keep the parser lock through sequence publication so output
             // parsed at the new size cannot overtake the Resized marker.
             self.broadcast_with_colors(
@@ -917,6 +1236,21 @@ mod unix {
                 encode_resize(cols, rows, &replay),
                 encode_terminal_color_overrides(&colors),
             );
+            Ok(())
+        }
+
+        fn child_exited(&self) -> bool {
+            *self.child_exit.0.lock().unwrap()
+        }
+
+        fn terminate_and_wait(&self) {
+            if !self.child_exited() {
+                let _ = self.killer.lock().unwrap().kill();
+            }
+            let mut exited = self.child_exit.0.lock().unwrap();
+            while !*exited {
+                exited = self.child_exit.1.wait(exited).unwrap();
+            }
         }
     }
 
@@ -927,15 +1261,99 @@ mod unix {
     fn mutate_viewer_sizes(
         viewer_sizes: &Mutex<HashMap<u64, (u16, u16)>>,
         mutation: impl FnOnce(&mut HashMap<u64, (u16, u16)>),
-        apply: impl FnOnce(Option<(u16, u16)>),
-    ) {
+        apply: impl FnOnce(Option<(u16, u16)>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
         let mut viewer_sizes = viewer_sizes.lock().unwrap();
+        let previous = viewer_sizes.clone();
         mutation(&mut viewer_sizes);
         let desired = viewer_sizes
             .values()
             .copied()
             .reduce(|left, right| (left.0.min(right.0), left.1.min(right.1)));
-        apply(desired);
+        if let Err(error) = apply(desired) {
+            *viewer_sizes = previous;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    struct HostLivenessLease {
+        file: File,
+        path: PathBuf,
+    }
+
+    impl HostLivenessLease {
+        fn acquire(path: PathBuf) -> anyhow::Result<Self> {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+                .open(&path)?;
+            // SAFETY: flock only changes the advisory lock on this newly
+            // created, valid file descriptor.
+            if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+                let error = std::io::Error::last_os_error();
+                let _ = fs::remove_file(&path);
+                return Err(error.into());
+            }
+            file.sync_all()?;
+            Ok(Self { file, path })
+        }
+    }
+
+    struct HostServiceGuard {
+        shared: Arc<HostShared>,
+        endpoint: PathBuf,
+        record_path: PathBuf,
+        record: TerminalHostRecord,
+        lease: HostLivenessLease,
+        published: bool,
+    }
+
+    struct UnpublishedHostGuard {
+        shared: Arc<HostShared>,
+        endpoint: PathBuf,
+        armed: bool,
+    }
+
+    impl Drop for UnpublishedHostGuard {
+        fn drop(&mut self) {
+            if self.armed {
+                self.shared.terminate_and_wait();
+                let _ = fs::remove_file(&self.endpoint);
+            }
+        }
+    }
+
+    impl Drop for HostServiceGuard {
+        fn drop(&mut self) {
+            // All normal and early-error paths confirm the PTY child exited
+            // before removing its discoverability record. If this host is
+            // SIGKILLed, Drop cannot run; the locked nonce file remains on
+            // disk but unlocks automatically, giving the next mux positive
+            // stale-record proof.
+            self.shared.terminate_and_wait();
+            if !self.shared.child_exited() {
+                return;
+            }
+            let mut removed_record = !self.published;
+            if self.published
+                && let Ok(bytes) = fs::read(&self.record_path)
+                && let Ok(current) = serde_json::from_slice::<TerminalHostRecord>(&bytes)
+                && current.terminal_id == self.record.terminal_id
+                && current.incarnation == self.record.incarnation
+                && current.host_start_nonce == self.record.host_start_nonce
+            {
+                removed_record = fs::remove_file(&self.record_path).is_ok();
+            }
+            let _ = fs::remove_file(&self.endpoint);
+            if removed_record {
+                let _ = fs::remove_file(&self.lease.path);
+            }
+            let _ = self.lease.file.sync_all();
+        }
     }
 
     pub fn serve_terminal_host_stdio(
@@ -960,6 +1378,11 @@ mod unix {
         let shared = spawn_host_runtime(&launch, &bootstrapped)?;
 
         let endpoint = PathBuf::from(&launch.endpoint);
+        let mut unpublished = UnpublishedHostGuard {
+            shared: shared.clone(),
+            endpoint: endpoint.clone(),
+            armed: true,
+        };
         let _ = fs::remove_file(&endpoint);
         if let Some(parent) = endpoint.parent() {
             prepare_private_dir(parent)?;
@@ -968,18 +1391,45 @@ mod unix {
         fs::set_permissions(&endpoint, fs::Permissions::from_mode(0o600))?;
         listener.set_nonblocking(true)?;
 
+        let start_nonce = CapabilityToken::random()?;
+        let record = TerminalHostRecord {
+            record_version: HOST_RECORD_VERSION,
+            terminal_id: bootstrapped.terminal_id.to_hex(),
+            incarnation: bootstrapped.incarnation.to_hex(),
+            endpoint: launch.endpoint.clone(),
+            owner_token: encode_hex(bootstrapped.owner_token().as_bytes()),
+            host_pid: std::process::id(),
+            host_start_nonce: encode_hex(start_nonce.as_bytes()),
+            workspace_key: String::new(),
+        };
+        let lease =
+            HostLivenessLease::acquire(liveness_path(Path::new(&launch.record_path), &record))?;
+        let mut guard = HostServiceGuard {
+            shared: shared.clone(),
+            endpoint,
+            record_path: PathBuf::from(&launch.record_path),
+            record: record.clone(),
+            lease,
+            published: false,
+        };
+        unpublished.armed = false;
+
         // The PTY owner publishes its own adoption record before Ready. A
         // daemon killed immediately after launch acknowledgement can never
         // leave behind an undiscoverable terminal process.
-        let record = TerminalHostRecord {
-            record_version: HOST_RECORD_VERSION,
-            terminal_id: encode_hex(bootstrapped.terminal_id.as_bytes()),
-            incarnation: encode_hex(bootstrapped.incarnation.as_bytes()),
-            endpoint: launch.endpoint.clone(),
-            owner_token: encode_hex(bootstrapped.owner_token().as_bytes()),
-            workspace_key: String::new(),
-        };
         write_record(Path::new(&launch.record_path), &record)?;
+        guard.published = true;
+
+        // Integration failure-injection seam for the narrow record-before-
+        // Ready crash window. It is inherited only by explicitly configured
+        // test daemons and bounded so an accidental environment setting
+        // cannot wedge a production host indefinitely.
+        if let Ok(delay) = std::env::var("CMUX_TUI_TEST_HOST_READY_DELAY_MS")
+            && let Ok(delay) = delay.parse::<u64>()
+            && delay > 0
+        {
+            thread::sleep(Duration::from_millis(delay.min(5_000)));
+        }
 
         let ready = HostReady {
             selected_version: PROTOCOL_VERSION,
@@ -988,7 +1438,11 @@ mod unix {
         };
         let mut response = Frame::new(MessageKind::Ready, ready.encode());
         response.request_id = launch_frame.request_id;
-        write_frame(writer, &response)?;
+        // Publication is the ownership handoff. If the launcher dies in the
+        // narrow record-before-Ready window, EPIPE must not tear down the
+        // independently adoptable shell; a replacement daemon discovers the
+        // record and connects through the already-listening Unix socket.
+        let _ = write_frame(writer, &response);
 
         while !shared.dead.load(Ordering::Acquire) {
             match listener.accept() {
@@ -1011,10 +1465,8 @@ mod unix {
                 Err(error) => return Err(error.into()),
             }
         }
-        shared.broadcast(MessageKind::Exit, Vec::new());
         thread::sleep(Duration::from_millis(20));
-        let _ = fs::remove_file(&endpoint);
-        let _ = fs::remove_file(&launch.record_path);
+        drop(guard);
         Ok(())
     }
 
@@ -1091,6 +1543,7 @@ mod unix {
             sequence: AtomicU64::new(0),
             next_client: AtomicU64::new(1),
             dead: AtomicBool::new(false),
+            child_exit: (Mutex::new(false), Condvar::new()),
         });
 
         let reader_host = shared.clone();
@@ -1143,11 +1596,17 @@ mod unix {
                     let _ = writer.flush();
                 }
             }
-            reader_host.dead.store(true, Ordering::Release);
-            reader_host.broadcast(MessageKind::Exit, Vec::new());
         })?;
+        let child_host = shared.clone();
         thread::Builder::new().name("terminal-host-child".into()).spawn(move || {
             let _ = child.wait();
+            {
+                let mut exited = child_host.child_exit.0.lock().unwrap();
+                *exited = true;
+            }
+            child_host.dead.store(true, Ordering::Release);
+            child_host.broadcast(MessageKind::Exit, Vec::new());
+            child_host.child_exit.1.notify_all();
         })?;
         Ok(shared)
     }
@@ -1262,7 +1721,12 @@ mod unix {
                         }
                         let cols = u16::from_le_bytes([frame.payload[0], frame.payload[1]]);
                         let rows = u16::from_le_bytes([frame.payload[2], frame.payload[3]]);
-                        command_host.set_viewer_size(client, cols, rows);
+                        if command_host.set_viewer_size(client, cols, rows).is_err() {
+                            // Invalid geometry or a PTY/parser resize failure
+                            // rejects this admin stream. No Resized/replay was
+                            // published, and the host remains adoptable.
+                            break;
+                        }
                     }
                     MessageKind::ReleaseViewer => {
                         if !granted_rights.contains(CapabilityRights::RESIZE) {
@@ -1299,6 +1763,11 @@ mod unix {
                     _ => break,
                 }
             }
+            // Wake a writer that is waiting on an otherwise-empty live-frame
+            // channel. The socket is shut down first, so this private wakeup
+            // frame can never be mistaken for a sequenced host transition.
+            command_sender.close();
+            let _ = command_sender.try_send(Frame::new(MessageKind::ResyncRequired, Vec::new()));
             command_host.remove_client(client);
         })?;
 
@@ -1367,9 +1836,10 @@ mod unix {
     }
 
     fn encode_snapshot(snapshot: &HostSnapshot) -> anyhow::Result<Vec<u8>> {
+        let (cols, rows) = normalize_terminal_geometry(snapshot.cols, snapshot.rows)?;
         let mut output = Vec::new();
-        output.extend_from_slice(&snapshot.cols.to_le_bytes());
-        output.extend_from_slice(&snapshot.rows.to_le_bytes());
+        output.extend_from_slice(&cols.to_le_bytes());
+        output.extend_from_slice(&rows.to_le_bytes());
         output.extend_from_slice(&snapshot.pid.unwrap_or(0).to_le_bytes());
         put_blob(&mut output, &snapshot.replay)?;
         put_optional_string(&mut output, snapshot.cwd.as_deref())?;
@@ -1385,8 +1855,7 @@ mod unix {
 
     fn decode_snapshot(payload: &[u8]) -> anyhow::Result<HostSnapshot> {
         let mut decoder = PayloadDecoder::new(payload);
-        let cols = decoder.u16()?.max(1);
-        let rows = decoder.u16()?.max(1);
+        let (cols, rows) = normalize_terminal_geometry(decoder.u16()?, decoder.u16()?)?;
         let pid = match decoder.u32()? {
             0 => None,
             pid => Some(pid),
@@ -1415,10 +1884,9 @@ mod unix {
     }
 
     fn encode_resize(cols: u16, rows: u16, replay: &[u8]) -> Vec<u8> {
-        let mut output = Vec::with_capacity(8 + replay.len());
+        let mut output = Vec::with_capacity(4 + replay.len());
         output.extend_from_slice(&cols.to_le_bytes());
         output.extend_from_slice(&rows.to_le_bytes());
-        output.extend_from_slice(&(replay.len() as u32).to_le_bytes());
         output.extend_from_slice(replay);
         output
     }
@@ -1471,6 +1939,23 @@ mod unix {
                 .map_err(|_| anyhow::anyhow!("terminal-host identity is not hexadecimal"))?;
         }
         Ok(bytes)
+    }
+
+    fn decode_lower_hex_array<const N: usize>(text: &str, field: &str) -> anyhow::Result<[u8; N]> {
+        if !text.bytes().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')) {
+            anyhow::bail!("terminal-host {field} is not canonical lowercase hexadecimal");
+        }
+        decode_hex_array(text)
+    }
+
+    fn process_definitely_absent(pid: u32) -> bool {
+        let Ok(pid) = libc::pid_t::try_from(pid) else { return true };
+        // SAFETY: signal zero performs a liveness/permission probe and does
+        // not deliver a signal to the target process.
+        if unsafe { libc::kill(pid, 0) } == 0 {
+            return false;
+        }
+        std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
     }
 
     struct PayloadDecoder<'a> {
@@ -1582,6 +2067,35 @@ mod unix {
     mod tests {
         use super::*;
 
+        fn record_fixture(name: &str) -> (PathBuf, TerminalHostRecord, HostLivenessLease) {
+            let root = std::env::temp_dir().join(format!(
+                "cmux-host-record-{name}-{}-{}",
+                std::process::id(),
+                RECORD_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+            ));
+            prepare_private_dir(&root).unwrap();
+            let terminal_id = TerminalId::random().unwrap();
+            let incarnation = HostIncarnation::random().unwrap();
+            let owner = CapabilityToken::random().unwrap();
+            let nonce = CapabilityToken::random().unwrap();
+            let terminal_hex = terminal_id.to_hex();
+            let uid = fs::metadata(&root).unwrap().uid();
+            let record = TerminalHostRecord {
+                record_version: HOST_RECORD_VERSION,
+                terminal_id: terminal_hex.clone(),
+                incarnation: incarnation.to_hex(),
+                endpoint: format!("/tmp/cmux-th-{uid}/{terminal_hex}.sock"),
+                owner_token: encode_hex(owner.as_bytes()),
+                host_pid: std::process::id(),
+                host_start_nonce: encode_hex(nonce.as_bytes()),
+                workspace_key: String::new(),
+            };
+            let record_path = record.record_path(&root);
+            let lease = HostLivenessLease::acquire(liveness_path(&record_path, &record)).unwrap();
+            write_record(&record_path, &record).unwrap();
+            (record_path, record, lease)
+        }
+
         #[test]
         fn launch_round_trip_preserves_ghostty_defaults() {
             let mut default_colors = DefaultColors {
@@ -1611,6 +2125,130 @@ mod unix {
             assert_eq!(decoded.default_colors, default_colors);
             assert_eq!(decoded.command, launch.command);
             assert_eq!(decoded.extra_env, launch.extra_env);
+        }
+
+        #[test]
+        fn process_nonce_proves_stale_record_even_if_pid_is_live_and_reused() {
+            let (record_path, record, lease) = record_fixture("liveness");
+            assert_eq!(
+                terminal_host_record_liveness(&record_path, &record).unwrap(),
+                TerminalHostLiveness::Live
+            );
+
+            // The recorded PID is this still-running test process. Releasing
+            // the process-start nonce nevertheless proves that the exact
+            // recorded host lifetime ended; PID existence cannot mask it.
+            drop(lease);
+            assert!(!process_definitely_absent(record.host_pid));
+            assert_eq!(
+                terminal_host_record_liveness(&record_path, &record).unwrap(),
+                TerminalHostLiveness::Dead
+            );
+            assert!(remove_stale_terminal_host_record(&record_path, &record).unwrap());
+            assert!(!record_path.exists());
+            let _ = fs::remove_dir_all(record_path.parent().unwrap());
+        }
+
+        #[test]
+        fn record_loader_rejects_noncanonical_filenames_and_identity_spellings() {
+            let (record_path, record, lease) = record_fixture("canonical");
+            let root = record_path.parent().unwrap();
+            fs::write(root.join("duplicate.json"), serde_json::to_vec(&record).unwrap()).unwrap();
+            let mut uppercase = record.clone();
+            uppercase.host_start_nonce.make_ascii_uppercase();
+            fs::write(
+                root.join(format!("{}.json", TerminalId::random().unwrap().to_hex())),
+                serde_json::to_vec(&uppercase).unwrap(),
+            )
+            .unwrap();
+
+            let loaded = load_terminal_host_records(root).unwrap();
+            assert_eq!(loaded, vec![(record_path.clone(), record.clone())]);
+            drop(lease);
+            assert!(remove_stale_terminal_host_record(&record_path, &record).unwrap());
+            let _ = fs::remove_dir_all(root);
+        }
+
+        #[test]
+        fn legacy_record_is_adoptable_shape_but_never_unsafely_reaped() {
+            let (v2_path, v2, lease) = record_fixture("legacy");
+            let root = v2_path.parent().unwrap();
+            let terminal_id = TerminalId::random().unwrap().to_hex();
+            let mut legacy = v2.clone();
+            legacy.record_version = 1;
+            legacy.terminal_id = terminal_id.clone();
+            legacy.endpoint =
+                format!("/tmp/cmux-th-{}/{terminal_id}.sock", fs::metadata(root).unwrap().uid());
+            legacy.host_pid = 0;
+            legacy.host_start_nonce.clear();
+            let legacy_path = legacy.record_path(root);
+            write_record(&legacy_path, &legacy).unwrap();
+
+            validate_terminal_host_record(&legacy_path, &legacy).unwrap();
+            assert_eq!(
+                terminal_host_record_liveness(&legacy_path, &legacy).unwrap(),
+                TerminalHostLiveness::Indeterminate
+            );
+            assert!(
+                load_terminal_host_records(root)
+                    .unwrap()
+                    .iter()
+                    .any(|(_, record)| record.terminal_id == terminal_id)
+            );
+            assert!(!remove_stale_terminal_host_record(&legacy_path, &legacy).unwrap());
+
+            fs::remove_file(&legacy_path).unwrap();
+            drop(lease);
+            assert!(remove_stale_terminal_host_record(&v2_path, &v2).unwrap());
+            let _ = fs::remove_dir_all(root);
+        }
+
+        #[test]
+        fn geometry_is_bounded_and_failed_apply_rolls_back_viewer_set() {
+            assert_eq!(normalize_terminal_geometry(0, 0).unwrap(), (1, 1));
+            assert_eq!(normalize_terminal_geometry(u16::MAX, 1).unwrap(), (10_000, 1));
+            assert!(normalize_terminal_geometry(10_000, 10_000).is_err());
+
+            let viewers = Mutex::new(HashMap::from([(1, (80, 24))]));
+            let error = mutate_viewer_sizes(
+                &viewers,
+                |sizes| {
+                    sizes.insert(2, (70, 20));
+                },
+                |_| anyhow::bail!("injected PTY resize failure"),
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("injected PTY"));
+            assert_eq!(*viewers.lock().unwrap(), HashMap::from([(1, (80, 24))]));
+        }
+
+        #[test]
+        fn stalled_host_handshake_is_time_bounded() {
+            let (record_path, record, lease) = record_fixture("handshake-timeout");
+            let endpoint = PathBuf::from(&record.endpoint);
+            prepare_private_dir(endpoint.parent().unwrap()).unwrap();
+            let _ = fs::remove_file(&endpoint);
+            let listener = UnixListener::bind(&endpoint).unwrap();
+            let stalled = thread::spawn(move || {
+                let (_stream, _) = listener.accept().unwrap();
+                thread::sleep(Duration::from_millis(200));
+            });
+
+            let started = std::time::Instant::now();
+            assert!(
+                connect_record_with_timeout(
+                    record.clone(),
+                    record_path.clone(),
+                    Duration::from_millis(30),
+                )
+                .is_err()
+            );
+            assert!(started.elapsed() < Duration::from_secs(1));
+            stalled.join().unwrap();
+            let _ = fs::remove_file(endpoint);
+            drop(lease);
+            assert!(remove_stale_terminal_host_record(&record_path, &record).unwrap());
+            let _ = fs::remove_dir_all(record_path.parent().unwrap());
         }
 
         #[test]
@@ -1670,8 +2308,10 @@ mod unix {
                             first_applying_tx.send(()).unwrap();
                             release_first_rx.recv().unwrap();
                             applied.lock().unwrap().push(desired.unwrap());
+                            Ok(())
                         },
-                    );
+                    )
+                    .unwrap();
                 })
             };
             first_applying_rx.recv().unwrap();
@@ -1689,8 +2329,12 @@ mod unix {
                             second_mutating_tx.send(()).unwrap();
                             sizes.insert(2, (80, 24));
                         },
-                        |desired| applied.lock().unwrap().push(desired.unwrap()),
-                    );
+                        |desired| {
+                            applied.lock().unwrap().push(desired.unwrap());
+                            Ok(())
+                        },
+                    )
+                    .unwrap();
                 })
             };
             second_attempting_rx.recv().unwrap();
@@ -1772,8 +2416,8 @@ mod unix {
 #[cfg(unix)]
 pub use unix::{
     HostAttachment, adopt_terminal_host, launch_terminal_host, launch_terminal_host_with_identity,
-    load_terminal_host_records, remove_terminal_host_record, serve_terminal_host_stdio,
-    terminal_host_root,
+    load_terminal_host_records, remove_stale_terminal_host_record, serve_terminal_host_stdio,
+    terminal_host_record_liveness, terminal_host_root, validate_terminal_host_record,
 };
 
 #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -16,9 +16,10 @@ use serde_json::Value;
 
 use crate::platform;
 
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 const MAX_ID_LEN: usize = 128;
 const MAX_PROJECTION_BYTES: usize = 1024 * 1024;
+const MAX_LAUNCH_SPEC_BYTES: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegistryWorkspace {
@@ -67,6 +68,75 @@ pub struct RegistryCommit {
 pub struct RegistryEvent {
     pub revision: u64,
     pub kind: String,
+    pub workspace_key: String,
+    pub origin: String,
+    pub mutation_id: String,
+    pub result: Value,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TerminalLifecycle {
+    Launching,
+    Adopting,
+    Running,
+    Exited,
+    Tombstoned,
+}
+
+impl TerminalLifecycle {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Launching => "launching",
+            Self::Adopting => "adopting",
+            Self::Running => "running",
+            Self::Exited => "exited",
+            Self::Tombstoned => "tombstoned",
+        }
+    }
+
+    fn parse(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "launching" => Ok(Self::Launching),
+            "adopting" => Ok(Self::Adopting),
+            "running" => Ok(Self::Running),
+            "exited" => Ok(Self::Exited),
+            "tombstoned" => Ok(Self::Tombstoned),
+            other => anyhow::bail!("invalid terminal lifecycle {other:?}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegistryTerminal {
+    pub terminal_id: String,
+    pub workspace_key: String,
+    pub incarnation: Option<String>,
+    pub lifecycle: TerminalLifecycle,
+    pub launch_spec: Value,
+    pub exit: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TerminalRegistrySnapshot {
+    pub registry_id: String,
+    pub generation: String,
+    pub revision: u64,
+    pub terminals: Vec<RegistryTerminal>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TerminalRegistryCommit {
+    pub revision: u64,
+    pub result: Value,
+    pub replayed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TerminalRegistryEvent {
+    pub revision: u64,
+    pub kind: String,
+    pub terminal_id: String,
     pub workspace_key: String,
     pub origin: String,
     pub mutation_id: String,
@@ -145,69 +215,55 @@ impl WorkspaceRegistry {
              CREATE TABLE IF NOT EXISTS meta (
                key TEXT PRIMARY KEY NOT NULL,
                value TEXT NOT NULL
-             );
-             CREATE TABLE IF NOT EXISTS workspaces (
-               workspace_key TEXT PRIMARY KEY NOT NULL,
-               numeric_id INTEGER UNIQUE NOT NULL,
-               name TEXT NOT NULL,
-               group_key TEXT NOT NULL,
-               position INTEGER,
-               tombstoned INTEGER NOT NULL DEFAULT 0 CHECK(tombstoned IN (0,1)),
-               created_revision INTEGER NOT NULL,
-               updated_revision INTEGER NOT NULL
-               ,deleted_revision INTEGER
-             );
-             CREATE UNIQUE INDEX IF NOT EXISTS live_workspace_position
-               ON workspaces(position) WHERE tombstoned = 0;
-             CREATE TABLE IF NOT EXISTS mutations (
-               origin TEXT NOT NULL,
-               mutation_id TEXT NOT NULL,
-               fingerprint TEXT NOT NULL,
-               result_json TEXT NOT NULL,
-               committed_revision INTEGER NOT NULL,
-               PRIMARY KEY(origin, mutation_id)
-             );
-             CREATE TABLE IF NOT EXISTS workspace_events (
-               revision INTEGER PRIMARY KEY NOT NULL,
-               kind TEXT NOT NULL,
-               workspace_key TEXT NOT NULL,
-               origin TEXT NOT NULL,
-               mutation_id TEXT NOT NULL,
-               result_json TEXT NOT NULL
-             );
-             CREATE TABLE IF NOT EXISTS frontend_projections (
-               frontend TEXT NOT NULL,
-               scope TEXT NOT NULL,
-               subject_key TEXT NOT NULL,
-               schema_version INTEGER NOT NULL,
-               projection_revision INTEGER NOT NULL,
-               payload TEXT NOT NULL,
-               PRIMARY KEY(frontend, scope, subject_key)
-             );
-             CREATE TABLE IF NOT EXISTS projection_mutations (
-               origin TEXT NOT NULL,
-               mutation_id TEXT NOT NULL,
-               fingerprint TEXT NOT NULL,
-               result_json TEXT NOT NULL,
-               PRIMARY KEY(origin, mutation_id)
              );",
         )?;
 
         let stored_schema = meta_value(&connection, "schema_version")?;
         match stored_schema {
-            Some(value) if value.parse::<i64>()? != SCHEMA_VERSION => {
+            Some(value) if value.parse::<i64>()? > SCHEMA_VERSION => {
                 anyhow::bail!(
-                    "unsupported workspace registry schema {value}; expected {SCHEMA_VERSION}"
+                    "unsupported workspace registry schema {value}; newest supported is {SCHEMA_VERSION}"
                 );
             }
-            Some(_) => {}
+            Some(value) if value.parse::<i64>()? == SCHEMA_VERSION => {
+                let tx = connection.unchecked_transaction()?;
+                create_workspace_schema(&tx)?;
+                create_terminal_schema(&tx)?;
+                tx.execute(
+                    "INSERT OR IGNORE INTO meta(key, value) VALUES('terminal_revision', '0')",
+                    [],
+                )?;
+                tx.commit()?;
+            }
+            Some(value) if value.parse::<i64>()? == 1 => {
+                let tx = connection.unchecked_transaction()?;
+                create_workspace_schema(&tx)?;
+                create_terminal_schema(&tx)?;
+                tx.execute(
+                    "INSERT OR IGNORE INTO meta(key, value) VALUES('terminal_revision', '0')",
+                    [],
+                )?;
+                tx.execute(
+                    "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
+                    [SCHEMA_VERSION.to_string()],
+                )?;
+                tx.commit()?;
+            }
+            Some(value) => {
+                anyhow::bail!(
+                    "unsupported workspace registry schema {value}; expected 1 or {SCHEMA_VERSION}"
+                );
+            }
             None => {
                 let tx = connection.unchecked_transaction()?;
+                create_workspace_schema(&tx)?;
+                create_terminal_schema(&tx)?;
                 tx.execute(
                     "INSERT INTO meta(key, value) VALUES('schema_version', ?1)",
                     [SCHEMA_VERSION.to_string()],
                 )?;
                 tx.execute("INSERT INTO meta(key, value) VALUES('revision', '0')", [])?;
+                tx.execute("INSERT INTO meta(key, value) VALUES('terminal_revision', '0')", [])?;
                 tx.execute(
                     "INSERT INTO meta(key, value) VALUES('session_name', ?1)",
                     [&session_name],
@@ -280,6 +336,329 @@ impl WorkspaceRegistry {
 
     pub fn generation(&self) -> &str {
         &self.generation
+    }
+
+    /// Returns the canonical, non-tombstoned terminal placement projection.
+    /// Runtime surface ids and renderer process ids are intentionally absent.
+    pub fn terminal_snapshot(&self) -> anyhow::Result<TerminalRegistrySnapshot> {
+        let revision = current_terminal_revision(&self.connection)?;
+        let mut statement = self.connection.prepare(
+            "SELECT terminal_id, workspace_key, incarnation, lifecycle,
+                    launch_spec_json, exit_json
+             FROM terminal_placements
+             WHERE lifecycle != 'tombstoned'
+             ORDER BY created_revision ASC, terminal_id ASC",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        })?;
+        let terminals =
+            rows.map(|row| terminal_from_stored(row?)).collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(TerminalRegistrySnapshot {
+            registry_id: self.registry_id.clone(),
+            generation: self.generation.clone(),
+            revision,
+            terminals,
+        })
+    }
+
+    /// Includes tombstones and is intended for reconciliation and idempotent
+    /// close handling, not frontend materialization.
+    pub fn terminal_record(&self, terminal_id: &str) -> anyhow::Result<Option<RegistryTerminal>> {
+        validate_identifier("terminal id", terminal_id)?;
+        read_terminal(&self.connection, terminal_id)
+    }
+
+    pub fn replay_terminal(
+        &self,
+        mutation: &WorkspaceMutation,
+        fingerprint: &Value,
+    ) -> anyhow::Result<Option<TerminalRegistryCommit>> {
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        let fingerprint = canonical_json(fingerprint)?;
+        terminal_replay(&self.connection, mutation, &fingerprint)
+    }
+
+    /// Commits one terminal state transition and its event in a single SQLite
+    /// transaction. Callers reserve a stable id in `launching` before spawning
+    /// a host, then advance it through `adopting`/`running` only after the host
+    /// record is durable. A tombstoned id can never be resurrected.
+    #[allow(clippy::too_many_arguments)]
+    pub fn commit_terminal(
+        &mut self,
+        mutation: &WorkspaceMutation,
+        fingerprint: &Value,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        event_kind: &str,
+        terminal: &RegistryTerminal,
+        result: &Value,
+    ) -> anyhow::Result<TerminalRegistryCommit> {
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        validate_identifier("terminal event kind", event_kind)?;
+        validate_terminal(terminal)?;
+        let fingerprint = canonical_json(fingerprint)?;
+        let result_json = canonical_json(result)?;
+        let launch_spec_json = canonical_json(&terminal.launch_spec)?;
+        if launch_spec_json.len() > MAX_LAUNCH_SPEC_BYTES {
+            anyhow::bail!("terminal launch spec exceeds {MAX_LAUNCH_SPEC_BYTES} bytes");
+        }
+        let exit_json = terminal.exit.as_ref().map(canonical_json).transpose()?;
+        let tx = self.connection.transaction()?;
+
+        if let Some(replay) = terminal_replay(&tx, mutation, &fingerprint)? {
+            return Ok(replay);
+        }
+        if let Some(expected) = expected_generation
+            && expected != self.generation
+        {
+            anyhow::bail!(
+                "terminal generation conflict: expected {expected}, current {}",
+                self.generation
+            );
+        }
+        let current_revision = transaction_terminal_revision(&tx)?;
+        if let Some(expected) = expected_revision
+            && expected != current_revision
+        {
+            anyhow::bail!(
+                "terminal revision conflict: expected {expected}, current {current_revision}"
+            );
+        }
+        let existing = read_terminal(&tx, &terminal.terminal_id)?;
+        validate_terminal_transition(existing.as_ref(), terminal)?;
+        if terminal.lifecycle != TerminalLifecycle::Tombstoned {
+            require_live_workspace(&tx, &terminal.workspace_key)?;
+        }
+
+        let revision = current_revision
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("terminal revision exhausted"))?;
+        let sqlite_revision =
+            i64::try_from(revision).context("terminal revision exceeds SQLite integer range")?;
+        tx.execute(
+            "INSERT INTO terminal_placements(
+               terminal_id, workspace_key, incarnation, lifecycle, launch_spec_json,
+               exit_json, created_revision, updated_revision, deleted_revision
+             ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8)
+             ON CONFLICT(terminal_id) DO UPDATE SET
+               workspace_key=excluded.workspace_key,
+               incarnation=excluded.incarnation,
+               lifecycle=excluded.lifecycle,
+               launch_spec_json=excluded.launch_spec_json,
+               exit_json=excluded.exit_json,
+               updated_revision=excluded.updated_revision,
+               deleted_revision=excluded.deleted_revision",
+            params![
+                terminal.terminal_id,
+                terminal.workspace_key,
+                terminal.incarnation,
+                terminal.lifecycle.as_str(),
+                launch_spec_json,
+                exit_json,
+                sqlite_revision,
+                (terminal.lifecycle == TerminalLifecycle::Tombstoned).then_some(sqlite_revision),
+            ],
+        )?;
+        tx.execute(
+            "UPDATE meta SET value = ?1 WHERE key = 'terminal_revision'",
+            [revision.to_string()],
+        )?;
+        tx.execute(
+            "INSERT INTO terminal_mutations(
+               origin, mutation_id, fingerprint, result_json, committed_revision
+             ) VALUES(?1, ?2, ?3, ?4, ?5)",
+            params![mutation.origin, mutation.id, fingerprint, result_json, sqlite_revision],
+        )?;
+        tx.execute(
+            "INSERT INTO terminal_events(
+               revision, kind, terminal_id, workspace_key, origin, mutation_id, result_json
+             ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                sqlite_revision,
+                event_kind,
+                terminal.terminal_id,
+                terminal.workspace_key,
+                mutation.origin,
+                mutation.id,
+                result_json,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(TerminalRegistryCommit { revision, result: result.clone(), replayed: false })
+    }
+
+    /// Durably tombstones a terminal before the caller signals its host. This
+    /// makes a repeated close safe even if the first success reply was lost.
+    pub fn close_terminal(
+        &mut self,
+        mutation: &WorkspaceMutation,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        terminal_id: &str,
+        expected_incarnation: Option<&str>,
+    ) -> anyhow::Result<TerminalRegistryCommit> {
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        validate_identifier("terminal id", terminal_id)?;
+        if let Some(incarnation) = expected_incarnation {
+            validate_identifier("terminal incarnation", incarnation)?;
+        }
+        let fingerprint_value = serde_json::json!({
+            "op": "close-terminal",
+            "terminal_id": terminal_id,
+            "incarnation": expected_incarnation,
+        });
+        let fingerprint = canonical_json(&fingerprint_value)?;
+        let tx = self.connection.transaction()?;
+        if let Some(replay) = terminal_replay(&tx, mutation, &fingerprint)? {
+            return Ok(replay);
+        }
+        if let Some(expected) = expected_generation
+            && expected != self.generation
+        {
+            anyhow::bail!(
+                "terminal generation conflict: expected {expected}, current {}",
+                self.generation
+            );
+        }
+        let current_revision = transaction_terminal_revision(&tx)?;
+        if let Some(expected) = expected_revision
+            && expected != current_revision
+        {
+            anyhow::bail!(
+                "terminal revision conflict: expected {expected}, current {current_revision}"
+            );
+        }
+        let Some(terminal) = read_terminal(&tx, terminal_id)? else {
+            anyhow::bail!("unknown terminal {terminal_id}; it may not have been adopted yet");
+        };
+        if let Some(expected) = expected_incarnation
+            && terminal.incarnation.as_deref() != Some(expected)
+        {
+            anyhow::bail!(
+                "terminal incarnation conflict for {terminal_id}: expected {expected}, current {:?}",
+                terminal.incarnation
+            );
+        }
+
+        if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+            let result = serde_json::json!({
+                "terminal_id": terminal_id,
+                "incarnation": terminal.incarnation,
+                "closed": true,
+                "already_closed": true,
+            });
+            let result_json = canonical_json(&result)?;
+            tx.execute(
+                "INSERT INTO terminal_mutations(
+                   origin, mutation_id, fingerprint, result_json, committed_revision
+                 ) VALUES(?1, ?2, ?3, ?4, ?5)",
+                params![
+                    mutation.origin,
+                    mutation.id,
+                    fingerprint,
+                    result_json,
+                    i64::try_from(current_revision)
+                        .context("terminal revision exceeds SQLite integer range")?,
+                ],
+            )?;
+            tx.commit()?;
+            return Ok(TerminalRegistryCommit {
+                revision: current_revision,
+                result,
+                replayed: false,
+            });
+        }
+
+        let revision = current_revision
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("terminal revision exhausted"))?;
+        let sqlite_revision =
+            i64::try_from(revision).context("terminal revision exceeds SQLite integer range")?;
+        let result = serde_json::json!({
+            "terminal_id": terminal_id,
+            "incarnation": terminal.incarnation,
+            "closed": true,
+            "already_closed": false,
+        });
+        let result_json = canonical_json(&result)?;
+        tx.execute(
+            "UPDATE terminal_placements
+             SET lifecycle = 'tombstoned', updated_revision = ?1, deleted_revision = ?1
+             WHERE terminal_id = ?2",
+            params![sqlite_revision, terminal_id],
+        )?;
+        tx.execute(
+            "UPDATE meta SET value = ?1 WHERE key = 'terminal_revision'",
+            [revision.to_string()],
+        )?;
+        tx.execute(
+            "INSERT INTO terminal_mutations(
+               origin, mutation_id, fingerprint, result_json, committed_revision
+             ) VALUES(?1, ?2, ?3, ?4, ?5)",
+            params![mutation.origin, mutation.id, fingerprint, result_json, sqlite_revision],
+        )?;
+        tx.execute(
+            "INSERT INTO terminal_events(
+               revision, kind, terminal_id, workspace_key, origin, mutation_id, result_json
+             ) VALUES(?1, 'terminal-closed', ?2, ?3, ?4, ?5, ?6)",
+            params![
+                sqlite_revision,
+                terminal_id,
+                terminal.workspace_key,
+                mutation.origin,
+                mutation.id,
+                result_json,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(TerminalRegistryCommit { revision, result, replayed: false })
+    }
+
+    pub fn terminal_events_after(
+        &self,
+        revision: u64,
+    ) -> anyhow::Result<Vec<TerminalRegistryEvent>> {
+        let mut statement = self.connection.prepare(
+            "SELECT revision, kind, terminal_id, workspace_key, origin, mutation_id, result_json
+             FROM terminal_events WHERE revision > ?1 ORDER BY revision ASC",
+        )?;
+        let sqlite_revision =
+            i64::try_from(revision).context("terminal revision exceeds SQLite integer range")?;
+        let rows = statement.query_map([sqlite_revision], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+            ))
+        })?;
+        rows.map(|row| {
+            let (revision, kind, terminal_id, workspace_key, origin, mutation_id, result) = row?;
+            Ok(TerminalRegistryEvent {
+                revision: u64::try_from(revision).context("terminal event revision is negative")?,
+                kind,
+                terminal_id,
+                workspace_key,
+                origin,
+                mutation_id,
+                result: serde_json::from_str(&result)?,
+            })
+        })
+        .collect()
     }
 
     /// Look up an already-committed mutation before resolving any live
@@ -404,6 +783,12 @@ impl WorkspaceRegistry {
                 anyhow::bail!("tombstoned workspace key cannot be reused: {}", workspace.key);
             }
         }
+
+        // Child terminals become durable tombstones in this same transaction,
+        // before their workspace rows are tombstoned. Process termination is a
+        // post-commit effect and can therefore be retried after a daemon crash
+        // without ever letting a frontend resurrect the terminal elsewhere.
+        tombstone_terminals_in_removed_workspaces(&tx, workspaces, mutation)?;
 
         tx.execute(
             "UPDATE workspaces SET tombstoned = 1, position = NULL,
@@ -637,6 +1022,176 @@ impl WorkspaceRegistry {
     }
 }
 
+fn create_workspace_schema(transaction: &Transaction<'_>) -> anyhow::Result<()> {
+    transaction.execute_batch(
+        "CREATE TABLE IF NOT EXISTS workspaces (
+           workspace_key TEXT PRIMARY KEY NOT NULL,
+           numeric_id INTEGER UNIQUE NOT NULL,
+           name TEXT NOT NULL,
+           group_key TEXT NOT NULL,
+           position INTEGER,
+           tombstoned INTEGER NOT NULL DEFAULT 0 CHECK(tombstoned IN (0,1)),
+           created_revision INTEGER NOT NULL,
+           updated_revision INTEGER NOT NULL,
+           deleted_revision INTEGER
+         );
+         CREATE UNIQUE INDEX IF NOT EXISTS live_workspace_position
+           ON workspaces(position) WHERE tombstoned = 0;
+         CREATE TABLE IF NOT EXISTS mutations (
+           origin TEXT NOT NULL,
+           mutation_id TEXT NOT NULL,
+           fingerprint TEXT NOT NULL,
+           result_json TEXT NOT NULL,
+           committed_revision INTEGER NOT NULL,
+           PRIMARY KEY(origin, mutation_id)
+         );
+         CREATE TABLE IF NOT EXISTS workspace_events (
+           revision INTEGER PRIMARY KEY NOT NULL,
+           kind TEXT NOT NULL,
+           workspace_key TEXT NOT NULL,
+           origin TEXT NOT NULL,
+           mutation_id TEXT NOT NULL,
+           result_json TEXT NOT NULL
+         );
+         CREATE TABLE IF NOT EXISTS frontend_projections (
+           frontend TEXT NOT NULL,
+           scope TEXT NOT NULL,
+           subject_key TEXT NOT NULL,
+           schema_version INTEGER NOT NULL,
+           projection_revision INTEGER NOT NULL,
+           payload TEXT NOT NULL,
+           PRIMARY KEY(frontend, scope, subject_key)
+         );
+         CREATE TABLE IF NOT EXISTS projection_mutations (
+           origin TEXT NOT NULL,
+           mutation_id TEXT NOT NULL,
+           fingerprint TEXT NOT NULL,
+           result_json TEXT NOT NULL,
+           PRIMARY KEY(origin, mutation_id)
+         );",
+    )?;
+    Ok(())
+}
+
+fn create_terminal_schema(transaction: &Transaction<'_>) -> anyhow::Result<()> {
+    transaction.execute_batch(
+        "CREATE TABLE IF NOT EXISTS terminal_placements (
+           terminal_id TEXT PRIMARY KEY NOT NULL,
+           workspace_key TEXT NOT NULL REFERENCES workspaces(workspace_key),
+           incarnation TEXT,
+           lifecycle TEXT NOT NULL CHECK(
+             lifecycle IN ('launching','adopting','running','exited','tombstoned')
+           ),
+           launch_spec_json TEXT NOT NULL,
+           exit_json TEXT,
+           created_revision INTEGER NOT NULL,
+           updated_revision INTEGER NOT NULL,
+           deleted_revision INTEGER
+         );
+         CREATE UNIQUE INDEX IF NOT EXISTS terminal_incarnation
+           ON terminal_placements(incarnation) WHERE incarnation IS NOT NULL;
+         CREATE INDEX IF NOT EXISTS live_terminals_by_workspace
+           ON terminal_placements(workspace_key, updated_revision)
+           WHERE lifecycle != 'tombstoned';
+         CREATE TABLE IF NOT EXISTS terminal_mutations (
+           origin TEXT NOT NULL,
+           mutation_id TEXT NOT NULL,
+           fingerprint TEXT NOT NULL,
+           result_json TEXT NOT NULL,
+           committed_revision INTEGER NOT NULL,
+           PRIMARY KEY(origin, mutation_id)
+         );
+         CREATE TABLE IF NOT EXISTS terminal_events (
+           revision INTEGER PRIMARY KEY NOT NULL,
+           kind TEXT NOT NULL,
+           terminal_id TEXT NOT NULL,
+           workspace_key TEXT NOT NULL,
+           origin TEXT NOT NULL,
+           mutation_id TEXT NOT NULL,
+           result_json TEXT NOT NULL
+         );
+         CREATE INDEX IF NOT EXISTS terminal_events_by_terminal
+           ON terminal_events(terminal_id, revision);",
+    )?;
+    Ok(())
+}
+
+fn tombstone_terminals_in_removed_workspaces(
+    transaction: &Transaction<'_>,
+    remaining_workspaces: &[RegistryWorkspace],
+    mutation: &WorkspaceMutation,
+) -> anyhow::Result<()> {
+    let remaining = remaining_workspaces
+        .iter()
+        .map(|workspace| workspace.key.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    let terminals = {
+        let mut statement = transaction.prepare(
+            "SELECT terminal_id, workspace_key, incarnation
+             FROM terminal_placements
+             WHERE lifecycle != 'tombstoned'
+             ORDER BY created_revision ASC, terminal_id ASC",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    let removed = terminals
+        .into_iter()
+        .filter(|(_, workspace_key, _)| !remaining.contains(workspace_key.as_str()))
+        .collect::<Vec<_>>();
+    if removed.is_empty() {
+        return Ok(());
+    }
+
+    let mut revision = transaction_terminal_revision(transaction)?;
+    for (terminal_id, workspace_key, incarnation) in removed {
+        revision = revision
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("terminal revision exhausted"))?;
+        let sqlite_revision =
+            i64::try_from(revision).context("terminal revision exceeds SQLite integer range")?;
+        let result = serde_json::json!({
+            "terminal_id": terminal_id,
+            "workspace_key": workspace_key,
+            "incarnation": incarnation,
+            "closed": true,
+            "reason": "workspace-closed",
+        });
+        let result_json = canonical_json(&result)?;
+        transaction.execute(
+            "UPDATE terminal_placements
+             SET lifecycle = 'tombstoned', updated_revision = ?1, deleted_revision = ?1
+             WHERE terminal_id = ?2 AND lifecycle != 'tombstoned'",
+            params![sqlite_revision, terminal_id],
+        )?;
+        transaction.execute(
+            "INSERT INTO terminal_events(
+               revision, kind, terminal_id, workspace_key, origin, mutation_id, result_json
+             ) VALUES(?1, 'terminal-closed', ?2, ?3, ?4, ?5, ?6)",
+            params![
+                sqlite_revision,
+                terminal_id,
+                workspace_key,
+                mutation.origin,
+                mutation.id,
+                result_json,
+            ],
+        )?;
+    }
+    transaction.execute(
+        "UPDATE meta SET value = ?1 WHERE key = 'terminal_revision'",
+        [revision.to_string()],
+    )?;
+    Ok(())
+}
+
 fn validate_registry(workspaces: &[RegistryWorkspace]) -> anyhow::Result<()> {
     let mut keys = std::collections::HashSet::new();
     for workspace in workspaces {
@@ -650,6 +1205,157 @@ fn validate_registry(workspaces: &[RegistryWorkspace]) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+fn validate_terminal(terminal: &RegistryTerminal) -> anyhow::Result<()> {
+    validate_identifier("terminal id", &terminal.terminal_id)?;
+    validate_identifier("workspace key", &terminal.workspace_key)?;
+    if let Some(incarnation) = &terminal.incarnation {
+        validate_identifier("terminal incarnation", incarnation)?;
+    }
+    match terminal.lifecycle {
+        TerminalLifecycle::Launching if terminal.incarnation.is_some() => {
+            anyhow::bail!("launching terminal cannot have an incarnation before host adoption");
+        }
+        TerminalLifecycle::Adopting | TerminalLifecycle::Running
+            if terminal.incarnation.is_none() =>
+        {
+            anyhow::bail!("{:?} terminal requires a host incarnation", terminal.lifecycle);
+        }
+        _ => {}
+    }
+    if terminal.lifecycle != TerminalLifecycle::Exited && terminal.exit.is_some() {
+        anyhow::bail!("only an exited terminal can carry exit metadata");
+    }
+    Ok(())
+}
+
+fn validate_terminal_transition(
+    existing: Option<&RegistryTerminal>,
+    desired: &RegistryTerminal,
+) -> anyhow::Result<()> {
+    let Some(existing) = existing else {
+        if desired.lifecycle != TerminalLifecycle::Launching {
+            anyhow::bail!("new terminal must be reserved in launching state before host spawn");
+        }
+        return Ok(());
+    };
+    if existing.lifecycle == TerminalLifecycle::Tombstoned {
+        anyhow::bail!("tombstoned terminal id cannot be reused: {}", desired.terminal_id);
+    }
+    let allowed = matches!(
+        (existing.lifecycle, desired.lifecycle),
+        (TerminalLifecycle::Launching, TerminalLifecycle::Launching)
+            | (TerminalLifecycle::Launching, TerminalLifecycle::Adopting)
+            | (TerminalLifecycle::Launching, TerminalLifecycle::Running)
+            | (TerminalLifecycle::Launching, TerminalLifecycle::Exited)
+            | (TerminalLifecycle::Launching, TerminalLifecycle::Tombstoned)
+            | (TerminalLifecycle::Adopting, TerminalLifecycle::Adopting)
+            | (TerminalLifecycle::Adopting, TerminalLifecycle::Running)
+            | (TerminalLifecycle::Adopting, TerminalLifecycle::Exited)
+            | (TerminalLifecycle::Adopting, TerminalLifecycle::Tombstoned)
+            | (TerminalLifecycle::Running, TerminalLifecycle::Running)
+            | (TerminalLifecycle::Running, TerminalLifecycle::Exited)
+            | (TerminalLifecycle::Running, TerminalLifecycle::Tombstoned)
+            | (TerminalLifecycle::Exited, TerminalLifecycle::Exited)
+            | (TerminalLifecycle::Exited, TerminalLifecycle::Launching)
+            | (TerminalLifecycle::Exited, TerminalLifecycle::Tombstoned)
+    );
+    if !allowed {
+        anyhow::bail!(
+            "invalid terminal transition {:?} -> {:?}",
+            existing.lifecycle,
+            desired.lifecycle
+        );
+    }
+    if existing.lifecycle == TerminalLifecycle::Running
+        && desired.lifecycle == TerminalLifecycle::Running
+        && existing.incarnation != desired.incarnation
+    {
+        anyhow::bail!("running terminal incarnation cannot change without an exit transition");
+    }
+    if existing.lifecycle != TerminalLifecycle::Exited
+        && existing.launch_spec != desired.launch_spec
+    {
+        anyhow::bail!("terminal launch spec cannot change during a live incarnation");
+    }
+    Ok(())
+}
+
+fn require_live_workspace(connection: &Connection, workspace_key: &str) -> anyhow::Result<()> {
+    let live = connection
+        .query_row(
+            "SELECT 1 FROM workspaces WHERE workspace_key = ?1 AND tombstoned = 0",
+            [workspace_key],
+            |_| Ok(()),
+        )
+        .optional()?;
+    if live.is_none() {
+        anyhow::bail!("terminal workspace is missing or closed: {workspace_key}");
+    }
+    Ok(())
+}
+
+type StoredTerminal = (String, String, Option<String>, String, String, Option<String>);
+
+fn terminal_from_stored(stored: StoredTerminal) -> anyhow::Result<RegistryTerminal> {
+    let (terminal_id, workspace_key, incarnation, lifecycle, launch_spec, exit) = stored;
+    Ok(RegistryTerminal {
+        terminal_id,
+        workspace_key,
+        incarnation,
+        lifecycle: TerminalLifecycle::parse(&lifecycle)?,
+        launch_spec: serde_json::from_str(&launch_spec)?,
+        exit: exit.map(|value| serde_json::from_str(&value)).transpose()?,
+    })
+}
+
+fn read_terminal(
+    connection: &Connection,
+    terminal_id: &str,
+) -> anyhow::Result<Option<RegistryTerminal>> {
+    let stored = connection
+        .query_row(
+            "SELECT terminal_id, workspace_key, incarnation, lifecycle,
+                    launch_spec_json, exit_json
+             FROM terminal_placements WHERE terminal_id = ?1",
+            [terminal_id],
+            |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?))
+            },
+        )
+        .optional()?;
+    stored.map(terminal_from_stored).transpose()
+}
+
+fn terminal_replay(
+    connection: &Connection,
+    mutation: &WorkspaceMutation,
+    fingerprint: &str,
+) -> anyhow::Result<Option<TerminalRegistryCommit>> {
+    let stored = connection
+        .query_row(
+            "SELECT fingerprint, result_json, committed_revision
+             FROM terminal_mutations WHERE origin = ?1 AND mutation_id = ?2",
+            params![mutation.origin, mutation.id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?)),
+        )
+        .optional()?;
+    let Some((stored_fingerprint, stored_result, revision)) = stored else {
+        return Ok(None);
+    };
+    if stored_fingerprint != fingerprint {
+        anyhow::bail!(
+            "terminal mutation {} from {} was retried with a different payload",
+            mutation.id,
+            mutation.origin
+        );
+    }
+    Ok(Some(TerminalRegistryCommit {
+        revision: u64::try_from(revision).context("stored terminal revision is negative")?,
+        result: serde_json::from_str(&stored_result)?,
+        replayed: true,
+    }))
 }
 
 fn validate_identifier(label: &str, value: &str) -> anyhow::Result<()> {
@@ -721,6 +1427,21 @@ fn transaction_revision(transaction: &Transaction<'_>) -> anyhow::Result<u64> {
         transaction
             .query_row("SELECT value FROM meta WHERE key = 'revision'", [], |row| row.get(0))?;
     value.parse().context("workspace registry revision is invalid")
+}
+
+fn current_terminal_revision(connection: &Connection) -> anyhow::Result<u64> {
+    required_meta(connection, "terminal_revision")?
+        .parse()
+        .context("terminal registry revision is invalid")
+}
+
+fn transaction_terminal_revision(transaction: &Transaction<'_>) -> anyhow::Result<u64> {
+    let value: String = transaction.query_row(
+        "SELECT value FROM meta WHERE key = 'terminal_revision'",
+        [],
+        |row| row.get(0),
+    )?;
+    value.parse().context("terminal registry revision is invalid")
 }
 
 fn session_storage_component(session: &str) -> String {
@@ -802,6 +1523,32 @@ mod tests {
 
     fn workspace(id: u64, key: &str, name: &str) -> RegistryWorkspace {
         RegistryWorkspace { id, key: key.into(), name: name.into(), group_key: "default".into() }
+    }
+
+    fn seed_workspace(registry: &mut WorkspaceRegistry, key: &str) {
+        registry
+            .commit(
+                &WorkspaceMutation::new(format!("create-{key}"), "test").unwrap(),
+                &json!({"op":"create","key":key}),
+                None,
+                Some(registry.snapshot().unwrap().revision),
+                "workspace-added",
+                key,
+                &[workspace(1, key, "Workspace")],
+                &json!({"key":key}),
+            )
+            .unwrap();
+    }
+
+    fn terminal(id: &str, workspace_key: &str) -> RegistryTerminal {
+        RegistryTerminal {
+            terminal_id: id.into(),
+            workspace_key: workspace_key.into(),
+            incarnation: None,
+            lifecycle: TerminalLifecycle::Launching,
+            launch_spec: json!({"command":["/bin/zsh"],"cwd":"/tmp","rows":24,"cols":80}),
+            exit: None,
+        }
     }
 
     #[test]
@@ -1005,6 +1752,213 @@ mod tests {
             .unwrap();
         assert_eq!(recovered.projection_revision, 1);
         assert_eq!(recovered.projection["columns"][0]["workspace"], "one");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn terminal_lifecycle_is_exactly_once_and_has_an_independent_revision() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        seed_workspace(&mut registry, "one");
+        assert_eq!(registry.snapshot().unwrap().revision, 1);
+        assert_eq!(registry.terminal_snapshot().unwrap().revision, 0);
+
+        let terminal = terminal("terminal-1", "one");
+        let reserve = WorkspaceMutation::new("reserve-1", "browser").unwrap();
+        let fingerprint = json!({"op":"reserve-terminal","terminal_id":"terminal-1"});
+        let result = json!({"terminal_id":"terminal-1","state":"launching"});
+        let first = registry
+            .commit_terminal(
+                &reserve,
+                &fingerprint,
+                None,
+                Some(0),
+                "terminal-added",
+                &terminal,
+                &result,
+            )
+            .unwrap();
+        assert_eq!(first.revision, 1);
+        assert!(!first.replayed);
+        let retry = registry
+            .commit_terminal(
+                &reserve,
+                &fingerprint,
+                None,
+                Some(0),
+                "terminal-added",
+                &terminal,
+                &result,
+            )
+            .unwrap();
+        assert_eq!(retry.revision, 1);
+        assert!(retry.replayed);
+
+        let mut adopting = terminal.clone();
+        adopting.lifecycle = TerminalLifecycle::Adopting;
+        adopting.incarnation = Some("incarnation-1".into());
+        registry
+            .commit_terminal(
+                &WorkspaceMutation::new("adopt-1", "daemon").unwrap(),
+                &json!({"op":"adopt-terminal","terminal_id":"terminal-1"}),
+                None,
+                Some(1),
+                "terminal-adopting",
+                &adopting,
+                &json!({"terminal_id":"terminal-1","state":"adopting"}),
+            )
+            .unwrap();
+        let mut running = adopting;
+        running.lifecycle = TerminalLifecycle::Running;
+        registry
+            .commit_terminal(
+                &WorkspaceMutation::new("ready-1", "daemon").unwrap(),
+                &json!({"op":"terminal-ready","terminal_id":"terminal-1"}),
+                None,
+                Some(2),
+                "terminal-ready",
+                &running,
+                &json!({"terminal_id":"terminal-1","state":"running"}),
+            )
+            .unwrap();
+
+        let terminals = registry.terminal_snapshot().unwrap();
+        assert_eq!(terminals.revision, 3);
+        assert_eq!(terminals.terminals, vec![running]);
+        assert_eq!(registry.snapshot().unwrap().revision, 1);
+        assert_eq!(registry.terminal_events_after(0).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn terminal_close_tombstones_before_kill_and_retries_safely() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        seed_workspace(&mut registry, "one");
+        let terminal = terminal("terminal-1", "one");
+        registry
+            .commit_terminal(
+                &WorkspaceMutation::new("reserve-1", "browser").unwrap(),
+                &json!({"op":"reserve-terminal","terminal_id":"terminal-1"}),
+                None,
+                Some(0),
+                "terminal-added",
+                &terminal,
+                &json!({"terminal_id":"terminal-1"}),
+            )
+            .unwrap();
+
+        let close = WorkspaceMutation::new("close-1", "browser").unwrap();
+        let first = registry.close_terminal(&close, None, Some(1), "terminal-1", None).unwrap();
+        assert_eq!(first.revision, 2);
+        assert_eq!(first.result["already_closed"], false);
+        assert_eq!(
+            registry.terminal_record("terminal-1").unwrap().unwrap().lifecycle,
+            TerminalLifecycle::Tombstoned
+        );
+        assert!(registry.terminal_snapshot().unwrap().terminals.is_empty());
+
+        let lost_reply_retry =
+            registry.close_terminal(&close, None, Some(1), "terminal-1", None).unwrap();
+        assert!(lost_reply_retry.replayed);
+        assert_eq!(lost_reply_retry.revision, 2);
+
+        let second_close = registry
+            .close_terminal(
+                &WorkspaceMutation::new("close-2", "tui").unwrap(),
+                None,
+                Some(2),
+                "terminal-1",
+                None,
+            )
+            .unwrap();
+        assert_eq!(second_close.revision, 2);
+        assert_eq!(second_close.result["already_closed"], true);
+        assert_eq!(registry.terminal_events_after(0).unwrap().len(), 2);
+
+        assert!(
+            registry
+                .commit_terminal(
+                    &WorkspaceMutation::new("reuse", "browser").unwrap(),
+                    &json!({"op":"reserve-terminal","terminal_id":"terminal-1"}),
+                    None,
+                    Some(2),
+                    "terminal-added",
+                    &terminal,
+                    &json!({"terminal_id":"terminal-1"}),
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("tombstoned terminal id cannot be reused")
+        );
+    }
+
+    #[test]
+    fn closing_workspace_atomically_tombstones_all_child_terminals() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        seed_workspace(&mut registry, "one");
+        for index in 1..=2 {
+            let id = format!("terminal-{index}");
+            registry
+                .commit_terminal(
+                    &WorkspaceMutation::new(format!("reserve-{index}"), "browser").unwrap(),
+                    &json!({"op":"reserve-terminal","terminal_id":id}),
+                    None,
+                    Some(index - 1),
+                    "terminal-added",
+                    &terminal(&id, "one"),
+                    &json!({"terminal_id":id}),
+                )
+                .unwrap();
+        }
+        registry
+            .commit(
+                &WorkspaceMutation::new("close-workspace", "browser").unwrap(),
+                &json!({"op":"close-workspace","workspace_key":"one"}),
+                None,
+                Some(1),
+                "workspace-closed",
+                "one",
+                &[],
+                &json!({"workspace_key":"one"}),
+            )
+            .unwrap();
+
+        assert!(registry.snapshot().unwrap().workspaces.is_empty());
+        let terminals = registry.terminal_snapshot().unwrap();
+        assert_eq!(terminals.revision, 4);
+        assert!(terminals.terminals.is_empty());
+        for index in 1..=2 {
+            assert_eq!(
+                registry.terminal_record(&format!("terminal-{index}")).unwrap().unwrap().lifecycle,
+                TerminalLifecycle::Tombstoned
+            );
+        }
+        let events = registry.terminal_events_after(2).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| event.result["reason"] == "workspace-closed"));
+    }
+
+    #[test]
+    fn schema_one_migrates_transactionally_to_terminal_registry() {
+        let root = temp_root("schema-one");
+        let session_dir = root.join(session_storage_component("session"));
+        {
+            let registry = WorkspaceRegistry::open(&root, "session").unwrap();
+            drop(registry);
+            let connection =
+                Connection::open(session_dir.join("workspace-registry.sqlite3")).unwrap();
+            connection
+                .execute_batch(
+                    "DROP TABLE terminal_events;
+                     DROP TABLE terminal_mutations;
+                     DROP TABLE terminal_placements;
+                     DELETE FROM meta WHERE key = 'terminal_revision';
+                     UPDATE meta SET value = '1' WHERE key = 'schema_version';",
+                )
+                .unwrap();
+        }
+        let migrated = WorkspaceRegistry::open(&root, "session").unwrap();
+        assert_eq!(migrated.terminal_snapshot().unwrap().revision, 0);
+        assert!(migrated.terminal_snapshot().unwrap().terminals.is_empty());
+        assert_eq!(required_meta(&migrated.connection, "schema_version").unwrap(), "2");
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -33,6 +33,7 @@ pub struct RegistrySnapshot {
     pub registry_id: String,
     pub generation: String,
     pub revision: u64,
+    pub next_numeric_id: u64,
     pub workspaces: Vec<RegistryWorkspace>,
 }
 
@@ -236,6 +237,15 @@ impl WorkspaceRegistry {
 
     pub fn snapshot(&self) -> anyhow::Result<RegistrySnapshot> {
         let revision = current_revision(&self.connection)?;
+        let max_numeric_id = self.connection.query_row(
+            "SELECT COALESCE(MAX(numeric_id), 0) FROM workspaces",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        let next_numeric_id = u64::try_from(max_numeric_id)
+            .context("stored workspace id is negative")?
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("workspace id space exhausted"))?;
         let mut statement = self.connection.prepare(
             "SELECT numeric_id, workspace_key, name, group_key
              FROM workspaces WHERE tombstoned = 0 ORDER BY position ASC",
@@ -259,6 +269,7 @@ impl WorkspaceRegistry {
             registry_id: self.registry_id.clone(),
             generation: self.generation.clone(),
             revision,
+            next_numeric_id,
             workspaces,
         })
     }
@@ -315,6 +326,7 @@ impl WorkspaceRegistry {
     /// Duplicate lookup intentionally precedes revision validation: a retry of
     /// a committed command must return its original result even after newer
     /// commands have advanced the registry.
+    #[allow(clippy::too_many_arguments)]
     pub fn commit(
         &mut self,
         mutation: &WorkspaceMutation,
@@ -659,7 +671,7 @@ fn canonical_json(value: &Value) -> anyhow::Result<String> {
             Value::Object(map) => {
                 output.push('{');
                 let mut entries = map.iter().collect::<Vec<_>>();
-                entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+                entries.sort_by_key(|(key, _)| *key);
                 for (index, (key, value)) in entries.into_iter().enumerate() {
                     if index != 0 {
                         output.push(',');
@@ -762,7 +774,8 @@ struct SessionLease {
 
 impl SessionLease {
     fn acquire(path: &Path) -> anyhow::Result<Self> {
-        let file = OpenOptions::new().create(true).read(true).write(true).open(path)?;
+        let file =
+            OpenOptions::new().create(true).truncate(false).read(true).write(true).open(path)?;
         platform::restrict_file(path)?;
         FileExt::try_lock(&file).with_context(|| {
             format!("workspace session is already owned by another daemon: {}", path.display())
@@ -908,6 +921,7 @@ mod tests {
                 &json!({"workspace":1,"key":"stable"}),
             )
             .unwrap();
+        assert_eq!(registry.snapshot().unwrap().next_numeric_id, 2);
         registry
             .commit(
                 &WorkspaceMutation::new("close", "browser").unwrap(),
@@ -920,6 +934,7 @@ mod tests {
                 &json!({"workspace":1,"key":"stable"}),
             )
             .unwrap();
+        assert_eq!(registry.snapshot().unwrap().next_numeric_id, 2);
         let error = registry
             .commit(
                 &WorkspaceMutation::new("recreate", "browser").unwrap(),

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -372,7 +372,7 @@ impl WorkspaceRegistry {
     /// Includes tombstones and is intended for reconciliation and idempotent
     /// close handling, not frontend materialization.
     pub fn terminal_record(&self, terminal_id: &str) -> anyhow::Result<Option<RegistryTerminal>> {
-        validate_identifier("terminal id", terminal_id)?;
+        validate_terminal_identity("terminal id", terminal_id)?;
         read_terminal(&self.connection, terminal_id)
     }
 
@@ -509,9 +509,9 @@ impl WorkspaceRegistry {
     ) -> anyhow::Result<TerminalRegistryCommit> {
         validate_identifier("mutation id", &mutation.id)?;
         validate_identifier("mutation origin", &mutation.origin)?;
-        validate_identifier("terminal id", terminal_id)?;
+        validate_terminal_identity("terminal id", terminal_id)?;
         if let Some(incarnation) = expected_incarnation {
-            validate_identifier("terminal incarnation", incarnation)?;
+            validate_terminal_identity("terminal incarnation", incarnation)?;
         }
         let fingerprint_value = serde_json::json!({
             "op": "close-terminal",
@@ -545,10 +545,7 @@ impl WorkspaceRegistry {
         if let Some(expected) = expected_incarnation
             && terminal.incarnation.as_deref() != Some(expected)
         {
-            anyhow::bail!(
-                "terminal incarnation conflict for {terminal_id}: expected {expected}, current {:?}",
-                terminal.incarnation
-            );
+            anyhow::bail!("terminal_incarnation_mismatch");
         }
 
         if terminal.lifecycle == TerminalLifecycle::Tombstoned {
@@ -1208,10 +1205,10 @@ fn validate_registry(workspaces: &[RegistryWorkspace]) -> anyhow::Result<()> {
 }
 
 fn validate_terminal(terminal: &RegistryTerminal) -> anyhow::Result<()> {
-    validate_identifier("terminal id", &terminal.terminal_id)?;
+    validate_terminal_identity("terminal id", &terminal.terminal_id)?;
     validate_identifier("workspace key", &terminal.workspace_key)?;
     if let Some(incarnation) = &terminal.incarnation {
-        validate_identifier("terminal incarnation", incarnation)?;
+        validate_terminal_identity("terminal incarnation", incarnation)?;
     }
     match terminal.lifecycle {
         TerminalLifecycle::Launching if terminal.incarnation.is_some() => {
@@ -1226,6 +1223,17 @@ fn validate_terminal(terminal: &RegistryTerminal) -> anyhow::Result<()> {
     }
     if terminal.lifecycle != TerminalLifecycle::Exited && terminal.exit.is_some() {
         anyhow::bail!("only an exited terminal can carry exit metadata");
+    }
+    Ok(())
+}
+
+fn validate_terminal_identity(label: &str, value: &str) -> anyhow::Result<()> {
+    if value.len() != 32
+        || !value.bytes().all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        || value.as_bytes()[12] != b'4'
+        || !matches!(value.as_bytes()[16], b'8'..=b'b')
+    {
+        anyhow::bail!("{label} must be a 32-character lowercase UUIDv4 hex value");
     }
     Ok(())
 }
@@ -1254,6 +1262,7 @@ fn validate_terminal_transition(
             | (TerminalLifecycle::Adopting, TerminalLifecycle::Running)
             | (TerminalLifecycle::Adopting, TerminalLifecycle::Exited)
             | (TerminalLifecycle::Adopting, TerminalLifecycle::Tombstoned)
+            | (TerminalLifecycle::Running, TerminalLifecycle::Adopting)
             | (TerminalLifecycle::Running, TerminalLifecycle::Running)
             | (TerminalLifecycle::Running, TerminalLifecycle::Exited)
             | (TerminalLifecycle::Running, TerminalLifecycle::Tombstoned)
@@ -1268,11 +1277,11 @@ fn validate_terminal_transition(
             desired.lifecycle
         );
     }
-    if existing.lifecycle == TerminalLifecycle::Running
-        && desired.lifecycle == TerminalLifecycle::Running
+    if matches!(existing.lifecycle, TerminalLifecycle::Adopting | TerminalLifecycle::Running)
+        && matches!(desired.lifecycle, TerminalLifecycle::Adopting | TerminalLifecycle::Running)
         && existing.incarnation != desired.incarnation
     {
-        anyhow::bail!("running terminal incarnation cannot change without an exit transition");
+        anyhow::bail!("live terminal incarnation cannot change without an exit transition");
     }
     if existing.lifecycle != TerminalLifecycle::Exited
         && existing.launch_spec != desired.launch_spec
@@ -1515,6 +1524,10 @@ impl Drop for SessionLease {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TERMINAL_ONE: &str = "00000000000040008000000000000001";
+    const TERMINAL_TWO: &str = "00000000000040008000000000000002";
+    const INCARNATION_ONE: &str = "10000000000040008000000000000001";
     use serde_json::json;
 
     fn temp_root(label: &str) -> PathBuf {
@@ -1762,10 +1775,10 @@ mod tests {
         assert_eq!(registry.snapshot().unwrap().revision, 1);
         assert_eq!(registry.terminal_snapshot().unwrap().revision, 0);
 
-        let terminal = terminal("terminal-1", "one");
+        let terminal = terminal(TERMINAL_ONE, "one");
         let reserve = WorkspaceMutation::new("reserve-1", "browser").unwrap();
-        let fingerprint = json!({"op":"reserve-terminal","terminal_id":"terminal-1"});
-        let result = json!({"terminal_id":"terminal-1","state":"launching"});
+        let fingerprint = json!({"op":"reserve-terminal","terminal_id":TERMINAL_ONE});
+        let result = json!({"terminal_id":TERMINAL_ONE,"state":"launching"});
         let first = registry
             .commit_terminal(
                 &reserve,
@@ -1795,16 +1808,16 @@ mod tests {
 
         let mut adopting = terminal.clone();
         adopting.lifecycle = TerminalLifecycle::Adopting;
-        adopting.incarnation = Some("incarnation-1".into());
+        adopting.incarnation = Some(INCARNATION_ONE.into());
         registry
             .commit_terminal(
                 &WorkspaceMutation::new("adopt-1", "daemon").unwrap(),
-                &json!({"op":"adopt-terminal","terminal_id":"terminal-1"}),
+                &json!({"op":"adopt-terminal","terminal_id":TERMINAL_ONE}),
                 None,
                 Some(1),
                 "terminal-adopting",
                 &adopting,
-                &json!({"terminal_id":"terminal-1","state":"adopting"}),
+                &json!({"terminal_id":TERMINAL_ONE,"state":"adopting"}),
             )
             .unwrap();
         let mut running = adopting;
@@ -1812,12 +1825,12 @@ mod tests {
         registry
             .commit_terminal(
                 &WorkspaceMutation::new("ready-1", "daemon").unwrap(),
-                &json!({"op":"terminal-ready","terminal_id":"terminal-1"}),
+                &json!({"op":"terminal-ready","terminal_id":TERMINAL_ONE}),
                 None,
                 Some(2),
                 "terminal-ready",
                 &running,
-                &json!({"terminal_id":"terminal-1","state":"running"}),
+                &json!({"terminal_id":TERMINAL_ONE,"state":"running"}),
             )
             .unwrap();
 
@@ -1832,31 +1845,31 @@ mod tests {
     fn terminal_close_tombstones_before_kill_and_retries_safely() {
         let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
         seed_workspace(&mut registry, "one");
-        let terminal = terminal("terminal-1", "one");
+        let terminal = terminal(TERMINAL_ONE, "one");
         registry
             .commit_terminal(
                 &WorkspaceMutation::new("reserve-1", "browser").unwrap(),
-                &json!({"op":"reserve-terminal","terminal_id":"terminal-1"}),
+                &json!({"op":"reserve-terminal","terminal_id":TERMINAL_ONE}),
                 None,
                 Some(0),
                 "terminal-added",
                 &terminal,
-                &json!({"terminal_id":"terminal-1"}),
+                &json!({"terminal_id":TERMINAL_ONE}),
             )
             .unwrap();
 
         let close = WorkspaceMutation::new("close-1", "browser").unwrap();
-        let first = registry.close_terminal(&close, None, Some(1), "terminal-1", None).unwrap();
+        let first = registry.close_terminal(&close, None, Some(1), TERMINAL_ONE, None).unwrap();
         assert_eq!(first.revision, 2);
         assert_eq!(first.result["already_closed"], false);
         assert_eq!(
-            registry.terminal_record("terminal-1").unwrap().unwrap().lifecycle,
+            registry.terminal_record(TERMINAL_ONE).unwrap().unwrap().lifecycle,
             TerminalLifecycle::Tombstoned
         );
         assert!(registry.terminal_snapshot().unwrap().terminals.is_empty());
 
         let lost_reply_retry =
-            registry.close_terminal(&close, None, Some(1), "terminal-1", None).unwrap();
+            registry.close_terminal(&close, None, Some(1), TERMINAL_ONE, None).unwrap();
         assert!(lost_reply_retry.replayed);
         assert_eq!(lost_reply_retry.revision, 2);
 
@@ -1865,7 +1878,7 @@ mod tests {
                 &WorkspaceMutation::new("close-2", "tui").unwrap(),
                 None,
                 Some(2),
-                "terminal-1",
+                TERMINAL_ONE,
                 None,
             )
             .unwrap();
@@ -1877,12 +1890,12 @@ mod tests {
             registry
                 .commit_terminal(
                     &WorkspaceMutation::new("reuse", "browser").unwrap(),
-                    &json!({"op":"reserve-terminal","terminal_id":"terminal-1"}),
+                    &json!({"op":"reserve-terminal","terminal_id":TERMINAL_ONE}),
                     None,
                     Some(2),
                     "terminal-added",
                     &terminal,
-                    &json!({"terminal_id":"terminal-1"}),
+                    &json!({"terminal_id":TERMINAL_ONE}),
                 )
                 .unwrap_err()
                 .to_string()
@@ -1894,16 +1907,16 @@ mod tests {
     fn closing_workspace_atomically_tombstones_all_child_terminals() {
         let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
         seed_workspace(&mut registry, "one");
-        for index in 1..=2 {
-            let id = format!("terminal-{index}");
+        for (index, id) in [TERMINAL_ONE, TERMINAL_TWO].into_iter().enumerate() {
+            let revision = u64::try_from(index).unwrap();
             registry
                 .commit_terminal(
-                    &WorkspaceMutation::new(format!("reserve-{index}"), "browser").unwrap(),
+                    &WorkspaceMutation::new(format!("reserve-{}", index + 1), "browser").unwrap(),
                     &json!({"op":"reserve-terminal","terminal_id":id}),
                     None,
-                    Some(index - 1),
+                    Some(revision),
                     "terminal-added",
-                    &terminal(&id, "one"),
+                    &terminal(id, "one"),
                     &json!({"terminal_id":id}),
                 )
                 .unwrap();
@@ -1925,15 +1938,47 @@ mod tests {
         let terminals = registry.terminal_snapshot().unwrap();
         assert_eq!(terminals.revision, 4);
         assert!(terminals.terminals.is_empty());
-        for index in 1..=2 {
+        for id in [TERMINAL_ONE, TERMINAL_TWO] {
             assert_eq!(
-                registry.terminal_record(&format!("terminal-{index}")).unwrap().unwrap().lifecycle,
+                registry.terminal_record(id).unwrap().unwrap().lifecycle,
                 TerminalLifecycle::Tombstoned
             );
         }
         let events = registry.terminal_events_after(2).unwrap();
         assert_eq!(events.len(), 2);
         assert!(events.iter().all(|event| event.result["reason"] == "workspace-closed"));
+    }
+
+    #[test]
+    fn terminal_reserve_after_workspace_close_fails_referentially() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        seed_workspace(&mut registry, "one");
+        registry
+            .commit(
+                &WorkspaceMutation::new("close", "browser").unwrap(),
+                &json!({"op":"close-workspace"}),
+                None,
+                Some(1),
+                "workspace-closed",
+                "one",
+                &[],
+                &json!({"key":"one"}),
+            )
+            .unwrap();
+        let error = registry
+            .commit_terminal(
+                &WorkspaceMutation::new("late-reserve", "browser").unwrap(),
+                &json!({"op":"create-terminal","terminal_id":TERMINAL_ONE}),
+                None,
+                Some(0),
+                "terminal-reserved",
+                &terminal(TERMINAL_ONE, "one"),
+                &json!({"terminal_id":TERMINAL_ONE}),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("workspace is missing or closed"));
+        assert!(registry.terminal_record(TERMINAL_ONE).unwrap().is_none());
+        assert_eq!(registry.terminal_snapshot().unwrap().revision, 0);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -731,6 +731,21 @@ impl WorkspaceRegistry {
         Ok(TerminalBatchClose { revision, closed })
     }
 
+    #[cfg(test)]
+    pub(crate) fn set_terminal_close_failure(&self, enabled: bool) -> anyhow::Result<()> {
+        if enabled {
+            self.connection.execute_batch(
+                "CREATE TEMP TRIGGER cmux_test_fail_terminal_close
+                 BEFORE UPDATE OF lifecycle ON terminal_placements
+                 BEGIN SELECT RAISE(ABORT, 'forced terminal close failure'); END;",
+            )?;
+        } else {
+            self.connection
+                .execute_batch("DROP TRIGGER IF EXISTS cmux_test_fail_terminal_close")?;
+        }
+        Ok(())
+    }
+
     pub fn terminal_events_after(
         &self,
         revision: u64,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -132,6 +132,12 @@ pub struct TerminalRegistryCommit {
     pub replayed: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalBatchClose {
+    pub revision: u64,
+    pub closed: usize,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TerminalRegistryEvent {
     pub revision: u64,
@@ -435,6 +441,24 @@ impl WorkspaceRegistry {
             );
         }
         let existing = read_terminal(&tx, &terminal.terminal_id)?;
+        if let Some(existing) = existing.as_ref()
+            && existing.lifecycle == TerminalLifecycle::Exited
+            && terminal.lifecycle == TerminalLifecycle::Exited
+        {
+            if existing.incarnation != terminal.incarnation {
+                anyhow::bail!("terminal_incarnation_mismatch");
+            }
+            // Process exit is a latch: the first observed reason/status is
+            // authoritative. Reader EOF, child wait, and reconnect failure can
+            // race, but later observations neither rewrite metadata nor mint a
+            // new durable revision/event.
+            tx.commit()?;
+            return Ok(TerminalRegistryCommit {
+                revision: current_revision,
+                result: result.clone(),
+                replayed: true,
+            });
+        }
         validate_terminal_transition(existing.as_ref(), terminal)?;
         if terminal.lifecycle != TerminalLifecycle::Tombstoned {
             require_live_workspace(&tx, &terminal.workspace_key)?;
@@ -620,6 +644,91 @@ impl WorkspaceRegistry {
         )?;
         tx.commit()?;
         Ok(TerminalRegistryCommit { revision, result, replayed: false })
+    }
+
+    /// Tombstone every hosted tab in one pane/screen as one SQLite unit. All
+    /// identities and incarnations are validated before the first update, and
+    /// any later SQLite failure rolls the entire set back. Hosts are signaled
+    /// only after this method commits successfully.
+    pub fn close_terminals_atomically(
+        &mut self,
+        mutation: &WorkspaceMutation,
+        terminals: &[(String, Option<String>)],
+    ) -> anyhow::Result<TerminalBatchClose> {
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        let mut unique = std::collections::HashSet::with_capacity(terminals.len());
+        for (terminal_id, incarnation) in terminals {
+            validate_terminal_identity("terminal id", terminal_id)?;
+            if let Some(incarnation) = incarnation {
+                validate_terminal_identity("terminal incarnation", incarnation)?;
+            }
+            if !unique.insert(terminal_id.as_str()) {
+                anyhow::bail!("duplicate terminal in batch close: {terminal_id}");
+            }
+        }
+
+        let tx = self.connection.transaction()?;
+        let mut rows = Vec::with_capacity(terminals.len());
+        for (terminal_id, expected_incarnation) in terminals {
+            let terminal = read_terminal(&tx, terminal_id)?.ok_or_else(|| {
+                anyhow::anyhow!("unknown terminal {terminal_id}; it may not have been adopted yet")
+            })?;
+            if let Some(expected) = expected_incarnation
+                && terminal.incarnation.as_deref() != Some(expected)
+            {
+                anyhow::bail!("terminal_incarnation_mismatch");
+            }
+            rows.push(terminal);
+        }
+
+        let mut revision = transaction_terminal_revision(&tx)?;
+        let mut closed = 0usize;
+        for terminal in rows {
+            if terminal.lifecycle == TerminalLifecycle::Tombstoned {
+                continue;
+            }
+            revision = revision
+                .checked_add(1)
+                .ok_or_else(|| anyhow::anyhow!("terminal revision exhausted"))?;
+            let sqlite_revision = i64::try_from(revision)
+                .context("terminal revision exceeds SQLite integer range")?;
+            let result_json = canonical_json(&serde_json::json!({
+                "terminal_id": terminal.terminal_id,
+                "workspace_key": terminal.workspace_key,
+                "incarnation": terminal.incarnation,
+                "closed": true,
+                "reason": "topology-closed",
+            }))?;
+            tx.execute(
+                "UPDATE terminal_placements
+                 SET lifecycle = 'tombstoned', updated_revision = ?1, deleted_revision = ?1
+                 WHERE terminal_id = ?2 AND lifecycle != 'tombstoned'",
+                params![sqlite_revision, terminal.terminal_id],
+            )?;
+            tx.execute(
+                "INSERT INTO terminal_events(
+                   revision, kind, terminal_id, workspace_key, origin, mutation_id, result_json
+                 ) VALUES(?1, 'terminal-closed', ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    sqlite_revision,
+                    terminal.terminal_id,
+                    terminal.workspace_key,
+                    mutation.origin,
+                    mutation.id,
+                    result_json,
+                ],
+            )?;
+            closed += 1;
+        }
+        if closed != 0 {
+            tx.execute(
+                "UPDATE meta SET value = ?1 WHERE key = 'terminal_revision'",
+                [revision.to_string()],
+            )?;
+        }
+        tx.commit()?;
+        Ok(TerminalBatchClose { revision, closed })
     }
 
     pub fn terminal_events_after(
@@ -1267,7 +1376,6 @@ fn validate_terminal_transition(
             | (TerminalLifecycle::Running, TerminalLifecycle::Exited)
             | (TerminalLifecycle::Running, TerminalLifecycle::Tombstoned)
             | (TerminalLifecycle::Exited, TerminalLifecycle::Exited)
-            | (TerminalLifecycle::Exited, TerminalLifecycle::Launching)
             | (TerminalLifecycle::Exited, TerminalLifecycle::Tombstoned)
     );
     if !allowed {
@@ -1839,6 +1947,134 @@ mod tests {
         assert_eq!(terminals.terminals, vec![running]);
         assert_eq!(registry.snapshot().unwrap().revision, 1);
         assert_eq!(registry.terminal_events_after(0).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn first_exit_metadata_wins_and_exited_ids_cannot_be_relaunched() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        seed_workspace(&mut registry, "one");
+        let launching = terminal(TERMINAL_ONE, "one");
+        registry
+            .commit_terminal(
+                &WorkspaceMutation::new("reserve", "browser").unwrap(),
+                &json!({"op":"reserve-terminal","terminal_id":TERMINAL_ONE}),
+                None,
+                Some(0),
+                "terminal-reserved",
+                &launching,
+                &json!({"terminal_id":TERMINAL_ONE}),
+            )
+            .unwrap();
+
+        let mut first_exit = launching.clone();
+        first_exit.lifecycle = TerminalLifecycle::Exited;
+        first_exit.exit = Some(json!({"reason":"first-observer","status":17}));
+        let first = registry
+            .commit_terminal(
+                &WorkspaceMutation::new("exit-one", "daemon").unwrap(),
+                &json!({"op":"terminal-exited","terminal_id":TERMINAL_ONE}),
+                None,
+                Some(1),
+                "terminal-exited",
+                &first_exit,
+                &json!({"terminal_id":TERMINAL_ONE}),
+            )
+            .unwrap();
+        assert_eq!(first.revision, 2);
+
+        let mut late_exit = first_exit.clone();
+        late_exit.exit = Some(json!({"reason":"late-observer","status":99}));
+        let duplicate = registry
+            .commit_terminal(
+                &WorkspaceMutation::new("exit-two", "daemon").unwrap(),
+                &json!({"op":"terminal-exited-again","terminal_id":TERMINAL_ONE}),
+                None,
+                Some(2),
+                "terminal-exited",
+                &late_exit,
+                &json!({"terminal_id":TERMINAL_ONE}),
+            )
+            .unwrap();
+        assert!(duplicate.replayed);
+        assert_eq!(duplicate.revision, 2);
+        assert_eq!(registry.terminal_record(TERMINAL_ONE).unwrap().unwrap().exit, first_exit.exit);
+        assert_eq!(registry.terminal_events_after(0).unwrap().len(), 2);
+
+        let error = registry
+            .commit_terminal(
+                &WorkspaceMutation::new("reuse-exited", "browser").unwrap(),
+                &json!({"op":"reserve-terminal","terminal_id":TERMINAL_ONE}),
+                None,
+                Some(2),
+                "terminal-reserved",
+                &launching,
+                &json!({"terminal_id":TERMINAL_ONE}),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("invalid terminal transition Exited -> Launching"));
+        assert_eq!(
+            registry.terminal_record(TERMINAL_ONE).unwrap().unwrap().lifecycle,
+            TerminalLifecycle::Exited
+        );
+    }
+
+    #[test]
+    fn batch_terminal_close_rolls_back_every_tab_on_mid_transaction_failure() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        seed_workspace(&mut registry, "one");
+        for (revision, terminal_id) in [(0, TERMINAL_ONE), (1, TERMINAL_TWO)] {
+            registry
+                .commit_terminal(
+                    &WorkspaceMutation::new(format!("reserve-{revision}"), "browser").unwrap(),
+                    &json!({"op":"reserve-terminal","terminal_id":terminal_id}),
+                    None,
+                    Some(revision),
+                    "terminal-reserved",
+                    &terminal(terminal_id, "one"),
+                    &json!({"terminal_id":terminal_id}),
+                )
+                .unwrap();
+        }
+        registry
+            .connection
+            .execute_batch(&format!(
+                "CREATE TEMP TRIGGER fail_second_terminal_close
+                 BEFORE UPDATE OF lifecycle ON terminal_placements
+                 WHEN NEW.terminal_id = '{TERMINAL_TWO}'
+                 BEGIN SELECT RAISE(ABORT, 'forced batch failure'); END;"
+            ))
+            .unwrap();
+        let requests = vec![(TERMINAL_ONE.to_string(), None), (TERMINAL_TWO.to_string(), None)];
+        let error = registry
+            .close_terminals_atomically(
+                &WorkspaceMutation::new("close-pane-failed", "tui").unwrap(),
+                &requests,
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("forced batch failure"));
+        assert_eq!(registry.terminal_snapshot().unwrap().revision, 2);
+        for terminal_id in [TERMINAL_ONE, TERMINAL_TWO] {
+            assert_eq!(
+                registry.terminal_record(terminal_id).unwrap().unwrap().lifecycle,
+                TerminalLifecycle::Launching
+            );
+        }
+        registry.connection.execute_batch("DROP TRIGGER fail_second_terminal_close").unwrap();
+
+        let closed = registry
+            .close_terminals_atomically(
+                &WorkspaceMutation::new("close-pane", "tui").unwrap(),
+                &requests,
+            )
+            .unwrap();
+        assert_eq!(closed, TerminalBatchClose { revision: 4, closed: 2 });
+        assert_eq!(registry.terminal_events_after(2).unwrap().len(), 2);
+        for terminal_id in [TERMINAL_ONE, TERMINAL_TWO] {
+            assert_eq!(
+                registry.terminal_record(terminal_id).unwrap().unwrap().lifecycle,
+                TerminalLifecycle::Tombstoned
+            );
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -1,0 +1,1026 @@
+//! Durable, single-writer workspace registry.
+//!
+//! The mux owns one of these behind its workspace-commit mutex. A registry
+//! transaction commits before the corresponding in-memory projection and
+//! event are published, so durable order, reply order, and event order are the
+//! same order. Runtime pane/surface ids deliberately never enter this store.
+
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use fs4::FileExt;
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::platform;
+
+const SCHEMA_VERSION: i64 = 1;
+const MAX_ID_LEN: usize = 128;
+const MAX_PROJECTION_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistryWorkspace {
+    pub id: u64,
+    pub key: String,
+    pub name: String,
+    pub group_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistrySnapshot {
+    pub registry_id: String,
+    pub generation: String,
+    pub revision: u64,
+    pub workspaces: Vec<RegistryWorkspace>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceMutation {
+    pub id: String,
+    pub origin: String,
+}
+
+impl WorkspaceMutation {
+    pub fn new(id: impl Into<String>, origin: impl Into<String>) -> anyhow::Result<Self> {
+        let mutation = Self { id: id.into(), origin: origin.into() };
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        Ok(mutation)
+    }
+
+    pub fn local(origin: &str) -> Self {
+        Self { id: new_uuid_v4(), origin: origin.to_string() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegistryCommit {
+    pub revision: u64,
+    pub result: Value,
+    pub replayed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegistryEvent {
+    pub revision: u64,
+    pub kind: String,
+    pub workspace_key: String,
+    pub origin: String,
+    pub mutation_id: String,
+    pub result: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FrontendProjection {
+    pub frontend: String,
+    pub scope: String,
+    pub subject_key: String,
+    pub schema_version: u32,
+    pub projection_revision: u64,
+    pub projection: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProjectionCommit {
+    pub projection: FrontendProjection,
+    pub replayed: bool,
+}
+
+/// The sole durable writer for one session. The owning `Mux` serializes all
+/// calls, and the OS lease prevents another daemon from opening the same
+/// session concurrently.
+pub struct WorkspaceRegistry {
+    connection: Connection,
+    registry_id: String,
+    generation: String,
+    session_name: String,
+    _lease: Option<SessionLease>,
+}
+
+impl std::fmt::Debug for WorkspaceRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkspaceRegistry")
+            .field("registry_id", &self.registry_id)
+            .field("generation", &self.generation)
+            .field("session_name", &self.session_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkspaceRegistry {
+    pub fn in_memory(session_name: &str) -> anyhow::Result<Self> {
+        let connection = Connection::open_in_memory()?;
+        Self::initialize(connection, session_name.to_string(), None)
+    }
+
+    pub fn open(root: &Path, session_name: &str) -> anyhow::Result<Self> {
+        let session_dir = root.join(session_storage_component(session_name));
+        fs::create_dir_all(&session_dir).with_context(|| {
+            format!("create workspace state directory {}", session_dir.display())
+        })?;
+        platform::restrict_directory(&session_dir)?;
+        let lease = SessionLease::acquire(&session_dir.join("writer.lock"))?;
+        let db_path = session_dir.join("workspace-registry.sqlite3");
+        let connection = Connection::open(&db_path)
+            .with_context(|| format!("open workspace registry {}", db_path.display()))?;
+        platform::restrict_file(&db_path)?;
+        Self::initialize(connection, session_name.to_string(), Some(lease))
+    }
+
+    fn initialize(
+        connection: Connection,
+        session_name: String,
+        lease: Option<SessionLease>,
+    ) -> anyhow::Result<Self> {
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.execute_batch(
+            "PRAGMA foreign_keys=ON;
+             PRAGMA journal_mode=WAL;
+             PRAGMA synchronous=FULL;
+             PRAGMA fullfsync=ON;
+             PRAGMA wal_autocheckpoint=1000;
+             CREATE TABLE IF NOT EXISTS meta (
+               key TEXT PRIMARY KEY NOT NULL,
+               value TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS workspaces (
+               workspace_key TEXT PRIMARY KEY NOT NULL,
+               numeric_id INTEGER UNIQUE NOT NULL,
+               name TEXT NOT NULL,
+               group_key TEXT NOT NULL,
+               position INTEGER,
+               tombstoned INTEGER NOT NULL DEFAULT 0 CHECK(tombstoned IN (0,1)),
+               created_revision INTEGER NOT NULL,
+               updated_revision INTEGER NOT NULL
+               ,deleted_revision INTEGER
+             );
+             CREATE UNIQUE INDEX IF NOT EXISTS live_workspace_position
+               ON workspaces(position) WHERE tombstoned = 0;
+             CREATE TABLE IF NOT EXISTS mutations (
+               origin TEXT NOT NULL,
+               mutation_id TEXT NOT NULL,
+               fingerprint TEXT NOT NULL,
+               result_json TEXT NOT NULL,
+               committed_revision INTEGER NOT NULL,
+               PRIMARY KEY(origin, mutation_id)
+             );
+             CREATE TABLE IF NOT EXISTS workspace_events (
+               revision INTEGER PRIMARY KEY NOT NULL,
+               kind TEXT NOT NULL,
+               workspace_key TEXT NOT NULL,
+               origin TEXT NOT NULL,
+               mutation_id TEXT NOT NULL,
+               result_json TEXT NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS frontend_projections (
+               frontend TEXT NOT NULL,
+               scope TEXT NOT NULL,
+               subject_key TEXT NOT NULL,
+               schema_version INTEGER NOT NULL,
+               projection_revision INTEGER NOT NULL,
+               payload TEXT NOT NULL,
+               PRIMARY KEY(frontend, scope, subject_key)
+             );
+             CREATE TABLE IF NOT EXISTS projection_mutations (
+               origin TEXT NOT NULL,
+               mutation_id TEXT NOT NULL,
+               fingerprint TEXT NOT NULL,
+               result_json TEXT NOT NULL,
+               PRIMARY KEY(origin, mutation_id)
+             );",
+        )?;
+
+        let stored_schema = meta_value(&connection, "schema_version")?;
+        match stored_schema {
+            Some(value) if value.parse::<i64>()? != SCHEMA_VERSION => {
+                anyhow::bail!(
+                    "unsupported workspace registry schema {value}; expected {SCHEMA_VERSION}"
+                );
+            }
+            Some(_) => {}
+            None => {
+                let tx = connection.unchecked_transaction()?;
+                tx.execute(
+                    "INSERT INTO meta(key, value) VALUES('schema_version', ?1)",
+                    [SCHEMA_VERSION.to_string()],
+                )?;
+                tx.execute("INSERT INTO meta(key, value) VALUES('revision', '0')", [])?;
+                tx.execute(
+                    "INSERT INTO meta(key, value) VALUES('session_name', ?1)",
+                    [&session_name],
+                )?;
+                tx.execute(
+                    "INSERT INTO meta(key, value) VALUES('registry_id', ?1)",
+                    [new_uuid_v4()],
+                )?;
+                tx.commit()?;
+            }
+        }
+        let stored_name = required_meta(&connection, "session_name")?;
+        if stored_name != session_name {
+            anyhow::bail!(
+                "workspace registry belongs to session {stored_name:?}, not {session_name:?}"
+            );
+        }
+        let registry_id = required_meta(&connection, "registry_id")?;
+        validate_identifier("registry id", &registry_id)?;
+        let quick_check: String =
+            connection.query_row("PRAGMA quick_check", [], |row| row.get(0))?;
+        if quick_check != "ok" {
+            anyhow::bail!("workspace registry integrity check failed: {quick_check}");
+        }
+        Ok(Self { connection, registry_id, generation: new_uuid_v4(), session_name, _lease: lease })
+    }
+
+    pub fn snapshot(&self) -> anyhow::Result<RegistrySnapshot> {
+        let revision = current_revision(&self.connection)?;
+        let mut statement = self.connection.prepare(
+            "SELECT numeric_id, workspace_key, name, group_key
+             FROM workspaces WHERE tombstoned = 0 ORDER BY position ASC",
+        )?;
+        let workspaces = statement
+            .query_map([], |row| {
+                let id: i64 = row.get(0)?;
+                Ok((id, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?
+            .map(|row| {
+                let (id, key, name, group_key): (i64, String, String, String) = row?;
+                Ok::<RegistryWorkspace, anyhow::Error>(RegistryWorkspace {
+                    id: u64::try_from(id).context("stored workspace id is negative")?,
+                    key,
+                    name,
+                    group_key,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(RegistrySnapshot {
+            registry_id: self.registry_id.clone(),
+            generation: self.generation.clone(),
+            revision,
+            workspaces,
+        })
+    }
+
+    pub fn registry_id(&self) -> &str {
+        &self.registry_id
+    }
+
+    pub fn generation(&self) -> &str {
+        &self.generation
+    }
+
+    /// Look up an already-committed mutation before resolving any live
+    /// workspace selector. This is what lets a lost-response retry of a
+    /// successful close return the original result after the workspace has
+    /// become a tombstone.
+    pub fn replay(
+        &self,
+        mutation: &WorkspaceMutation,
+        fingerprint: &Value,
+    ) -> anyhow::Result<Option<RegistryCommit>> {
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        let fingerprint = canonical_json(fingerprint)?;
+        let stored = self
+            .connection
+            .query_row(
+                "SELECT fingerprint, result_json, committed_revision
+                 FROM mutations WHERE origin = ?1 AND mutation_id = ?2",
+                params![mutation.origin, mutation.id],
+                |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+                },
+            )
+            .optional()?;
+        let Some((stored_fingerprint, stored_result, revision)) = stored else {
+            return Ok(None);
+        };
+        if stored_fingerprint != fingerprint {
+            anyhow::bail!(
+                "mutation {} from {} was retried with a different payload",
+                mutation.id,
+                mutation.origin
+            );
+        }
+        Ok(Some(RegistryCommit {
+            revision: u64::try_from(revision).context("stored mutation revision is negative")?,
+            result: serde_json::from_str(&stored_result)?,
+            replayed: true,
+        }))
+    }
+
+    /// Atomically replace the live ordered registry and record the mutation.
+    /// Duplicate lookup intentionally precedes revision validation: a retry of
+    /// a committed command must return its original result even after newer
+    /// commands have advanced the registry.
+    pub fn commit(
+        &mut self,
+        mutation: &WorkspaceMutation,
+        fingerprint: &Value,
+        expected_generation: Option<&str>,
+        expected_revision: Option<u64>,
+        event_kind: &str,
+        workspace_key: &str,
+        workspaces: &[RegistryWorkspace],
+        result: &Value,
+    ) -> anyhow::Result<RegistryCommit> {
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        let fingerprint = canonical_json(fingerprint)?;
+        let result_json = canonical_json(result)?;
+        let tx = self.connection.transaction()?;
+
+        if let Some((stored_fingerprint, stored_result, revision)) = tx
+            .query_row(
+                "SELECT fingerprint, result_json, committed_revision
+                 FROM mutations WHERE origin = ?1 AND mutation_id = ?2",
+                params![mutation.origin, mutation.id],
+                |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, i64>(2)?))
+                },
+            )
+            .optional()?
+        {
+            if stored_fingerprint != fingerprint {
+                anyhow::bail!(
+                    "mutation {} from {} was retried with a different payload",
+                    mutation.id,
+                    mutation.origin
+                );
+            }
+            return Ok(RegistryCommit {
+                revision: u64::try_from(revision)
+                    .context("stored mutation revision is negative")?,
+                result: serde_json::from_str(&stored_result)?,
+                replayed: true,
+            });
+        }
+
+        validate_identifier("workspace key", workspace_key)?;
+        validate_registry(workspaces)?;
+        if let Some(expected) = expected_generation
+            && expected != self.generation
+        {
+            anyhow::bail!(
+                "workspace generation conflict: expected {expected}, current {}",
+                self.generation
+            );
+        }
+        let current = transaction_revision(&tx)?;
+        if let Some(expected) = expected_revision
+            && expected != current
+        {
+            anyhow::bail!("workspace revision conflict: expected {expected}, current {current}");
+        }
+        let revision = current
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("workspace revision exhausted"))?;
+        let sqlite_revision =
+            i64::try_from(revision).context("workspace revision exceeds SQLite integer range")?;
+
+        for workspace in workspaces {
+            let was_tombstoned = tx
+                .query_row(
+                    "SELECT tombstoned FROM workspaces WHERE workspace_key = ?1",
+                    [&workspace.key],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()?;
+            if was_tombstoned == Some(1) {
+                anyhow::bail!("tombstoned workspace key cannot be reused: {}", workspace.key);
+            }
+        }
+
+        tx.execute(
+            "UPDATE workspaces SET tombstoned = 1, position = NULL,
+             updated_revision = ?1, deleted_revision = ?1
+             WHERE tombstoned = 0",
+            [sqlite_revision],
+        )?;
+        // Tombstone first to release the partial unique position index, then
+        // upsert the complete desired order in this same transaction.
+        for (position, workspace) in workspaces.iter().enumerate() {
+            tx.execute(
+                "INSERT INTO workspaces(
+                   workspace_key, numeric_id, name, group_key, position, tombstoned,
+                   created_revision, updated_revision, deleted_revision
+                 ) VALUES(?1, ?2, ?3, ?4, ?5, 0, ?6, ?6, NULL)
+                 ON CONFLICT(workspace_key) DO UPDATE SET
+                   numeric_id=excluded.numeric_id,
+                   name=excluded.name,
+                   group_key=excluded.group_key,
+                   position=excluded.position,
+                   tombstoned=0,
+                   updated_revision=excluded.updated_revision,
+                   deleted_revision=NULL",
+                params![
+                    workspace.key,
+                    i64::try_from(workspace.id).context("workspace id exceeds SQLite range")?,
+                    workspace.name,
+                    workspace.group_key,
+                    i64::try_from(position).context("workspace position exceeds SQLite range")?,
+                    sqlite_revision
+                ],
+            )?;
+        }
+        tx.execute("UPDATE meta SET value = ?1 WHERE key = 'revision'", [revision.to_string()])?;
+        tx.execute(
+            "INSERT INTO mutations(
+               origin, mutation_id, fingerprint, result_json, committed_revision
+             ) VALUES(?1, ?2, ?3, ?4, ?5)",
+            params![mutation.origin, mutation.id, fingerprint, result_json, sqlite_revision],
+        )?;
+        tx.execute(
+            "INSERT INTO workspace_events(
+               revision, kind, workspace_key, origin, mutation_id, result_json
+             ) VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                sqlite_revision,
+                event_kind,
+                workspace_key,
+                mutation.origin,
+                mutation.id,
+                result_json
+            ],
+        )?;
+        tx.commit()?;
+        Ok(RegistryCommit { revision, result: result.clone(), replayed: false })
+    }
+
+    pub fn events_after(&self, revision: u64) -> anyhow::Result<Vec<RegistryEvent>> {
+        let mut statement = self.connection.prepare(
+            "SELECT revision, kind, workspace_key, origin, mutation_id, result_json
+             FROM workspace_events WHERE revision > ?1 ORDER BY revision ASC",
+        )?;
+        let sqlite_revision =
+            i64::try_from(revision).context("workspace revision exceeds SQLite integer range")?;
+        let rows = statement.query_map([sqlite_revision], |row| {
+            let result: String = row.get(5)?;
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, result))
+        })?;
+        rows.map(|row| {
+            let (revision, kind, workspace_key, origin, mutation_id, result): (
+                i64,
+                String,
+                String,
+                String,
+                String,
+                String,
+            ) = row?;
+            Ok(RegistryEvent {
+                revision: u64::try_from(revision)
+                    .context("workspace event revision is negative")?,
+                kind,
+                workspace_key,
+                origin,
+                mutation_id,
+                result: serde_json::from_str(&result)?,
+            })
+        })
+        .collect()
+    }
+
+    pub fn get_frontend_projection(
+        &self,
+        frontend: &str,
+        scope: &str,
+        subject_key: &str,
+    ) -> anyhow::Result<Option<FrontendProjection>> {
+        validate_identifier("frontend", frontend)?;
+        validate_identifier("projection scope", scope)?;
+        validate_identifier("projection subject", subject_key)?;
+        let stored = self
+            .connection
+            .query_row(
+                "SELECT schema_version, projection_revision, payload
+                 FROM frontend_projections
+                 WHERE frontend = ?1 AND scope = ?2 AND subject_key = ?3",
+                params![frontend, scope, subject_key],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?, row.get::<_, String>(2)?)),
+            )
+            .optional()?;
+        stored
+            .map(|(schema_version, projection_revision, payload)| {
+                Ok(FrontendProjection {
+                    frontend: frontend.to_string(),
+                    scope: scope.to_string(),
+                    subject_key: subject_key.to_string(),
+                    schema_version: u32::try_from(schema_version)
+                        .context("projection schema version is invalid")?,
+                    projection_revision: u64::try_from(projection_revision)
+                        .context("projection revision is negative")?,
+                    projection: serde_json::from_str(&payload)?,
+                })
+            })
+            .transpose()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn put_frontend_projection(
+        &mut self,
+        mutation: &WorkspaceMutation,
+        frontend: &str,
+        scope: &str,
+        subject_key: &str,
+        schema_version: u32,
+        expected_projection_revision: Option<u64>,
+        projection: &Value,
+    ) -> anyhow::Result<ProjectionCommit> {
+        validate_identifier("mutation id", &mutation.id)?;
+        validate_identifier("mutation origin", &mutation.origin)?;
+        validate_identifier("frontend", frontend)?;
+        validate_identifier("projection scope", scope)?;
+        validate_identifier("projection subject", subject_key)?;
+        let payload = canonical_json(projection)?;
+        if payload.len() > MAX_PROJECTION_BYTES {
+            anyhow::bail!("frontend projection exceeds {MAX_PROJECTION_BYTES} bytes");
+        }
+        let fingerprint = canonical_json(&serde_json::json!({
+            "frontend": frontend,
+            "scope": scope,
+            "subject_key": subject_key,
+            "schema_version": schema_version,
+            "projection": projection,
+        }))?;
+        let tx = self.connection.transaction()?;
+        if let Some((stored_fingerprint, result_json)) = tx
+            .query_row(
+                "SELECT fingerprint, result_json FROM projection_mutations
+                 WHERE origin = ?1 AND mutation_id = ?2",
+                params![mutation.origin, mutation.id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?
+        {
+            if stored_fingerprint != fingerprint {
+                anyhow::bail!(
+                    "mutation {} from {} was retried with a different payload",
+                    mutation.id,
+                    mutation.origin
+                );
+            }
+            let stored: FrontendProjection = serde_json::from_str(&result_json)?;
+            return Ok(ProjectionCommit { projection: stored, replayed: true });
+        }
+        let current = tx
+            .query_row(
+                "SELECT projection_revision FROM frontend_projections
+                 WHERE frontend = ?1 AND scope = ?2 AND subject_key = ?3",
+                params![frontend, scope, subject_key],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?
+            .map(u64::try_from)
+            .transpose()
+            .context("projection revision is negative")?
+            .unwrap_or(0);
+        if let Some(expected) = expected_projection_revision
+            && expected != current
+        {
+            anyhow::bail!("projection revision conflict: expected {expected}, current {current}");
+        }
+        let projection_revision = current
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("projection revision exhausted"))?;
+        tx.execute(
+            "INSERT INTO frontend_projections(
+               frontend, scope, subject_key, schema_version, projection_revision, payload
+             ) VALUES(?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(frontend, scope, subject_key) DO UPDATE SET
+               schema_version=excluded.schema_version,
+               projection_revision=excluded.projection_revision,
+               payload=excluded.payload",
+            params![
+                frontend,
+                scope,
+                subject_key,
+                i64::from(schema_version),
+                i64::try_from(projection_revision)
+                    .context("projection revision exceeds SQLite range")?,
+                payload
+            ],
+        )?;
+        let stored = FrontendProjection {
+            frontend: frontend.to_string(),
+            scope: scope.to_string(),
+            subject_key: subject_key.to_string(),
+            schema_version,
+            projection_revision,
+            projection: projection.clone(),
+        };
+        tx.execute(
+            "INSERT INTO projection_mutations(origin, mutation_id, fingerprint, result_json)
+             VALUES(?1, ?2, ?3, ?4)",
+            params![
+                mutation.origin,
+                mutation.id,
+                fingerprint,
+                canonical_json(&serde_json::to_value(&stored)?)?
+            ],
+        )?;
+        tx.commit()?;
+        Ok(ProjectionCommit { projection: stored, replayed: false })
+    }
+}
+
+fn validate_registry(workspaces: &[RegistryWorkspace]) -> anyhow::Result<()> {
+    let mut keys = std::collections::HashSet::new();
+    for workspace in workspaces {
+        validate_identifier("workspace key", &workspace.key)?;
+        validate_identifier("workspace group key", &workspace.group_key)?;
+        if workspace.id == 0 {
+            anyhow::bail!("workspace id cannot be zero");
+        }
+        if !keys.insert(&workspace.key) {
+            anyhow::bail!("workspace key already exists: {}", workspace.key);
+        }
+    }
+    Ok(())
+}
+
+fn validate_identifier(label: &str, value: &str) -> anyhow::Result<()> {
+    if value.trim().is_empty() {
+        anyhow::bail!("{label} cannot be empty");
+    }
+    if value.len() > MAX_ID_LEN {
+        anyhow::bail!("{label} exceeds {MAX_ID_LEN} bytes");
+    }
+    if value.chars().any(char::is_control) {
+        anyhow::bail!("{label} contains a control character");
+    }
+    Ok(())
+}
+
+fn canonical_json(value: &Value) -> anyhow::Result<String> {
+    fn write(value: &Value, output: &mut String) -> anyhow::Result<()> {
+        match value {
+            Value::Object(map) => {
+                output.push('{');
+                let mut entries = map.iter().collect::<Vec<_>>();
+                entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+                for (index, (key, value)) in entries.into_iter().enumerate() {
+                    if index != 0 {
+                        output.push(',');
+                    }
+                    output.push_str(&serde_json::to_string(key)?);
+                    output.push(':');
+                    write(value, output)?;
+                }
+                output.push('}');
+            }
+            Value::Array(values) => {
+                output.push('[');
+                for (index, value) in values.iter().enumerate() {
+                    if index != 0 {
+                        output.push(',');
+                    }
+                    write(value, output)?;
+                }
+                output.push(']');
+            }
+            primitive => output.push_str(&serde_json::to_string(primitive)?),
+        }
+        Ok(())
+    }
+    let mut output = String::new();
+    write(value, &mut output)?;
+    Ok(output)
+}
+
+fn meta_value(connection: &Connection, key: &str) -> anyhow::Result<Option<String>> {
+    Ok(connection
+        .query_row("SELECT value FROM meta WHERE key = ?1", [key], |row| row.get(0))
+        .optional()?)
+}
+
+fn required_meta(connection: &Connection, key: &str) -> anyhow::Result<String> {
+    meta_value(connection, key)?
+        .ok_or_else(|| anyhow::anyhow!("workspace registry is missing {key}"))
+}
+
+fn current_revision(connection: &Connection) -> anyhow::Result<u64> {
+    required_meta(connection, "revision")?.parse().context("workspace registry revision is invalid")
+}
+
+fn transaction_revision(transaction: &Transaction<'_>) -> anyhow::Result<u64> {
+    let value: String =
+        transaction
+            .query_row("SELECT value FROM meta WHERE key = 'revision'", [], |row| row.get(0))?;
+    value.parse().context("workspace registry revision is invalid")
+}
+
+fn session_storage_component(session: &str) -> String {
+    let mut readable = String::new();
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in session.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+        if readable.len() < 48 && (byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')) {
+            readable.push(char::from(byte));
+        } else if readable.len() < 48 {
+            readable.push('_');
+        }
+    }
+    if readable.is_empty() {
+        readable.push_str("session");
+    }
+    format!("{readable}-{hash:016x}")
+}
+
+pub(crate) fn new_uuid_v4() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::fill(&mut bytes).expect("operating system randomness unavailable");
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15]
+    )
+}
+
+struct SessionLease {
+    file: File,
+    path: PathBuf,
+}
+
+impl SessionLease {
+    fn acquire(path: &Path) -> anyhow::Result<Self> {
+        let file = OpenOptions::new().create(true).read(true).write(true).open(path)?;
+        platform::restrict_file(path)?;
+        FileExt::try_lock(&file).with_context(|| {
+            format!("workspace session is already owned by another daemon: {}", path.display())
+        })?;
+        Ok(Self { file, path: path.to_path_buf() })
+    }
+}
+
+impl Drop for SessionLease {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+        let _ = &self.path;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_root(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("cmux-registry-{label}-{}", new_uuid_v4()))
+    }
+
+    fn workspace(id: u64, key: &str, name: &str) -> RegistryWorkspace {
+        RegistryWorkspace { id, key: key.into(), name: name.into(), group_key: "default".into() }
+    }
+
+    #[test]
+    fn durable_commit_recovers_and_changes_generation() {
+        let root = temp_root("recover");
+        let first = {
+            let mut registry = WorkspaceRegistry::open(&root, "session").unwrap();
+            let before = registry.snapshot().unwrap();
+            let mutation = WorkspaceMutation::new(new_uuid_v4(), "browser").unwrap();
+            let result = json!({"key":"one"});
+            let commit = registry
+                .commit(
+                    &mutation,
+                    &json!({"op":"create","key":"one"}),
+                    None,
+                    Some(0),
+                    "workspace-added",
+                    "one",
+                    &[RegistryWorkspace {
+                        id: 1,
+                        key: "one".into(),
+                        name: "One".into(),
+                        group_key: "default".into(),
+                    }],
+                    &result,
+                )
+                .unwrap();
+            assert_eq!(commit.revision, 1);
+            (before.registry_id, before.generation)
+        };
+        let recovered = WorkspaceRegistry::open(&root, "session").unwrap();
+        let snapshot = recovered.snapshot().unwrap();
+        assert_eq!(snapshot.registry_id, first.0);
+        assert_ne!(snapshot.generation, first.1);
+        assert_eq!(snapshot.revision, 1);
+        assert_eq!(snapshot.workspaces[0].key, "one");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn retry_precedes_revision_check_and_payload_mismatch_is_rejected() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        let mutation = WorkspaceMutation::new("mutation", "browser").unwrap();
+        let fingerprint = json!({"op":"create","key":"one"});
+        let result = json!({"key":"one"});
+        let workspaces = [RegistryWorkspace {
+            id: 1,
+            key: "one".into(),
+            name: "One".into(),
+            group_key: "default".into(),
+        }];
+        let first = registry
+            .commit(
+                &mutation,
+                &fingerprint,
+                None,
+                Some(0),
+                "workspace-added",
+                "one",
+                &workspaces,
+                &result,
+            )
+            .unwrap();
+        assert!(!first.replayed);
+        let retry = registry
+            .commit(
+                &mutation,
+                &fingerprint,
+                None,
+                Some(0),
+                "workspace-added",
+                "one",
+                &workspaces,
+                &result,
+            )
+            .unwrap();
+        assert!(retry.replayed);
+        assert_eq!(retry.revision, 1);
+        assert!(
+            registry
+                .commit(
+                    &mutation,
+                    &json!({"op":"create","key":"different"}),
+                    None,
+                    None,
+                    "workspace-added",
+                    "different",
+                    &workspaces,
+                    &result,
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn second_writer_is_rejected() {
+        let root = temp_root("lease");
+        let first = WorkspaceRegistry::open(&root, "same").unwrap();
+        assert!(WorkspaceRegistry::open(&root, "same").is_err());
+        drop(first);
+        WorkspaceRegistry::open(&root, "same").unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn tombstones_prevent_workspace_key_reuse() {
+        let mut registry = WorkspaceRegistry::in_memory("test").unwrap();
+        registry
+            .commit(
+                &WorkspaceMutation::new("create", "browser").unwrap(),
+                &json!({"op":"create"}),
+                None,
+                Some(0),
+                "workspace-added",
+                "stable",
+                &[workspace(1, "stable", "One")],
+                &json!({"workspace":1,"key":"stable"}),
+            )
+            .unwrap();
+        registry
+            .commit(
+                &WorkspaceMutation::new("close", "browser").unwrap(),
+                &json!({"op":"close"}),
+                None,
+                Some(1),
+                "workspace-closed",
+                "stable",
+                &[],
+                &json!({"workspace":1,"key":"stable"}),
+            )
+            .unwrap();
+        let error = registry
+            .commit(
+                &WorkspaceMutation::new("recreate", "browser").unwrap(),
+                &json!({"op":"create"}),
+                None,
+                Some(2),
+                "workspace-added",
+                "stable",
+                &[workspace(2, "stable", "Again")],
+                &json!({"workspace":2,"key":"stable"}),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("tombstoned workspace key cannot be reused"));
+    }
+
+    #[test]
+    fn frontend_projection_is_durable_cas_and_exactly_once() {
+        let root = temp_root("projection");
+        let mutation = WorkspaceMutation::new("layout-1", "browser-profile").unwrap();
+        {
+            let mut registry = WorkspaceRegistry::open(&root, "session").unwrap();
+            let first = registry
+                .put_frontend_projection(
+                    &mutation,
+                    "cmux-browser",
+                    "window-group",
+                    "group-a",
+                    1,
+                    Some(0),
+                    &json!({"columns":[{"workspace":"one"}]}),
+                )
+                .unwrap();
+            assert_eq!(first.projection.projection_revision, 1);
+            assert!(!first.replayed);
+            let retry = registry
+                .put_frontend_projection(
+                    &mutation,
+                    "cmux-browser",
+                    "window-group",
+                    "group-a",
+                    1,
+                    Some(0),
+                    &json!({"columns":[{"workspace":"one"}]}),
+                )
+                .unwrap();
+            assert!(retry.replayed);
+            assert_eq!(retry.projection.projection_revision, 1);
+            assert!(
+                registry
+                    .put_frontend_projection(
+                        &WorkspaceMutation::new("layout-2", "browser-profile").unwrap(),
+                        "cmux-browser",
+                        "window-group",
+                        "group-a",
+                        1,
+                        Some(0),
+                        &json!({}),
+                    )
+                    .unwrap_err()
+                    .to_string()
+                    .contains("projection revision conflict")
+            );
+        }
+        let registry = WorkspaceRegistry::open(&root, "session").unwrap();
+        let recovered = registry
+            .get_frontend_projection("cmux-browser", "window-group", "group-a")
+            .unwrap()
+            .unwrap();
+        assert_eq!(recovered.projection_revision, 1);
+        assert_eq!(recovered.projection["columns"][0]["workspace"], "one");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn interrupted_transaction_and_newer_schema_fail_closed() {
+        let root = temp_root("transaction");
+        {
+            let mut registry = WorkspaceRegistry::open(&root, "session").unwrap();
+            let tx = registry.connection.transaction().unwrap();
+            tx.execute("UPDATE meta SET value = '77' WHERE key = 'revision'", []).unwrap();
+            drop(tx);
+            assert_eq!(registry.snapshot().unwrap().revision, 0);
+        }
+        fs::remove_dir_all(&root).unwrap();
+
+        let newer_root = temp_root("newer");
+        let session_dir = newer_root.join(session_storage_component("session"));
+        fs::create_dir_all(&session_dir).unwrap();
+        let db = Connection::open(session_dir.join("workspace-registry.sqlite3")).unwrap();
+        db.execute_batch(
+            "CREATE TABLE meta(key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+             INSERT INTO meta(key,value) VALUES('schema_version','999');",
+        )
+        .unwrap();
+        drop(db);
+        assert!(
+            WorkspaceRegistry::open(&newer_root, "session")
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported workspace registry schema")
+        );
+        fs::remove_dir_all(newer_root).unwrap();
+    }
+}

--- a/cmux-tui/crates/cmux-tui-core/tests/browser_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/browser_runtime.rs
@@ -492,7 +492,7 @@ fn socket_browser_attach_streams_frames_input_and_cell_pixels() {
     .expect("navigate errorText surfaced as browser failure");
     assert_eq!(failed, "net::ERR_NAME_NOT_RESOLVED");
 
-    mux.close_surface(surface);
+    mux.close_surface(surface).unwrap();
     mux.shutdown();
     server::cleanup(&socket_path);
     server.join().unwrap();
@@ -621,7 +621,7 @@ fn wedged_browser_navigate_does_not_block_same_socket_connection() {
     );
 
     let close_started = Instant::now();
-    mux.close_surface(surface);
+    mux.close_surface(surface).unwrap();
     assert!(
         close_started.elapsed() < Duration::from_millis(500),
         "wedged browser close blocked for {:?}",
@@ -754,7 +754,7 @@ fn queued_back_and_forward_do_not_collapse_while_worker_is_blocked() {
         "forward must not be swallowed by back through a shared latest-wins slot"
     );
 
-    mux.close_surface(surface);
+    mux.close_surface(surface).unwrap();
     mux.shutdown();
     server::cleanup(&socket_path);
     server.join().unwrap();
@@ -868,7 +868,7 @@ fn control_command_reports_backpressure_when_worker_queue_is_full() {
         "a full command queue must be reported as ok:false, not silently dropped with ok:true"
     );
 
-    mux.close_surface(surface);
+    mux.close_surface(surface).unwrap();
     mux.shutdown();
     server::cleanup(&socket_path);
     server.join().unwrap();

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -73,10 +73,18 @@ fn socket_request(
     reader: &mut impl BufRead,
     request: serde_json::Value,
 ) -> serde_json::Value {
-    writeln!(writer, "{request}").unwrap();
-    let response = read_json_line(reader).expect("socket response");
+    let response = socket_response(writer, reader, request);
     assert_eq!(response["ok"], true, "request failed: {response}");
     response
+}
+
+fn socket_response(
+    writer: &mut impl Write,
+    reader: &mut impl BufRead,
+    request: serde_json::Value,
+) -> serde_json::Value {
+    writeln!(writer, "{request}").unwrap();
+    read_json_line(reader).expect("socket response")
 }
 
 fn assert_vt_state_size(
@@ -1326,18 +1334,16 @@ fn create_empty_workspace_is_visible_and_materialized_in_place() {
     assert_eq!(snapshot["data"]["workspaces"][0]["key"], key);
     assert!(snapshot["data"]["workspaces"][0]["screens"].as_array().unwrap().is_empty());
 
-    writeln!(
-        writer,
-        "{}",
+    let stale = socket_response(
+        &mut writer,
+        &mut reader,
         serde_json::json!({
             "id": 21,
             "cmd": "create-workspace",
             "name": "stale",
             "expected_revision": 0,
-        })
-    )
-    .unwrap();
-    let stale = read_json_line(&mut reader).expect("stale create-workspace response");
+        }),
+    );
     assert_eq!(stale["ok"], false);
     assert_eq!(stale["error"], "workspace revision conflict: expected 0, current 1");
 
@@ -1397,6 +1403,131 @@ fn create_empty_workspace_is_visible_and_materialized_in_place() {
     );
     assert_eq!(closed["ok"], true, "close by key failed: {closed}");
     assert_eq!(closed["data"]["workspace_revision"], 3);
+    cmux_tui_core::server::cleanup(&sock_path);
+}
+
+#[test]
+fn workspace_mutations_are_exactly_once_before_guards_and_close_resolution() {
+    let mux = Mux::new(unique_session("test-workspace-dedupe"), SurfaceOptions::default());
+    let sock_path = cmux_tui_core::server::serve(mux.clone(), None).unwrap();
+    let request = serde_json::json!({
+        "id": 1,
+        "cmd": "create-workspace",
+        "name": "once",
+        "key": "stable-once",
+        "origin": "browser-profile-a",
+        "mutation_id": "create-once",
+        "expected_revision": 0,
+    });
+
+    // Commit the mutation, then throw away the connection without consuming
+    // its response to model a frontend losing the reply.
+    {
+        let stream = connect(&sock_path);
+        let mut writer = stream.try_clone_box().unwrap();
+        writeln!(writer, "{request}").unwrap();
+    }
+    wait_for(
+        || mux.with_state(|state| (state.workspace_revision == 1).then_some(())),
+        Duration::from_secs(5),
+    )
+    .expect("create mutation was not committed");
+
+    let stream = connect(&sock_path);
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    let retry = socket_request(&mut writer, &mut reader, request.clone());
+    assert_eq!(retry["data"]["workspace_revision"], 1);
+    assert_eq!(retry["data"]["replayed"], true);
+    mux.with_state(|state| {
+        assert_eq!(state.workspace_revision, 1);
+        assert_eq!(state.workspaces.len(), 1);
+    });
+
+    let mismatch = socket_response(
+        &mut writer,
+        &mut reader,
+        serde_json::json!({
+            "id": 2,
+            "cmd": "create-workspace",
+            "name": "different",
+            "key": "stable-once",
+            "origin": "browser-profile-a",
+            "mutation_id": "create-once",
+            "expected_revision": 1,
+        }),
+    );
+    assert_eq!(mismatch["ok"], false);
+    assert!(mismatch["error"].as_str().unwrap().contains("different payload"));
+
+    let generation = retry["data"]["generation"].as_str().unwrap().to_string();
+    let close = serde_json::json!({
+        "id": 3,
+        "cmd": "close-workspace",
+        "key": "stable-once",
+        "origin": "browser-profile-a",
+        "mutation_id": "close-once",
+        "expected_generation": generation,
+        "expected_revision": 1,
+    });
+    let first_close = socket_request(&mut writer, &mut reader, close.clone());
+    assert_eq!(first_close["data"]["workspace_revision"], 2);
+    assert_eq!(first_close["data"]["replayed"], false);
+    let mut stale_guard_retry = close;
+    stale_guard_retry["expected_generation"] = serde_json::json!("stale-generation");
+    stale_guard_retry["expected_revision"] = serde_json::json!(0);
+    let close_retry = socket_request(&mut writer, &mut reader, stale_guard_retry);
+    assert_eq!(close_retry["data"]["workspace_revision"], 2);
+    assert_eq!(close_retry["data"]["replayed"], true);
+    assert_eq!(close_retry["data"]["key"], "stable-once");
+    mux.with_state(|state| assert!(state.workspaces.is_empty()));
+
+    cmux_tui_core::server::cleanup(&sock_path);
+}
+
+#[test]
+fn frontend_projection_round_trips_without_advancing_workspace_revision() {
+    let mux = Mux::new(unique_session("test-projection"), SurfaceOptions::default());
+    let sock_path = cmux_tui_core::server::serve(mux, None).unwrap();
+    let stream = connect(&sock_path);
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    let put = serde_json::json!({
+        "id": 1,
+        "cmd": "put-frontend-projection",
+        "frontend": "cmux-browser",
+        "scope": "window-group",
+        "subject_key": "profile-a:window-a",
+        "schema_version": 1,
+        "expected_projection_revision": 0,
+        "projection": {"columns":[{"workspace":"stable-one"}]},
+        "origin": "browser-profile-a",
+        "mutation_id": "projection-one",
+    });
+    let first = socket_request(&mut writer, &mut reader, put.clone());
+    assert_eq!(first["data"]["projection_revision"], 1);
+    assert_eq!(first["data"]["replayed"], false);
+    let retry = socket_request(&mut writer, &mut reader, put);
+    assert_eq!(retry["data"]["projection_revision"], 1);
+    assert_eq!(retry["data"]["replayed"], true);
+    let get = socket_request(
+        &mut writer,
+        &mut reader,
+        serde_json::json!({
+            "id": 2,
+            "cmd": "get-frontend-projection",
+            "frontend": "cmux-browser",
+            "scope": "window-group",
+            "subject_key": "profile-a:window-a",
+        }),
+    );
+    assert_eq!(get["data"]["projection"]["columns"][0]["workspace"], "stable-one");
+    let list = socket_request(
+        &mut writer,
+        &mut reader,
+        serde_json::json!({"id":3,"cmd":"list-workspaces"}),
+    );
+    assert_eq!(list["data"]["workspace_revision"], 0);
     cmux_tui_core::server::cleanup(&sock_path);
 }
 

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -267,9 +267,14 @@ fn surface_exit_reaps_tree_and_emits_event() {
     );
     assert!(got.is_some(), "no SurfaceExited event");
     assert!(surface.is_dead());
-    // The mux reaps exited surfaces itself; the emptied workspace is gone.
+    // The mux reaps exited surfaces itself, but a canonical empty workspace is
+    // retained so GUI and TUI projections cannot disagree about its existence.
     let reaped = wait_for(
-        || mux.with_state(|s| s.workspaces.is_empty().then_some(())),
+        || {
+            mux.with_state(|s| {
+                (s.workspaces.len() == 1 && s.workspaces[0].screens.is_empty()).then_some(())
+            })
+        },
         Duration::from_secs(10),
     );
     assert!(reaped.is_some(), "exited surface not reaped from tree");
@@ -1285,6 +1290,10 @@ fn tree_event_modes_receive_delta_or_exact_coarse_fallback() {
     assert_eq!(delta["workspace"], delta["entity"]["id"]);
     assert_eq!(delta["index"], 0);
     assert_eq!(delta["workspace_revision"], 1);
+    assert_eq!(delta["origin"], "cmux-tui");
+    assert!(delta["mutation_id"].as_str().is_some());
+    assert!(delta["registry_id"].as_str().is_some());
+    assert!(delta["generation"].as_str().is_some());
     assert!(delta["entity"]["key"].as_str().is_some_and(|key| key.len() == 36));
     assert_eq!(delta["entity"]["name"], "delta");
     assert!(
@@ -1426,17 +1435,19 @@ fn workspace_mutations_are_exactly_once_before_guards_and_close_resolution() {
         let stream = connect(&sock_path);
         let mut writer = stream.try_clone_box().unwrap();
         writeln!(writer, "{request}").unwrap();
+        writer.flush().unwrap();
+        wait_for(
+            || mux.with_state(|state| (state.workspace_revision == 1).then_some(())),
+            Duration::from_secs(10),
+        )
+        .expect("create mutation was not committed");
+        // Deliberately drop both halves without reading the queued response.
     }
-    wait_for(
-        || mux.with_state(|state| (state.workspace_revision == 1).then_some(())),
-        Duration::from_secs(5),
-    )
-    .expect("create mutation was not committed");
 
     let stream = connect(&sock_path);
     let mut writer = stream.try_clone_box().unwrap();
     let mut reader = BufReader::new(stream);
-    let retry = socket_request(&mut writer, &mut reader, request.clone());
+    let retry = socket_request(&mut writer, &mut reader, request);
     assert_eq!(retry["data"]["workspace_revision"], 1);
     assert_eq!(retry["data"]["replayed"], true);
     mux.with_state(|state| {

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -267,12 +267,15 @@ fn surface_exit_reaps_tree_and_emits_event() {
     );
     assert!(got.is_some(), "no SurfaceExited event");
     assert!(surface.is_dead());
-    // The mux reaps exited surfaces itself, but a canonical empty workspace is
-    // retained so GUI and TUI projections cannot disagree about its existence.
+    // The mux reaps exited surfaces itself. Empty workspace containers are
+    // durable registry state and remain visible for GUI/TUI parity.
     let reaped = wait_for(
         || {
-            mux.with_state(|s| {
-                (s.workspaces.len() == 1 && s.workspaces[0].screens.is_empty()).then_some(())
+            mux.with_state(|state| {
+                (!state.surfaces.contains_key(&surface.id)
+                    && state.workspaces.len() == 1
+                    && state.workspaces[0].screens.is_empty())
+                .then_some(())
             })
         },
         Duration::from_secs(10),
@@ -627,6 +630,7 @@ fn control_socket_attach_vt_state_includes_effective_colors() {
             "selection_fg": null,
             "cursor_style": "bar",
             "cursor_blink": false,
+            "palette": {},
         })
     );
 
@@ -746,8 +750,58 @@ fn control_socket_attach_stream_receives_merged_colors_changed() {
             "selection_fg": null,
             "cursor_style": "bar",
             "cursor_blink": false,
+            "palette": {},
         })
     );
+
+    mux.close_surface(surface.id);
+    cmux_tui_core::server::cleanup(&sock_path);
+}
+
+#[test]
+fn control_socket_attach_palette_is_full_sparse_state_and_reset_clears_all_256() {
+    let mux = Mux::new(unique_session("test-attach-palette"), shell_opts("cat"));
+    let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+    let mut set_palette = Vec::new();
+    for index in 0..=255u8 {
+        set_palette.extend_from_slice(
+            format!("\x1b]4;{index};#{:02x}{:02x}{:02x}\x07", index, 255 - index, index ^ 0x55)
+                .as_bytes(),
+        );
+    }
+    surface.try_with_terminal(|term| term.vt_write(&set_palette)).unwrap();
+
+    let sock_path = cmux_tui_core::server::serve(mux.clone(), None).unwrap();
+    let attach_stream = connect(&sock_path);
+    attach_stream.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
+    let mut attach_writer = attach_stream.try_clone_box().unwrap();
+    let mut attach_reader = BufReader::new(attach_stream);
+    writeln!(attach_writer, r#"{{"id":1,"cmd":"attach-surface","surface":{}}}"#, surface.id)
+        .unwrap();
+    let vt_state = wait_for(|| read_json_line(&mut attach_reader), Duration::from_secs(5))
+        .expect("vt-state event");
+    let palette = vt_state["colors"]["palette"].as_object().expect("palette object");
+    assert_eq!(palette.len(), 256);
+    assert_eq!(palette["0"], "#00ff55");
+    assert_eq!(palette["255"], "#ff00aa");
+    let response = wait_for(|| read_json_line(&mut attach_reader), Duration::from_secs(5))
+        .expect("attach response");
+    assert_eq!(response["ok"], true, "attach failed: {response}");
+
+    surface.write_bytes(b"\x1b]104\x07\n").unwrap();
+    let reset = wait_for(
+        || {
+            while let Some(value) = read_json_line(&mut attach_reader) {
+                if value.get("event").and_then(|value| value.as_str()) == Some("colors-changed") {
+                    return Some(value);
+                }
+            }
+            None
+        },
+        Duration::from_secs(5),
+    )
+    .expect("palette reset colors-changed event");
+    assert_eq!(reset["palette"], serde_json::json!({}));
 
     mux.close_surface(surface.id);
     cmux_tui_core::server::cleanup(&sock_path);
@@ -905,13 +959,15 @@ fn attach_stream_replays_then_streams_without_duplication() {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         match attach.stream.recv_timeout(Duration::from_millis(200)) {
-            Ok(AttachFrame::Output(chunk)) => {
+            Ok(AttachFrame::Output(chunk))
+            | Ok(AttachFrame::OutputWithColors { output: chunk, .. }) => {
                 mirror.vt_write(&chunk);
                 if mirror.plain_text().unwrap().contains("after-attach") {
                     break;
                 }
             }
-            Ok(AttachFrame::Resized { cols, rows, replay }) => {
+            Ok(AttachFrame::Resized { cols, rows, replay })
+            | Ok(AttachFrame::ResizedWithColors { cols, rows, replay, .. }) => {
                 assert!(!replay.is_empty());
                 mirror =
                     ghostty_vt::Terminal::new(cols, rows, 1000, ghostty_vt::Callbacks::default())
@@ -939,6 +995,7 @@ fn attach_stream_orders_resize_between_output_frames() {
     loop {
         match attach.stream.recv_timeout(Duration::from_millis(200)) {
             Ok(AttachFrame::Output(bytes))
+            | Ok(AttachFrame::OutputWithColors { output: bytes, .. })
                 if bytes.windows(b"before-resize".len()).any(|w| w == b"before-resize") =>
             {
                 break;
@@ -951,7 +1008,8 @@ fn attach_stream_orders_resize_between_output_frames() {
     mux.resize_surface(surface.id, 100, 40).unwrap();
     let resized = wait_for(
         || match attach.stream.recv_timeout(Duration::from_millis(200)) {
-            Ok(AttachFrame::Resized { cols, rows, replay }) => {
+            Ok(AttachFrame::Resized { cols, rows, replay })
+            | Ok(AttachFrame::ResizedWithColors { cols, rows, replay, .. }) => {
                 assert!(!replay.is_empty());
                 Some((cols, rows))
             }
@@ -967,11 +1025,14 @@ fn attach_stream_orders_resize_between_output_frames() {
     loop {
         match attach.stream.recv_timeout(Duration::from_millis(200)) {
             Ok(AttachFrame::Output(bytes))
+            | Ok(AttachFrame::OutputWithColors { output: bytes, .. })
                 if bytes.windows(b"after-resize".len()).any(|w| w == b"after-resize") =>
             {
                 break;
             }
-            Ok(AttachFrame::Resized { .. }) => panic!("unexpected second resize marker"),
+            Ok(AttachFrame::Resized { .. } | AttachFrame::ResizedWithColors { .. }) => {
+                panic!("unexpected second resize marker")
+            }
             Ok(AttachFrame::ColorsChanged(_)) => {}
             Ok(_) => {}
             Err(_) => assert!(Instant::now() < deadline, "after output never arrived"),
@@ -1442,6 +1503,7 @@ fn workspace_mutations_are_exactly_once_before_guards_and_close_resolution() {
         )
         .expect("create mutation was not committed");
         // Deliberately drop both halves without reading the queued response.
+        drop(stream);
     }
 
     let stream = connect(&sock_path);

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -1357,8 +1357,29 @@ fn tree_event_modes_receive_delta_or_exact_coarse_fallback() {
     assert!(delta["generation"].as_str().is_some());
     assert!(delta["entity"]["key"].as_str().is_some_and(|key| key.len() == 36));
     assert_eq!(delta["entity"]["name"], "delta");
+    assert_eq!(delta["entity"]["screens"], serde_json::json!([]));
+
+    // Canonical creation commits the empty workspace before launching its
+    // terminal. The later topology delta must not retroactively change the
+    // immutable workspace event.
+    let topology = wait_for(|| read_json_line(&mut deltas_reader), Duration::from_secs(5))
+        .expect("terminal topology event");
+    assert_eq!(topology["event"], "screen-added");
+    assert_eq!(topology["workspace"], delta["workspace"]);
     assert!(
-        delta["entity"]["screens"][0]["panes"][0]["tabs"]
+        topology["entity"]["panes"][0]["tabs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|tab| tab["surface"] == surface)
+    );
+    let snapshot = socket_request(
+        &mut command_writer,
+        &mut command_reader,
+        serde_json::json!({"id": 4, "cmd": "list-workspaces"}),
+    );
+    assert!(
+        snapshot["data"]["workspaces"][0]["screens"][0]["panes"][0]["tabs"]
             .as_array()
             .unwrap()
             .iter()

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -130,7 +130,7 @@ fn surface_runs_command_and_screen_updates() {
     );
     assert!(text.is_some(), "marker never appeared on screen");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn surface_resize_reports_whether_the_size_changed() {
     assert_eq!(surface.size(), (1, 1));
     assert!(!surface.resize(0, 0).unwrap());
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
 }
 
 #[test]
@@ -505,7 +505,7 @@ fn control_socket_read_screen_reports_rendered_viewport_after_scrollback_clear()
         "read-screen should report the rendered viewport, got {text:?}"
     );
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -552,7 +552,7 @@ fn control_socket_wait_for_matches_one_shot_output_already_on_screen() {
     assert_eq!(value["ok"], true, "wait-for failed after one-shot output: {line}");
     assert_eq!(value["data"]["matched"], true);
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -638,7 +638,7 @@ fn control_socket_attach_vt_state_includes_effective_colors() {
     assert_eq!(response["id"], 1);
     assert_eq!(response["ok"], true, "attach failed: {response}");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -660,7 +660,7 @@ fn control_socket_attach_vt_state_cursor_is_null_without_config_or_decscusr() {
     let response = read_json_line(&mut reader).expect("attach response");
     assert_eq!(response["ok"], true, "attach failed: {response}");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -688,7 +688,7 @@ fn control_socket_attach_vt_state_prefers_surface_decscusr_cursor() {
     let response = read_json_line(&mut reader).expect("attach response");
     assert_eq!(response["ok"], true, "attach failed: {response}");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -754,7 +754,7 @@ fn control_socket_attach_stream_receives_merged_colors_changed() {
         })
     );
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -803,7 +803,7 @@ fn control_socket_attach_palette_is_full_sparse_state_and_reset_clears_all_256()
     .expect("palette reset colors-changed event");
     assert_eq!(reset["palette"], serde_json::json!({}));
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -879,7 +879,7 @@ fn control_socket_broadcasts_surface_resized_once_per_changed_size() {
     );
     assert!(repeated.is_none(), "same-size resize emitted another event: {repeated:?}");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -915,8 +915,8 @@ fn default_colors_apply_to_existing_and_future_surfaces() {
     );
     assert_eq!(second_state.cursor_visual().unwrap(), (CursorShape::Underline, true));
 
-    mux.close_surface(first.id);
-    mux.close_surface(second.id);
+    mux.close_surface(first.id).unwrap();
+    mux.close_surface(second.id).unwrap();
 }
 
 #[test]
@@ -981,7 +981,7 @@ fn attach_stream_replays_then_streams_without_duplication() {
     let text = mirror.plain_text().unwrap();
     assert_eq!(text.matches("before-attach").count(), 1, "duplicated replay: {text}");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
 }
 
 #[test]
@@ -1039,7 +1039,7 @@ fn attach_stream_orders_resize_between_output_frames() {
         }
     }
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
 }
 
 #[test]
@@ -1135,7 +1135,7 @@ fn render_attach_headless_fans_one_frame_to_render_and_byte_consumers() {
     );
     assert!(output.is_some(), "byte attachment stopped while render attachment was active");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -1178,7 +1178,7 @@ fn render_attach_snapshot_and_raced_write_have_no_gap_or_duplicate_frame() {
     assert!(saw_response, "render attach response was not delivered");
     assert_eq!(marker_events, 1, "raced output was missing or duplicated across snapshot/delta");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -1237,7 +1237,7 @@ fn render_attach_resize_is_a_full_replacement_at_the_new_size() {
     assert_eq!(delta["size"], serde_json::json!({"cols": 31, "rows": 6}));
     assert_eq!(delta["rows"].as_array().unwrap().len(), 6);
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -1301,7 +1301,7 @@ fn read_scrollback_pages_oldest_rows_and_clamps_bounds() {
     );
     assert!(empty["data"]["rows"].as_array().unwrap().is_empty());
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -1365,7 +1365,7 @@ fn tree_event_modes_receive_delta_or_exact_coarse_fallback() {
             .any(|tab| tab["surface"] == surface)
     );
 
-    mux.close_surface(surface);
+    mux.close_surface(surface).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -1696,7 +1696,7 @@ fn send_paste_wraps_only_while_dec_mode_2004_is_enabled() {
     )
     .expect("raw paste bytes");
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
     cmux_tui_core::server::cleanup(&sock_path);
 }
 
@@ -1717,5 +1717,5 @@ fn new_tab_on_empty_headless_session_creates_workspace() {
     assert!(mux.new_tab(Some(9999), None, None).is_err());
     assert_eq!(mux.surface_count(), before);
 
-    mux.close_surface(surface.id);
+    mux.close_surface(surface.id).unwrap();
 }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10951,6 +10951,60 @@ mod tests {
         mux.close_surface(surface.id).unwrap();
     }
 
+    #[test]
+    fn pane_cursor_and_active_border_yield_to_builtin_and_plugin_sidebars() {
+        let mux = Mux::new("sidebar-cursor-focus-test", SurfaceOptions::default());
+        let surface = mux.new_workspace(Some("work".to_string()), Some((20, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.replace_tree(app.session.tree());
+        let pane = app.tree.active_screen().unwrap().active_pane;
+        app.pane_areas.push(PaneArea {
+            pane,
+            surface: surface.id,
+            rect: Rect { x: 0, y: 0, width: 22, height: 10 },
+            bar: Some(Rect { x: 0, y: 0, width: 22, height: 1 }),
+            omnibar: None,
+            content: Rect { x: 1, y: 1, width: 20, height: 8 },
+            track: None,
+        });
+
+        for plugin in [false, true] {
+            app.config.sidebar.plugin = plugin.then(|| cmux_tui_core::SidebarPluginOptions {
+                command: vec!["/bin/sh".to_string()],
+                cwd: None,
+            });
+            app.sidebar_focused = false;
+            app.reset_frame_cursor_spec();
+            let mut pane_cursor = None;
+            let mut terminal = Terminal::new(TestBackend::new(30, 12)).unwrap();
+            terminal
+                .draw(|frame| pane_cursor = crate::ui::pane::draw_all(&mut app, frame))
+                .unwrap();
+            assert!(pane_cursor.is_some(), "active pane cursor missing for plugin={plugin}");
+            assert!(matches!(app.desired_outer_cursor, OuterCursorSpec::Terminal { .. }));
+            assert_eq!(
+                terminal.backend().buffer()[(0, 1)].fg,
+                app.config.theme.border_active,
+                "active pane border missing for plugin={plugin}"
+            );
+
+            app.sidebar_focused = true;
+            app.reset_frame_cursor_spec();
+            terminal
+                .draw(|frame| pane_cursor = crate::ui::pane::draw_all(&mut app, frame))
+                .unwrap();
+            assert!(pane_cursor.is_none(), "sidebar leaked pane cursor for plugin={plugin}");
+            assert_eq!(app.desired_outer_cursor, OuterCursorSpec::Reset);
+            assert_eq!(
+                terminal.backend().buffer()[(0, 1)].fg,
+                app.config.theme.border_inactive,
+                "sidebar focus left pane border active for plugin={plugin}"
+            );
+        }
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
     fn test_mouse_motion() -> MouseInput {
         MouseInput {
             action: MouseAction::Motion,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -29,8 +29,8 @@ use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use ghostty_vt::{
-    KeyEncoder, Mods, MouseAction, MouseButton as GhosttyMouseButton, MouseInput, RenderState,
-    Screen,
+    CursorShape, KeyEncoder, Mods, MouseAction, MouseButton as GhosttyMouseButton, MouseInput,
+    RenderState, Rgb, Screen,
 };
 use ratatui::Terminal as RatatuiTerminal;
 use ratatui::backend::CrosstermBackend;
@@ -2410,6 +2410,12 @@ enum PtyMouseReleaseCapture {
     Failed,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OuterCursorSpec {
+    Reset,
+    Terminal { color: Rgb, shape: CursorShape, blinking: bool },
+}
+
 #[derive(Clone)]
 struct DeferredInput {
     event: Event,
@@ -2425,6 +2431,12 @@ pub struct App {
     pub tree: TreeView,
     tab_locations: HashMap<SurfaceId, [usize; 4]>,
     pub render_states: HashMap<SurfaceId, RenderState>,
+    /// Terminal grid dimensions from the frame actually drawn for each
+    /// surface. Pointer routing uses this snapshot so resize transitions do
+    /// not target blank pane margins or wait on the PTY's terminal lock.
+    pub rendered_terminal_sizes: HashMap<SurfaceId, (u16, u16)>,
+    desired_outer_cursor: OuterCursorSpec,
+    applied_outer_cursor: Option<OuterCursorSpec>,
     pub graphics_writer: Option<GraphicsWriter>,
     pub graphics_supported: bool,
     stdout_lock: Arc<Mutex<()>>,
@@ -2800,6 +2812,9 @@ pub fn run(
         tree: TreeView::default(),
         tab_locations: HashMap::new(),
         render_states: HashMap::new(),
+        rendered_terminal_sizes: HashMap::new(),
+        desired_outer_cursor: OuterCursorSpec::Reset,
+        applied_outer_cursor: None,
         graphics_writer,
         graphics_supported,
         stdout_lock: stdout_lock.clone(),
@@ -2877,6 +2892,9 @@ fn restore_terminal(stdout_lock: Option<&Arc<Mutex<()>>>) -> anyhow::Result<()> 
     let mut stdout = std::io::stdout();
     // Reset the mouse pointer shape in case we left it as a hand.
     let _ = write!(stdout, "\x1b]22;default\x07");
+    // Cursor color and DECSCUSR shape are outer-terminal global state. Always
+    // restore both, including panic/startup-failure paths.
+    let _ = write!(stdout, "\x1b]112\x07\x1b[0 q");
     // Restore the conventional host behavior where Shift bypasses capture.
     let _ = write!(stdout, "\x1b[>0s");
     let _ = stdout.execute(DisableBracketedPaste);
@@ -3240,6 +3258,7 @@ impl App {
             self.drag = None;
         }
         self.render_states.remove(&surface);
+        self.rendered_terminal_sizes.remove(&surface);
         self.visible_size_surfaces.remove(&surface);
         self.pending_size_releases.remove(&surface);
         self.mux_titles.remove(surface);
@@ -3365,7 +3384,28 @@ impl App {
         let lock = self.stdout_lock.clone();
         let _guard = lock.lock().unwrap();
         terminal.draw(|f| crate::ui::draw(self, f))?;
+        if let Some(sequence) =
+            outer_cursor_escape_if_changed(self.applied_outer_cursor, self.desired_outer_cursor)
+        {
+            let mut stdout = std::io::stdout();
+            stdout.write_all(sequence.as_bytes())?;
+            stdout.flush()?;
+            self.applied_outer_cursor = Some(self.desired_outer_cursor);
+        }
         Ok(())
+    }
+
+    pub(crate) fn reset_frame_cursor_spec(&mut self) {
+        self.desired_outer_cursor = OuterCursorSpec::Reset;
+    }
+
+    pub(crate) fn use_terminal_cursor_spec(
+        &mut self,
+        color: Rgb,
+        shape: CursorShape,
+        blinking: bool,
+    ) {
+        self.desired_outer_cursor = OuterCursorSpec::Terminal { color, shape, blinking };
     }
 
     fn frame_only_browser_update(&self, id: SurfaceId) -> bool {
@@ -4218,6 +4258,9 @@ impl App {
             AppEvent::Input(Event::Resize(_, _)) => {
                 self.refresh_cell_pixels(false);
                 self.render_states.clear();
+                // Keep the dimensions of the frame that remains visible until
+                // the next draw publishes a replacement. Clearing this cache
+                // would briefly make newly exposed blank margins clickable.
                 self.sidebar_plugin_surface = None;
                 Ok(RenderAction::Draw)
             }
@@ -5860,12 +5903,16 @@ impl App {
         {
             return PtyMousePressResult::NotOwned;
         }
+        let content = self.canonical_pty_content(area.surface, area.content);
+        if !content.contains(x, y) {
+            return PtyMousePressResult::NotOwned;
+        }
         let Some(handle) = self.session.surface(area.surface) else {
             return PtyMousePressResult::Consumed;
         };
         let (release_capture, forwarded) = self.prepare_pty_mouse_press(
             (area.surface, handle.clone()),
-            area.content,
+            content,
             x,
             y,
             button,
@@ -5897,7 +5944,7 @@ impl App {
             handle: Some(handle),
             reservation_id,
             release_bytes,
-            content: area.content,
+            content,
             button,
             position: (x, y),
             modifiers,
@@ -6168,19 +6215,34 @@ impl App {
         {
             return false;
         }
+        let content = self.canonical_pty_content(area.surface, area.content);
         if action == MouseAction::Motion {
-            return self.forward_pty_mouse_motion_if_uncontended(
+            let inside = content.contains(x, y);
+            let owned = self.forward_pty_mouse_motion_if_uncontended(
                 area.surface,
-                area.content,
+                content,
                 (x, y),
                 None,
                 modifiers,
                 any_button_pressed,
             );
+            // A no-button motion outside the canonical viewport is
+            // intentionally suppressed by Ghostty. Reset dedupe so re-entering
+            // through the same edge cell still reports a fresh hover sample.
+            if !inside
+                && !any_button_pressed
+                && let Some(surface) = self.session.surface(area.surface)
+            {
+                surface.reset_mouse_motion_dedupe();
+            }
+            return owned;
+        }
+        if !content.contains(x, y) {
+            return false;
         }
         self.forward_pty_mouse_to_surface(
             area.surface,
-            area.content,
+            content,
             x,
             y,
             action,
@@ -6457,7 +6519,14 @@ impl App {
     }
 
     fn current_pty_content(&self, surface: SurfaceId) -> Option<Rect> {
-        self.pane_areas.iter().find(|area| area.surface == surface).map(|area| area.content)
+        self.pane_areas
+            .iter()
+            .find(|area| area.surface == surface)
+            .map(|area| self.canonical_pty_content(surface, area.content))
+    }
+
+    fn canonical_pty_content(&self, surface: SurfaceId, content: Rect) -> Rect {
+        canonical_terminal_content(content, self.rendered_terminal_sizes.get(&surface).copied())
     }
 
     fn cancel_pty_release_reservation(&self) {
@@ -7277,6 +7346,10 @@ impl App {
             }
             return Ok(RenderAction::None);
         }
+        let canonical_content = self.canonical_pty_content(surface_id, area.content);
+        if !canonical_content.contains(x, y) {
+            return Ok(RenderAction::None);
+        }
         if area.content.contains(x, y)
             && self.forward_pty_mouse_at(
                 x,
@@ -7330,6 +7403,11 @@ impl App {
         };
         if self.active_pane() != Some(area.pane) {
             self.focus_pane_after_input(area.pane);
+        }
+        if self.surface_kind(area.surface) == Some(SurfaceKind::Pty)
+            && !self.canonical_pty_content(area.surface, area.content).contains(x, y)
+        {
+            return Ok(RenderAction::None);
         }
         if area.content.contains(x, y)
             && self.forward_pty_mouse_at(
@@ -7405,6 +7483,43 @@ impl App {
                 click_count: dispatch.click_count,
             },
         });
+    }
+}
+
+fn canonical_terminal_content(content: Rect, rendered_size: Option<(u16, u16)>) -> Rect {
+    let (cols, rows) = rendered_size.unwrap_or((content.width, content.height));
+    Rect {
+        x: content.x,
+        y: content.y,
+        width: content.width.min(cols),
+        height: content.height.min(rows),
+    }
+}
+
+fn outer_cursor_escape_if_changed(
+    applied: Option<OuterCursorSpec>,
+    desired: OuterCursorSpec,
+) -> Option<String> {
+    (applied != Some(desired)).then(|| outer_cursor_escape(desired))
+}
+
+fn outer_cursor_escape(spec: OuterCursorSpec) -> String {
+    match spec {
+        OuterCursorSpec::Reset => "\x1b]112\x07\x1b[0 q".to_string(),
+        OuterCursorSpec::Terminal { color, shape, blinking } => {
+            let style = match (shape, blinking) {
+                (CursorShape::Block, true) => 1,
+                (CursorShape::Block, false) => 2,
+                (CursorShape::Underline, true) => 3,
+                (CursorShape::Underline, false) => 4,
+                (CursorShape::Bar, true) => 5,
+                (CursorShape::Bar, false) => 6,
+                // DECSCUSR has no hollow-block form. A steady block preserves
+                // shape and avoids inventing blink behavior.
+                (CursorShape::BlockHollow, _) => 2,
+            };
+            format!("\x1b]12;#{:02x}{:02x}{:02x}\x07\x1b[{style} q", color.r, color.g, color.b)
+        }
     }
 }
 
@@ -7521,12 +7636,13 @@ fn browser_key_mapping(
 mod tests {
     use super::{
         App, AppEvent, BACKGROUND_REFRESH_RETRIES, ContextMenu, DeferredInput, Drag,
-        ForwardMuxOutcome, MenuAction, MenuItem, MuxTitleIngress, OrderedSession, PaneArea,
-        PendingSessionMutation, PendingSessionMutationState, PtyFailureIngress,
+        ForwardMuxOutcome, MenuAction, MenuItem, MuxTitleIngress, OrderedSession, OuterCursorSpec,
+        PaneArea, PendingSessionMutation, PendingSessionMutationState, PtyFailureIngress,
         PtyMousePressResult, RenderAction, Selection, SessionCompletion, SessionCompletionAction,
         SidebarPluginSyncClaim, SidebarPluginSyncState, SurfaceResizeDecision,
         SurfaceResizeOwnership, browser_content_size_for_rect, browser_hover_forward_allowed,
-        client_menu_item, forward_mux_event, forward_mux_events, pane_context_menu_groups,
+        canonical_terminal_content, client_menu_item, forward_mux_event, forward_mux_events,
+        outer_cursor_escape, outer_cursor_escape_if_changed, pane_context_menu_groups,
         pane_parts_for_rect, preserve_client_view, record_surface_resize_dispatch_result,
         sidebar_plugin_status_settles_passive_claim, workspace_destination_index,
     };
@@ -7544,7 +7660,8 @@ mod tests {
         Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
     use ghostty_vt::{
-        KeyEncoder, Mods, MouseAction, MouseButton as GhosttyMouseButton, MouseInput, RenderState,
+        CursorShape, KeyEncoder, Mods, MouseAction, MouseButton as GhosttyMouseButton, MouseInput,
+        RenderState, Rgb,
     };
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -8055,6 +8172,188 @@ mod tests {
         assert!(matches!(app.drag, Some(Drag::Select { .. })));
 
         mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn pty_mouse_uses_the_canonical_rendered_grid_during_resize_margins() {
+        let mux = Mux::new(
+            "mouse-canonical-grid-test",
+            SurfaceOptions {
+                command: Some(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "sleep 30".to_string(),
+                ]),
+                ..Default::default()
+            },
+        );
+        let surface = mux.new_workspace(Some("work".to_string()), Some((20, 8))).unwrap();
+        surface.with_terminal(|terminal| terminal.vt_write(b"\x1b[?1003h\x1b[?1006h"));
+
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.replace_tree(app.session.tree());
+        let pane = app.tree.active_screen().unwrap().active_pane;
+        let content = Rect { x: 2, y: 3, width: 20, height: 8 };
+        app.pane_areas.push(PaneArea {
+            pane,
+            surface: surface.id,
+            rect: Rect { x: 1, y: 2, width: 23, height: 10 },
+            bar: Some(Rect { x: 1, y: 2, width: 23, height: 1 }),
+            omnibar: None,
+            content,
+            track: None,
+        });
+        // The pane has already grown, but the only frame visible to the user
+        // is still 12x5. The remaining cells are renderer-owned margins.
+        app.rendered_terminal_sizes.insert(surface.id, (12, 5));
+        app.handle(AppEvent::Input(Event::Resize(40, 12))).unwrap();
+        assert_eq!(
+            app.rendered_terminal_sizes.get(&surface.id),
+            Some(&(12, 5)),
+            "outer resize must retain the dimensions of the still-visible frame"
+        );
+
+        let outside = (content.x + 15, content.y + 2);
+        assert_eq!(
+            app.begin_pty_mouse_drag(outside.0, outside.1, MouseButton::Left, KeyModifiers::NONE,),
+            PtyMousePressResult::NotOwned
+        );
+        assert!(app.drag.is_none());
+        assert!(app.encode_buf.is_empty());
+        assert_eq!(
+            app.handle_scroll(outside.0, outside.1, true, KeyModifiers::NONE).unwrap(),
+            RenderAction::None
+        );
+        assert!(app.encode_buf.is_empty());
+        assert_eq!(
+            app.handle_horizontal_scroll(outside.0, outside.1, true, KeyModifiers::NONE).unwrap(),
+            RenderAction::None
+        );
+        assert!(app.encode_buf.is_empty());
+
+        // Leaving through a blank margin suppresses no-button motion, then
+        // clears Ghostty's cell dedupe so the same edge cell reports on reentry.
+        let edge = (content.x + 11, content.y + 2);
+        assert!(app.forward_pty_mouse_at(
+            edge.0,
+            edge.1,
+            MouseAction::Motion,
+            None,
+            KeyModifiers::NONE,
+            false,
+        ));
+        assert_eq!(app.encode_buf, b"\x1b[<35;12;3M");
+        assert!(!app.forward_pty_mouse_at(
+            outside.0,
+            outside.1,
+            MouseAction::Motion,
+            None,
+            KeyModifiers::NONE,
+            false,
+        ));
+        assert!(app.encode_buf.is_empty());
+        assert!(app.forward_pty_mouse_at(
+            edge.0,
+            edge.1,
+            MouseAction::Motion,
+            None,
+            KeyModifiers::NONE,
+            false,
+        ));
+        assert_eq!(app.encode_buf, b"\x1b[<35;12;3M");
+
+        // A press that starts inside keeps capture while crossing the margin;
+        // Ghostty reports the edge cell and, critically, always emits release.
+        let inside = (content.x + 4, content.y + 2);
+        assert_eq!(
+            app.begin_pty_mouse_drag(inside.0, inside.1, MouseButton::Left, KeyModifiers::NONE,),
+            PtyMousePressResult::Started
+        );
+        assert_eq!(app.encode_buf, b"\x1b[<0;5;3M");
+        assert!(app.forward_pty_mouse_drag(
+            outside.0,
+            outside.1,
+            MouseButton::Left,
+            KeyModifiers::NONE,
+        ));
+        assert_eq!(app.encode_buf, b"\x1b[<32;12;3M");
+        assert!(app.finish_pty_mouse_drag(
+            outside.0,
+            outside.1,
+            MouseButton::Left,
+            KeyModifiers::NONE,
+        ));
+        assert_eq!(app.encode_buf, b"\x1b[<0;12;3m");
+        assert!(app.drag.is_none());
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn canonical_terminal_content_clamps_to_the_visible_pane() {
+        let content = Rect { x: 7, y: 11, width: 20, height: 8 };
+        assert_eq!(canonical_terminal_content(content, None), content);
+        assert_eq!(
+            canonical_terminal_content(content, Some((12, 5))),
+            Rect { x: 7, y: 11, width: 12, height: 5 }
+        );
+        assert_eq!(
+            canonical_terminal_content(content, Some((40, 30))),
+            content,
+            "a stale larger frame must never claim cells outside its pane"
+        );
+    }
+
+    #[test]
+    fn outer_cursor_escapes_cover_color_shape_blink_and_reset() {
+        let color = Rgb { r: 0x12, g: 0x34, b: 0x56 };
+        let terminal = |shape, blinking| OuterCursorSpec::Terminal { color, shape, blinking };
+        assert_eq!(
+            outer_cursor_escape(terminal(CursorShape::Block, true)),
+            "\x1b]12;#123456\x07\x1b[1 q"
+        );
+        assert_eq!(
+            outer_cursor_escape(terminal(CursorShape::Block, false)),
+            "\x1b]12;#123456\x07\x1b[2 q"
+        );
+        assert_eq!(
+            outer_cursor_escape(terminal(CursorShape::Underline, true)),
+            "\x1b]12;#123456\x07\x1b[3 q"
+        );
+        assert_eq!(
+            outer_cursor_escape(terminal(CursorShape::Underline, false)),
+            "\x1b]12;#123456\x07\x1b[4 q"
+        );
+        assert_eq!(
+            outer_cursor_escape(terminal(CursorShape::Bar, true)),
+            "\x1b]12;#123456\x07\x1b[5 q"
+        );
+        assert_eq!(
+            outer_cursor_escape(terminal(CursorShape::Bar, false)),
+            "\x1b]12;#123456\x07\x1b[6 q"
+        );
+        assert_eq!(
+            outer_cursor_escape(terminal(CursorShape::BlockHollow, true)),
+            "\x1b]12;#123456\x07\x1b[2 q",
+            "DECSCUSR has no hollow block, so it degrades to steady block"
+        );
+        assert_eq!(outer_cursor_escape(OuterCursorSpec::Reset), "\x1b]112\x07\x1b[0 q");
+    }
+
+    #[test]
+    fn outer_cursor_state_suppresses_redundant_global_terminal_writes() {
+        let desired = OuterCursorSpec::Terminal {
+            color: Rgb { r: 1, g: 2, b: 3 },
+            shape: CursorShape::Bar,
+            blinking: false,
+        };
+        assert!(outer_cursor_escape_if_changed(None, desired).is_some());
+        assert!(outer_cursor_escape_if_changed(Some(desired), desired).is_none());
+        assert!(outer_cursor_escape_if_changed(Some(desired), OuterCursorSpec::Reset).is_some());
+        assert!(
+            outer_cursor_escape_if_changed(Some(OuterCursorSpec::Reset), OuterCursorSpec::Reset)
+                .is_none()
+        );
     }
 
     #[test]
@@ -10830,6 +11129,9 @@ mod tests {
             tree: TreeView::default(),
             tab_locations: HashMap::new(),
             render_states: HashMap::<u64, RenderState>::new(),
+            rendered_terminal_sizes: HashMap::new(),
+            desired_outer_cursor: OuterCursorSpec::Reset,
+            applied_outer_cursor: None,
             graphics_writer: None,
             graphics_supported: false,
             stdout_lock: Arc::new(Mutex::new(())),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5032,7 +5032,6 @@ impl App {
                 // Close the active tab; the pane collapses with its last
                 // tab, so this is also "close pane" for single-tab panes.
                 if let Some(surface) = self.active_surface() {
-                    self.render_states.remove(&surface);
                     self.session.close_surface(surface);
                 }
             }
@@ -5349,7 +5348,6 @@ impl App {
             MenuAction::SplitDown(id) => self.split_pane(id, SplitDir::Down)?,
             MenuAction::CloseTab(id) => {
                 if let Some(surface) = self.tree.pane(id).and_then(|p| p.active_surface()) {
-                    self.render_states.remove(&surface);
                     self.session.close_surface(surface);
                 }
             }
@@ -8056,7 +8054,7 @@ mod tests {
         assert!(app.selection.is_some());
         assert!(matches!(app.drag, Some(Drag::Select { .. })));
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -8105,7 +8103,7 @@ mod tests {
 
         release_tx.send(()).unwrap();
         holder.join().unwrap();
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -8165,7 +8163,7 @@ mod tests {
         input.join().unwrap();
 
         assert_eq!(result.unwrap(), PtyMousePressResult::Started);
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -8199,7 +8197,7 @@ mod tests {
         assert!(app.sidebar_focused);
         assert!(app.drag.is_none());
         assert!(app.encode_buf.is_empty());
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -8327,7 +8325,7 @@ mod tests {
             PtyInputEnqueueResult::Failed,
         );
         assert!(!encode_test_mouse_motion(&handle, input).is_empty());
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -8364,7 +8362,7 @@ mod tests {
         }))
         .unwrap();
         assert!(!encode_test_mouse_motion(&handle, input).is_empty());
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -10554,7 +10552,7 @@ mod tests {
             Some("PTY input queue is full; input was not sent")
         );
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -10609,7 +10607,7 @@ mod tests {
         assert!(!row_contains(buffer, 1, "•"), "tab bar dot should clear");
         assert_ne!(buffer[(0, 2)].symbol(), "•", "sidebar dot should clear");
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -10651,7 +10649,7 @@ mod tests {
             "plugin sidebar must register the SidebarResize hit on the divider column"
         );
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     fn test_mouse_motion() -> MouseInput {
@@ -10743,7 +10741,7 @@ mod tests {
         assert!(text.contains("known-sidebar-file"), "{text}");
         assert!(text.lines().next().is_some_and(|line| line.contains("• 1")), "{text}");
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
         std::fs::remove_dir_all(temp).unwrap();
     }
 
@@ -10770,7 +10768,7 @@ mod tests {
         terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
         assert!(buffer_text(terminal.backend().buffer()).contains("toggle-marker"));
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
         std::fs::remove_dir_all(temp).unwrap();
     }
 
@@ -10787,7 +10785,7 @@ mod tests {
 
         app.run_action(Action::FocusSidebar).unwrap();
         assert!(!app.sidebar_focused);
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
     }
 
     #[test]
@@ -10813,7 +10811,7 @@ mod tests {
             );
         }
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
         std::fs::remove_dir_all(temp).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -1749,7 +1749,7 @@ mod tests {
         assert_eq!(colors.selection_bg, Some(Rgb { r: 0x22, g: 0x33, b: 0x44 }));
         assert_eq!(colors.selection_fg, Some(Rgb { r: 0xfe, g: 0xfe, b: 0xfe }));
 
-        mux.close_surface(surface.id);
+        mux.close_surface(surface.id).unwrap();
         mux.shutdown();
         server::cleanup(&socket);
     }

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -234,18 +234,11 @@ fn main() {
 }
 
 fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
-    if args.iter().map(String::as_str).ne(["--bootstrap-stdio"]) {
-        anyhow::bail!("hidden mode requires --bootstrap-stdio");
-    }
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut reader = stdin.lock();
     let mut writer = stdout.lock();
-    // This first slice establishes the private bootstrap and versioned wire
-    // boundary. The long-lived PTY/admin/data loops will consume the returned
-    // owner state when process isolation is wired into Surface::spawn.
-    let _host = cmux_tui_core::terminal_host::bootstrap_stdio_once(&mut reader, &mut writer)?;
-    Ok(())
+    cmux_tui_core::terminal_host_runtime::serve_terminal_host_stdio(args, &mut reader, &mut writer)
 }
 
 fn run_attach(args: Args) -> anyhow::Result<()> {
@@ -274,16 +267,25 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     surface_options.extra_env.push(("CMUX_TUI_SOCKET".into(), socket_path.display().to_string()));
     surface_options.extra_env.push(("CMUX_MUX_SOCKET".into(), socket_path.display().to_string()));
 
-    let mux = if args.ephemeral {
-        Mux::new(args.session.clone(), surface_options)
+    let state_root = if args.ephemeral {
+        None
     } else {
-        let state_root = match args.state {
+        Some(match args.state {
             Some(path) => path,
             None if explicit_socket => socket_path.with_extension("state"),
             None => cmux_tui_core::platform::workspace_state_dir()
                 .ok_or_else(|| anyhow::anyhow!("cannot determine durable state directory"))?,
-        };
-        Mux::open_persistent(args.session.clone(), surface_options, &state_root)?
+        })
+    };
+    if let Some(state_root) = state_root.as_deref() {
+        surface_options.terminal_host_root = Some(
+            cmux_tui_core::terminal_host_runtime::terminal_host_root(state_root, &args.session),
+        );
+    }
+    let mux = if let Some(state_root) = state_root.as_deref() {
+        Mux::open_persistent(args.session.clone(), surface_options, state_root)?
+    } else {
+        Mux::new(args.session.clone(), surface_options)
     };
     // Headless sessions have no host terminal to query, so seed the mux from
     // Ghostty's config before any protocol client can create a surface.

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -62,6 +62,8 @@ USAGE:
 OPTIONS:
   --session <name>   Session name (default: main). Determines the socket path.
   --socket <path>    Explicit control socket path.
+  --state <path>     Durable session-state root (default: platform state dir).
+  --ephemeral        Keep workspace state in memory for this run only.
   --headless         Run only the control socket, no TUI.
   --ws <addr>        Also listen for WebSocket clients (default: off).
   --ws-token <token> Allow a static-token bypass for interactive pairing.
@@ -118,6 +120,8 @@ struct Args {
     attach: bool,
     session: String,
     socket: Option<PathBuf>,
+    state: Option<PathBuf>,
+    ephemeral: bool,
     headless: bool,
     ws: Option<String>,
     ws_token: Option<String>,
@@ -130,6 +134,8 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
         attach: false,
         session: "main".to_string(),
         socket: None,
+        state: None,
+        ephemeral: false,
         headless: false,
         ws: None,
         ws_token: None,
@@ -151,6 +157,11 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
                     args.next().unwrap_or_else(|| usage_exit("--socket needs a value")).into(),
                 );
             }
+            "--state" => {
+                out.state =
+                    Some(args.next().unwrap_or_else(|| usage_exit("--state needs a value")).into());
+            }
+            "--ephemeral" => out.ephemeral = true,
             "--headless" => out.headless = true,
             "--ws" => {
                 out.ws = Some(args.next().unwrap_or_else(|| usage_exit("--ws needs a value")));
@@ -218,6 +229,9 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
 }
 
 fn run_server(args: Args) -> anyhow::Result<()> {
+    if args.ephemeral && args.state.is_some() {
+        anyhow::bail!("--ephemeral and --state are mutually exclusive");
+    }
     let mut surface_options = SurfaceOptions::default();
     let config = config::load();
     let ws_addr = args.ws.or(config.server.ws.clone());
@@ -227,12 +241,23 @@ fn run_server(args: Args) -> anyhow::Result<()> {
         surface_options.term = term;
     }
     // Compute the socket path up front so surface children inherit it.
+    let explicit_socket = args.socket.is_some();
     let socket_path =
         args.socket.unwrap_or_else(|| cmux_tui_core::server::default_socket_path(&args.session));
     surface_options.extra_env.push(("CMUX_TUI_SOCKET".into(), socket_path.display().to_string()));
     surface_options.extra_env.push(("CMUX_MUX_SOCKET".into(), socket_path.display().to_string()));
 
-    let mux = Mux::new(args.session.clone(), surface_options);
+    let mux = if args.ephemeral {
+        Mux::new(args.session.clone(), surface_options)
+    } else {
+        let state_root = match args.state {
+            Some(path) => path,
+            None if explicit_socket => socket_path.with_extension("state"),
+            None => cmux_tui_core::platform::workspace_state_dir()
+                .ok_or_else(|| anyhow::anyhow!("cannot determine durable state directory"))?,
+        };
+        Mux::open_persistent(args.session.clone(), surface_options, &state_root)?
+    };
     // Headless sessions have no host terminal to query, so seed the mux from
     // Ghostty's config before any protocol client can create a surface.
     mux.set_default_colors(config.terminal_defaults);

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -204,8 +204,20 @@ fn version_string() -> String {
 }
 
 fn main() {
-    install_signal_handlers();
     let raw_args = std::env::args().skip(1).collect::<Vec<_>>();
+    // Private process mode used by the daemon when it launches one durable
+    // terminal host per PTY. Keep this out of public help and dispatch it
+    // before installing the interactive daemon's signal handlers: the host
+    // owns its own lifecycle and must not inherit "request mux shutdown"
+    // semantics.
+    if raw_args.first().map(String::as_str) == Some("__terminal-host") {
+        if let Err(error) = run_terminal_host_process(&raw_args[1..]) {
+            eprintln!("cmux-tui terminal host: {error}");
+            std::process::exit(1);
+        }
+        return;
+    }
+    install_signal_handlers();
     if raw_args.first().map(|arg| arg.as_str()) == Some("help") {
         cli::print_help(USAGE);
         std::process::exit(0);
@@ -219,6 +231,21 @@ fn main() {
         eprintln!("cmux-tui: {e}");
         std::process::exit(1);
     }
+}
+
+fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
+    if args.iter().map(String::as_str).ne(["--bootstrap-stdio"]) {
+        anyhow::bail!("hidden mode requires --bootstrap-stdio");
+    }
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let mut reader = stdin.lock();
+    let mut writer = stdout.lock();
+    // This first slice establishes the private bootstrap and versioned wire
+    // boundary. The long-lived PTY/admin/data loops will consume the returned
+    // owner state when process isolation is wired into Surface::spawn.
+    let _host = cmux_tui_core::terminal_host::bootstrap_stdio_once(&mut reader, &mut writer)?;
+    Ok(())
 }
 
 fn run_attach(args: Args) -> anyhow::Result<()> {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -234,6 +234,7 @@ fn main() {
 }
 
 fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
+    cmux_tui_core::terminal_host_runtime::isolate_terminal_host_process_fds()?;
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut reader = stdin.lock();

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -640,8 +640,11 @@ impl Session {
     pub fn close_screen(&self, screen: ScreenId) -> anyhow::Result<()> {
         match self {
             Session::Local(mux) => {
-                mux.close_screen(screen);
-                Ok(())
+                if mux.close_screen(screen)? {
+                    Ok(())
+                } else {
+                    anyhow::bail!("unknown screen {screen}")
+                }
             }
             Session::Remote(remote) => {
                 remote.request(json!({"cmd": "close-screen", "screen": screen})).map(|_| ())
@@ -726,8 +729,11 @@ impl Session {
     pub fn close_surface(&self, surface: SurfaceId) -> anyhow::Result<()> {
         match self {
             Session::Local(mux) => {
-                mux.close_surface(surface);
-                Ok(())
+                if mux.close_surface(surface)? {
+                    Ok(())
+                } else {
+                    anyhow::bail!("unknown surface {surface}")
+                }
             }
             Session::Remote(remote) => {
                 remote.request(json!({"cmd": "close-surface", "surface": surface})).map(|_| ())
@@ -738,8 +744,11 @@ impl Session {
     pub fn close_pane(&self, pane: PaneId) -> anyhow::Result<()> {
         match self {
             Session::Local(mux) => {
-                mux.close_pane(pane);
-                Ok(())
+                if mux.close_pane(pane)? {
+                    Ok(())
+                } else {
+                    anyhow::bail!("unknown pane {pane}")
+                }
             }
             Session::Remote(remote) => {
                 remote.request(json!({"cmd": "close-pane", "pane": pane})).map(|_| ())

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -762,7 +762,7 @@ impl Session {
     pub fn close_workspace(&self, workspace: WorkspaceId) -> anyhow::Result<()> {
         match self {
             Session::Local(mux) => {
-                mux.close_workspace(workspace);
+                mux.close_workspace_at_revision(workspace, None)?;
                 Ok(())
             }
             Session::Remote(remote) => remote
@@ -786,7 +786,7 @@ impl Session {
     pub fn rename_workspace(&self, workspace: WorkspaceId, name: String) -> anyhow::Result<()> {
         match self {
             Session::Local(mux) => {
-                mux.rename_workspace(workspace, name);
+                mux.rename_workspace_at_revision(workspace, name, None)?;
                 Ok(())
             }
             Session::Remote(remote) => remote
@@ -877,7 +877,7 @@ impl Session {
     pub fn move_workspace(&self, workspace: WorkspaceId, index: usize) -> anyhow::Result<()> {
         match self {
             Session::Local(mux) => {
-                mux.move_workspace(workspace, index);
+                mux.move_workspace_at_revision(workspace, index, None)?;
                 Ok(())
             }
             Session::Remote(remote) => remote

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -23,6 +23,7 @@ use crate::app::{App, Hit};
 pub(crate) use scrollbar::thumb_geometry;
 
 pub fn draw(app: &mut App, frame: &mut Frame) {
+    app.reset_frame_cursor_spec();
     let area = frame.area();
     if area.height == 0 {
         return;

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -82,10 +82,11 @@ pub(crate) fn client_border_labels(clients: &[ClientInfo]) -> HashMap<u64, Strin
 /// position for the focused pane, if visible.
 pub fn draw_all(app: &mut App, frame: &mut Frame) -> Option<(u16, u16)> {
     let active_pane = app.tree.active_screen().map(|screen| screen.active_pane);
+    let panes_accept_focus = !app.sidebar_focused;
     let areas = app.pane_areas.clone();
     let mut cursor = None;
     for area in &areas {
-        let focused = Some(area.pane) == active_pane;
+        let focused = panes_accept_focus && Some(area.pane) == active_pane;
         draw_box(app, frame, area, focused);
         if area.bar.is_some() {
             draw_tab_bar(app, frame, area, focused);

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -352,6 +352,15 @@ fn draw_content(
         .entry(area.surface)
         .or_insert_with(|| RenderState::new().expect("render state alloc"));
     let render = surface.render_frame(rs).ok()?;
+    app.rendered_terminal_sizes.insert(area.surface, render.frame.size);
+    if focused && app.menu.is_none() && app.prompt.is_none() && app.pairing_dialog.is_none() {
+        let (shape, blinking) = render.frame.cursor_visual;
+        app.use_terminal_cursor_spec(
+            super::terminal_grid::resolved_cursor_color(&render),
+            shape,
+            blinking,
+        );
+    }
 
     let cursor =
         super::terminal_grid::draw_render_frame(frame, rect, &render, &theme, |col, row| {

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -19,6 +19,7 @@ pub fn draw_render_frame(
     let max_cols = rect.width.min(screen.width.saturating_sub(rect.x)) as usize;
     let max_rows = rect.height.min(screen.height.saturating_sub(rect.y)) as usize;
     let colors = PaletteResolver::from_frame(render);
+    let blank_style = colors.blank_style();
     let buf = frame.buffer_mut();
 
     for (row, cells) in render.frame.styled_rows().iter().enumerate() {
@@ -36,7 +37,7 @@ pub fn draw_render_frame(
         }
         for col in cells.len()..max_cols {
             let x = rect.x + col as u16;
-            buf[(x, y)].set_symbol(" ").set_style(Style::default());
+            buf[(x, y)].set_symbol(" ").set_style(blank_style);
         }
     }
 
@@ -45,7 +46,7 @@ pub fn draw_render_frame(
         let y = rect.y + row as u16;
         for col in 0..max_cols {
             let x = rect.x + col as u16;
-            buf[(x, y)].set_symbol(" ").set_style(Style::default());
+            buf[(x, y)].set_symbol(" ").set_style(blank_style);
         }
     }
 
@@ -59,22 +60,52 @@ pub fn draw_render_frame(
 struct PaletteResolver<'a> {
     colors: &'a [Rgb; 256],
     overridden: &'a [bool; 256],
+    default_fg: Rgb,
+    default_bg: Rgb,
+}
+
+pub(crate) fn resolved_cursor_color(frame: &SurfaceRenderFrame) -> Rgb {
+    frame.frame.cursor_color.unwrap_or(frame.frame.default_colors.1)
 }
 
 impl<'a> PaletteResolver<'a> {
     fn from_frame(frame: &'a SurfaceRenderFrame) -> Self {
-        Self { colors: &frame.palette_colors, overridden: &frame.palette_overridden }
+        // RenderFrame follows Ghostty's native (background, foreground)
+        // ordering; keep the visual roles explicit at this boundary.
+        let (default_bg, default_fg) = frame.frame.default_colors;
+        Self {
+            colors: &frame.palette_colors,
+            overridden: &frame.palette_overridden,
+            default_fg,
+            default_bg,
+        }
     }
 
-    fn resolve(&self, spec: ColorSpec) -> Color {
+    fn resolve(&self, spec: ColorSpec, default: Rgb) -> Color {
         match spec {
-            ColorSpec::Default => Color::Reset,
+            ColorSpec::Default => rgb_color(default),
             ColorSpec::Rgb(rgb) => Color::Rgb(rgb.r, rgb.g, rgb.b),
             ColorSpec::Palette(idx) => {
                 resolve_palette_color(idx, self.overridden[idx as usize], self.colors[idx as usize])
             }
         }
     }
+
+    fn resolve_fg(&self, spec: ColorSpec) -> Color {
+        self.resolve(spec, self.default_fg)
+    }
+
+    fn resolve_bg(&self, spec: ColorSpec) -> Color {
+        self.resolve(spec, self.default_bg)
+    }
+
+    fn blank_style(&self) -> Style {
+        Style::default().fg(rgb_color(self.default_fg)).bg(rgb_color(self.default_bg))
+    }
+}
+
+fn rgb_color(rgb: Rgb) -> Color {
+    Color::Rgb(rgb.r, rgb.g, rgb.b)
 }
 
 fn resolve_palette_color(idx: u8, overridden: bool, rgb: Rgb) -> Color {
@@ -119,8 +150,8 @@ fn apply_cell(
     }
 
     let mut style = Style::default();
-    style = style.fg(colors.resolve(cell.fg));
-    style = style.bg(colors.resolve(cell.bg));
+    style = style.fg(colors.resolve_fg(cell.fg));
+    style = style.bg(colors.resolve_bg(cell.bg));
     let mut modifier = Modifier::empty();
     if cell.bold {
         modifier |= Modifier::BOLD;
@@ -160,12 +191,41 @@ fn apply_cell(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ghostty_vt::{Callbacks, RenderState, Terminal};
+    use ratatui::Terminal as RatatuiTerminal;
+    use ratatui::backend::TestBackend;
+
+    fn render_frame_with_defaults(
+        foreground: Rgb,
+        background: Rgb,
+        cursor: Option<Rgb>,
+    ) -> SurfaceRenderFrame {
+        let mut terminal = Terminal::new(2, 1, 0, Callbacks::default()).unwrap();
+        terminal.set_default_colors(Some(foreground), Some(background), cursor);
+        let mut state = RenderState::new().unwrap();
+        state.update(&mut terminal).unwrap();
+        SurfaceRenderFrame {
+            frame: state.build_frame().unwrap(),
+            scrollback_rows: 0,
+            palette_colors: [Rgb::default(); 256],
+            palette_overridden: [false; 256],
+        }
+    }
+
+    fn resolver<'a>(colors: &'a [Rgb; 256], overridden: &'a [bool; 256]) -> PaletteResolver<'a> {
+        PaletteResolver {
+            colors,
+            overridden,
+            default_fg: Rgb { r: 0x11, g: 0x22, b: 0x33 },
+            default_bg: Rgb { r: 0x44, g: 0x55, b: 0x66 },
+        }
+    }
 
     #[test]
     fn palette_resolver_preserves_host_palette_for_non_overridden_entries() {
         let colors = [Rgb { r: 1, g: 2, b: 3 }; 256];
         let overridden = [false; 256];
-        let resolver = PaletteResolver { colors: &colors, overridden: &overridden };
+        let resolver = resolver(&colors, &overridden);
         let expected = [
             Color::Black,
             Color::Red,
@@ -186,10 +246,10 @@ mod tests {
         ];
 
         for (idx, color) in expected.into_iter().enumerate() {
-            assert_eq!(resolver.resolve(ColorSpec::Palette(idx as u8)), color);
+            assert_eq!(resolver.resolve_fg(ColorSpec::Palette(idx as u8)), color);
         }
-        assert_eq!(resolver.resolve(ColorSpec::Palette(16)), Color::Indexed(16));
-        assert_eq!(resolver.resolve(ColorSpec::Palette(196)), Color::Indexed(196));
+        assert_eq!(resolver.resolve_fg(ColorSpec::Palette(16)), Color::Indexed(16));
+        assert_eq!(resolver.resolve_fg(ColorSpec::Palette(196)), Color::Indexed(196));
     }
 
     #[test]
@@ -200,9 +260,69 @@ mod tests {
         let mut overridden = [false; 256];
         overridden[1] = true;
         overridden[196] = true;
-        let resolver = PaletteResolver { colors: &colors, overridden: &overridden };
+        let resolver = resolver(&colors, &overridden);
 
-        assert_eq!(resolver.resolve(ColorSpec::Palette(1)), Color::Rgb(1, 2, 3));
-        assert_eq!(resolver.resolve(ColorSpec::Palette(196)), Color::Rgb(4, 5, 6));
+        assert_eq!(resolver.resolve_fg(ColorSpec::Palette(1)), Color::Rgb(1, 2, 3));
+        assert_eq!(resolver.resolve_bg(ColorSpec::Palette(196)), Color::Rgb(4, 5, 6));
+    }
+
+    #[test]
+    fn default_colors_are_resolved_by_visual_role() {
+        let colors = [Rgb::default(); 256];
+        let overridden = [false; 256];
+        let resolver = resolver(&colors, &overridden);
+
+        assert_eq!(resolver.resolve_fg(ColorSpec::Default), Color::Rgb(0x11, 0x22, 0x33));
+        assert_eq!(resolver.resolve_bg(ColorSpec::Default), Color::Rgb(0x44, 0x55, 0x66));
+        assert_eq!(
+            resolver.blank_style(),
+            Style::default().fg(Color::Rgb(0x11, 0x22, 0x33)).bg(Color::Rgb(0x44, 0x55, 0x66))
+        );
+    }
+
+    #[test]
+    fn explicit_rgb_does_not_inherit_a_default_role() {
+        let colors = [Rgb::default(); 256];
+        let overridden = [false; 256];
+        let resolver = resolver(&colors, &overridden);
+        let explicit = ColorSpec::Rgb(Rgb { r: 7, g: 8, b: 9 });
+
+        assert_eq!(resolver.resolve_fg(explicit), Color::Rgb(7, 8, 9));
+        assert_eq!(resolver.resolve_bg(explicit), Color::Rgb(7, 8, 9));
+    }
+
+    #[test]
+    fn frame_default_order_and_spare_cells_follow_canonical_roles() {
+        let foreground = Rgb { r: 0x11, g: 0x22, b: 0x33 };
+        let background = Rgb { r: 0x44, g: 0x55, b: 0x66 };
+        let cursor = Rgb { r: 0x77, g: 0x88, b: 0x99 };
+        let render = render_frame_with_defaults(foreground, background, Some(cursor));
+        let colors = PaletteResolver::from_frame(&render);
+
+        assert_eq!(colors.resolve_fg(ColorSpec::Default), Color::Rgb(0x11, 0x22, 0x33));
+        assert_eq!(colors.resolve_bg(ColorSpec::Default), Color::Rgb(0x44, 0x55, 0x66));
+        assert_eq!(resolved_cursor_color(&render), cursor);
+        let implicit_cursor = render_frame_with_defaults(foreground, background, None);
+        assert_eq!(resolved_cursor_color(&implicit_cursor), foreground);
+
+        let mut terminal = RatatuiTerminal::new(TestBackend::new(4, 2)).unwrap();
+        terminal
+            .draw(|frame| {
+                draw_render_frame(
+                    frame,
+                    Rect { x: 0, y: 0, width: 4, height: 2 },
+                    &render,
+                    &Theme::default(),
+                    |_, _| false,
+                );
+            })
+            .unwrap();
+
+        for position in [(2, 0), (3, 0), (0, 1), (3, 1)] {
+            let cell = &terminal.backend().buffer()[position];
+            assert_eq!(cell.fg, Color::Rgb(0x11, 0x22, 0x33));
+            assert_eq!(cell.bg, Color::Rgb(0x44, 0x55, 0x66));
+            assert_eq!(cell.symbol(), " ");
+        }
     }
 }

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -40,15 +40,153 @@ impl HeadlessServer {
         }
         panic!("headless server did not create socket at {}", self.socket.display());
     }
+
+    fn close_all_surfaces(&self) -> bool {
+        let state_root = self.socket.with_extension("state");
+        let host_root =
+            cmux_tui_core::terminal_host_runtime::terminal_host_root(&state_root, "main");
+        // Capture exact host PIDs before close can remove their discovery
+        // records. Waiting on both proves teardown did not merely unlink the
+        // record while leaving its process behind.
+        let host_pids = terminal_host_pids(&host_root);
+        let Some(tree) = try_json_socket_request(
+            &self.socket,
+            serde_json::json!({"id": u64::MAX - 1, "cmd": "list-workspaces"}),
+        ) else {
+            return host_pids.is_empty();
+        };
+        let mut surfaces = tree["workspaces"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .flat_map(|workspace| workspace["screens"].as_array().into_iter().flatten())
+            .flat_map(|screen| screen["panes"].as_array().into_iter().flatten())
+            .flat_map(|pane| pane["tabs"].as_array().into_iter().flatten())
+            .filter_map(|tab| tab["surface"].as_u64())
+            .collect::<Vec<_>>();
+        surfaces.sort_unstable();
+        surfaces.dedup();
+        let terminal_pids = surfaces
+            .iter()
+            .filter_map(|surface| {
+                try_json_socket_request(
+                    &self.socket,
+                    serde_json::json!({
+                        "id": u64::MAX - 2,
+                        "cmd": "process-info",
+                        "surface": surface,
+                    }),
+                )?["pid"]
+                    .as_u64()
+            })
+            .filter_map(|pid| u32::try_from(pid).ok())
+            .collect::<Vec<_>>();
+        for (index, surface) in surfaces.into_iter().enumerate() {
+            let index = u64::try_from(index).expect("surface count fits a protocol request id");
+            let _ = try_json_socket_request(
+                &self.socket,
+                serde_json::json!({
+                    "id": u64::MAX - 3 - index,
+                    "cmd": "close-surface",
+                    "surface": surface,
+                }),
+            );
+        }
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            let records_remain =
+                fs::read_dir(&host_root).ok().into_iter().flatten().filter_map(Result::ok).any(
+                    |entry| {
+                        entry.path().extension().and_then(|value| value.to_str()) == Some("json")
+                    },
+                );
+            let processes_remain = host_pids.iter().copied().any(process_exists);
+            let terminals_remain = terminal_pids
+                .iter()
+                .copied()
+                .any(|pid| process_exists(pid) || process_group_exists(pid));
+            if !records_remain && !processes_remain && !terminals_remain {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        false
+    }
 }
 
 impl Drop for HeadlessServer {
     fn drop(&mut self) {
+        // Durable terminal hosts intentionally outlive the daemon. Tests must
+        // close their canonical surfaces first rather than assuming SIGKILL
+        // of the daemon also owns or reaps its per-terminal processes.
+        let hosts_stopped = self.close_all_surfaces();
         let _ = self.child.kill();
         let _ = self.child.wait();
         let _ = fs::remove_file(&self.socket);
         let _ = fs::remove_dir_all(&self.dir);
+        if !hosts_stopped && !std::thread::panicking() {
+            panic!("headless CLI fixture left a durable terminal-host process behind");
+        }
     }
+}
+
+fn try_json_socket_request(
+    path: &std::path::Path,
+    request: serde_json::Value,
+) -> Option<serde_json::Value> {
+    let stream = transport::connect(path).ok()?;
+    let mut writer = stream.try_clone_box().ok()?;
+    let mut reader = BufReader::new(stream);
+    writeln!(writer, "{request}").ok()?;
+    let mut line = String::new();
+    reader.read_line(&mut line).ok()?;
+    let response: serde_json::Value = serde_json::from_str(&line).ok()?;
+    (response["ok"] == true).then(|| response["data"].clone())
+}
+
+fn terminal_host_pids(root: &std::path::Path) -> Vec<u32> {
+    fs::read_dir(root)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .filter_map(|entry| fs::read(entry.path()).ok())
+        .filter_map(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .filter_map(|record| record["host_pid"].as_u64())
+        .filter_map(|pid| u32::try_from(pid).ok())
+        .collect()
+}
+
+#[cfg(unix)]
+fn process_exists(pid: u32) -> bool {
+    let Ok(pid) = libc::pid_t::try_from(pid) else { return false };
+    // SAFETY: signal zero performs only an existence/permission check.
+    if unsafe { libc::kill(pid, 0) == 0 } {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(unix)]
+fn process_group_exists(pid: u32) -> bool {
+    let Ok(pid) = libc::pid_t::try_from(pid) else { return false };
+    // SAFETY: a negative PID with signal zero checks the process group and
+    // cannot deliver a signal.
+    if unsafe { libc::kill(-pid, 0) == 0 } {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn process_exists(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(not(unix))]
+fn process_group_exists(_pid: u32) -> bool {
+    false
 }
 
 fn wait_for_socket_path(path: &std::path::Path) {

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc;
@@ -49,6 +49,96 @@ impl Drop for HeadlessServer {
         let _ = fs::remove_file(&self.socket);
         let _ = fs::remove_dir_all(&self.dir);
     }
+}
+
+fn wait_for_socket_path(path: &std::path::Path) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if transport::connect(path).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    panic!("server did not accept connections at {}", path.display());
+}
+
+fn json_socket_request(path: &std::path::Path, request: serde_json::Value) -> serde_json::Value {
+    let stream = transport::connect(path).unwrap();
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    writeln!(writer, "{request}").unwrap();
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    let response: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(response["ok"], true, "request failed: {response}");
+    response["data"].clone()
+}
+
+#[test]
+fn durable_registry_survives_sigkill_and_rejects_a_second_writer() {
+    let dir = unique_temp_dir("durable-restart");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("mux.sock");
+    let second_socket = dir.join("second.sock");
+    let state = dir.join("state");
+    let spawn = |socket: &std::path::Path| {
+        Command::new(bin())
+            .args(["--headless", "--session", "durable", "--socket"])
+            .arg(socket)
+            .arg("--state")
+            .arg(&state)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
+    };
+
+    let mut first = spawn(&socket);
+    wait_for_socket_path(&socket);
+    let identify = json_socket_request(&socket, serde_json::json!({"id":1,"cmd":"identify"}));
+    let registry_id = identify["registry_id"].as_str().unwrap().to_string();
+    let generation = identify["generation"].as_str().unwrap().to_string();
+    let created = json_socket_request(
+        &socket,
+        serde_json::json!({
+            "id":2,
+            "cmd":"create-workspace",
+            "name":"survivor",
+            "key":"durable-key",
+            "origin":"process-test",
+            "mutation_id":"create-durable",
+            "expected_revision":0,
+        }),
+    );
+    assert_eq!(created["workspace_revision"], 1);
+
+    let mut second = spawn(&second_socket);
+    let second_status = second.wait().unwrap();
+    assert!(!second_status.success());
+    let mut second_stderr = String::new();
+    second.stderr.take().unwrap().read_to_string(&mut second_stderr).unwrap();
+    assert!(second_stderr.contains("already owned by another daemon"), "{second_stderr}");
+
+    // Child::kill is SIGKILL on Unix, intentionally bypassing graceful
+    // cleanup and leaving the old socket behind.
+    first.kill().unwrap();
+    first.wait().unwrap();
+    let _ = fs::remove_file(&socket);
+
+    let mut restarted = spawn(&socket);
+    wait_for_socket_path(&socket);
+    let recovered =
+        json_socket_request(&socket, serde_json::json!({"id":3,"cmd":"list-workspaces"}));
+    assert_eq!(recovered["registry_id"], registry_id);
+    assert_ne!(recovered["generation"], generation);
+    assert_eq!(recovered["workspace_revision"], 1);
+    assert_eq!(recovered["workspaces"][0]["key"], "durable-key");
+    assert_eq!(recovered["workspaces"][0]["name"], "survivor");
+    assert!(recovered["workspaces"][0]["screens"].as_array().unwrap().is_empty());
+
+    restarted.kill().unwrap();
+    restarted.wait().unwrap();
+    let _ = fs::remove_dir_all(dir);
 }
 
 #[test]

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_mode.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_mode.rs
@@ -1,6 +1,17 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::io::Read;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
 use cmux_tui_core::terminal_host::{
     CAPABILITY_TOKEN_LEN, CapabilityToken, HostBootstrap, HostReady, TerminalId,
 };
@@ -50,4 +61,70 @@ fn hidden_terminal_host_mode_rejects_unframed_invocation() {
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("requires --bootstrap-stdio"));
     assert!(output.stdout.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn hidden_terminal_host_closes_deliberately_inherited_non_stdio_pipe() {
+    let mut pipe = [0; 2];
+    // SAFETY: `pipe` points to storage for exactly two descriptors.
+    assert_eq!(unsafe { libc::pipe(pipe.as_mut_ptr()) }, 0);
+    for descriptor in pipe {
+        // Keep the pipe out of unrelated concurrently spawned test children.
+        // The pre-exec hook below deliberately opts it into this host only.
+        // SAFETY: both descriptors were returned by pipe(2).
+        assert_eq!(unsafe { libc::fcntl(descriptor, libc::F_SETFD, libc::FD_CLOEXEC) }, 0);
+    }
+    // SAFETY: ownership of the read descriptor transfers to this File.
+    let mut read_end = unsafe { File::from_raw_fd(pipe[0]) };
+    // SAFETY: F_GETFL/F_SETFL operate on the valid read descriptor.
+    let flags = unsafe { libc::fcntl(pipe[0], libc::F_GETFL) };
+    assert!(flags >= 0);
+    assert_eq!(unsafe { libc::fcntl(pipe[0], libc::F_SETFL, flags | libc::O_NONBLOCK) }, 0);
+
+    let inherited_writer = pipe[1];
+    let mut command = Command::new(env!("CARGO_BIN_EXE_cmux-tui"));
+    command
+        .args(["__terminal-host", "--bootstrap-stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // SAFETY: the hook calls only async-signal-safe fcntl(2), and its captured
+    // descriptor is valid in the forked child. Clearing CLOEXEC deliberately
+    // models the inherited integration-test pipe that caused the regression.
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fcntl(inherited_writer, libc::F_SETFD, 0) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+    let mut child = command.spawn().unwrap();
+    // SAFETY: the parent no longer needs its writer after the child has
+    // exec'd; EOF now depends solely on whether the hidden host retained it.
+    assert_eq!(unsafe { libc::close(pipe[1]) }, 0);
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let reached_eof = loop {
+        let mut byte = [0; 1];
+        match read_end.read(&mut byte) {
+            Ok(0) => break true,
+            Ok(_) => panic!("nothing writes to the inherited-descriptor test pipe"),
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    break false;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => panic!("read inherited-descriptor test pipe: {error}"),
+        }
+    };
+    let host_was_alive = child.try_wait().unwrap().is_none();
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(reached_eof, "terminal host retained an unrelated inherited descriptor");
+    assert!(host_was_alive, "EOF came only from the terminal host exiting");
 }

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_mode.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_mode.rs
@@ -1,0 +1,53 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use cmux_tui_core::terminal_host::{
+    CAPABILITY_TOKEN_LEN, CapabilityToken, HostBootstrap, HostReady, TerminalId,
+};
+use cmux_tui_core::terminal_host_protocol::{
+    MAX_FRAME_PAYLOAD, MessageKind, PROTOCOL_VERSION, encode_frame, read_frame,
+};
+
+#[test]
+fn hidden_terminal_host_mode_bootstraps_over_private_stdio() {
+    let terminal_id = TerminalId::from_bytes([0x31; 16]);
+    let owner_token = CapabilityToken::from_bytes([0xa7; CAPABILITY_TOKEN_LEN]);
+    let bootstrap = HostBootstrap {
+        min_version: PROTOCOL_VERSION,
+        max_version: PROTOCOL_VERSION,
+        terminal_id,
+        owner_token,
+    };
+    let input = encode_frame(&bootstrap.into_frame(99)).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cmux-tui"))
+        .args(["__terminal-host", "--bootstrap-stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(&input).unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.stderr.is_empty());
+    assert!(
+        !output.stdout.windows(CAPABILITY_TOKEN_LEN).any(|window| window == owner_token.as_bytes())
+    );
+
+    let frame = read_frame(&mut output.stdout.as_slice(), MAX_FRAME_PAYLOAD).unwrap().unwrap();
+    assert_eq!(frame.kind, MessageKind::Ready);
+    assert_eq!(frame.request_id, 99);
+    let ready = HostReady::decode(&frame.payload).unwrap();
+    assert_eq!(ready.selected_version, PROTOCOL_VERSION);
+    assert_eq!(ready.terminal_id, terminal_id);
+}
+
+#[test]
+fn hidden_terminal_host_mode_rejects_unframed_invocation() {
+    let output =
+        Command::new(env!("CARGO_BIN_EXE_cmux-tui")).arg("__terminal-host").output().unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires --bootstrap-stdio"));
+    assert!(output.stdout.is_empty());
+}

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -58,6 +59,31 @@ impl RecoveryHarness {
         harness
     }
 
+    fn start_in_own_session(name: &str) -> Self {
+        let mut harness = Self::start_unstarted(name);
+        let mut command = harness.daemon_command();
+        // SAFETY: setsid(2) is async-signal-safe and touches no Rust state in
+        // the post-fork child. A private daemon session lets this test send a
+        // real process-group hangup without affecting the test runner.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 { Err(std::io::Error::last_os_error()) } else { Ok(()) }
+            });
+        }
+        harness.child = Some(command.spawn().unwrap());
+        wait_for_socket(&harness.socket);
+        harness
+    }
+
+    fn start_with_hosted_spawn_failure(name: &str, delay_ms: u64) -> Self {
+        let mut harness = Self::start_unstarted(name);
+        let mut command = harness.daemon_command();
+        command.env("CMUX_TUI_TEST_HOSTED_SPAWN_FAIL_AFTER_CONNECT", delay_ms.to_string());
+        harness.child = Some(command.spawn().unwrap());
+        wait_for_socket(&harness.socket);
+        harness
+    }
+
     fn start_unstarted(name: &str) -> Self {
         let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
         let dir = PathBuf::from("/tmp")
@@ -75,6 +101,12 @@ impl RecoveryHarness {
 
     fn restart(&mut self) {
         assert!(self.child.is_none());
+        let child = self.daemon_command().spawn().unwrap();
+        self.child = Some(child);
+        wait_for_socket(&self.socket);
+    }
+
+    fn daemon_command(&self) -> Command {
         let mut command = Command::new(bin());
         command
             .args(["--headless", "--session", &self.session, "--socket"])
@@ -86,9 +118,7 @@ impl RecoveryHarness {
         if let Some(delay_ms) = self.host_ready_delay_ms {
             command.env("CMUX_TUI_TEST_HOST_READY_DELAY_MS", delay_ms.to_string());
         }
-        let child = command.spawn().unwrap();
-        self.child = Some(child);
-        wait_for_socket(&self.socket);
+        command
     }
 
     fn sigkill(&mut self) {
@@ -103,6 +133,28 @@ impl RecoveryHarness {
         // SAFETY: the harness owns this child process and passes a platform
         // signal constant.
         assert_eq!(unsafe { libc::kill(pid, signal) }, 0);
+    }
+
+    fn hangup_daemon_process_group(&mut self) {
+        let mut child = self.child.take().unwrap();
+        let pid = child.id() as libc::pid_t;
+        // SAFETY: start_in_own_session made this daemon its private process
+        // group leader; a negative pid addresses exactly that group.
+        assert_eq!(unsafe { libc::kill(-pid, libc::SIGHUP) }, 0);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                let _ = status;
+                break;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("daemon did not exit after process-group SIGHUP");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let _ = fs::remove_file(&self.socket);
     }
 
     fn host_root(&self) -> PathBuf {
@@ -151,6 +203,238 @@ impl Drop for RecoveryHarness {
         }
         let _ = fs::remove_dir_all(&self.dir);
     }
+}
+
+#[test]
+fn terminal_host_survives_daemon_process_group_hangup() {
+    let mut harness = RecoveryHarness::start_in_own_session("session-hangup");
+    let daemon_pid = harness.child.as_ref().unwrap().id() as libc::pid_t;
+    // SAFETY: the daemon is live and owned by this harness.
+    assert_eq!(unsafe { libc::getsid(daemon_pid) }, daemon_pid);
+    // SAFETY: the daemon is live and owned by this harness.
+    assert_eq!(unsafe { libc::getpgid(daemon_pid) }, daemon_pid);
+
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 1,
+            "cmd": "run",
+            "argv": ["/bin/cat"],
+            "new_workspace": true,
+            "name": "session-survivor",
+        }),
+    );
+    let (record_path, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+    let host_pid = record.host_pid as libc::pid_t;
+    // The host is both session and process-group leader, rather than a member
+    // of the daemon's group that the following SIGHUP targets.
+    // SAFETY: the discovery record's locked nonce proves this host is live.
+    assert_eq!(unsafe { libc::getsid(host_pid) }, host_pid);
+    // SAFETY: the discovery record's locked nonce proves this host is live.
+    assert_eq!(unsafe { libc::getpgid(host_pid) }, host_pid);
+
+    harness.hangup_daemon_process_group();
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Live,
+    );
+    let host = adopt_terminal_host(record, record_path).unwrap();
+    host.terminate().unwrap();
+    host.disconnect();
+    wait_for_no_host_records(&harness.host_root());
+}
+
+#[test]
+fn new_host_rolls_back_when_surface_setup_fails_after_connect() {
+    let harness = RecoveryHarness::start_with_hosted_spawn_failure("post-connect-rollback", 500);
+    let socket = harness.socket.clone();
+    let shell_pid_path = harness.dir.join("rollback-shell.pid");
+    let request_value = serde_json::json!({
+        "id": 1,
+        "cmd": "run",
+        "argv": [
+            "/bin/sh",
+            "-c",
+            "trap '' HUP; printf '%s' \"$$\" > \"$1\"; while :; do sleep 60; done",
+            "cmux-rollback-shell",
+            shell_pid_path,
+        ],
+        "new_workspace": true,
+        "name": "must-roll-back",
+    });
+    let request_thread = std::thread::spawn(move || request_response(&socket, request_value));
+
+    // The injection runs only after the host has published its record and the
+    // daemon has authenticated a complete Snapshot, proving this exercises
+    // the ownership handoff rather than an earlier spawn failure.
+    let (record_path, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Live,
+    );
+    let shell_pid = wait_for_pid_file(&harness.dir.join("rollback-shell.pid"));
+    let response = request_thread.join().unwrap();
+    assert_eq!(response["ok"], false);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if terminal_host_record_liveness(&record_path, &record).unwrap()
+            == TerminalHostLiveness::Dead
+        {
+            break;
+        }
+        assert!(Instant::now() < deadline, "rolled-back host remained alive");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    wait_for_no_host_records(&harness.host_root());
+    wait_for_process_and_group_absent(shell_pid);
+}
+
+#[test]
+fn explicit_terminate_escalates_past_a_sighup_ignoring_child() {
+    let harness = RecoveryHarness::start("terminate-hup-ignoring-child");
+    let marker = format!("hup-ignored-ready-{}", std::process::id());
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 1,
+            "cmd": "run",
+            "argv": [
+                "/bin/sh",
+                "-c",
+                format!("trap '' HUP; printf '{marker}\\n'; while :; do sleep 60; done"),
+            ],
+            "new_workspace": true,
+            "name": "hup-ignoring-child",
+        }),
+    );
+    let surface = created["surface"].as_u64().unwrap();
+    assert!(wait_for_screen(&harness.socket, surface, &marker).contains(&marker));
+
+    let (record_path, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+    let host = adopt_terminal_host(record.clone(), record_path.clone()).unwrap();
+    let shell_pid = host.snapshot.pid.unwrap() as libc::pid_t;
+    host.terminate().unwrap();
+    host.disconnect();
+    wait_for_no_host_records(&harness.host_root());
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Dead,
+    );
+    wait_for_process_and_group_absent(shell_pid);
+}
+
+#[test]
+fn explicit_terminate_reaps_descendants_in_the_pty_group() {
+    let harness = RecoveryHarness::start("terminate-pty-descendant");
+    let marker = format!("descendant-retained-pty-{}", std::process::id());
+    let descendant_pid_path = harness.dir.join("pty-descendant.pid");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 1,
+            "cmd": "run",
+            "argv": [
+                "/bin/sh",
+                "-c",
+                concat!(
+                    "(trap '' HUP; while :; do sleep 60; done) & ",
+                    "printf '%s' \"$!\" > \"$1\"; printf '%s\\n' \"$2\"; ",
+                    "while :; do sleep 60; done",
+                ),
+                "cmux-pty-descendant",
+                descendant_pid_path,
+                marker,
+            ],
+            "new_workspace": true,
+            "name": "pty-retaining-descendant",
+        }),
+    );
+    let surface = created["surface"].as_u64().unwrap();
+    assert!(wait_for_screen(&harness.socket, surface, &marker).contains(&marker));
+    let descendant_pid = wait_for_pid_file(&harness.dir.join("pty-descendant.pid"));
+    let (record_path, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+    let observer = adopt_terminal_host(record.clone(), record_path.clone()).unwrap();
+    let direct_pid = observer.snapshot.pid.unwrap() as libc::pid_t;
+    observer.disconnect();
+    assert!(process_exists(direct_pid), "direct PTY child exited before Terminate");
+    assert!(process_exists(descendant_pid), "PTY-retaining descendant exited before Terminate");
+    // SAFETY: both fixture processes are live and owned by this test.
+    let direct_group = unsafe { libc::getpgid(direct_pid) };
+    // SAFETY: both fixture processes are live and owned by this test.
+    let descendant_group = unsafe { libc::getpgid(descendant_pid) };
+    assert!(direct_group > 0);
+    assert_eq!(descendant_group, direct_group, "fixture descendant left the PTY process group");
+
+    // ProcessSignaller's HUP exits the direct child while the descendant
+    // ignores it. The reserved-PGID escalation must still reap the latter.
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Live,
+    );
+    let host = adopt_terminal_host(record.clone(), record_path.clone()).unwrap();
+    host.terminate().unwrap();
+    host.disconnect();
+    wait_for_no_host_records(&harness.host_root());
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Dead,
+    );
+    wait_for_process_and_group_absent(direct_pid);
+    wait_for_process_and_group_absent(descendant_pid);
+}
+
+#[test]
+fn exit_follows_all_final_pty_bytes_on_the_live_stream() {
+    let harness = RecoveryHarness::start("exit-after-final-bytes");
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 1,
+            "cmd": "run",
+            "argv": [
+                "/bin/sh",
+                "-c",
+                concat!(
+                    "IFS= read -r trigger; i=0; ",
+                    "while [ \"$i\" -lt 20000 ]; do ",
+                    "printf 'drain-%05d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n' \"$i\"; ",
+                    "i=$((i + 1)); done; ",
+                    "printf 'FINAL-PTY-BYTE-MARKER\\n'",
+                ),
+            ],
+            "new_workspace": true,
+            "name": "final-byte-ordering",
+        }),
+    );
+    let (_, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+    let mut renderer = connect_host_detailed(
+        &record.endpoint,
+        &record.terminal_id,
+        &record.owner_token,
+        ClientRole::Admin,
+        CapabilityRights::ADMIN,
+    )
+    .unwrap();
+    renderer.stream.set_read_timeout(Some(Duration::from_secs(15))).unwrap();
+    write_frame(&mut renderer.stream, &Frame::new(MessageKind::Input, b"go\n".to_vec())).unwrap();
+
+    let mut output = Vec::new();
+    loop {
+        let frame = read_frame(&mut renderer.stream, MAX_FRAME_PAYLOAD)
+            .unwrap()
+            .expect("terminal host closed before sequenced Exit");
+        assert_eq!(frame.sequence, renderer.next_sequence);
+        renderer.next_sequence = renderer.next_sequence.wrapping_add(1);
+        if frame.kind == MessageKind::Output {
+            output.extend_from_slice(&frame.payload);
+        }
+        if frame.kind == MessageKind::Exit {
+            break;
+        }
+    }
+    assert!(contains_bytes(&output, b"FINAL-PTY-BYTE-MARKER"), "Exit overtook the final PTY bytes");
+    wait_for_no_host_records(&harness.host_root());
 }
 
 #[test]
@@ -834,6 +1118,23 @@ fn failed_terminate_and_rejected_resize_leave_live_record_discoverable() {
         CapabilityRights::RENDERER,
     )
     .unwrap();
+    let mut non_minimum = Vec::new();
+    non_minimum.extend_from_slice(&120u16.to_le_bytes());
+    non_minimum.extend_from_slice(&40u16.to_le_bytes());
+    write_frame(&mut renderer.stream, &Frame::new(MessageKind::ViewerSize, non_minimum)).unwrap();
+    renderer.stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let resized = read_frame(&mut renderer.stream, MAX_FRAME_PAYLOAD).unwrap().unwrap();
+    assert_eq!(resized.sequence, renderer.next_sequence);
+    renderer.next_sequence = renderer.next_sequence.wrapping_add(1);
+    assert_eq!(resized.kind, MessageKind::Resized);
+    assert_eq!(resized.flags, FLAG_COLORS_FOLLOW);
+    assert_eq!(&resized.payload[..4], &[80, 0, 24, 0]);
+    let colors = read_frame(&mut renderer.stream, MAX_FRAME_PAYLOAD).unwrap().unwrap();
+    assert_eq!(colors.sequence, renderer.next_sequence);
+    renderer.next_sequence = renderer.next_sequence.wrapping_add(1);
+    assert_eq!(colors.kind, MessageKind::Colors);
+    assert_eq!(colors.flags, 0);
+
     let mut oversized = Vec::new();
     oversized.extend_from_slice(&5_000u16.to_le_bytes());
     oversized.extend_from_slice(&1_000u16.to_le_bytes());
@@ -1131,6 +1432,41 @@ fn wait_for_no_host_records(root: &Path) {
         std::thread::sleep(Duration::from_millis(25));
     }
     panic!("terminal host record was not removed after close");
+}
+
+fn wait_for_pid_file(path: &Path) -> libc::pid_t {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(contents) = fs::read_to_string(path)
+            && let Ok(pid) = contents.trim().parse::<libc::pid_t>()
+            && pid > 0
+        {
+            return pid;
+        }
+        assert!(Instant::now() < deadline, "process did not publish pid at {}", path.display());
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_process_and_group_absent(pid: libc::pid_t) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let process_exists = process_exists(pid);
+        // SAFETY: same signal-0 probe for the positive process-group id.
+        let group_exists = unsafe { libc::killpg(pid, 0) } == 0
+            || std::io::Error::last_os_error().kind() == std::io::ErrorKind::PermissionDenied;
+        if !process_exists && !group_exists {
+            return;
+        }
+        assert!(Instant::now() < deadline, "terminated PTY process/group {pid} remained alive");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn process_exists(pid: libc::pid_t) -> bool {
+    // SAFETY: signal 0 performs existence/permission checks only.
+    (unsafe { libc::kill(pid, 0) }) == 0
+        || std::io::Error::last_os_error().kind() == std::io::ErrorKind::PermissionDenied
 }
 
 fn wait_for_host_size(root: &Path, cols: u16, rows: u16) {

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -170,7 +170,7 @@ fn terminal_host_survives_sigkill_and_is_adopted_with_io_and_size() {
         serde_json::json!({
             "id": 22,
             "cmd": "resolve-terminal",
-            "terminal_id": "ffffffffffffffffffffffffffffffff",
+            "terminal_id": "ffffffffffff4fffbfffffffffffffff",
         }),
     );
     assert_eq!(missing["ok"], false);
@@ -376,7 +376,7 @@ fn terminal_host_survives_sigkill_and_is_adopted_with_io_and_size() {
             "id": 10,
             "cmd": "close-terminal",
             "terminal_id": &terminal_id,
-            "terminal_incarnation": "00000000000000000000000000000000",
+            "terminal_incarnation": "00000000000040008000000000000000",
         }),
     );
     assert_eq!(stale_close["ok"], false);
@@ -402,9 +402,123 @@ fn terminal_host_survives_sigkill_and_is_adopted_with_io_and_size() {
         &harness.socket,
         serde_json::json!({"id": 12, "cmd": "resolve-terminal", "terminal_id": &terminal_id}),
     );
-    assert_eq!(tombstoned["ok"], false);
-    assert_eq!(tombstoned["error"], "terminal_not_found");
+    assert_eq!(tombstoned["ok"], true);
+    assert_eq!(tombstoned["data"]["surface"], serde_json::Value::Null);
+    assert_eq!(tombstoned["data"]["lifecycle"], "tombstoned");
     wait_for_no_host_records(&harness.host_root());
+}
+
+#[test]
+fn transient_startup_adoption_failure_retries_in_process_until_running() {
+    let mut harness = RecoveryHarness::start("retry-adopt");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":1,
+            "cmd":"run",
+            "argv":["/bin/cat"],
+            "new_workspace":true,
+            "cols":80,
+            "rows":24,
+        }),
+    );
+    let terminal_id = created["terminal_id"].as_str().unwrap().to_string();
+    let records = wait_for_host_records(&harness.host_root(), 1);
+    let endpoint = PathBuf::from(&records[0].1.endpoint);
+    let held_endpoint = endpoint.with_extension("held-for-adoption-test");
+
+    harness.sigkill();
+    fs::rename(&endpoint, &held_endpoint).unwrap();
+    harness.restart();
+
+    let pending = request(
+        &harness.socket,
+        serde_json::json!({"id":2,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+    );
+    assert_eq!(pending["surface"], serde_json::Value::Null);
+    assert_eq!(pending["lifecycle"], "adopting");
+
+    fs::rename(&held_endpoint, &endpoint).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let surface = loop {
+        let resolved = request(
+            &harness.socket,
+            serde_json::json!({"id":3,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+        );
+        if resolved["lifecycle"] == "running"
+            && let Some(surface) = resolved["surface"].as_u64()
+        {
+            break surface;
+        }
+        assert!(Instant::now() < deadline, "terminal never completed in-process adoption");
+        std::thread::sleep(Duration::from_millis(50));
+    };
+
+    let marker = format!("scheduled-adoption-{}", std::process::id());
+    request(
+        &harness.socket,
+        serde_json::json!({"id":4,"cmd":"send","surface":surface,"text":format!("{marker}\n")}),
+    );
+    assert!(wait_for_screen(&harness.socket, surface, &marker).contains(&marker));
+}
+
+#[test]
+fn client_reserved_create_retry_returns_original_binding_without_second_host() {
+    let harness = RecoveryHarness::start("reserved-create");
+    let workspace = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":1,
+            "cmd":"create-workspace",
+            "name":"Browser",
+            "key":"browser-workspace",
+            "origin":"browser",
+            "mutation_id":"workspace-create",
+            "expected_revision":0,
+        }),
+    );
+    let terminal_id = TerminalId::random().unwrap().to_hex();
+    let create = serde_json::json!({
+        "id":2,
+        "cmd":"create-terminal",
+        "key":"browser-workspace",
+        "argv":["/bin/cat"],
+        "terminal_id":terminal_id,
+        "origin":"browser",
+        "mutation_id":"terminal-create",
+        "expected_generation":workspace["generation"],
+        "expected_terminal_revision":0,
+        "cols":80,
+        "rows":24,
+    });
+    let first = request(&harness.socket, create.clone());
+    assert_eq!(first["terminal_id"], terminal_id);
+    assert_eq!(first["replayed"], false);
+    assert_eq!(wait_for_host_records(&harness.host_root(), 1).len(), 1);
+
+    let retry = request(&harness.socket, create);
+    assert_eq!(retry["replayed"], true);
+    assert_eq!(retry["terminal_id"], terminal_id);
+    assert_eq!(retry["surface"], first["surface"]);
+    assert_eq!(retry["pane"], first["pane"]);
+    assert_eq!(retry["screen"], first["screen"]);
+    assert_eq!(wait_for_host_records(&harness.host_root(), 1).len(), 1);
+
+    let mismatch = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "id":3,
+            "cmd":"create-terminal",
+            "key":"browser-workspace",
+            "argv":["/bin/echo","different"],
+            "terminal_id":terminal_id,
+            "origin":"browser",
+            "mutation_id":"terminal-create",
+            "expected_terminal_revision":0,
+        }),
+    );
+    assert_eq!(mismatch["ok"], false);
+    assert!(mismatch["error"].as_str().unwrap().contains("different payload"));
 }
 
 #[test]

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -5,6 +5,8 @@ use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::platform::transport;
@@ -16,8 +18,9 @@ use cmux_tui_core::terminal_host_protocol::{
     read_frame, write_frame,
 };
 use cmux_tui_core::terminal_host_runtime::{
-    adopt_terminal_host, decode_terminal_color_overrides, load_terminal_host_records,
-    remove_terminal_host_record, terminal_host_root,
+    TerminalHostLiveness, adopt_terminal_host, decode_terminal_color_overrides,
+    load_terminal_host_records, remove_stale_terminal_host_record, terminal_host_record_liveness,
+    terminal_host_root,
 };
 use ghostty_vt::{Rgb, TerminalColorOverrides};
 
@@ -27,6 +30,7 @@ struct RecoveryHarness {
     socket: PathBuf,
     state: PathBuf,
     session: String,
+    host_ready_delay_ms: Option<u64>,
 }
 
 impl RecoveryHarness {
@@ -40,23 +44,49 @@ impl RecoveryHarness {
             socket: dir.join("mux.sock"),
             state: dir.join("state"),
             session: "host-recovery".into(),
+            host_ready_delay_ms: None,
             dir,
         };
         harness.restart();
         harness
     }
 
+    fn start_with_host_ready_delay(name: &str, delay_ms: u64) -> Self {
+        let mut harness = Self::start_unstarted(name);
+        harness.host_ready_delay_ms = Some(delay_ms);
+        harness.restart();
+        harness
+    }
+
+    fn start_unstarted(name: &str) -> Self {
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = PathBuf::from("/tmp")
+            .join(format!("cmux-terminal-host-{name}-{}-{stamp}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        Self {
+            child: None,
+            socket: dir.join("mux.sock"),
+            state: dir.join("state"),
+            session: "host-recovery".into(),
+            host_ready_delay_ms: None,
+            dir,
+        }
+    }
+
     fn restart(&mut self) {
         assert!(self.child.is_none());
-        let child = Command::new(bin())
+        let mut command = Command::new(bin());
+        command
             .args(["--headless", "--session", &self.session, "--socket"])
             .arg(&self.socket)
             .arg("--state")
             .arg(&self.state)
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .unwrap();
+            .stderr(Stdio::null());
+        if let Some(delay_ms) = self.host_ready_delay_ms {
+            command.env("CMUX_TUI_TEST_HOST_READY_DELAY_MS", delay_ms.to_string());
+        }
+        let child = command.spawn().unwrap();
         self.child = Some(child);
         wait_for_socket(&self.socket);
     }
@@ -66,6 +96,13 @@ impl RecoveryHarness {
         child.kill().unwrap();
         child.wait().unwrap();
         let _ = fs::remove_file(&self.socket);
+    }
+
+    fn signal_daemon(&self, signal: libc::c_int) {
+        let pid = self.child.as_ref().unwrap().id() as libc::pid_t;
+        // SAFETY: the harness owns this child process and passes a platform
+        // signal constant.
+        assert_eq!(unsafe { libc::kill(pid, signal) }, 0);
     }
 
     fn host_root(&self) -> PathBuf {
@@ -83,16 +120,31 @@ impl Drop for RecoveryHarness {
         let records = load_terminal_host_records(&self.host_root()).unwrap_or_default();
         let endpoints =
             records.iter().map(|(_, record)| PathBuf::from(&record.endpoint)).collect::<Vec<_>>();
-        for (path, record) in records {
-            if let Ok(host) = adopt_terminal_host(record, path.clone()) {
+        for (path, record) in &records {
+            if let Ok(host) = adopt_terminal_host(record.clone(), path.clone()) {
                 let _ = host.terminate();
                 host.disconnect();
             }
-            remove_terminal_host_record(&path);
         }
         let deadline = Instant::now() + Duration::from_secs(2);
         while endpoints.iter().any(|endpoint| endpoint.exists()) && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(20));
+        }
+        for (path, record) in &records {
+            if terminal_host_record_liveness(path, record).ok() != Some(TerminalHostLiveness::Dead)
+            {
+                // SAFETY: test teardown owns these dedicated host processes;
+                // SIGKILL is a last resort after graceful Terminate timed out.
+                let _ = unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) };
+                let deadline = Instant::now() + Duration::from_secs(2);
+                while terminal_host_record_liveness(path, record).ok()
+                    != Some(TerminalHostLiveness::Dead)
+                    && Instant::now() < deadline
+                {
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+            }
+            let _ = remove_stale_terminal_host_record(path, record);
         }
         for endpoint in endpoints {
             let _ = fs::remove_file(endpoint);
@@ -628,6 +680,388 @@ fn stalled_renderer_is_disconnected_without_freezing_the_host() {
         serde_json::json!({"id": 5, "cmd": "close-surface", "surface": surface}),
     );
     wait_for_no_host_records(&harness.host_root());
+}
+
+#[test]
+fn daemon_admin_backpressure_reconnects_without_restarting_host_or_renderer() {
+    let harness = RecoveryHarness::start("admin-reconnect");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":1,"cmd":"run","argv":["/bin/sh"],"new_workspace":true,
+            "cols":80,"rows":24,
+        }),
+    );
+    let surface = created["surface"].as_u64().unwrap();
+    let terminal_id = created["terminal_id"].as_str().unwrap().to_string();
+    let incarnation = created["terminal_incarnation"].as_str().unwrap().to_string();
+    let before_record = wait_for_host_records(&harness.host_root(), 1).remove(0).1;
+    let terminal_snapshot =
+        request(&harness.socket, serde_json::json!({"id":20,"cmd":"list-terminals"}));
+    let before_revision = terminal_snapshot["terminal_revision"].as_u64().unwrap();
+    let grant = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":2,"cmd":"mint-terminal-renderer","surface":surface,"ttl_ms":10_000,
+        }),
+    );
+    let renderer = connect_host_detailed(
+        grant["endpoint"].as_str().unwrap(),
+        grant["terminal_id"].as_str().unwrap(),
+        grant["token"].as_str().unwrap(),
+        ClientRole::Renderer,
+        CapabilityRights::RENDERER,
+    )
+    .unwrap();
+    let mut renderer_writer = renderer.stream.try_clone().unwrap();
+    let drained = Arc::new(AtomicUsize::new(0));
+    let drain_count = drained.clone();
+    let (overflow_tx, overflow_rx) = mpsc::sync_channel(1);
+    let drain = std::thread::spawn(move || {
+        let mut renderer = renderer;
+        let mut reported = false;
+        loop {
+            match read_frame(&mut renderer.stream, MAX_FRAME_PAYLOAD) {
+                Ok(Some(frame)) => {
+                    if frame.request_id == 0 {
+                        assert_eq!(frame.sequence, renderer.next_sequence);
+                        renderer.next_sequence = renderer.next_sequence.wrapping_add(1);
+                    }
+                    if frame.kind == MessageKind::Output {
+                        let total = drain_count.fetch_add(frame.payload.len(), Ordering::AcqRel)
+                            + frame.payload.len();
+                        if total >= 12_000_000 && !reported {
+                            reported = true;
+                            let _ = overflow_tx.send(());
+                        }
+                    }
+                }
+                Ok(None) | Err(ProtocolError::Truncated { .. }) | Err(ProtocolError::Io(_)) => {
+                    break;
+                }
+                Err(error) => panic!("renderer stream failed during admin reconnect: {error}"),
+            }
+        }
+    });
+
+    // Freeze only the mux. The terminal host and renderer remain scheduled;
+    // enough PTY output fills the daemon tap's bounded queue and deliberately
+    // disconnects that admin stream.
+    harness.signal_daemon(libc::SIGSTOP);
+    write_frame(
+        &mut renderer_writer,
+        &Frame::new(
+            MessageKind::Input,
+            b"/usr/bin/head -c 14000000 /dev/zero; printf '\\nadmin-flood-done\\n'\n".to_vec(),
+        ),
+    )
+    .unwrap();
+    overflow_rx.recv_timeout(Duration::from_secs(15)).unwrap();
+    harness.signal_daemon(libc::SIGCONT);
+
+    let after = format!("renderer-after-reconnect-{}", std::process::id());
+    write_frame(
+        &mut renderer_writer,
+        &Frame::new(MessageKind::Input, format!("printf '{after}\\n'\n").into_bytes()),
+    )
+    .unwrap();
+    assert!(wait_for_screen(&harness.socket, surface, &after).contains(&after));
+    let resolved = request(
+        &harness.socket,
+        serde_json::json!({"id":3,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+    );
+    assert_eq!(resolved["lifecycle"], "running");
+    assert_eq!(resolved["terminal_incarnation"], incarnation);
+    let after_record = wait_for_host_records(&harness.host_root(), 1).remove(0).1;
+    assert_eq!(after_record.host_pid, before_record.host_pid);
+    assert_eq!(after_record.host_start_nonce, before_record.host_start_nonce);
+    assert_eq!(after_record.incarnation, before_record.incarnation);
+    assert!(drained.load(Ordering::Acquire) >= 12_000_000);
+    let lifecycle_events = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":21,"cmd":"terminal-events","after_revision":before_revision,
+        }),
+    );
+    let kinds = lifecycle_events["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|event| event["kind"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(kinds.contains(&"terminal-adopting"));
+    assert!(kinds.contains(&"terminal-ready"));
+
+    let _ = renderer_writer.shutdown(std::net::Shutdown::Both);
+    drain.join().unwrap();
+    request(&harness.socket, serde_json::json!({"id":4,"cmd":"close-surface","surface":surface}));
+    wait_for_no_host_records(&harness.host_root());
+}
+
+#[test]
+fn failed_terminate_and_rejected_resize_leave_live_record_discoverable() {
+    let harness = RecoveryHarness::start("failed-control");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "cols":80,"rows":24,
+        }),
+    );
+    let surface = created["surface"].as_u64().unwrap();
+    let (record_path, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+
+    let disconnected = adopt_terminal_host(record.clone(), record_path.clone()).unwrap();
+    disconnected.disconnect();
+    assert!(disconnected.terminate().is_err());
+    assert!(record_path.exists(), "failed Terminate unlinked a live host record");
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Live
+    );
+
+    let grant = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":2,"cmd":"mint-terminal-renderer","surface":surface,"ttl_ms":10_000,
+        }),
+    );
+    let mut renderer = connect_host_detailed(
+        grant["endpoint"].as_str().unwrap(),
+        grant["terminal_id"].as_str().unwrap(),
+        grant["token"].as_str().unwrap(),
+        ClientRole::Renderer,
+        CapabilityRights::RENDERER,
+    )
+    .unwrap();
+    let mut oversized = Vec::new();
+    oversized.extend_from_slice(&5_000u16.to_le_bytes());
+    oversized.extend_from_slice(&1_000u16.to_le_bytes());
+    write_frame(&mut renderer.stream, &Frame::new(MessageKind::ViewerSize, oversized)).unwrap();
+    renderer.stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    loop {
+        match read_frame(&mut renderer.stream, MAX_FRAME_PAYLOAD) {
+            Ok(None) | Err(ProtocolError::Truncated { .. }) | Err(ProtocolError::Io(_)) => break,
+            Ok(Some(frame)) => assert_ne!(frame.kind, MessageKind::Resized),
+            Err(error) => panic!("invalid resize produced malformed stream: {error}"),
+        }
+    }
+    let state =
+        request(&harness.socket, serde_json::json!({"id":3,"cmd":"vt-state","surface":surface}));
+    assert_eq!(state["cols"], 80);
+    assert_eq!(state["rows"], 24);
+    assert!(record_path.exists());
+
+    let marker = format!("after-failed-controls-{}", std::process::id());
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id":4,"cmd":"send","surface":surface,"text":format!("{marker}\\n"),
+        }),
+    );
+    assert!(wait_for_screen(&harness.socket, surface, &marker).contains(&marker));
+    request(&harness.socket, serde_json::json!({"id":5,"cmd":"close-surface","surface":surface}));
+    wait_for_no_host_records(&harness.host_root());
+}
+
+#[test]
+fn daemon_crash_after_record_before_ready_adopts_same_live_host() {
+    let mut harness = RecoveryHarness::start_with_host_ready_delay("pre-ready-crash", 2_000);
+    let stream = transport::connect(&harness.socket).unwrap();
+    let mut writer = stream.try_clone_box().unwrap();
+    writeln!(
+        writer,
+        "{}",
+        serde_json::json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "cols":80,"rows":24,
+        })
+    )
+    .unwrap();
+    let (record_path, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Live,
+        "record was not live while the host was paused before Ready"
+    );
+    let host_pid = record.host_pid;
+    let terminal_id = record.terminal_id.clone();
+    let incarnation = record.incarnation.clone();
+    harness.sigkill();
+    drop(writer);
+    drop(stream);
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Live,
+        "daemon crash incorrectly killed the already-published terminal host"
+    );
+    harness.restart();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let surface = loop {
+        let resolved = request(
+            &harness.socket,
+            serde_json::json!({"id":2,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+        );
+        if resolved["lifecycle"] == "running"
+            && let Some(surface) = resolved["surface"].as_u64()
+        {
+            assert_eq!(resolved["terminal_incarnation"], incarnation);
+            break surface;
+        }
+        assert!(Instant::now() < deadline, "pre-Ready host was not adopted after restart");
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    let adopted = wait_for_host_records(&harness.host_root(), 1).remove(0).1;
+    assert_eq!(adopted.host_pid, host_pid);
+    assert_eq!(adopted.host_start_nonce, record.host_start_nonce);
+    assert_eq!(adopted.incarnation, incarnation);
+    let marker = format!("pre-ready-survivor-{}", std::process::id());
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id":3,"cmd":"send","surface":surface,"text":format!("{marker}\\n"),
+        }),
+    );
+    assert!(wait_for_screen(&harness.socket, surface, &marker).contains(&marker));
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id":4,"cmd":"close-terminal","terminal_id":terminal_id,
+            "terminal_incarnation":incarnation,
+        }),
+    );
+    wait_for_no_host_records(&harness.host_root());
+}
+
+#[test]
+fn running_host_sigkill_retains_read_only_exited_binding() {
+    let harness = RecoveryHarness::start("running-host-sigkill");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "cols":80,"rows":24,
+        }),
+    );
+    let surface = created["surface"].as_u64().unwrap();
+    let terminal_id = created["terminal_id"].as_str().unwrap().to_string();
+    let (record_path, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+    // SAFETY: the record PID is the dedicated host process owned by this
+    // harness; killing it is the failure under test.
+    assert_eq!(unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) }, 0);
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let resolved = request(
+            &harness.socket,
+            serde_json::json!({"id":2,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+        );
+        if resolved["lifecycle"] == "exited" {
+            assert_eq!(resolved["surface"].as_u64(), Some(surface));
+            break;
+        }
+        assert!(Instant::now() < deadline, "running host never transitioned to Exited");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let write = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "id":3,"cmd":"send","surface":surface,"text":"must-not-write\\n",
+        }),
+    );
+    assert_eq!(write["ok"], false);
+    assert!(write["error"].as_str().unwrap().contains("exited"));
+    assert_eq!(
+        terminal_host_record_liveness(&record_path, &record).unwrap(),
+        TerminalHostLiveness::Dead
+    );
+    assert!(remove_stale_terminal_host_record(&record_path, &record).unwrap());
+
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id":4,"cmd":"close-terminal","terminal_id":terminal_id,
+            "terminal_incarnation":record.incarnation,
+        }),
+    );
+}
+
+#[test]
+fn daemon_restart_safe_prunes_dead_host_and_materializes_exited_workspace_binding() {
+    let mut harness = RecoveryHarness::start("dead-host-restart");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id":1,"cmd":"run","argv":["/bin/cat"],"new_workspace":true,
+            "cols":80,"rows":24,
+        }),
+    );
+    let terminal_id = created["terminal_id"].as_str().unwrap().to_string();
+    let incarnation = created["terminal_incarnation"].as_str().unwrap().to_string();
+    let workspace_id = created["workspace"].as_u64().unwrap();
+    let tree = request(&harness.socket, serde_json::json!({"id":2,"cmd":"list-workspaces"}));
+    let workspace_key = tree["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workspace| workspace["id"].as_u64() == Some(workspace_id))
+        .unwrap()["key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let (_, record) = wait_for_host_records(&harness.host_root(), 1).remove(0);
+
+    // Stop the mux first so it cannot observe the host Exit and update the
+    // registry. The restart must reconcile a dead proof against a still-
+    // Running/Adopting row without spawning a replacement shell.
+    harness.signal_daemon(libc::SIGSTOP);
+    // SAFETY: the record PID is the harness-owned terminal host.
+    assert_eq!(unsafe { libc::kill(record.host_pid as libc::pid_t, libc::SIGKILL) }, 0);
+    harness.sigkill();
+    harness.restart();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let exited_surface = loop {
+        let resolved = request(
+            &harness.socket,
+            serde_json::json!({"id":3,"cmd":"resolve-terminal","terminal_id":terminal_id}),
+        );
+        if resolved["lifecycle"] == "exited"
+            && let Some(surface) = resolved["surface"].as_u64()
+        {
+            assert_eq!(resolved["terminal_incarnation"], incarnation);
+            break surface;
+        }
+        assert!(Instant::now() < deadline, "dead startup host was not projected as Exited");
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    wait_for_no_host_records(&harness.host_root());
+    let recovered = request(&harness.socket, serde_json::json!({"id":4,"cmd":"list-workspaces"}));
+    let workspace = recovered["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|workspace| workspace["key"].as_str() == Some(&workspace_key))
+        .expect("original workspace was not recovered");
+    let tab = first_tab(workspace).expect("Exited terminal placeholder was not materialized");
+    assert_eq!(tab["surface"].as_u64(), Some(exited_surface));
+    assert_eq!(tab["terminal_id"].as_str(), Some(terminal_id.as_str()));
+
+    let write = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "id":5,"cmd":"send","surface":exited_surface,"text":"must-not-respawn\\n",
+        }),
+    );
+    assert_eq!(write["ok"], false);
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id":6,"cmd":"close-terminal","terminal_id":terminal_id,
+            "terminal_incarnation":incarnation,
+        }),
+    );
 }
 
 fn request(path: &Path, value: serde_json::Value) -> serde_json::Value {

--- a/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
+++ b/cmux-tui/crates/cmux-tui/tests/terminal_host_recovery.rs
@@ -1,0 +1,763 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use cmux_tui_core::platform::transport;
+use cmux_tui_core::terminal_host::{
+    CapabilityRights, CapabilityToken, ClientHello, ClientRole, TerminalId,
+};
+use cmux_tui_core::terminal_host_protocol::{
+    FLAG_COLORS_FOLLOW, Frame, MAX_FRAME_PAYLOAD, MessageKind, PROTOCOL_VERSION, ProtocolError,
+    read_frame, write_frame,
+};
+use cmux_tui_core::terminal_host_runtime::{
+    adopt_terminal_host, decode_terminal_color_overrides, load_terminal_host_records,
+    remove_terminal_host_record, terminal_host_root,
+};
+use ghostty_vt::{Rgb, TerminalColorOverrides};
+
+struct RecoveryHarness {
+    child: Option<Child>,
+    dir: PathBuf,
+    socket: PathBuf,
+    state: PathBuf,
+    session: String,
+}
+
+impl RecoveryHarness {
+    fn start(name: &str) -> Self {
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = PathBuf::from("/tmp")
+            .join(format!("cmux-terminal-host-{name}-{}-{stamp}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let mut harness = Self {
+            child: None,
+            socket: dir.join("mux.sock"),
+            state: dir.join("state"),
+            session: "host-recovery".into(),
+            dir,
+        };
+        harness.restart();
+        harness
+    }
+
+    fn restart(&mut self) {
+        assert!(self.child.is_none());
+        let child = Command::new(bin())
+            .args(["--headless", "--session", &self.session, "--socket"])
+            .arg(&self.socket)
+            .arg("--state")
+            .arg(&self.state)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        self.child = Some(child);
+        wait_for_socket(&self.socket);
+    }
+
+    fn sigkill(&mut self) {
+        let mut child = self.child.take().unwrap();
+        child.kill().unwrap();
+        child.wait().unwrap();
+        let _ = fs::remove_file(&self.socket);
+    }
+
+    fn host_root(&self) -> PathBuf {
+        terminal_host_root(&self.state, &self.session)
+    }
+}
+
+impl Drop for RecoveryHarness {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+
+        let records = load_terminal_host_records(&self.host_root()).unwrap_or_default();
+        let endpoints =
+            records.iter().map(|(_, record)| PathBuf::from(&record.endpoint)).collect::<Vec<_>>();
+        for (path, record) in records {
+            if let Ok(host) = adopt_terminal_host(record, path.clone()) {
+                let _ = host.terminate();
+                host.disconnect();
+            }
+            remove_terminal_host_record(&path);
+        }
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while endpoints.iter().any(|endpoint| endpoint.exists()) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        for endpoint in endpoints {
+            let _ = fs::remove_file(endpoint);
+        }
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[test]
+fn terminal_host_survives_sigkill_and_is_adopted_with_io_and_size() {
+    let mut harness = RecoveryHarness::start("sigkill-adopt");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 1,
+            "cmd": "run",
+            "argv": ["/bin/cat"],
+            "new_workspace": true,
+            "name": "survivor",
+            "cols": 80,
+            "rows": 24,
+        }),
+    );
+    let original_surface = created["surface"].as_u64().unwrap();
+    let workspace = created["workspace"].as_u64().unwrap();
+
+    let tree = request(&harness.socket, serde_json::json!({"id": 2, "cmd": "list-workspaces"}));
+    let workspace_key = tree["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["id"].as_u64() == Some(workspace))
+        .and_then(|item| item["key"].as_str())
+        .unwrap()
+        .to_string();
+
+    let before = format!("before-sigkill-{}", std::process::id());
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 3,
+            "cmd": "send",
+            "surface": original_surface,
+            "text": format!("{before}\n"),
+        }),
+    );
+    assert!(wait_for_screen(&harness.socket, original_surface, &before).contains(&before));
+
+    let records = wait_for_host_records(&harness.host_root(), 1);
+    assert_eq!(records[0].1.workspace_key, workspace_key);
+    let terminal_id = records[0].1.terminal_id.clone();
+    let incarnation = records[0].1.incarnation.clone();
+    let endpoint = PathBuf::from(&records[0].1.endpoint);
+    assert!(endpoint.exists());
+    assert_eq!(created["terminal_id"].as_str(), Some(terminal_id.as_str()));
+    assert_eq!(created["terminal_incarnation"].as_str(), Some(incarnation.as_str()));
+    let tree_workspace = tree["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["id"].as_u64() == Some(workspace))
+        .unwrap();
+    let tree_tab = first_tab(tree_workspace).unwrap();
+    assert_eq!(tree_tab["terminal_id"].as_str(), Some(terminal_id.as_str()));
+    assert_eq!(tree_tab["terminal_incarnation"].as_str(), Some(incarnation.as_str()));
+    let resolved = request(
+        &harness.socket,
+        serde_json::json!({"id": 21, "cmd": "resolve-terminal", "terminal_id": &terminal_id}),
+    );
+    assert_eq!(resolved["surface"].as_u64(), Some(original_surface));
+    assert_eq!(resolved["terminal_id"].as_str(), Some(terminal_id.as_str()));
+    assert_eq!(resolved["terminal_incarnation"].as_str(), Some(incarnation.as_str()));
+    let missing = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "id": 22,
+            "cmd": "resolve-terminal",
+            "terminal_id": "ffffffffffffffffffffffffffffffff",
+        }),
+    );
+    assert_eq!(missing["ok"], false);
+    assert_eq!(missing["error"], "terminal_not_found");
+
+    // Rights are enforced after authentication, not merely reported in the
+    // hello. A READ-only owner connection cannot terminate the terminal.
+    let mut read_only = connect_host(
+        &records[0].1.endpoint,
+        &terminal_id,
+        &records[0].1.owner_token,
+        ClientRole::Admin,
+        CapabilityRights::READ,
+    )
+    .unwrap();
+    write_frame(&mut read_only, &Frame::new(MessageKind::Terminate, Vec::new())).unwrap();
+    drop(read_only);
+
+    // JSON brokers a one-use renderer grant while keeping the durable owner
+    // secret private. The minted renderer attaches directly to the host and
+    // writes to the same PTY.
+    let grant = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 3,
+            "cmd": "mint-terminal-renderer",
+            "surface": original_surface,
+            "ttl_ms": 10_000,
+        }),
+    );
+    assert_eq!(grant["terminal_id"].as_str(), Some(terminal_id.as_str()));
+    assert_eq!(grant["incarnation"].as_str(), Some(incarnation.as_str()));
+    assert_eq!(grant["rights"].as_u64(), Some(u64::from(CapabilityRights::RENDERER.bits())));
+    let mut renderer = connect_host_detailed(
+        grant["endpoint"].as_str().unwrap(),
+        grant["terminal_id"].as_str().unwrap(),
+        grant["token"].as_str().unwrap(),
+        ClientRole::Renderer,
+        CapabilityRights::RENDERER,
+    )
+    .unwrap();
+    let direct = format!("direct-renderer-{}", std::process::id());
+    write_frame(
+        &mut renderer.stream,
+        &Frame::new(MessageKind::Input, format!("{direct}\n").into_bytes()),
+    )
+    .unwrap();
+    assert!(wait_for_screen(&harness.socket, original_surface, &direct).contains(&direct));
+    assert!(
+        connect_host(
+            grant["endpoint"].as_str().unwrap(),
+            grant["terminal_id"].as_str().unwrap(),
+            grant["token"].as_str().unwrap(),
+            ClientRole::Renderer,
+            CapabilityRights::RENDERER,
+        )
+        .is_err(),
+        "renderer capability was reusable"
+    );
+    let expected_colors = {
+        let mut colors = TerminalColorOverrides {
+            foreground: Some(Rgb { r: 17, g: 18, b: 19 }),
+            background: Some(Rgb { r: 33, g: 34, b: 35 }),
+            cursor: Some(Rgb { r: 49, g: 50, b: 51 }),
+            ..Default::default()
+        };
+        colors.palette[3] = Some(Rgb { r: 1, g: 2, b: 3 });
+        colors
+    };
+    write_frame(
+        &mut renderer.stream,
+        &Frame::new(
+            MessageKind::Input,
+            b"\x1b]4;3;#010203\x07\x1b]10;#111213\x07\x1b]11;#212223\x07\x1b]12;#313233\x07\n"
+                .to_vec(),
+        ),
+    )
+    .unwrap();
+    renderer.wait_for_colors(&expected_colors);
+
+    // A fresh renderer receives portable VT state and the complete sparse
+    // color state as a separate frame at the same atomic sequence boundary.
+    let color_grant = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 31,
+            "cmd": "mint-terminal-renderer",
+            "surface": original_surface,
+            "ttl_ms": 10_000,
+        }),
+    );
+    let color_snapshot = connect_host_detailed(
+        color_grant["endpoint"].as_str().unwrap(),
+        color_grant["terminal_id"].as_str().unwrap(),
+        color_grant["token"].as_str().unwrap(),
+        ClientRole::Renderer,
+        CapabilityRights::RENDERER,
+    )
+    .unwrap();
+    assert_eq!(color_snapshot.colors, expected_colors);
+    let replay = snapshot_replay(&color_snapshot.snapshot.payload);
+    for forbidden in [b"\x1b]4;".as_slice(), b"\x1b]10;", b"\x1b]11;", b"\x1b]12;"] {
+        assert!(!contains_bytes(replay, forbidden), "portable Snapshot leaked color OSC");
+    }
+    drop(color_snapshot);
+
+    write_frame(
+        &mut renderer.stream,
+        &Frame::new(
+            MessageKind::Input,
+            b"\x1b]104;3\x07\x1b]110\x07\x1b]111\x07\x1b]112\x07\n".to_vec(),
+        ),
+    )
+    .unwrap();
+    renderer.wait_for_colors(&TerminalColorOverrides::default());
+    drop(renderer);
+
+    // Child::kill is SIGKILL on Unix. The mux cannot run shutdown hooks, so
+    // this proves the PTY and parser live in the independent host process.
+    harness.sigkill();
+    assert!(endpoint.exists(), "terminal host socket disappeared with the daemon");
+    assert_eq!(wait_for_host_records(&harness.host_root(), 1)[0].1.terminal_id, terminal_id);
+
+    harness.restart();
+    let recovered =
+        request(&harness.socket, serde_json::json!({"id": 4, "cmd": "list-workspaces"}));
+    let recovered_workspace = recovered["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["key"].as_str() == Some(&workspace_key))
+        .expect("durable workspace was not recovered");
+    let adopted_surface =
+        first_surface(recovered_workspace).expect("terminal host was not adopted");
+    let rebound = request(
+        &harness.socket,
+        serde_json::json!({"id": 41, "cmd": "resolve-terminal", "terminal_id": &terminal_id}),
+    );
+    assert_eq!(rebound["surface"].as_u64(), Some(adopted_surface));
+    assert_eq!(rebound["terminal_id"].as_str(), Some(terminal_id.as_str()));
+    assert_eq!(rebound["terminal_incarnation"].as_str(), Some(incarnation.as_str()));
+
+    let replay = wait_for_screen(&harness.socket, adopted_surface, &before);
+    assert!(replay.contains(&before), "host replay did not survive SIGKILL: {replay:?}");
+
+    let after = format!("after-adoption-{}", std::process::id());
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 5,
+            "cmd": "send",
+            "surface": adopted_surface,
+            "text": format!("{after}\n"),
+        }),
+    );
+    assert!(wait_for_screen(&harness.socket, adopted_surface, &after).contains(&after));
+
+    let resized = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 6,
+            "cmd": "resize-surface",
+            "surface": adopted_surface,
+            "cols": 101,
+            "rows": 37,
+        }),
+    );
+    assert_eq!(resized["accepted"], true);
+    let state = wait_for_vt_size(&harness.socket, adopted_surface, 101, 37);
+    assert_eq!(state["cols"].as_u64(), Some(101));
+    assert_eq!(state["rows"].as_u64(), Some(37));
+    wait_for_host_size(&harness.host_root(), 101, 37);
+
+    let records = wait_for_host_records(&harness.host_root(), 1);
+    assert_eq!(records[0].1.terminal_id, terminal_id);
+    assert_eq!(records[0].1.incarnation, incarnation);
+
+    // A second crash proves the resize landed in the PTY-owning process, not
+    // only in the disposable daemon-side Ghostty mirror.
+    harness.sigkill();
+    harness.restart();
+    let recovered =
+        request(&harness.socket, serde_json::json!({"id": 8, "cmd": "list-workspaces"}));
+    let recovered_workspace = recovered["workspaces"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["key"].as_str() == Some(&workspace_key))
+        .expect("workspace was not recovered after the resized host survived again");
+    let resized_surface =
+        first_surface(recovered_workspace).expect("resized terminal host was not adopted");
+    let state = request(
+        &harness.socket,
+        serde_json::json!({"id": 9, "cmd": "vt-state", "surface": resized_surface}),
+    );
+    assert_eq!(state["cols"].as_u64(), Some(101));
+    assert_eq!(state["rows"].as_u64(), Some(37));
+    assert!(wait_for_screen(&harness.socket, resized_surface, &after).contains(&after));
+
+    let stale_close = request_response(
+        &harness.socket,
+        serde_json::json!({
+            "id": 10,
+            "cmd": "close-terminal",
+            "terminal_id": &terminal_id,
+            "terminal_incarnation": "00000000000000000000000000000000",
+        }),
+    );
+    assert_eq!(stale_close["ok"], false);
+    assert_eq!(stale_close["error"], "terminal_incarnation_mismatch");
+    assert_eq!(wait_for_host_records(&harness.host_root(), 1).len(), 1);
+
+    // This stable-id close was logically queued while the daemon was down;
+    // after adoption it atomically resolves the new local surface generation,
+    // verifies the incarnation, removes it, and only then terminates the host.
+    let closed = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 11,
+            "cmd": "close-terminal",
+            "terminal_id": &terminal_id,
+            "terminal_incarnation": &incarnation,
+        }),
+    );
+    assert_eq!(closed["surface"].as_u64(), Some(resized_surface));
+    assert_eq!(closed["terminal_id"].as_str(), Some(terminal_id.as_str()));
+    assert_eq!(closed["terminal_incarnation"].as_str(), Some(incarnation.as_str()));
+    let tombstoned = request_response(
+        &harness.socket,
+        serde_json::json!({"id": 12, "cmd": "resolve-terminal", "terminal_id": &terminal_id}),
+    );
+    assert_eq!(tombstoned["ok"], false);
+    assert_eq!(tombstoned["error"], "terminal_not_found");
+    wait_for_no_host_records(&harness.host_root());
+}
+
+#[test]
+fn stalled_renderer_is_disconnected_without_freezing_the_host() {
+    let harness = RecoveryHarness::start("stalled-renderer");
+    let created = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 1,
+            "cmd": "run",
+            "argv": ["/bin/sh"],
+            "new_workspace": true,
+            "cols": 80,
+            "rows": 24,
+        }),
+    );
+    let surface = created["surface"].as_u64().unwrap();
+    let grant = request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 2,
+            "cmd": "mint-terminal-renderer",
+            "surface": surface,
+            "ttl_ms": 10_000,
+        }),
+    );
+    let mut stalled = connect_host_detailed(
+        grant["endpoint"].as_str().unwrap(),
+        grant["terminal_id"].as_str().unwrap(),
+        grant["token"].as_str().unwrap(),
+        ClientRole::Renderer,
+        CapabilityRights::RENDERER,
+    )
+    .unwrap();
+
+    let done = format!("overflow-done-{}", std::process::id());
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 3,
+            "cmd": "send",
+            "surface": surface,
+            "text": format!(
+                "/usr/bin/head -c 20000000 /dev/zero; printf '{done}\\n'\n"
+            ),
+        }),
+    );
+    assert!(wait_for_screen(&harness.socket, surface, &done).contains(&done));
+
+    let disconnected_before_drain =
+        match stalled.stream.set_read_timeout(Some(Duration::from_secs(5))) {
+            Ok(()) => false,
+            // Darwin reports EINVAL when setting SO_RCVTIMEO after the peer has
+            // already issued shutdown(2); that is the overflow outcome under test.
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidInput => true,
+            Err(error) => panic!("set stalled-renderer timeout: {error}"),
+        };
+    let mut complete_frames = 0usize;
+    if !disconnected_before_drain {
+        loop {
+            match read_frame(&mut stalled.stream, MAX_FRAME_PAYLOAD) {
+                Ok(Some(frame)) => {
+                    assert_eq!(frame.request_id, 0);
+                    assert_eq!(frame.sequence, stalled.next_sequence);
+                    stalled.next_sequence = stalled.next_sequence.wrapping_add(1);
+                    complete_frames += 1;
+                }
+                Ok(None) => break,
+                Err(ProtocolError::Io(error))
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+                {
+                    panic!("stalled renderer silently froze instead of being disconnected")
+                }
+                // Shutdown can interrupt a frame already being copied into the
+                // kernel socket buffer. A clean EOF or truncated final frame are
+                // both explicit disconnects and require a fresh Snapshot.
+                Err(ProtocolError::Truncated { .. }) | Err(ProtocolError::Io(_)) => break,
+                Err(error) => panic!("stalled renderer received invalid protocol data: {error}"),
+            }
+        }
+    }
+    assert!(
+        disconnected_before_drain || complete_frames > 0,
+        "stalled renderer received no output before disconnect"
+    );
+
+    // Overflow is isolated to the stalled renderer. The daemon proxy and PTY
+    // remain responsive and the durable host record remains adoptable.
+    let after = format!("host-still-live-{}", std::process::id());
+    request(
+        &harness.socket,
+        serde_json::json!({
+            "id": 4,
+            "cmd": "send",
+            "surface": surface,
+            "text": format!("printf '{after}\\n'\n"),
+        }),
+    );
+    assert!(wait_for_screen(&harness.socket, surface, &after).contains(&after));
+    assert_eq!(wait_for_host_records(&harness.host_root(), 1).len(), 1);
+
+    request(
+        &harness.socket,
+        serde_json::json!({"id": 5, "cmd": "close-surface", "surface": surface}),
+    );
+    wait_for_no_host_records(&harness.host_root());
+}
+
+fn request(path: &Path, value: serde_json::Value) -> serde_json::Value {
+    let response = request_response(path, value);
+    assert_eq!(response["ok"], true, "request failed: {response}");
+    response["data"].clone()
+}
+
+fn request_response(path: &Path, value: serde_json::Value) -> serde_json::Value {
+    let stream = transport::connect(path).unwrap();
+    let mut writer = stream.try_clone_box().unwrap();
+    let mut reader = BufReader::new(stream);
+    writeln!(writer, "{value}").unwrap();
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    serde_json::from_str(&line).unwrap()
+}
+
+fn wait_for_socket(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if transport::connect(path).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    panic!("server did not accept connections at {}", path.display());
+}
+
+fn wait_for_screen(path: &Path, surface: u64, marker: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last = String::new();
+    while Instant::now() < deadline {
+        last = request(path, serde_json::json!({"cmd": "read-screen", "surface": surface}))["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        if last.contains(marker) {
+            return last;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    last
+}
+
+fn wait_for_host_records(
+    root: &Path,
+    expected: usize,
+) -> Vec<(PathBuf, cmux_tui_core::terminal_host_runtime::TerminalHostRecord)> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let records = load_terminal_host_records(root).unwrap();
+        if records.len() == expected {
+            return records;
+        }
+        assert!(Instant::now() < deadline, "expected {expected} host records, got {records:?}");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_no_host_records(root: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if load_terminal_host_records(root).unwrap().is_empty() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    panic!("terminal host record was not removed after close");
+}
+
+fn wait_for_host_size(root: &Path, cols: u16, rows: u16) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let mut records = load_terminal_host_records(root).unwrap();
+        if records.len() == 1 {
+            let (path, record) = records.pop().unwrap();
+            if let Ok(host) = adopt_terminal_host(record, path) {
+                let size = (host.snapshot.cols, host.snapshot.rows);
+                host.disconnect();
+                if size == (cols, rows) {
+                    return;
+                }
+            }
+        }
+        assert!(Instant::now() < deadline, "host did not resize to {cols}x{rows}");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn wait_for_vt_size(path: &Path, surface: u64, cols: u16, rows: u16) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let state = request(path, serde_json::json!({"cmd": "vt-state", "surface": surface}));
+        if state["cols"].as_u64() == Some(u64::from(cols))
+            && state["rows"].as_u64() == Some(u64::from(rows))
+        {
+            return state;
+        }
+        assert!(Instant::now() < deadline, "daemon mirror did not resize to {cols}x{rows}");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn first_surface(workspace: &serde_json::Value) -> Option<u64> {
+    first_tab(workspace)?.get("surface")?.as_u64()
+}
+
+fn first_tab(workspace: &serde_json::Value) -> Option<&serde_json::Value> {
+    workspace["screens"]
+        .as_array()?
+        .iter()
+        .flat_map(|screen| screen["panes"].as_array().into_iter().flatten())
+        .flat_map(|pane| pane["tabs"].as_array().into_iter().flatten())
+        .next()
+}
+
+fn connect_host(
+    endpoint: &str,
+    terminal_id: &str,
+    token: &str,
+    role: ClientRole,
+    rights: CapabilityRights,
+) -> anyhow::Result<UnixStream> {
+    Ok(connect_host_detailed(endpoint, terminal_id, token, role, rights)?.stream)
+}
+
+struct DirectHostConnection {
+    stream: UnixStream,
+    snapshot: Frame,
+    colors: TerminalColorOverrides,
+    next_sequence: u64,
+}
+
+impl DirectHostConnection {
+    fn wait_for_colors(&mut self, expected: &TerminalColorOverrides) {
+        self.stream.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+        let mut awaiting_colors = false;
+        loop {
+            let frame = read_frame(&mut self.stream, MAX_FRAME_PAYLOAD)
+                .expect("read terminal-host live frame")
+                .expect("terminal host closed before Colors");
+            assert_eq!(frame.request_id, 0, "unexpected control response on renderer stream");
+            assert_eq!(
+                frame.sequence, self.next_sequence,
+                "terminal-host live sequence was not contiguous"
+            );
+            self.next_sequence = self.next_sequence.wrapping_add(1);
+            match frame.kind {
+                MessageKind::Output => match frame.flags {
+                    0 => assert!(!awaiting_colors, "unflagged Output split a coupled pair"),
+                    FLAG_COLORS_FOLLOW => {
+                        assert!(!awaiting_colors, "nested coupled Output frames");
+                        awaiting_colors = true;
+                    }
+                    flags => panic!("unknown Output flags {flags:#x}"),
+                },
+                MessageKind::Colors => {
+                    assert_eq!(frame.flags, 0, "Colors defines no flags");
+                    assert!(awaiting_colors, "unpaired live Colors frame");
+                    awaiting_colors = false;
+                    let colors = decode_terminal_color_overrides(&frame.payload).unwrap();
+                    if &colors == expected {
+                        return;
+                    }
+                }
+                MessageKind::ResyncRequired => panic!("renderer was told to resync"),
+                _ => {
+                    assert_eq!(frame.flags, 0, "flags on non-coupled live frame");
+                    assert!(!awaiting_colors, "live frame split Output/Colors pair");
+                }
+            }
+        }
+    }
+}
+
+fn connect_host_detailed(
+    endpoint: &str,
+    terminal_id: &str,
+    token: &str,
+    role: ClientRole,
+    rights: CapabilityRights,
+) -> anyhow::Result<DirectHostConnection> {
+    let mut stream = UnixStream::connect(endpoint)?;
+    let hello = ClientHello {
+        min_version: PROTOCOL_VERSION,
+        max_version: PROTOCOL_VERSION,
+        role,
+        requested_rights: rights,
+        terminal_id: TerminalId::from_bytes(decode_hex(terminal_id)?),
+        token: CapabilityToken::from_bytes(decode_hex(token)?),
+    };
+    write_frame(&mut stream, &hello.into_frame(1))?;
+    let hello = read_frame(&mut stream, MAX_FRAME_PAYLOAD)?
+        .ok_or_else(|| anyhow::anyhow!("host rejected capability"))?;
+    if hello.kind != MessageKind::HostHello {
+        anyhow::bail!("host did not return HostHello");
+    }
+    let snapshot = read_frame(&mut stream, MAX_FRAME_PAYLOAD)?
+        .ok_or_else(|| anyhow::anyhow!("host closed before snapshot"))?;
+    if snapshot.kind != MessageKind::Snapshot || snapshot.flags != 0 || snapshot.request_id != 0 {
+        anyhow::bail!("host did not return Snapshot");
+    }
+    let colors_frame = read_frame(&mut stream, MAX_FRAME_PAYLOAD)?
+        .ok_or_else(|| anyhow::anyhow!("host closed before Colors"))?;
+    if colors_frame.kind != MessageKind::Colors
+        || colors_frame.flags != 0
+        || colors_frame.sequence != snapshot.sequence
+        || colors_frame.request_id != 0
+    {
+        anyhow::bail!("host did not return Colors at the Snapshot boundary");
+    }
+    let colors = decode_terminal_color_overrides(&colors_frame.payload)?;
+    Ok(DirectHostConnection {
+        stream,
+        next_sequence: snapshot.sequence.wrapping_add(1),
+        snapshot,
+        colors,
+    })
+}
+
+fn snapshot_replay(payload: &[u8]) -> &[u8] {
+    assert!(payload.len() >= 12, "Snapshot payload was truncated");
+    let replay_len = u32::from_le_bytes(payload[8..12].try_into().unwrap()) as usize;
+    let end = 12usize.checked_add(replay_len).expect("Snapshot replay length overflow");
+    assert!(end <= payload.len(), "Snapshot replay was truncated");
+    &payload[12..end]
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|window| window == needle)
+}
+
+fn decode_hex<const N: usize>(text: &str) -> anyhow::Result<[u8; N]> {
+    if text.len() != N * 2 {
+        anyhow::bail!("hex value has wrong length");
+    }
+    let mut output = [0; N];
+    for (index, byte) in output.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&text[index * 2..index * 2 + 2], 16)?;
+    }
+    Ok(output)
+}
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cmux-tui")
+}

--- a/cmux-tui/crates/ghostty-vt/src/lib.rs
+++ b/cmux-tui/crates/ghostty-vt/src/lib.rs
@@ -20,8 +20,8 @@ pub use render::{
     RenderState, StyledRun, UnderlineStyle, rows_to_runs,
 };
 pub use terminal::{
-    Callbacks, NotifyFn, PtyWriteFn, Rgb, Screen, Scrollbar, Terminal, parse_color,
-    parse_palette_entry,
+    Callbacks, NotifyFn, PtyWriteFn, Rgb, Screen, Scrollbar, Terminal, TerminalColorOverrides,
+    parse_color, parse_palette_entry,
 };
 
 pub(crate) fn check(result: ghostty_vt_sys::GhosttyResult) -> std::result::Result<(), Error> {

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -9,6 +10,7 @@ use crate::{Result, check};
 
 static NEXT_TERMINAL_ID: AtomicU64 = AtomicU64::new(1);
 const VT_REPLAY_ESTIMATED_BYTES_PER_CELL: u64 = 32;
+const MAX_COLOR_OSC_BYTES: usize = 16 * 1024;
 
 /// RGB color triple.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -21,6 +23,22 @@ pub struct Rgb {
 impl From<sys::GhosttyColorRgb> for Rgb {
     fn from(c: sys::GhosttyColorRgb) -> Self {
         Rgb { r: c.r, g: c.g, b: c.b }
+    }
+}
+
+/// Application-authored dynamic color overrides, excluding embedder theme
+/// defaults. `None` means the renderer must continue using its own theme.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalColorOverrides {
+    pub foreground: Option<Rgb>,
+    pub background: Option<Rgb>,
+    pub cursor: Option<Rgb>,
+    pub palette: [Option<Rgb>; 256],
+}
+
+impl Default for TerminalColorOverrides {
+    fn default() -> Self {
+        Self { foreground: None, background: None, cursor: None, palette: [None; 256] }
     }
 }
 
@@ -235,6 +253,306 @@ pub struct Terminal {
     // lifetime.
     callbacks: Box<Callbacks>,
     cursor_override: CursorOverrideTracker,
+    color_overrides: ColorOverrideTracker,
+    c1_normalizer: C1Normalizer,
+}
+
+/// Ghostty's parser intentionally treats bytes >= 0x80 as UTF-8 in ground
+/// state, while PTYs can still emit the 8-bit OSC/ST forms. Normalize only
+/// standalone C1 OSC/ST bytes; continuation bytes inside UTF-8 text remain
+/// byte-for-byte unchanged.
+#[derive(Default)]
+struct C1Normalizer {
+    utf8_remaining: u8,
+}
+
+impl C1Normalizer {
+    fn normalize<'a>(&mut self, data: &'a [u8]) -> Cow<'a, [u8]> {
+        let mut output: Option<Vec<u8>> = None;
+        for (index, &byte) in data.iter().enumerate() {
+            let continuation = if self.utf8_remaining != 0 && matches!(byte, 0x80..=0xbf) {
+                self.utf8_remaining -= 1;
+                true
+            } else {
+                self.utf8_remaining = 0;
+                false
+            };
+            let replacement = (!continuation).then_some(byte).and_then(|byte| match byte {
+                0x9d => Some(b']'),
+                0x9c => Some(b'\\'),
+                _ => None,
+            });
+            if let Some(replacement) = replacement {
+                let output = output.get_or_insert_with(|| {
+                    let mut output = Vec::with_capacity(data.len() + 1);
+                    output.extend_from_slice(&data[..index]);
+                    output
+                });
+                output.extend_from_slice(&[0x1b, replacement]);
+            } else if let Some(output) = output.as_mut() {
+                output.push(byte);
+            }
+            if !continuation {
+                self.utf8_remaining = match byte {
+                    0xc2..=0xdf => 1,
+                    0xe0..=0xef => 2,
+                    0xf0..=0xf4 => 3,
+                    _ => 0,
+                };
+            }
+        }
+        output.map(Cow::Owned).unwrap_or(Cow::Borrowed(data))
+    }
+}
+
+#[derive(Default)]
+struct ColorOverrideTracker {
+    state: ColorTrackState,
+    utf8_remaining: u8,
+    foreground: bool,
+    background: bool,
+    cursor: bool,
+    palette: [u64; 4],
+}
+
+#[derive(Default)]
+enum ColorTrackState {
+    #[default]
+    Ground,
+    Escape,
+    EscapeIntermediate,
+    Osc {
+        payload: Vec<u8>,
+        overflowed: bool,
+    },
+    OscEscape {
+        payload: Vec<u8>,
+        overflowed: bool,
+    },
+    String,
+    StringEscape,
+}
+
+impl ColorOverrideTracker {
+    fn write(&mut self, data: &[u8]) {
+        for &byte in data {
+            let state = std::mem::take(&mut self.state);
+            self.state = match state {
+                ColorTrackState::Ground => self.ground(byte),
+                ColorTrackState::Escape => self.escape(byte),
+                ColorTrackState::EscapeIntermediate => match byte {
+                    0x1b => ColorTrackState::Escape,
+                    0x20..=0x2f => ColorTrackState::EscapeIntermediate,
+                    _ => ColorTrackState::Ground,
+                },
+                ColorTrackState::Osc { mut payload, mut overflowed } => {
+                    if self.consume_utf8_continuation(byte) {
+                        Self::push_osc_byte(&mut payload, &mut overflowed, byte);
+                        ColorTrackState::Osc { payload, overflowed }
+                    } else {
+                        match byte {
+                            0x07 | 0x9c => {
+                                self.finish_osc(&payload, overflowed);
+                                ColorTrackState::Ground
+                            }
+                            0x1b => ColorTrackState::OscEscape { payload, overflowed },
+                            _ => {
+                                self.note_utf8_lead(byte);
+                                Self::push_osc_byte(&mut payload, &mut overflowed, byte);
+                                ColorTrackState::Osc { payload, overflowed }
+                            }
+                        }
+                    }
+                }
+                ColorTrackState::OscEscape { mut payload, mut overflowed } => match byte {
+                    b'\\' | 0x9c => {
+                        self.utf8_remaining = 0;
+                        self.finish_osc(&payload, overflowed);
+                        ColorTrackState::Ground
+                    }
+                    0x1b => ColorTrackState::OscEscape { payload, overflowed },
+                    _ => {
+                        self.utf8_remaining = 0;
+                        Self::push_osc_byte(&mut payload, &mut overflowed, 0x1b);
+                        Self::push_osc_byte(&mut payload, &mut overflowed, byte);
+                        self.note_utf8_lead(byte);
+                        ColorTrackState::Osc { payload, overflowed }
+                    }
+                },
+                ColorTrackState::String => {
+                    if self.consume_utf8_continuation(byte) {
+                        ColorTrackState::String
+                    } else {
+                        match byte {
+                            0x9c => ColorTrackState::Ground,
+                            0x1b => ColorTrackState::StringEscape,
+                            _ => {
+                                self.note_utf8_lead(byte);
+                                ColorTrackState::String
+                            }
+                        }
+                    }
+                }
+                ColorTrackState::StringEscape => match byte {
+                    b'\\' | 0x9c => {
+                        self.utf8_remaining = 0;
+                        ColorTrackState::Ground
+                    }
+                    0x1b => ColorTrackState::StringEscape,
+                    _ => {
+                        self.note_utf8_lead(byte);
+                        ColorTrackState::String
+                    }
+                },
+            };
+        }
+    }
+
+    fn ground(&mut self, byte: u8) -> ColorTrackState {
+        if self.consume_utf8_continuation(byte) {
+            return ColorTrackState::Ground;
+        }
+        match byte {
+            0x1b => ColorTrackState::Escape,
+            // A standalone 8-bit OSC is a control. A 0x9d occurring inside
+            // UTF-8 text was consumed above and cannot open an OSC.
+            0x9d => self.osc(),
+            _ => {
+                self.note_utf8_lead(byte);
+                ColorTrackState::Ground
+            }
+        }
+    }
+
+    fn escape(&mut self, byte: u8) -> ColorTrackState {
+        self.utf8_remaining = 0;
+        match byte {
+            b']' | 0x9d => self.osc(),
+            b'P' | b'X' | b'^' | b'_' => ColorTrackState::String,
+            b'c' => {
+                self.reset_all();
+                ColorTrackState::Ground
+            }
+            0x1b => ColorTrackState::Escape,
+            0x20..=0x2f => ColorTrackState::EscapeIntermediate,
+            _ => ColorTrackState::Ground,
+        }
+    }
+
+    fn osc(&mut self) -> ColorTrackState {
+        self.utf8_remaining = 0;
+        ColorTrackState::Osc { payload: Vec::new(), overflowed: false }
+    }
+
+    fn push_osc_byte(payload: &mut Vec<u8>, overflowed: &mut bool, byte: u8) {
+        if *overflowed {
+            return;
+        }
+        if payload.len() == MAX_COLOR_OSC_BYTES {
+            payload.clear();
+            *overflowed = true;
+        } else {
+            payload.push(byte);
+        }
+    }
+
+    fn consume_utf8_continuation(&mut self, byte: u8) -> bool {
+        if self.utf8_remaining == 0 {
+            return false;
+        }
+        if matches!(byte, 0x80..=0xbf) {
+            self.utf8_remaining -= 1;
+            true
+        } else {
+            self.utf8_remaining = 0;
+            false
+        }
+    }
+
+    fn note_utf8_lead(&mut self, byte: u8) {
+        self.utf8_remaining = match byte {
+            0xc2..=0xdf => 1,
+            0xe0..=0xef => 2,
+            0xf0..=0xf4 => 3,
+            _ => 0,
+        };
+    }
+
+    fn finish_osc(&mut self, payload: &[u8], overflowed: bool) {
+        self.utf8_remaining = 0;
+        if overflowed {
+            return;
+        }
+        let Ok(payload) = std::str::from_utf8(payload) else { return };
+        let mut parts = payload.split(';');
+        let Some(command) = parts.next().and_then(|value| value.parse::<u16>().ok()) else {
+            return;
+        };
+        match command {
+            4 => {
+                while let (Some(index), Some(value)) = (parts.next(), parts.next()) {
+                    let Some(index) = index.parse::<u8>().ok() else { continue };
+                    if value != "?" && parse_color(value).is_some() {
+                        self.set_palette_authored(index as usize, true);
+                    }
+                }
+            }
+            104 => {
+                let mut had_parameter = false;
+                for value in parts {
+                    had_parameter = true;
+                    let Some(index) = value.parse::<u8>().ok() else {
+                        continue;
+                    };
+                    self.set_palette_authored(index as usize, false);
+                }
+                if !had_parameter {
+                    self.palette.fill(0);
+                }
+            }
+            10..=12 => {
+                for (offset, value) in parts.enumerate() {
+                    let code = command.saturating_add(offset as u16);
+                    if code > 12 {
+                        break;
+                    }
+                    if value == "?" || parse_color(value).is_none() {
+                        continue;
+                    }
+                    match code {
+                        10 => self.foreground = true,
+                        11 => self.background = true,
+                        12 => self.cursor = true,
+                        _ => unreachable!(),
+                    }
+                }
+            }
+            110 => self.foreground = false,
+            111 => self.background = false,
+            112 => self.cursor = false,
+            _ => {}
+        }
+    }
+
+    fn reset_all(&mut self) {
+        self.foreground = false;
+        self.background = false;
+        self.cursor = false;
+        self.palette.fill(0);
+    }
+
+    fn set_palette_authored(&mut self, index: usize, authored: bool) {
+        let (word, bit) = (index / 64, index % 64);
+        if authored {
+            self.palette[word] |= 1u64 << bit;
+        } else {
+            self.palette[word] &= !(1u64 << bit);
+        }
+    }
+
+    fn palette_authored(&self, index: usize) -> bool {
+        self.palette[index / 64] & (1u64 << (index % 64)) != 0
+    }
 }
 
 #[derive(Default)]
@@ -407,6 +725,8 @@ impl Terminal {
             mouse_mode_scan: MouseModeScan::default(),
             callbacks: Box::new(callbacks),
             cursor_override: CursorOverrideTracker::default(),
+            color_overrides: ColorOverrideTracker::default(),
+            c1_normalizer: C1Normalizer::default(),
         };
         let userdata = &mut *term.callbacks as *mut Callbacks as *mut c_void;
         unsafe {
@@ -451,7 +771,9 @@ impl Terminal {
             self.mouse_mode_revision = self.mouse_mode_revision.wrapping_add(1);
         }
         self.cursor_override.write(data);
-        unsafe { sys::ghostty_terminal_vt_write(self.raw, data.as_ptr(), data.len()) }
+        self.color_overrides.write(data);
+        let normalized = self.c1_normalizer.normalize(data);
+        unsafe { sys::ghostty_terminal_vt_write(self.raw, normalized.as_ptr(), normalized.len()) }
     }
 
     /// Whether the current cursor style/blink came from an active DECSCUSR
@@ -552,6 +874,44 @@ impl Terminal {
             color(sys::GHOSTTY_TERMINAL_DATA_COLOR_BACKGROUND),
             color(sys::GHOSTTY_TERMINAL_DATA_COLOR_CURSOR),
         )
+    }
+
+    /// Sparse dynamic overrides authored by terminal applications through
+    /// OSC 4/10/11/12. Embedder-provided and Ghostty-compiled defaults are
+    /// deliberately excluded so another renderer can retain its own theme.
+    pub fn color_overrides(&self) -> TerminalColorOverrides {
+        let effective_color = |active: bool, data| {
+            active.then(|| self.get::<sys::GhosttyColorRgb>(data).ok().map(Rgb::from)).flatten()
+        };
+        let palette = self
+            .get_palette(sys::GHOSTTY_TERMINAL_DATA_COLOR_PALETTE)
+            .map(|effective| {
+                std::array::from_fn(|index| {
+                    self.color_overrides.palette_authored(index).then(|| effective[index].into())
+                })
+            })
+            .unwrap_or([None; 256]);
+        TerminalColorOverrides {
+            foreground: effective_color(
+                self.color_overrides.foreground,
+                sys::GHOSTTY_TERMINAL_DATA_COLOR_FOREGROUND,
+            ),
+            background: effective_color(
+                self.color_overrides.background,
+                sys::GHOSTTY_TERMINAL_DATA_COLOR_BACKGROUND,
+            ),
+            cursor: effective_color(
+                self.color_overrides.cursor,
+                sys::GHOSTTY_TERMINAL_DATA_COLOR_CURSOR,
+            ),
+            palette,
+        }
+    }
+
+    fn get_palette(&self, data: sys::GhosttyTerminalData) -> Result<[sys::GhosttyColorRgb; 256]> {
+        let mut output = [sys::GhosttyColorRgb::default(); 256];
+        check(unsafe { sys::ghostty_terminal_get(self.raw, data, output.as_mut_ptr().cast()) })?;
+        Ok(output)
     }
 
     /// Cursor position (col, row), 0-indexed within the active area.
@@ -827,7 +1187,7 @@ impl Terminal {
     /// state, charsets, and tabstops. This is the attach primitive: a new
     /// frontend replays this, then follows the live pty stream.
     pub fn vt_replay(&mut self) -> Result<Vec<u8>> {
-        self.vt_replay_with_selection(None)
+        self.vt_replay_with_selection(None, true)
     }
 
     /// VT replay bounded to `max_bytes`, retaining the newest complete rows.
@@ -840,6 +1200,24 @@ impl Terminal {
     /// back to a terminal reset so callers can still attach and receive live
     /// output instead of entering a permanent overflow loop.
     pub fn vt_replay_bounded(&mut self, max_bytes: usize) -> Result<Vec<u8>> {
+        self.vt_replay_bounded_with_palette(max_bytes, true)
+    }
+
+    /// Theme-portable replay for process-separated renderers.
+    ///
+    /// This reproduces cells, styles, modes, cursor, and history but omits
+    /// terminal palette/default-color OSC state. Pair it with a sparse
+    /// [`TerminalColorOverrides`] snapshot so the receiving renderer keeps
+    /// its own Ghostty theme for every color the application did not set.
+    pub fn vt_replay_bounded_theme_portable(&mut self, max_bytes: usize) -> Result<Vec<u8>> {
+        self.vt_replay_bounded_with_palette(max_bytes, false)
+    }
+
+    fn vt_replay_bounded_with_palette(
+        &mut self,
+        max_bytes: usize,
+        include_palette: bool,
+    ) -> Result<Vec<u8>> {
         let Some(scrollbar) = self.scrollbar() else {
             return Ok(minimal_vt_replay(max_bytes));
         };
@@ -854,7 +1232,9 @@ impl Terminal {
         let mut upper_failed = false;
 
         loop {
-            if let Some(replay) = self.vt_replay_screen_tail_bounded(tail_rows, max_bytes)? {
+            if let Some(replay) =
+                self.vt_replay_screen_tail_bounded(tail_rows, max_bytes, include_palette)?
+            {
                 if upper_failed || tail_rows == scrollbar.total {
                     return Ok(replay);
                 }
@@ -887,6 +1267,7 @@ impl Terminal {
         &mut self,
         rows: u64,
         max_bytes: usize,
+        include_palette: bool,
     ) -> Result<Option<Vec<u8>>> {
         let scrollbar = self.scrollbar().ok_or(crate::Error::InvalidValue)?;
         let cols = self.cols();
@@ -907,14 +1288,15 @@ impl Terminal {
                 .ok_or(crate::Error::InvalidValue)?,
             rectangle: false,
         };
-        self.vt_replay_with_selection_bounded(Some(&selection), max_bytes)
+        self.vt_replay_with_selection_bounded(Some(&selection), max_bytes, include_palette)
     }
 
     fn vt_replay_with_selection(
         &mut self,
         selection: Option<&sys::GhosttySelection>,
+        include_palette: bool,
     ) -> Result<Vec<u8>> {
-        let mut bytes = self.format(Self::vt_replay_options(selection))?;
+        let mut bytes = self.format(Self::vt_replay_options(selection, include_palette))?;
         self.append_cursor_position(&mut bytes);
         Ok(bytes)
     }
@@ -923,8 +1305,10 @@ impl Terminal {
         &mut self,
         selection: Option<&sys::GhosttySelection>,
         max_bytes: usize,
+        include_palette: bool,
     ) -> Result<Option<Vec<u8>>> {
-        let mut bytes = self.format_bounded(Self::vt_replay_options(selection), max_bytes)?;
+        let mut bytes =
+            self.format_bounded(Self::vt_replay_options(selection, include_palette), max_bytes)?;
         if let Some(bytes) = bytes.as_mut() {
             self.append_cursor_position(bytes);
         }
@@ -933,6 +1317,7 @@ impl Terminal {
 
     fn vt_replay_options(
         selection: Option<&sys::GhosttySelection>,
+        include_palette: bool,
     ) -> sys::GhosttyFormatterTerminalOptions {
         sys::GhosttyFormatterTerminalOptions {
             size: size_of::<sys::GhosttyFormatterTerminalOptions>(),
@@ -941,7 +1326,7 @@ impl Terminal {
             trim: false,
             extra: sys::GhosttyFormatterTerminalExtra {
                 size: size_of::<sys::GhosttyFormatterTerminalExtra>(),
-                palette: true,
+                palette: include_palette,
                 modes: true,
                 scrolling_region: true,
                 tabstops: true,

--- a/cmux-tui/crates/ghostty-vt/tests/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/terminal.rs
@@ -359,3 +359,95 @@ fn render_state_reports_palette_overrides() {
     assert_eq!(rs.palette_color(1), Rgb { r: 1, g: 2, b: 3 });
     assert!(!rs.palette_overridden(2));
 }
+
+#[test]
+fn color_overrides_are_sparse_and_resets_return_to_embedder_defaults() {
+    let mut term = Terminal::new(5, 1, 0, Callbacks::default()).unwrap();
+    term.set_default_colors(
+        Some(Rgb { r: 220, g: 221, b: 222 }),
+        Some(Rgb { r: 10, g: 11, b: 12 }),
+        Some(Rgb { r: 30, g: 31, b: 32 }),
+    );
+    let mut palette = [None; 256];
+    palette[3] = Some(Rgb { r: 40, g: 41, b: 42 });
+    term.set_default_palette(&palette);
+    assert_eq!(term.color_overrides(), Default::default());
+
+    term.vt_write(b"\x1b]4;3;#010203\x07\x1b]10;#111213\x07\x1b]11;#212223\x07\x1b]12;#313233\x07");
+    let colors = term.color_overrides();
+    assert_eq!(colors.palette[3], Some(Rgb { r: 1, g: 2, b: 3 }));
+    assert_eq!(colors.foreground, Some(Rgb { r: 17, g: 18, b: 19 }));
+    assert_eq!(colors.background, Some(Rgb { r: 33, g: 34, b: 35 }));
+    assert_eq!(colors.cursor, Some(Rgb { r: 49, g: 50, b: 51 }));
+
+    term.vt_write(b"\x1b]104;3\x07\x1b]110\x07\x1b]111\x07\x1b]112\x07");
+    assert_eq!(term.color_overrides(), Default::default());
+}
+
+#[test]
+fn color_override_authorship_survives_equal_defaults_fragmentation_and_queries() {
+    let foreground = Rgb { r: 17, g: 18, b: 19 };
+    let palette_color = Rgb { r: 1, g: 2, b: 3 };
+    let mut term = Terminal::new(5, 1, 0, Callbacks::default()).unwrap();
+    term.set_default_colors(Some(foreground), None, None);
+    let mut palette = [None; 256];
+    palette[3] = Some(palette_color);
+    term.set_default_palette(&palette);
+
+    // Queries do not author state, even when split across writes.
+    term.vt_write(b"\x1b]10;");
+    term.vt_write(b"?\x1b\\\x1b]4;3;?\x07");
+    assert_eq!(term.color_overrides(), Default::default());
+
+    // Setting exactly the embedder default is still application-authored.
+    term.vt_write(b"\x1b]10;#111213\x1b");
+    term.vt_write(b"\\\x1b]4;3;#010203");
+    term.vt_write(b"\x07");
+    let colors = term.color_overrides();
+    assert_eq!(colors.foreground, Some(foreground));
+    assert_eq!(colors.palette[3], Some(palette_color));
+
+    term.vt_write(b"\x1b]110\x1b\\\x1b]104;3\x07");
+    assert_eq!(term.color_overrides(), Default::default());
+}
+
+#[test]
+fn color_override_tracker_handles_c1_osc_and_st_without_misreading_utf8() {
+    let mut term = Terminal::new(5, 1, 0, Callbacks::default()).unwrap();
+    term.vt_write("❝👍".as_bytes());
+    assert_eq!(term.color_overrides(), Default::default());
+
+    term.vt_write(b"\x9d10;#010203");
+    term.vt_write(b"\x9c\x1b]4;7;#040506");
+    term.vt_write(b"\x9c");
+    let colors = term.color_overrides();
+    assert_eq!(colors.foreground, Some(Rgb { r: 1, g: 2, b: 3 }));
+    assert_eq!(colors.palette[7], Some(Rgb { r: 4, g: 5, b: 6 }));
+
+    term.vt_write(b"\x9d110\x9c\x9d104;7\x9c");
+    assert_eq!(term.color_overrides(), Default::default());
+}
+
+#[test]
+fn theme_portable_replay_omits_terminal_color_osc_state() {
+    let mut source = Terminal::new(20, 2, 100, Callbacks::default()).unwrap();
+    source.vt_write(
+        b"\x1b]4;3;#010203\x07\x1b]10;#111213\x07\x1b]11;#212223\x07\
+          \x1b]12;#313233\x07hello",
+    );
+    let portable = source.vt_replay_bounded_theme_portable(1024 * 1024).unwrap();
+    let replay_text = String::from_utf8_lossy(&portable);
+    for color_osc in ["\x1b]4;", "\x1b]10;", "\x1b]11;", "\x1b]12;"] {
+        assert!(!replay_text.contains(color_osc), "portable replay leaked {color_osc:?}");
+    }
+
+    let mut target = Terminal::new(20, 2, 100, Callbacks::default()).unwrap();
+    target.set_default_colors(
+        Some(Rgb { r: 240, g: 241, b: 242 }),
+        Some(Rgb { r: 4, g: 5, b: 6 }),
+        Some(Rgb { r: 7, g: 8, b: 9 }),
+    );
+    target.vt_write(&portable);
+    assert_eq!(target.color_overrides(), Default::default());
+    assert!(target.viewport_text().unwrap().contains("hello"));
+}

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -120,6 +120,30 @@ Frontends report their grid after a surface becomes visible and whenever that vi
 
 ## Implemented Commands
 
+### Durable workspace mutation envelope
+
+`create-workspace`, `rename-workspace`, `move-workspace`, and
+`close-workspace` accept the following additive fields:
+
+| Name | JSON type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `origin` | `string` | paired with `mutation_id` | Stable frontend/profile identity |
+| `mutation_id` | `string` | paired with `origin` | Stable UUID/id reused for every retry of one logical mutation |
+| `expected_generation` | `string` | optional | Compare-and-swap guard for the daemon boot UUID |
+| `expected_revision` | `uint64` | optional | Compare-and-swap guard for the ordered workspace registry |
+
+The server durably records `(origin, mutation_id)`, the logical request
+fingerprint, original result, and committed revision. Duplicate lookup occurs
+before generation/revision guards and before resolving a live workspace. A
+lost-response retry therefore returns the original result with
+`replayed:true`, including after a successful close has tombstoned the key or
+after the daemon has restarted. Reusing the same mutation identity for a
+different logical payload is an error. Guards are not part of the fingerprint.
+
+Workspace mutation results add `registry_id`, `generation`,
+`workspace_revision`, `replayed`, stable `key`, and the compatibility numeric
+`workspace` id. Canonical frontend state must use `key`, not the numeric id.
+
 ### identify
 
 | Field | Value |
@@ -135,7 +159,7 @@ Params: none.
 Result:
 
 ```text
-object{app:"cmux-tui",version:string,protocol:uint32,session:string,pid:uint32}
+object{app:"cmux-tui",version:string,protocol:uint32,session:string,pid:uint32,registry_id:string,generation:string,workspace_revision:uint64}
 ```
 
 Errors:
@@ -419,7 +443,11 @@ Example:
 | status | implemented |
 | since | protocol 5 |
 
-Returns the full workspace, screen, pane, tab, and split-tree snapshot. The snapshot includes the ordered workspace registry revision, each workspace's stable key, active flags, active pane ids, active tab indexes, tab titles, tab names, surface kinds, browser source, size, and dead flags.
+Returns the full workspace, screen, pane, tab, and split-tree snapshot. The
+snapshot includes `registry_id`, the current boot `generation`, the durable
+`workspace_revision`, and every empty canonical workspace. It also includes
+active flags, active pane ids, active tab indexes, tab titles, tab names,
+surface kinds, browser source, size, and dead flags.
 
 Params: none.
 
@@ -451,6 +479,36 @@ Example:
 {"id":2,"cmd":"list-workspaces"}
 {"id":2,"ok":true,"data":{"workspace_revision":1,"workspaces":[{"id":4,"key":"6ba7b810-9dad-41d1-80b4-00c04fd430c8","name":"1","active":true,"screens":[{"id":3,"name":null,"active":true,"active_pane":2,"layout":{"type":"leaf","pane":2},"panes":[{"id":2,"name":null,"active_tab":0,"tabs":[{"surface":1,"kind":"pty","browser_source":null,"name":null,"title":"","size":{"cols":80,"rows":24},"dead":false}]}]}]}]}}
 ```
+
+### get-frontend-projection / put-frontend-projection
+
+| Field | Value |
+| --- | --- |
+| names | `get-frontend-projection`, `put-frontend-projection` |
+| status | implemented |
+| since | protocol 7 |
+
+Stores one opaque, schema-versioned frontend layout document per
+`(frontend, scope, subject_key)`. The browser convention is
+`frontend:"cmux-browser"`, `scope:"window-group"`, with a stable
+profile/window-group identity in `subject_key`.
+
+`put-frontend-projection` additionally requires `schema_version`, a JSON
+`projection`, optional `expected_projection_revision`, and `origin` plus
+`mutation_id`. It uses its own exactly-once ledger and projection CAS; it does
+not advance `workspace_revision`. A projection may contain browser columns,
+splits, web tabs, focus, and terminal placement keyed by canonical workspace
+UUID. It must not duplicate workspace existence, name, order, or group
+membership.
+
+Result:
+
+```text
+object{frontend:string,scope:string,subject_key:string,schema_version:uint32,projection_revision:uint64,projection:any,replayed?:bool}
+```
+
+Missing projections return revision/schema `0` and `projection:null`.
+Documents larger than 1 MiB are rejected.
 
 ### export-layout
 
@@ -857,20 +915,23 @@ Example:
 | status | implemented |
 | since | protocol 7 |
 
-Adds an empty workspace to the ordered registry and makes it active. The caller may provide a stable key or let the mux generate one. `expected_revision` provides compare-and-swap protection against concurrent registry mutations.
+Creates a canonical ordered workspace without implicitly spawning a terminal,
+pane, or screen. This is the preferred GUI workflow: commit the shared
+workspace first, then create browser-only layout or a terminal inside its
+stable `key`.
 
 Params:
 
 | Name | JSON type | Required/default | Constraints |
 | --- | --- | --- | --- |
 | `name` | `string` | default null | Defaults to the next 1-based workspace count |
-| `key` | `string` | default generated UUID | Must be non-empty and unique |
-| `expected_revision` | `uint64` | default null | Must equal the current registry revision when supplied |
+| `key` | `string` | default generated UUID | Must be non-empty and never previously used |
+| mutation fields | see [common envelope](#durable-workspace-mutation-envelope) | optional | Exactly-once retry and CAS |
 
 Result:
 
 ```text
-object{workspace:Id,key:string,index:uint64,workspace_revision:uint64}
+object{workspace:Id,key:string,index:usize,workspace_revision:uint64,replayed:bool,registry_id:string,generation:string}
 ```
 
 Errors include `workspace key cannot be empty`, `workspace key already exists: <key>`, `workspace revision conflict: expected <n>, current <n>`, and malformed request errors.
@@ -882,6 +943,10 @@ Example:
 {"id":9,"ok":true,"data":{"workspace":12,"key":"ops-stable","index":1,"workspace_revision":2}}
 ```
 
+The server retains tombstones indefinitely; a closed `key` cannot be reused.
+The last terminal exiting never closes this workspace. Only
+`close-workspace` removes it from the live registry.
+
 ### create-terminal
 
 | Field | Value |
@@ -890,7 +955,10 @@ Example:
 | status | implemented |
 | since | protocol 7 |
 
-Creates a PTY terminal in an existing workspace selected by stable `key` or numeric `workspace` id. An empty workspace receives its first screen and pane; a populated workspace receives a new active tab in its active pane. `argv` executes directly, while `command` executes through the default shell.
+Creates a PTY tab in the workspace selected by stable `key` or compatibility
+numeric `workspace`. An empty workspace is materialized in place with its
+first screen and pane; no workspace revision is advanced. `argv` executes
+directly, while `command` executes through the default shell.
 
 Params:
 
@@ -1369,20 +1437,23 @@ Example:
 | status | implemented |
 | since | protocol 5 |
 
-Closes a workspace and every screen, pane, and tab in it. The workspace may be selected by stable key or numeric id. The active workspace selection is adjusted to keep a remaining workspace active when possible. `expected_revision` provides compare-and-swap protection against concurrent registry mutations.
+Explicitly tombstones a workspace and closes every screen, pane, and tab in
+it. Terminal/pane exit alone never invokes this operation. The active
+workspace selection is adjusted to keep a remaining workspace active when
+possible.
 
 Params:
 
 | Name | JSON type | Required/default | Constraints |
 | --- | --- | --- | --- |
-| `workspace` | `Id` | required unless `key` is supplied | Must identify a live workspace |
-| `key` | `string` | required unless `workspace` is supplied | Must match `workspace` when both are supplied |
-| `expected_revision` | `uint64` | default null | Must equal the current registry revision when supplied |
+| `workspace` | `Id` | one of id/key | Must identify a live workspace |
+| `key` | `string` | one of id/key | Stable workspace identity |
+| mutation fields | see common envelope | optional | Exactly-once retry and CAS |
 
 Result:
 
 ```text
-object{workspace:Id,key:string,workspace_revision:uint64}
+object{workspace:Id,key:string,index:usize,workspace_revision:uint64,changed:bool,replayed:bool,registry_id:string,generation:string}
 ```
 
 Errors:
@@ -1567,15 +1638,15 @@ Params:
 
 | Name | JSON type | Required/default | Constraints |
 | --- | --- | --- | --- |
-| `workspace` | `Id` | required unless `key` is supplied | Must identify a live workspace |
-| `key` | `string` | required unless `workspace` is supplied | Must match `workspace` when both are supplied |
+| `workspace` | `Id` | one of id/key | Must identify a live workspace |
+| `key` | `string` | one of id/key | Stable workspace identity |
 | `name` | `string` | required | Empty string is stored |
-| `expected_revision` | `uint64` | default null | Must equal the current registry revision when supplied |
+| mutation fields | see common envelope | optional | Exactly-once retry and CAS |
 
 Result:
 
 ```text
-object{workspace:Id,key:string,workspace_revision:uint64}
+object{workspace:Id,key:string,index:usize,workspace_revision:uint64,changed:bool,replayed:bool,registry_id:string,generation:string}
 ```
 
 Errors:
@@ -1930,21 +2001,23 @@ Example:
 | status | implemented |
 | since | protocol 5 |
 
-Moves an existing workspace to zero-based `index`. The workspace may be selected by stable key or numeric id. The destination is clamped to the last workspace. Moving a workspace to its current index is an `ok:true` no-op that preserves the current revision. `expected_revision` provides compare-and-swap protection against concurrent registry mutations.
+Moves an existing workspace to zero-based `index`. A same-position request is
+serialized as a valid mutation with `changed:false`, giving retries one stable
+result and revision.
 
 Params:
 
 | Name | JSON type | Required/default | Constraints |
 | --- | --- | --- | --- |
-| `workspace` | `Id` | required unless `key` is supplied | Workspace to move |
-| `key` | `string` | required unless `workspace` is supplied | Must match `workspace` when both are supplied |
+| `workspace` | `Id` | one of id/key | Workspace to move |
+| `key` | `string` | one of id/key | Stable workspace identity |
 | `index` | `usize` | required | Zero-based destination index |
-| `expected_revision` | `uint64` | default null | Must equal the current registry revision when supplied |
+| mutation fields | see common envelope | optional | Exactly-once retry and CAS |
 
 Result:
 
 ```text
-object{workspace:Id,key:string,workspace_revision:uint64}
+object{workspace:Id,key:string,index:usize,workspace_revision:uint64,changed:bool,replayed:bool,registry_id:string,generation:string}
 ```
 
 Errors:

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -27,6 +27,7 @@ Subscribe events belong to the `subscribe` registration. Tree lifecycle deltas b
 | `workspace-closed` | subscribe (`deltas`) | `workspace` | protocol 7 |
 | `workspace-renamed` | subscribe (`deltas`) | `workspace` | protocol 7 |
 | `workspace-moved` | subscribe (`deltas`) | `workspace` | protocol 7 |
+| `frontend-projection-changed` | subscribe | projection subject | protocol 7 |
 | `screen-added` | subscribe (`deltas`) | `screen` | protocol 7; parent `workspace` |
 | `screen-closed` | subscribe (`deltas`) | `screen` | protocol 7; parent `workspace` |
 | `screen-renamed` | subscribe (`deltas`) | `screen` | protocol 7; parent `workspace` |
@@ -175,7 +176,19 @@ Example:
 
 Protocol v7 adds typed lifecycle deltas for ordinary tree mutations, delivered only when the subscription explicitly requests `tree_events:"deltas"`. The default `"coarse"` subscription receives none of these events. `entity` is the exact `Workspace`, `Screen`, `Pane`, or `Tab` payload defined for `list-workspaces` in `commands.md`; it is not a reduced event-only projection. Added and renamed events carry the entity after the mutation. Closed events carry its last-known payload immediately before removal. This lets clients remove a subtree without having to retain a second copy for close animation or cleanup.
 
-For `*-added`, `index` is the zero-based insertion index in the parent's corresponding array. For `*-closed`, it is the former index. `workspace-moved` carries the new zero-based root index. Workspace events use the root `workspaces` array, include the resulting `workspace_revision`, and carry the stable key in `entity`. Tab events use the pane's `tabs` array. Rename events do not carry `index` because they do not reorder the entity.
+Ordered workspace events additionally carry `workspace_revision`, stable
+`registry_id`, boot `generation`, `origin`, and `mutation_id`. A client applies
+only the exact next revision for the same registry/generation and refetches
+`list-workspaces` after a gap or generation change. The server commits the
+durable mutation before publishing this event and holds one registry writer
+through event publication, so revision order and stream order are identical.
+
+For `*-added`, `index` is the zero-based insertion index in the parent's
+corresponding array. For `*-closed`, it is the former index.
+`workspace-moved` carries the new zero-based root index. Workspace events use
+the root `workspaces` array and carry the stable key in `entity`; tab events
+use the pane's `tabs` array. Rename events do not carry `index` because they do
+not reorder the entity.
 
 One settled mutation may affect a subtree. A server may emit only the highest-level delta when its `entity` already contains the complete affected subtree; it must not also emit redundant descendant add/close deltas. If it emits multiple independent deltas, adds are parent-first and closes are child-first.
 
@@ -192,7 +205,7 @@ These lifecycle deltas do not encode every mutable tree field. Selection, reorde
 Payload:
 
 ```text
-object{event:"workspace-added",workspace:Id,index:usize,workspace_revision:uint64,entity:Workspace}
+object{event:"workspace-added",workspace:Id,index:usize,entity:Workspace,workspace_revision:uint64,registry_id:string,generation:string,origin:string,mutation_id:string}
 ```
 
 ### workspace-closed
@@ -206,7 +219,7 @@ object{event:"workspace-added",workspace:Id,index:usize,workspace_revision:uint6
 Payload:
 
 ```text
-object{event:"workspace-closed",workspace:Id,index:usize,workspace_revision:uint64,entity:Workspace}
+object{event:"workspace-closed",workspace:Id,index:usize,entity:Workspace,workspace_revision:uint64,registry_id:string,generation:string,origin:string,mutation_id:string}
 ```
 
 ### workspace-renamed
@@ -220,7 +233,7 @@ object{event:"workspace-closed",workspace:Id,index:usize,workspace_revision:uint
 Payload:
 
 ```text
-object{event:"workspace-renamed",workspace:Id,workspace_revision:uint64,entity:Workspace}
+object{event:"workspace-renamed",workspace:Id,entity:Workspace,workspace_revision:uint64,registry_id:string,generation:string,origin:string,mutation_id:string}
 ```
 
 ### workspace-moved
@@ -231,11 +244,17 @@ object{event:"workspace-renamed",workspace:Id,workspace_revision:uint64,entity:W
 | status | implemented |
 | since | protocol 7 |
 
-Payload:
-
 ```text
-object{event:"workspace-moved",workspace:Id,index:usize,workspace_revision:uint64,entity:Workspace}
+object{event:"workspace-moved",workspace:Id,index:usize,entity:Workspace,workspace_revision:uint64,registry_id:string,generation:string,origin:string,mutation_id:string}
 ```
+
+### frontend-projection-changed
+
+Published after a successful non-replayed projection CAS commit. The payload
+contains `frontend`, `scope`, `subject_key`, `projection_revision`, `origin`,
+and `mutation_id`. It does not contain the opaque projection; interested
+frontends fetch it with `get-frontend-projection`. Projection changes do not
+advance `workspace_revision`.
 
 ### screen-added
 

--- a/cmux-tui/spec/frontends.md
+++ b/cmux-tui/spec/frontends.md
@@ -33,6 +33,21 @@ Require `protocol >= 7` before requesting render mode, `read-scrollback`, or bra
 
 Open [`subscribe`](commands.md#subscribe) with `tree_events:"deltas"`, buffer events as soon as the request is sent, then fetch [`list-workspaces`](commands.md#list-workspaces). Apply the snapshot before draining the buffer. The subscribe receiver is registered before its success response, so responses and events may race. Omitting `tree_events` selects the protocol-v6-compatible coarse stream instead.
 
+Treat cmux-tui as the only authority for workspace UUID, existence, name, and
+order. A browser window model is a disposable projection. Use a stable
+profile/window-group identity as the cmux session and as the
+`put-frontend-projection` subject; do not generate a new session on every app
+launch. Every canonical workspace, including an empty one, must appear in the
+frontend immediately. Browser-only columns, splits, web tabs, focus, and
+terminal placement belong in the opaque frontend projection and refer to
+workspaces by stable `key`.
+
+Generate `origin` and `mutation_id` before sending a workspace mutation and
+reuse both for retries. Apply a successful local response immediately, then
+deduplicate its matching event by mutation identity. On boot-generation
+change, event gap, or subscription overflow, discard daemon-local ids and
+reconcile from a fresh `list-workspaces` snapshot plus the latest projection.
+
 Protocol v7 lifecycle events (`workspace-*`, `screen-*`, `pane-*`, and `tab-*`) carry subject ids, parent ids, and exact `list-workspaces` entity payloads. Apply those deltas in stream order. `layout-changed`, surface events, and title events retain their documented focused invalidation paths.
 
 Always implement `tree-changed`: it is the delta stream's coarse resync fallback for churn and changes not represented by lifecycle deltas. Do not rely on it for ordinary delta-representable mutations. On receipt, fetch a new `list-workspaces` snapshot and treat it as authoritative over older buffered deltas. See the [event-scoping table](events.md#event-scoping) before routing events from a connection with streams.

--- a/cmux-tui/spec/transports.md
+++ b/cmux-tui/spec/transports.md
@@ -25,7 +25,13 @@ $TMPDIR/cmux-tui-<uid>/<session>.sock
 
 The implementation uses Rust `std::env::temp_dir()` for `$TMPDIR`, appends `cmux-tui-<uid>`, and then appends `<session>.sock`. The TUI exports the resolved path to child surfaces as `CMUX_TUI_SOCKET` and legacy `CMUX_MUX_SOCKET`.
 
-The `cmux-tui` process accepts `--session <name>` to select the default socket name and `--socket <path>` to override the path.
+The `cmux-tui` process accepts `--session <name>` to select the default socket name and `--socket <path>` to override the path. The socket contains no canonical state. Workspace identity/order, mutation results/tombstones, and frontend projections are stored in SQLite under the platform state directory (macOS: `~/Library/Application Support/cmux-tui/sessions`), or under `--state <root>`. An explicit temporary `--socket` derives an isolated `<socket>.state` root unless `--state` is supplied. `--ephemeral` selects an in-memory registry and is mutually exclusive with `--state`.
+
+One process holds an exclusive cross-platform writer lease for each session
+database. SQLite uses WAL, foreign keys, `synchronous=FULL`, and macOS
+`fullfsync`. A second daemon for the same state/session fails startup instead
+of racing. Corruption or an unsupported schema also fails closed; the daemon
+never silently falls back to ephemeral state.
 
 ### Framing And Canonical Envelope
 


### PR DESCRIPTION
Depends on #8340.

## Summary

- Make the SQLite workspace registry authoritative for terminal identity, placement, and lifecycle.
- Run every terminal PTY in an independent `setsid` host process and expose authenticated, scoped frontend attachments.
- Recover crash-consistently across daemon/frontend restarts, including host adoption, stale-record handling, final-output draining, and descendant cleanup.
- Arbitrate PTY size from attached viewers while preserving canonical color, cursor, mouse, close, and topology semantics.
- Preserve the refreshed base's final-destination drag/move semantics and two-phase empty-workspace/terminal event ordering.

## Validation

- `cmux-tui`: 258 unit, 6 CLI, 3 hidden-host-mode, and 14 recovery tests passed (281 total).
- `cmux-tui-core`: 219 unit, 7 browser-runtime, 28 PTY, and 9 WebSocket tests passed (263 total).
- Full default-parallel suites passed after rebasing onto the latest #8340 head.
- All-target Clippy with `-D warnings` and formatting checks passed.
- Go, Python, and TypeScript SDK tests passed; Java was unavailable on this machine.
- Post-suite audit found zero leaked terminal hosts, daemons, PTYs/process groups, registry records, nonces, or PID files.

## Risks

- Unix-only host/runtime implementation.
- One OS host process per terminal increases process count intentionally.
- Legacy or unverifiable records fail conservatively.
- Requires the pinned manaflow Ghostty revision.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786964645&installation_id=133855650&pr_number=8422&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8422&signature=31ffb34155087a77f745b6c4daa6cbeda57d51b2a59106f81d125ff67bed06e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes terminal placement and lifecycle canonical in a durable SQLite registry and runs each PTY in its own resilient `setsid` host process. Improves crash consistency, recovery, and identity across restarts while preserving color, cursor, mouse, close, and topology behavior.

- New Features
  - Canonical registry for workspaces and terminals with ordered revisions and crash-consistent commits.
  - New protocol v7 fields in `identify`: `registry_id`, `generation`, `workspace_revision`, `terminal_revision`.
  - New commands and events: `list-terminals`, `terminal-events`, and `terminal-registry-changed`.
  - Per-terminal host processes with authenticated, scoped attachments; host adoption, stale-record cleanup, final-output draining, and process-group reaping.
  - Viewer-driven PTY size arbitration and sparse OSC color/palette overrides; cursor blink and palette overrides are reflected in `TerminalColors`.

- Migration
  - Require protocol >= 7. Read the new fields from `identify`.
  - Sync terminal placement via `list-terminals` and `terminal-events`, or refetch on `terminal-registry-changed`.
  - For workspace mutations, include `origin` and `mutation_id` (idempotency) and optionally `expected_generation`/`expected_revision` (CAS).
  - If you render colors, handle `TerminalColors.palette` overrides.
  - Use `--state <path>` or `--ephemeral` for session-state location as needed; the host/runtime is Unix-only.

<sup>Written for commit 8e4965dd2b0bb671daafe305b102768f264294ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

