### PR TITLE
Fix iOS workspace resets during transient Iroh recovery

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -102,13 +102,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000
     /// How long the render-grid stream may stay silent (no event of any topic)
     /// before the liveness watchdog suspects the push subscription is dead and
-    /// runs a bounded host probe; only a failed probe forces the
+    /// runs a bounded host probe; only repeated failed probes force the
     /// re-subscribe + replay (silence alone is the normal state of an idle
     /// terminal). Picked at the low end of the acceptable 8-12s window so a
     /// wedged stream recovers in a few seconds instead of the transport's ~85s
     /// timeout, while staying well above any normal inter-event gap on a busy
     /// shell.
     static let renderGridLivenessSilenceThreshold: TimeInterval = 9
+    /// A single timed-out probe is ambiguous during Iroh path migration, app
+    /// resume, or a short Mac stall. Require independent confirmation before
+    /// replacing a session that may still be healthy.
+    static let renderGridLivenessFailuresBeforeRecovery = 2
     /// Cadence of the liveness watchdog tick. It only reads a timestamp and
     /// compares against the threshold, so a short interval is cheap; it does not
     /// reschedule per received event (an actively-streaming connection just keeps
@@ -709,8 +713,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     // pushes nothing (the Mac dedupes unchanged render-grid frames), so a
     // silence-threshold crossing first runs a bounded idempotent
     // `mobile.events.subscribe` probe (same stream id, current topics) and
-    // only tears down + re-subscribes + replays when the host fails to answer
-    // it.
+    // only tears down + re-subscribes + replays after repeated probe failures
+    // with no intervening event or successful probe.
     private var renderGridLivenessTimer: (any DispatchSourceTimer)?
     private var renderGridLivenessListenerID: UUID?
     /// The in-flight liveness probe spawned by a silence-threshold crossing.
@@ -721,6 +725,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// in-flight slot.
     private var renderGridLivenessProbeTask: Task<Void, Never>?
     private var renderGridLivenessProbeID: UUID?
+    private var renderGridLivenessConsecutiveProbeFailures = 0
     var lastTerminalEventAt: Date?
     var lastBackgroundedAt: Date?
     private var terminalSubscriptionRefreshTask: Task<Void, Never>?
@@ -6756,6 +6761,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         renderGridLivenessProbeTask?.cancel()
         renderGridLivenessProbeTask = nil
         renderGridLivenessProbeID = nil
+        renderGridLivenessConsecutiveProbeFailures = 0
     }
 
     /// Single ownership point for the liveness clock the watchdog reads.
@@ -6769,6 +6775,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// the connection context is torn down entirely.
     private func recordTerminalEventStreamLiveness() {
         lastTerminalEventAt = runtime?.now() ?? Date()
+        renderGridLivenessConsecutiveProbeFailures = 0
     }
 
     #if DEBUG
@@ -6785,8 +6792,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// One watchdog tick on the main actor: if the subscription generation still
     /// matches, the store is connected, and the stream has been silent past the
     /// threshold, verify the silence with a bounded host probe and only tear
-    /// down + re-subscribe + replay (via the existing resync path) when the
-    /// probe fails.
+    /// down + re-subscribe + replay (via the existing resync path) after two
+    /// consecutive probe failures with no intervening evidence of liveness.
     ///
     /// The probe step exists because silence is ambiguous: a healthy idle
     /// terminal emits nothing (the Mac dedupes unchanged render-grid frames by
@@ -6879,6 +6886,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 return
             }
             let silentMs = Int(recheckNow.timeIntervalSince(recheckLast) * 1000)
+            self.renderGridLivenessConsecutiveProbeFailures += 1
+            let probeFailures = self.renderGridLivenessConsecutiveProbeFailures
+            guard probeFailures >= Self.renderGridLivenessFailuresBeforeRecovery else {
+                MobileDebugLog.anchormux(
+                    "sync.liveness probe_failed awaiting_confirmation failures=\(probeFailures) silentMs=\(silentMs)"
+                )
+                mobileShellLog.info(
+                    "render-grid subscription probe failed once after \(silentMs, privacy: .public)ms of silence; awaiting confirmation"
+                )
+                return
+            }
+            self.renderGridLivenessConsecutiveProbeFailures = 0
             MobileDebugLog.anchormux("sync.liveness re-subscribe silentMs=\(silentMs)")
             self.diagnosticLog?.record(DiagnosticEvent(.livenessResubscribe, ms: UInt32(clamping: silentMs)))
             mobileShellLog.info("render-grid stream silent for \(silentMs, privacy: .public)ms and subscription probe failed, re-subscribing")

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6893,7 +6893,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     "sync.liveness probe_failed awaiting_confirmation failures=\(probeFailures) silentMs=\(silentMs)"
                 )
                 mobileShellLog.info(
-                    "render-grid subscription probe failed once after \(silentMs, privacy: .public)ms of silence; awaiting confirmation"
+                    "render-grid subscription probe failed \(probeFailures, privacy: .public)x after \(silentMs, privacy: .public)ms of silence; awaiting confirmation"
                 )
                 return
             }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -445,6 +445,55 @@ import Testing
     collector.unmount()
 }
 
+/// One timed-out liveness probe is ambiguous during Iroh path migration or a
+/// short Mac stall. The original stream must remain installed until a second
+/// independent probe confirms failure; a successful follow-up clears the
+/// suspicion without changing the client or connection generation.
+@MainActor
+@Test func watchdogKeepsSessionAfterOneTransientProbeFailure() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+    defer {
+        Task { await router.releaseAllHeld() }
+    }
+
+    let sawSubscribe = try await pollUntil {
+        await router.count(of: "mobile.events.subscribe") >= 1
+    }
+    #expect(sawSubscribe, "listener must establish the push subscription")
+    let originalClient = try #require(store.remoteClient)
+    let originalGeneration = store.connectionGeneration
+    let hostStatusCountBeforeFailure = await router.count(of: "mobile.host.status")
+
+    // Hold only the first watchdog probe. The follow-up probe can complete,
+    // modeling a short stall that resolves without the Iroh session dying.
+    await router.holdSubscribeRequest(number: 2)
+    clock.advance(by: 10)
+    store.debugRunRenderGridLivenessCheckForTesting()
+    #expect(await router.waitForCount(of: "mobile.events.subscribe", atLeast: 2))
+    try await Task.sleep(for: .milliseconds(300))
+
+    #expect(store.remoteClient === originalClient)
+    #expect(store.connectionGeneration == originalGeneration)
+    #expect(store.connectionState == .connected)
+    #expect(
+        await router.count(of: "mobile.host.status") == hostStatusCountBeforeFailure,
+        "one transient probe miss must not restart the event listener"
+    )
+
+    // The second independent probe succeeds and resets the liveness window.
+    store.debugRunRenderGridLivenessCheckForTesting()
+    #expect(await router.waitForCount(of: "mobile.events.subscribe", atLeast: 3))
+    try await Task.sleep(for: .milliseconds(50))
+
+    #expect(store.remoteClient === originalClient)
+    #expect(store.connectionGeneration == originalGeneration)
+    #expect(store.macConnectionStatus == .connected)
+    #expect(await router.count(of: "mobile.host.status") == hostStatusCountBeforeFailure)
+}
+
 /// A successful probe that REPAIRED a lost registration (the host reports
 /// `already_subscribed: false`) must replay mounted surfaces: render-grid
 /// deltas emitted while the registration was absent were never delivered, so

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -563,8 +563,8 @@ import Testing
 }
 
 /// The watchdog's original purpose (the ~85s silent-death hang) must keep
-/// working: silence past the threshold plus a host that stops answering the
-/// probe must still tear down and re-subscribe.
+/// working: silence past the threshold plus a host that repeatedly stops
+/// answering independent probes must still tear down and re-subscribe.
 @MainActor
 @Test func watchdogStillResubscribesGenuinelyDeadStream() async throws {
     let clock = TestClock()
@@ -579,11 +579,19 @@ import Testing
     #expect(sawSubscribe, "listener must establish the push subscription")
     let hostStatusCountBeforeFailure = await router.count(of: "mobile.host.status")
 
-    // The host stops answering the next mobile.events.subscribe (the
-    // watchdog's re-assert probe), modeling a dead push path while the
-    // request had already left the phone.
+    // The host stops answering two independent mobile.events.subscribe probes,
+    // confirming a dead push path rather than a transient stall.
     await router.holdSubscribeRequest(number: 2)
+    await router.holdSubscribeRequest(number: 3)
     clock.advance(by: 10)
+    store.debugRunRenderGridLivenessCheckForTesting()
+    #expect(await router.waitForCount(of: "mobile.events.subscribe", atLeast: 2))
+    try await Task.sleep(for: .milliseconds(300))
+    #expect(
+        await router.count(of: "mobile.host.status") == hostStatusCountBeforeFailure,
+        "the first ambiguous probe failure must preserve the current listener"
+    )
+
     store.debugRunRenderGridLivenessCheckForTesting()
 
     // Recovery restarts the listener, which re-resolves capabilities. A new

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
@@ -114,9 +114,9 @@ public struct MobileRootAuthGate {
     ///   - hasKnownPairedMac: The persisted hint that this device has paired a Mac before.
     ///   - pairedMacHintUndetermined: Whether the hint has never been written on this install (key absent).
     ///   - didFinishStoredMacReconnectAttempt: Whether the first launch reconnect attempt has resolved.
-    /// - Returns: `true` while authenticated, not yet connected, and either actively
-    ///   reconnecting a stored Mac or — before the first attempt resolves — holding
-    ///   the paired-Mac hint or an undetermined hint.
+    /// - Returns: `true` while authenticated and the first stored-Mac reconnect
+    ///   attempt has not resolved, provided a reconnect is active or a paired-Mac
+    ///   hint indicates that restoration may be possible.
     public static func shouldShowRestoringStoredMac(
         authenticated: Bool,
         connectionState: MobileConnectionState,
@@ -126,8 +126,8 @@ public struct MobileRootAuthGate {
         didFinishStoredMacReconnectAttempt: Bool
     ) -> Bool {
         guard authenticated, connectionState != .connected else { return false }
-        if isReconnectingStoredMac { return true }
         guard !didFinishStoredMacReconnectAttempt else { return false }
+        if isReconnectingStoredMac { return true }
         return hasKnownPairedMac || pairedMacHintUndetermined
     }
 }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
@@ -154,6 +154,17 @@ import Testing
             pairedMacHintUndetermined: false,
             didFinishStoredMacReconnectAttempt: true
         ))
+        // A later runtime redial must keep the established workspace shell
+        // mounted. Re-entering the launch-only restoring branch destroys the
+        // shell's compact navigation path and returns the user to the list.
+        #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
+            authenticated: true,
+            connectionState: .disconnected,
+            isReconnectingStoredMac: true,
+            hasKnownPairedMac: true,
+            pairedMacHintUndetermined: false,
+            didFinishStoredMacReconnectAttempt: true
+        ))
         // Never paired (hint determined-false): add-device immediately, no flash.
         #expect(!MobileRootAuthGate.shouldShowRestoringStoredMac(
             authenticated: true,


### PR DESCRIPTION
## Summary

- keep the established workspace shell mounted during runtime reconnects, preserving compact navigation state
- require two consecutive failed liveness probes before replacing an Iroh session
- reset the failure suspicion after any terminal event or successful subscription probe

## Regression proof

- `449aedf71b` adds tests that fail on the prior implementation: one delayed probe restarts a healthy client, and runtime reconnect enters the launch-only restoring root
- `a61ef2af02` applies the fix and updates the genuinely-dead-stream test to require confirmed failure

## Verification

- `swift test --package-path Packages/iOS/CmuxMobileWorkspace` (30 passed)
- `swift test --package-path Packages/iOS/CmuxMobileShell` (597 passed)
- tagged macOS build `irrec` succeeded on Blacksmith
- isolated iOS 26.5 Simulator build succeeded
- Simulator connected through a physical-device attach ticket containing a real Iroh route
- forced Iroh runtime restart produced `sync.stream_ended`, then `sync.subscribe_ok`; all 37 accessibility samples retained `MobileWorkspaceBackButton`
- inspected 120 video frames across the reconnect; the terminal detail stayed mounted and output resumed without a workspace-list flash

No user-facing strings changed, so no localization catalog update is required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786979566&installation_id=133855650&pr_number=8424&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8424&signature=b01cce6668148dd11a634c5bf480ef754af5c26f5353139ca8aea00f95e2d235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS workspace resets during transient Iroh reconnects by preserving the mounted workspace shell and making the liveness watchdog more conservative. Also improves liveness probe failure reporting for clearer diagnostics.

- **Bug Fixes**
  - Keep the existing workspace shell mounted on runtime reconnects; do not re-enter the launch-only restoring view after the first reconnect attempt completes (`CmuxMobileWorkspace`).
  - In `CmuxMobileShell`, require two consecutive failed `mobile.events.subscribe` probes before teardown/re-subscribe; reset the failure count on any terminal event or successful probe; log probe-failure counts accurately.
  - Add tests to confirm a single missed probe does not restart the listener, and that genuinely dead streams still trigger recovery.

<sup>Written for commit 87f8caad56808d2a1ae1236dff851225d81bf862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the render-grid liveness watchdog to wait for repeated confirmation before restarting recovery, preventing unnecessary session interruption after a single transient probe failure.
  * Ensured the restoring-session UI doesn’t reappear once the stored device reconnect flow has already completed.
* **Tests**
  * Added regression coverage to verify sessions remain stable after one ambiguous liveness probe failure and only recover after confirmed repeated failures.
  * Extended liveness watchdog tests to better distinguish transient vs truly dead streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->