### PR TITLE
Fix AppKit sidebar settings fidelity

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
@@ -27,8 +27,10 @@ public struct SidebarCatalogSection: SettingCatalogSection {
     /// Bool-backed to match the legacy in-app store. The on-disk key
     /// `sidebarBranchVerticalLayout` is written as a Bool by every
     /// shipped cmux build; using an enum here would silently revert
-    /// every user with a saved preference. `true` means vertical
-    /// (branch and directory stacked on their own lines).
+    /// every user with a saved preference. `true` means vertical branch
+    /// topology (each panel's branch/directory record gets its own row).
+    /// `stackBranchDirectory` independently controls whether the branch and
+    /// directory within each record share a row or use separate subrows.
     public let branchVerticalLayout = DefaultsKey<Bool>(
         id: "sidebar.branchVerticalLayout",
         defaultValue: true,

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
@@ -6,6 +6,15 @@ public struct SidebarCatalogSection: SettingCatalogSection {
     /// Valid notification-preview line limits for settings UI and configuration parsing.
     public static let notificationMessageLineLimitRange = 1...50
 
+    /// Resolves the shipped legacy layout contract together with the newer
+    /// branch/directory placement preference.
+    public static func stacksBranchAndDirectory(
+        vertical: Bool,
+        explicit: Bool
+    ) -> Bool {
+        vertical || explicit
+    }
+
     public let hideAllDetails = DefaultsKey<Bool>(
         id: "sidebar.hideAllDetails",
         defaultValue: false,
@@ -27,10 +36,11 @@ public struct SidebarCatalogSection: SettingCatalogSection {
     /// Bool-backed to match the legacy in-app store. The on-disk key
     /// `sidebarBranchVerticalLayout` is written as a Bool by every
     /// shipped cmux build; using an enum here would silently revert
-    /// every user with a saved preference. `true` means vertical branch
-    /// topology (each panel's branch/directory record gets its own row).
-    /// `stackBranchDirectory` independently controls whether the branch and
-    /// directory within each record share a row or use separate subrows.
+    /// every user with a saved preference. `true` preserves the legacy
+    /// vertical presentation: each panel's branch/directory record gets its
+    /// own row, with branch and directory on separate subrows. When this is
+    /// `false`, `stackBranchDirectory` can still opt the compact branch layout
+    /// into separate branch and directory subrows.
     public let branchVerticalLayout = DefaultsKey<Bool>(
         id: "sidebar.branchVerticalLayout",
         defaultValue: true,

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/SidebarSection.swift
@@ -307,15 +307,15 @@ public struct SidebarSection: View {
             SettingsCardRow(
                 configurationReview: .json("sidebar.stackBranchDirectory"),
                 String(localized: "settings.app.stackBranchDirectory", defaultValue: "Stack Branch and Directory"),
-                subtitle: stackBranchDir.current
+                subtitle: SidebarCatalogSection.stacksBranchAndDirectory(vertical: branchVerticalLayout.current, explicit: stackBranchDir.current)
                     ? String(localized: "settings.app.stackBranchDirectory.subtitleOn", defaultValue: "Branch and directory render on separate lines.")
                     : String(localized: "settings.app.stackBranchDirectory.subtitleOff", defaultValue: "Branch and directory share a single line.")
             ) {
-                Toggle("", isOn: Binding(get: { stackBranchDir.current }, set: { stackBranchDir.set($0) }))
+                Toggle("", isOn: Binding(get: { SidebarCatalogSection.stacksBranchAndDirectory(vertical: branchVerticalLayout.current, explicit: stackBranchDir.current) }, set: { stackBranchDir.set($0) }))
                     .labelsHidden()
                     .controlSize(.small)
             }
-            .disabled(hideAll.current)
+            .disabled(hideAll.current || branchVerticalLayout.current)
             SettingsCardDivider()
 
             SettingsCardRow(

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -5,37 +5,36 @@ import Foundation
 typealias RightSidebarWidthSettings = CmuxSettings.RightSidebarWidthSettings
 
 enum SidebarWorkspaceDetailDefaults {
-    static let showBranchDirectoryKey = "sidebarShowBranchDirectory"
-    static let showPullRequestsKey = "sidebarShowPullRequest"
-    static let watchGitStatusKey = "sidebarWatchGitStatus"
-    static let showSSHKey = "sidebarShowSSH"
-    static let showPortsKey = "sidebarShowPorts"
-    static let showLogKey = "sidebarShowLog"
-    static let showProgressKey = "sidebarShowProgress"
-    static let showAgentActivityKey = "sidebarShowAgentActivity"
-    static let showCustomMetadataKey = "sidebarShowStatusPills"
+    private static let sidebar = SidebarCatalogSection()
 
-    static let showBranchDirectory = true
-    static let showPullRequests = true
-    static let watchGitStatus = true
-    static let showSSH = true
-    static let showPorts = true
-    static let showLog = true
-    static let showProgress = true
-    static let showAgentActivity = true
-    static let showCustomMetadata = true
+    static let showBranchDirectoryKey = sidebar.showBranchDirectory.userDefaultsKey
+    static let showPullRequestsKey = sidebar.showPullRequests.userDefaultsKey
+    static let watchGitStatusKey = sidebar.watchGitStatus.userDefaultsKey
+    static let showSSHKey = sidebar.showSSH.userDefaultsKey
+    static let showPortsKey = sidebar.showPorts.userDefaultsKey
+    static let showLogKey = sidebar.showLog.userDefaultsKey
+    static let showProgressKey = sidebar.showProgress.userDefaultsKey
+    static let showAgentActivityKey = sidebar.showAgentActivity.userDefaultsKey
+    static let showCustomMetadataKey = sidebar.showCustomMetadata.userDefaultsKey
+
+    static let showBranchDirectory = sidebar.showBranchDirectory.defaultValue
+    static let showPullRequests = sidebar.showPullRequests.defaultValue
+    static let watchGitStatus = sidebar.watchGitStatus.defaultValue
+    static let showSSH = sidebar.showSSH.defaultValue
+    static let showPorts = sidebar.showPorts.defaultValue
+    static let showLog = sidebar.showLog.defaultValue
+    static let showProgress = sidebar.showProgress.defaultValue
+    static let showAgentActivity = sidebar.showAgentActivity.defaultValue
+    static let showCustomMetadata = sidebar.showCustomMetadata.defaultValue
 }
 
 enum SidebarWorkspaceTitleWrapSettings {
-    static let key = "sidebarWrapWorkspaceTitles"
-    static let defaultWrap = false
+    private static let setting = SidebarCatalogSection().wrapWorkspaceTitles
+    static let key = setting.userDefaultsKey
+    static let defaultWrap = setting.defaultValue
 
     static func wraps(defaults: UserDefaults = .standard) -> Bool {
-        SidebarWorkspaceDetailDefaults.boolValue(
-            defaults: defaults,
-            key: key,
-            defaultValue: defaultWrap
-        )
+        UserDefaultsSettingsClient(defaults: defaults).value(for: setting)
     }
 }
 
@@ -48,35 +47,29 @@ extension SidebarWorkspaceDetailDefaults {
     }
 
     static func showPullRequestsValue(defaults: UserDefaults) -> Bool {
-        boolValue(defaults: defaults, key: showPullRequestsKey, defaultValue: showPullRequests)
+        UserDefaultsSettingsClient(defaults: defaults).value(for: SidebarCatalogSection().showPullRequests)
     }
 
     static func showBranchDirectoryValue(defaults: UserDefaults) -> Bool {
-        boolValue(defaults: defaults, key: showBranchDirectoryKey, defaultValue: showBranchDirectory)
+        UserDefaultsSettingsClient(defaults: defaults).value(for: SidebarCatalogSection().showBranchDirectory)
     }
 
     static func watchGitStatusValue(defaults: UserDefaults) -> Bool {
-        boolValue(defaults: defaults, key: watchGitStatusKey, defaultValue: watchGitStatus)
+        UserDefaultsSettingsClient(defaults: defaults).value(for: SidebarCatalogSection().watchGitStatus)
     }
 
     static func auxiliaryDetailVisibility(defaults: UserDefaults) -> SidebarWorkspaceAuxiliaryDetailVisibility {
-        let hideAllDetails = SidebarCatalogSection().hideAllDetails
+        let sidebar = SidebarCatalogSection()
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let details = SidebarWorkspaceDetailSettings(defaults: defaults)
         return SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
-            showMetadata: boolValue(
-                defaults: defaults,
-                key: showCustomMetadataKey,
-                defaultValue: showCustomMetadata
-            ),
-            showLog: boolValue(defaults: defaults, key: showLogKey, defaultValue: showLog),
-            showProgress: boolValue(defaults: defaults, key: showProgressKey, defaultValue: showProgress),
-            showBranchDirectory: showBranchDirectoryValue(defaults: defaults),
-            showPullRequests: showPullRequestsValue(defaults: defaults),
-            showPorts: boolValue(defaults: defaults, key: showPortsKey, defaultValue: showPorts),
-            hideAllDetails: boolValue(
-                defaults: defaults,
-                key: hideAllDetails.userDefaultsKey,
-                defaultValue: hideAllDetails.defaultValue
-            )
+            showMetadata: details.showCustomMetadata,
+            showLog: details.showLog,
+            showProgress: details.showProgress,
+            showBranchDirectory: details.showBranchDirectory,
+            showPullRequests: details.showPullRequests,
+            showPorts: details.showPorts,
+            hideAllDetails: settings.value(for: sidebar.hideAllDetails)
         )
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10037,104 +10037,6 @@ private enum SidebarFontSizeProvider {
     }
 }
 
-struct SidebarTabItemSettingsSnapshot: Equatable {
-    let hidesAllDetails: Bool
-    let wrapsWorkspaceTitles: Bool
-    let showsWorkspaceDescription: Bool
-    let sidebarShortcutHintXOffset: Double
-    let sidebarShortcutHintYOffset: Double
-    let alwaysShowShortcutHints: Bool
-    let sidebarFontScale: CGFloat
-    let showsGitBranch: Bool
-    let usesVerticalBranchLayout: Bool
-    let stacksBranchAndDirectory: Bool
-    let usesLastSegmentPath: Bool
-    let showsGitBranchIcon: Bool
-    let showsSSH: Bool
-    let makesPullRequestsClickable: Bool
-    let openPullRequestLinksInCmuxBrowser: Bool
-    let openPortLinksInCmuxBrowser: Bool
-    let showsNotificationMessage: Bool
-    let notificationMessageLineLimit: Int
-    let activeTabIndicatorStyle: WorkspaceIndicatorStyle
-    let loadingSpinnerPosition: SidebarIndicatorPosition
-    let notificationBadgePosition: SidebarIndicatorPosition
-    let selectionColorHex: String?
-    let notificationBadgeColorHex: String?
-    let visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility
-    let iMessageModeEnabled: Bool
-    let workspaceTodoChecklistStyle: WorkspaceTodoChecklistStyle
-
-    init(
-        defaults: UserDefaults = .standard,
-        sidebarFontSize: CGFloat = GhosttyConfig.defaultSidebarFontSize
-    ) {
-        sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
-        sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
-        alwaysShowShortcutHints = ShortcutHintDebugSettings().alwaysShowHints
-        sidebarFontScale = SidebarTabItemFontScale.scale(for: sidebarFontSize)
-        let settings = UserDefaultsSettingsClient(defaults: defaults)
-        let catalog = SettingCatalog()
-        showsGitBranch = Self.bool(defaults: defaults, key: "sidebarShowGitBranch", defaultValue: true)
-        usesVerticalBranchLayout = settings.value(for: catalog.sidebar.branchVerticalLayout)
-        stacksBranchAndDirectory = settings.value(for: catalog.sidebar.stackBranchDirectory)
-        usesLastSegmentPath = settings.value(for: catalog.sidebar.pathLastSegmentOnly)
-        showsGitBranchIcon = Self.bool(defaults: defaults, key: "sidebarShowGitBranchIcon", defaultValue: false)
-        showsSSH = Self.bool(defaults: defaults, key: "sidebarShowSSH", defaultValue: SidebarWorkspaceDetailDefaults.showSSH)
-        makesPullRequestsClickable = settings.value(for: catalog.sidebar.makePullRequestsClickable)
-        openPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowser(
-            defaults: defaults
-        )
-        openPortLinksInCmuxBrowser = BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowser(
-            defaults: defaults
-        )
-        hidesAllDetails = settings.value(for: catalog.sidebar.hideAllDetails)
-        wrapsWorkspaceTitles = SidebarWorkspaceTitleWrapSettings.wraps(defaults: defaults)
-        let detailVisibility = SidebarWorkspaceDetailVisibility(
-            showWorkspaceDescription: settings.value(for: catalog.sidebar.showWorkspaceDescription),
-            showNotificationMessage: settings.value(for: catalog.sidebar.showNotificationMessage),
-            hideAllDetails: hidesAllDetails
-        )
-        showsWorkspaceDescription = detailVisibility.showsWorkspaceDescription
-        showsNotificationMessage = detailVisibility.showsNotificationMessage
-        notificationMessageLineLimit = min(max(settings.value(for: catalog.sidebar.notificationMessageLineLimit), SidebarCatalogSection.notificationMessageLineLimitRange.lowerBound), SidebarCatalogSection.notificationMessageLineLimitRange.upperBound)
-        let showsMetadata = Self.bool(defaults: defaults, key: "sidebarShowStatusPills", defaultValue: SidebarWorkspaceDetailDefaults.showCustomMetadata)
-        let showsLog = Self.bool(defaults: defaults, key: "sidebarShowLog", defaultValue: SidebarWorkspaceDetailDefaults.showLog)
-        let showsProgress = Self.bool(defaults: defaults, key: "sidebarShowProgress", defaultValue: SidebarWorkspaceDetailDefaults.showProgress)
-        let showsBranchDirectory = Self.bool(defaults: defaults, key: "sidebarShowBranchDirectory", defaultValue: SidebarWorkspaceDetailDefaults.showBranchDirectory)
-        let showsPullRequests = Self.bool(defaults: defaults, key: "sidebarShowPullRequest", defaultValue: SidebarWorkspaceDetailDefaults.showPullRequests)
-        let showsPorts = Self.bool(defaults: defaults, key: "sidebarShowPorts", defaultValue: SidebarWorkspaceDetailDefaults.showPorts)
-        visibleAuxiliaryDetails = SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
-            showMetadata: showsMetadata,
-            showLog: showsLog,
-            showProgress: showsProgress,
-            showBranchDirectory: showsBranchDirectory,
-            showPullRequests: showsPullRequests,
-            showPorts: showsPorts,
-            hideAllDetails: hidesAllDetails
-        )
-
-        activeTabIndicatorStyle = settings.value(for: catalog.workspaceColors.indicatorStyle)
-        loadingSpinnerPosition = settings.value(for: catalog.sidebar.loadingSpinnerPosition)
-        notificationBadgePosition = settings.value(for: catalog.sidebar.notificationBadgePosition)
-        selectionColorHex = defaults.string(forKey: "sidebarSelectionColorHex")
-        notificationBadgeColorHex = defaults.string(forKey: "sidebarNotificationBadgeColorHex")
-        iMessageModeEnabled = IMessageModeSettings.isEnabled(defaults: defaults)
-        workspaceTodoChecklistStyle = settings.value(for: catalog.betaFeatures.workspaceTodosChecklistStyle)
-    }
-
-    private static func bool(
-        defaults: UserDefaults,
-        key: String,
-        defaultValue: Bool
-    ) -> Bool {
-        guard defaults.object(forKey: key) != nil else { return defaultValue }
-        return defaults.bool(forKey: key)
-    }
-
-}
-
-
 enum CmuxExtensionSidebarSelection {
     static let defaultsKey = "cmuxExtensionSidebar.providerId"
     static let selectedExtensionNameDefaultsKey = "cmuxExtensionSidebar.selectedExtensionName"
@@ -10606,7 +10508,6 @@ struct VerticalTabsSidebar: View, Equatable {
     @LiveSetting(\.betaFeatures.customSidebars) private var customSidebarsExperimentalEnabled
     @LiveSetting(\.customSidebars.renderer) private var customSidebarRenderer
     @LiveSetting(\.shortcuts.showModifierHoldHints) private var showModifierHoldHints
-    @LiveSetting(\.sidebar.showAgentActivity) private var showAgentActivity
 #if DEBUG
     @Environment(\.minimalModeInvalidationProbe) private var minimalModeInvalidationProbe
     @Environment(\.sidebarLazyContractProbe) private var sidebarLazyContractProbe
@@ -10936,7 +10837,8 @@ struct VerticalTabsSidebar: View, Equatable {
             canCloseWorkspace: canCloseWorkspace,
             workspaceNumberShortcut: workspaceNumberShortcut,
             tabItemSettings: tabItemSettings,
-            showsAgentActivity: showAgentActivity && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled,
+            showsAgentActivity: tabItemSettings.details.showAgentActivity
+                && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled,
             pinResolutionContext: pinResolutionContext,
             tabIndexById: tabIndexById,
             workspaceById: workspaceById,
@@ -11970,7 +11872,8 @@ struct VerticalTabsSidebar: View, Equatable {
         guard !workspaceIds.isEmpty else { return }
         let workspaceById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
         let settings = tabItemSettingsStore.snapshot
-        let showsAgentActivity = showAgentActivity && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled
+        let showsAgentActivity = settings.details.showAgentActivity
+            && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled
         var next = workspaceSnapshotsById
         var changed = false
         for workspaceId in workspaceIds {
@@ -11999,7 +11902,8 @@ struct VerticalTabsSidebar: View, Equatable {
         let tabs = tabManager.tabs
         let liveIds = Set(tabs.map(\.id))
         let settings = tabItemSettingsStore.snapshot
-        let showsAgentActivity = showAgentActivity && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled
+        let showsAgentActivity = settings.details.showAgentActivity
+            && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled
         var next: [UUID: SidebarWorkspaceSnapshotBuilder.Snapshot] = [:]
         next.reserveCapacity(tabs.count)
         for workspace in tabs {
@@ -14698,12 +14602,12 @@ struct TabItemView: View, Equatable {
         settings.showsGitBranch
     }
 
-    private var sidebarBranchVerticalLayout: Bool {
-        settings.usesVerticalBranchLayout
+    private var sidebarBranchLayout: SidebarWorkspaceBranchDirectorySettings.BranchLayout {
+        settings.branchDirectory.branchLayout
     }
 
-    private var sidebarStacksBranchAndDirectory: Bool {
-        settings.stacksBranchAndDirectory
+    private var sidebarBranchDirectoryPlacement: SidebarWorkspaceBranchDirectorySettings.BranchDirectoryPlacement {
+        settings.branchDirectory.branchDirectoryPlacement
     }
 
     private var sidebarUsesLastSegmentPath: Bool {
@@ -15223,7 +15127,7 @@ struct TabItemView: View, Equatable {
 
             // Branch + directory row
             if detailVisibility.showsBranchDirectory {
-                if sidebarBranchVerticalLayout {
+                if sidebarBranchLayout == .vertical {
                     if !workspaceSnapshot.branchDirectoryLines.isEmpty {
                         HStack(alignment: .top, spacing: 3) {
                             if sidebarShowGitBranchIcon, workspaceSnapshot.branchLinesContainBranch {
@@ -15232,7 +15136,7 @@ struct TabItemView: View, Equatable {
                             }
                             VStack(alignment: .leading, spacing: 1) {
                                 ForEach(Array(workspaceSnapshot.branchDirectoryLines.enumerated()), id: \.offset) { _, line in
-                                    if sidebarStacksBranchAndDirectory {
+                                    if sidebarBranchDirectoryPlacement == .stacked {
                                         if let branch = line.branch {
                                             Text(branch)
                                                 .font(magnifiedFont(scaledFontSize(10), design: .monospaced))
@@ -15274,7 +15178,7 @@ struct TabItemView: View, Equatable {
                             }
                         }
                     }
-                } else if sidebarStacksBranchAndDirectory,
+                } else if sidebarBranchDirectoryPlacement == .stacked,
                           (workspaceSnapshot.compactGitBranchSummaryText != nil
                            || !workspaceSnapshot.compactDirectoryCandidates.isEmpty) {
                     HStack(alignment: .top, spacing: 3) {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -649,15 +649,15 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         let showsSection = settings.visibleAuxiliaryDetails.showsBranchDirectory
         var lines: [SidebarRowIconTextLine.BranchLineContent] = []
         if showsSection {
-            if settings.usesVerticalBranchLayout {
+            if settings.branchDirectory.branchLayout == .vertical {
                 for line in snapshot.branchDirectoryLines {
                     lines.append(.init(
                         branch: settings.showsGitBranch ? line.branch : nil,
                         directoryCandidates: line.directoryCandidates,
-                        stacked: settings.stacksBranchAndDirectory
+                        stacked: settings.branchDirectory.branchDirectoryPlacement == .stacked
                     ))
                 }
-            } else if settings.stacksBranchAndDirectory {
+            } else if settings.branchDirectory.branchDirectoryPlacement == .stacked {
                 if snapshot.compactGitBranchSummaryText != nil || !snapshot.compactDirectoryCandidates.isEmpty {
                     lines.append(.init(
                         branch: snapshot.compactGitBranchSummaryText,
@@ -674,7 +674,9 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             }
         }
         let showsIcon = showsSection && settings.showsGitBranchIcon
-            && (settings.usesVerticalBranchLayout ? snapshot.branchLinesContainBranch : snapshot.compactGitBranchSummaryText != nil || !snapshot.compactBranchDirectoryCandidates.isEmpty)
+            && (settings.branchDirectory.branchLayout == .vertical
+                ? snapshot.branchLinesContainBranch
+                : snapshot.compactGitBranchSummaryText != nil || !snapshot.compactBranchDirectoryCandidates.isEmpty)
         branchIconView.isHidden = !(showsIcon && !lines.isEmpty)
         if !branchIconView.isHidden {
             branchIconView.image = RenderableSystemSymbol.configuredAppKitImage(

--- a/Sources/SidebarTabItemSettingsSnapshot.swift
+++ b/Sources/SidebarTabItemSettingsSnapshot.swift
@@ -1,0 +1,104 @@
+import CmuxFoundation
+import CmuxSettings
+import CmuxSidebar
+import CoreGraphics
+import Foundation
+
+/// Immutable settings projection consumed by both SwiftUI and AppKit sidebar rows.
+struct SidebarTabItemSettingsSnapshot: Equatable {
+    let hidesAllDetails: Bool
+    let wrapsWorkspaceTitles: Bool
+    let showsWorkspaceDescription: Bool
+    let sidebarShortcutHintXOffset: Double
+    let sidebarShortcutHintYOffset: Double
+    let alwaysShowShortcutHints: Bool
+    let sidebarFontScale: CGFloat
+    let showsGitBranch: Bool
+    let branchDirectory: SidebarWorkspaceBranchDirectorySettings
+    let details: SidebarWorkspaceDetailSettings
+    let showsGitBranchIcon: Bool
+    let makesPullRequestsClickable: Bool
+    let openPullRequestLinksInCmuxBrowser: Bool
+    let openPortLinksInCmuxBrowser: Bool
+    let showsNotificationMessage: Bool
+    let notificationMessageLineLimit: Int
+    let activeTabIndicatorStyle: WorkspaceIndicatorStyle
+    let loadingSpinnerPosition: SidebarIndicatorPosition
+    let notificationBadgePosition: SidebarIndicatorPosition
+    let selectionColorHex: String?
+    let notificationBadgeColorHex: String?
+    let visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility
+    let iMessageModeEnabled: Bool
+    let workspaceTodoChecklistStyle: WorkspaceTodoChecklistStyle
+
+    var usesLastSegmentPath: Bool { branchDirectory.usesLastSegmentPath }
+    var showsSSH: Bool { details.showSSH }
+
+    init(
+        defaults: UserDefaults = .standard,
+        sidebarFontSize: CGFloat = GhosttyConfig.defaultSidebarFontSize
+    ) {
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let sidebar = SidebarCatalogSection()
+        let workspaceColors = WorkspaceColorsCatalogSection()
+        let betaFeatures = BetaFeaturesCatalogSection()
+        branchDirectory = SidebarWorkspaceBranchDirectorySettings(defaults: defaults)
+        details = SidebarWorkspaceDetailSettings(defaults: defaults)
+
+        sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
+        sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
+        alwaysShowShortcutHints = ShortcutHintDebugSettings(defaults: defaults).alwaysShowHints
+        sidebarFontScale = SidebarTabItemFontScale.scale(for: sidebarFontSize)
+        showsGitBranch = Self.bool(defaults: defaults, key: "sidebarShowGitBranch", defaultValue: true)
+        showsGitBranchIcon = Self.bool(defaults: defaults, key: "sidebarShowGitBranchIcon", defaultValue: false)
+        makesPullRequestsClickable = settings.value(for: sidebar.makePullRequestsClickable)
+        openPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowser(
+            defaults: defaults
+        )
+        openPortLinksInCmuxBrowser = BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowser(
+            defaults: defaults
+        )
+        hidesAllDetails = settings.value(for: sidebar.hideAllDetails)
+        wrapsWorkspaceTitles = settings.value(for: sidebar.wrapWorkspaceTitles)
+        let detailVisibility = SidebarWorkspaceDetailVisibility(
+            showWorkspaceDescription: settings.value(for: sidebar.showWorkspaceDescription),
+            showNotificationMessage: settings.value(for: sidebar.showNotificationMessage),
+            hideAllDetails: hidesAllDetails
+        )
+        showsWorkspaceDescription = detailVisibility.showsWorkspaceDescription
+        showsNotificationMessage = detailVisibility.showsNotificationMessage
+        notificationMessageLineLimit = min(
+            max(
+                settings.value(for: sidebar.notificationMessageLineLimit),
+                SidebarCatalogSection.notificationMessageLineLimitRange.lowerBound
+            ),
+            SidebarCatalogSection.notificationMessageLineLimitRange.upperBound
+        )
+        visibleAuxiliaryDetails = SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
+            showMetadata: details.showCustomMetadata,
+            showLog: details.showLog,
+            showProgress: details.showProgress,
+            showBranchDirectory: details.showBranchDirectory,
+            showPullRequests: details.showPullRequests,
+            showPorts: details.showPorts,
+            hideAllDetails: hidesAllDetails
+        )
+
+        activeTabIndicatorStyle = settings.value(for: workspaceColors.indicatorStyle)
+        loadingSpinnerPosition = settings.value(for: sidebar.loadingSpinnerPosition)
+        notificationBadgePosition = settings.value(for: sidebar.notificationBadgePosition)
+        selectionColorHex = settings.value(for: workspaceColors.selectionColorHex).nilIfEmpty
+        notificationBadgeColorHex = settings.value(for: workspaceColors.notificationBadgeColorHex).nilIfEmpty
+        iMessageModeEnabled = IMessageModeSettings.isEnabled(defaults: defaults)
+        workspaceTodoChecklistStyle = settings.value(for: betaFeatures.workspaceTodosChecklistStyle)
+    }
+
+    private static func bool(
+        defaults: UserDefaults,
+        key: String,
+        defaultValue: Bool
+    ) -> Bool {
+        guard defaults.object(forKey: key) != nil else { return defaultValue }
+        return defaults.bool(forKey: key)
+    }
+}

--- a/Sources/SidebarWorkspaceBranchDirectorySettings.swift
+++ b/Sources/SidebarWorkspaceBranchDirectorySettings.swift
@@ -3,10 +3,11 @@ import Foundation
 
 /// Resolved branch and directory presentation settings shared by both sidebar renderers.
 ///
-/// Branch topology and branch/directory placement are independent axes backed by
-/// different persisted keys. Keeping them in one named value prevents renderers
-/// from treating the newer placement toggle as a replacement for the legacy
-/// topology preference.
+/// The legacy layout preference controls branch topology and, when vertical,
+/// carries its historical stacked branch/directory presentation. The newer
+/// placement preference can opt an inline branch topology into those stacked
+/// subrows. Keeping that compatibility rule here prevents either renderer from
+/// replacing or reinterpreting the shipped Bool preference.
 struct SidebarWorkspaceBranchDirectorySettings: Equatable {
     /// Whether multiple branches use separate rows or one compact row.
     enum BranchLayout: Equatable {
@@ -27,10 +28,15 @@ struct SidebarWorkspaceBranchDirectorySettings: Equatable {
     init(defaults: UserDefaults) {
         let settings = UserDefaultsSettingsClient(defaults: defaults)
         let sidebar = SidebarCatalogSection()
-        branchLayout = settings.value(for: sidebar.branchVerticalLayout)
+        let usesVerticalBranchLayout = settings.value(for: sidebar.branchVerticalLayout)
+        let explicitlyStacksBranchDirectory = settings.value(for: sidebar.stackBranchDirectory)
+        branchLayout = usesVerticalBranchLayout
             ? .vertical
             : .inline
-        branchDirectoryPlacement = settings.value(for: sidebar.stackBranchDirectory)
+        branchDirectoryPlacement = SidebarCatalogSection.stacksBranchAndDirectory(
+            vertical: usesVerticalBranchLayout,
+            explicit: explicitlyStacksBranchDirectory
+        )
             ? .stacked
             : .inline
         usesLastSegmentPath = settings.value(for: sidebar.pathLastSegmentOnly)

--- a/Sources/SidebarWorkspaceBranchDirectorySettings.swift
+++ b/Sources/SidebarWorkspaceBranchDirectorySettings.swift
@@ -1,0 +1,38 @@
+import CmuxSettings
+import Foundation
+
+/// Resolved branch and directory presentation settings shared by both sidebar renderers.
+///
+/// Branch topology and branch/directory placement are independent axes backed by
+/// different persisted keys. Keeping them in one named value prevents renderers
+/// from treating the newer placement toggle as a replacement for the legacy
+/// topology preference.
+struct SidebarWorkspaceBranchDirectorySettings: Equatable {
+    /// Whether multiple branches use separate rows or one compact row.
+    enum BranchLayout: Equatable {
+        case vertical
+        case inline
+    }
+
+    /// Whether a branch and its directory share a row or use separate subrows.
+    enum BranchDirectoryPlacement: Equatable {
+        case stacked
+        case inline
+    }
+
+    let branchLayout: BranchLayout
+    let branchDirectoryPlacement: BranchDirectoryPlacement
+    let usesLastSegmentPath: Bool
+
+    init(defaults: UserDefaults) {
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let sidebar = SidebarCatalogSection()
+        branchLayout = settings.value(for: sidebar.branchVerticalLayout)
+            ? .vertical
+            : .inline
+        branchDirectoryPlacement = settings.value(for: sidebar.stackBranchDirectory)
+            ? .stacked
+            : .inline
+        usesLastSegmentPath = settings.value(for: sidebar.pathLastSegmentOnly)
+    }
+}

--- a/Sources/SidebarWorkspaceDetailSettings.swift
+++ b/Sources/SidebarWorkspaceDetailSettings.swift
@@ -1,0 +1,29 @@
+import CmuxSettings
+import Foundation
+
+/// Catalog-backed workspace-detail preferences shared by both sidebar row models.
+struct SidebarWorkspaceDetailSettings: Equatable {
+    let showBranchDirectory: Bool
+    let showPullRequests: Bool
+    let watchGitStatus: Bool
+    let showSSH: Bool
+    let showPorts: Bool
+    let showLog: Bool
+    let showProgress: Bool
+    let showAgentActivity: Bool
+    let showCustomMetadata: Bool
+
+    init(defaults: UserDefaults) {
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        let sidebar = SidebarCatalogSection()
+        showBranchDirectory = settings.value(for: sidebar.showBranchDirectory)
+        showPullRequests = settings.value(for: sidebar.showPullRequests)
+        watchGitStatus = settings.value(for: sidebar.watchGitStatus)
+        showSSH = settings.value(for: sidebar.showSSH)
+        showPorts = settings.value(for: sidebar.showPorts)
+        showLog = settings.value(for: sidebar.showLog)
+        showProgress = settings.value(for: sidebar.showProgress)
+        showAgentActivity = settings.value(for: sidebar.showAgentActivity)
+        showCustomMetadata = settings.value(for: sidebar.showCustomMetadata)
+    }
+}

--- a/Sources/SidebarWorkspaceSnapshotFactory.swift
+++ b/Sources/SidebarWorkspaceSnapshotFactory.swift
@@ -24,7 +24,7 @@ struct SidebarWorkspaceSnapshotFactory {
                 : nil
         let compactGitBranchSummaryText: String? = {
             guard detailVisibility.showsBranchDirectory,
-                  !settings.usesVerticalBranchLayout,
+                  settings.branchDirectory.branchLayout == .inline,
                   settings.showsGitBranch,
                   let orderedPanelIds else {
                 return nil
@@ -33,7 +33,7 @@ struct SidebarWorkspaceSnapshotFactory {
         }()
         let compactDirectoryCandidates: [String] = {
             guard detailVisibility.showsBranchDirectory,
-                  !settings.usesVerticalBranchLayout,
+                  settings.branchDirectory.branchLayout == .inline,
                   let orderedPanelIds else {
                 return []
             }
@@ -45,7 +45,7 @@ struct SidebarWorkspaceSnapshotFactory {
         )
         let branchDirectoryLines: [SidebarWorkspaceSnapshotBuilder.VerticalBranchDirectoryLine] = {
             guard detailVisibility.showsBranchDirectory,
-                  settings.usesVerticalBranchLayout,
+                  settings.branchDirectory.branchLayout == .vertical,
                   let orderedPanelIds else {
                 return []
             }
@@ -131,7 +131,7 @@ struct SidebarWorkspaceSnapshotFactory {
     ) -> SidebarWorkspaceSnapshotBuilder.PresentationKey {
         SidebarWorkspaceSnapshotBuilder.PresentationKey(
             showsWorkspaceDescription: settings.showsWorkspaceDescription,
-            usesVerticalBranchLayout: settings.usesVerticalBranchLayout,
+            usesVerticalBranchLayout: settings.branchDirectory.branchLayout == .vertical,
             showsGitBranch: settings.showsGitBranch,
             usesViewportAwarePath: settings.usesLastSegmentPath,
             showsAgentActivity: showsAgentActivity,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1531,13 +1531,16 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D73440010000000000000001 /* SidebarTabDragPayloadProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */; };
 		D7AB34300000000000000105 /* SidebarTabDropIndicatorPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */; };
 		F7216006000000000000001 /* SidebarTabItemContextMenuState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7216006000000000000002 /* SidebarTabItemContextMenuState.swift */; };
+		8430A0030000000000000003 /* SidebarTabItemSettingsSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8430B0030000000000000003 /* SidebarTabItemSettingsSnapshot.swift */; };
 		A6AC73F10000000000000001 /* SidebarTitleFirstLineCenterAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73F10000000000000002 /* SidebarTitleFirstLineCenterAlignment.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
+		8430A0010000000000000001 /* SidebarWorkspaceBranchDirectorySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8430B0010000000000000001 /* SidebarWorkspaceBranchDirectorySettings.swift */; };
 		EDA24082C65B4E2A2A03F276 /* SidebarWorkspaceChecklistPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC8DE2AF74EC2C272681A75 /* SidebarWorkspaceChecklistPopover.swift */; };
 		B290FAD92C810ACB2D9CD9C6 /* SidebarWorkspaceChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E7BB6EF7C9F8D2C681999D /* SidebarWorkspaceChecklistView.swift */; };
 		6707F0036707F0036707F003 /* SidebarWorkspaceContextMenuSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0046707F0046707F004 /* SidebarWorkspaceContextMenuSnapshot.swift */; };
 		6707F0196707F0196707F019 /* SidebarWorkspaceContextMenuTargetAggregate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0206707F0206707F020 /* SidebarWorkspaceContextMenuTargetAggregate.swift */; };
 		6707F0176707F0176707F017 /* SidebarWorkspaceContextMenuWindowTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0186707F0186707F018 /* SidebarWorkspaceContextMenuWindowTargetsTests.swift */; };
+		8430A0020000000000000002 /* SidebarWorkspaceDetailSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8430B0020000000000000002 /* SidebarWorkspaceDetailSettings.swift */; };
 		D7AB34300000000000000005 /* SidebarWorkspaceDropPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */; };
 		C9A57605C9A57605C9A57605 /* SidebarWorkspaceDropTargetWriters.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57606C9A57606C9A57606 /* SidebarWorkspaceDropTargetWriters.swift */; };
 		C9A57103C9A57103C9A57103 /* SidebarWorkspaceGroupConfigOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */; };
@@ -3574,13 +3577,16 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDragPayloadProviderTests.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabDropIndicatorPredicateTests.swift; sourceTree = "<group>"; };
 		F7216006000000000000002 /* SidebarTabItemContextMenuState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabItemContextMenuState.swift; sourceTree = "<group>"; };
+		8430B0030000000000000003 /* SidebarTabItemSettingsSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabItemSettingsSnapshot.swift; sourceTree = "<group>"; };
 		A6AC73F10000000000000002 /* SidebarTitleFirstLineCenterAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarTitleFirstLineCenterAlignment.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
+		8430B0010000000000000001 /* SidebarWorkspaceBranchDirectorySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceBranchDirectorySettings.swift; sourceTree = "<group>"; };
 		BAC8DE2AF74EC2C272681A75 /* SidebarWorkspaceChecklistPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SidebarWorkspaceChecklistPopover.swift"; sourceTree = "<group>"; };
 		E9E7BB6EF7C9F8D2C681999D /* SidebarWorkspaceChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceChecklistView.swift; sourceTree = "<group>"; };
 		6707F0046707F0046707F004 /* SidebarWorkspaceContextMenuSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceContextMenuSnapshot.swift; sourceTree = "<group>"; };
 		6707F0206707F0206707F020 /* SidebarWorkspaceContextMenuTargetAggregate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceContextMenuTargetAggregate.swift; sourceTree = "<group>"; };
 		6707F0186707F0186707F018 /* SidebarWorkspaceContextMenuWindowTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceContextMenuWindowTargetsTests.swift; sourceTree = "<group>"; };
+		8430B0020000000000000002 /* SidebarWorkspaceDetailSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceDetailSettings.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceDropPlannerTests.swift; sourceTree = "<group>"; };
 		C9A57606C9A57606C9A57606 /* SidebarWorkspaceDropTargetWriters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceDropTargetWriters.swift; sourceTree = "<group>"; };
 		C9A57104C9A57104C9A57104 /* SidebarWorkspaceGroupConfigOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceGroupConfigOpener.swift; sourceTree = "<group>"; };
@@ -4455,6 +4461,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */,
 					A5001012 /* ContentView.swift */,
 					F7216001000000000000002 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift */,
+					8430B0030000000000000003 /* SidebarTabItemSettingsSnapshot.swift */,
+					8430B0010000000000000001 /* SidebarWorkspaceBranchDirectorySettings.swift */,
+					8430B0020000000000000002 /* SidebarWorkspaceDetailSettings.swift */,
 					F7216005000000000000002 /* SidebarWorkspaceSnapshotBuilder.swift */,
 					6707F0026707F0026707F002 /* SidebarWorkspaceSnapshotFactory.swift */,
 					6707F0166707F0166707F016 /* SidebarWorkspaceSnapshotRefreshCoalescer.swift */,
@@ -7631,11 +7640,14 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F57072635F25EBCA741E125D /* SidebarState.swift in Sources */,
 				D7344F010000000000000001 /* SidebarTabDragPayload.swift in Sources */,
 				F7216006000000000000001 /* SidebarTabItemContextMenuState.swift in Sources */,
+				8430A0030000000000000003 /* SidebarTabItemSettingsSnapshot.swift in Sources */,
 				A6AC73F10000000000000001 /* SidebarTitleFirstLineCenterAlignment.swift in Sources */,
+				8430A0010000000000000001 /* SidebarWorkspaceBranchDirectorySettings.swift in Sources */,
 				EDA24082C65B4E2A2A03F276 /* SidebarWorkspaceChecklistPopover.swift in Sources */,
 				B290FAD92C810ACB2D9CD9C6 /* SidebarWorkspaceChecklistView.swift in Sources */,
 				6707F0036707F0036707F003 /* SidebarWorkspaceContextMenuSnapshot.swift in Sources */,
 				6707F0196707F0196707F019 /* SidebarWorkspaceContextMenuTargetAggregate.swift in Sources */,
+				8430A0020000000000000002 /* SidebarWorkspaceDetailSettings.swift in Sources */,
 				C9A57605C9A57605C9A57605 /* SidebarWorkspaceDropTargetWriters.swift in Sources */,
 				C9A57103C9A57103C9A57103 /* SidebarWorkspaceGroupConfigOpener.swift in Sources */,
 				C9A57105C9A57105C9A57105 /* SidebarWorkspaceGroupContextMenuRunner.swift in Sources */,

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -50,20 +50,23 @@ struct SidebarAppKitRowCellTests {
     private static func makeModel(
         workspaceId: UUID = UUID(),
         isActive: Bool = false,
-        canClose: Bool = true
+        canClose: Bool = true,
+        settings: SidebarTabItemSettingsSnapshot? = nil
     ) -> SidebarWorkspaceRowModel {
-        SidebarWorkspaceRowModel(
+        let resolvedSettings = settings
+            ?? SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+        return SidebarWorkspaceRowModel(
             workspaceId: workspaceId,
             index: 0,
             snapshot: makeSnapshot(),
-            settings: SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!),
+            settings: resolvedSettings,
             isActive: isActive,
             isMultiSelected: false,
             canCloseWorkspace: canClose,
             accessibilityWorkspaceCount: 1,
             unreadCount: 0,
             latestNotificationText: nil,
-            showsAgentActivity: false,
+            showsAgentActivity: resolvedSettings.details.showAgentActivity,
             rowSpacing: 8,
             isBeingDragged: false,
             topDropIndicatorVisible: false,
@@ -79,6 +82,62 @@ struct SidebarAppKitRowCellTests {
             isMetadataExpanded: false,
             isMarkdownExpanded: false
         )
+    }
+
+    private static func makeSwiftUIRow(
+        settings: SidebarTabItemSettingsSnapshot
+    ) -> SidebarWorkspaceRowSnapshot {
+        SidebarWorkspaceRowSnapshot(
+            workspaceId: UUID(),
+            groupId: nil,
+            index: 0,
+            workspaceCount: 1,
+            workspace: makeSnapshot(),
+            isActive: false,
+            isMultiSelected: false,
+            hasUserCustomTitle: false,
+            hasCustomTitle: false,
+            hasCustomDescription: false,
+            customTitle: nil,
+            workspaceShortcutDigit: nil,
+            workspaceShortcutModifierSymbol: "⌘",
+            canCloseWorkspace: true,
+            unreadCount: 0,
+            latestNotificationText: nil,
+            showsAgentActivity: settings.details.showAgentActivity,
+            rowSpacing: 8,
+            showsModifierShortcutHints: false,
+            isPointerHovering: false,
+            isBeingDragged: false,
+            topDropIndicatorVisible: false,
+            bottomDropIndicatorVisible: false,
+            isBonsplitWorkspaceDropActive: false,
+            settings: settings,
+            isChecklistExpanded: false,
+            checklistAddFieldActivationToken: 0,
+            isChecklistPopoverPresented: false,
+            contextMenu: SidebarWorkspaceContextMenuSnapshot(
+                targetWorkspaceIds: [],
+                remoteTargetWorkspaceIds: [],
+                allRemoteTargetsConnecting: false,
+                allRemoteTargetsDisconnected: false,
+                pinState: nil,
+                groupMenuSnapshot: WorkspaceGroupMenuSnapshot(items: []),
+                canCreateEmptyGroup: true,
+                eligibleGroupTargetIds: [],
+                allEligibleTargetsGroupId: nil,
+                hasGroupedEligibleTarget: false,
+                todoStatusLanes: [],
+                canMarkRead: false,
+                canMarkUnread: false,
+                hasLatestNotification: false,
+                notifications: []
+            )
+        )
+    }
+
+    private static func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "SidebarAppKitRowCellTests.\(UUID().uuidString)")!
     }
 
     private static func makeActions(model: SidebarWorkspaceRowModel) -> SidebarAppKitRowActions {
@@ -179,5 +238,114 @@ struct SidebarAppKitRowCellTests {
         activeCell.showOptimisticDeselection()
         #expect(activeApplied == [false])
         #expect(activeCell.currentModelForMeasurement?.isActive == true)
+    }
+
+    @Test
+    func defaultSettingsResolveTheSameVerticalBranchLayoutForBothRows() {
+        let settings = SidebarTabItemSettingsSnapshot(defaults: Self.makeDefaults())
+        let swiftUIRow = Self.makeSwiftUIRow(settings: settings)
+        let appKitRow = Self.makeModel(settings: settings)
+
+        #expect(settings.branchDirectory.branchLayout == .vertical)
+        #expect(settings.branchDirectory.branchDirectoryPlacement == .inline)
+        #expect(!settings.branchDirectory.usesLastSegmentPath)
+        #expect(!settings.wrapsWorkspaceTitles)
+        #expect(swiftUIRow.settings.branchDirectory == settings.branchDirectory)
+        #expect(appKitRow.settings.branchDirectory == settings.branchDirectory)
+    }
+
+    @Test(arguments: [false, true])
+    func storedLegacyBranchLayoutControlsBothRows(_ usesVerticalLayout: Bool) {
+        let defaults = Self.makeDefaults()
+        defaults.set(usesVerticalLayout, forKey: "sidebarBranchVerticalLayout")
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+        let expected: SidebarWorkspaceBranchDirectorySettings.BranchLayout = usesVerticalLayout
+            ? .vertical
+            : .inline
+
+        #expect(settings.branchDirectory.branchLayout == expected)
+        #expect(Self.makeSwiftUIRow(settings: settings).settings.branchDirectory.branchLayout == expected)
+        #expect(Self.makeModel(settings: settings).settings.branchDirectory.branchLayout == expected)
+    }
+
+    @Test(arguments: [false, true])
+    func storedBranchDirectoryPlacementRemainsAnIndependentSetting(_ stacks: Bool) {
+        let defaults = Self.makeDefaults()
+        defaults.set(stacks, forKey: "sidebarBranchDirectoryStacked")
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+        let expected: SidebarWorkspaceBranchDirectorySettings.BranchDirectoryPlacement = stacks
+            ? .stacked
+            : .inline
+
+        #expect(settings.branchDirectory.branchLayout == .vertical)
+        #expect(settings.branchDirectory.branchDirectoryPlacement == expected)
+        #expect(Self.makeSwiftUIRow(settings: settings).settings.branchDirectory == settings.branchDirectory)
+        #expect(Self.makeModel(settings: settings).settings.branchDirectory == settings.branchDirectory)
+    }
+
+    @Test(arguments: [false, true])
+    func storedPathAndTitlePreferencesAreSharedByBothRows(_ enabled: Bool) {
+        let defaults = Self.makeDefaults()
+        defaults.set(enabled, forKey: "sidebarPathLastSegmentOnly")
+        defaults.set(enabled, forKey: SidebarWorkspaceTitleWrapSettings.key)
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+        let swiftUISettings = Self.makeSwiftUIRow(settings: settings).settings
+        let appKitSettings = Self.makeModel(settings: settings).settings
+
+        #expect(settings.branchDirectory.usesLastSegmentPath == enabled)
+        #expect(settings.wrapsWorkspaceTitles == enabled)
+        #expect(swiftUISettings.branchDirectory.usesLastSegmentPath == enabled)
+        #expect(swiftUISettings.wrapsWorkspaceTitles == enabled)
+        #expect(appKitSettings.branchDirectory.usesLastSegmentPath == enabled)
+        #expect(appKitSettings.wrapsWorkspaceTitles == enabled)
+    }
+
+    @Test
+    func everyWorkspaceDetailSettingUsesCatalogDefaultsInBothRows() {
+        let settings = SidebarTabItemSettingsSnapshot(defaults: Self.makeDefaults())
+        let swiftUIDetails = Self.makeSwiftUIRow(settings: settings).settings.details
+        let appKitDetails = Self.makeModel(settings: settings).settings.details
+        let keys: [KeyPath<SidebarWorkspaceDetailSettings, Bool>] = [
+            \.showBranchDirectory,
+            \.showPullRequests,
+            \.watchGitStatus,
+            \.showSSH,
+            \.showPorts,
+            \.showLog,
+            \.showProgress,
+            \.showAgentActivity,
+            \.showCustomMetadata,
+        ]
+
+        for key in keys {
+            #expect(settings.details[keyPath: key])
+            #expect(swiftUIDetails[keyPath: key] == settings.details[keyPath: key])
+            #expect(appKitDetails[keyPath: key] == settings.details[keyPath: key])
+        }
+    }
+
+    @Test
+    func everyStoredWorkspaceDetailPreferenceIsHonoredInBothRows() {
+        let cases: [(String, KeyPath<SidebarWorkspaceDetailSettings, Bool>)] = [
+            ("sidebarShowBranchDirectory", \.showBranchDirectory),
+            ("sidebarShowPullRequest", \.showPullRequests),
+            ("sidebarWatchGitStatus", \.watchGitStatus),
+            ("sidebarShowSSH", \.showSSH),
+            ("sidebarShowPorts", \.showPorts),
+            ("sidebarShowLog", \.showLog),
+            ("sidebarShowProgress", \.showProgress),
+            ("sidebarShowAgentActivity", \.showAgentActivity),
+            ("sidebarShowStatusPills", \.showCustomMetadata),
+        ]
+
+        for (defaultsKey, detailKey) in cases {
+            let defaults = Self.makeDefaults()
+            defaults.set(false, forKey: defaultsKey)
+            let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+
+            #expect(!settings.details[keyPath: detailKey])
+            #expect(!Self.makeSwiftUIRow(settings: settings).settings.details[keyPath: detailKey])
+            #expect(!Self.makeModel(settings: settings).settings.details[keyPath: detailKey])
+        }
     }
 }

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -241,13 +241,13 @@ struct SidebarAppKitRowCellTests {
     }
 
     @Test
-    func defaultSettingsResolveTheSameVerticalBranchLayoutForBothRows() {
+    func defaultSettingsResolveTheSameStackedVerticalBranchLayoutForBothRows() {
         let settings = SidebarTabItemSettingsSnapshot(defaults: Self.makeDefaults())
         let swiftUIRow = Self.makeSwiftUIRow(settings: settings)
         let appKitRow = Self.makeModel(settings: settings)
 
         #expect(settings.branchDirectory.branchLayout == .vertical)
-        #expect(settings.branchDirectory.branchDirectoryPlacement == .inline)
+        #expect(settings.branchDirectory.branchDirectoryPlacement == .stacked)
         #expect(!settings.branchDirectory.usesLastSegmentPath)
         #expect(!settings.wrapsWorkspaceTitles)
         #expect(swiftUIRow.settings.branchDirectory == settings.branchDirectory)
@@ -258,26 +258,32 @@ struct SidebarAppKitRowCellTests {
     func storedLegacyBranchLayoutControlsBothRows(_ usesVerticalLayout: Bool) {
         let defaults = Self.makeDefaults()
         defaults.set(usesVerticalLayout, forKey: "sidebarBranchVerticalLayout")
+        defaults.set(false, forKey: "sidebarBranchDirectoryStacked")
         let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
-        let expected: SidebarWorkspaceBranchDirectorySettings.BranchLayout = usesVerticalLayout
+        let expectedLayout: SidebarWorkspaceBranchDirectorySettings.BranchLayout = usesVerticalLayout
             ? .vertical
             : .inline
+        let expectedPlacement: SidebarWorkspaceBranchDirectorySettings.BranchDirectoryPlacement = usesVerticalLayout
+            ? .stacked
+            : .inline
 
-        #expect(settings.branchDirectory.branchLayout == expected)
-        #expect(Self.makeSwiftUIRow(settings: settings).settings.branchDirectory.branchLayout == expected)
-        #expect(Self.makeModel(settings: settings).settings.branchDirectory.branchLayout == expected)
+        #expect(settings.branchDirectory.branchLayout == expectedLayout)
+        #expect(settings.branchDirectory.branchDirectoryPlacement == expectedPlacement)
+        #expect(Self.makeSwiftUIRow(settings: settings).settings.branchDirectory == settings.branchDirectory)
+        #expect(Self.makeModel(settings: settings).settings.branchDirectory == settings.branchDirectory)
     }
 
     @Test(arguments: [false, true])
     func storedBranchDirectoryPlacementRemainsAnIndependentSetting(_ stacks: Bool) {
         let defaults = Self.makeDefaults()
+        defaults.set(false, forKey: "sidebarBranchVerticalLayout")
         defaults.set(stacks, forKey: "sidebarBranchDirectoryStacked")
         let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
         let expected: SidebarWorkspaceBranchDirectorySettings.BranchDirectoryPlacement = stacks
             ? .stacked
             : .inline
 
-        #expect(settings.branchDirectory.branchLayout == .vertical)
+        #expect(settings.branchDirectory.branchLayout == .inline)
         #expect(settings.branchDirectory.branchDirectoryPlacement == expected)
         #expect(Self.makeSwiftUIRow(settings: settings).settings.branchDirectory == settings.branchDirectory)
         #expect(Self.makeModel(settings: settings).settings.branchDirectory == settings.branchDirectory)


### PR DESCRIPTION
## Summary

- resolve every sidebar-row preference once in an immutable settings snapshot shared by the SwiftUI and AppKit row models
- restore the shipped legacy default so a fresh AppKit sidebar renders branch and directory on separate lines
- preserve saved legacy values without migration or reinterpretation, while retaining the newer branch/directory placement preference
- derive workspace-detail keys/defaults, title wrapping, path presentation, colors, and indicator settings from the same catalog-backed path to prevent renderer drift

Closes #8430

Issue: https://github.com/manaflow-ai/cmux/issues/8430

## Two-setting compatibility contract

These settings are deliberately distinct:

- `sidebarBranchVerticalLayout` / `sidebar.branchVerticalLayout` is the shipped Bool-backed legacy topology preference (default `true`). `true` uses vertical branch records and preserves its historical stacked branch/directory subrows. `false` uses the compact branch topology. The key remains Bool-backed, and this PR performs no migration or stored-value rewrite.
- `sidebarBranchDirectoryStacked` / `sidebar.stackBranchDirectory` is the newer placement preference (default `false`). When the legacy topology is inline, it independently chooses whether branch and directory share one line or use separate subrows. Vertical legacy layout already implies stacked placement, so Settings displays the effective toggle as on and disables it until Inline layout is selected.

The resulting truth table is:

| Legacy vertical | Newer stack | Branch topology | Branch/directory placement |
| --- | --- | --- | --- |
| `true` | `false` or `true` | vertical | stacked |
| `false` | `false` | inline | inline |
| `false` | `true` | inline | stacked |

## Structural fix and audit

`SidebarTabItemSettingsSnapshot` is now the single resolved input for both renderers. It owns catalog-backed `SidebarWorkspaceBranchDirectorySettings` and `SidebarWorkspaceDetailSettings`, so AppKit no longer maintains a parallel raw-defaults interpretation.

The audit covers all workspace detail defaults (`showBranchDirectory`, `showPullRequests`, `watchGitStatus`, `showSSH`, `showPorts`, `showLog`, `showProgress`, `showAgentActivity`, and `showCustomMetadata`), title wrapping, path presentation, shortcut hints, colors, indicator positions, browser-link behavior, notification details, and the remaining settings consumed by AppKit rows. Behavior tests pass the same resolved snapshot into both row models and verify defaults plus stored overrides.

## Coordination

- #8413 / #8409: aligns with its shared row-presentation direction by sharing the immutable settings projection; this PR stays scoped to settings keys, defaults, and derivation fidelity.
- #8414 / #8412: does not change AppKit background rendering or appearance-toggle behavior.
- #8303: does not change the feature-flag rollout; it makes the AppKit path faithful whenever that flag is enabled.

## Verification

- red/green regression commit pairs:
  - `15d58b93b2` then `b49710feea`
  - `3b81ee6d5c` then `5bdac63059` (fresh-default stacked rendering caught during dogfood)
- `arch -arm64 swift test` in `Packages/macOS/CmuxSettings` — 260 tests passed
- `arch -arm64 swift test` in `Packages/macOS/CmuxSettingsUI` — 115 tests passed
- tagged cloud Debug build: https://github.com/manaflow-ai/cmux/actions/runs/29662299715
- zero cmux-owned Swift warnings in the tagged build
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh` — 528 test files checked
- `git diff --check`
- file-length audit: new files are below 500 lines; `SidebarSection.swift` remains at 499; neither budget TSV changed (the requested file-length script is absent on this base)

Build command:

```bash
CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-8430-sidebar-settings-fidelity --launch
```

## Visual verification

The tagged defaults domain was verified with the AppKit flag enabled and both layout keys absent before launch. Before/after and both saved-preference screenshots will be attached here from the tag-bound dev instance during PR verification.

## Localization

No new user-facing strings were added. The Settings change reuses the existing localized English/Japanese keys for Vertical/Inline layout and Stack Branch and Directory; no localization catalog changes are required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787003882&installation_id=133855650&pr_number=8432&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8432&signature=35368093e0cd80e8b3e17de9abc67e36756a9e745ca5a98cb7add27338696a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drift between AppKit and SwiftUI sidebar rows by resolving sidebar settings once and sharing them across both renderers. Restores the legacy default (vertical branch layout with branch and directory stacked) and preserves existing saved values. Closes #8430

- **Bug Fixes**
  - Use a single source of truth via `SidebarTabItemSettingsSnapshot` for both SwiftUI and AppKit rows.
  - Add `SidebarWorkspaceBranchDirectorySettings` to encode the compatibility rule: legacy `sidebar.branchVerticalLayout` (Bool, default `true`) sets topology; `sidebar.stackBranchDirectory` only affects inline layout; vertical is always stacked.
  - Settings UI now computes the effective stacked state with `SidebarCatalogSection.stacksBranchAndDirectory(...)` and disables the toggle when vertical.
  - Derive workspace-detail flags, title wrapping, path mode, colors, and indicator positions from catalog-backed keys to prevent renderer drift.
  - No migrations; existing on-disk values are honored.
  - Tests verify both rows resolve identical layouts and respect stored preferences.

<sup>Written for commit 5bdac6305978f25ae390cf9dfcd34295dae37e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent sidebar settings for branch and directory display, including inline, vertical, and stacked layouts.
  * Sidebar workspace rows now share unified settings for branch information, paths, titles, and detail visibility.
  * Added support for displaying workspace details such as pull requests, Git status, logs, progress, ports, SSH, metadata, and agent activity according to preferences.

* **Bug Fixes**
  * Improved handling of legacy sidebar preferences and ensured settings are applied consistently across sidebar views.
  * Disabled incompatible stacking controls when vertical branch layout is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->