### PR TITLE
Default AppKit sidebar on and enforce remote flag precedence

### DIFF
--- a/Sources/CmuxFeatureFlagResolution.swift
+++ b/Sources/CmuxFeatureFlagResolution.swift
@@ -1,0 +1,23 @@
+struct CmuxFeatureFlagResolution: Equatable, Sendable {
+    enum Source: Equatable, Sendable {
+        case remote
+        case override
+        case `default`
+    }
+
+    let effectiveValue: Bool
+    let source: Source
+
+    init(remoteValue: Bool?, overrideValue: Bool?, defaultValue: Bool) {
+        if let remoteValue {
+            effectiveValue = remoteValue
+            source = .remote
+        } else if let overrideValue {
+            effectiveValue = overrideValue
+            source = .override
+        } else {
+            effectiveValue = defaultValue
+            source = .default
+        }
+    }
+}

--- a/Sources/CmuxFeatureFlagResolution.swift
+++ b/Sources/CmuxFeatureFlagResolution.swift
@@ -1,12 +1,6 @@
 struct CmuxFeatureFlagResolution: Equatable, Sendable {
-    enum Source: Equatable, Sendable {
-        case remote
-        case override
-        case `default`
-    }
-
     let effectiveValue: Bool
-    let source: Source
+    let source: CmuxFeatureFlagSource
 
     init(remoteValue: Bool?, overrideValue: Bool?, defaultValue: Bool) {
         if let remoteValue {

--- a/Sources/CmuxFeatureFlagSource.swift
+++ b/Sources/CmuxFeatureFlagSource.swift
@@ -1,0 +1,5 @@
+enum CmuxFeatureFlagSource: Equatable, Sendable {
+    case remote
+    case override
+    case `default`
+}

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -16,12 +16,12 @@ struct CmuxFeatureFlagDefinition: Identifiable, Equatable {
 /// refreshed when the SDK reports a flag payload, so gated UI can be toggled
 /// from the PostHog dashboard without shipping a build.
 ///
-/// Fallback semantics (flags must never break the app):
-/// - Until a payload arrives — including forever, when the SDK never starts
+/// Resolution semantics (flags must never break the app):
+/// - A remote value is authoritative when present, so rollout and kill-switch
+///   changes cannot be masked by a stale local override.
+/// - Without a remote value — including forever, when the SDK never starts
 ///   because telemetry is off or a DEBUG build lacks CMUX_POSTHOG_ENABLE=1 —
-///   every flag keeps its safe default.
-/// - Once a payload has arrived, a false flag reads as off. An absent flag
-///   still uses the explicit per-flag fallback below.
+///   a local override applies, followed by the explicit per-flag default.
 ///
 /// Registry contract (enforced by scripts/lint-feature-flags.py in CI): each
 /// flag declares key / owner / reviewBy / defaultWhenUnavailable in the FLAG
@@ -47,7 +47,7 @@ final class CmuxFeatureFlags {
     private static let agentChatUIDefault = false
     private static let sidebarWorkspaceAgentSpinnerDefault = false
     private static let workspaceTodoControlsDefault = false
-    private static let appKitSidebarListDefault = false
+    private static let appKitSidebarListDefault = true
 
     private static let overrideKeyPrefix = "cmux.flags.override."
 
@@ -154,10 +154,10 @@ final class CmuxFeatureFlags {
             ),
 
             // FLAG(key: sidebar-appkit-list-experiment, owner: lawrencecchen,
-            //      reviewBy: 2026-10-01, defaultWhenUnavailable: false)
+            //      reviewBy: 2026-10-01, defaultWhenUnavailable: true)
             // Renders the workspace sidebar with the AppKit NSTableView list
             // (virtualized rows, measured-once heights) instead of the SwiftUI
-            // LazyVStack. Off by default while the rewrite soaks.
+            // LazyVStack. On by default after the remote rollout reached 100%.
             CmuxFeatureFlagDefinition(
                 key: "sidebar-appkit-list-experiment",
                 title: String(
@@ -210,7 +210,7 @@ final class CmuxFeatureFlags {
 
     private var localOverridesByKey: [String: Bool] = [:]
     private var remoteValuesByKey: [String: Bool] = [:]
-    private var effectiveValuesByKey: [String: Bool] = [:]
+    private var resolutionsByKey: [String: CmuxFeatureFlagResolution] = [:]
 
     init(
         defaults: UserDefaults = .standard,
@@ -227,7 +227,7 @@ final class CmuxFeatureFlags {
     }
 
     /// Called once from AppDelegate after PostHog analytics starts. Safe when
-    /// the SDK never sets up — flags then keep their defaults.
+    /// the SDK never sets up — flags then keep their local fallback resolution.
     func start() {
         guard flagsObserver == nil else { return }
         flagsObserver = NotificationCenter.default.addObserver(
@@ -243,7 +243,15 @@ final class CmuxFeatureFlags {
     }
 
     func effectiveValue(for definition: CmuxFeatureFlagDefinition) -> Bool {
-        effectiveValuesByKey[definition.key] ?? definition.defaultWhenUnavailable
+        resolution(for: definition).effectiveValue
+    }
+
+    func resolution(for definition: CmuxFeatureFlagDefinition) -> CmuxFeatureFlagResolution {
+        resolutionsByKey[definition.key] ?? CmuxFeatureFlagResolution(
+            remoteValue: remoteValuesByKey[definition.key],
+            overrideValue: localOverridesByKey[definition.key],
+            defaultValue: definition.defaultWhenUnavailable
+        )
     }
 
     func overrideValue(for definition: CmuxFeatureFlagDefinition) -> Bool? {
@@ -255,7 +263,9 @@ final class CmuxFeatureFlags {
     }
 
     func setOverride(_ value: Bool?, for definition: CmuxFeatureFlagDefinition) {
-        let previousEffectiveValues = effectiveValuesByKey
+        guard value == nil || remoteValuesByKey[definition.key] == nil else { return }
+
+        let previousResolutions = resolutionsByKey
         if let value {
             localOverridesByKey[definition.key] = value
             defaults.set(value, forKey: Self.overrideDefaultsKey(for: definition.key))
@@ -264,11 +274,11 @@ final class CmuxFeatureFlags {
             defaults.removeObject(forKey: Self.overrideDefaultsKey(for: definition.key))
         }
         recomputeEffectiveValues()
-        postChangeIfNeeded(previousEffectiveValues: previousEffectiveValues)
+        postChangeIfNeeded(previousResolutions: previousResolutions)
     }
 
     func clearAllOverrides() {
-        let previousEffectiveValues = effectiveValuesByKey
+        let previousResolutions = resolutionsByKey
         var clearedAnyOverride = false
         for definition in Self.allFlags {
             if localOverridesByKey.removeValue(forKey: definition.key) != nil {
@@ -278,32 +288,32 @@ final class CmuxFeatureFlags {
         }
         guard clearedAnyOverride else { return }
         recomputeEffectiveValues()
-        postChangeIfNeeded(previousEffectiveValues: previousEffectiveValues)
+        postChangeIfNeeded(previousResolutions: previousResolutions)
     }
 
     func applyLoadedFlags() {
-        let previousEffectiveValues = effectiveValuesByKey
+        let previousResolutions = resolutionsByKey
         remoteValuesByKey = Self.allFlags.reduce(into: [:]) { values, definition in
             if let value = Self.coerceBoolFlagValue(remoteFlagValueProvider(definition.key)) {
                 values[definition.key] = value
             }
         }
         recomputeEffectiveValues()
-        postChangeIfNeeded(previousEffectiveValues: previousEffectiveValues)
+        postChangeIfNeeded(previousResolutions: previousResolutions)
     }
 
     private func recomputeEffectiveValues() {
-        effectiveValuesByKey = Self.allFlags.reduce(into: [:]) { values, definition in
-            values[definition.key] = localOverridesByKey[definition.key]
-                ?? remoteValuesByKey[definition.key]
-                ?? definition.defaultWhenUnavailable
+        resolutionsByKey = Self.allFlags.reduce(into: [:]) { values, definition in
+            values[definition.key] = CmuxFeatureFlagResolution(
+                remoteValue: remoteValuesByKey[definition.key],
+                overrideValue: localOverridesByKey[definition.key],
+                defaultValue: definition.defaultWhenUnavailable
+            )
         }
     }
 
-    private func postChangeIfNeeded(previousEffectiveValues: [String: Bool]) {
-        if Self.allFlags.contains(where: { definition in
-            previousEffectiveValues[definition.key] != effectiveValuesByKey[definition.key]
-        }) {
+    private func postChangeIfNeeded(previousResolutions: [String: CmuxFeatureFlagResolution]) {
+        if previousResolutions != resolutionsByKey {
             NotificationCenter.default.post(name: .cmuxFeatureFlagsDidChange, object: self)
         }
     }

--- a/Sources/InternalFlagsWindow.swift
+++ b/Sources/InternalFlagsWindow.swift
@@ -49,9 +49,8 @@ private struct InternalFlagsView: View {
         CmuxFeatureFlags.allFlags.map { definition in
             InternalFlagRowSnapshot(
                 definition: definition,
-                effectiveValue: flags.effectiveValue(for: definition),
-                overrideValue: flags.overrideValue(for: definition),
-                remoteValue: flags.remoteValue(for: definition)
+                resolution: flags.resolution(for: definition),
+                overrideValue: flags.overrideValue(for: definition)
             )
         }
     }
@@ -94,7 +93,7 @@ private struct InternalFlagsView: View {
             HStack(alignment: .center, spacing: 16) {
                 Text(String(
                     localized: "featureFlags.footer.note",
-                    defaultValue: "Overrides are local to this Mac and take precedence over remote flags."
+                    defaultValue: "Local overrides apply only when no remote value is available."
                 ))
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -139,18 +138,22 @@ private struct InternalFlagRowSnapshot: Identifiable, Equatable {
     var id: String { definition.key }
 
     let definition: CmuxFeatureFlagDefinition
-    let effectiveValue: Bool
+    let resolution: CmuxFeatureFlagResolution
     let overrideValue: Bool?
-    let remoteValue: Bool?
 
-    var source: InternalFlagValueSource {
-        if overrideValue != nil {
-            return .override
+    var isRemoteControlled: Bool {
+        resolution.source == .remote
+    }
+
+    var sourceTitle: String {
+        switch resolution.source {
+        case .remote:
+            return String(localized: "featureFlags.source.remote", defaultValue: "Remote")
+        case .override:
+            return String(localized: "featureFlags.source.override", defaultValue: "Override")
+        case .default:
+            return String(localized: "featureFlags.source.default", defaultValue: "Default")
         }
-        if remoteValue != nil {
-            return .remote
-        }
-        return .default
     }
 
     var overrideChoice: InternalFlagOverrideChoice {
@@ -160,7 +163,7 @@ private struct InternalFlagRowSnapshot: Identifiable, Equatable {
         case .some(false):
             return .off
         case .none:
-            return .remote
+            return .noOverride
         }
     }
 }
@@ -186,27 +189,39 @@ private struct InternalFlagRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            InternalFlagValueBadge(isOn: snapshot.effectiveValue)
+            InternalFlagValueBadge(isOn: snapshot.resolution.effectiveValue)
                 .frame(width: 96, alignment: .leading)
 
-            Text(snapshot.source.title)
+            Text(snapshot.sourceTitle)
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .frame(width: 96, alignment: .leading)
 
-            Picker(
-                String(localized: "featureFlags.override.pickerLabel", defaultValue: "Override"),
-                selection: Binding(
-                    get: { snapshot.overrideChoice },
-                    set: { choice in setOverride(choice.overrideValue) }
-                )
-            ) {
-                ForEach(InternalFlagOverrideChoice.allCases) { choice in
-                    Text(choice.title).tag(choice)
+            VStack(alignment: .leading, spacing: 4) {
+                Picker(
+                    String(localized: "featureFlags.override.pickerLabel", defaultValue: "Override"),
+                    selection: Binding(
+                        get: { snapshot.overrideChoice },
+                        set: { choice in setOverride(choice.overrideValue) }
+                    )
+                ) {
+                    ForEach(InternalFlagOverrideChoice.allCases) { choice in
+                        Text(choice.title).tag(choice)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .disabled(snapshot.isRemoteControlled)
+
+                if snapshot.isRemoteControlled {
+                    Text(String(
+                        localized: "featureFlags.override.remoteControlledNote",
+                        defaultValue: "Controlled remotely; local override inactive."
+                    ))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
                 }
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
             .frame(width: 240)
         }
         .padding(.horizontal, 24)
@@ -234,27 +249,10 @@ private struct InternalFlagValueBadge: View {
     }
 }
 
-private enum InternalFlagValueSource {
-    case override
-    case remote
-    case `default`
-
-    var title: String {
-        switch self {
-        case .override:
-            return String(localized: "featureFlags.source.override", defaultValue: "Override")
-        case .remote:
-            return String(localized: "featureFlags.source.remote", defaultValue: "Remote")
-        case .default:
-            return String(localized: "featureFlags.source.default", defaultValue: "Default")
-        }
-    }
-}
-
 private enum InternalFlagOverrideChoice: CaseIterable, Hashable, Identifiable {
     case on
     case off
-    case remote
+    case noOverride
 
     var id: Self { self }
 
@@ -264,8 +262,8 @@ private enum InternalFlagOverrideChoice: CaseIterable, Hashable, Identifiable {
             return String(localized: "featureFlags.override.on", defaultValue: "On")
         case .off:
             return String(localized: "featureFlags.override.off", defaultValue: "Off")
-        case .remote:
-            return String(localized: "featureFlags.override.remote", defaultValue: "Remote")
+        case .noOverride:
+            return String(localized: "featureFlags.override.none", defaultValue: "No override")
         }
     }
 
@@ -275,7 +273,7 @@ private enum InternalFlagOverrideChoice: CaseIterable, Hashable, Identifiable {
             return true
         case .off:
             return false
-        case .remote:
+        case .noOverride:
             return nil
         }
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE49000000000000000001 /* CmuxExtensionSidebarExamples in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */; };
 		C57B00050000000000000001 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57B00050000000000000002 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift */; };
 		A117FF000000000000000001 /* CmuxFeatureFlagResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = A117FF000000000000000002 /* CmuxFeatureFlagResolution.swift */; };
+		A117FF000000000000000003 /* CmuxFeatureFlagSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A117FF000000000000000004 /* CmuxFeatureFlagSource.swift */; };
 		C9A2C00000000000000000C3 /* CmuxFeedback in Frameworks */ = {isa = PBXBuildFile; productRef = C9A2C00000000000000000C2 /* CmuxFeedback */; };
 		5E2701040000000000000004 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 5E2701040000000000000002 /* CmuxFoundation */; };
 		CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
@@ -2689,6 +2690,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		E7E000000000000000000002 /* CmuxEventStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventStream.swift; sourceTree = "<group>"; };
 		C57B00050000000000000002 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CmuxExtensionSidebarSelection+CustomSidebarName.swift"; sourceTree = "<group>"; };
 		A117FF000000000000000002 /* CmuxFeatureFlagResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxFeatureFlagResolution.swift; sourceTree = "<group>"; };
+		A117FF000000000000000004 /* CmuxFeatureFlagSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxFeatureFlagSource.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000003 /* CmuxHelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpCommands.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000004 /* CmuxHelpResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpResource.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
@@ -4516,6 +4518,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEA7710000000000000004 /* ContentView+ProCommandPalette.swift */,
 				C0DEA7710000000000000006 /* SidebarProBadge.swift */,
 				A117FF000000000000000002 /* CmuxFeatureFlagResolution.swift */,
+				A117FF000000000000000004 /* CmuxFeatureFlagSource.swift */,
 				C0DEA7710000000000000008 /* FeatureFlags.swift */,
 				C0DEA7720000000000000002 /* InternalFlagsWindow.swift */,
 				C0DEA771000000000000000A /* MobileConnectTitlebarAccessory.swift */,
@@ -7056,6 +7059,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				E7E000000000000000000001 /* CmuxEventStream.swift in Sources */,
 				C57B00050000000000000001 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift in Sources */,
 				A117FF000000000000000001 /* CmuxFeatureFlagResolution.swift in Sources */,
+				A117FF000000000000000003 /* CmuxFeatureFlagSource.swift in Sources */,
 				C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */,
 				C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */,
 				C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -591,6 +591,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE45000000000000000001 /* CmuxExtensionKit in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE45000000000000000002 /* CmuxExtensionKit */; };
 		C0DE49000000000000000001 /* CmuxExtensionSidebarExamples in Frameworks */ = {isa = PBXBuildFile; productRef = C0DE49000000000000000002 /* CmuxExtensionSidebarExamples */; };
 		C57B00050000000000000001 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57B00050000000000000002 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift */; };
+		A117FF000000000000000001 /* CmuxFeatureFlagResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = A117FF000000000000000002 /* CmuxFeatureFlagResolution.swift */; };
 		C9A2C00000000000000000C3 /* CmuxFeedback in Frameworks */ = {isa = PBXBuildFile; productRef = C9A2C00000000000000000C2 /* CmuxFeedback */; };
 		5E2701040000000000000004 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 5E2701040000000000000002 /* CmuxFoundation */; };
 		CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = CF00F00000000000000000A2 /* CmuxFoundation */; };
@@ -2687,6 +2688,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		E7E000000000000000000008 /* CmuxEventPublishing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventPublishing.swift; sourceTree = "<group>"; };
 		E7E000000000000000000002 /* CmuxEventStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxEventStream.swift; sourceTree = "<group>"; };
 		C57B00050000000000000002 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CmuxExtensionSidebarSelection+CustomSidebarName.swift"; sourceTree = "<group>"; };
+		A117FF000000000000000002 /* CmuxFeatureFlagResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxFeatureFlagResolution.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000003 /* CmuxHelpCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpCommands.swift; sourceTree = "<group>"; };
 		C0DE34020000000000000004 /* CmuxHelpResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxHelpResource.swift; sourceTree = "<group>"; };
 		C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXInstalledExtensionSidebarHostView.swift; sourceTree = "<group>"; };
@@ -4513,6 +4515,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEA7710000000000000002 /* ContentView+AuthCommandPalette.swift */,
 				C0DEA7710000000000000004 /* ContentView+ProCommandPalette.swift */,
 				C0DEA7710000000000000006 /* SidebarProBadge.swift */,
+				A117FF000000000000000002 /* CmuxFeatureFlagResolution.swift */,
 				C0DEA7710000000000000008 /* FeatureFlags.swift */,
 				C0DEA7720000000000000002 /* InternalFlagsWindow.swift */,
 				C0DEA771000000000000000A /* MobileConnectTitlebarAccessory.swift */,
@@ -7052,6 +7055,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				E7E000000000000000000007 /* CmuxEventPublishing.swift in Sources */,
 				E7E000000000000000000001 /* CmuxEventStream.swift in Sources */,
 				C57B00050000000000000001 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift in Sources */,
+				A117FF000000000000000001 /* CmuxFeatureFlagResolution.swift in Sources */,
 				C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */,
 				C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */,
 				C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */,

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -71,6 +71,30 @@ struct PostHogAnalyticsPropertiesTests {
     }
 
     @MainActor
+    @Test("remote-controlled flags reject new local override writes")
+    func remoteControlledFlagsRejectNewLocalOverrideWrites() throws {
+        let flag = try #require(CmuxFeatureFlags.allFlags.first {
+            $0.key == "sidebar-appkit-list-experiment"
+        })
+        let suiteName = "cmux.feature.flags.remote.controlled.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let remoteValues: [String: Any] = [flag.key: true]
+        let flags = CmuxFeatureFlags(defaults: defaults) { key in
+            remoteValues[key]
+        }
+        flags.applyLoadedFlags()
+
+        flags.setOverride(false, for: flag)
+
+        #expect(flags.overrideValue(for: flag) == nil)
+        #expect(flags.effectiveValue(for: flag))
+    }
+
+    @MainActor
     @Test("workspace todo controls feature flag follows remote values")
     func workspaceTodoControlsFeatureFlagFollowsRemoteValues() throws {
         let flag = try #require(CmuxFeatureFlags.allFlags.first {

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -21,9 +21,11 @@ struct PostHogAnalyticsPropertiesTests {
     }
 
     @MainActor
-    @Test("feature flag resolution prefers override, then remote, then default")
+    @Test("feature flag resolution prefers remote, then override, then default")
     func featureFlagResolutionPrecedence() throws {
-        let flag = try #require(CmuxFeatureFlags.allFlags.first { $0.defaultWhenUnavailable })
+        let flag = try #require(CmuxFeatureFlags.allFlags.first {
+            $0.key == "sidebar-appkit-list-experiment"
+        })
         let suiteName = "cmux.feature.flags.precedence.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer {
@@ -39,24 +41,33 @@ struct PostHogAnalyticsPropertiesTests {
         #expect(flags.remoteValue(for: flag) == nil)
         #expect(flags.effectiveValue(for: flag))
 
-        remoteValues[flag.key] = false
+        flags.setOverride(false, for: flag)
+        #expect(flags.overrideValue(for: flag) == false)
+        #expect(!flags.effectiveValue(for: flag))
+
+        remoteValues[flag.key] = true
         flags.applyLoadedFlags()
-        #expect(flags.remoteValue(for: flag) == false)
-        #expect(!flags.effectiveValue(for: flag))
-
-        flags.setOverride(true, for: flag)
-        #expect(flags.overrideValue(for: flag) == true)
-        #expect(flags.remoteValue(for: flag) == false)
+        #expect(flags.overrideValue(for: flag) == false)
+        #expect(flags.remoteValue(for: flag) == true)
         #expect(flags.effectiveValue(for: flag))
-
-        flags.setOverride(nil, for: flag)
-        #expect(flags.overrideValue(for: flag) == nil)
-        #expect(!flags.effectiveValue(for: flag))
 
         remoteValues.removeValue(forKey: flag.key)
         flags.applyLoadedFlags()
         #expect(flags.remoteValue(for: flag) == nil)
+        #expect(!flags.effectiveValue(for: flag))
+
+        flags.setOverride(nil, for: flag)
+        #expect(flags.overrideValue(for: flag) == nil)
         #expect(flags.effectiveValue(for: flag))
+    }
+
+    @MainActor
+    @Test("AppKit sidebar feature flag defaults on")
+    func appKitSidebarFeatureFlagDefaultsOn() throws {
+        let flag = try #require(CmuxFeatureFlags.allFlags.first {
+            $0.key == "sidebar-appkit-list-experiment"
+        })
+        #expect(flag.defaultWhenUnavailable)
     }
 
     @MainActor
@@ -113,47 +124,40 @@ struct PostHogAnalyticsPropertiesTests {
     }
 
     @MainActor
-    @Test("feature flag override notifications follow effective value changes")
-    func featureFlagOverrideNotificationsFollowEffectiveValueChanges() throws {
-        let flag = try #require(CmuxFeatureFlags.allFlags.first { $0.defaultWhenUnavailable })
+    @Test("remote payload superseding a local override posts a change notification")
+    func remotePayloadSupersedingLocalOverridePostsChangeNotification() async throws {
+        let flag = try #require(CmuxFeatureFlags.allFlags.first {
+            $0.key == "sidebar-appkit-list-experiment"
+        })
         let suiteName = "cmux.feature.flags.notifications.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer {
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        let remoteValues: [String: Any] = [flag.key: false]
+        var remoteValues: [String: Any] = [:]
         let flags = CmuxFeatureFlags(defaults: defaults) { key in
             remoteValues[key]
         }
-        flags.applyLoadedFlags()
-
-        let notificationQueue = DispatchQueue(label: "cmux.feature.flags.notification.count")
-        var notificationCount = 0
-        let token = NotificationCenter.default.addObserver(
-            forName: .cmuxFeatureFlagsDidChange,
-            object: flags,
-            queue: nil
-        ) { _ in
-            notificationQueue.sync {
-                notificationCount += 1
-            }
-        }
-        defer {
-            NotificationCenter.default.removeObserver(token)
-        }
-
         flags.setOverride(false, for: flag)
-        #expect(notificationQueue.sync { notificationCount } == 0)
 
-        flags.setOverride(true, for: flag)
-        #expect(notificationQueue.sync { notificationCount } == 1)
+        await confirmation("feature flag resolution changed") { didChange in
+            let token = NotificationCenter.default.addObserver(
+                forName: .cmuxFeatureFlagsDidChange,
+                object: flags,
+                queue: nil
+            ) { _ in
+                didChange()
+            }
+            defer { NotificationCenter.default.removeObserver(token) }
 
-        flags.setOverride(true, for: flag)
-        #expect(notificationQueue.sync { notificationCount } == 1)
+            remoteValues[flag.key] = true
+            flags.applyLoadedFlags()
+        }
 
-        flags.setOverride(nil, for: flag)
-        #expect(notificationQueue.sync { notificationCount } == 2)
+        #expect(flags.overrideValue(for: flag) == false)
+        #expect(flags.remoteValue(for: flag) == true)
+        #expect(flags.effectiveValue(for: flag))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- make the AppKit Lawrence Sidebar the compiled fallback when PostHog is unavailable
- make an available remote flag authoritative over a persisted local override
- disable and annotate the Internal Flags override control while remote controls a flag
- reject new in-app On/Off override writes at the shared model boundary when a remote value is present

## Feature flag precedence

Resolution is now: remote PostHog value when present → local override when no remote value is present → compiled default.

The local dogfood carve-out remains intact: overrides work as before in DEBUG builds without `CMUX_POSTHOG_ENABLE=1`, telemetry-off installs, and for keys absent from PostHog. Once a remote value is available, it is authoritative for rollout and kill-switch safety. A pre-existing local override remains only as an inactive fallback if that remote key later becomes unavailable; the app cannot create a new On/Off override while the key is remotely controlled.

The inspector now labels the nil override state as **No override**. When a remote value is present, the picker is disabled and the row says that remote controls the flag and the local override is inactive.

## AppKit sidebar default

The `sidebar-appkit-list-experiment` compiled fallback is on. This overlaps with the default-flip commit in #8303; whichever PR merges second will have a trivial conflict on that line.

https://github.com/manaflow-ai/cmux/issues/8263 is context for the sidebar rollout only; this PR does not close it.

## Tests

The first two commits contain behavior-first regression coverage and are intentionally red without the implementation commit. Coverage includes remote-over-override resolution, override/default fallbacks, change notification delivery, the AppKit default, and rejection of in-app override writes while remote controls a flag.

Local validation: `./scripts/reload.sh --tag feat-appkit-default-and-flag-precedence` and the checked-in Swift warning budget. Per task constraints, no local Xcode test command was run; the `cmux-unit` tests run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated feature-flag resolution: remote values are authoritative; local overrides apply only when no remote value is available (otherwise defaults are used).
  * Improved remote-payload behavior so effective values follow the remote even if an override remains set, and correctly revert when the remote is removed or the override is cleared.
  * Ensured the AppKit sidebar experiment is enabled by default when remote control is unavailable.
* **Documentation / Localization**
  * Refined the on-screen wording for local overrides and remote control status.
  * Added localized strings for “No override” and “Controlled remotely; local override inactive.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->