### PR TITLE
fix(terminal): preserve command status across Bash prompt hooks

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1509,8 +1509,8 @@ _cmux_prompt_command() {
 
     local cmux_has_unix_socket=0
     _cmux_socket_is_unix && cmux_has_unix_socket=1
-    (( cmux_has_unix_socket )) || _cmux_has_port_scan_transport || return 0
-    [[ -n "$CMUX_TAB_ID" ]] || return 0
+    (( cmux_has_unix_socket )) || _cmux_has_port_scan_transport || return "$last_status"
+    [[ -n "$CMUX_TAB_ID" ]] || return "$last_status"
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then
         local t
@@ -1535,10 +1535,10 @@ _cmux_prompt_command() {
         if (( now - _CMUX_PORTS_LAST_RUN >= 10 )); then
             _cmux_ports_kick refresh
         fi
-        return 0
+        return "$last_status"
     fi
 
-    [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    [[ -n "$CMUX_PANEL_ID" ]] || return "$last_status"
     _cmux_set_git_active_pwd "$pwd"
 
     # Post-wake socket writes can occasionally leave a probe process wedged.
@@ -1648,6 +1648,7 @@ _cmux_prompt_command() {
     if (( now - _CMUX_PORTS_LAST_RUN >= 10 )); then
         _cmux_ports_kick refresh
     fi
+    return "$last_status"
 }
 
 _cmux_install_prompt_command() {

--- a/tests/test_issue_5164_starship_prompt_composition.py
+++ b/tests/test_issue_5164_starship_prompt_composition.py
@@ -31,6 +31,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BOOTSTRAP = REPO_ROOT / "Resources/shell-integration/cmux-bash-bootstrap.bash"
 INTEGRATION_DIR = REPO_ROOT / "Resources/shell-integration"
+INTEGRATION = INTEGRATION_DIR / "cmux-bash-integration.bash"
 
 
 def _lean_bootstrap(text: str) -> str:
@@ -266,7 +267,45 @@ def test_plain_bash_bootstrap_installs_cmux_prompt_command() -> None:
         )
 
 
+def test_cmux_prompt_command_preserves_status_for_downstream_hooks() -> None:
+    """Regression coverage for https://github.com/manaflow-ai/cmux/issues/5389."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("CMUX")
+    }
+    env.update(
+        {
+            "CMUX_BASH_INTEGRATION": str(INTEGRATION),
+            "CMUX_SOCKET_PATH": "",
+            "CMUX_TAB_ID": "tab-test",
+        }
+    )
+    script = r"""
+source "$CMUX_BASH_INTEGRATION"
+downstream_prompt_hook() { printf 'STATUS=%s\n' "$?"; }
+(exit 7)
+_cmux_prompt_command
+downstream_prompt_hook
+"""
+    proc = subprocess.run(
+        ["/bin/bash", "--noprofile", "--norc", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert proc.returncode == 0, (
+        f"bash exited {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert proc.stdout.splitlines() == ["STATUS=7"], (
+        "downstream PROMPT_COMMAND hook did not receive the user's command status; "
+        f"stdout=<{proc.stdout}> stderr=<{proc.stderr}>"
+    )
+
+
 if __name__ == "__main__":
     test_starship_precmd_survives_under_cmux_bash_bootstrap()
     test_plain_bash_bootstrap_installs_cmux_prompt_command()
-    print("PASS: cmux bash bootstrap composes with (and without) user prompt hooks")
+    test_cmux_prompt_command_preserves_status_for_downstream_hooks()
+    print("PASS: cmux bash prompt hooks compose and preserve command status")

--- a/tests/test_issue_5164_starship_prompt_composition.py
+++ b/tests/test_issue_5164_starship_prompt_composition.py
@@ -268,40 +268,97 @@ def test_plain_bash_bootstrap_installs_cmux_prompt_command() -> None:
 
 
 def test_cmux_prompt_command_preserves_status_for_downstream_hooks() -> None:
-    """Regression coverage for https://github.com/manaflow-ai/cmux/issues/5389."""
-    env = {
-        key: value
-        for key, value in os.environ.items()
-        if not key.startswith("CMUX")
-    }
-    env.update(
-        {
-            "CMUX_BASH_INTEGRATION": str(INTEGRATION),
-            "CMUX_SOCKET_PATH": "",
-            "CMUX_TAB_ID": "tab-test",
-        }
-    )
+    """Regression coverage for every return path fixed by issue #5389."""
     script = r"""
 source "$CMUX_BASH_INTEGRATION"
+_cmux_tmux_sync_cmux_environment() { :; }
+_cmux_reset_terminal_keyboard_protocols() { :; }
+_cmux_report_shell_activity_state() { :; }
+_cmux_report_tty_once() { :; }
+_cmux_set_git_active_pwd() { :; }
+_cmux_now() { printf '100\n'; }
+_cmux_report_pwd_via_relay() { return 0; }
+_cmux_send_bg() { :; }
+_cmux_stop_pr_poll_loop() { :; }
+_cmux_clear_pr_command_hint_file() { :; }
+_cmux_ports_kick() { :; }
+case "$CMUX_TEST_PATH" in
+    no-tab|no-panel|full)
+        _cmux_socket_is_unix() { return 0; }
+        ;;
+    port-scan)
+        _cmux_socket_is_unix() { return 1; }
+        _cmux_has_port_scan_transport() { return 0; }
+        ;;
+esac
+_CMUX_PWD_LAST_PWD="$PWD"
+_CMUX_PORTS_LAST_RUN=100
 downstream_prompt_hook() { printf 'STATUS=%s\n' "$?"; }
 (exit 7)
 _cmux_prompt_command
 downstream_prompt_hook
 """
-    proc = subprocess.run(
-        ["/bin/bash", "--noprofile", "--norc", "-c", script],
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    assert proc.returncode == 0, (
-        f"bash exited {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
-    )
-    assert proc.stdout.splitlines() == ["STATUS=7"], (
-        "downstream PROMPT_COMMAND hook did not receive the user's command status; "
-        f"stdout=<{proc.stdout}> stderr=<{proc.stderr}>"
-    )
+    scenarios = {
+        "no transport": {
+            "CMUX_TEST_PATH": "no-transport",
+            "CMUX_SOCKET_PATH": "",
+            "CMUX_TAB_ID": "tab-test",
+            "CMUX_PANEL_ID": "",
+        },
+        "no tab": {
+            "CMUX_TEST_PATH": "no-tab",
+            "CMUX_SOCKET_PATH": "/tmp/cmux-test.sock",
+            "CMUX_TAB_ID": "",
+            "CMUX_PANEL_ID": "",
+        },
+        "port scan": {
+            "CMUX_TEST_PATH": "port-scan",
+            "CMUX_SOCKET_PATH": "",
+            "CMUX_TAB_ID": "tab-test",
+            "CMUX_PANEL_ID": "",
+        },
+        "no panel": {
+            "CMUX_TEST_PATH": "no-panel",
+            "CMUX_SOCKET_PATH": "/tmp/cmux-test.sock",
+            "CMUX_TAB_ID": "tab-test",
+            "CMUX_PANEL_ID": "",
+        },
+        "full path": {
+            "CMUX_TEST_PATH": "full",
+            "CMUX_SOCKET_PATH": "/tmp/cmux-test.sock",
+            "CMUX_TAB_ID": "tab-test",
+            "CMUX_PANEL_ID": "panel-test",
+        },
+    }
+    for scenario, overrides in scenarios.items():
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("CMUX")
+        }
+        env.update(
+            {
+                "CMUX_BASH_INTEGRATION": str(INTEGRATION),
+                "CMUX_NO_GIT_WATCH": "1",
+                **overrides,
+            }
+        )
+        proc = subprocess.run(
+            ["/bin/bash", "--noprofile", "--norc", "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert proc.returncode == 0, (
+            f"{scenario}: bash exited {proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+        assert proc.stdout.splitlines() == ["STATUS=7"], (
+            f"{scenario}: downstream PROMPT_COMMAND hook did not receive the user's "
+            f"command status; stdout=<{proc.stdout}> stderr=<{proc.stderr}>"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_5164_starship_prompt_composition.py
+++ b/tests/test_issue_5164_starship_prompt_composition.py
@@ -307,7 +307,7 @@ downstream_prompt_hook
         },
         "no tab": {
             "CMUX_TEST_PATH": "no-tab",
-            "CMUX_SOCKET_PATH": "/tmp/cmux-test.sock",
+            "CMUX_SOCKET_PATH": "/dummy/cmux-test.sock",
             "CMUX_TAB_ID": "",
             "CMUX_PANEL_ID": "",
         },
@@ -319,13 +319,13 @@ downstream_prompt_hook
         },
         "no panel": {
             "CMUX_TEST_PATH": "no-panel",
-            "CMUX_SOCKET_PATH": "/tmp/cmux-test.sock",
+            "CMUX_SOCKET_PATH": "/dummy/cmux-test.sock",
             "CMUX_TAB_ID": "tab-test",
             "CMUX_PANEL_ID": "",
         },
         "full path": {
             "CMUX_TEST_PATH": "full",
-            "CMUX_SOCKET_PATH": "/tmp/cmux-test.sock",
+            "CMUX_SOCKET_PATH": "/dummy/cmux-test.sock",
             "CMUX_TAB_ID": "tab-test",
             "CMUX_PANEL_ID": "panel-test",
         },


### PR DESCRIPTION
## Summary
- Preserve the incoming command exit status across every `_cmux_prompt_command` return path.
- Let downstream Bash `PROMPT_COMMAND` hooks, including Starship, observe the user's real command status.
- Add regression coverage for nonzero status propagation through the actual shell integration.

Fixes #5389

## Testing
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `python3 tests/test_issue_5164_starship_prompt_composition.py`
- Live cmux terminal: sourced the changed integration with the current socket/tab/panel environment, ran a command exiting 7, then invoked a downstream prompt hook; observed `downstream_status=7 socket=set tab=set panel=set`.

## Demo Video
Not applicable — shell-only behavior, verified in a live cmux terminal.

## Risk
- Low. The only runtime change is `_cmux_prompt_command` returning the status it already captures instead of replacing it with success.

## Notes
- No docs or changelog change: this restores Bash hook composition semantics and the repository has no unreleased changelog section.

## AI Review Report
- Reviewed every early and terminal return path in `_cmux_prompt_command`; each now returns the captured status.
- Regression test executes the real integration in Bash and asserts the downstream hook receives status 7.

## Security Audit
- No authentication, authorization, persistence, networking, or untrusted-input behavior changed.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist
- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787016778&installation_id=133855650&pr_number=8435&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8435&signature=5dc7a65821ebefffebe9677e7b1af96af80bc7a823d5f71f9894f54323071c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve the user command’s exit status across `cmux`’s Bash prompt hook so downstream `PROMPT_COMMAND` hooks (e.g., Starship) see the real code, fixing #5389. Add integration-level regression tests that source the real Bash integration and cover all early-return paths (no transport, no tab, port scan, no panel, full path), and update tests to avoid a temporary-path SAST warning.

<sup>Written for commit 48202a1c16ef486037fbbffe6c5b7bd97b745263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the shell’s original command exit status during CMUX prompt handling, including early-exit scenarios and cases where CMUX transport or required IDs are unavailable.
  * Ensured downstream `PROMPT_COMMAND` hooks receive the correct status from the preceding command.

* **Tests**
  * Added an integration-driven regression test that sources the real CMUX bash integration and verifies status preservation for downstream prompt hooks across multiple CMUX environment permutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->