### PR TITLE
Fix stable IDs in mirror workspace CLI output

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6015,7 +6015,7 @@ struct CMUXCLI {
                 break
             case .refs:
                 let preservesBareID = preservingIDKinds.contains { kind in
-                    (out["ref"] as? String)?.hasPrefix("\(kind):") == true
+                    (out["ref"] as? String)?.split(separator: ":", omittingEmptySubsequences: false).map { $0.count == 2 && $0.first == Substring(kind) && $0.last?.isEmpty == false } == true
                 }
                 if out["ref"] != nil && out["id"] != nil && !preservesBareID {
                     out.removeValue(forKey: "id")

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3576,6 +3576,9 @@ struct CMUXCLI {
         )
 
         let idFormat = try resolvedIDFormat(jsonOutput: jsonOutput, raw: idFormatArg)
+        // Workspace inspection JSON is a scripting boundary: keep stable UUIDs
+        // beside renumberable refs unless the caller explicitly chooses a format.
+        let workspaceInspectionIDFormat: CLIIDFormat = jsonOutput && idFormatArg == nil ? .both : idFormat
         // Most CLI --window routing focuses first so commands without an
         // explicit window_id still target the selected window.
         if let windowId, Self.shouldFocusWindowBeforeDispatch(command: command, commandArgs: commandArgs) {
@@ -4403,6 +4406,7 @@ struct CMUXCLI {
                 client: client,
                 jsonOutput: jsonOutput,
                 idFormat: idFormat,
+                listIDFormat: workspaceInspectionIDFormat,
                 windowOverride: windowId
             )
 
@@ -4423,7 +4427,7 @@ struct CMUXCLI {
                 commandArgs: commandArgs,
                 client: client,
                 jsonOutput: jsonOutput,
-                idFormat: idFormat,
+                idFormat: workspaceInspectionIDFormat,
                 windowOverride: windowId
             )
 
@@ -4568,10 +4572,10 @@ struct CMUXCLI {
             }
 
         case "tree":
-            try runTreeCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+            try runTreeCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: workspaceInspectionIDFormat)
 
         case "top":
-            try runTopCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+            try runTopCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: workspaceInspectionIDFormat)
 
         case "memory":
             try runMemoryCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
@@ -4866,7 +4870,7 @@ struct CMUXCLI {
             try applyWindowOrCallerContext(to: &params, client: client, windowRaw: windowFromArgsOrOverride(commandArgs, windowOverride: windowId))
             let response = try client.sendV2(method: "workspace.current", params: params)
             if jsonOutput {
-                print(jsonString(formatIDs(response, mode: idFormat)))
+                print(jsonString(formatIDs(response, mode: workspaceInspectionIDFormat)))
             } else {
                 let handle = formatHandle(response, kind: "workspace", idFormat: idFormat)
                     ?? (response["workspace_id"] as? String)
@@ -8135,6 +8139,7 @@ struct CMUXCLI {
         client: SocketClient,
         jsonOutput: Bool,
         idFormat: CLIIDFormat,
+        listIDFormat: CLIIDFormat,
         windowOverride: String?
     ) throws {
         guard let sub = commandArgs.first?.lowercased() else {
@@ -8158,7 +8163,7 @@ struct CMUXCLI {
                 commandArgs: rest,
                 client: client,
                 jsonOutput: jsonOutput,
-                idFormat: idFormat,
+                idFormat: listIDFormat,
                 windowOverride: windowOverride
             )
         case "create":

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5997,7 +5997,6 @@ struct CMUXCLI {
         }
         return response
     }
-
     func formatIDs(
         _ object: Any,
         mode: CLIIDFormat,
@@ -6009,14 +6008,15 @@ struct CMUXCLI {
             for (k, v) in dict {
                 out[k] = formatIDs(v, mode: mode, preservingIDKinds: preservingIDKinds)
             }
-
             switch mode {
             case .both:
                 break
             case .refs:
-                let preservesBareID = preservingIDKinds.contains { kind in
-                    (out["ref"] as? String)?.split(separator: ":", omittingEmptySubsequences: false).map { $0.count == 2 && $0.first == Substring(kind) && $0.last?.isEmpty == false } == true
-                }
+                let ref = out["ref"] as? String ?? ""
+                let components = ref.split(separator: ":", omittingEmptySubsequences: false)
+                let preservesBareID = components.count == 2
+                    && !components[1].isEmpty
+                    && preservingIDKinds.contains(String(components[0]))
                 if out["ref"] != nil && out["id"] != nil && !preservesBareID {
                     out.removeValue(forKey: "id")
                 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3578,7 +3578,7 @@ struct CMUXCLI {
         let idFormat = try resolvedIDFormat(jsonOutput: jsonOutput, raw: idFormatArg)
         // Workspace inspection JSON is a scripting boundary: keep stable UUIDs
         // beside renumberable refs unless the caller explicitly chooses a format.
-        let workspaceInspectionIDFormat: CLIIDFormat = jsonOutput && idFormatArg == nil ? .both : idFormat
+        let preserveStableWorkspaceIDs = jsonOutput && idFormatArg == nil
         // Most CLI --window routing focuses first so commands without an
         // explicit window_id still target the selected window.
         if let windowId, Self.shouldFocusWindowBeforeDispatch(command: command, commandArgs: commandArgs) {
@@ -4406,7 +4406,7 @@ struct CMUXCLI {
                 client: client,
                 jsonOutput: jsonOutput,
                 idFormat: idFormat,
-                listIDFormat: workspaceInspectionIDFormat,
+                preserveStableListIDs: preserveStableWorkspaceIDs,
                 windowOverride: windowId
             )
 
@@ -4427,7 +4427,8 @@ struct CMUXCLI {
                 commandArgs: commandArgs,
                 client: client,
                 jsonOutput: jsonOutput,
-                idFormat: workspaceInspectionIDFormat,
+                idFormat: idFormat,
+                preserveStableIDs: preserveStableWorkspaceIDs,
                 windowOverride: windowId
             )
 
@@ -4572,10 +4573,10 @@ struct CMUXCLI {
             }
 
         case "tree":
-            try runTreeCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: workspaceInspectionIDFormat)
+            try runTreeCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat, preserveStableWorkspaceIDs: preserveStableWorkspaceIDs)
 
         case "top":
-            try runTopCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: workspaceInspectionIDFormat)
+            try runTopCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat, preserveStableWorkspaceIDs: preserveStableWorkspaceIDs)
 
         case "memory":
             try runMemoryCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
@@ -4870,7 +4871,11 @@ struct CMUXCLI {
             try applyWindowOrCallerContext(to: &params, client: client, windowRaw: windowFromArgsOrOverride(commandArgs, windowOverride: windowId))
             let response = try client.sendV2(method: "workspace.current", params: params)
             if jsonOutput {
-                print(jsonString(formatIDs(response, mode: workspaceInspectionIDFormat)))
+                print(jsonString(formatWorkspaceInspectionIDs(
+                    response,
+                    mode: idFormat,
+                    preserveStableIDs: preserveStableWorkspaceIDs
+                )))
             } else {
                 let handle = formatHandle(response, kind: "workspace", idFormat: idFormat)
                     ?? (response["workspace_id"] as? String)
@@ -5993,31 +5998,40 @@ struct CMUXCLI {
         return response
     }
 
-    func formatIDs(_ object: Any, mode: CLIIDFormat) -> Any {
+    func formatIDs(
+        _ object: Any,
+        mode: CLIIDFormat,
+        preservingIDKinds: Set<String> = []
+    ) -> Any {
         switch object {
         case let dict as [String: Any]:
             var out: [String: Any] = [:]
             for (k, v) in dict {
-                out[k] = formatIDs(v, mode: mode)
+                out[k] = formatIDs(v, mode: mode, preservingIDKinds: preservingIDKinds)
             }
 
             switch mode {
             case .both:
                 break
             case .refs:
-                if out["ref"] != nil && out["id"] != nil {
+                let preservesBareID = preservingIDKinds.contains { kind in
+                    (out["ref"] as? String)?.hasPrefix("\(kind):") == true
+                }
+                if out["ref"] != nil && out["id"] != nil && !preservesBareID {
                     out.removeValue(forKey: "id")
                 }
                 let keys = Array(out.keys)
                 for key in keys where key.hasSuffix("_id") {
                     let prefix = String(key.dropLast(3))
-                    if out["\(prefix)_ref"] != nil {
+                    let preservesID = preservingIDKinds.contains { prefix == $0 || prefix.hasSuffix("_\($0)") }
+                    if out["\(prefix)_ref"] != nil && !preservesID {
                         out.removeValue(forKey: key)
                     }
                 }
                 for key in keys where key.hasSuffix("_ids") {
                     let prefix = String(key.dropLast(4))
-                    if out["\(prefix)_refs"] != nil {
+                    let preservesIDs = preservingIDKinds.contains { prefix == $0 || prefix.hasSuffix("_\($0)") }
+                    if out["\(prefix)_refs"] != nil && !preservesIDs {
                         out.removeValue(forKey: key)
                     }
                 }
@@ -6042,11 +6056,19 @@ struct CMUXCLI {
             return out
 
         case let array as [Any]:
-            return array.map { formatIDs($0, mode: mode) }
+            return array.map { formatIDs($0, mode: mode, preservingIDKinds: preservingIDKinds) }
 
         default:
             return object
         }
+    }
+
+    func formatWorkspaceInspectionIDs(
+        _ object: Any,
+        mode: CLIIDFormat,
+        preserveStableIDs: Bool
+    ) -> Any {
+        formatIDs(object, mode: mode, preservingIDKinds: preserveStableIDs ? ["workspace"] : [])
     }
 
     func intFromAny(_ value: Any?) -> Int? {
@@ -7387,6 +7409,7 @@ struct CMUXCLI {
         client: SocketClient,
         jsonOutput: Bool,
         idFormat: CLIIDFormat,
+        preserveStableIDs: Bool,
         windowOverride: String?
     ) throws {
         var params: [String: Any] = [:]
@@ -7397,7 +7420,11 @@ struct CMUXCLI {
         )
         let payload = try client.sendV2(method: "workspace.list", params: params)
         if jsonOutput {
-            print(jsonString(formatIDs(payload, mode: idFormat)))
+            print(jsonString(formatWorkspaceInspectionIDs(
+                payload,
+                mode: idFormat,
+                preserveStableIDs: preserveStableIDs
+            )))
         } else {
             let workspaces = payload["workspaces"] as? [[String: Any]] ?? []
             if workspaces.isEmpty {
@@ -8139,7 +8166,7 @@ struct CMUXCLI {
         client: SocketClient,
         jsonOutput: Bool,
         idFormat: CLIIDFormat,
-        listIDFormat: CLIIDFormat,
+        preserveStableListIDs: Bool,
         windowOverride: String?
     ) throws {
         guard let sub = commandArgs.first?.lowercased() else {
@@ -8163,7 +8190,8 @@ struct CMUXCLI {
                 commandArgs: rest,
                 client: client,
                 jsonOutput: jsonOutput,
-                idFormat: listIDFormat,
+                idFormat: idFormat,
+                preserveStableIDs: preserveStableListIDs,
                 windowOverride: windowOverride
             )
         case "create":
@@ -17705,12 +17733,17 @@ struct CMUXCLI {
         commandArgs: [String],
         client: SocketClient,
         jsonOutput: Bool,
-        idFormat: CLIIDFormat
+        idFormat: CLIIDFormat,
+        preserveStableWorkspaceIDs: Bool
     ) throws {
         let options = try parseTreeCommandOptions(commandArgs)
         let payload = try buildTreePayload(options: options, client: client)
         if jsonOutput || options.jsonOutput {
-            print(jsonString(formatIDs(payload, mode: idFormat)))
+            print(jsonString(formatWorkspaceInspectionIDs(
+                payload,
+                mode: idFormat,
+                preserveStableIDs: preserveStableWorkspaceIDs
+            )))
         } else {
             let windows = payload["windows"] as? [[String: Any]] ?? []
             print(renderTreeText(windows: windows, idFormat: idFormat))
@@ -17756,7 +17789,8 @@ struct CMUXCLI {
         commandArgs: [String],
         client: SocketClient,
         jsonOutput: Bool,
-        idFormat: CLIIDFormat
+        idFormat: CLIIDFormat,
+        preserveStableWorkspaceIDs: Bool
     ) throws {
         let options = try parseTopCommandOptions(commandArgs)
         let structuredOutput = jsonOutput || options.jsonOutput
@@ -17768,7 +17802,11 @@ struct CMUXCLI {
         }
         let payload = try buildTopPayload(options: options, client: client)
         if structuredOutput {
-            print(jsonString(formatIDs(payload, mode: idFormat)))
+            print(jsonString(formatWorkspaceInspectionIDs(
+                payload,
+                mode: idFormat,
+                preserveStableIDs: preserveStableWorkspaceIDs
+            )))
         } else {
             switch options.textFormat {
             case .tree:

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -450,6 +450,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */; };
 		773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000002 /* CLIWindowCommandMockServer.swift */; };
 		773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */; };
+		799100000000000000000001 /* CLIWorkspaceStableIDMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */; };
+		799100000000000000000003 /* CLIWorkspaceStableIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799100000000000000000004 /* CLIWorkspaceStableIDTests.swift */; };
 		C10D51700000000000000002 /* ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D51700000000000000001 /* ClosedItemHistory.swift */; };
 		7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */; };
 		B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */; };
@@ -2568,6 +2570,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatResizePaneTests.swift; sourceTree = "<group>"; };
 		773600000000000000000002 /* CLIWindowCommandMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowCommandMockServer.swift; sourceTree = "<group>"; };
 		773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowHandleRoutingTests.swift; sourceTree = "<group>"; };
+		799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceStableIDMockServer.swift; sourceTree = "<group>"; };
+		799100000000000000000004 /* CLIWorkspaceStableIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWorkspaceStableIDTests.swift; sourceTree = "<group>"; };
 		C10D51700000000000000001 /* ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedItemHistory.swift; sourceTree = "<group>"; };
 		7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedMainWindowRoutingTests.swift; sourceTree = "<group>"; };
 		B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWindowConfirmDialogUITests.swift; sourceTree = "<group>"; };
@@ -6001,6 +6005,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A7367002A1B2C3D4E5F60718 /* CLISSHSessionAttachAnchorTests.swift */,
 				773600000000000000000002 /* CLIWindowCommandMockServer.swift */,
 				773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */,
+				799100000000000000000002 /* CLIWorkspaceStableIDMockServer.swift */,
+				799100000000000000000004 /* CLIWorkspaceStableIDTests.swift */,
 				805500000000000000000002 /* CLIBrowserEvalOutputTests.swift */,
 				CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */,
 				C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
@@ -8323,6 +8329,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7837E0057837E0057837E005 /* CLITmuxCompatResizePaneTests.swift in Sources */,
 					773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */,
 					773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */,
+					799100000000000000000001 /* CLIWorkspaceStableIDMockServer.swift in Sources */,
+					799100000000000000000003 /* CLIWorkspaceStableIDTests.swift in Sources */,
 				7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */,
 				C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */,
 				C0DE43000000000000000009 /* CmuxAgentChatConfigTests.swift in Sources */,

--- a/cmuxTests/CLIWorkspaceStableIDMockServer.swift
+++ b/cmuxTests/CLIWorkspaceStableIDMockServer.swift
@@ -1,0 +1,206 @@
+import Darwin
+import Foundation
+
+/// One-connection control-socket fixture that serves a remote-tmux workspace.
+struct CLIWorkspaceStableIDMockServer: Sendable {
+    private let socketPath: String
+    private let listenerDescriptor: Int32
+    private let windowID: String
+    private let workspaceID: String
+
+    init(socketPath: String, windowID: String, workspaceID: String) throws {
+        self.socketPath = socketPath
+        self.windowID = windowID
+        self.workspaceID = workspaceID
+
+        unlink(socketPath)
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            throw Self.posixError("socket")
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathCapacity = MemoryLayout.size(ofValue: address.sun_path)
+        guard socketPath.utf8.count < pathCapacity else {
+            Darwin.close(descriptor)
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ENAMETOOLONG),
+                userInfo: [NSLocalizedDescriptionKey: "Unix socket path is too long"]
+            )
+        }
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                let buffer = UnsafeMutableRawPointer(destination).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, source, pathCapacity - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.bind(descriptor, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0, Darwin.listen(descriptor, 1) == 0 else {
+            let error = Self.posixError("bind/listen")
+            Darwin.close(descriptor)
+            unlink(socketPath)
+            throw error
+        }
+
+        listenerDescriptor = descriptor
+    }
+
+    /// Serves one CLI process and returns the socket requests it sent.
+    func start() -> Task<[String], Never> {
+        Task.detached(priority: .userInitiated) { [self] in
+            defer {
+                Darwin.close(listenerDescriptor)
+                unlink(socketPath)
+            }
+
+            var readiness = pollfd(fd: listenerDescriptor, events: Int16(POLLIN), revents: 0)
+            guard Darwin.poll(&readiness, 1, 5_000) > 0 else { return [] }
+
+            var clientAddress = sockaddr_un()
+            var clientAddressLength = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientDescriptor = withUnsafeMutablePointer(to: &clientAddress) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                    Darwin.accept(listenerDescriptor, socketPointer, &clientAddressLength)
+                }
+            }
+            guard clientDescriptor >= 0 else { return [] }
+            defer { Darwin.close(clientDescriptor) }
+
+            var requests: [String] = []
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4_096)
+            while true {
+                let count = Darwin.read(clientDescriptor, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    return requests
+                }
+                if count == 0 { return requests }
+                pending.append(buffer, count: count)
+
+                while let newline = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newline.lowerBound)
+                    pending.removeSubrange(0...newline.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    requests.append(line)
+                    guard writeResponse(response(for: line), to: clientDescriptor) else {
+                        return requests
+                    }
+                }
+            }
+        }
+    }
+
+    private func response(for line: String) -> String {
+        guard let data = line.data(using: .utf8),
+              let request = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let requestID = request["id"] as? String,
+              let method = request["method"] as? String else {
+            return "ERROR: malformed request"
+        }
+
+        switch method {
+        case "workspace.list":
+            return encodedResponse(
+                id: requestID,
+                result: [
+                    "window_id": windowID,
+                    "window_ref": "window:1",
+                    "workspaces": [workspaceRow()],
+                ]
+            )
+        case "workspace.current":
+            return encodedResponse(
+                id: requestID,
+                result: [
+                    "window_id": windowID,
+                    "window_ref": "window:1",
+                    "workspace_id": workspaceID,
+                    "workspace_ref": "workspace:1",
+                    "workspace": workspaceRow(),
+                ]
+            )
+        case "system.tree", "system.top":
+            return encodedResponse(
+                id: requestID,
+                result: [
+                    "active": NSNull(),
+                    "caller": NSNull(),
+                    "windows": [[
+                        "id": windowID,
+                        "ref": "window:1",
+                        "index": 0,
+                        "workspaces": [workspaceRow()],
+                    ]],
+                ]
+            )
+        default:
+            return encodedResponse(
+                id: requestID,
+                error: ["code": "unexpected_method", "message": method]
+            )
+        }
+    }
+
+    private func workspaceRow() -> [String: Any] {
+        [
+            "id": workspaceID,
+            "ref": "workspace:1",
+            "index": 0,
+            "title": "remote",
+            "has_custom_title": false,
+            "selected": true,
+            "remote": [
+                "enabled": true,
+                "transport": "remote-tmux",
+                "state": "connected",
+            ],
+        ]
+    }
+
+    private func encodedResponse(
+        id: String,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": error == nil]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return "{}" }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func writeResponse(_ response: String, to descriptor: Int32) -> Bool {
+        let data = Data((response + "\n").utf8)
+        return data.withUnsafeBytes { bytes in
+            guard let base = bytes.bindMemory(to: UInt8.self).baseAddress else { return true }
+            var offset = 0
+            while offset < bytes.count {
+                let written = Darwin.write(descriptor, base.advanced(by: offset), bytes.count - offset)
+                if written > 0 {
+                    offset += written
+                } else if written < 0, errno == EINTR {
+                    continue
+                } else {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+
+    private static func posixError(_ operation: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(errno)))"]
+        )
+    }
+}

--- a/cmuxTests/CLIWorkspaceStableIDMockServer.swift
+++ b/cmuxTests/CLIWorkspaceStableIDMockServer.swift
@@ -127,7 +127,7 @@ struct CLIWorkspaceStableIDMockServer: Sendable {
                     "workspace": workspaceRow(),
                 ]
             )
-        case "system.tree", "system.top":
+        case "system.tree":
             return encodedResponse(
                 id: requestID,
                 result: [
@@ -141,6 +141,20 @@ struct CLIWorkspaceStableIDMockServer: Sendable {
                     ]],
                 ]
             )
+        case "system.top":
+            return encodedResponse(
+                id: requestID,
+                result: [
+                    "active": NSNull(),
+                    "caller": NSNull(),
+                    "windows": [[
+                        "id": windowID,
+                        "ref": "window:1",
+                        "index": 0,
+                        "workspaces": [workspaceRow(includingTopTag: true)],
+                    ]],
+                ]
+            )
         default:
             return encodedResponse(
                 id: requestID,
@@ -149,8 +163,8 @@ struct CLIWorkspaceStableIDMockServer: Sendable {
         }
     }
 
-    private func workspaceRow() -> [String: Any] {
-        [
+    private func workspaceRow(includingTopTag: Bool = false) -> [String: Any] {
+        var row: [String: Any] = [
             "id": workspaceID,
             "ref": "workspace:1",
             "index": 0,
@@ -172,6 +186,17 @@ struct CLIWorkspaceStableIDMockServer: Sendable {
                 "state": "connected",
             ],
         ]
+        if includingTopTag {
+            row["tags"] = [[
+                "kind": "tag",
+                "id": "\(workspaceID):tag:agent",
+                "ref": "workspace:\(workspaceID):tag:agent",
+                "index": 0,
+                "key": "agent",
+                "value": "running",
+            ]]
+        }
+        return row
     }
 
     private func encodedResponse(

--- a/cmuxTests/CLIWorkspaceStableIDMockServer.swift
+++ b/cmuxTests/CLIWorkspaceStableIDMockServer.swift
@@ -171,6 +171,8 @@ struct CLIWorkspaceStableIDMockServer: Sendable {
             "title": "remote",
             "has_custom_title": false,
             "selected": true,
+            "workspace_ids": [workspaceID],
+            "workspace_refs": ["workspace:1"],
             "panes": [[
                 "id": Self.paneID,
                 "ref": "pane:1",

--- a/cmuxTests/CLIWorkspaceStableIDMockServer.swift
+++ b/cmuxTests/CLIWorkspaceStableIDMockServer.swift
@@ -157,6 +157,15 @@ struct CLIWorkspaceStableIDMockServer: Sendable {
             "title": "remote",
             "has_custom_title": false,
             "selected": true,
+            "panes": [[
+                "id": Self.paneID,
+                "ref": "pane:1",
+                "surfaces": [[
+                    "id": Self.surfaceID,
+                    "ref": "surface:1",
+                    "type": "terminal",
+                ]],
+            ]],
             "remote": [
                 "enabled": true,
                 "transport": "remote-tmux",
@@ -203,4 +212,7 @@ struct CLIWorkspaceStableIDMockServer: Sendable {
             userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(errno)))"]
         )
     }
+
+    private static let paneID = "33333333-3333-3333-3333-333333333333"
+    private static let surfaceID = "44444444-4444-4444-4444-444444444444"
 }

--- a/cmuxTests/CLIWorkspaceStableIDTests.swift
+++ b/cmuxTests/CLIWorkspaceStableIDTests.swift
@@ -19,9 +19,11 @@ struct CLIWorkspaceStableIDTests {
             let result = try await run(command: command, cliPath: cliPath)
             #expect(!result.timedOut, Comment(rawValue: result.stderr))
             #expect(result.status == 0, Comment(rawValue: result.stderr))
-            let workspace = try workspaceRow(in: result.stdout)
+            let root = try responseObject(in: result.stdout)
+            let workspace = try workspaceRow(in: root)
             #expect(workspace["id"] as? String == Self.workspaceID, Comment(rawValue: "command=\(command) row=\(workspace)"))
             #expect(workspace["ref"] as? String == "workspace:1", Comment(rawValue: "command=\(command) row=\(workspace)"))
+            assertDefaultIdentifierShape(in: root, command: command)
         }
     }
 
@@ -42,7 +44,7 @@ struct CLIWorkspaceStableIDTests {
             let result = try await run(command: command, cliPath: cliPath)
             #expect(!result.timedOut, Comment(rawValue: result.stderr))
             #expect(result.status == 0, Comment(rawValue: result.stderr))
-            let workspace = try workspaceRow(in: result.stdout)
+            let workspace = try workspaceRow(in: responseObject(in: result.stdout))
             #expect((workspace["id"] as? String) == (expectation.hasID ? Self.workspaceID : nil))
             #expect((workspace["ref"] as? String) == (expectation.hasRef ? "workspace:1" : nil))
         }
@@ -77,11 +79,14 @@ struct CLIWorkspaceStableIDTests {
         return result
     }
 
-    private func workspaceRow(in stdout: String) throws -> [String: Any] {
-        let root = try #require(
+    private func responseObject(in stdout: String) throws -> [String: Any] {
+        try #require(
             JSONSerialization.jsonObject(with: Data(stdout.utf8)) as? [String: Any],
             "Expected JSON object, got: \(stdout)"
         )
+    }
+
+    private func workspaceRow(in root: [String: Any]) throws -> [String: Any] {
         if let workspace = (root["workspaces"] as? [[String: Any]])?.first {
             return workspace
         }
@@ -90,6 +95,34 @@ struct CLIWorkspaceStableIDTests {
         }
         let window = try #require((root["windows"] as? [[String: Any]])?.first)
         return try #require((window["workspaces"] as? [[String: Any]])?.first)
+    }
+
+    private func assertDefaultIdentifierShape(in value: Any, command: [String]) {
+        if let dictionary = value as? [String: Any] {
+            if let ref = dictionary["ref"] as? String {
+                let id = dictionary["id"] as? String
+                if ref.hasPrefix("workspace:") {
+                    #expect(id == Self.workspaceID, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                } else {
+                    #expect(id == nil, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                }
+            }
+            for kind in ["window", "workspace", "pane", "surface"] where dictionary["\(kind)_ref"] != nil {
+                let id = dictionary["\(kind)_id"] as? String
+                if kind == "workspace" {
+                    #expect(id == Self.workspaceID, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                } else {
+                    #expect(id == nil, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                }
+            }
+            for child in dictionary.values {
+                assertDefaultIdentifierShape(in: child, command: command)
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                assertDefaultIdentifierShape(in: child, command: command)
+            }
+        }
     }
 
     private static func runProcess(

--- a/cmuxTests/CLIWorkspaceStableIDTests.swift
+++ b/cmuxTests/CLIWorkspaceStableIDTests.swift
@@ -141,6 +141,14 @@ struct CLIWorkspaceStableIDTests {
                     #expect(id == nil, Comment(rawValue: "command=\(command) row=\(dictionary)"))
                 }
             }
+            for kind in ["window", "workspace", "pane", "surface"] where dictionary["\(kind)_refs"] != nil {
+                let ids = dictionary["\(kind)_ids"] as? [String]
+                if kind == "workspace" {
+                    #expect(ids == [Self.workspaceID], Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                } else {
+                    #expect(ids == nil, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                }
+            }
             for child in dictionary.values {
                 assertDefaultIdentifierShape(in: child, command: command)
             }

--- a/cmuxTests/CLIWorkspaceStableIDTests.swift
+++ b/cmuxTests/CLIWorkspaceStableIDTests.swift
@@ -24,6 +24,11 @@ struct CLIWorkspaceStableIDTests {
             #expect(workspace["id"] as? String == Self.workspaceID, Comment(rawValue: "command=\(command) row=\(workspace)"))
             #expect(workspace["ref"] as? String == "workspace:1", Comment(rawValue: "command=\(command) row=\(workspace)"))
             assertDefaultIdentifierShape(in: root, command: command)
+            if command.first == "top" {
+                let tag = try topTagRow(in: root)
+                #expect(tag["id"] == nil, Comment(rawValue: "command=\(command) row=\(tag)"))
+                #expect(tag["ref"] as? String == "workspace:\(Self.workspaceID):tag:agent")
+            }
         }
     }
 
@@ -36,17 +41,31 @@ struct CLIWorkspaceStableIDTests {
             ("both", true, true),
         ]
 
+        let commands = [
+            ["list-workspaces", "--window", Self.windowID, "--json"],
+            ["workspace", "list", "--window", Self.windowID, "--json"],
+            ["current-workspace", "--window", Self.windowID, "--json"],
+            ["tree", "--window", Self.windowID, "--json"],
+            ["top", "--window", Self.windowID, "--json"],
+        ]
+
         for expectation in expectations {
-            let command = [
-                "workspace", "list", "--window", Self.windowID, "--json",
-                "--id-format", expectation.mode,
-            ]
-            let result = try await run(command: command, cliPath: cliPath)
-            #expect(!result.timedOut, Comment(rawValue: result.stderr))
-            #expect(result.status == 0, Comment(rawValue: result.stderr))
-            let workspace = try workspaceRow(in: responseObject(in: result.stdout))
-            #expect((workspace["id"] as? String) == (expectation.hasID ? Self.workspaceID : nil))
-            #expect((workspace["ref"] as? String) == (expectation.hasRef ? "workspace:1" : nil))
+            for baseCommand in commands {
+                let command = baseCommand + ["--id-format", expectation.mode]
+                let result = try await run(command: command, cliPath: cliPath)
+                #expect(!result.timedOut, Comment(rawValue: result.stderr))
+                #expect(result.status == 0, Comment(rawValue: result.stderr))
+                let root = try responseObject(in: result.stdout)
+                let workspace = try workspaceRow(in: root)
+                #expect((workspace["id"] as? String) == (expectation.hasID ? Self.workspaceID : nil))
+                #expect((workspace["ref"] as? String) == (expectation.hasRef ? "workspace:1" : nil))
+                assertExplicitIdentifierShape(
+                    in: root,
+                    command: command,
+                    hasIDs: expectation.hasID,
+                    hasRefs: expectation.hasRef
+                )
+            }
         }
     }
 
@@ -97,11 +116,18 @@ struct CLIWorkspaceStableIDTests {
         return try #require((window["workspaces"] as? [[String: Any]])?.first)
     }
 
+    private func topTagRow(in root: [String: Any]) throws -> [String: Any] {
+        let window = try #require((root["windows"] as? [[String: Any]])?.first)
+        let workspace = try #require((window["workspaces"] as? [[String: Any]])?.first)
+        return try #require((workspace["tags"] as? [[String: Any]])?.first)
+    }
+
     private func assertDefaultIdentifierShape(in value: Any, command: [String]) {
         if let dictionary = value as? [String: Any] {
             if let ref = dictionary["ref"] as? String {
                 let id = dictionary["id"] as? String
-                if ref.hasPrefix("workspace:") {
+                let components = ref.split(separator: ":", omittingEmptySubsequences: false)
+                if components.count == 2, components.first == Substring("workspace") {
                     #expect(id == Self.workspaceID, Comment(rawValue: "command=\(command) row=\(dictionary)"))
                 } else {
                     #expect(id == nil, Comment(rawValue: "command=\(command) row=\(dictionary)"))
@@ -121,6 +147,58 @@ struct CLIWorkspaceStableIDTests {
         } else if let array = value as? [Any] {
             for child in array {
                 assertDefaultIdentifierShape(in: child, command: command)
+            }
+        }
+    }
+
+    private func assertExplicitIdentifierShape(
+        in value: Any,
+        command: [String],
+        hasIDs: Bool,
+        hasRefs: Bool
+    ) {
+        if let dictionary = value as? [String: Any] {
+            if dictionary["id"] != nil || dictionary["ref"] != nil {
+                #expect((dictionary["id"] != nil) == hasIDs, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                #expect((dictionary["ref"] != nil) == hasRefs, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+            }
+
+            let singularPrefixes = Set(dictionary.keys.compactMap { key -> String? in
+                if key.hasSuffix("_id") { return String(key.dropLast(3)) }
+                if key.hasSuffix("_ref") { return String(key.dropLast(4)) }
+                return nil
+            })
+            for prefix in singularPrefixes {
+                #expect((dictionary["\(prefix)_id"] != nil) == hasIDs, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                #expect((dictionary["\(prefix)_ref"] != nil) == hasRefs, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+            }
+
+            let pluralPrefixes = Set(dictionary.keys.compactMap { key -> String? in
+                if key.hasSuffix("_ids") { return String(key.dropLast(4)) }
+                if key.hasSuffix("_refs") { return String(key.dropLast(5)) }
+                return nil
+            })
+            for prefix in pluralPrefixes {
+                #expect((dictionary["\(prefix)_ids"] != nil) == hasIDs, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+                #expect((dictionary["\(prefix)_refs"] != nil) == hasRefs, Comment(rawValue: "command=\(command) row=\(dictionary)"))
+            }
+
+            for child in dictionary.values {
+                assertExplicitIdentifierShape(
+                    in: child,
+                    command: command,
+                    hasIDs: hasIDs,
+                    hasRefs: hasRefs
+                )
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                assertExplicitIdentifierShape(
+                    in: child,
+                    command: command,
+                    hasIDs: hasIDs,
+                    hasRefs: hasRefs
+                )
             }
         }
     }

--- a/cmuxTests/CLIWorkspaceStableIDTests.swift
+++ b/cmuxTests/CLIWorkspaceStableIDTests.swift
@@ -1,0 +1,145 @@
+import Darwin
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct CLIWorkspaceStableIDTests {
+    @Test("Workspace inspection JSON keeps mirror UUIDs by default")
+    func workspaceInspectionJSONKeepsMirrorUUIDsByDefault() async throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+        let commands = [
+            ["list-workspaces", "--window", Self.windowID, "--json"],
+            ["workspace", "list", "--window", Self.windowID, "--json"],
+            ["current-workspace", "--window", Self.windowID, "--json"],
+            ["tree", "--window", Self.windowID, "--json"],
+            ["top", "--window", Self.windowID, "--json"],
+        ]
+
+        for command in commands {
+            let result = try await run(command: command, cliPath: cliPath)
+            #expect(!result.timedOut, Comment(rawValue: result.stderr))
+            #expect(result.status == 0, Comment(rawValue: result.stderr))
+            let workspace = try workspaceRow(in: result.stdout)
+            #expect(workspace["id"] as? String == Self.workspaceID, Comment(rawValue: "command=\(command) row=\(workspace)"))
+            #expect(workspace["ref"] as? String == "workspace:1", Comment(rawValue: "command=\(command) row=\(workspace)"))
+        }
+    }
+
+    @Test("Explicit ID formats still shape workspace inspection JSON")
+    func explicitIDFormatsStillShapeWorkspaceInspectionJSON() async throws {
+        let cliPath = try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
+        let expectations: [(mode: String, hasID: Bool, hasRef: Bool)] = [
+            ("refs", false, true),
+            ("uuids", true, false),
+            ("both", true, true),
+        ]
+
+        for expectation in expectations {
+            let command = [
+                "workspace", "list", "--window", Self.windowID, "--json",
+                "--id-format", expectation.mode,
+            ]
+            let result = try await run(command: command, cliPath: cliPath)
+            #expect(!result.timedOut, Comment(rawValue: result.stderr))
+            #expect(result.status == 0, Comment(rawValue: result.stderr))
+            let workspace = try workspaceRow(in: result.stdout)
+            #expect((workspace["id"] as? String) == (expectation.hasID ? Self.workspaceID : nil))
+            #expect((workspace["ref"] as? String) == (expectation.hasRef ? "workspace:1" : nil))
+        }
+    }
+
+    private func run(
+        command: [String],
+        cliPath: String
+    ) async throws -> (status: Int32, stdout: String, stderr: String, timedOut: Bool) {
+        let socketPath = Self.socketPath()
+        let server = try CLIWorkspaceStableIDMockServer(
+            socketPath: socketPath,
+            windowID: Self.windowID,
+            workspaceID: Self.workspaceID
+        )
+        let requests = server.start()
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "2"
+        let result = Self.runProcess(
+            executablePath: cliPath,
+            arguments: command,
+            environment: environment
+        )
+        let received = await requests.value
+        #expect(received.count == 1, Comment(rawValue: "command=\(command) requests=\(received)"))
+        return result
+    }
+
+    private func workspaceRow(in stdout: String) throws -> [String: Any] {
+        let root = try #require(
+            JSONSerialization.jsonObject(with: Data(stdout.utf8)) as? [String: Any],
+            "Expected JSON object, got: \(stdout)"
+        )
+        if let workspace = (root["workspaces"] as? [[String: Any]])?.first {
+            return workspace
+        }
+        if let workspace = root["workspace"] as? [String: Any] {
+            return workspace
+        }
+        let window = try #require((root["windows"] as? [[String: Any]])?.first)
+        return try #require((window["workspaces"] as? [[String: Any]])?.first)
+    }
+
+    private static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String]
+    ) -> (status: Int32, stdout: String, stderr: String, timedOut: Bool) {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        // One-shot process completion signal; it does not guard mutable state.
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exited.signal() }
+        do {
+            try process.run()
+        } catch {
+            return (-1, "", String(describing: error), false)
+        }
+
+        let timedOut = exited.wait(timeout: .now() + 5) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exited.wait(timeout: .now() + 1) == .timedOut, process.isRunning {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                _ = exited.wait(timeout: .now() + 1)
+            }
+        }
+
+        return (
+            timedOut ? 124 : process.terminationStatus,
+            String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            timedOut
+        )
+    }
+
+    private static func socketPath() -> String {
+        let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-wsid-\(suffix).sock")
+            .path
+    }
+
+    private static let windowID = "11111111-1111-1111-1111-111111111111"
+    private static let workspaceID = "22222222-2222-2222-2222-222222222222"
+}

--- a/tests_v2/test_cli_id_format_defaults.py
+++ b/tests_v2/test_cli_id_format_defaults.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression: CLI defaults to refs output; UUIDs only when requested."""
+"""Regression: refs-first defaults retain stable workspace inspection UUIDs."""
 
 import glob
 import json
@@ -150,8 +150,8 @@ def main() -> int:
             f"list-workspaces default should include refs: {ws_default}",
         )
         _must(
-            len(_id_ref_pairs(ws_default)) == 0,
-            f"list-workspaces default should suppress id when ref exists; pairs={_id_ref_pairs(ws_default)}",
+            len(_id_ref_pairs(ws_default)) > 0,
+            f"list-workspaces default should retain stable ids alongside refs; payload={ws_default}",
         )
 
     # surface-health

--- a/tests_v2/test_cli_id_format_defaults.py
+++ b/tests_v2/test_cli_id_format_defaults.py
@@ -149,10 +149,11 @@ def main() -> int:
             _has_any_key(ws_default, lambda k: k.endswith("_ref") or k == "ref"),
             f"list-workspaces default should include refs: {ws_default}",
         )
-        _must(
-            len(_id_ref_pairs(ws_default)) > 0,
-            f"list-workspaces default should retain stable ids alongside refs; payload={ws_default}",
-        )
+        for workspace in workspaces:
+            _must(
+                isinstance(workspace, dict) and bool(workspace.get("id")) and bool(workspace.get("ref")),
+                f"Every listed workspace should retain a stable id alongside its ref; workspace={workspace} payload={ws_default}",
+            )
 
     # surface-health
     health_default = _run_cli_json(cli, ["surface-health"])


### PR DESCRIPTION
## Summary

- cover remote-tmux mirror workspace IDs through the bundled CLI and a deterministic fake control socket
- retain stable workspace UUIDs alongside refs by default for JSON workspace discovery/inspection
- apply the shared default to `list-workspaces`, `workspace list`, `current-workspace`, `tree`, and `top`
- preserve explicit `--id-format refs|uuids|both` behavior

## Testing

- `./scripts/reload.sh --tag issue-7991-mirror-workspace-id-null`
- isolated fake-socket CLI matrix for all five commands and all ID formats
- `swiftc -parse` for changed Swift files
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `git diff --check`

Per the task instructions, no local Xcode tests or XCUITests were run.

Closes #7991

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787018377&installation_id=133855650&pr_number=8437&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8437&signature=ad49b2849b700d97138081a6ea41e3b4d3bbf885d279ef4c4c6e61417821de9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix unstable or missing workspace UUIDs in CLI JSON for mirror workspaces. Default inspection `--json` keeps each workspace’s UUID next to its ref, including `workspace_id` and `workspace_ids`, while other IDs are hidden unless `--id-format` is set.

- **Bug Fixes**
  - Default `--json` for `list-workspaces`, `workspace list`, `current-workspace`, `tree`, and `top` preserves IDs only for exact workspace refs; window/pane/surface IDs and top tag IDs stay hidden unless `--id-format` is `uuids` or `both`.
  - Added a deterministic fake control socket and tests covering singular and plural workspace identifiers; new Swift suite and updated Python regression validate all five commands, explicit `id-format` behavior, and the exact-ref rule.

<sup>Written for commit 131033f019160ba5ed8c35f67e902eda13d08aae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced workspace inspection `--json` output to preserve stable workspace `id`/list identifiers by default (when no explicit `--id-format` is provided).
  - Improved consistency of `--id-format` behavior across inspection-style outputs (workspace list/current and tree/top).

- **Bug Fixes**
  - Corrected default CLI JSON formatting to retain workspace `id`/`ref` fields as expected.

- **Tests**
  - Added a Unix-socket mock server fixture and a serialized CLI test suite for workspace identifier stability.
  - Updated related regression assertions for default output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->