### PR TITLE
Remove working directory control from agent chat

### DIFF
--- a/agent-chat/README.md
+++ b/agent-chat/README.md
@@ -51,7 +51,7 @@ bun test/e2e.ts               # or: bun test/e2e.ts codex pi
 The frontend is a small React app built with Bun and styled to match the
 terminal. Dropdowns and controls use `@base-ui-components/react` (Base UI),
 the same component library the cmux web app uses: `Select` for the provider
-picker and `Popover` for the working-directory editor and overflow menus.
+picker and `Popover` for overflow menus.
 Base UI ships unstyled, so every part is themed with the resolved Ghostty
 colors. The server bundles `src/main.tsx` with `Bun.build` on startup and
 serves it as `/app.js`; the HTML shell injects the theme CSS variables and

--- a/agent-chat/public/app.css
+++ b/agent-chat/public/app.css
@@ -130,10 +130,8 @@ button, [role="button"], .menu-item, .model-row, .row-control { cursor: default 
   0%, 100% { opacity: .58; }
   50% { opacity: 1; }
 }
-.row-value, .cwd-label { overflow: hidden; text-overflow: ellipsis; }
-.cwd-label { font-family: var(--font-mono); font-size: calc(var(--font-size-base) - 2.5px); }
+.row-value { overflow: hidden; text-overflow: ellipsis; }
 .provider-trigger, .provider-model-trigger { max-width: 360px; }
-.cwd-trigger { max-width: 150px; }
 .row-select { max-width: 220px; }
 .row-icon-only { width: 24px; justify-content: center; padding: 0; }
 .fast-toggle {
@@ -312,17 +310,6 @@ button, [role="button"], .menu-item, .model-row, .row-control { cursor: default 
 .command-item.active { background: var(--bg-hover); color: var(--text); }
 .cmd-name { flex: none; color: var(--text); font-family: var(--font-mono); }
 .cmd-desc { color: var(--text-faint); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-.popover {
-  min-width: 340px; max-width: 70vw; background: var(--bg-raised); border: 0;
-  border-radius: 12px; padding: 12px; box-shadow: 0 12px 32px rgba(0,0,0,.4); z-index: 30;
-}
-.popover-label { font: 600 calc(var(--font-size-base) - 3px) var(--font-sans); color: var(--text-faint); margin-bottom: 6px; }
-.cwd-edit {
-  width: 100%; height: 32px; padding: 0 10px; border-radius: 8px;
-  border: 0; background: var(--bg); color: var(--text);
-  font: var(--font-size-code) var(--font-mono); outline: none;
-}
 
 #composer-hint { color: var(--text-faint); font-size: calc(var(--font-size-base) - 2px); }
 .composer-error { width: min(660px, 100%); color: var(--red); font-size: calc(var(--font-size-base) - 2px); }
@@ -645,8 +632,6 @@ details.thinking .t-body { white-space: pre-wrap; font-size: calc(var(--font-siz
 }
 
 @container (max-width: 520px) {
-  .status-row .cwd-label { display: none; }
-  .status-row .cwd-trigger { max-width: 24px; }
   .status-row .row-select:not(.provider-model-trigger) .row-value { max-width: 78px; }
 }
 @container (max-width: 390px) {

--- a/agent-chat/src/components/Chat.tsx
+++ b/agent-chat/src/components/Chat.tsx
@@ -158,7 +158,6 @@ export function Chat() {
             providers={providers}
             allProviderOptions={allProviderOptions}
             onProviderModelChange={switchHarnessModel}
-            cwd={session?.cwd ?? ""}
             options={options}
             onChange={setOption}
             openOptionId={openOptionId}

--- a/agent-chat/src/components/Composer.tsx
+++ b/agent-chat/src/components/Composer.tsx
@@ -101,13 +101,6 @@ export function Composer() {
     localStorage.setItem("agentui.provider", provider);
     localStorage.setItem("agentui.cwd", runCwd);
   };
-  const changeCwd = (v: string) => { setCwd(v); };
-  const commitCwd = (v: string) => {
-    const next = v.trim();
-    if (!next) return;
-    setCommittedCwd(next);
-    localStorage.setItem("agentui.cwd", next);
-  };
   const changeProvider = (v: string) => {
     setProvider(v);
     setStartOptionsByProvider((all) => all[v] ? all : { ...all, [v]: readProviderOptions(v) });
@@ -153,9 +146,6 @@ export function Composer() {
           providers={providers}
           allProviderOptions={allProviderOptions}
           onProviderModelChange={changeProviderModel}
-          cwd={cwd}
-          onCwdChange={changeCwd}
-          onCwdCommit={commitCwd}
           options={options}
           onChange={setLocalOption}
           openOptionId={openOptionId}

--- a/agent-chat/src/components/StatusRow.tsx
+++ b/agent-chat/src/components/StatusRow.tsx
@@ -2,44 +2,10 @@ import { Popover } from "@base-ui-components/react/popover";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState, type Dispatch, type ReactNode, type RefObject, type SetStateAction } from "react";
 import { menuActionForKey } from "../keymap";
 import type { OptionValue, Provider, SessionOption } from "../session";
-import { BarsIcon, BoltIcon, Check, Chevron, EllipsisIcon, FolderIcon, PlanIcon, ProviderIcon, SearchIcon, ShieldIcon, SparkIcon, basename } from "./icons";
+import { BarsIcon, BoltIcon, Check, Chevron, EllipsisIcon, PlanIcon, ProviderIcon, SearchIcon, ShieldIcon, SparkIcon } from "./icons";
 import { CmdkMenu, type CmdkGroup } from "./CmdkMenu";
 import { HintTooltip } from "./Tooltips";
 import { currentChoice, cycleSelect, effortFill, isOffLikeValue, optionAction, optionTooltip, prettyValue, visibleChoices } from "./options";
-
-function CwdPopover({ cwd, onChange, onCommit }: { cwd: string; onChange: (v: string) => void; onCommit: (v: string) => void }) {
-  return (
-    <Popover.Root onOpenChange={(open) => { if (!open) onCommit(cwd); }}>
-      <HintTooltip label="Change working directory">
-        <Popover.Trigger className="row-control cwd-trigger">
-          <FolderIcon />
-          <span className="cwd-label">{basename(cwd)}</span>
-        </Popover.Trigger>
-      </HintTooltip>
-      <Popover.Portal>
-        <Popover.Positioner sideOffset={8} align="start">
-          <Popover.Popup className="popover" data-agent-popup="true">
-            <div className="popover-label">Working directory</div>
-            <input
-              className="cwd-edit"
-              spellCheck={false}
-              value={cwd}
-              autoFocus
-              onChange={(e) => onChange(e.target.value)}
-              onBlur={(e) => onCommit(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  onCommit((e.target as HTMLInputElement).value);
-                  (e.target as HTMLInputElement).blur();
-                }
-              }}
-            />
-          </Popover.Popup>
-        </Popover.Positioner>
-      </Popover.Portal>
-    </Popover.Root>
-  );
-}
 
 function InlineSelect({
   option,
@@ -146,17 +112,6 @@ function StaticProvider({ provider, running = false }: { provider: Provider; run
       <span className={"row-control static-provider" + (running ? " provider-running" : "")}>
         <ProviderIcon provider={provider} />
         <span className="row-value">{provider.label}</span>
-      </span>
-    </HintTooltip>
-  );
-}
-
-function StaticCwd({ cwd }: { cwd: string }) {
-  return (
-    <HintTooltip label="Working directory">
-      <span className="row-control cwd-trigger">
-        <FolderIcon />
-        <span className="cwd-label">{basename(cwd)}</span>
       </span>
     </HintTooltip>
   );
@@ -491,9 +446,6 @@ export function StatusRow({
   providers,
   allProviderOptions,
   onProviderModelChange,
-  cwd,
-  onCwdChange,
-  onCwdCommit,
   options,
   onChange,
   openOptionId,
@@ -505,9 +457,6 @@ export function StatusRow({
   providers?: Provider[];
   allProviderOptions?: Record<string, SessionOption[]>;
   onProviderModelChange?: (provider: string, model: string) => void;
-  cwd: string;
-  onCwdChange?: (v: string) => void;
-  onCwdCommit?: (v: string) => void;
   options: SessionOption[];
   onChange: (id: string, value: OptionValue) => void;
   openOptionId: string | null;
@@ -582,7 +531,6 @@ export function StatusRow({
           </button>
         </HintTooltip>
       ) : null}
-      {onCwdChange && onCwdCommit ? <CwdPopover cwd={cwd} onChange={onCwdChange} onCommit={onCwdCommit} /> : <StaticCwd cwd={cwd} />}
       {approval ? (
         <HintTooltip label={optionTooltip(approval)}>
           <button

--- a/agent-chat/src/gallery.tsx
+++ b/agent-chat/src/gallery.tsx
@@ -19,8 +19,6 @@ import {
 } from "./gallery-fixtures";
 import { groupTurns } from "./turns";
 
-const cwd = "/Users/lawrence/fun/cmuxterm-hq/worktrees/feat-agent-chat-ui/agent-chat";
-
 function setOption(options: SessionOption[], id: string, value: OptionValue): SessionOption[] {
   return options.map((o) => o.id === id ? { ...o, value } : o);
 }
@@ -50,7 +48,6 @@ function DemoStatusRow({
         providers={galleryProviders}
         allProviderOptions={galleryOptions}
         onProviderModelChange={(nextProvider, model) => console.log("gallery model", nextProvider, model)}
-        cwd={cwd}
         options={options}
         onChange={(id, value) => setOptions((current) => setOption(current, id, value))}
         openOptionId={openOptionId}
@@ -80,7 +77,6 @@ function ComposerMock({ state }: { state: "idle" | "starting" | "draft" | "error
           providers={galleryProviders}
           allProviderOptions={galleryOptions}
           onProviderModelChange={(p, model) => console.log("gallery composer pick", p, model)}
-          cwd={cwd}
           options={galleryOptions[provider]}
           onChange={(id, value) => console.log("gallery composer option", id, value)}
           openOptionId={null}


### PR DESCRIPTION
Removes the working-directory chip and editor from the shared agent-chat status row. Agent sessions still receive their resolved working directory internally.

Verification:
- `bun run check`
- `bun run build`
- Tagged WKWebView preflight in `nocwd`: `.status-row` = 1, `.cwd-trigger` = 0, `.cwd-edit` = 0
- No WKWebView console errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787030662&installation_id=133855650&pr_number=8448&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8448&signature=14c95dad9786d728a6b7e99d3115f6c8b68cc8a2d8b122681c860c0ba629be2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the working-directory chip and editor from the agent chat status row. Sessions still resolve and use the working directory internally.

- **Refactors**
  - Removed cwd props and UI from `StatusRow`, `Composer`, `Chat`, and `src/gallery.tsx`.
  - Deleted related CSS (`.cwd-*`, popover styles) and updated README to reflect `Popover` usage only for overflow menus.

<sup>Written for commit 7fa894b07a7311084fedaa7973c5459e802ec245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed working-directory display and editing controls from chat status rows.
  * Simplified status-row layouts, including improved value truncation.
  * Removed obsolete working-directory popover styling and small-screen layout overrides.

* **Documentation**
  * Updated the architecture documentation to describe popovers as overflow menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->