### PR TITLE
Fix AppKit sidebar agent status labels

### DIFF
--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Status/SidebarStatusEntry+Presentation.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Status/SidebarStatusEntry+Presentation.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public extension SidebarStatusEntry {
+extension SidebarStatusEntry {
     /// Text shown for this entry by every built-in workspace sidebar renderer.
-    var sidebarDisplayText: String {
+    public var sidebarDisplayText: String {
         let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedValue.isEmpty ? key : trimmedValue
     }

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Status/SidebarStatusEntry+Presentation.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Status/SidebarStatusEntry+Presentation.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public extension SidebarStatusEntry {
+    /// Text shown for this entry by every built-in workspace sidebar renderer.
+    var sidebarDisplayText: String {
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? key : trimmedValue
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15861,10 +15861,7 @@ private struct SidebarMetadataRows: View {
     }
 
     private var helpText: String {
-        entries.map { entry in
-            let trimmed = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? entry.key : trimmed
-        }
+        entries.map(\.sidebarDisplayText)
         .joined(separator: "\n")
     }
 
@@ -15954,8 +15951,7 @@ private struct SidebarMetadataEntryRow: View {
 
     @ViewBuilder
     private func metadataText(underlined: Bool) -> some View {
-        let trimmed = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
-        let display = trimmed.isEmpty ? entry.key : trimmed
+        let display = entry.sidebarDisplayText
         if entry.format == .markdown,
            let attributed = try? AttributedString(
                 markdown: display,

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -106,8 +106,7 @@ final class SidebarRowIconTextLine: NSView {
                 }
             }
         }
-        let text = entry.key.isEmpty ? entry.value : "\(entry.key): \(entry.value)"
-        textView.stringValue = text
+        textView.stringValue = entry.sidebarDisplayText
         textView.font = .systemFont(ofSize: model.scaled(10))
         textView.textColor = color
         needsLayout = true

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -190,6 +190,22 @@ struct SidebarAppKitRowCellTests {
         return cell
     }
 
+    @Test(arguments: zip(["codex", "claude_code"], ["Running", "Needs input"]))
+    func metadataStatusTextOmitsRawAgentKey(_ key: String, _ status: String) throws {
+        let model = Self.makeModel()
+        let row = SidebarRowIconTextLine()
+
+        row.configureMetadataEntry(
+            SidebarStatusEntry(key: key, value: status, icon: "bolt.fill"),
+            model: model,
+            color: .labelColor
+        )
+
+        let textView = try #require(row.subviews.compactMap { $0 as? SidebarRowTextView }.first)
+        #expect(textView.stringValue == status)
+        #expect(!textView.stringValue.contains(key))
+    }
+
     @Test
     func hoverEnforcementShortCircuitsWhenAlreadyCorrect() {
         let model = Self.makeModel()

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxSidebar
 import Testing
 @testable import cmux_DEV
 


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/8445

## Summary

- Centralize the original SwiftUI `SidebarStatusEntry` display rule and have both built-in sidebar renderers consume it.
- Remove the AppKit-only raw key prefix, so status pills render `Running` / `Needs input` instead of `codex: Running` / `claude_code: Needs input`.
- Keep the fix narrow against current `main`; this addresses one drift tracked by https://github.com/manaflow-ai/cmux/issues/8409 without taking the broader, conflicting changes from https://github.com/manaflow-ai/cmux/pull/8413.

## Testing

- Commit 1 adds a behavior regression test against the real AppKit metadata row for Codex and Claude hook keys.
- Commit 2 adds the shared presentation helper and switches both renderers to it.
- Passed `./scripts/check-pbxproj.sh`.
- Passed `./scripts/lint-pbxproj-test-wiring.sh`.
- Passed `python3 scripts/check-workspace-package-groups.py --check`.
- Passed `python3 scripts/check-package-resolved-policy.py`.
- Parsed `Resources/Localizable.xcstrings` and audited the Swift diff for new bare user-facing strings; none were added.
- Passed the focused exact-HEAD macOS workflow: 10 `SidebarAppKitRowCellTests` executed successfully at https://github.com/manaflow-ai/cmux/actions/runs/29676481212.
- No local Xcode build, test, or app launch was run, per task instructions; CI is the compile/test gate.
- `scripts/swift_file_length_budget.py` is absent on current `origin/main`; manually verified the new Swift file is 9 lines and both existing >=500-line production files shrink. No budget TSV was touched.

## Demo Video

- Not recorded: this task explicitly forbids building or launching the app locally. The AppKit row behavior is covered by the regression test and remote CI.

## Localization Audit

No new user-facing strings were introduced. The shared helper preserves SwiftUI’s existing trimmed-value/key-fallback behavior exactly, so `Resources/Localizable.xcstrings` does not change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally (intentionally not run; task forbids local Xcode builds/tests)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed for this scoped bug fix)
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved (none received)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Display**
  * Sidebar status entries now show cleaned status text when available.
  * Empty status values fall back to the entry label.
  * Sidebar metadata consistently displays the status text without exposing raw keys.

* **Tests**
  * Added coverage confirming rendered metadata omits raw status keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
