### PR TITLE
Own admitted Iroh connection lifetime

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/README.md
+++ b/Packages/Shared/CmuxIrohTransport/README.md
@@ -23,3 +23,17 @@ Run the package behavior tests without launching either app:
 ```sh
 swift test --package-path Packages/Shared/CmuxIrohTransport
 ```
+
+An admitted Mac connection gives one supervisor ownership of its control and
+application-lane tasks. Injecting those operations keeps the lifetime policy
+testable without an endpoint or app process:
+
+```swift
+let supervisor = CmxIrohAdmittedConnectionSupervisor(
+    runControl: { await serveControl() },
+    runApplicationLanes: { await serveApplicationLanes() },
+    closeConnection: { await connection.close() },
+    stopApplicationLanes: { await lanes.stop() }
+)
+await supervisor.run()
+```

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedConnectionSupervisor.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedConnectionSupervisor.swift
@@ -1,0 +1,69 @@
+/// Owns the coupled control and application-lane lifetime of one admitted connection.
+///
+/// Construct one supervisor per admitted peer. The first child operation to
+/// finish, or cancellation of ``run()``, cancels the sibling before the
+/// connection and application lanes are closed in a stable order. Repeated
+/// calls to ``run()`` are ignored so cleanup cannot run twice for one owner.
+///
+/// ```swift
+/// let supervisor = CmxIrohAdmittedConnectionSupervisor(
+///     runControl: { await serveControl() },
+///     runApplicationLanes: { await serveApplicationLanes() },
+///     closeConnection: { await connection.close() },
+///     stopApplicationLanes: { await lanes.stop() }
+/// )
+/// await supervisor.run()
+/// ```
+public actor CmxIrohAdmittedConnectionSupervisor {
+    private let runControl: @Sendable () async -> Void
+    private let runApplicationLanes: @Sendable () async -> Void
+    private let closeConnection: @Sendable () async -> Void
+    private let stopApplicationLanes: @Sendable () async -> Void
+    private var didRun = false
+
+    /// Creates the sole lifetime owner for one admitted connection.
+    ///
+    /// - Parameters:
+    ///   - runControl: Serves the authenticated control protocol until it ends
+    ///     or is cancelled.
+    ///   - runApplicationLanes: Accepts and serves post-admission application
+    ///     lanes until it ends or is cancelled.
+    ///   - closeConnection: Closes the complete peer connection and unblocks
+    ///     outstanding stream operations.
+    ///   - stopApplicationLanes: Cancels and joins every accepted application
+    ///     lane after the connection starts closing.
+    public init(
+        runControl: @escaping @Sendable () async -> Void,
+        runApplicationLanes: @escaping @Sendable () async -> Void,
+        closeConnection: @escaping @Sendable () async -> Void,
+        stopApplicationLanes: @escaping @Sendable () async -> Void
+    ) {
+        self.runControl = runControl
+        self.runApplicationLanes = runApplicationLanes
+        self.closeConnection = closeConnection
+        self.stopApplicationLanes = stopApplicationLanes
+    }
+
+    /// Runs the connection until either child exits, then closes all owned work.
+    public func run() async {
+        guard !didRun else { return }
+        didRun = true
+        let runControl = runControl
+        let runApplicationLanes = runApplicationLanes
+        let closeConnection = closeConnection
+        let stopApplicationLanes = stopApplicationLanes
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await runControl()
+            }
+            group.addTask {
+                await runApplicationLanes()
+            }
+            _ = await group.next()
+            group.cancelAll()
+            await closeConnection()
+            await stopApplicationLanes()
+        }
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohAdmittedConnectionSupervisorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohAdmittedConnectionSupervisorTests.swift
@@ -1,0 +1,72 @@
+import Testing
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohAdmittedConnectionSupervisorTests {
+    @Test(arguments: ["control", "lanes", "together", "caller"])
+    func firstExitClosesTheConnectionAndStopsLanesExactlyOnce(
+        trigger: String
+    ) async {
+        let control = AsyncStream<Void>.makeStream()
+        let lanes = AsyncStream<Void>.makeStream()
+        let started = AsyncStream<Void>.makeStream()
+        var startedIterator = started.stream.makeAsyncIterator()
+        let cleanupRecorder = TestIrohEventRecorder()
+        let childExitRecorder = TestIrohEventRecorder()
+        let supervisor = CmxIrohAdmittedConnectionSupervisor(
+            runControl: {
+                started.continuation.yield()
+                for await _ in control.stream {}
+                await childExitRecorder.record("control")
+            },
+            runApplicationLanes: {
+                started.continuation.yield()
+                for await _ in lanes.stream {}
+                await childExitRecorder.record("lanes")
+            },
+            closeConnection: {
+                await cleanupRecorder.record("connection.close")
+            },
+            stopApplicationLanes: {
+                await cleanupRecorder.record("lanes.stop")
+            }
+        )
+        let runTask = Task {
+            await supervisor.run()
+        }
+        defer {
+            runTask.cancel()
+            control.continuation.finish()
+            lanes.continuation.finish()
+            started.continuation.finish()
+        }
+
+        #expect(await startedIterator.next() != nil)
+        #expect(await startedIterator.next() != nil)
+        switch trigger {
+        case "control":
+            control.continuation.finish()
+        case "lanes":
+            lanes.continuation.finish()
+        case "together":
+            control.continuation.finish()
+            lanes.continuation.finish()
+        default:
+            runTask.cancel()
+        }
+        await runTask.value
+
+        // One actor instance owns one admitted connection lifetime. A repeated
+        // call cannot launch or clean up the same connection again.
+        await supervisor.run()
+
+        #expect(
+            await cleanupRecorder.observedEvents()
+                == ["connection.close", "lanes.stop"]
+        )
+        #expect(
+            Set(await childExitRecorder.observedEvents())
+                == Set(["control", "lanes"])
+        )
+    }
+}

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -203,27 +203,30 @@ extension MobileHostIrohRuntime {
                     session: session
                 )
                 let laneRouter = MobileHostIrohApplicationLaneRouter(session: session)
-                await withTaskGroup(of: Void.self) { group in
-                    group.addTask {
+                let connectionSupervisor = CmxIrohAdmittedConnectionSupervisor(
+                    runControl: {
                         await MobileHostService.acceptTransport(
                             session.controlTransport,
                             authorization: .irohAdmission(session.peer),
                             independentEventWriter: eventWriter,
                             isCurrent: isCurrent
                         )
-                    }
-                    group.addTask {
+                    },
+                    runApplicationLanes: {
                         await laneRouter.run(isCurrent: isCurrent)
+                    },
+                    closeConnection: {
+                        await session.close()
+                    },
+                    stopApplicationLanes: {
+                        await laneRouter.stop()
                     }
-                    _ = await group.next()
-                    group.cancelAll()
-                    await session.close()
-                    await laneRouter.stop()
-                    diagnosticLog.record(DiagnosticEvent(
-                        .sessionClosed,
-                        a: DiagnosticTransportKind.iroh.rawValue
-                    ))
-                }
+                )
+                await connectionSupervisor.run()
+                diagnosticLog.record(DiagnosticEvent(
+                    .sessionClosed,
+                    a: DiagnosticTransportKind.iroh.rawValue
+                ))
             },
             handleBinding: { [weak self] registration, discovery, attestation in
                 let binding = registration.binding

--- a/cmuxTests/MobileHostConnectionLifecycleTests.swift
+++ b/cmuxTests/MobileHostConnectionLifecycleTests.swift
@@ -36,9 +36,40 @@ extension MobileHostAuthorizationTests {
 
         await transport.finishReceiving()
         await runTask.value
+        await session.close(reason: "duplicate close after remote EOF")
 
         #expect(await transport.observedConnectCount() == 1)
         #expect(await transport.observedCloseCount() == 1)
+        #expect(await closeRecorder.recordedIDs() == [connectionID])
+    }
+
+    @Test func testMobileHostConnectionCancellationClosesTransportExactlyOnce() async {
+        let connectionID = UUID()
+        let transport = GatedMobileHostByteTransport()
+        let closeRecorder = MobileHostConnectionCloseRecorder()
+        let session = MobileHostConnection(
+            id: connectionID,
+            transport: transport,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { id in
+                await closeRecorder.record(id)
+            }
+        )
+
+        let runTask = Task {
+            await session.run()
+        }
+        await transport.waitUntilReceiveStarted()
+
+        runTask.cancel()
+        await runTask.value
+        await session.close(reason: "duplicate close after cancellation")
+
+        #expect(await transport.observedConnectCount() == 1)
+        #expect(await transport.observedCloseCount() == 1)
+        #expect(await transport.observedReceiveCancellation())
         #expect(await closeRecorder.recordedIDs() == [connectionID])
     }
 
@@ -357,6 +388,7 @@ private actor GatedMobileHostByteTransport: CmxByteTransport {
     private var receiveContinuation: CheckedContinuation<Data?, Never>?
     private var connectCount = 0
     private var closeCount = 0
+    private var receiveCancellationObserved = false
 
     init() {
         let receiveStarted = AsyncStream<Void>.makeStream()
@@ -370,8 +402,19 @@ private actor GatedMobileHostByteTransport: CmxByteTransport {
 
     func receive() async -> Data? {
         receiveStartedContinuation.yield()
-        return await withCheckedContinuation { continuation in
-            receiveContinuation = continuation
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    receiveCancellationObserved = true
+                    continuation.resume(returning: nil)
+                    return
+                }
+                receiveContinuation = continuation
+            }
+        } onCancel: {
+            Task {
+                await self.cancelReceive()
+            }
         }
     }
 
@@ -401,6 +444,16 @@ private actor GatedMobileHostByteTransport: CmxByteTransport {
 
     func observedCloseCount() -> Int {
         closeCount
+    }
+
+    func observedReceiveCancellation() -> Bool {
+        receiveCancellationObserved
+    }
+
+    private func cancelReceive() {
+        receiveCancellationObserved = true
+        receiveContinuation?.resume(returning: nil)
+        receiveContinuation = nil
     }
 }
 


### PR DESCRIPTION
## Summary

- move admitted Iroh control and application-lane lifetime into one instance-owned actor in CmuxIrohTransport
- cancel the sibling task when either child exits or the caller cancels, then close the peer connection before stopping application lanes
- preserve the existing admission decision, EndpointID authorization, diagnostics, framing, and reconnect policy

This ports the principled part of Lawrence Chen PR https://github.com/manaflow-ai/cmux/pull/8400 onto current main while addressing its architecture feedback. The reusable policy lives in the transport package, uses an instance-owned actor, and leaves the app target as composition wiring.

## Verification

- red proof: the new supervisor test failed to compile before the implementation
- swift test --package-path Packages/Shared/CmuxIrohTransport (380 tests passed)
- focused MobileHostAuthorizationTests suite (78 tests passed, including remote EOF and caller-cancellation lifetime cases)
- python3 scripts/check-workspace-package-groups.py --check
- python3 scripts/check-package-resolved-policy.py
- git diff --check

Tagged build: irown, GitHub run https://github.com/manaflow-ai/cmux/actions/runs/29675557663

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787032781&installation_id=133855650&pr_number=8453&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8453&signature=5056fd11ad6316f4c063408e5bfa632e8f9c73bb0757483c83de8253dc215d69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own the admitted Iroh connection lifetime with a single supervisor actor that couples control and application-lane tasks for deterministic shutdown and exactly-once connection close. Mobile host runtime now uses this supervisor; adds tests for cancellation and EOF cases.

- **Refactors**
  - Added `CmxIrohAdmittedConnectionSupervisor` in `CmuxIrohTransport` to run control and lanes, cancel the sibling on first exit, then close the connection before stopping lanes; ignores repeated run calls.
  - Rewired mobile host activation to use the supervisor and emit session-closed diagnostics after it completes.
  - Updated README and added transport-level tests for cleanup order and single ownership.

- **Bug Fixes**
  - Ensure the Iroh transport closes exactly once after remote EOF or caller cancellation; duplicate closes are no-ops.
  - Cancellation now reaches the transport receive loop and lanes are stopped after connection close begins.

<sup>Written for commit 02dfe7946c1cc52d53d1db58543bc232a2496df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated lifecycle management for admitted connections, including orderly shutdown of control and application operations.
  * Ensured connection cleanup occurs in a predictable order when either operation ends.

* **Bug Fixes**
  * Improved cancellation handling so interrupted connections close exactly once.
  * Prevented connection lifecycles from being started or cleaned up more than once.

* **Documentation**
  * Added instructions and a Swift example for running connection lifecycle behavior tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->