### PR TITLE
Harden Iroh relay server activation

### DIFF
--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -55,6 +55,49 @@ const requireVercelNonPreviewValue = (
       });
     }
   });
+const requireVercelRelayValue = (
+  schema: z.ZodString = z.string().min(1),
+): z.ZodType<string | undefined> =>
+  schema.optional().superRefine((value, context) => {
+    if (isVercelNonPreviewDeployment && !value) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Self-hosted relay runtime configuration is incomplete",
+      });
+    }
+  });
+const privateRelayEnvNames = new Set([
+  "CMUX_RELAY_JWT_PRIVATE_KEY_PEM",
+  "CMUX_RELAY_POLICY_KEY_ID",
+  "CMUX_RELAY_POLICY_PRIVATE_KEY_PEM",
+  "CMUX_RELAY_TOKEN_RATE_LIMIT_ID",
+]);
+const publicEnvValidationIssues = (issues: readonly unknown[]): readonly unknown[] => {
+  const publicIssues: unknown[] = [];
+  let hasPrivateRelayIssue = false;
+  for (const issue of issues) {
+    const path = (issue as { path?: unknown } | null)?.path;
+    const firstSegment = Array.isArray(path) ? path[0] : undefined;
+    const pathKey = typeof firstSegment === "string"
+      ? firstSegment
+      : typeof firstSegment === "object" && firstSegment !== null && "key" in firstSegment
+      ? String((firstSegment as { key: unknown }).key)
+      : undefined;
+    if (pathKey && privateRelayEnvNames.has(pathKey)) {
+      hasPrivateRelayIssue = true;
+    } else {
+      publicIssues.push(issue);
+    }
+  }
+  if (hasPrivateRelayIssue) {
+    publicIssues.push({
+      code: "custom",
+      message: "Self-hosted relay runtime configuration is incomplete",
+      path: ["relayRuntimeConfiguration"],
+    });
+  }
+  return publicIssues;
+};
 const localDevelopmentOptIn = (name: string) =>
   z.enum(["0", "1"]).optional().superRefine((value, context) => {
     if (
@@ -203,21 +246,16 @@ export const env = createEnv({
     // Self-hosted relay fleet. Preview and local builds remain credential-free,
     // while every deployed non-preview runtime must be able to mint endpoint-
     // bound credentials, sign the fleet policy, and enforce its account limit.
-    CMUX_RELAY_JWT_PRIVATE_KEY_PEM: requireVercelNonPreviewValue(
-      "CMUX_RELAY_JWT_PRIVATE_KEY_PEM",
+    CMUX_RELAY_JWT_PRIVATE_KEY_PEM: requireVercelRelayValue(
       z.string().min(64).max(16_384),
     ),
-    CMUX_RELAY_POLICY_KEY_ID: requireVercelNonPreviewValue(
-      "CMUX_RELAY_POLICY_KEY_ID",
+    CMUX_RELAY_POLICY_KEY_ID: requireVercelRelayValue(
       z.string().regex(/^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,62}[A-Za-z0-9])?$/),
     ),
-    CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: requireVercelNonPreviewValue(
-      "CMUX_RELAY_POLICY_PRIVATE_KEY_PEM",
+    CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: requireVercelRelayValue(
       z.string().min(64).max(16_384),
     ),
-    CMUX_RELAY_TOKEN_RATE_LIMIT_ID: requireVercelNonPreviewValue(
-      "CMUX_RELAY_TOKEN_RATE_LIMIT_ID",
-    ),
+    CMUX_RELAY_TOKEN_RATE_LIMIT_ID: requireVercelRelayValue(),
     // Optional dedicated rule. Preferences deliberately fall back to the token
     // rule so existing deployments keep one shared account-scoped limiter.
     CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID: z.string().min(1).optional(),
@@ -296,4 +334,8 @@ export const env = createEnv({
     ),
   },
   skipValidation: skipEnvValidation,
+  onValidationError: (issues) => {
+    console.error("❌ Invalid environment variables:", publicEnvValidationIssues(issues));
+    throw new Error("Invalid environment variables");
+  },
 });

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -200,6 +200,27 @@ export const env = createEnv({
     CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS: z.string().max(256).optional(),
     CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT: irohBindingLimit.optional(),
     CMUX_IROH_DEV_BINDING_DEVICE_LIMIT: irohBindingLimit.optional(),
+    // Self-hosted relay fleet. Preview and local builds remain credential-free,
+    // while every deployed non-preview runtime must be able to mint endpoint-
+    // bound credentials, sign the fleet policy, and enforce its account limit.
+    CMUX_RELAY_JWT_PRIVATE_KEY_PEM: requireVercelNonPreviewValue(
+      "CMUX_RELAY_JWT_PRIVATE_KEY_PEM",
+      z.string().min(64).max(16_384),
+    ),
+    CMUX_RELAY_POLICY_KEY_ID: requireVercelNonPreviewValue(
+      "CMUX_RELAY_POLICY_KEY_ID",
+      z.string().regex(/^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,62}[A-Za-z0-9])?$/),
+    ),
+    CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: requireVercelNonPreviewValue(
+      "CMUX_RELAY_POLICY_PRIVATE_KEY_PEM",
+      z.string().min(64).max(16_384),
+    ),
+    CMUX_RELAY_TOKEN_RATE_LIMIT_ID: requireVercelNonPreviewValue(
+      "CMUX_RELAY_TOKEN_RATE_LIMIT_ID",
+    ),
+    // Optional dedicated rule. Preferences deliberately fall back to the token
+    // rule so existing deployments keep one shared account-scoped limiter.
+    CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID: z.string().min(1).optional(),
   },
   client: {
     NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
@@ -254,6 +275,13 @@ export const env = createEnv({
     CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS: trimEnv(process.env.CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS),
     CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT: trimEnv(process.env.CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT),
     CMUX_IROH_DEV_BINDING_DEVICE_LIMIT: trimEnv(process.env.CMUX_IROH_DEV_BINDING_DEVICE_LIMIT),
+    CMUX_RELAY_JWT_PRIVATE_KEY_PEM: trimEnv(process.env.CMUX_RELAY_JWT_PRIVATE_KEY_PEM),
+    CMUX_RELAY_POLICY_KEY_ID: trimEnv(process.env.CMUX_RELAY_POLICY_KEY_ID),
+    CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: trimEnv(process.env.CMUX_RELAY_POLICY_PRIVATE_KEY_PEM),
+    CMUX_RELAY_TOKEN_RATE_LIMIT_ID: trimEnv(process.env.CMUX_RELAY_TOKEN_RATE_LIMIT_ID),
+    CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID: trimEnv(
+      process.env.CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID,
+    ),
     NEXT_PUBLIC_STACK_PROJECT_ID: stackEnv(
       process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
       "00000000-0000-4000-8000-000000000000"

--- a/web/db/migrations/20260718120000_iroh_relay_status_validation/migration.sql
+++ b/web/db/migrations/20260718120000_iroh_relay_status_validation/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "iroh_relay_token_issuances"
+  VALIDATE CONSTRAINT "iroh_relay_token_issuances_status_check";

--- a/web/db/migrations/20260718121000_iroh_relay_catalog_body/migration.sql
+++ b/web/db/migrations/20260718121000_iroh_relay_catalog_body/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "iroh_relay_catalog_state"
+  ADD COLUMN "catalog" jsonb;

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -102,8 +102,8 @@ export const accountDeletionTombstones = pgTable(
 
 /**
  * The last server-configured relay catalog accepted by this database.
- * Persisting its sequence and digest prevents an older or conflicting deploy
- * from signing a rollback after a newer catalog has already been served.
+ * Persisting its complete non-secret body lets activation enforce add-before-
+ * remove rotation under the same lock that prevents sequence rollback.
  */
 export const irohRelayCatalogState = pgTable(
   "iroh_relay_catalog_state",
@@ -111,6 +111,10 @@ export const irohRelayCatalogState = pgTable(
     id: text("id").primaryKey(),
     catalogSequence: bigint("catalog_sequence", { mode: "number" }).notNull(),
     catalogDigest: text("catalog_digest").notNull(),
+    // Nullable for rolling compatibility with an older web process. The new
+    // process backfills only an exact sequence/digest match and refuses to
+    // advance until the prior catalog body is authoritative.
+    catalog: jsonb("catalog"),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/web/services/iroh/README.md
+++ b/web/services/iroh/README.md
@@ -76,12 +76,11 @@ hints and removes existing Iroh route bodies from the legacy device registry.
 Hosts republish sanitized EndpointID/managed-relay routes on their next refresh;
 non-Iroh routes are preserved in order.
 
-The `20260710113000_iroh_relay_reservation_expiry` migration adds the
-expanded status constraint with `NOT VALID` so its `ACCESS EXCLUSIVE` lock is
-released without scanning existing rows. Drizzle 1.0 applies all pending
-Postgres migrations in one transaction, so constraint validation must ship in
-a later deployment after this migration is recorded. That follow-up migration
-must run:
+The `20260710113000_iroh_relay_reservation_expiry` migration added the expanded
+status constraint with `NOT VALID` so its `ACCESS EXCLUSIVE` lock was released
+without scanning existing rows. The later
+`20260718120000_iroh_relay_status_validation` migration validates it after the
+schema change was recorded:
 
 ```sql
 ALTER TABLE "iroh_relay_token_issuances"

--- a/web/services/relay/catalog.ts
+++ b/web/services/relay/catalog.ts
@@ -36,7 +36,17 @@ export function configuredRelayCatalog(): RelayCatalog {
 }
 
 export function relayCatalogDigest(catalog: RelayCatalog): string {
-  return createHash("sha256").update(JSON.stringify(catalog)).digest("hex");
+  const canonicalCatalog = {
+    version: catalog.version,
+    sequence: catalog.sequence,
+    relays: catalog.relays.map((relay) => ({
+      id: relay.id,
+      provider: relay.provider,
+      region: relay.region,
+      url: relay.url,
+    })),
+  };
+  return createHash("sha256").update(JSON.stringify(canonicalCatalog)).digest("hex");
 }
 
 /**

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -13,7 +13,11 @@ export class RelayConfigurationError extends Data.TaggedError("RelayConfiguratio
 export class RelayCatalogRollbackError extends Data.TaggedError("RelayCatalogRollbackError")<{
   readonly configuredSequence: number;
   readonly persistedSequence: number;
-  readonly reason: "sequence_regressed" | "sequence_reused_with_different_catalog";
+  readonly reason:
+    | "sequence_regressed"
+    | "sequence_reused_with_different_catalog"
+    | "previous_catalog_unavailable"
+    | "unsafe_transition";
 }> {}
 
 export class RelayDatabaseError extends Data.TaggedError("RelayDatabaseError")<{

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -20,6 +20,10 @@ export class RelayCatalogRollbackError extends Data.TaggedError("RelayCatalogRol
     | "unsafe_transition";
 }> {}
 
+export class RelayCatalogIntegrityError extends Data.TaggedError("RelayCatalogIntegrityError")<{
+  readonly reason: "persisted_catalog_digest_mismatch";
+}> {}
+
 export class RelayDatabaseError extends Data.TaggedError("RelayDatabaseError")<{
   readonly operation: string;
   readonly cause: unknown;
@@ -58,6 +62,7 @@ export class RelaySigningError extends Data.TaggedError("RelaySigningError")<{
 export type RelayServiceError =
   | RelayConfigurationError
   | RelayCatalogRollbackError
+  | RelayCatalogIntegrityError
   | RelayDatabaseError
   | RelayPreferenceValidationError
   | RelayPreferenceConflictError

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -100,6 +100,7 @@ export function relayErrorResponse(error: unknown): Response {
     console.error("relay.policy.catalog_rollback", {
       configuredSequence: (error as { configuredSequence?: unknown }).configuredSequence,
       persistedSequence: (error as { persistedSequence?: unknown }).persistedSequence,
+      reason: (error as { reason?: unknown }).reason,
     });
     return jsonResponse({ error: "relay_policy_unavailable" }, 503);
   }

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -104,6 +104,11 @@ export function relayErrorResponse(error: unknown): Response {
     });
     return jsonResponse({ error: "relay_policy_unavailable" }, 503);
   }
+  if (tag === "RelayCatalogIntegrityError") {
+    const typed = error as Extract<RelayServiceError, { _tag: "RelayCatalogIntegrityError" }>;
+    console.error("relay.policy.catalog_integrity", { reason: typed.reason });
+    return jsonResponse({ error: "relay_policy_unavailable" }, 503);
+  }
   if (
     tag === "RelayConfigurationError" ||
     tag === "RelayDatabaseError" ||

--- a/web/services/relay/repository.ts
+++ b/web/services/relay/repository.ts
@@ -14,6 +14,7 @@ import {
 } from "../account/deletionLock";
 import {
   RelayAccountDeletionBlockedError,
+  RelayCatalogIntegrityError,
   RelayCatalogRollbackError,
   RelayConfigurationError,
   RelayDatabaseError,
@@ -69,7 +70,10 @@ export type RelayRepositoryShape = {
   readonly acceptCatalog: (input: {
     readonly catalog: RelayCatalog;
     readonly nowSeconds: number;
-  }) => Effect.Effect<void, RelayCatalogRollbackError | RelayDatabaseError>;
+  }) => Effect.Effect<
+    void,
+    RelayCatalogRollbackError | RelayCatalogIntegrityError | RelayDatabaseError
+  >;
   readonly getPreference: (
     accountId: string,
   ) => Effect.Effect<RelayPreferenceRecord, RelayDatabaseError>;
@@ -165,7 +169,9 @@ export const RelayRepositoryLive = Layer.succeed(RelayRepository, {
             }
             const previous = parseRelayCatalog(JSON.stringify(current.catalog));
             if (relayCatalogDigest(previous) !== current.catalogDigest) {
-              throw new Error("persisted relay catalog digest mismatch");
+              throw new RelayCatalogIntegrityError({
+                reason: "persisted_catalog_digest_mismatch",
+              });
             }
             const overlapSeconds = Math.max(
               0,
@@ -187,17 +193,15 @@ export const RelayRepositoryLive = Layer.succeed(RelayRepository, {
               }
               throw cause;
             }
-            if (catalog.sequence > current.catalogSequence) {
-              await tx
-                .update(irohRelayCatalogState)
-                .set({
-                  catalogSequence: catalog.sequence,
-                  catalogDigest: digest,
-                  catalog,
-                  updatedAt: new Date(nowSeconds * 1_000),
-                })
-                .where(eq(irohRelayCatalogState.id, "managed"));
-            }
+            await tx
+              .update(irohRelayCatalogState)
+              .set({
+                catalogSequence: catalog.sequence,
+                catalogDigest: digest,
+                catalog,
+                updatedAt: new Date(nowSeconds * 1_000),
+              })
+              .where(eq(irohRelayCatalogState.id, "managed"));
             return;
           }
           await tx.insert(irohRelayCatalogState).values({
@@ -209,8 +213,9 @@ export const RelayRepositoryLive = Layer.succeed(RelayRepository, {
           });
         });
       },
-      (cause): cause is RelayCatalogRollbackError =>
-        tagged(cause, "RelayCatalogRollbackError"),
+      (cause): cause is RelayCatalogRollbackError | RelayCatalogIntegrityError =>
+        tagged(cause, "RelayCatalogRollbackError") ||
+        tagged(cause, "RelayCatalogIntegrityError"),
     ),
 
   getPreference: (accountId) =>

--- a/web/services/relay/repository.ts
+++ b/web/services/relay/repository.ts
@@ -15,14 +15,21 @@ import {
 import {
   RelayAccountDeletionBlockedError,
   RelayCatalogRollbackError,
+  RelayConfigurationError,
   RelayDatabaseError,
   RelayPreferenceConflictError,
 } from "./errors";
 import {
   defaultRelayPreference,
+  parseRelayCatalog,
   relayPreferenceSchema,
+  type RelayCatalog,
   type RelayPreference,
 } from "./model";
+import {
+  assertSafeRelayCatalogRotation,
+  relayCatalogDigest,
+} from "./catalog";
 
 export type RelayPreferenceRecord = {
   readonly preference: RelayPreference;
@@ -60,8 +67,8 @@ export function assertCatalogAdvance(
 
 export type RelayRepositoryShape = {
   readonly acceptCatalog: (input: {
-    readonly sequence: number;
-    readonly digest: string;
+    readonly catalog: RelayCatalog;
+    readonly nowSeconds: number;
   }) => Effect.Effect<void, RelayCatalogRollbackError | RelayDatabaseError>;
   readonly getPreference: (
     accountId: string,
@@ -118,10 +125,11 @@ function rowPreference(row: {
 }
 
 export const RelayRepositoryLive = Layer.succeed(RelayRepository, {
-  acceptCatalog: ({ sequence, digest }) =>
+  acceptCatalog: ({ catalog, nowSeconds }) =>
     typedDbEffect(
       "acceptCatalog",
       async () => {
+        const digest = relayCatalogDigest(catalog);
         await cloudDb().transaction(async (tx) => {
           await tx.execute(
             sql`select pg_advisory_xact_lock(hashtextextended('cmux/iroh-relay-catalog', 0))`,
@@ -137,15 +145,56 @@ export const RelayRepositoryLive = Layer.succeed(RelayRepository, {
                 sequence: current.catalogSequence,
                 digest: current.catalogDigest,
               },
-              { sequence, digest },
+              { sequence: catalog.sequence, digest },
             );
-            if (sequence > current.catalogSequence) {
+            if (catalog.sequence === current.catalogSequence) {
+              if (current.catalog === null) {
+                await tx
+                  .update(irohRelayCatalogState)
+                  .set({ catalog })
+                  .where(eq(irohRelayCatalogState.id, "managed"));
+              }
+              return;
+            }
+            if (current.catalog === null) {
+              throw new RelayCatalogRollbackError({
+                configuredSequence: catalog.sequence,
+                persistedSequence: current.catalogSequence,
+                reason: "previous_catalog_unavailable",
+              });
+            }
+            const previous = parseRelayCatalog(JSON.stringify(current.catalog));
+            if (relayCatalogDigest(previous) !== current.catalogDigest) {
+              throw new Error("persisted relay catalog digest mismatch");
+            }
+            const overlapSeconds = Math.max(
+              0,
+              nowSeconds - Math.floor(current.updatedAt.getTime() / 1_000),
+            );
+            try {
+              assertSafeRelayCatalogRotation({
+                current: previous,
+                next: catalog,
+                overlapSeconds,
+              });
+            } catch (cause) {
+              if (cause instanceof RelayConfigurationError) {
+                throw new RelayCatalogRollbackError({
+                  configuredSequence: catalog.sequence,
+                  persistedSequence: current.catalogSequence,
+                  reason: "unsafe_transition",
+                });
+              }
+              throw cause;
+            }
+            if (catalog.sequence > current.catalogSequence) {
               await tx
                 .update(irohRelayCatalogState)
                 .set({
-                  catalogSequence: sequence,
+                  catalogSequence: catalog.sequence,
                   catalogDigest: digest,
-                  updatedAt: new Date(),
+                  catalog,
+                  updatedAt: new Date(nowSeconds * 1_000),
                 })
                 .where(eq(irohRelayCatalogState.id, "managed"));
             }
@@ -153,8 +202,10 @@ export const RelayRepositoryLive = Layer.succeed(RelayRepository, {
           }
           await tx.insert(irohRelayCatalogState).values({
             id: "managed",
-            catalogSequence: sequence,
+            catalogSequence: catalog.sequence,
             catalogDigest: digest,
+            catalog,
+            updatedAt: new Date(nowSeconds * 1_000),
           });
         });
       },

--- a/web/services/relay/workflows.ts
+++ b/web/services/relay/workflows.ts
@@ -2,7 +2,6 @@ import * as Effect from "effect/Effect";
 
 import {
   configuredRelayCatalog,
-  relayCatalogDigest,
   relayPolicyPayload,
   relayPolicySigningKey,
   signRelayPolicy,
@@ -52,8 +51,8 @@ export function signedRelayPolicy(
   return Effect.gen(function* () {
     const repository = yield* RelayRepository;
     yield* repository.acceptCatalog({
-      sequence: config.catalog.sequence,
-      digest: relayCatalogDigest(config.catalog),
+      catalog: config.catalog,
+      nowSeconds: config.nowSeconds,
     });
     const record = yield* repository.getPreference(accountId);
     const signed = yield* Effect.try({

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -23,6 +23,15 @@ const requiredIrohProductionEnv = {
   CMUX_IROH_RATE_LIMIT_ID: "iroh-rule",
 };
 
+const requiredRelayProductionEnv = {
+  CMUX_RELAY_JWT_PRIVATE_KEY_PEM:
+    `-----BEGIN PRIVATE KEY-----\n${"B".repeat(64)}\n-----END PRIVATE KEY-----`,
+  CMUX_RELAY_POLICY_KEY_ID: "relay-policy-current",
+  CMUX_RELAY_POLICY_PRIVATE_KEY_PEM:
+    `-----BEGIN PRIVATE KEY-----\n${"C".repeat(64)}\n-----END PRIVATE KEY-----`,
+  CMUX_RELAY_TOKEN_RATE_LIMIT_ID: "relay-token-rule",
+};
+
 describe("client config env validation", () => {
   test("allows local builds with VERCEL set but no deployment environment", () => {
     const result = importEnv({
@@ -54,6 +63,7 @@ describe("client config env validation", () => {
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
       ...requiredIrohProductionEnv,
+      ...requiredRelayProductionEnv,
     });
 
     expect(result.exitCode).toBe(0);
@@ -78,6 +88,7 @@ describe("client config env validation", () => {
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       ...requiredIrohProductionEnv,
+      ...requiredRelayProductionEnv,
     });
 
     expect(result.exitCode).not.toBe(0);
@@ -91,6 +102,7 @@ describe("client config env validation", () => {
       VERCEL_ENV: "development",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       ...requiredIrohProductionEnv,
+      ...requiredRelayProductionEnv,
     });
 
     expect(result.exitCode).toBe(0);
@@ -109,6 +121,7 @@ describe("client config env validation", () => {
       CMUX_IROH_GRANT_VERIFICATION_KEYS_JSON:
         requiredIrohProductionEnv.CMUX_IROH_GRANT_VERIFICATION_KEYS_JSON,
       CMUX_IROH_RATE_LIMIT_ID: requiredIrohProductionEnv.CMUX_IROH_RATE_LIMIT_ID,
+      ...requiredRelayProductionEnv,
     });
 
     expect(result.exitCode).toBe(0);
@@ -140,6 +153,33 @@ describe("client config env validation", () => {
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("CMUX_IROH_GRANT_SIGNING_KEY_P8 is required");
     expect(result.stderr).not.toContain("CMUX_IROH_MINT_HMAC_SECRET_B64 is required");
+  });
+
+  test("requires the self-hosted relay signing and rate-limit configuration in production", () => {
+    const result = importEnv({
+      ...requiredEnv,
+      ...requiredIrohProductionEnv,
+      VERCEL: "1",
+      VERCEL_ENV: "production",
+      CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+      CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("CMUX_RELAY_JWT_PRIVATE_KEY_PEM is required");
+    expect(result.stderr).toContain("CMUX_RELAY_POLICY_KEY_ID is required");
+    expect(result.stderr).toContain("CMUX_RELAY_POLICY_PRIVATE_KEY_PEM is required");
+    expect(result.stderr).toContain("CMUX_RELAY_TOKEN_RATE_LIMIT_ID is required");
+  });
+
+  test("keeps Vercel previews credential-free for the self-hosted relay fleet", () => {
+    const result = importEnv({
+      ...requiredEnv,
+      VERCEL: "1",
+      VERCEL_ENV: "preview",
+    });
+
+    expect(result.exitCode).toBe(0);
   });
 
   test("allows an explicitly opted-in loopback HTTP relay minter only in local development", () => {
@@ -184,6 +224,7 @@ describe("client config env validation", () => {
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
+      ...requiredRelayProductionEnv,
       CMUX_IROH_DEV_ALLOW_INSECURE_LOOPBACK_MINTER: "1",
       CMUX_IROH_MINT_URL: "http://localhost:49152/api/relay-token",
     });

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -166,10 +166,11 @@ describe("client config env validation", () => {
     });
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stderr).toContain("CMUX_RELAY_JWT_PRIVATE_KEY_PEM is required");
-    expect(result.stderr).toContain("CMUX_RELAY_POLICY_KEY_ID is required");
-    expect(result.stderr).toContain("CMUX_RELAY_POLICY_PRIVATE_KEY_PEM is required");
-    expect(result.stderr).toContain("CMUX_RELAY_TOKEN_RATE_LIMIT_ID is required");
+    expect(result.stderr).toContain("Self-hosted relay runtime configuration is incomplete");
+    expect(result.stderr).not.toContain("CMUX_RELAY_JWT_PRIVATE_KEY_PEM");
+    expect(result.stderr).not.toContain("CMUX_RELAY_POLICY_KEY_ID");
+    expect(result.stderr).not.toContain("CMUX_RELAY_POLICY_PRIVATE_KEY_PEM");
+    expect(result.stderr).not.toContain("CMUX_RELAY_TOKEN_RATE_LIMIT_ID");
   });
 
   test("keeps Vercel previews credential-free for the self-hosted relay fleet", () => {

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -133,6 +133,54 @@ describe("Iroh trust broker database behavior", () => {
     expect(state).toEqual({ sequence: "22", catalog: removed });
   });
 
+  dbTest("fails closed when the persisted relay catalog digest is corrupt", async () => {
+    const current: RelayCatalog = {
+      version: 1,
+      sequence: 30,
+      relays: [{
+        id: "relay-a",
+        provider: "cmux",
+        region: "A",
+        url: "https://relay-a.cmux.dev/",
+      }],
+    };
+    const next: RelayCatalog = {
+      ...current,
+      sequence: 31,
+      relays: [
+        ...current.relays,
+        {
+          id: "relay-b",
+          provider: "cmux",
+          region: "B",
+          url: "https://relay-b.cmux.dev/",
+        },
+      ],
+    };
+    await requiredSql()`
+      insert into iroh_relay_catalog_state (
+        id, catalog_sequence, catalog_digest, catalog, updated_at
+      ) values (
+        'managed', ${current.sequence}, ${"0".repeat(64)}, ${requiredSql().json(current)},
+        to_timestamp(1_000)
+      )
+    `;
+
+    const exit = await Effect.runPromiseExit(
+      requiredRelayRepository().acceptCatalog({ catalog: next, nowSeconds: 1_001 }),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    expect(String(exit)).toContain("RelayCatalogIntegrityError");
+    expect(String(exit)).toContain("persisted_catalog_digest_mismatch");
+    const [state] = await requiredSql()<Array<{ sequence: string }>>`
+      select catalog_sequence::text as sequence
+      from iroh_relay_catalog_state
+      where id = 'managed'
+    `;
+    expect(state).toEqual({ sequence: "30" });
+  });
+
   dbTest("blocks new trust state once account deletion wins the account fence", async () => {
     const userId = "user-deleting";
     let mutation: ReturnType<typeof Effect.runPromiseExit> | undefined;

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -14,6 +14,12 @@ import {
   IrohRepositoryLive,
   type IrohRepositoryShape,
 } from "../services/iroh/repository";
+import type { RelayCatalog } from "../services/relay/model";
+import {
+  RelayRepository,
+  RelayRepositoryLive,
+  type RelayRepositoryShape,
+} from "../services/relay/repository";
 
 const runDbTests = process.env.CMUX_DB_TEST === "1";
 const dbTest = runDbTests ? test : test.skip;
@@ -21,6 +27,7 @@ const NOW = new Date("2026-07-09T20:00:00.000Z");
 
 let sql: Sql | null = null;
 let repository: IrohRepositoryShape | null = null;
+let relayRepository: RelayRepositoryShape | null = null;
 
 beforeAll(async () => {
   if (!runDbTests) return;
@@ -30,6 +37,11 @@ beforeAll(async () => {
   repository = await Effect.runPromise(
     Effect.gen(function* () { return yield* IrohRepository; }).pipe(
       Effect.provide(IrohRepositoryLive),
+    ),
+  );
+  relayRepository = await Effect.runPromise(
+    Effect.gen(function* () { return yield* RelayRepository; }).pipe(
+      Effect.provide(RelayRepositoryLive),
     ),
   );
 });
@@ -43,6 +55,8 @@ beforeEach(async () => {
       iroh_registration_challenges,
       iroh_endpoint_bindings,
       iroh_account_security_states,
+      iroh_relay_preferences,
+      iroh_relay_catalog_state,
       account_deletion_tombstones
     restart identity cascade
   `;
@@ -54,6 +68,71 @@ afterAll(async () => {
 });
 
 describe("Iroh trust broker database behavior", () => {
+  dbTest("validates the expanded relay issuance status constraint", async () => {
+    const [constraint] = await requiredSql()<Array<{ validated: boolean }>>`
+      select convalidated as validated
+      from pg_constraint
+      where conname = 'iroh_relay_token_issuances_status_check'
+        and conrelid = 'iroh_relay_token_issuances'::regclass
+    `;
+
+    expect(constraint).toEqual({ validated: true });
+  });
+
+  dbTest("serializes and rejects unsafe managed relay catalog activation", async () => {
+    const current: RelayCatalog = {
+      version: 1,
+      sequence: 20,
+      relays: [{
+        id: "relay-a",
+        provider: "cmux",
+        region: "A",
+        url: "https://relay-a.cmux.dev/",
+      }],
+    };
+    const added: RelayCatalog = {
+      ...current,
+      sequence: 21,
+      relays: [
+        ...current.relays,
+        {
+          id: "relay-b",
+          provider: "cmux",
+          region: "B",
+          url: "https://relay-b.cmux.dev/",
+        },
+      ],
+    };
+    const removed: RelayCatalog = {
+      ...added,
+      sequence: 22,
+      relays: [added.relays[1]!],
+    };
+    const acceptCatalog = requiredRelayRepository().acceptCatalog as unknown as (
+      input: { readonly catalog: RelayCatalog; readonly nowSeconds: number },
+    ) => Effect.Effect<void, unknown>;
+
+    await Effect.runPromise(acceptCatalog({ catalog: current, nowSeconds: 1_000 }));
+    await Effect.runPromise(acceptCatalog({ catalog: added, nowSeconds: 1_001 }));
+
+    const earlyRemoval = await Effect.runPromiseExit(
+      acceptCatalog({ catalog: removed, nowSeconds: 1_300 }),
+    );
+    expect(earlyRemoval._tag).toBe("Failure");
+    expect(String(earlyRemoval)).toContain("unsafe_transition");
+
+    await Effect.runPromise(acceptCatalog({ catalog: removed, nowSeconds: 1_301 }));
+    const [state] = await requiredSql()<Array<{
+      sequence: string;
+      catalog: RelayCatalog;
+    }>>`
+      select catalog_sequence::text as sequence, catalog
+      from iroh_relay_catalog_state
+      where id = 'managed'
+    `;
+    expect(state).toEqual({ sequence: "22", catalog: removed });
+  });
+
   dbTest("blocks new trust state once account deletion wins the account fence", async () => {
     const userId = "user-deleting";
     let mutation: ReturnType<typeof Effect.runPromiseExit> | undefined;
@@ -1327,6 +1406,11 @@ async function insertBinding(input: {
   `;
   if (!row) throw new Error("binding insert returned no row");
   return row.id;
+}
+
+function requiredRelayRepository(): RelayRepositoryShape {
+  if (!relayRepository) throw new Error("relay repository not initialized");
+  return relayRepository;
 }
 
 async function pairPeer(bindingId: string): Promise<PairGrantPeer> {

--- a/web/tests/relay-policy.test.ts
+++ b/web/tests/relay-policy.test.ts
@@ -13,6 +13,8 @@ import {
   relayPolicySigningKey,
   signRelayPolicy,
 } from "../services/relay/catalog";
+import { RelayCatalogIntegrityError } from "../services/relay/errors";
+import { relayErrorResponse } from "../services/relay/http";
 import {
   assertManagedSelectionExists,
   parseRelayCatalog,
@@ -53,6 +55,41 @@ const catalog: RelayCatalog = {
 };
 
 describe("signed relay policy", () => {
+  test("uses a canonical catalog digest across JSON object key order", () => {
+    const reordered = {
+      relays: catalog.relays.map((relay) => ({
+        url: relay.url,
+        region: relay.region,
+        provider: relay.provider,
+        id: relay.id,
+      })),
+      sequence: catalog.sequence,
+      version: catalog.version,
+    } as RelayCatalog;
+
+    expect(relayCatalogDigest(reordered)).toBe(relayCatalogDigest(catalog));
+  });
+
+  test("logs a safe reason when persisted catalog integrity fails", async () => {
+    const originalConsoleError = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]) => { calls.push(args); };
+    try {
+      const response = relayErrorResponse(new RelayCatalogIntegrityError({
+        reason: "persisted_catalog_digest_mismatch",
+      }));
+
+      expect(response.status).toBe(503);
+      expect(await response.json()).toEqual({ error: "relay_policy_unavailable" });
+      expect(calls).toEqual([[
+        "relay.policy.catalog_integrity",
+        { reason: "persisted_catalog_digest_mismatch" },
+      ]]);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
   test("keeps signed policy, web publication, and Presence on one catalog digest", () => {
     const configured = configuredRelayCatalog();
     const presence = parseRelayCatalog(JSON.stringify(APPROVED_IROH_RELAY_CATALOG));

--- a/web/tests/relay-workflows.test.ts
+++ b/web/tests/relay-workflows.test.ts
@@ -24,9 +24,9 @@ const catalog: RelayCatalog = {
 describe("relay workflows", () => {
   test("issues the current signed catalog when an account selection is stale", async () => {
     const { privateKey } = generateKeyPairSync("ed25519");
-    let acceptedSequence: number | undefined;
+    let acceptedInput: unknown;
     const repository: RelayRepositoryShape = {
-      acceptCatalog: ({ sequence }) => Effect.sync(() => { acceptedSequence = sequence; }),
+      acceptCatalog: (input) => Effect.sync(() => { acceptedInput = input; }),
       getPreference: () => Effect.succeed({
         preference: {
           mode: "managed",
@@ -47,7 +47,10 @@ describe("relay workflows", () => {
       }).pipe(Effect.provide(Layer.succeed(RelayRepository, repository))),
     );
 
-    expect(acceptedSequence).toBe(8);
+    expect(acceptedInput).toEqual({
+      catalog,
+      nowSeconds: 1_700_000_000,
+    });
     expect(result.payload.relays).toEqual(catalog.relays);
     expect(result.preference).toEqual({
       mode: "managed",


### PR DESCRIPTION
## Summary
- validate the deferred Iroh relay issuance status constraint
- persist the accepted managed relay catalog and enforce serialized add-before-remove rotation before signing policies
- validate self-hosted relay signing and rate-limit env in deployed non-preview runtimes while keeping previews credential-free

## Testing
- `bun test tests/client-config-env.test.ts tests/relay-policy.test.ts tests/relay-workflows.test.ts tests/relay-token.test.ts tests/relay-token-route.test.ts tests/relay-preferences-route.test.ts` (45 pass)
- `bun run typecheck`
- `bun run lint -- app/env.ts db/schema.ts services/relay/errors.ts services/relay/http.ts services/relay/repository.ts services/relay/workflows.ts tests/client-config-env.test.ts tests/iroh-db-behavior.test.ts tests/relay-workflows.test.ts`
- `CMUX_PORT=4681 bun run db:test` (all 11 database behavior suites pass; Iroh suite 26 pass)
- `bun run db:check`
- `bun tools/generate-managed-iroh-relay-catalog.ts --check`

A later full preflight retry reached the host Docker network allocator limit before starting Postgres. It did not invalidate the earlier green isolated database run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787033285&installation_id=133855650&pr_number=8454&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8454&signature=6223d4f8873ab280457d263e9de17a5a7551740b7e6a0090f75fc227779f7088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens activation of the self-hosted Iroh relay fleet by persisting the full managed catalog, using a canonical digest, and enforcing safe add-before-remove rotation. Production builds now require relay signing keys and rate‑limit IDs; previews stay credential‑free with sanitized error output for missing private config.

- **New Features**
  - Enforce safe managed relay catalog rotation: persist the catalog body (`iroh_relay_catalog_state.catalog`), verify previous digest, compute overlap, and reject unsafe transitions with `RelayCatalogRollbackError` reasons `previous_catalog_unavailable` and `unsafe_transition` (reason logged).
  - Canonicalize the catalog digest so it’s stable across JSON key order; fail-closed on corruption with `RelayCatalogIntegrityError` (HTTP 503, safe reason logged).
  - Repository API: `acceptCatalog({ catalog, nowSeconds })` computes the digest, timestamps updates, backfills the previous body on same-sequence, and validates rotation under lock.
  - Validate the expanded relay issuance status constraint.
  - Redact private relay env issues in logs; surface a single “Self-hosted relay runtime configuration is incomplete” error in production.

- **Migration**
  - Apply DB migrations to add the `catalog` JSONB column and validate `iroh_relay_token_issuances_status_check`.
  - In non-preview deployments, set: `CMUX_RELAY_JWT_PRIVATE_KEY_PEM`, `CMUX_RELAY_POLICY_KEY_ID`, `CMUX_RELAY_POLICY_PRIVATE_KEY_PEM`, `CMUX_RELAY_TOKEN_RATE_LIMIT_ID` (optional `CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID`). Previews/local remain credential-free.

<sup>Written for commit 93c88c81af6ceccf3bef1563a3ee8eeb1624b0f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added relay catalog state storage (including catalog JSON) and safer relay catalog acceptance/rotation.
  - Updated self-hosted relay production configuration to require relay signing/policy and rate-limit settings, while keeping preview deployments more permissive.
- **Bug Fixes**
  - Improved validation and fail-closed handling for relay catalog integrity issues, returning a consistent relay policy unavailable response.
  - Improved relay token issuance constraint validation behavior.
- **Documentation**
  - Clarified migration and constraint validation timing/locking behavior.
- **Tests**
  - Expanded coverage for relay configuration completeness, catalog integrity, and safer activation transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->