### PR TITLE
Preserve Tailscale access across Nightly Iroh upgrades

### DIFF
--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -429,8 +429,11 @@ final class MobileHostService {
 
     /// Whether the mobile pairing host should bind a network listener at all.
     ///
-    /// Defaults off in every build so macOS does not ask for Local Network
-    /// permission until the user enables iOS pairing in Settings.
+    /// An explicit current or legacy preference always wins. Without one,
+    /// dev and nightly builds preserve their historical listener default so an
+    /// older iOS app can still reach an updated Mac over Tailscale. Stable
+    /// remains opt-in so macOS does not ask every user for Local Network
+    /// permission.
     nonisolated static var isListeningEnabled: Bool {
         isListeningEnabled(defaults: .standard)
     }
@@ -448,13 +451,20 @@ final class MobileHostService {
     #endif
 
     nonisolated static func isListeningEnabled(defaults: UserDefaults) -> Bool {
+        isListeningEnabled(defaults: defaults, buildFlavor: .current)
+    }
+
+    nonisolated static func isListeningEnabled(
+        defaults: UserDefaults,
+        buildFlavor: BuildFlavor
+    ) -> Bool {
         if let override = defaults.object(forKey: listeningEnabledDefaultsKey) as? Bool {
             return override
         }
         if let legacyOverride = defaults.object(forKey: legacyListeningEnabledDefaultsKey) as? Bool {
             return legacyOverride
         }
-        return SettingCatalog().mobile.iOSPairingHost.defaultValue
+        return buildFlavor != .stable
     }
 
     /// User-default key for the preferred iOS pairing listener port.

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -81,6 +81,16 @@ struct MobileHostServiceSettingsTests {
         #expect(!MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .nightly))
     }
 
+    @Test func legacyExplicitDisableWinsOverNightlyCompatibility() throws {
+        let suiteName = "MobileHostServiceSettingsTests.LegacyNightlyDisabled.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: "cmuxMobilePairingHostEnabled")
+
+        #expect(!MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .nightly))
+    }
+
     @Test func stableWithoutExplicitOptInKeepsLegacyListenerOff() throws {
         let suiteName = "MobileHostServiceSettingsTests.StableDefault.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -11,21 +11,18 @@ import Testing
 #endif
 
 struct MobileHostServiceSettingsTests {
-    @Test func mobileHostListenerHonorsBuildDefaultUntilIOSPairingIsOverridden() throws {
+    @Test func mobileHostListenerHonorsDevelopmentDefaultUntilIOSPairingIsOverridden() throws {
         let suiteName = "MobileHostServiceSettingsTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        #expect(
-            MobileHostService.isListeningEnabled(defaults: defaults)
-                == SettingCatalog().mobile.iOSPairingHost.defaultValue
-        )
+        #expect(MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .dev))
 
         defaults.set(true, forKey: MobileHostService.listeningEnabledDefaultsKey)
-        #expect(MobileHostService.isListeningEnabled(defaults: defaults))
+        #expect(MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .dev))
 
         defaults.set(false, forKey: MobileHostService.listeningEnabledDefaultsKey)
-        #expect(!MobileHostService.isListeningEnabled(defaults: defaults))
+        #expect(!MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .dev))
     }
 
     @Test func signedInIrohStartsWithoutEnablingTheLegacyListener() {

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -63,6 +63,32 @@ struct MobileHostServiceSettingsTests {
         #expect(!MobileHostService.isListeningEnabled(defaults: defaults))
     }
 
+    @Test func nightlyPreservesLegacyListenerWhenNoSettingWasEverWritten() throws {
+        let suiteName = "MobileHostServiceSettingsTests.NightlyCompatibility.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .nightly))
+    }
+
+    @Test func explicitDisableWinsOverNightlyCompatibility() throws {
+        let suiteName = "MobileHostServiceSettingsTests.NightlyDisabled.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: MobileHostService.listeningEnabledDefaultsKey)
+
+        #expect(!MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .nightly))
+    }
+
+    @Test func stableWithoutExplicitOptInKeepsLegacyListenerOff() throws {
+        let suiteName = "MobileHostServiceSettingsTests.StableDefault.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(!MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .stable))
+    }
+
     @Test func configuredPortDefaultsToCatalogDefaultWhenUnset() throws {
         let suiteName = "MobileHostServiceSettingsTests.Port.Default.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))


### PR DESCRIPTION
## Summary

- preserve the historical legacy mobile listener default for dev and Nightly Macs when no preference has ever been written
- keep explicit current and legacy preferences authoritative, including an explicit off
- keep stable builds opt-in and retain the new iOS fail-closed rule for bearer tokens over raw Tailscale TCP

This is compatibility ingress only. An older iOS app can still reach an updated Nightly Mac, where the Mac performs same-account Stack authentication. A new iOS app still requires Iroh from a truly old Mac because that Mac has no cryptographic challenge that can attest a raw Tailscale route.

## Verification

- regression-only commit `9a688df060` fails before the policy overload exists
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS" -derivedDataPath /tmp/cmux-tsmigr test -only-testing:cmuxTests/MobileHostServiceSettingsTests CODE_SIGNING_ALLOWED=NO` (14 passed)
- `swift test --package-path Packages/iOS/CmuxMobileTransport --filter CmxNetworkByteTransportFactorySecurityTests` (5 passed)
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter IrohReconnectRouteSelectionTests` (24 passed)
- cloud tagged build `tsmigr` succeeded: https://github.com/manaflow-ai/cmux/actions/runs/29676343291
- tagged runtime reported the legacy listener running and published both IPv4 and IPv6 Tailscale routes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787034649&installation_id=133855650&pr_number=8457&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8457&signature=4cff78da7534f385c41f9f5d6a921f0876711c29ba20a1173e503ed2bd3a1e67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Tailscale pairing access across Nightly Iroh upgrades by keeping the legacy mobile listener on for dev/nightly builds when no preference exists. Explicit settings still win, and stable builds remain opt-in.

- **Bug Fixes**
  - Default listener depends on build flavor: dev/nightly on, stable off when no preference is set.
  - Explicit current or legacy preference overrides, including an explicit off.
  - Made build flavor explicit via `isListeningEnabled(defaults:buildFlavor:)` for deterministic behavior; added tests for nightly compatibility, explicit and legacy disables, and stable default.

<sup>Written for commit a05a0ccb322a6ce71cace21d6ee62285abcce35e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed listener-enable behavior to consistently respect explicit current and legacy preferences.
  * Updated defaults by build type: nightly retains the prior behavior, while stable remains opt-in to avoid local network permission prompts.
* **Tests**
  * Added/expanded unit tests for build-flavor-specific defaults, including nightly behavior, explicit true/false handling, legacy overrides, and stable-build opt-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->