### PR TITLE
Canonicalize paired Mac UUID device IDs

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxDeviceIDCanonicalization.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxDeviceIDCanonicalization.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Returns one stable lowercase spelling for a UUID device identifier.
+///
+/// Device identifiers outside the UUID grammar are opaque protocol values and
+/// are returned byte-for-byte, including their original case and whitespace.
+public func cmxCanonicalDeviceID(_ deviceID: String) -> String {
+    guard let uuid = UUID(uuidString: deviceID) else { return deviceID }
+    return uuid.uuidString.lowercased()
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTransport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTransport.swift
@@ -344,7 +344,7 @@ public struct CmxAttachTicket: Codable, Equatable, Sendable {
         self.version = version
         self.workspaceID = workspaceID
         self.terminalID = terminalID
-        self.macDeviceID = macDeviceID
+        self.macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         self.macDisplayName = macDisplayName
         self.macUserEmail = macUserEmail
         self.macUserID = macUserID

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSyncProtocol.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/MobileSyncProtocol.swift
@@ -64,7 +64,7 @@ public struct MobileSyncPairingPayload: Equatable, Sendable, Codable {
         transport: MobileSyncTransportKind
     ) throws {
         self.version = version
-        self.macDeviceID = macDeviceID
+        self.macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         self.macDisplayName = macDisplayName
         self.host = host
         self.port = port
@@ -84,7 +84,9 @@ public struct MobileSyncPairingPayload: Equatable, Sendable, Codable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
         version = try container.decode(Int.self, forKey: .version)
-        macDeviceID = try container.decode(String.self, forKey: .macDeviceID)
+        macDeviceID = cmxCanonicalDeviceID(
+            try container.decode(String.self, forKey: .macDeviceID)
+        )
         macDisplayName = try container.decodeIfPresent(String.self, forKey: .macDisplayName)
         host = try container.decode(String.self, forKey: .host)
         port = try container.decode(Int.self, forKey: .port)

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxDeviceIDCanonicalizationTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxDeviceIDCanonicalizationTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import CMUXMobileCore
+
+@Suite struct CmxDeviceIDCanonicalizationTests {
+    private let uppercaseUUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+    private let lowercaseUUID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+    @Test func canonicalizerLowercasesOnlyUUIDDeviceIDs() {
+        #expect(cmxCanonicalDeviceID(uppercaseUUID) == lowercaseUUID)
+        #expect(cmxCanonicalDeviceID(lowercaseUUID) == lowercaseUUID)
+        #expect(cmxCanonicalDeviceID("Legacy-Mac-ID") == "Legacy-Mac-ID")
+        #expect(cmxCanonicalDeviceID(" legacy-id ") == " legacy-id ")
+    }
+
+    @Test func attachTicketCanonicalizesInitializerAndLegacyWireIdentity() throws {
+        let route = try CmxAttachRoute(
+            id: "manual",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.2", port: 58_465)
+        )
+        let initialized = try CmxAttachTicket(
+            workspaceID: "workspace",
+            terminalID: nil,
+            macDeviceID: uppercaseUUID,
+            macDisplayName: "Studio",
+            routes: [route]
+        )
+        #expect(initialized.macDeviceID == lowercaseUUID)
+
+        let data = Data("""
+        {
+          "version": 1,
+          "workspaceID": "workspace",
+          "macDeviceID": "\(uppercaseUUID)",
+          "routes": [
+            {
+              "id": "manual",
+              "kind": "tailscale",
+              "endpoint": { "type": "host_port", "host": "100.64.0.2", "port": 58465 },
+              "priority": 0
+            }
+          ]
+        }
+        """.utf8)
+        let decoded = try JSONDecoder().decode(CmxAttachTicket.self, from: data)
+        #expect(decoded.macDeviceID == lowercaseUUID)
+    }
+
+    @Test func pairingPayloadCanonicalizesUUIDAndPreservesOpaqueIdentity() throws {
+        let expiresAt = Date().addingTimeInterval(60)
+        let uuidPayload = try MobileSyncPairingPayload(
+            macDeviceID: uppercaseUUID,
+            macDisplayName: nil,
+            host: "100.64.0.2",
+            port: 58_465,
+            expiresAt: expiresAt,
+            transport: .tailscale
+        )
+        let opaquePayload = try MobileSyncPairingPayload(
+            macDeviceID: "Legacy-Mac-ID",
+            macDisplayName: nil,
+            host: "100.64.0.2",
+            port: 58_465,
+            expiresAt: expiresAt,
+            transport: .tailscale
+        )
+
+        #expect(uuidPayload.macDeviceID == lowercaseUUID)
+        #expect(opaquePayload.macDeviceID == "Legacy-Mac-ID")
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntimeConfiguration.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntimeConfiguration.swift
@@ -1,3 +1,5 @@
+internal import CMUXMobileCore
+
 /// Stable, account-and-build-scoped inputs for one iOS Iroh lifecycle.
 public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
     /// The authenticated account scope used only for device-local policy isolation.
@@ -60,7 +62,7 @@ public struct CmxIrohClientRuntimeConfiguration: Equatable, Sendable {
         cachedRelayCredential: CmxIrohRelayTokenResponse? = nil
     ) {
         self.accountID = accountID
-        self.deviceID = deviceID.lowercased()
+        self.deviceID = cmxCanonicalDeviceID(deviceID)
         self.appInstanceID = appInstanceID.lowercased()
         self.tag = tag
         self.displayName = displayName

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntimeConfiguration.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntimeConfiguration.swift
@@ -1,3 +1,5 @@
+internal import CMUXMobileCore
+
 /// Stable, account-scoped inputs for one Mac Iroh host lifecycle.
 public struct CmxIrohHostRuntimeConfiguration: Equatable, Sendable {
     /// The authenticated account scope used only for pending-revocation isolation.
@@ -53,7 +55,7 @@ public struct CmxIrohHostRuntimeConfiguration: Equatable, Sendable {
         cachedHostPolicy: CmxIrohCachedHostPolicy? = nil
     ) {
         self.accountID = accountID
-        self.deviceID = deviceID.lowercased()
+        self.deviceID = cmxCanonicalDeviceID(deviceID)
         self.appInstanceID = appInstanceID.lowercased()
         self.tag = tag
         self.displayName = displayName

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANDiscoveryResolver.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANDiscoveryResolver.swift
@@ -58,7 +58,8 @@ public struct CmxIrohLANDiscoveryResolver: Sendable {
         }
         let candidates = authenticatedBindings.filter { binding in
             binding.platform == .mac
-                && binding.deviceID.lowercased() == expectedMacDeviceID.lowercased()
+                && cmxCanonicalDeviceID(binding.deviceID)
+                    == cmxCanonicalDeviceID(expectedMacDeviceID)
                 && (expectedEndpointID == nil || binding.endpointID == expectedEndpointID)
         }
         guard !candidates.isEmpty,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANPeerDiscovery.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLANPeerDiscovery.swift
@@ -117,7 +117,7 @@ public actor CmxIrohLANPeerDiscovery {
         }
         let path = await networkPath()
         let key = RequestKey(
-            deviceID: expectedMacDeviceID.lowercased(),
+            deviceID: cmxCanonicalDeviceID(expectedMacDeviceID),
             endpointID: expectedEndpointID
         )
         guard requests[key] != nil || requests.count < 32 else { return .notFound }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistrationPayload.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistrationPayload.swift
@@ -80,7 +80,7 @@ public struct CmxIrohRegistrationPayload: Encodable, Equatable, Sendable {
             }
         }
         routeContractVersion = 1
-        self.deviceID = deviceID.lowercased()
+        self.deviceID = cmxCanonicalDeviceID(deviceID)
         self.appInstanceID = appInstanceID.lowercased()
         self.tag = tag
         self.platform = platform

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRuntimeConfigurationDeviceIDTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRuntimeConfigurationDeviceIDTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohRuntimeConfigurationDeviceIDTests {
+    @Test
+    func runtimeConfigurationsCanonicalizeUUIDsWithoutFoldingOpaqueDeviceIDs() throws {
+        let fixture = try HostRuntimeFixture()
+        let uppercaseUUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let lowercaseUUID = uppercaseUUID.lowercased()
+
+        let uuidHost = hostConfiguration(deviceID: uppercaseUUID, fixture: fixture)
+        let opaqueHost = hostConfiguration(deviceID: "Legacy-Mac-ID", fixture: fixture)
+        let uuidClient = clientConfiguration(deviceID: uppercaseUUID, fixture: fixture)
+        let opaqueClient = clientConfiguration(deviceID: "Legacy-iOS-ID", fixture: fixture)
+
+        #expect(uuidHost.deviceID == lowercaseUUID)
+        #expect(opaqueHost.deviceID == "Legacy-Mac-ID")
+        #expect(uuidClient.deviceID == lowercaseUUID)
+        #expect(opaqueClient.deviceID == "Legacy-iOS-ID")
+    }
+
+    private func hostConfiguration(
+        deviceID: String,
+        fixture: HostRuntimeFixture
+    ) -> CmxIrohHostRuntimeConfiguration {
+        CmxIrohHostRuntimeConfiguration(
+            accountID: "account-a",
+            deviceID: deviceID,
+            appInstanceID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            tag: "test",
+            displayName: nil,
+            identity: fixture.identity,
+            pairingEnabled: true,
+            capabilities: [],
+            managedRelayURLs: []
+        )
+    }
+
+    private func clientConfiguration(
+        deviceID: String,
+        fixture: HostRuntimeFixture
+    ) -> CmxIrohClientRuntimeConfiguration {
+        CmxIrohClientRuntimeConfiguration(
+            accountID: "account-a",
+            deviceID: deviceID,
+            appInstanceID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+            tag: "test",
+            displayName: nil,
+            identity: fixture.identity,
+            capabilities: [],
+            managedRelayURLs: []
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
@@ -54,8 +54,9 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
     ///   - instanceTag: Authenticated app-instance tag, or `nil` for a legacy host.
     /// - Returns: An identifier unique to the physical Mac and app instance.
     public static func pairingID(macDeviceID: String, instanceTag: String?) -> String {
-        guard let instanceTag, !instanceTag.isEmpty else { return macDeviceID }
-        return "\(macDeviceID)\u{1F}\(instanceTag)"
+        let canonicalDeviceID = cmxCanonicalDeviceID(macDeviceID)
+        guard let instanceTag, !instanceTag.isEmpty else { return canonicalDeviceID }
+        return "\(canonicalDeviceID)\u{1F}\(instanceTag)"
     }
 
     /// Splits a pairing identity received from backup into its physical Mac id
@@ -69,9 +70,9 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
             omittingEmptySubsequences: false
         )
         guard parts.count == 2, !parts[1].isEmpty else {
-            return (pairingID, nil)
+            return (cmxCanonicalDeviceID(pairingID), nil)
         }
-        return (String(parts[0]), String(parts[1]))
+        return (cmxCanonicalDeviceID(String(parts[0])), String(parts[1]))
     }
 
     /// The name to show: the user's custom override if set, else the Mac-reported

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+DeviceIDCanonicalization.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+DeviceIDCanonicalization.swift
@@ -1,0 +1,158 @@
+import CMUXMobileCore
+import Foundation
+import SQLite3
+
+extension MobilePairedMacStore {
+    /// v7: canonicalize UUID device IDs and collapse case-only duplicates within
+    /// each existing account/team/instance owner scope.
+    ///
+    /// A duplicate group's freshest row owns route authority and mutable metadata.
+    /// Selection is preserved if any spelling was active, while creation and
+    /// freshness retain the group's minimum and maximum timestamps respectively.
+    func migrateToV7() throws {
+        let rows = try fetchMacRowsForDeviceIDCanonicalization()
+        try exec("""
+            CREATE TABLE paired_macs_v7 (
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                display_name TEXT,
+                stack_user_id TEXT,
+                team_id TEXT,
+                created_at REAL NOT NULL,
+                last_seen_at REAL NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 0,
+                custom_name TEXT,
+                custom_color TEXT,
+                custom_icon TEXT,
+                instance_tag TEXT,
+                PRIMARY KEY (mac_device_id, owner_key)
+            );
+        """)
+        try exec("""
+            CREATE TABLE mac_routes_v7 (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                endpoint_json TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (mac_device_id, owner_key)
+                    REFERENCES paired_macs_v7(mac_device_id, owner_key)
+                    ON DELETE CASCADE
+            );
+        """)
+
+        for ownerRows in Dictionary(grouping: rows, by: \.ownerKey).values {
+            let canonicalGroups = Dictionary(grouping: ownerRows) {
+                cmxCanonicalDeviceID($0.macDeviceID)
+            }
+            for (canonicalDeviceID, duplicateRows) in canonicalGroups {
+                guard let authoritative = authoritativeRow(
+                    in: duplicateRows,
+                    canonicalDeviceID: canonicalDeviceID
+                ) else { continue }
+                let createdAt = duplicateRows.map(\.createdAt).min() ?? authoritative.createdAt
+                let lastSeenAt = duplicateRows.map(\.lastSeenAt).max() ?? authoritative.lastSeenAt
+                let isActive = duplicateRows.contains(where: \.isActive)
+                try exec("""
+                    INSERT INTO paired_macs_v7 (
+                        mac_device_id, owner_key, display_name, stack_user_id, team_id,
+                        created_at, last_seen_at, is_active, custom_name, custom_color,
+                        custom_icon, instance_tag
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+                """, binding: [
+                    .text(canonicalDeviceID),
+                    .text(authoritative.ownerKey),
+                    authoritative.displayName.map(BindValue.text) ?? .null,
+                    authoritative.stackUserID.map(BindValue.text) ?? .null,
+                    authoritative.teamID.map(BindValue.text) ?? .null,
+                    .real(createdAt.timeIntervalSince1970),
+                    .real(lastSeenAt.timeIntervalSince1970),
+                    .int(isActive ? 1 : 0),
+                    authoritative.customName.map(BindValue.text) ?? .null,
+                    authoritative.customColor.map(BindValue.text) ?? .null,
+                    authoritative.customIcon.map(BindValue.text) ?? .null,
+                    authoritative.instanceTag.map(BindValue.text) ?? .null,
+                ])
+                try exec("""
+                    INSERT INTO mac_routes_v7 (
+                        mac_device_id, owner_key, route_id, kind, endpoint_json, priority
+                    )
+                    SELECT ?, owner_key, route_id, kind, endpoint_json, priority
+                    FROM mac_routes
+                    WHERE mac_device_id = ? AND owner_key = ?
+                    ORDER BY id ASC;
+                """, binding: [
+                    .text(canonicalDeviceID),
+                    .text(authoritative.macDeviceID),
+                    .text(authoritative.ownerKey),
+                ])
+            }
+        }
+
+        try exec("DROP TABLE mac_routes;")
+        try exec("DROP TABLE paired_macs;")
+        try exec("ALTER TABLE paired_macs_v7 RENAME TO paired_macs;")
+        try exec("ALTER TABLE mac_routes_v7 RENAME TO mac_routes;")
+        try exec("CREATE INDEX IF NOT EXISTS idx_macs_stack_user ON paired_macs(stack_user_id);")
+        try exec("CREATE INDEX IF NOT EXISTS idx_macs_team ON paired_macs(stack_user_id, team_id);")
+        try exec("CREATE INDEX IF NOT EXISTS idx_routes_device ON mac_routes(mac_device_id, owner_key);")
+    }
+
+    private func fetchMacRowsForDeviceIDCanonicalization() throws -> [MacRow] {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        let sql = """
+            SELECT mac_device_id, owner_key, display_name, stack_user_id, team_id,
+                   created_at, last_seen_at, is_active, custom_name, custom_color,
+                   custom_icon, instance_tag
+            FROM paired_macs;
+        """
+        let result = sqlite3_prepare_v2(db, sql, -1, &statement, nil)
+        guard result == SQLITE_OK else {
+            throw MobilePairedMacStoreError.prepareFailed(result, lastErrorMessage())
+        }
+
+        var rows: [MacRow] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let deviceID = Self.readNullableText(statement, column: 0),
+                  let ownerKey = Self.readNullableText(statement, column: 1) else {
+                continue
+            }
+            rows.append(MacRow(
+                macDeviceID: deviceID,
+                ownerKey: ownerKey,
+                displayName: Self.readNullableText(statement, column: 2),
+                instanceTag: Self.readNullableText(statement, column: 11),
+                stackUserID: Self.readNullableText(statement, column: 3),
+                teamID: Self.readNullableText(statement, column: 4),
+                createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
+                lastSeenAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 6)),
+                isActive: sqlite3_column_int(statement, 7) != 0,
+                customName: Self.readNullableText(statement, column: 8),
+                customColor: Self.readNullableText(statement, column: 9),
+                customIcon: Self.readNullableText(statement, column: 10)
+            ))
+        }
+        return rows
+    }
+
+    private func authoritativeRow(
+        in rows: [MacRow],
+        canonicalDeviceID: String
+    ) -> MacRow? {
+        guard let first = rows.first else { return nil }
+        return rows.dropFirst().reduce(first) { selected, candidate in
+            guard candidate.lastSeenAt == selected.lastSeenAt else {
+                return candidate.lastSeenAt > selected.lastSeenAt ? candidate : selected
+            }
+            let candidateIsCanonical = candidate.macDeviceID == canonicalDeviceID
+            let selectedIsCanonical = selected.macDeviceID == canonicalDeviceID
+            if candidateIsCanonical != selectedIsCanonical {
+                return candidateIsCanonical ? candidate : selected
+            }
+            return candidate.macDeviceID < selected.macDeviceID ? candidate : selected
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
@@ -14,7 +14,7 @@ let pairedMacStoreLog = Logger(subsystem: "com.cmuxterm.app", category: "PairedM
 /// inject it as `any MobilePairedMacStoring`.
 public actor MobilePairedMacStore: MobilePairedMacStoring {
     /// The schema version this build creates and migrates to.
-    public static let currentSchemaVersion: Int32 = 6
+    public static let currentSchemaVersion: Int32 = 7
 
     private let dbPath: String
     // `nonisolated(unsafe)` only so the (Swift 6 nonisolated) `deinit` can close
@@ -111,7 +111,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV4()
                 try migrateToV5()
                 try migrateToV6()
-                try setUserVersion(6)
+                try migrateToV7()
+                try setUserVersion(7)
             }
         case 1:
             try transaction {
@@ -120,7 +121,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV4()
                 try migrateToV5()
                 try migrateToV6()
-                try setUserVersion(6)
+                try migrateToV7()
+                try setUserVersion(7)
             }
         case 2:
             try transaction {
@@ -128,27 +130,36 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV4()
                 try migrateToV5()
                 try migrateToV6()
-                try setUserVersion(6)
+                try migrateToV7()
+                try setUserVersion(7)
             }
         case 3:
             try transaction {
                 try migrateToV4()
                 try migrateToV5()
                 try migrateToV6()
-                try setUserVersion(6)
+                try migrateToV7()
+                try setUserVersion(7)
             }
         case 4:
             try transaction {
                 try migrateToV5()
                 try migrateToV6()
-                try setUserVersion(6)
+                try migrateToV7()
+                try setUserVersion(7)
             }
         case 5:
             try transaction {
                 try migrateToV6()
-                try setUserVersion(6)
+                try migrateToV7()
+                try setUserVersion(7)
             }
         case 6:
+            try transaction {
+                try migrateToV7()
+                try setUserVersion(7)
+            }
+        case 7:
             break
         default:
             // A newer build wrote a higher schema version. Schema migrations are
@@ -510,6 +521,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         routeWriteCondition: MobilePairedMacRouteWriteCondition? = nil
     ) throws -> Bool {
         try ensureReady()
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         var didWrite = false
         try transaction {
             let recordInstanceTag: String?
@@ -724,6 +736,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         teamID: String? = nil
     ) throws {
         try ensureReady()
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let instanceTag = try fetchAllMacs(
             stackUserID: stackUserID,
             teamID: teamID
@@ -744,6 +757,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         teamID: String? = nil
     ) throws {
         try ensureReady()
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let ownerKey = Self.ownerKey(
             stackUserID: stackUserID,
             teamID: teamID,
@@ -773,6 +787,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         now: Date = Date()
     ) throws {
         try ensureReady()
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let instanceTag = try fetchAllMacs(
             stackUserID: stackUserID,
             teamID: teamID
@@ -801,6 +816,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         now: Date = Date()
     ) throws {
         try ensureReady()
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         // Bump last_seen_at so the change is the freshest write for this record and
         // the LWW backup/restore propagates it to the user's other devices. Leaves
         // display_name / routes / is_active untouched (the Mac owns those).
@@ -828,6 +844,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         stackUserID: String? = nil,
         teamID: String? = nil
     ) throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         if stackUserID == nil && teamID == nil {
             try ensureReady()
             try exec("DELETE FROM paired_macs WHERE mac_device_id = ?;",
@@ -855,6 +872,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         teamID: String? = nil
     ) throws {
         try ensureReady()
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         try exec(
             "DELETE FROM paired_macs WHERE mac_device_id = ? AND owner_key = ?;",
             binding: [.text(macDeviceID), .text(Self.ownerKey(

--- a/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacDeviceIDCanonicalizationTests.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacDeviceIDCanonicalizationTests.swift
@@ -1,0 +1,288 @@
+import CMUXMobileCore
+import Foundation
+import SQLite3
+import Testing
+@testable import CmuxMobilePairedMac
+
+@Suite
+struct MobilePairedMacDeviceIDCanonicalizationTests {
+    private let canonicalDeviceID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+    private let mixedCaseDeviceID = "Aaaaaaaa-BbBb-4cCc-8dDd-EeEeEeEeEeEe"
+
+    @Test
+    func migratesV6UUIDCaseDuplicatesWithoutRetainingStaleRouteAuthority() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+        let staleIrohRoute = try CmxAttachRoute(
+            id: "stale-iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(endpointID: String(repeating: "a", count: 64)),
+                pathHints: []
+            ),
+            priority: -10_000
+        )
+        let freshRoute = try route(id: "fresh", host: "100.64.0.2", port: 52_002)
+        let otherTeamRoute = try route(id: "other-team", host: "100.64.0.3", port: 52_003)
+
+        try seedV6Database(
+            at: databaseURL,
+            staleIrohRoute: staleIrohRoute,
+            freshRoute: freshRoute,
+            otherTeamRoute: otherTeamRoute
+        )
+
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        let teamA = try await store.loadAll(stackUserID: "user-1", teamID: "team-a")
+        let canonical = try #require(teamA.first { $0.macDeviceID == canonicalDeviceID })
+
+        #expect(teamA.count == 3)
+        #expect(teamA.filter { $0.macDeviceID == canonicalDeviceID }.count == 1)
+        #expect(canonical.displayName == "Fresh lowercase")
+        #expect(canonical.customName == "Fresh custom")
+        #expect(canonical.customColor == "palette:7")
+        #expect(canonical.customIcon == "desktopcomputer")
+        #expect(canonical.createdAt == Date(timeIntervalSince1970: 10))
+        #expect(canonical.lastSeenAt == Date(timeIntervalSince1970: 30))
+        #expect(canonical.isActive)
+        #expect(canonical.routes == [freshRoute])
+        #expect(!canonical.routes.contains { $0.id == staleIrohRoute.id })
+
+        let opaqueIDs = Set(teamA.map(\.macDeviceID)).intersection(["Opaque-Mac-ID", "opaque-mac-id"])
+        #expect(opaqueIDs == ["Opaque-Mac-ID", "opaque-mac-id"])
+
+        let teamB = try await store.loadAll(stackUserID: "user-1", teamID: "team-b")
+        let scopedCopy = try #require(teamB.first)
+        #expect(teamB.count == 1)
+        #expect(scopedCopy.macDeviceID == canonicalDeviceID)
+        #expect(scopedCopy.displayName == "Other team")
+        #expect(scopedCopy.routes == [otherTeamRoute])
+    }
+
+    @Test
+    func canonicalizesUUIDsAcrossProductionMutationsWhilePreservingOpaqueIDs() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        let initialRoute = try route(id: "initial", host: "100.64.0.10", port: 52_010)
+        let restoredRoute = try route(id: "restored", host: "100.64.0.11", port: 52_011)
+        let authorizedRoute = try route(id: "authorized", host: "100.64.0.12", port: 52_012)
+
+        try await store.upsert(
+            macDeviceID: mixedCaseDeviceID,
+            displayName: "Initial",
+            routes: [initialRoute],
+            instanceTag: "stable",
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 1)
+        )
+        #expect(try await store.upsertIfNewer(
+            macDeviceID: canonicalDeviceID,
+            displayName: "Restored",
+            routes: [restoredRoute],
+            instanceTag: "stable",
+            customName: "Restored custom",
+            customColor: nil,
+            customIcon: nil,
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 2)
+        ))
+        #expect(try await store.upsertRoutesIfAuthorized(
+            macDeviceID: mixedCaseDeviceID,
+            displayName: "Authorized",
+            routes: [authorizedRoute],
+            condition: .matchingInstanceTag("stable"),
+            markActive: nil,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 3)
+        ))
+        try await store.setCustomization(
+            macDeviceID: mixedCaseDeviceID,
+            customName: "Customized",
+            customColor: "palette:2",
+            customIcon: "laptopcomputer",
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 4)
+        )
+        try await store.upsert(
+            macDeviceID: "other-mac",
+            displayName: "Other",
+            routes: [initialRoute],
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 5)
+        )
+        try await store.setActive(
+            macDeviceID: mixedCaseDeviceID,
+            stackUserID: "user-1",
+            teamID: "team-a"
+        )
+
+        let canonicalRows = try await store.loadAll(stackUserID: "user-1", teamID: "team-a")
+            .filter { $0.macDeviceID == canonicalDeviceID }
+        let canonical = try #require(canonicalRows.first)
+        #expect(canonicalRows.count == 1)
+        #expect(canonical.displayName == "Authorized")
+        #expect(canonical.customName == "Customized")
+        #expect(canonical.customColor == "palette:2")
+        #expect(canonical.customIcon == "laptopcomputer")
+        #expect(canonical.createdAt == Date(timeIntervalSince1970: 1))
+        #expect(canonical.lastSeenAt == Date(timeIntervalSince1970: 4))
+        #expect(canonical.routes == [authorizedRoute])
+        #expect(canonical.isActive)
+
+        try await store.upsert(
+            macDeviceID: "Opaque-Mac-ID",
+            displayName: nil,
+            routes: [],
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 6)
+        )
+        try await store.upsert(
+            macDeviceID: "opaque-mac-id",
+            displayName: nil,
+            routes: [],
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 7)
+        )
+        let opaqueIDs = Set(try await store.loadAll(
+            stackUserID: "user-1",
+            teamID: "team-a"
+        ).map(\.macDeviceID)).intersection(["Opaque-Mac-ID", "opaque-mac-id"])
+        #expect(opaqueIDs == ["Opaque-Mac-ID", "opaque-mac-id"])
+
+        try await store.remove(
+            macDeviceID: mixedCaseDeviceID,
+            instanceTag: "stable",
+            stackUserID: "user-1",
+            teamID: "team-a"
+        )
+        #expect(try await store.loadAll(stackUserID: "user-1", teamID: "team-a")
+            .allSatisfy { $0.macDeviceID != canonicalDeviceID })
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func route(id: String, host: String, port: Int) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: id,
+            kind: .tailscale,
+            endpoint: .hostPort(host: host, port: port)
+        )
+    }
+
+    private func seedV6Database(
+        at databaseURL: URL,
+        staleIrohRoute: CmxAttachRoute,
+        freshRoute: CmxAttachRoute,
+        otherTeamRoute: CmxAttachRoute
+    ) throws {
+        let teamAOwnerKey = "user-1\u{1F}team-a\u{1F}stable"
+        let teamBOwnerKey = "user-1\u{1F}team-b\u{1F}stable"
+        let staleRouteJSON = try encodedRoute(staleIrohRoute)
+        let freshRouteJSON = try encodedRoute(freshRoute)
+        let otherTeamRouteJSON = try encodedRoute(otherTeamRoute)
+        var database: OpaquePointer?
+        #expect(sqlite3_open(databaseURL.path, &database) == SQLITE_OK)
+        defer { sqlite3_close(database) }
+
+        let seed = """
+            CREATE TABLE paired_macs (
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                display_name TEXT,
+                stack_user_id TEXT,
+                team_id TEXT,
+                created_at REAL NOT NULL,
+                last_seen_at REAL NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 0,
+                custom_name TEXT,
+                custom_color TEXT,
+                custom_icon TEXT,
+                instance_tag TEXT,
+                PRIMARY KEY (mac_device_id, owner_key)
+            );
+            CREATE TABLE mac_routes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                endpoint_json TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (mac_device_id, owner_key)
+                    REFERENCES paired_macs(mac_device_id, owner_key)
+                    ON DELETE CASCADE
+            );
+            INSERT INTO paired_macs VALUES (
+                \(sqlQuoted(mixedCaseDeviceID)), \(sqlQuoted(teamAOwnerKey)),
+                'Stale mixed case', 'user-1', 'team-a', 10, 20, 0,
+                'Stale custom', 'palette:1', 'desktopcomputer.fill', 'stable'
+            );
+            INSERT INTO paired_macs VALUES (
+                \(sqlQuoted(canonicalDeviceID)), \(sqlQuoted(teamAOwnerKey)),
+                'Fresh lowercase', 'user-1', 'team-a', 15, 30, 1,
+                'Fresh custom', 'palette:7', 'desktopcomputer', 'stable'
+            );
+            INSERT INTO paired_macs VALUES (
+                \(sqlQuoted(mixedCaseDeviceID.uppercased())), \(sqlQuoted(teamBOwnerKey)),
+                'Other team', 'user-1', 'team-b', 5, 50, 1,
+                NULL, NULL, NULL, 'stable'
+            );
+            INSERT INTO paired_macs VALUES (
+                'Opaque-Mac-ID', \(sqlQuoted(teamAOwnerKey)), NULL,
+                'user-1', 'team-a', 40, 40, 0, NULL, NULL, NULL, 'stable'
+            );
+            INSERT INTO paired_macs VALUES (
+                'opaque-mac-id', \(sqlQuoted(teamAOwnerKey)), NULL,
+                'user-1', 'team-a', 41, 41, 0, NULL, NULL, NULL, 'stable'
+            );
+            INSERT INTO mac_routes (mac_device_id, owner_key, route_id, kind, endpoint_json, priority)
+            VALUES (
+                \(sqlQuoted(mixedCaseDeviceID)), \(sqlQuoted(teamAOwnerKey)),
+                'stale-iroh', 'iroh', \(sqlQuoted(staleRouteJSON)), -10000
+            );
+            INSERT INTO mac_routes (mac_device_id, owner_key, route_id, kind, endpoint_json, priority)
+            VALUES (
+                \(sqlQuoted(canonicalDeviceID)), \(sqlQuoted(teamAOwnerKey)),
+                'fresh', 'tailscale', \(sqlQuoted(freshRouteJSON)), 0
+            );
+            INSERT INTO mac_routes (mac_device_id, owner_key, route_id, kind, endpoint_json, priority)
+            VALUES (
+                \(sqlQuoted(mixedCaseDeviceID.uppercased())), \(sqlQuoted(teamBOwnerKey)),
+                'other-team', 'tailscale', \(sqlQuoted(otherTeamRouteJSON)), 0
+            );
+            PRAGMA user_version = 6;
+        """
+        let result = sqlite3_exec(database, seed, nil, nil, nil)
+        #expect(result == SQLITE_OK)
+    }
+
+    private func encodedRoute(_ route: CmxAttachRoute) throws -> String {
+        let data = try JSONEncoder().encode(route)
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    private func sqlQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileHostStatusResponse.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileHostStatusResponse.swift
@@ -57,6 +57,7 @@ public struct MobileHostStatusResponse: Decodable, Sendable {
         terminalFidelity = try container.decodeIfPresent(String.self, forKey: .terminalFidelity)
         macDisplayName = try container.decodeIfPresent(String.self, forKey: .macDisplayName)
         macDeviceID = try container.decodeIfPresent(String.self, forKey: .macDeviceID)
+            .map(cmxCanonicalDeviceID)
         macInstanceTag = try container.decodeIfPresent(String.self, forKey: .macInstanceTag)
         terminalThemeRevisionEpoch = try container.decodeIfPresent(String.self, forKey: .terminalThemeRevisionEpoch)
         macAppVersion = try container.decodeIfPresent(String.self, forKey: .macAppVersion)

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileTerminalDTODecodeTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileTerminalDTODecodeTests.swift
@@ -49,6 +49,19 @@ import Testing
         #expect(response.terminalThemeRevisionEpoch == "boot-one")
     }
 
+    @Test func hostStatusCanonicalizesOnlyUUIDDeviceIDs() throws {
+        let uppercaseUUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let uuidResponse = try MobileHostStatusResponse.decode(Data(
+            #"{"mac_device_id":"\#(uppercaseUUID)"}"#.utf8
+        ))
+        let opaqueResponse = try MobileHostStatusResponse.decode(Data(
+            #"{"mac_device_id":"Legacy-Mac-ID"}"#.utf8
+        ))
+
+        #expect(uuidResponse.macDeviceID == uppercaseUUID.lowercased())
+        #expect(opaqueResponse.macDeviceID == "Legacy-Mac-ID")
+    }
+
     /// A theme nested in the host-status payload, serialized with the Mac
     /// producer's `[String: Any]` key shape, round-trips back into the exact
     /// `TerminalTheme` the Mac sent. This pins the producer/consumer wire

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore+AuthorizedRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore+AuthorizedRoutes.swift
@@ -14,6 +14,7 @@ extension BackingUpPairedMacStore {
         teamID: String?,
         now: Date
     ) async throws -> Bool {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await resolvedTeam(teamID)
         let existing: [MobilePairedMac]
         if let account = stackUserID, !account.isEmpty {
@@ -30,7 +31,8 @@ extension BackingUpPairedMacStore {
         }
         let previousActive = markActive == true ? existing.first(where: \.isActive) : nil
         let existedBeforeWrite = existing.contains {
-            $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+            cmxCanonicalDeviceID($0.macDeviceID) == macDeviceID
+                && $0.instanceTag == instanceTag
         }
         let wrote = try await inner.upsertRoutesIfAuthorized(
             macDeviceID: macDeviceID,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore+ConditionalRestore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore+ConditionalRestore.swift
@@ -19,7 +19,8 @@ extension BackingUpPairedMacStore {
         teamID: String?,
         now: Date
     ) async throws -> Bool {
-        try await inner.upsertIfNewer(
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
+        return try await inner.upsertIfNewer(
             macDeviceID: macDeviceID,
             displayName: displayName,
             routes: routes,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore.swift
@@ -71,6 +71,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         teamID: String?,
         now: Date
     ) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         // Inject the current team (callers go through the no-team convenience
         // overload, so `teamID` arrives nil) so the local row is scoped to the team
         // it was paired under. An explicit teamID (e.g. from restore) wins.
@@ -85,7 +86,8 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
             let existing = (try? await inner.loadAll(stackUserID: account, teamID: team)) ?? []
             previouslyActive = existing.first { $0.isActive }
             existedBeforeUpsert = existing.contains {
-                $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+                cmxCanonicalDeviceID($0.macDeviceID) == macDeviceID
+                    && $0.instanceTag == instanceTag
             }
         } else {
             previouslyActive = nil
@@ -153,6 +155,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         customIcon: String?,
         now: Date
     ) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await teamIDProvider()
         let target = try? await macFor(
             macDeviceID,
@@ -191,6 +194,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
 
     /// Mark one paired Mac active and mirror the changed active flags to backup.
     public func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await resolvedTeam(teamID)
         let target = try? await macFor(
             macDeviceID,
@@ -214,6 +218,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         stackUserID: String?,
         teamID: String?
     ) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         // Resolve the scope and the previously-active host BEFORE the flip, so we can
         // mirror exactly the two records that change. Scoped to the current team
         // (single-active is per (account, team)).
@@ -297,6 +302,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         teamID: String?,
         now: Date
     ) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await resolvedTeam(teamID)
         let target = try? await macFor(
             macDeviceID,
@@ -328,6 +334,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         teamID: String?,
         now: Date
     ) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await resolvedTeam(teamID)
         try await inner.setCustomization(
             macDeviceID: macDeviceID,
@@ -363,6 +370,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
 
     /// Remove one paired Mac locally and tombstone it in backup when signed in.
     public func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await resolvedTeam(teamID)
         let target = try? await macFor(
             macDeviceID,
@@ -386,6 +394,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         stackUserID: String?,
         teamID: String?
     ) async throws {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await resolvedTeam(teamID)
         let account: String?
         if let stackUserID {
@@ -562,8 +571,9 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         teamID: String?,
         requiresExactInstanceTag: Bool
     ) async throws -> MobilePairedMac? {
-        try await inner.loadAll(stackUserID: stackUserID, teamID: teamID).first {
-            $0.macDeviceID == macDeviceID
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
+        return try await inner.loadAll(stackUserID: stackUserID, teamID: teamID).first {
+            cmxCanonicalDeviceID($0.macDeviceID) == macDeviceID
                 && (!requiresExactInstanceTag || $0.instanceTag == instanceTag)
         }
     }
@@ -600,10 +610,12 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         allowTombstoneRevive: Bool = false,
         instanceAuthority: PairedMacBackupInstanceAuthorityWriteMode = .authoritative
     ) async -> Bool {
+        let macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let team = await resolvedTeam(teamID)
         guard let mac = (try? await inner.loadAll(stackUserID: account, teamID: team))?
             .first(where: {
-                $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+                cmxCanonicalDeviceID($0.macDeviceID) == macDeviceID
+                    && $0.instanceTag == instanceTag
             }) else { return false }
         let record = Self.backupRecord(from: mac)
         let op: PairedMacBackupOp
@@ -672,7 +684,14 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
 
     private func pendingDeleteIDs(scope: String) async -> Set<String> {
         if let ids = pendingDeleteIDsByScope[scope] { return ids }
-        let ids = await pendingDeleteStore.load(scope: scope)
+        let storedIDs = await pendingDeleteStore.load(scope: scope)
+        let ids = Set(storedIDs.map { pairingID in
+            let identity = MobilePairedMac.pairingIdentity(from: pairingID)
+            return MobilePairedMac.pairingID(
+                macDeviceID: identity.macDeviceID,
+                instanceTag: identity.instanceTag
+            )
+        })
         pendingDeleteIDsByScope[scope] = ids
         return ids
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacInstanceTagAuthority.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacInstanceTagAuthority.swift
@@ -1,3 +1,4 @@
+internal import CMUXMobileCore
 import Foundation
 
 /// Route authority expected from the authenticated Mac status handshake.
@@ -48,7 +49,8 @@ struct MobileMacInstanceTagAuthority {
         reportedDeviceID: String?,
         expectedDeviceID: String
     ) -> Bool {
-        normalized(reportedDeviceID)?.caseInsensitiveCompare(expectedDeviceID) == .orderedSame
+        guard let reported = normalized(reportedDeviceID) else { return false }
+        return cmxCanonicalDeviceID(reported) == cmxCanonicalDeviceID(expectedDeviceID)
     }
 
     static func sameStoredAuthority(_ lhs: String?, _ rhs: String?) -> Bool {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+InstanceAuthority.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+InstanceAuthority.swift
@@ -1,3 +1,4 @@
+internal import CMUXMobileCore
 import CmuxMobilePairedMac
 import Foundation
 
@@ -17,10 +18,11 @@ extension MobileShellComposite {
               !macDeviceID.isEmpty,
               let pairedMacStore,
               let scope = await currentScopeSnapshot() else { return false }
+        let canonicalDeviceID = cmxCanonicalDeviceID(macDeviceID)
         let existing = try? await pairedMacStore.loadAll(
             stackUserID: scope.userID,
             teamID: scope.teamID
-        ).first { $0.macDeviceID.caseInsensitiveCompare(macDeviceID) == .orderedSame }
+        ).first { cmxCanonicalDeviceID($0.macDeviceID) == canonicalDeviceID }
         guard await isScopeCurrent(scope) else { return true }
         return MobileMacInstanceTagAuthority.normalized(existing?.instanceTag) != nil
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
@@ -3,6 +3,48 @@ internal import CmuxMobilePairedMac
 internal import CmuxMobileShellModel
 
 extension MobileShellComposite {
+    /// Select one authoritative stored row per physical device identifier.
+    ///
+    /// UUID spellings share a lowercase identity, while opaque identifiers stay
+    /// case-sensitive. The freshest row owns all routes and metadata; no route
+    /// or customization fields are merged from an older alias.
+    static func coalescePairedMacsByCanonicalDeviceID(
+        _ macs: [MobilePairedMac]
+    ) -> [MobilePairedMac] {
+        var selectedByDeviceID: [String: MobilePairedMac] = [:]
+        var deviceOrder: [String] = []
+
+        for mac in macs where !mac.macDeviceID.isEmpty {
+            let canonicalDeviceID = cmxCanonicalDeviceID(mac.macDeviceID)
+            guard let selected = selectedByDeviceID[canonicalDeviceID] else {
+                selectedByDeviceID[canonicalDeviceID] = mac
+                deviceOrder.append(canonicalDeviceID)
+                continue
+            }
+            let shouldReplace: Bool
+            let candidateUsesCanonicalSpelling = mac.macDeviceID == canonicalDeviceID
+            let selectedUsesCanonicalSpelling = selected.macDeviceID == canonicalDeviceID
+            if mac.lastSeenAt != selected.lastSeenAt {
+                shouldReplace = mac.lastSeenAt > selected.lastSeenAt
+            } else if candidateUsesCanonicalSpelling != selectedUsesCanonicalSpelling {
+                shouldReplace = candidateUsesCanonicalSpelling
+            } else if mac.isActive != selected.isActive {
+                shouldReplace = mac.isActive
+            } else {
+                shouldReplace = mac.id < selected.id
+            }
+            if shouldReplace {
+                selectedByDeviceID[canonicalDeviceID] = mac
+            }
+        }
+
+        return deviceOrder.compactMap { deviceID in
+            guard var selected = selectedByDeviceID[deviceID] else { return nil }
+            selected.macDeviceID = deviceID
+            return selected
+        }
+    }
+
     /// Collapse duplicate paired-Mac rows that have the same Mac-reported name
     /// and dial the same host/port.
     ///

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ZeroTouchIroh.swift
@@ -26,7 +26,7 @@ extension MobileShellComposite {
         var candidates: [MobilePairedMac] = []
         for mac in discovered {
             let pairingID = MobilePairedMac.pairingID(
-                macDeviceID: mac.deviceID.lowercased(),
+                macDeviceID: mac.deviceID,
                 instanceTag: mac.instanceTag
             )
             guard !mac.routes.isEmpty,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1831,7 +1831,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 generation: generation,
                 excluding: Set(candidates.map {
                     MobilePairedMac.pairingID(
-                        macDeviceID: $0.macDeviceID.lowercased(),
+                        macDeviceID: $0.macDeviceID,
                         instanceTag: $0.instanceTag
                     )
                 })
@@ -2768,9 +2768,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         instanceTag: String?
     ) async {
         guard remoteClient === client,
-              let reportedID = deviceID?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !reportedID.isEmpty,
+              let rawReportedID = deviceID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawReportedID.isEmpty,
               let ticket = activeTicket else { return }
+        let reportedID = cmxCanonicalDeviceID(rawReportedID)
         let resolvedTicket: CmxAttachTicket
         if ticket.macDeviceID.isEmpty,
            let adopted = try? CmxAttachTicket(
@@ -3438,32 +3439,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return secondaryAggregationCandidateMacs(from: visibleLoadedMacs).map(\.macDeviceID)
     }
 
-    private func secondaryAggregationCandidateMacs(from visibleLoadedMacs: [MobilePairedMac]) -> [MobilePairedMac] {
+    func secondaryAggregationCandidateMacs(from visibleLoadedMacs: [MobilePairedMac]) -> [MobilePairedMac] {
         let supportedRouteKinds = runtime?.supportedRouteKinds ?? []
+        let physicalMacs = Self.coalescePairedMacsByCanonicalDeviceID(visibleLoadedMacs)
         let endpointDistinctMacs = Self.coalescePairedMacsByDialEndpoint(
-            visibleLoadedMacs,
+            physicalMacs,
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
-        var selectedByPhysicalMac: [String: MobilePairedMac] = [:]
-        var physicalMacOrder: [String] = []
-        for mac in endpointDistinctMacs where !mac.macDeviceID.isEmpty {
-            guard let selected = selectedByPhysicalMac[mac.macDeviceID] else {
-                selectedByPhysicalMac[mac.macDeviceID] = mac
-                physicalMacOrder.append(mac.macDeviceID)
-                continue
-            }
-            let shouldReplace = mac.isActive != selected.isActive
-                ? mac.isActive
-                : mac.lastSeenAt != selected.lastSeenAt
-                    ? mac.lastSeenAt > selected.lastSeenAt
-                    : mac.id < selected.id
-            if shouldReplace {
-                selectedByPhysicalMac[mac.macDeviceID] = mac
-            }
-        }
         let macs = Self.coalescePairedMacsByIrohEndpointAuthority(
-            physicalMacOrder.compactMap { selectedByPhysicalMac[$0] },
+            endpointDistinctMacs,
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
@@ -3475,13 +3460,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let foregroundMacDeviceIDs = foregroundMacDeviceID.map {
             aliasIDsByMacID[$0] ?? [$0]
         } ?? []
-        let foregroundIDSet = Set(foregroundMacDeviceIDs)
+        let foregroundIDSet = Set(foregroundMacDeviceIDs.map(cmxCanonicalDeviceID))
         var foregroundIrohEndpointIDs = Set<String>()
         if case let .peer(identity, _)? = activeRoute?.endpoint {
             foregroundIrohEndpointIDs.insert(identity.endpointID)
         }
         if let foregroundMacDeviceID {
-            for mac in visibleLoadedMacs where mac.macDeviceID == foregroundMacDeviceID {
+            let canonicalForegroundID = cmxCanonicalDeviceID(foregroundMacDeviceID)
+            for mac in visibleLoadedMacs
+                where cmxCanonicalDeviceID(mac.macDeviceID) == canonicalForegroundID {
                 if let endpointID = Self.irohEndpointID(
                     for: mac,
                     supportedKinds: supportedRouteKinds,
@@ -3493,7 +3480,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         return macs.filter { mac in
             guard !mac.macDeviceID.isEmpty,
-                  !foregroundIDSet.contains(mac.macDeviceID) else { return false }
+                  !foregroundIDSet.contains(cmxCanonicalDeviceID(mac.macDeviceID)) else {
+                return false
+            }
             guard let endpointID = Self.irohEndpointID(
                 for: mac,
                 supportedKinds: supportedRouteKinds,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupListResponse.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupListResponse.swift
@@ -1,3 +1,4 @@
+internal import CmuxMobilePairedMac
 import Foundation
 
 struct PairedMacBackupListResponse: Decodable {
@@ -20,5 +21,12 @@ struct PairedMacBackupListResponse: Decodable {
         deletedMacDeviceIDs = ((try? c.decodeIfPresent([String].self, forKey: .deletedMacDeviceIDs)) ?? [])
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+            .map { pairingID in
+                let identity = MobilePairedMac.pairingIdentity(from: pairingID)
+                return MobilePairedMac.pairingID(
+                    macDeviceID: identity.macDeviceID,
+                    instanceTag: identity.instanceTag
+                )
+            }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupOpWire.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupOpWire.swift
@@ -1,3 +1,4 @@
+internal import CMUXMobileCore
 import Foundation
 
 /// `{ macDeviceID, deleted?, record? }` matching the server's parse.
@@ -11,7 +12,7 @@ struct PairedMacBackupOpWire: Encodable {
     init(op: PairedMacBackupOp, routeDisclosureDate: Date = Date()) {
         switch op {
         case .upsert(let record, let instanceAuthority):
-            self.macDeviceID = record.macDeviceID
+            self.macDeviceID = cmxCanonicalDeviceID(record.macDeviceID)
             self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = nil
@@ -22,7 +23,7 @@ struct PairedMacBackupOpWire: Encodable {
                 instanceAuthority: instanceAuthority
             )
         case .upsertPreservingCustomizations(let record, let instanceAuthority):
-            self.macDeviceID = record.macDeviceID
+            self.macDeviceID = cmxCanonicalDeviceID(record.macDeviceID)
             self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = nil
@@ -33,7 +34,7 @@ struct PairedMacBackupOpWire: Encodable {
                 instanceAuthority: instanceAuthority
             )
         case .revive(let record, let instanceAuthority):
-            self.macDeviceID = record.macDeviceID
+            self.macDeviceID = cmxCanonicalDeviceID(record.macDeviceID)
             self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = true
@@ -44,7 +45,7 @@ struct PairedMacBackupOpWire: Encodable {
                 instanceAuthority: instanceAuthority
             )
         case .revivePreservingCustomizations(let record, let instanceAuthority):
-            self.macDeviceID = record.macDeviceID
+            self.macDeviceID = cmxCanonicalDeviceID(record.macDeviceID)
             self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = true
@@ -55,13 +56,13 @@ struct PairedMacBackupOpWire: Encodable {
                 instanceAuthority: instanceAuthority
             )
         case .delete(let macDeviceID):
-            self.macDeviceID = macDeviceID
+            self.macDeviceID = cmxCanonicalDeviceID(macDeviceID)
             self.instanceTag = nil
             self.deleted = true
             self.reviveDeleted = nil
             self.record = nil
         case .deleteInstance(let macDeviceID, let instanceTag):
-            self.macDeviceID = macDeviceID
+            self.macDeviceID = cmxCanonicalDeviceID(macDeviceID)
             self.instanceTag = instanceTag
             self.deleted = true
             self.reviveDeleted = nil

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecord.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecord.swift
@@ -39,7 +39,7 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
         routeDisclosureDate: Date = Date(),
         instanceTag: String? = nil
     ) {
-        self.macDeviceID = macDeviceID
+        self.macDeviceID = cmxCanonicalDeviceID(macDeviceID)
         self.displayName = displayName
         self.routes = PairedMacBackupRouteDisclosure(routes: routes)
             .cloudSafe(at: routeDisclosureDate)
@@ -62,7 +62,9 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
     /// while preserving the rest of the record for restore.
     public init(from decoder: any Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        macDeviceID = try c.decode(String.self, forKey: .macDeviceID)
+        macDeviceID = cmxCanonicalDeviceID(
+            try c.decode(String.self, forKey: .macDeviceID)
+        )
         displayName = try c.decodeIfPresent(String.self, forKey: .displayName)
         let decodedRoutes = try c.decodeIfPresent(
             [PairedMacBackupFailableRoute].self,
@@ -84,7 +86,7 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
     /// Encode custom override keys even when they are `nil`, so clears sync.
     public func encode(to encoder: any Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
-        try c.encode(macDeviceID, forKey: .macDeviceID)
+        try c.encode(cmxCanonicalDeviceID(macDeviceID), forKey: .macDeviceID)
         try c.encodeIfPresent(displayName, forKey: .displayName)
         try c.encode(
             PairedMacBackupRouteDisclosure(routes: routes).cloudPrivacySafe(),

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecordWire.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecordWire.swift
@@ -1,3 +1,4 @@
+internal import CMUXMobileCore
 import Foundation
 
 /// Encodes a backup record either as an authoritative iOS customization write
@@ -11,7 +12,7 @@ struct PairedMacBackupRecordWire: Encodable {
 
     func encode(to encoder: any Encoder) throws {
         var c = encoder.container(keyedBy: PairedMacBackupRecord.CodingKeys.self)
-        try c.encode(record.macDeviceID, forKey: .macDeviceID)
+        try c.encode(cmxCanonicalDeviceID(record.macDeviceID), forKey: .macDeviceID)
         try c.encodeIfPresent(record.displayName, forKey: .displayName)
         try c.encode(
             record.routes.compactMap {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacRestore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacRestore.swift
@@ -1,3 +1,4 @@
+internal import CMUXMobileCore
 public import CmuxMobilePairedMac
 public import Foundation
 import os
@@ -60,10 +61,17 @@ public struct PairedMacRestore: Sendable {
         if !isCurrent() {
             return RestoreOutcome(completed: false, restored: 0)
         }
-        let tombstoneIDs = Set(snapshot.deletedMacDeviceIDs
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty })
-            .union(locallyDeletedMacDeviceIDs)
+        func canonicalPairingID(_ value: String) -> String? {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let identity = MobilePairedMac.pairingIdentity(from: trimmed)
+            return MobilePairedMac.pairingID(
+                macDeviceID: identity.macDeviceID,
+                instanceTag: identity.instanceTag
+            )
+        }
+        let tombstoneIDs = Set(snapshot.deletedMacDeviceIDs.compactMap(canonicalPairingID))
+            .union(locallyDeletedMacDeviceIDs.compactMap(canonicalPairingID))
         let liveRecords = snapshot.records.filter { record in
             !tombstoneIDs.contains(MobilePairedMac.pairingID(
                 macDeviceID: record.macDeviceID,
@@ -128,8 +136,9 @@ public struct PairedMacRestore: Sendable {
             if !isCurrent() {
                 return RestoreOutcome(completed: false, restored: restored)
             }
+            let canonicalDeviceID = cmxCanonicalDeviceID(record.macDeviceID)
             let pairingID = MobilePairedMac.pairingID(
-                macDeviceID: record.macDeviceID,
+                macDeviceID: canonicalDeviceID,
                 instanceTag: record.instanceTag
             )
             let backupSeconds = record.lastSeenAt / 1000.0
@@ -154,7 +163,7 @@ public struct PairedMacRestore: Sendable {
             do {
                 let backupDate = Date(timeIntervalSince1970: backupSeconds)
                 let restoredThisRecord = try await store.upsertIfNewer(
-                    macDeviceID: record.macDeviceID,
+                    macDeviceID: canonicalDeviceID,
                     displayName: record.displayName,
                     routes: record.routes,
                     instanceTag: record.instanceTag,
@@ -170,7 +179,7 @@ public struct PairedMacRestore: Sendable {
                 if !isCurrent() {
                     if localByID[pairingID] == nil {
                         try? await store.remove(
-                            macDeviceID: record.macDeviceID,
+                            macDeviceID: canonicalDeviceID,
                             instanceTag: record.instanceTag,
                             stackUserID: accountID,
                             teamID: teamID
@@ -184,7 +193,7 @@ public struct PairedMacRestore: Sendable {
                 restored += 1
             } catch {
                 pairedMacRestoreLog.warning(
-                    "failed to restore paired mac \(record.macDeviceID, privacy: .public): \(String(describing: error), privacy: .public)"
+                    "failed to restore paired mac \(canonicalDeviceID, privacy: .public): \(String(describing: error), privacy: .public)"
                 )
             }
         }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacInstanceTagAuthorityTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacInstanceTagAuthorityTests.swift
@@ -68,6 +68,17 @@ import Testing
         ))
     }
 
+    @Test func deviceAuthorityCanonicalizesUUIDsWithoutFoldingOpaqueIDs() {
+        #expect(MobileMacInstanceTagAuthority.authenticatedDeviceMatches(
+            reportedDeviceID: "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE",
+            expectedDeviceID: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+        ))
+        #expect(!MobileMacInstanceTagAuthority.authenticatedDeviceMatches(
+            reportedDeviceID: "Legacy-Mac-ID",
+            expectedDeviceID: "legacy-mac-id"
+        ))
+    }
+
     @Test func registryRefreshRequiresSameDeviceAndInstanceAuthority() {
         #expect(DeviceRegistryService.shouldApplyRegistryRefresh(
             isSignedIn: true,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeForgottenMacRefreshTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeForgottenMacRefreshTests.swift
@@ -271,6 +271,69 @@ import Testing
         #expect(await store.secondaryAggregationCandidateMacIDs() == ["mac-a"])
     }
 
+    @Test func secondaryAggregationUsesFreshUUIDAliasWithoutMergingStaleRoutes() throws {
+        let uppercaseUUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let lowercaseUUID = uppercaseUUID.lowercased()
+        let staleRoute = try CmxAttachRoute(
+            id: "stale",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.10", port: 50_901)
+        )
+        let freshRoute = try CmxAttachRoute(
+            id: "fresh",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.10", port: 50_902)
+        )
+        let shell = MobileShellComposite(isSignedIn: true)
+        let candidates = shell.secondaryAggregationCandidateMacs(from: [
+            try Self.pairedMac(
+                id: uppercaseUUID,
+                displayName: "Stale Studio",
+                host: "unused",
+                lastSeenAt: Date(timeIntervalSince1970: 10),
+                isActive: true,
+                customName: "Stale Name",
+                routes: [staleRoute],
+                instanceTag: "stale"
+            ),
+            try Self.pairedMac(
+                id: lowercaseUUID,
+                displayName: "Fresh Studio",
+                host: "unused",
+                lastSeenAt: Date(timeIntervalSince1970: 20),
+                isActive: false,
+                customName: "Fresh Name",
+                routes: [freshRoute],
+                instanceTag: "fresh"
+            ),
+            try Self.pairedMac(
+                id: "Legacy-ID",
+                displayName: "Opaque Upper",
+                host: "100.64.0.11",
+                lastSeenAt: Date(timeIntervalSince1970: 30),
+                isActive: false
+            ),
+            try Self.pairedMac(
+                id: "legacy-id",
+                displayName: "Opaque Lower",
+                host: "100.64.0.12",
+                lastSeenAt: Date(timeIntervalSince1970: 40),
+                isActive: false
+            ),
+        ])
+
+        let canonical = try #require(candidates.first { $0.macDeviceID == lowercaseUUID })
+        #expect(candidates.count == 3)
+        #expect(Set(candidates.map(\.macDeviceID)) == Set([
+            lowercaseUUID, "Legacy-ID", "legacy-id",
+        ]))
+        #expect(canonical.displayName == "Fresh Studio")
+        #expect(canonical.customName == "Fresh Name")
+        #expect(canonical.instanceTag == "fresh")
+        #expect(canonical.routes.map(\.id) == ["fresh"])
+        #expect(!canonical.isActive)
+    }
+
     @Test func secondaryAggregationExcludesStaleRecordSharingForegroundIrohEndpoint() async throws {
         let identity = try CmxIrohPeerIdentity(endpointID: String(repeating: "a", count: 64))
         let liveRoute = try CmxAttachRoute(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PairedMacBackupTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PairedMacBackupTests.swift
@@ -121,6 +121,58 @@ private let backupRouteDisclosureDate = Date(timeIntervalSince1970: 2_000_000_00
         }
     }
 
+    @Test func backupUploadCanonicalizesUUIDMutationsAndPreservesOpaqueIDs() async throws {
+        let uppercaseUUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let lowercaseUUID = uppercaseUUID.lowercased()
+        let (inner, dir) = try makeInnerStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let backup = FakeBackup()
+        let store = BackingUpPairedMacStore(inner: inner, backup: backup)
+
+        try await store.upsert(
+            macDeviceID: uppercaseUUID,
+            displayName: "Studio",
+            routes: [try route("10.0.0.1", 22)],
+            markActive: true,
+            stackUserID: "user-1",
+            now: Date(timeIntervalSince1970: 100)
+        )
+        try await store.remove(
+            macDeviceID: uppercaseUUID,
+            stackUserID: "user-1",
+            teamID: nil
+        )
+
+        let ops = await backup.uploadedOps()
+        #expect(ops.contains { op in
+            uploadedRecord(from: op)?.macDeviceID == lowercaseUUID
+        })
+        #expect(ops.contains { op in
+            if case .delete(let macDeviceID) = op {
+                return macDeviceID == lowercaseUUID
+            }
+            return false
+        })
+
+        let opaqueRecord = try backupRecord(
+            "Legacy-Mac-ID",
+            host: "10.0.0.2",
+            lastSeenMs: 200_000,
+            active: false
+        )
+        let body = PairedMacBackupRequestBody(ops: [
+            PairedMacBackupOpWire(op: .upsert(opaqueRecord)),
+            PairedMacBackupOpWire(op: .delete(macDeviceID: "Legacy-Mac-ID")),
+        ])
+        let object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(body)) as? [String: Any]
+        )
+        let wireOps = try #require(object["ops"] as? [[String: Any]])
+        #expect(wireOps.map { $0["macDeviceID"] as? String } == [
+            "Legacy-Mac-ID", "Legacy-Mac-ID",
+        ])
+    }
+
     @Test func anonymousUpsertIsNotBackedUp() async throws {
         let (inner, dir) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -841,6 +893,79 @@ private let backupRouteDisclosureDate = Date(timeIntervalSince1970: 2_000_000_00
         #expect(outcome.completed)
         #expect(outcome.restored == 0)
         #expect(try await inner.loadAll(stackUserID: "user-1").map(\.macDeviceID) == ["mac-x"])
+    }
+
+    @Test func backupRestoreCollapsesUUIDAliasesUnderFreshRouteAuthority() async throws {
+        let uppercaseUUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let lowercaseUUID = uppercaseUUID.lowercased()
+        var fresh = PairedMacBackupRecord(
+            macDeviceID: lowercaseUUID,
+            displayName: "Fresh Studio",
+            routes: [try CmxAttachRoute(
+                id: "fresh",
+                kind: .tailscale,
+                endpoint: .hostPort(host: "10.0.0.1", port: 50_902)
+            )],
+            createdAt: 1_000,
+            lastSeenAt: 20_000,
+            isActive: false,
+            customName: "Fresh Name"
+        )
+        var stale = PairedMacBackupRecord(
+            macDeviceID: uppercaseUUID,
+            displayName: "Stale Studio",
+            routes: [try CmxAttachRoute(
+                id: "stale",
+                kind: .tailscale,
+                endpoint: .hostPort(host: "10.0.0.1", port: 50_901)
+            )],
+            createdAt: 500,
+            lastSeenAt: 10_000,
+            isActive: true,
+            customName: "Stale Name"
+        )
+        // Model legacy server rows decoded before this boundary existed.
+        fresh.macDeviceID = lowercaseUUID
+        stale.macDeviceID = uppercaseUUID
+
+        let (inner, dir) = try makeInnerStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let outcome = await PairedMacRestore(
+            store: inner,
+            backup: FakeBackup(records: [fresh, stale])
+        ).run(accountID: "user-1")
+
+        let rows = try await inner.loadAll(stackUserID: "user-1")
+        let restored = try #require(rows.first)
+        #expect(outcome.restored == 1)
+        #expect(rows.count == 1)
+        #expect(restored.macDeviceID == lowercaseUUID)
+        #expect(restored.displayName == "Fresh Studio")
+        #expect(restored.customName == "Fresh Name")
+        #expect(restored.routes.map(\.id) == ["fresh"])
+        #expect(!restored.isActive)
+    }
+
+    @Test func legacyUppercaseBackupTombstoneDeletesCanonicalUUIDRow() async throws {
+        let uppercaseUUID = "AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE"
+        let lowercaseUUID = uppercaseUUID.lowercased()
+        let (inner, dir) = try makeInnerStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try await inner.upsert(
+            macDeviceID: lowercaseUUID,
+            displayName: "Studio",
+            routes: [try route("10.0.0.1", 22)],
+            markActive: true,
+            stackUserID: "user-1",
+            now: Date(timeIntervalSince1970: 100)
+        )
+
+        _ = await PairedMacRestore(
+            store: inner,
+            backup: FakeBackup(deletedMacDeviceIDs: [uppercaseUUID])
+        ).run(accountID: "user-1")
+
+        #expect(try await inner.loadAll(stackUserID: "user-1").isEmpty)
     }
 
     @Test func failedFetchRetriesOnNextRead() async throws {

--- a/Sources/Mobile/MobileHostIdentity.swift
+++ b/Sources/Mobile/MobileHostIdentity.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxSettings
 import Foundation
 
@@ -40,7 +41,7 @@ enum MobileHostIdentity {
             return settleSharedDeviceID(id, defaults: defaults, sharedIDURL: sharedIDURL)
         }
 
-        let generated = UUID().uuidString
+        let generated = cmxCanonicalDeviceID(UUID().uuidString)
         return settleSharedDeviceID(generated, defaults: defaults, sharedIDURL: sharedIDURL)
     }
 
@@ -70,8 +71,8 @@ enum MobileHostIdentity {
 
     private static func normalizedID(_ value: String?) -> String? {
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard let uuid = UUID(uuidString: trimmed) else { return nil }
-        return uuid.uuidString
+        guard UUID(uuidString: trimmed) != nil else { return nil }
+        return cmxCanonicalDeviceID(trimmed)
     }
 
     private static func readSharedDeviceID(from url: URL?) -> String? {
@@ -83,6 +84,7 @@ enum MobileHostIdentity {
     }
 
     private static func settleSharedDeviceID(_ candidate: String, defaults: UserDefaults, sharedIDURL: URL?) -> String {
+        let candidate = cmxCanonicalDeviceID(candidate)
         guard let sharedIDURL else {
             defaults.set(candidate, forKey: deviceIDKey)
             return candidate

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -17,7 +17,7 @@ extension MobileHostIrohRuntime {
             accountID: accountID,
             appInstanceID: appInstanceID
         )
-        let deviceID = MobileHostIdentity.deviceID().lowercased()
+        let deviceID = cmxCanonicalDeviceID(MobileHostIdentity.deviceID())
         let cachedBinding = try await brokerCredentials.loadBinding(
             accountID: accountID,
             appInstanceID: appInstanceID

--- a/cmuxTests/MobileHostIdentityTests.swift
+++ b/cmuxTests/MobileHostIdentityTests.swift
@@ -172,8 +172,8 @@ struct MobileHostIdentityTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set("175dff61-cabe-4076-b5ac-f5c1c04b62fa", forKey: "mobileHost.deviceID")
 
-        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == sharedID)
-        #expect(defaults.string(forKey: "mobileHost.deviceID") == sharedID)
+        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == sharedID.lowercased())
+        #expect(defaults.string(forKey: "mobileHost.deviceID") == sharedID.lowercased())
     }
 
     @Test func migratesExistingBundleIDToSharedFile() throws {
@@ -189,9 +189,9 @@ struct MobileHostIdentityTests {
         let defaultID = "C2FD4C2D-E0AF-447D-A8A4-D37BF67751EF"
         defaults.set(defaultID.lowercased(), forKey: "mobileHost.deviceID")
 
-        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == defaultID)
+        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == defaultID.lowercased())
         let persisted = try String(contentsOf: sharedIDURL, encoding: .utf8)
-        #expect(persisted == defaultID)
+        #expect(persisted == defaultID.lowercased())
     }
 
     @Test func taggedBuildMigratesStableBundleIDBeforeOwnBundleID() throws {
@@ -218,9 +218,9 @@ struct MobileHostIdentityTests {
             sharedIDURL: sharedIDURL,
             stableDefaults: stableDefaults,
             bundleIdentifier: "com.cmuxterm.app.debug.mpick"
-        ) == stableID)
-        #expect(taggedDefaults.string(forKey: "mobileHost.deviceID") == stableID)
-        #expect(try String(contentsOf: sharedIDURL, encoding: .utf8) == stableID)
+        ) == stableID.lowercased())
+        #expect(taggedDefaults.string(forKey: "mobileHost.deviceID") == stableID.lowercased())
+        #expect(try String(contentsOf: sharedIDURL, encoding: .utf8) == stableID.lowercased())
     }
 
     @Test func readsExistingSharedIDWithoutDefaults() throws {
@@ -236,8 +236,8 @@ struct MobileHostIdentityTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == sharedID)
-        #expect(defaults.string(forKey: "mobileHost.deviceID") == sharedID)
+        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == sharedID.lowercased())
+        #expect(defaults.string(forKey: "mobileHost.deviceID") == sharedID.lowercased())
     }
 
     @Test func repairsInvalidSharedIDFile() throws {
@@ -254,9 +254,9 @@ struct MobileHostIdentityTests {
         let fallbackID = "08E3578B-195D-486F-B874-023CDA2B647D"
         defaults.set(fallbackID, forKey: "mobileHost.deviceID")
 
-        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == fallbackID)
-        #expect(defaults.string(forKey: "mobileHost.deviceID") == fallbackID)
-        #expect(try String(contentsOf: sharedIDURL, encoding: .utf8) == fallbackID)
+        #expect(MobileHostIdentity.deviceID(defaults: defaults, sharedIDURL: sharedIDURL) == fallbackID.lowercased())
+        #expect(defaults.string(forKey: "mobileHost.deviceID") == fallbackID.lowercased())
+        #expect(try String(contentsOf: sharedIDURL, encoding: .utf8) == fallbackID.lowercased())
     }
 
     @Test func testMobileHostRouteDisclosureSeparatesAuthenticatedAndPublicHints() throws {

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -180,9 +180,9 @@ public struct CMUXMobileRootScene: View {
                     stackUserID: userID,
                     teamID: teamID
                 )
-                let target = macDeviceID.lowercased()
+                let target = cmxCanonicalDeviceID(macDeviceID)
                 return pairedMacs?.first(where: {
-                    $0.macDeviceID.lowercased() == target
+                    cmxCanonicalDeviceID($0.macDeviceID) == target
                         && $0.instanceTag == instanceTag
                 })?.routes
             }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRouteCatalog.swift
@@ -74,7 +74,7 @@ public actor MobileIrohRouteCatalog {
             endpointCounts[$0.endpointID] == 1
         }
         let grouped = Dictionary(grouping: unambiguousMacs) {
-            $0.deviceID.lowercased()
+            cmxCanonicalDeviceID($0.deviceID)
         }
 
         var replacement: [String: [String: [CmxAttachRoute]]] = [:]
@@ -129,7 +129,7 @@ public actor MobileIrohRouteCatalog {
             endpointCounts[$0.endpointID] == 1
         }
         let bindingsByDeviceTag = Dictionary(grouping: unambiguousEndpoints) {
-            DeviceTag(deviceID: $0.deviceID.lowercased(), tag: $0.tag)
+            DeviceTag(deviceID: cmxCanonicalDeviceID($0.deviceID), tag: $0.tag)
         }
         let selectedBindingIDs = Set(
             bindingsByDeviceTag.values.compactMap { candidates in
@@ -161,7 +161,7 @@ public actor MobileIrohRouteCatalog {
                       priority: preferredRoutePriority
                   ) else { return nil }
             return MobileDiscoveredIrohMac(
-                deviceID: binding.deviceID.lowercased(),
+                deviceID: cmxCanonicalDeviceID(binding.deviceID),
                 displayName: binding.displayName,
                 instanceTag: binding.tag,
                 routes: [route],
@@ -211,7 +211,7 @@ public actor MobileIrohRouteCatalog {
         forKnownMacDeviceID macDeviceID: String,
         instanceTag: String?
     ) -> [CmxAttachRoute] {
-        guard let routesByTag = routesByMacDeviceID[macDeviceID.lowercased()] else {
+        guard let routesByTag = routesByMacDeviceID[cmxCanonicalDeviceID(macDeviceID)] else {
             return []
         }
         if let instanceTag {
@@ -373,13 +373,13 @@ public struct PersonalIrohDeviceRegistryDecorator: DeviceRegistryRefreshing {
         var result = team
         var deviceIndexes: [String: Int] = [:]
         for (index, device) in result.enumerated() {
-            let key = device.deviceId.lowercased()
+            let key = cmxCanonicalDeviceID(device.deviceId)
             if deviceIndexes[key] == nil {
                 deviceIndexes[key] = index
             }
         }
         for personalDevice in personal {
-            let deviceKey = personalDevice.deviceId.lowercased()
+            let deviceKey = cmxCanonicalDeviceID(personalDevice.deviceId)
             guard let deviceIndex = deviceIndexes[deviceKey] else {
                 deviceIndexes[deviceKey] = result.endIndex
                 result.append(personalDevice)

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -1101,7 +1101,7 @@ public final class MobileIrohRuntimeComposition:
             appInstanceID: appInstanceID
         )
         let endpointID = try Self.peerIdentity(for: identity)
-        let deviceID = deviceID().lowercased()
+        let deviceID = cmxCanonicalDeviceID(deviceID())
         let cachedBinding = try await brokerCredentials.loadBinding(
             accountID: accountID,
             appInstanceID: appInstanceID


### PR DESCRIPTION
## Summary

- Canonicalize valid UUID device IDs at host emission, ticket/status adoption, paired-store operations, Iroh routes, backup/restore, reconnect/zero-touch, and secondary-client aggregation while preserving opaque IDs byte-for-byte.
- Migrate paired storage from schema v6 to v7 atomically. Deduplication stays within the exact owner scope, ORs active state, preserves minimum creation and maximum last-seen times, and takes metadata, customization, and routes only from the freshest row.
- Coalesce UUID aliases before secondary aggregation so differently cased forms cannot create duplicate clients.

## Verification

- `Packages/Shared/CMUXMobileCore: swift test` (225 tests)
- `Packages/iOS/CmuxMobilePairedMac: swift package clean && swift test` (21 tests)
- Focused `CmuxMobileRPC`, `CmuxMobileShell`, Iroh zero-touch/reconnect, authority, LAN discovery, and host identity suites passed.
- macOS tagged cloud build `idcanon`: https://github.com/manaflow-ai/cmux/actions/runs/29677783792
- Isolated iOS Simulator `cmux-idcanon-codex-0718` built, signed in, auto-paired, and opened the terminal list. Its live paired store reports schema v7 and one lowercase UUID identity with active Iroh routes.
- `ios/cmuxPackage swift test --filter MobileIrohRuntimeCompositionTests` is blocked before compilation by the existing SwiftPM platform mismatch: targets default to macOS 10.13 while dependencies require macOS 14. The Xcode simulator build compiled this composition path.

## Commit structure

- `d66c3e3e4f` adds the failing regression coverage.
- `0575f04392` implements the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes UUID device IDs to lowercase across pairing, Iroh, backup/restore, and store paths to prevent duplicate Macs and stabilize matching, while preserving non-UUID IDs exactly. Adds a v7 paired-store migration that dedupes case-only UUID aliases and keeps the freshest metadata and routes.

- New Features
  - Added `cmxCanonicalDeviceID` in `CMUXMobileCore` (lowercases UUIDs; returns opaque IDs unchanged).
  - Applied canonicalization in tickets/pairing payloads, `CmuxIrohTransport` configs and LAN discovery, host identity generation, `CmuxMobilePairedMac` store CRUD, backup encode/decode, route catalog, and secondary aggregation.
  - Coalesces UUID aliases before secondary aggregation so mixed-case forms can’t create duplicate clients.

- Migration
  - Upgrades paired store schema v6 → v7, deduping case-only UUID aliases per owner scope (account/team/instance).
  - Freshest row owns routes/metadata; active state is OR’ed; createdAt=min, lastSeenAt=max.
  - Migration is atomic and rebuilds indexes; runs on first launch with v7.

<sup>Written for commit 0575f04392b5dc32b05ad164cb1d5187b5e536ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

