### PR TITLE
Classify Iroh live discovery failures

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+PolicyRefresh.swift
@@ -1,3 +1,4 @@
+internal import CMUXMobileCore
 internal import Foundation
 
 extension CmxIrohClientRuntime {
@@ -56,12 +57,18 @@ extension CmxIrohClientRuntime {
         let refreshID = UUID()
         registrationRefreshTaskID = refreshID
         registrationRefreshTask = Task { [weak self] in
-            guard let self else { return }
-            try await self.refreshRegistration(revision: revision, refreshID: refreshID)
+            guard let self else { return .failed(.superseded) }
+            return try await self.refreshRegistration(
+                revision: revision,
+                refreshID: refreshID
+            )
         }
     }
 
-    func refreshRegistration(revision: UInt64, refreshID: UUID) async throws {
+    func refreshRegistration(
+        revision: UInt64,
+        refreshID: UUID
+    ) async throws -> CmxIrohLiveDiscoveryRefreshOutcome {
         defer {
             if lifecycleRevision == revision,
                registrationRefreshTaskID == refreshID {
@@ -75,8 +82,12 @@ extension CmxIrohClientRuntime {
             }
         }
         guard lifecyclePhase == .active,
-              lifecycleRevision == revision,
-              let previousBinding = localBinding else { return }
+              lifecycleRevision == revision else {
+            return .failed(.superseded)
+        }
+        guard let previousBinding = localBinding else {
+            return .failed(.endpointUnavailable)
+        }
         do {
             let endpoint = try await supervisor.activeEndpoint()
             let endpointID = await endpoint.identity()
@@ -98,10 +109,14 @@ extension CmxIrohClientRuntime {
                let discovery = policy.discovery {
                 let published = await handleBinding(registration, discovery)
                 try requireCurrent(revision)
-                if published { liveDiscoveryGeneration &+= 1 }
+                guard published else { return .failed(.superseded) }
+                liveDiscoveryGeneration &+= 1
+                return .refreshed
             } else if let lanRendezvous = policy.cachedLANRendezvous {
                 await handleCachedBindings(policy.cachedTargetBindings, lanRendezvous)
+                return .failed(.offline)
             }
+            return .failed(.policyUnavailable)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -113,7 +128,7 @@ extension CmxIrohClientRuntime {
                 .preservesVerifiedPolicyDuringRefresh(error) else {
                 // Keep the last exact verified binding while broker availability
                 // prevents a refresh.
-                return
+                return .failed(DiagnosticFailureKind.classify(error))
             }
             lifecyclePhase = .stopping
             lifecycleRevision &+= 1

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -85,7 +85,7 @@ public actor CmxIrohClientRuntime {
     var signOutOperation: Task<CmxIrohClientSignOutPreparation, Never>?
     var relayCoordinator: CmxIrohRelayCredentialCoordinator?
     var supervisorEventTask: Task<Void, Never>?
-    var registrationRefreshTask: Task<Void, any Error>?
+    var registrationRefreshTask: Task<CmxIrohLiveDiscoveryRefreshOutcome, any Error>?
     var registrationRefreshTaskID: UUID?
     var registrationRefreshPending = false
     var registrationRefreshEnabled = false
@@ -192,17 +192,39 @@ public actor CmxIrohClientRuntime {
     /// already-paired Macs, but returns false here so a cached or stale snapshot
     /// can never authorize a first pairing.
     public func refreshLiveDiscovery() async -> Bool {
+        await refreshLiveDiscoveryOutcome() == .refreshed
+    }
+
+    /// Refreshes registration and discovery with a privacy-safe failure reason.
+    ///
+    /// Connectivity fallback may preserve the existing verified runtime, but
+    /// returns a categorical failure so diagnostics can distinguish an offline
+    /// broker, unavailable policy, inactive endpoint, and superseded lifecycle.
+    /// Raw errors and their potentially sensitive associated data are discarded.
+    ///
+    /// - Returns: Whether a new verified snapshot was installed, or the bounded
+    ///   reason it was not.
+    public func refreshLiveDiscoveryOutcome() async -> CmxIrohLiveDiscoveryRefreshOutcome {
         do {
-            return try await refreshLiveDiscoveryThrowing()
+            return try await refreshLiveDiscoveryOutcomeThrowing()
         } catch {
-            return false
+            return .failed(DiagnosticFailureKind.classify(error))
         }
     }
 
     func refreshLiveDiscoveryThrowing() async throws -> Bool {
-        guard lifecyclePhase == .active else { return false }
+        try await refreshLiveDiscoveryOutcomeThrowing() == .refreshed
+    }
+
+    private func refreshLiveDiscoveryOutcomeThrowing() async throws
+        -> CmxIrohLiveDiscoveryRefreshOutcome
+    {
+        guard lifecyclePhase == .active else {
+            return .failed(.endpointUnavailable)
+        }
         let priorGeneration = liveDiscoveryGeneration
         var mayScheduleFreshRequest = registrationRefreshTask != nil
+        var latestOutcome: CmxIrohLiveDiscoveryRefreshOutcome = .failed(.superseded)
         if registrationRefreshTask == nil {
             scheduleRegistrationRefresh(revision: lifecycleRevision)
         }
@@ -212,18 +234,22 @@ public actor CmxIrohClientRuntime {
               let refreshID = registrationRefreshTaskID,
               refreshID != lastAwaitedTaskID {
             lastAwaitedTaskID = refreshID
-            try await refresh.value
-            guard lifecyclePhase == .active else { return false }
-            if liveDiscoveryGeneration > priorGeneration { return true }
+            latestOutcome = try await refresh.value
+            guard lifecyclePhase == .active else {
+                return .failed(.endpointUnavailable)
+            }
+            if liveDiscoveryGeneration > priorGeneration { return .refreshed }
             if registrationRefreshTaskID != nil {
                 mayScheduleFreshRequest = false
                 continue
             }
-            guard mayScheduleFreshRequest else { return false }
+            guard mayScheduleFreshRequest else { return latestOutcome }
             mayScheduleFreshRequest = false
             scheduleRegistrationRefresh(revision: lifecycleRevision)
         }
-        return false
+        return lifecyclePhase == .active
+            ? latestOutcome
+            : .failed(.endpointUnavailable)
     }
 
     /// Returns the selected live path after removing raw transport coordinates.
@@ -354,7 +380,7 @@ public actor CmxIrohClientRuntime {
         registrationRefreshEnabled = false
         do {
             if let refresh = registrationRefreshTask {
-                try await refresh.value
+                _ = try await refresh.value
                 try requireCurrent(revision)
             }
             let checked = try await supervisor.ensureHealthy()

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLiveDiscoveryRefreshOutcome.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLiveDiscoveryRefreshOutcome.swift
@@ -1,0 +1,14 @@
+public import CMUXMobileCore
+
+/// The privacy-safe result of requesting a fresh broker discovery snapshot.
+///
+/// Failures carry only the bounded diagnostic category. The outcome never
+/// retains an error description, endpoint identity, relay URL, account value,
+/// or network address.
+public enum CmxIrohLiveDiscoveryRefreshOutcome: Equatable, Sendable {
+    /// A new verified broker snapshot was installed for first-pair discovery.
+    case refreshed
+
+    /// No new live snapshot was installed for the given categorical reason.
+    case failed(DiagnosticFailureKind)
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeLifecycleRaceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeLifecycleRaceTests.swift
@@ -267,7 +267,7 @@ extension CmxIrohClientRuntimeTests {
 
         await runtime.stop()
         await gate.open()
-        try? await refresh?.value
+        _ = try? await refresh?.value
 
         #expect(await runtime.snapshot().state == .inactive)
         #expect(await endpoint.observedCloseCallCount() == 1)
@@ -300,7 +300,7 @@ extension CmxIrohClientRuntimeTests {
 
         let preparation = await runtime.deactivateForSignOut()
         await gate.open()
-        try? await refresh?.value
+        _ = try? await refresh?.value
 
         #expect(preparation.wasPersisted)
         #expect(await runtime.snapshot().state == .inactive)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeTests.swift
@@ -82,7 +82,7 @@ struct CmxIrohClientRuntimeTests {
     }
 
     @Test
-    func unavailableBrokerCannotReuseStaleSnapshotForFirstPairing() async throws {
+    func unavailableBrokerReportsOfflineWithoutReusingStaleDiscovery() async throws {
         let fixture = try ClientRuntimeTestFixture()
         let broker = TestIrohClientBroker(
             binding: fixture.binding,
@@ -106,9 +106,45 @@ struct CmxIrohClientRuntimeTests {
         try await runtime.start()
         await broker.setRegistrationError(CmxIrohTrustBrokerClientError.connectivity)
 
-        #expect(!(await runtime.refreshLiveDiscovery()))
+        #expect(
+            await runtime.refreshLiveDiscoveryOutcome()
+                == .failed(.offline)
+        )
         #expect(await runtime.snapshot().state == .active)
         #expect(await recorder.observedBindingCount() == 1)
+        await runtime.stop()
+    }
+
+    @Test
+    func rateLimitedBrokerReportsPolicyUnavailableWithoutDroppingRuntime() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let broker = TestIrohClientBroker(
+            binding: fixture.binding,
+            discovery: fixture.discovery,
+            relay: fixture.relayResponse()
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [
+                TestIrohEndpoint(identity: fixture.endpointID),
+            ]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+        try await runtime.start()
+        await broker.setRegistrationError(
+            CmxIrohTrustBrokerClientError.rateLimited(
+                code: nil,
+                retryAfterSeconds: 15
+            )
+        )
+
+        #expect(
+            await runtime.refreshLiveDiscoveryOutcome()
+                == .failed(.policyUnavailable)
+        )
+        #expect(await runtime.snapshot().state == .active)
         await runtime.stop()
     }
 
@@ -132,9 +168,33 @@ struct CmxIrohClientRuntimeTests {
 
         try await runtime.start()
         #expect(await runtime.liveDiscoverySnapshotGeneration() == 0)
-        #expect(!(await runtime.refreshLiveDiscovery()))
+        #expect(
+            await runtime.refreshLiveDiscoveryOutcome()
+                == .failed(.superseded)
+        )
         #expect(await runtime.liveDiscoverySnapshotGeneration() == 0)
         await runtime.stop()
+    }
+
+    @Test
+    func inactiveRuntimeReportsEndpointUnavailable() async throws {
+        let fixture = try ClientRuntimeTestFixture()
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(endpoints: []),
+            broker: TestIrohClientBroker(
+                binding: fixture.binding,
+                discovery: fixture.discovery,
+                relay: fixture.relayResponse()
+            ),
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { fixture.now }
+        )
+
+        #expect(
+            await runtime.refreshLiveDiscoveryOutcome()
+                == .failed(.endpointUnavailable)
+        )
     }
 
     @Test

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -402,14 +402,13 @@ public final class MobileIrohRuntimeComposition:
             recordDiscoveryOutcome(candidateCount: candidates.count)
             return candidates
         }
-        guard await runtime.refreshLiveDiscovery() else {
+        let refreshOutcome = await runtime.refreshLiveDiscoveryOutcome()
+        guard refreshOutcome == .refreshed else {
             guard self.runtime === runtime else { return [] }
             await routeCatalog.clearLiveMacCandidates(scope: lifecycleRevision)
-            diagnosticLog?.record(DiagnosticEvent(
-                .discoveryFailed,
-                a: DiagnosticTransportKind.iroh.rawValue,
-                b: DiagnosticFailureKind.unknown.rawValue
-            ))
+            if let event = Self.discoveryRefreshFailureEvent(for: refreshOutcome) {
+                diagnosticLog?.record(event)
+            }
             return []
         }
         generation = await runtime.liveDiscoverySnapshotGeneration()
@@ -437,6 +436,17 @@ public final class MobileIrohRuntimeComposition:
                 b: DiagnosticFailureKind.noRoute.rawValue
             ))
         }
+    }
+
+    nonisolated static func discoveryRefreshFailureEvent(
+        for outcome: CmxIrohLiveDiscoveryRefreshOutcome
+    ) -> DiagnosticEvent? {
+        guard case let .failed(failure) = outcome else { return nil }
+        return DiagnosticEvent(
+            .discoveryFailed,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: failure.rawValue
+        )
     }
 
     /// Resolves a disconnected transport from the active account runtime.

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -84,6 +84,32 @@ struct MobileIrohRuntimeCompositionTests {
     }
 
     @Test
+    func discoveryRefreshDiagnosticPreservesTypedFailureCategory() throws {
+        let offline = try #require(
+            MobileIrohRuntimeComposition.discoveryRefreshFailureEvent(
+                for: .failed(.offline)
+            )
+        )
+        #expect(offline.code == .discoveryFailed)
+        #expect(offline.a == DiagnosticTransportKind.iroh.rawValue)
+        #expect(offline.b == DiagnosticFailureKind.offline.rawValue)
+        #expect(offline.surface == nil)
+        #expect(offline.c == nil)
+
+        let unavailable = try #require(
+            MobileIrohRuntimeComposition.discoveryRefreshFailureEvent(
+                for: .failed(.policyUnavailable)
+            )
+        )
+        #expect(unavailable.b == DiagnosticFailureKind.policyUnavailable.rawValue)
+        #expect(
+            MobileIrohRuntimeComposition.discoveryRefreshFailureEvent(
+                for: .refreshed
+            ) == nil
+        )
+    }
+
+    @Test
     func discoveryCatalogRetainsFortyConcurrentDevelopmentBindings() async throws {
         let bindings = (0..<40).map { index in
             mobileIrohBinding(


### PR DESCRIPTION
## Summary
- preserve the typed cause when live Iroh discovery cannot refresh
- record only bounded diagnostic categories, never raw errors, endpoint IDs, relay URLs, account data, or addresses
- keep the existing Boolean refresh API and lifecycle coalescing behavior

## Verification
- red commit: `e8fc4241d9` failed because the typed outcome API did not exist
- `swift test` in `Packages/Shared/CmuxIrohTransport` (381 tests passed)
- tagged iOS Simulator build on isolated `cmux-irdisc-diag-0719` succeeded
- tagged macOS cloud build `irdisc` succeeded: https://github.com/manaflow-ai/cmux/actions/runs/29678638316

## Test limitation
The standalone `ios/cmuxPackage` macOS test invocation is blocked on its pre-existing package platform declarations. The same composition compiled successfully through the iOS Simulator app graph.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787039521&installation_id=133855650&pr_number=8464&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8464&signature=370d5a1954d44f782ffd9b5e1238e12a28a5c8436564665a59499819013f5326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies Iroh live discovery refresh failures into bounded categories and records privacy-safe diagnostics, without exposing raw errors or IDs. Adds an outcome-based API while keeping the existing boolean call and preserving lifecycle coalescing.

- **New Features**
  - Added `CmxIrohLiveDiscoveryRefreshOutcome` with `.refreshed` and `.failed(DiagnosticFailureKind)`.
  - Introduced `refreshLiveDiscoveryOutcome()`; `refreshLiveDiscovery()` remains and maps to the outcome.
  - Categorized failures: `.offline`, `.policyUnavailable`, `.endpointUnavailable`, `.superseded`.
  - `ios/cmuxPackage` records a `DiagnosticEvent` only with the failure category; no endpoint IDs, relay URLs, account data, or addresses are logged.
  - Refresh task now returns the outcome; tests verify outcomes and state handling.

<sup>Written for commit d884ef3ca6f72522559f2223aa62421e60e4877f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-safe, categorized outcomes for live discovery refreshes.
  * Refresh results now distinguish successful updates from conditions such as offline status, unavailable policy, missing endpoints, or superseded requests.
  * Existing refresh behavior remains available through the Boolean result.

* **Bug Fixes**
  * Improved lifecycle and concurrent refresh handling.
  * Prevented stale discovery data from being reused after unsuccessful refreshes.
  * Diagnostics now preserve failure categories without exposing sensitive error details.

* **Tests**
  * Expanded coverage for refresh failures, lifecycle races, offline behavior, and diagnostic reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->