### PR TITLE
Stabilize Iroh reconnect capacity and Intel macOS 14 builds

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -226,7 +226,9 @@ jobs:
           xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
             -disableAutomaticPackageResolution \
-            -destination "platform=macOS" build
+            -destination "platform=macOS" \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            build
 
       - name: Smoke test
         if: matrix.startup_smoke

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -166,6 +166,7 @@ jobs:
               -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
               -disableAutomaticPackageResolution \
               -destination "platform=macOS" \
+              COMPILER_INDEX_STORE_ENABLE=NO \
               test 2>&1
           }
 

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -18,7 +18,7 @@ jobs:
             expected_arch: x86_64
             expected_os_major: "14"
           - os: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            timeout: 30
+            timeout: 60
             run_unit_tests: true
             startup_smoke: true
             virtual_display: true
@@ -26,7 +26,7 @@ jobs:
             expected_arch: ""
             expected_os_major: ""
           - os: ${{ vars.MACOS_RUNNER_26 || 'blacksmith-6vcpu-macos-26' }}
-            timeout: 30
+            timeout: 60
             run_unit_tests: true
             startup_smoke: true
             virtual_display: false

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests+Capacity.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests+Capacity.swift
@@ -183,11 +183,11 @@ extension CmxIrohEndpointServerTests {
             connection,
             generation,
             markAdmitted in
+            #expect(await markAdmitted())
             await recorder.record(
                 identity: await connection.remoteIdentity(),
                 generation: generation
             )
-            #expect(await markAdmitted())
             await blocker.wait()
         }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests+Capacity.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests+Capacity.swift
@@ -183,11 +183,11 @@ extension CmxIrohEndpointServerTests {
             connection,
             generation,
             markAdmitted in
-            #expect(await markAdmitted())
             await recorder.record(
                 identity: await connection.remoteIdentity(),
                 generation: generation
             )
+            #expect(await markAdmitted())
             await blocker.wait()
         }
 
@@ -201,6 +201,9 @@ extension CmxIrohEndpointServerTests {
             reconnects.append(reconnect)
             await endpoint.enqueue(reconnect)
             #expect(await recorder.next().identity == firstRemoteIdentity)
+            if reconnects.count > 1 {
+                await reconnects[reconnects.count - 2].waitUntilClosed()
+            }
         }
         #expect(await reconnects[0].observedCloseCallCount() == 1)
         #expect(await reconnects[1].observedCloseCallCount() == 1)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests.swift
@@ -3,9 +3,7 @@ import Foundation
 import Testing
 @testable import CmuxIrohTransport
 
-/// These tests coordinate server tasks with manual clocks and continuation gates.
-/// Serial execution keeps each test's causal scheduling assertions isolated.
-@Suite(.serialized)
+@Suite
 struct CmxIrohEndpointServerTests {
     @Test
     func activeGenerationAcceptsThroughTheBoundedServerLoop() async throws {
@@ -185,8 +183,10 @@ struct CmxIrohEndpointServerTests {
         )
         _ = try await supervisor.activate()
         let clock = EndpointServerManualClock()
+        let admissionGate = EndpointServerHandlerBlocker()
         let blocker = EndpointServerHandlerBlocker()
         let recorder = EndpointServerRecorder()
+        let admitted = EndpointServerRecorder()
         let server = CmxIrohEndpointServer(
             supervisor: supervisor,
             admissionTimeout: 15,
@@ -196,7 +196,12 @@ struct CmxIrohEndpointServerTests {
                 identity: await connection.remoteIdentity(),
                 generation: generation
             )
+            await admissionGate.wait()
             #expect(await markAdmitted())
+            await admitted.record(
+                identity: await connection.remoteIdentity(),
+                generation: generation
+            )
             await blocker.wait()
         }
         let connection = TestIrohConnection(
@@ -209,6 +214,8 @@ struct CmxIrohEndpointServerTests {
         await endpoint.enqueue(connection)
         #expect(await recorder.next().identity == remoteIdentity)
         await clock.waitUntilSleeping()
+        await admissionGate.releaseAll()
+        #expect(await admitted.next().identity == remoteIdentity)
         await clock.fire()
 
         #expect(await connection.observedCloseCallCount() == 0)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohEndpointServerTests.swift
@@ -3,7 +3,9 @@ import Foundation
 import Testing
 @testable import CmuxIrohTransport
 
-@Suite
+/// These tests coordinate server tasks with manual clocks and continuation gates.
+/// Serial execution keeps each test's causal scheduling assertions isolated.
+@Suite(.serialized)
 struct CmxIrohEndpointServerTests {
     @Test
     func activeGenerationAcceptsThroughTheBoundedServerLoop() async throws {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCapture.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCapture.swift
@@ -1,5 +1,5 @@
 /// Derives a context-rich annotation capture rectangle from freehand stroke bounds.
-public nonisolated struct BrowserDesignModeAnnotationCapture: Equatable, Sendable {
+public struct BrowserDesignModeAnnotationCapture: Equatable, Sendable {
     /// The number of CSS viewport points added around every side of a stroke.
     public let contextPadding: Double
 

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCaptureRequest.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCaptureRequest.swift
@@ -1,5 +1,5 @@
 /// A page-runtime request to turn one completed freehand stroke into a snapshot card.
-public nonisolated struct BrowserDesignModeAnnotationCaptureRequest: Codable, Equatable, Sendable {
+public struct BrowserDesignModeAnnotationCaptureRequest: Codable, Equatable, Sendable {
     /// Stable identity for the stroke and its eventual context selection.
     public let id: String
     /// The stroke bounds in CSS viewport points at the reported scroll position.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeEdit.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeEdit.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// One revertible mutation in the accumulated design-mode edit set.
-public nonisolated struct BrowserDesignModeEdit: Codable, Equatable, Identifiable, Sendable {
+public struct BrowserDesignModeEdit: Codable, Equatable, Identifiable, Sendable {
     /// The stable edit identifier used for per-edit reverts.
     public let id: String
     /// Whether the edit changes CSS or text.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeEditKind.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeEditKind.swift
@@ -1,5 +1,5 @@
 /// The kind of mutation recorded by design mode.
-public nonisolated enum BrowserDesignModeEditKind: String, Codable, Equatable, Sendable {
+public enum BrowserDesignModeEditKind: String, Codable, Equatable, Sendable {
     /// A CSS property override.
     case style
     /// A leaf element's text or form value.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePageURL.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePageURL.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Keeps URL structure while redacting route and value content before agent handoff.
-nonisolated struct BrowserDesignModePageURL {
+struct BrowserDesignModePageURL {
     private static let maxInputUTF8Bytes = 8_192
     private static let maxOutputUTF8Bytes = 4_096
     private let rawValue: String

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePromptContext.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePromptContext.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The complete context copied for a coding agent from selected page elements.
-public nonisolated struct BrowserDesignModePromptContext: Equatable, Sendable {
+public struct BrowserDesignModePromptContext: Equatable, Sendable {
     /// The page URL containing the edited element, reduced to safe structure and field names.
     public let pageURL: String
     /// The authoritative design-mode snapshot.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePromptFormatter.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePromptFormatter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Formats design-mode context into a prompt block that can be copied into a coding agent.
-public nonisolated struct BrowserDesignModePromptFormatter: Sendable {
+public struct BrowserDesignModePromptFormatter: Sendable {
     /// One selected element or region with its screenshot, encoded flat and
     /// with empty fields omitted so the payload stays small.
     private struct PayloadSelection: Encodable {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePromptRun.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModePromptRun.swift
@@ -5,7 +5,7 @@ import Foundation
 /// selector). The token field archives these so the prompt survives view
 /// recreation, and the prompt formatter ships them so agents see where each
 /// selection sits inside the instruction.
-public nonisolated enum BrowserDesignModePromptRun: Equatable, Sendable {
+public enum BrowserDesignModePromptRun: Equatable, Sendable {
     case text(String)
     case token(String)
 }

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeRect.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeRect.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A rectangle reported by the design-mode runtime in CSS viewport points.
-public nonisolated struct BrowserDesignModeRect: Codable, Equatable, Sendable {
+public struct BrowserDesignModeRect: Codable, Equatable, Sendable {
     /// The horizontal viewport coordinate.
     public let x: Double
     /// The vertical viewport coordinate.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeScript.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeScript.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Loads the isolated JavaScript runtime shipped with ``CmuxBrowser``.
-public nonisolated struct BrowserDesignModeScript: Sendable {
+public struct BrowserDesignModeScript: Sendable {
     /// Creates a runtime script loader.
     public init() {}
 

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeSelection.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeSelection.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The selected DOM element and the context needed to implement its visual edits in source.
-public nonisolated struct BrowserDesignModeSelection: Codable, Equatable, Sendable {
+public struct BrowserDesignModeSelection: Codable, Equatable, Sendable {
     /// The primary robust CSS selector.
     public let selector: String
     /// Ordered fallback selectors used when an SPA replaces the selected node.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeSnapshot.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeSnapshot.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An authoritative, revisioned snapshot returned by the page runtime.
-public nonisolated struct BrowserDesignModeSnapshot: Codable, Equatable, Sendable {
+public struct BrowserDesignModeSnapshot: Codable, Equatable, Sendable {
     /// The monotonic runtime revision.
     public let revision: Int
     /// Whether element picking is active in the current document.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeViewport.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeViewport.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The CSS viewport size associated with a design-mode selection.
-public nonisolated struct BrowserDesignModeViewport: Codable, Equatable, Sendable {
+public struct BrowserDesignModeViewport: Codable, Equatable, Sendable {
     /// The viewport width.
     public let width: Double
     /// The viewport height.

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/DesignMode/BrowserDesignModePromptPayload.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/DesignMode/BrowserDesignModePromptPayload.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Test-side mirror of the lean prompt payload: one ordered selections array
 /// (each entry a flattened selection plus its screenshot path), no duplicated
 /// selection objects, empty fields omitted.
-nonisolated struct BrowserDesignModePromptPayload: Decodable {
+struct BrowserDesignModePromptPayload: Decodable {
     struct SelectionEntry: Decodable {
         let selection: BrowserDesignModeSelection
         let screenshotPath: String?

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistAttachment.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistAttachment.swift
@@ -5,7 +5,7 @@ public import Foundation
 /// The attachment stores only file identity and lightweight metadata. Image
 /// bytes remain user-owned at ``filePath`` and are never copied or deleted by
 /// checklist value operations.
-nonisolated public struct WorkspaceChecklistAttachment: Codable, Sendable, Identifiable, Hashable {
+public struct WorkspaceChecklistAttachment: Codable, Sendable, Identifiable, Hashable {
     /// Stable identity for this attachment reference.
     public var id: UUID
     /// Name to show in compact UI.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistItem.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistItem.swift
@@ -3,7 +3,7 @@ public import Foundation
 /// One task item in a workspace's persisted checklist, writable by the user
 /// (sidebar, CLI) and by agents (control socket). Raw values of the nested
 /// enums are a control-socket and session wire format; frozen.
-nonisolated public struct WorkspaceChecklistItem: Codable, Sendable, Identifiable, Hashable {
+public struct WorkspaceChecklistItem: Codable, Sendable, Identifiable, Hashable {
     /// The item's completion state.
     public enum State: String, Codable, Sendable, CaseIterable {
         case pending

--- a/Sources/AboutLicenseContent.swift
+++ b/Sources/AboutLicenseContent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated struct AboutLicenseContent {
+struct AboutLicenseContent {
     let bundle: Bundle
     let repositoryURL: URL
 

--- a/Sources/AgentForkTimeoutResumeGate.swift
+++ b/Sources/AgentForkTimeoutResumeGate.swift
@@ -5,7 +5,7 @@ import Foundation
 /// @unchecked Sendable: `continuation` is immutable after init, and
 /// `didResume` atomically admits exactly one caller before the continuation is
 /// resumed.
-nonisolated final class AgentForkTimeoutResumeGate<Value>: @unchecked Sendable {
+final class AgentForkTimeoutResumeGate<Value>: @unchecked Sendable {
     private let didResume = AtomicBooleanGate(false)
     private let continuation: CheckedContinuation<Value, Never>
 

--- a/Sources/Panels/BrowserInsecureHTTPNavigationResolution.swift
+++ b/Sources/Panels/BrowserInsecureHTTPNavigationResolution.swift
@@ -1,4 +1,4 @@
-nonisolated enum BrowserInsecureHTTPNavigationResolution {
+enum BrowserInsecureHTTPNavigationResolution {
     case openedExternally
     case proceededInCurrentTab
     case proceededInNewTab

--- a/Sources/SessionPersistence+Todos.swift
+++ b/Sources/SessionPersistence+Todos.swift
@@ -23,7 +23,7 @@ struct SessionRightSidebarToolPanelSnapshot: Codable, Sendable {
 /// One persisted checklist item. Raw `state` / `origin` strings (not the
 /// package enums) so a manifest written by a future build with new cases
 /// still decodes here; unknown values degrade to pending/user on restore.
-nonisolated struct SessionChecklistItemSnapshot: Codable, Equatable, Sendable {
+struct SessionChecklistItemSnapshot: Codable, Equatable, Sendable {
     var id: UUID
     var text: String
     var state: String

--- a/Sources/ShortcutRecorderRejectedAttempt.swift
+++ b/Sources/ShortcutRecorderRejectedAttempt.swift
@@ -1,4 +1,4 @@
-nonisolated struct ShortcutRecorderRejectedAttempt: Equatable {
+struct ShortcutRecorderRejectedAttempt: Equatable {
     let reason: KeyboardShortcutSettings.ShortcutRecordingRejection
     let proposedShortcut: StoredShortcut?
 }

--- a/Sources/SidebarWorkspaceStatusPopover.swift
+++ b/Sources/SidebarWorkspaceStatusPopover.swift
@@ -21,7 +21,7 @@ struct WorkspaceTodoStatusLane: Equatable, Identifiable {
     var id: String { isNone ? "none" : (status?.rawValue ?? "auto") }
 }
 
-nonisolated struct SidebarWorkspaceCompactStatusMenuModel: Equatable {
+struct SidebarWorkspaceCompactStatusMenuModel: Equatable {
     let inferred: WorkspaceTaskStatus
     let activeOverride: WorkspaceTaskStatus?
 }


### PR DESCRIPTION
## Summary
- make reconnect capacity tests wait for admission and causal supersession before asserting server state
- keep the cancellation deadline alive until admission resolves
- remove nominal `nonisolated` modifiers unsupported by Xcode 16.2 from macOS value types
- disable index-store generation in compatibility tests and smoke builds
- give ARM baseline jobs enough time to finish tests plus startup smoke

Production reconnect behavior is unchanged. The test fixes synchronize against existing actor boundaries, and the source compatibility edits remove unsupported declaration syntax without changing the value types.

## Verification
- focused reconnect capacity regression passed 100 consecutive runs
- `swift test` in `Packages/Shared/CmuxIrohTransport` passed 380 tests
- `swift test` in `Packages/macOS/CmuxWorkspaces` passed 147 tests
- tagged macOS cloud build `irint` succeeded: https://github.com/manaflow-ai/cmux/actions/runs/29681918988
- final Intel macOS 14, ARM macOS 15, and ARM macOS 26 matrix: https://github.com/manaflow-ai/cmux/actions/runs/29683073416

## Related
- initial failing capacity run: https://github.com/manaflow-ai/cmux/actions/runs/29678627575/job/88170580262
- Xcode 16.2 compatibility discovery run: https://github.com/manaflow-ai/cmux/actions/runs/29680883147