### PR TITLE
Harden user-configured Iroh relay resolution

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayDiagnosticsSnapshot.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayDiagnosticsSnapshot.swift
@@ -17,11 +17,11 @@ public struct CmxIrohRelayDiagnosticsSnapshot: Equatable, Sendable {
     /// Current account preference revision.
     public let preferenceRevision: Int64?
 
-    /// Stable IDs selected from the managed policy.
+    /// Stable relay IDs selected from the active preference.
     public let selectedRelayIDs: [String]
 
-    /// Exact relay origins currently allowed by the endpoint.
-    public let selectedRelayURLs: [String]
+    /// Number of relay origins currently allowed by the endpoint.
+    public let selectedRelayCount: Int
 
     /// Requested managed IDs missing from the signed policy.
     public let staleRelayIDs: [String]
@@ -39,7 +39,7 @@ public struct CmxIrohRelayDiagnosticsSnapshot: Equatable, Sendable {
         policyExpiresAt: nil,
         preferenceRevision: nil,
         selectedRelayIDs: [],
-        selectedRelayURLs: [],
+        selectedRelayCount: 0,
         staleRelayIDs: [],
         missingCredentialRelayIDs: [],
         failure: nil

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyResolution.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyResolution.swift
@@ -77,20 +77,25 @@ enum CmxIrohRelayPolicyResolution {
             )
         case let .custom(definitions):
             let tokens: [String: String]
-            do {
-                tokens = try await credentialStore.staticTokens(
-                    for: definitions,
-                    accountID: accountID
-                )
-            } catch {
-                return unavailableResolution(
-                    configuration: configuration,
-                    revision: revision,
-                    source: .customUnavailable,
-                    policy: policy,
-                    usedCachedPolicy: usedCachedPolicy,
-                    failure: .customCredentialUnavailable
-                )
+            let authenticatedDefinitions = definitions.filter { $0.authMode == .staticToken }
+            if authenticatedDefinitions.isEmpty {
+                tokens = [:]
+            } else {
+                do {
+                    tokens = try await credentialStore.staticTokens(
+                        for: authenticatedDefinitions,
+                        accountID: accountID
+                    )
+                } catch {
+                    return unavailableResolution(
+                        configuration: configuration,
+                        revision: revision,
+                        source: .customUnavailable,
+                        policy: policy,
+                        usedCachedPolicy: usedCachedPolicy,
+                        failure: .customCredentialUnavailable
+                    )
+                }
             }
             let missing = Set(definitions.compactMap { definition in
                 definition.authMode == .staticToken && tokens[definition.id] == nil
@@ -292,7 +297,7 @@ enum CmxIrohRelayPolicyResolution {
             policyExpiresAt: policy.map { Date(timeIntervalSince1970: TimeInterval($0.expiresAt)) },
             preferenceRevision: effective.preferenceRevision,
             selectedRelayIDs: selectedIDs,
-            selectedRelayURLs: effective.endpointRelayProfile.allowedRelayURLs.sorted(),
+            selectedRelayCount: effective.endpointRelayProfile.allowedRelayURLs.count,
             staleRelayIDs: effective.staleRelayIDs.sorted(),
             missingCredentialRelayIDs: effective.missingCredentialRelayIDs.sorted(),
             failure: failure

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRelayPolicyService.swift
@@ -475,7 +475,7 @@ public actor CmxIrohRelayPolicyService {
                 policyExpiresAt: nil,
                 preferenceRevision: nil,
                 selectedRelayIDs: [],
-                selectedRelayURLs: [],
+                selectedRelayCount: 0,
                 staleRelayIDs: [],
                 missingCredentialRelayIDs: [],
                 failure: failure

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveEnvironment.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveEnvironment.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum CmxIrohCustomRelayLiveEnvironment {
+    enum EnvironmentError: Error {
+        case missing(String)
+    }
+
+    static let environment = ProcessInfo.processInfo.environment
+
+    static var isEnabled: Bool {
+        environment["CMUX_IROH_CUSTOM_RELAY_LIVE"] == "1"
+    }
+
+    static var hasNoTokenRelay: Bool {
+        environment["CMUX_IROH_CUSTOM_RELAY_NO_TOKEN_URL"]?.isEmpty == false
+    }
+
+    static var hasStaticTokenRelay: Bool {
+        environment["CMUX_IROH_CUSTOM_RELAY_STATIC_URL"]?.isEmpty == false
+            && environment["CMUX_IROH_CUSTOM_RELAY_STATIC_TOKEN"]?.isEmpty == false
+    }
+
+    static var timeout: TimeInterval {
+        environment["CMUX_IROH_CUSTOM_RELAY_TIMEOUT"]
+            .flatMap(TimeInterval.init) ?? 10
+    }
+
+    static func required(_ name: String) throws -> String {
+        guard let value = environment[name], !value.isEmpty else {
+            throw EnvironmentError.missing(name)
+        }
+        return value
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// Opt-in live checks for real custom relay address selection. CI skips this
+/// suite unless `CMUX_IROH_CUSTOM_RELAY_LIVE=1` is explicitly present.
+@Suite(
+    .serialized,
+    .enabled(if: CmxIrohCustomRelayLiveEnvironment.isEnabled)
+)
+struct CmxIrohCustomRelayLiveTests {
+    @Test(.enabled(if: CmxIrohCustomRelayLiveEnvironment.hasNoTokenRelay))
+    func unauthenticatedRelayUsesExactConfiguredURL() async throws {
+        let relayURL = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_NO_TOKEN_URL"
+        )
+        let profile = CmxIrohEndpointRelayProfile(
+            customProfile: try CmxIrohCustomRelayProfile(
+                relays: [CmxIrohCustomRelay(url: relayURL)]
+            )
+        )
+
+        let result = await CmxIrohCustomRelayProbe().probe(
+            profile: profile,
+            timeout: CmxIrohCustomRelayLiveEnvironment.timeout
+        )
+
+        #expect(result == .reachable(relayURL: relayURL))
+    }
+
+    @Test(.enabled(if: CmxIrohCustomRelayLiveEnvironment.hasStaticTokenRelay))
+    func staticTokenProfileAdvertisesExactConfiguredURL() async throws {
+        // Relay advertisement proves exact FFI map selection, not provider
+        // authentication. The product does not present this as a token test.
+        let relayURL = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_STATIC_URL"
+        )
+        let token = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_STATIC_TOKEN"
+        )
+        let profile = CmxIrohEndpointRelayProfile(
+            customProfile: try CmxIrohCustomRelayProfile(
+                relays: [
+                    CmxIrohCustomRelay(
+                        url: relayURL,
+                        authenticationToken: token
+                    ),
+                ]
+            )
+        )
+
+        let result = await CmxIrohCustomRelayProbe().probe(
+            profile: profile,
+            timeout: CmxIrohCustomRelayLiveEnvironment.timeout
+        )
+
+        #expect(result == .reachable(relayURL: relayURL))
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyCustomProfileTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyCustomProfileTests.swift
@@ -25,6 +25,12 @@ extension CmxIrohRelayPolicyTests {
         #expect(throws: CmxIrohRelayPolicyError.invalidClaims) {
             try CmxIrohCustomRelay(url: "http://relay.example.net/")
         }
+        #expect(throws: CmxIrohRelayPolicyError.invalidClaims) {
+            try CmxIrohCustomRelay(
+                url: "https://relay.example.net/",
+                authenticationToken: "invalid\nprovider-token"
+            )
+        }
     }
 
     @Test

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests+Preferences.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests+Preferences.swift
@@ -5,6 +5,99 @@ import Testing
 
 extension CmxIrohRelayPolicyServiceTests {
     @Test
+    func accountMetadataAndDeviceCredentialsStaySeparatedByAccountAndURL() async throws {
+        let secureStore = TestSecureCredentialStore()
+        let credentialStore = CmxIrohCustomRelayCredentialStore(secureStore: secureStore)
+        let relay = try CmxIrohCustomRelayDefinition(
+            id: "private-home",
+            url: "https://relay.example.net/",
+            provider: "personal",
+            region: "home",
+            authMode: .staticToken
+        )
+        let configuration = try CmxIrohAccountRelayConfiguration.custom([relay])
+        let token = "device-only-token"
+
+        try await credentialStore.setStaticToken(
+            token,
+            relayID: relay.id,
+            relayURL: relay.url,
+            accountID: "account-a"
+        )
+
+        let accountMetadata = try JSONEncoder().encode(configuration)
+        #expect(String(decoding: accountMetadata, as: UTF8.self).contains(token) == false)
+        #expect(
+            try await credentialStore.staticTokens(
+                for: [relay],
+                accountID: "account-a"
+            )[relay.id] == token
+        )
+        #expect(
+            try await credentialStore.staticTokens(
+                for: [relay],
+                accountID: "account-b"
+            ).isEmpty
+        )
+        let movedRelay = try CmxIrohCustomRelayDefinition(
+            id: relay.id,
+            url: "https://replacement.example.net/",
+            provider: relay.provider,
+            region: relay.region,
+            authMode: relay.authMode
+        )
+        #expect(
+            try await credentialStore.staticTokens(
+                for: [movedRelay],
+                accountID: "account-a"
+            ).isEmpty
+        )
+        #expect(
+            await secureStore.observedAccessibilities()
+                == [.afterFirstUnlockThisDeviceOnly]
+        )
+    }
+
+    @Test
+    func missingStaticTokenDisablesWholeCustomProfileWithoutManagedFallback() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let stores = makeStores()
+        let openRelay = try CmxIrohCustomRelayDefinition(
+            id: "open-relay",
+            url: "https://open.example.net/",
+            provider: "personal",
+            region: "home",
+            authMode: .none
+        )
+        let authenticatedRelay = try CmxIrohCustomRelayDefinition(
+            id: "authenticated-relay",
+            url: "https://authenticated.example.net/",
+            provider: "personal",
+            region: "home",
+            authMode: .staticToken
+        )
+
+        let effective = try await stores.service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .custom([openRelay, authenticatedRelay]),
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: fixture.relayCredential(),
+            now: fixture.now
+        )
+
+        #expect(effective.source == .customUnavailable)
+        #expect(effective.endpointRelayProfile.allowedRelayURLs.isEmpty)
+        #expect(effective.endpointRelayProfile.activeRelays.isEmpty)
+        #expect(effective.relayBootstrap == nil)
+        #expect(effective.missingCredentialRelayIDs == [authenticatedRelay.id])
+        #expect(await stores.service.diagnosticsSnapshot().failure == .missingCustomCredential)
+    }
+
+    @Test
     func dormantSelectionsAndCustomDefinitionsSurviveEveryActiveMode() async throws {
         let fixture = RelayPolicyServiceTestFixture()
         let stores = makeStores()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
@@ -97,11 +97,12 @@ struct CmxIrohRelayPolicyServiceTests {
             == "private-secret-token")
         let diagnostic = await stores.service.diagnosticsSnapshot()
         #expect(diagnostic.selectedRelayURLs == [definition.url])
+        #expect(String(describing: diagnostic).contains(definition.url) == false)
         #expect(String(describing: diagnostic).contains("private-secret-token") == false)
     }
 
     @Test
-    func unavailableCustomCredentialStorageFailsClosed() async throws {
+    func unauthenticatedCustomRelayDoesNotDependOnCredentialStorage() async throws {
         let fixture = RelayPolicyServiceTestFixture()
         let preferenceStore = CmxIrohRelayPreferenceStore(secureStore: TestSecureCredentialStore())
         let service = CmxIrohRelayPolicyService(
@@ -117,6 +118,42 @@ struct CmxIrohRelayPolicyServiceTests {
             provider: "personal",
             region: "home",
             authMode: .none
+        )
+
+        let effective = try await service.install(
+            response: CmxIrohRelayPolicyResponse(
+                policy: fixture.token(sequence: 1),
+                preference: .custom([definition]),
+                preferenceRevision: 1
+            ),
+            accountID: "account-a",
+            trustRoot: fixture.firstTrustRoot,
+            relayCredential: nil,
+            now: fixture.now
+        )
+
+        #expect(effective.source == .custom)
+        #expect(effective.endpointRelayProfile.allowedRelayURLs == [definition.url])
+        #expect(await service.diagnosticsSnapshot().failure == .customCredentialUnavailable)
+    }
+
+    @Test
+    func unavailableCustomCredentialStorageFailsClosedForStaticToken() async throws {
+        let fixture = RelayPolicyServiceTestFixture()
+        let preferenceStore = CmxIrohRelayPreferenceStore(secureStore: TestSecureCredentialStore())
+        let service = CmxIrohRelayPolicyService(
+            policyCache: CmxIrohRelayPolicyCache(secureStore: TestSecureCredentialStore()),
+            preferenceStore: preferenceStore,
+            credentialStore: CmxIrohCustomRelayCredentialStore(
+                secureStore: RelayPolicyServiceUnavailableSecureStore()
+            )
+        )
+        let definition = try CmxIrohCustomRelayDefinition(
+            id: "private-home",
+            url: "https://relay.example.net/",
+            provider: "personal",
+            region: "home",
+            authMode: .staticToken
         )
 
         let effective = try await service.install(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayPolicyServiceTests.swift
@@ -96,7 +96,7 @@ struct CmxIrohRelayPolicyServiceTests {
         #expect(active.endpointRelayProfile.activeRelays.first?.authenticationToken
             == "private-secret-token")
         let diagnostic = await stores.service.diagnosticsSnapshot()
-        #expect(diagnostic.selectedRelayURLs == [definition.url])
+        #expect(diagnostic.selectedRelayCount == 1)
         #expect(String(describing: diagnostic).contains(definition.url) == false)
         #expect(String(describing: diagnostic).contains("private-secret-token") == false)
     }


### PR DESCRIPTION
## Summary
- keep unauthenticated custom relays usable when device credential storage is unavailable
- keep static-token profiles fail-closed for missing or unavailable credentials
- remove exact relay origins from redacted diagnostics and publish only a relay count
- prove account metadata excludes tokens, credentials stay device/account/URL-bound, and custom profiles never widen to managed relays
- add opt-in live custom-relay address-selection checks

## Verification
- `swift test --package-path Packages/Shared/CmuxIrohTransport` (384 tests passed)
- live no-token probe against the exact configured `use1-1.relay.lawrence.cmux.iroh.link` origin (passed)
- first commit contains the failing regression tests; second commit makes them green

## Live harness
Set `CMUX_IROH_CUSTOM_RELAY_LIVE=1` and provide `CMUX_IROH_CUSTOM_RELAY_NO_TOKEN_URL` for unauthenticated reachability. `CMUX_IROH_CUSTOM_RELAY_STATIC_URL` plus `CMUX_IROH_CUSTOM_RELAY_STATIC_TOKEN` verifies exact FFI relay-map selection. Address advertisement does not prove provider-token authentication, so the product continues to mark token-authenticated throwaway probes incomplete.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787042334&installation_id=133855650&pr_number=8469&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8469&signature=f9f3c383f2db724e0fa1e924d03bf0353044df1290144dfe01482376e192b5d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened custom relay resolution in `CmuxIrohTransport` to keep unauthenticated relays usable without credential storage and to fail closed for static-token profiles when credentials are missing. Diagnostics now redact exact relay URLs by reporting a count instead.

- **Bug Fixes**
  - Fetch tokens only for relays with `authMode: .staticToken`; unauthenticated relays no longer depend on the credential store.
  - Static-token profiles fail closed when credentials are missing or storage is unavailable; no fallback to managed relays.
  - Replace `selectedRelayURLs` with `selectedRelayCount` in diagnostics to avoid leaking relay origins or tokens.
  - Validate provider-token input and reject invalid tokens.

- **New Features**
  - Opt-in live custom-relay checks via `CMUX_IROH_CUSTOM_RELAY_LIVE`.
  - Supports `CMUX_IROH_CUSTOM_RELAY_NO_TOKEN_URL`, `CMUX_IROH_CUSTOM_RELAY_STATIC_URL`, `CMUX_IROH_CUSTOM_RELAY_STATIC_TOKEN`, and `CMUX_IROH_CUSTOM_RELAY_TIMEOUT` for configuration.
  - Tests ensure account metadata excludes tokens and credentials remain scoped by device/account/URL.

<sup>Written for commit 3728577ff19a2ce8bc06cbcbba2cd1a7de9ecdac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostics reporting for the number of selected relays.
  * Custom relay configurations now process static-token credentials more selectively.
  * Added opt-in live validation for authenticated and unauthenticated custom relays.

* **Bug Fixes**
  * Custom profiles with missing credentials are now correctly disabled without fallback.
  * Improved separation of stored relay credentials across accounts and relay addresses.
  * Diagnostic output no longer exposes relay URLs or stored tokens.

* **Tests**
  * Expanded coverage for credential failures, invalid tokens, and relay reachability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->