### PR TITLE
test(iroh): gate Tailscale version skew

### DIFF
--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -225,6 +225,44 @@ extension MobileHostAuthorizationTests {
         #expect(error.code == "unauthorized")
         #expect(await recorder.count() == 1)
     }
+
+    @Test func testReleasedIOSWireFrameRemainsAcceptedByLegacyTCPAuthorization() async throws {
+        let legacyFrame = Data(
+            #"""
+            {
+              "id": "legacy-workspace-list",
+              "method": "workspace.list",
+              "params": {},
+              "auth": { "stack_access_token": "legacy-stack-token" }
+            }
+            """#.utf8
+        )
+        let request: MobileHostRPCRequest
+        switch MobileHostRPCEnvelope.decodeRequest(legacyFrame) {
+        case .success(let decoded):
+            request = decoded
+        case .failure(let error):
+            Issue.record("Legacy iOS frame did not decode: \(error.code)")
+            return
+        }
+
+        let result = await MobileHostService.connectionAuthorizationError(
+            for: request,
+            authorization: .stackBearer,
+            stackAuthorization: { decoded in
+                guard decoded.auth?.stackAccessToken == "legacy-stack-token" else {
+                    return .failure(MobileHostRPCError(
+                        code: "unauthorized",
+                        message: "Legacy Stack bearer was not preserved"
+                    ))
+                }
+                return nil
+            }
+        )
+
+        #expect(result == nil)
+    }
+
     @Test func testIrohAdmittedStatusIncludesIdentityWhileTCPPublicStatusDoesNot() async throws {
         let request = MobileHostRPCRequest(
             id: "host-status",

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -96,6 +96,44 @@ struct MobileHostServiceSettingsTests {
         #expect(!MobileHostService.isListeningEnabled(defaults: defaults, buildFlavor: .stable))
     }
 
+    @Test func stablePreservesExplicitTailscaleCompatibilityRequest() throws {
+        let suiteName = "MobileHostServiceSettingsTests.StableOptIn.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: MobileHostService.listeningEnabledDefaultsKey)
+
+        let enabled = MobileHostService.isListeningEnabled(
+            defaults: defaults,
+            buildFlavor: .stable
+        )
+        let plan = MobileHostService.startupPlan(
+            legacyListenerEnabled: enabled,
+            legacyListenerRunning: false
+        )
+
+        #expect(plan.activatesIroh)
+        #expect(plan.startsLegacyListener)
+    }
+
+    @Test func stablePreservesHistoricalTailscaleCompatibilityRequest() throws {
+        let suiteName = "MobileHostServiceSettingsTests.StableLegacyOptIn.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: "cmuxMobilePairingHostEnabled")
+
+        let enabled = MobileHostService.isListeningEnabled(
+            defaults: defaults,
+            buildFlavor: .stable
+        )
+        let plan = MobileHostService.startupPlan(
+            legacyListenerEnabled: enabled,
+            legacyListenerRunning: false
+        )
+
+        #expect(plan.activatesIroh)
+        #expect(plan.startsLegacyListener)
+    }
+
     @Test func configuredPortDefaultsToCatalogDefaultWhenUnset() throws {
         let suiteName = "MobileHostServiceSettingsTests.Port.Default.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))


### PR DESCRIPTION
## Summary

- freeze a released-iOS RPC frame and prove the new Mac accepts its Stack bearer on the legacy TCP authorization path
- prove stable builds start the compatibility listener when either the current or historical preference explicitly requests it
- retain the existing fail-closed new-iOS behavior, which never sends Stack or attach credentials over an unverified raw Tailscale TCP route

## Compatibility contract

- old iOS plus new Mac works when compatibility was requested
- new iOS plus old Mac retains the saved route and asks for a Mac update, then upgrades to Iroh without re-pairing when the Mac publishes an authenticated route
- new plus new defaults to Iroh; numeric Tailscale addresses remain fallback-only Iroh path hints under the pinned EndpointID
- stable defaults the legacy listener off; nightly and development keep migration compatibility unless explicitly disabled

## Tests

- `./scripts/test-unit.sh -derivedDataPath /tmp/cmux-irtsk -only-testing:cmuxTests/MobileHostServiceSettingsTests -only-testing:cmuxTests/MobileHostAuthorizationTests test` (96 passed)
- `swift test --filter CmxTransportFactorySecurityTests` (5 passed)
- `swift test --filter ReconnectRouteSelectionTests` (56 passed)
- `swift test --filter MobileCoreRPCClientTests.admittedIrohRequestCarriesNoStackOrAttachCredential` (1 passed)
- `swift test --filter CmxIrohPrivatePathSynthesizerTests` (4 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787044509&installation_id=133855650&pr_number=8470&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8470&signature=2f73a0731ee040ae06aac291a7295be014362924ab9d502b1f27cfa470d3ecce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to verify Tailscale version-skew handling. Confirms a released-iOS RPC frame is accepted by the legacy TCP authorization path, and that stable builds start the legacy compatibility listener when explicitly or historically enabled.

<sup>Written for commit c132adfe050f3c4bd869347bed35354d9067282a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

