### PR TITLE
Diagnose Iroh session path flaps by owner

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -138,8 +138,11 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// The selected network path changed. `a` is ``DiagnosticPathKind``. The
     /// foreground control session wins over background and feature sessions.
     case selectedPathChanged = 40
-    /// An established app-transport session closed. `b`, when present, is
-    /// ``DiagnosticFailureKind``; absence means an expected closure.
+    /// An established app-transport session closed. `a`, when present, is
+    /// ``DiagnosticTransportKind``; `b`, when present, is
+    /// ``DiagnosticFailureKind``; and `c`, when present, is the positive,
+    /// process-local session ID shared with ``transportSessionLifecycle``.
+    /// Absence of `b`, or `.none`, means an expected closure.
     case sessionClosed = 41
     /// No authenticated route was usable. `b`, when present, is
     /// ``DiagnosticFailureKind``.
@@ -164,4 +167,10 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// The authenticated RPC session failed before or after readiness. `b`,
     /// when present, is ``DiagnosticFailureKind``.
     case rpcFailed = 50
+    /// An admitted transport session was established or removed from its local
+    /// pool. `a` is ``DiagnosticSessionLifecycleKind``, `b` is the local
+    /// ``CmxTransportSessionPurpose`` raw value, and `c` is a positive,
+    /// process-local session correlation ID. The event contains no peer or route
+    /// identity.
+    case transportSessionLifecycle = 51
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -263,6 +263,30 @@ public extension DiagnosticEvent {
         }
         return DiagnosticPathKind(rawValue: a)
     }
+
+    /// Privacy-safe pool transition carried by
+    /// ``DiagnosticEventCode/transportSessionLifecycle``.
+    var diagnosticSessionLifecycleKind: DiagnosticSessionLifecycleKind? {
+        guard code == .transportSessionLifecycle, let a else { return nil }
+        return DiagnosticSessionLifecycleKind(rawValue: a)
+    }
+
+    /// Local owner role carried by a transport-session lifecycle event.
+    var diagnosticSessionPurpose: CmxTransportSessionPurpose? {
+        guard code == .transportSessionLifecycle,
+              let b,
+              let raw = UInt8(exactly: b) else { return nil }
+        return CmxTransportSessionPurpose(rawValue: raw)
+    }
+
+    /// Positive process-local session correlation ID. This value is not stable
+    /// across app launches or devices.
+    var diagnosticSessionID: Int? {
+        guard code == .transportSessionLifecycle || code == .sessionClosed,
+              let c,
+              c > 0 else { return nil }
+        return c
+    }
 }
 
 public extension DiagnosticEventCode {

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -166,6 +166,33 @@ public enum DiagnosticPathKind: Int, Sendable, Codable, CaseIterable {
     }
 }
 
+/// Why an admitted transport session entered or left its local pool.
+///
+/// Raw values are stable export vocabulary. The cases identify only local
+/// lifecycle ownership, never a peer, endpoint, address, account, or raw error.
+public enum DiagnosticSessionLifecycleKind: Int, Sendable, Codable, CaseIterable {
+    /// A newly authenticated session entered the pool.
+    case established = 1
+    /// The RPC owner intentionally relinquished its control stream.
+    case controlOwnerReleased = 2
+    /// The RPC control reader failed and relinquished ownership.
+    case controlReadFailed = 3
+    /// The RPC control writer failed and relinquished ownership.
+    case controlWriteFailed = 4
+    /// The transport reported that its peer connection closed.
+    case remoteClosed = 5
+    /// A caller found a cached session already closed before its watcher ran.
+    case closedSessionEvicted = 6
+    /// An application-lane operation found the shared connection closed.
+    case applicationLaneFailed = 7
+    /// The account-scoped runtime stopped.
+    case runtimeDeactivated = 8
+    /// The runtime generation changed and replaced its prior sessions.
+    case runtimeReconfigured = 9
+    /// A caller explicitly invalidated one exact peer session.
+    case explicitlyInvalidated = 10
+}
+
 /// Which component produced a diagnostic report.
 public enum DiagnosticRuntimeRole: Int, Sendable, Codable, CaseIterable {
     case unspecified = 0

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -183,6 +183,7 @@ import Testing
         #expect(DiagnosticEventCode.admissionFailed.rawValue == 48)
         #expect(DiagnosticEventCode.hostAuthenticationFailed.rawValue == 49)
         #expect(DiagnosticEventCode.rpcFailed.rawValue == 50)
+        #expect(DiagnosticEventCode.transportSessionLifecycle.rawValue == 51)
         #expect(Set(DiagnosticEventCode.allCases.map(\.rawValue)).count == DiagnosticEventCode.allCases.count)
     }
 
@@ -194,6 +195,16 @@ import Testing
         #expect(CmxAttachTransportKind.iroh.diagnosticTransportKind.rawValue == 1)
         #expect(DiagnosticFailureKind.cancelled.rawValue == 20)
         #expect(DiagnosticFailureKind.unknown.rawValue == 255)
+        #expect(DiagnosticSessionLifecycleKind.established.rawValue == 1)
+        #expect(DiagnosticSessionLifecycleKind.controlOwnerReleased.rawValue == 2)
+        #expect(DiagnosticSessionLifecycleKind.controlReadFailed.rawValue == 3)
+        #expect(DiagnosticSessionLifecycleKind.controlWriteFailed.rawValue == 4)
+        #expect(DiagnosticSessionLifecycleKind.remoteClosed.rawValue == 5)
+        #expect(DiagnosticSessionLifecycleKind.closedSessionEvicted.rawValue == 6)
+        #expect(DiagnosticSessionLifecycleKind.applicationLaneFailed.rawValue == 7)
+        #expect(DiagnosticSessionLifecycleKind.runtimeDeactivated.rawValue == 8)
+        #expect(DiagnosticSessionLifecycleKind.runtimeReconfigured.rawValue == 9)
+        #expect(DiagnosticSessionLifecycleKind.explicitlyInvalidated.rawValue == 10)
 
         #expect(DiagnosticPathKind(.unavailable) == .unknown)
         #expect(DiagnosticPathKind(.direct) == .direct)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -110,6 +110,7 @@ public actor CmxIrohClientRuntime {
     ///   - configuration: Stable account-and-build-scoped endpoint inputs.
     ///   - pendingRevocations: Device-only bindings that must be revoked before registration.
     ///   - protocolConfiguration: The cmux ALPN and stream framing configuration.
+    ///   - diagnosticLog: Optional privacy-safe lifecycle sink for pooled sessions.
     ///   - networkPathSnapshot: A generation-aware view of positively identified
     ///     private-network profiles. An empty profile set disables explicit hints.
     ///   - now: Wall-clock injection for route and relay validation.
@@ -124,6 +125,7 @@ public actor CmxIrohClientRuntime {
         configuration: CmxIrohClientRuntimeConfiguration,
         pendingRevocations: CmxIrohPendingRevocationOutbox,
         protocolConfiguration: CmxIrohProtocolConfiguration = .cmuxMobileV1,
+        diagnosticLog: DiagnosticLog? = nil,
         offlinePolicyCache: CmxIrohClientOfflinePolicyCache? = nil,
         networkPathSnapshot: @escaping @Sendable () async throws -> CmxIrohNetworkPathSnapshot = {
             CmxIrohNetworkPathSnapshot(generation: 1, activeNetworkProfiles: [])
@@ -152,7 +154,8 @@ public actor CmxIrohClientRuntime {
         let sessionPool = CmxIrohClientSessionPool(
             supervisor: supervisor,
             contextProvider: contextRouter,
-            protocolConfiguration: protocolConfiguration
+            protocolConfiguration: protocolConfiguration,
+            diagnosticLog: diagnosticLog
         )
         self.supervisor = supervisor
         self.contextRouter = contextRouter

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
@@ -16,6 +16,8 @@ actor CmxIrohClientSessionPool {
 
     private struct PooledSession: Sendable {
         let id: UUID
+        let diagnosticID: Int
+        let initialPurpose: CmxTransportSessionPurpose
         let session: CmxIrohClientSession
         let closureTask: Task<Void, Never>
         let pathObservationTask: Task<Void, Never>
@@ -36,7 +38,9 @@ actor CmxIrohClientSessionPool {
     private let supervisor: CmxIrohEndpointSupervisor
     private let contextProvider: any CmxIrohClientContextProvider
     private let protocolConfiguration: CmxIrohProtocolConfiguration
+    private let diagnosticLog: DiagnosticLog?
     private var lifecycleRevision: UInt64 = 0
+    private var nextDiagnosticSessionID = 0
     private var runtimeGeneration: UInt64?
     private var sessions: [SessionKey: PooledSession] = [:]
     private var sessionOrder: [SessionKey] = []
@@ -48,21 +52,23 @@ actor CmxIrohClientSessionPool {
     init(
         supervisor: CmxIrohEndpointSupervisor,
         contextProvider: any CmxIrohClientContextProvider,
-        protocolConfiguration: CmxIrohProtocolConfiguration = .cmuxMobileV1
+        protocolConfiguration: CmxIrohProtocolConfiguration = .cmuxMobileV1,
+        diagnosticLog: DiagnosticLog? = nil
     ) {
         self.supervisor = supervisor
         self.contextProvider = contextProvider
         self.protocolConfiguration = protocolConfiguration
+        self.diagnosticLog = diagnosticLog
     }
 
     func activate(runtimeGeneration: UInt64) async {
         guard self.runtimeGeneration != runtimeGeneration else { return }
-        await invalidateAll()
+        await invalidateAll(reason: .runtimeReconfigured)
         self.runtimeGeneration = runtimeGeneration
     }
 
     func deactivate() async {
-        await invalidateAll()
+        await invalidateAll(reason: .runtimeDeactivated)
         runtimeGeneration = nil
     }
 
@@ -80,7 +86,9 @@ actor CmxIrohClientSessionPool {
             await invalidateSession(
                 for: key,
                 matching: pooled.id,
-                releasesControlOwner: !preservesControlOwnerOnClosed
+                releasesControlOwner: !preservesControlOwnerOnClosed,
+                reason: .closedSessionEvicted,
+                failure: .connectionClosed
             )
         }
 
@@ -139,6 +147,7 @@ actor CmxIrohClientSessionPool {
                 return installed.session
             }
             let sessionID = UUID()
+            let diagnosticID = makeDiagnosticSessionID()
             let closureTask = Task { [weak self] in
                 await connected.waitUntilClosed()
                 guard !Task.isCancelled else { return }
@@ -156,12 +165,19 @@ actor CmxIrohClientSessionPool {
             }
             sessions[key] = PooledSession(
                 id: sessionID,
+                diagnosticID: diagnosticID,
+                initialPurpose: request.sessionPurpose,
                 session: connected,
                 closureTask: closureTask,
                 pathObservationTask: pathObservationTask
             )
             sessionOrder.removeAll { $0 == key }
             sessionOrder.append(key)
+            recordSessionLifecycle(
+                .established,
+                sessionID: diagnosticID,
+                purpose: controlOwners[key]?.purpose ?? request.sessionPurpose
+            )
             publishSelectedPathChange()
             return connected
         } catch {
@@ -210,7 +226,12 @@ actor CmxIrohClientSessionPool {
         } catch {
             try Task.checkCancellation()
             guard await session.isClosed() else { throw error }
-            await invalidateSession(for: key, matching: session)
+            await invalidateSession(
+                for: key,
+                matching: session,
+                reason: .applicationLaneFailed,
+                failure: DiagnosticFailureKind.classify(error)
+            )
             let replacement = try await self.session(for: request)
             return try await replacement.openBidirectionalLane(
                 lane,
@@ -230,36 +251,58 @@ actor CmxIrohClientSessionPool {
     /// framing can never be inherited by a replacement owner.
     func releaseControlSession(
         for request: CmxByteTransportRequest,
-        ownerID: UUID
+        ownerID: UUID,
+        reason: DiagnosticSessionLifecycleKind = .controlOwnerReleased,
+        failure: DiagnosticFailureKind = .none
     ) async {
         guard let key = try? sessionKey(for: request),
               controlOwners[key]?.id == ownerID else {
             return
         }
-        await invalidateSession(for: key, releasesControlOwner: false)
+        await invalidateSession(
+            for: key,
+            releasesControlOwner: false,
+            reason: reason,
+            failure: failure
+        )
         releaseControlOwner(for: key, ownerID: ownerID)
     }
 
     func invalidate(for request: CmxByteTransportRequest) async {
         guard let key = try? sessionKey(for: request) else { return }
-        await invalidateSession(for: key)
+        await invalidateSession(
+            for: key,
+            reason: .explicitlyInvalidated,
+            failure: .none
+        )
     }
 
     func invalidateAll() async {
+        await invalidateAll(reason: .runtimeDeactivated)
+    }
+
+    private func invalidateAll(reason: DiagnosticSessionLifecycleKind) async {
         lifecycleRevision &+= 1
         let tasks = connectionTasks.values.map(\.task)
         connectionTasks.removeAll(keepingCapacity: false)
         for task in tasks { task.cancel() }
-        let closing = sessions.values
+        let closing = sessions
+        let closingOwners = controlOwners
         sessions.removeAll(keepingCapacity: false)
         sessionOrder.removeAll(keepingCapacity: false)
         controlOwners.removeAll(keepingCapacity: false)
         let waiters = controlWaiters.values.flatMap { $0 }
         controlWaiters.removeAll(keepingCapacity: false)
         for waiter in waiters { waiter.continuation.resume() }
-        for pooled in closing {
+        for (key, pooled) in closing {
             pooled.closureTask.cancel()
             pooled.pathObservationTask.cancel()
+            recordSessionClosure(
+                reason,
+                pooled: pooled,
+                purpose: closingOwners[key]?.purpose ?? pooled.initialPurpose,
+                failure: .none
+            )
             await pooled.session.close()
         }
         publishSelectedPathChange()
@@ -300,6 +343,12 @@ actor CmxIrohClientSessionPool {
         sessions[key] = nil
         sessionOrder.removeAll { $0 == key }
         pooled.pathObservationTask.cancel()
+        recordSessionClosure(
+            .remoteClosed,
+            pooled: pooled,
+            purpose: owner?.purpose ?? pooled.initialPurpose,
+            failure: .connectionClosed
+        )
         await pooled.session.close()
         if let owner {
             releaseControlOwner(for: key, ownerID: owner.id)
@@ -309,28 +358,43 @@ actor CmxIrohClientSessionPool {
 
     private func invalidateSession(
         for key: SessionKey,
-        releasesControlOwner: Bool = true
+        releasesControlOwner: Bool = true,
+        reason: DiagnosticSessionLifecycleKind,
+        failure: DiagnosticFailureKind
     ) async {
         await invalidateSession(
             for: key,
             matching: Optional<UUID>.none,
-            releasesControlOwner: releasesControlOwner
+            releasesControlOwner: releasesControlOwner,
+            reason: reason,
+            failure: failure
         )
     }
 
     private func invalidateSession(
         for key: SessionKey,
         matching expectedID: UUID?,
-        releasesControlOwner: Bool = true
+        releasesControlOwner: Bool = true,
+        reason: DiagnosticSessionLifecycleKind,
+        failure: DiagnosticFailureKind
     ) async {
         if let expectedID, sessions[key]?.id != expectedID { return }
-        let owner = releasesControlOwner ? controlOwners[key] : nil
+        let currentOwner = controlOwners[key]
+        let owner = releasesControlOwner ? currentOwner : nil
         connectionTasks[key]?.task.cancel()
         connectionTasks[key] = nil
         let pooled = sessions.removeValue(forKey: key)
         sessionOrder.removeAll { $0 == key }
         pooled?.closureTask.cancel()
         pooled?.pathObservationTask.cancel()
+        if let pooled {
+            recordSessionClosure(
+                reason,
+                pooled: pooled,
+                purpose: currentOwner?.purpose ?? pooled.initialPurpose,
+                failure: failure
+            )
+        }
         await pooled?.session.close()
         if let owner {
             releaseControlOwner(for: key, ownerID: owner.id)
@@ -340,10 +404,17 @@ actor CmxIrohClientSessionPool {
 
     private func invalidateSession(
         for key: SessionKey,
-        matching expectedSession: CmxIrohClientSession
+        matching expectedSession: CmxIrohClientSession,
+        reason: DiagnosticSessionLifecycleKind,
+        failure: DiagnosticFailureKind
     ) async {
         guard let pooled = sessions[key], pooled.session === expectedSession else { return }
-        await invalidateSession(for: key, matching: pooled.id)
+        await invalidateSession(
+            for: key,
+            matching: pooled.id,
+            reason: reason,
+            failure: failure
+        )
     }
 
     private func reserveControlOwner(
@@ -423,6 +494,47 @@ actor CmxIrohClientSessionPool {
         controlOwners[key] = ControlOwner(id: next.ownerID, purpose: next.purpose)
         publishSelectedPathChangeIfEstablished(for: key)
         next.continuation.resume()
+    }
+
+    private func makeDiagnosticSessionID() -> Int {
+        if nextDiagnosticSessionID == Int.max {
+            nextDiagnosticSessionID = 1
+        } else {
+            nextDiagnosticSessionID += 1
+        }
+        return nextDiagnosticSessionID
+    }
+
+    private func recordSessionLifecycle(
+        _ kind: DiagnosticSessionLifecycleKind,
+        sessionID: Int,
+        purpose: CmxTransportSessionPurpose
+    ) {
+        diagnosticLog?.record(DiagnosticEvent(
+            .transportSessionLifecycle,
+            a: kind.rawValue,
+            b: Int(purpose.rawValue),
+            c: sessionID
+        ))
+    }
+
+    private func recordSessionClosure(
+        _ kind: DiagnosticSessionLifecycleKind,
+        pooled: PooledSession,
+        purpose: CmxTransportSessionPurpose,
+        failure: DiagnosticFailureKind
+    ) {
+        recordSessionLifecycle(
+            kind,
+            sessionID: pooled.diagnosticID,
+            purpose: purpose
+        )
+        diagnosticLog?.record(DiagnosticEvent(
+            .sessionClosed,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: failure.rawValue,
+            c: pooled.diagnosticID
+        ))
     }
 
     private func publishSelectedPathChangeIfEstablished(for key: SessionKey) {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohPooledByteTransport.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohPooledByteTransport.swift
@@ -36,7 +36,10 @@ actor CmxIrohPooledByteTransport: CmxByteTransport {
         do {
             return try await session.receiveControl()
         } catch {
-            await releaseOwnedControlSession()
+            await releaseOwnedControlSession(
+                reason: .controlReadFailed,
+                failure: DiagnosticFailureKind.classify(error)
+            )
             self.session = nil
             throw error
         }
@@ -48,7 +51,10 @@ actor CmxIrohPooledByteTransport: CmxByteTransport {
         do {
             try await session.sendControl(data)
         } catch {
-            await releaseOwnedControlSession()
+            await releaseOwnedControlSession(
+                reason: .controlWriteFailed,
+                failure: DiagnosticFailureKind.classify(error)
+            )
             self.session = nil
             throw error
         }
@@ -61,12 +67,23 @@ actor CmxIrohPooledByteTransport: CmxByteTransport {
         // The mobile RPC session owns control framing and may leave a cancelled
         // read or partial frame behind. Never hand that stream to a replacement
         // RPC owner; close the peer session so the next control transport redials.
-        await releaseOwnedControlSession()
+        await releaseOwnedControlSession(
+            reason: .controlOwnerReleased,
+            failure: .none
+        )
     }
 
-    private func releaseOwnedControlSession() async {
+    private func releaseOwnedControlSession(
+        reason: DiagnosticSessionLifecycleKind,
+        failure: DiagnosticFailureKind
+    ) async {
         guard ownsControlSession else { return }
         ownsControlSession = false
-        await pool.releaseControlSession(for: request, ownerID: ownerID)
+        await pool.releaseControlSession(
+            for: request,
+            ownerID: ownerID,
+            reason: reason,
+            failure: failure
+        )
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
@@ -663,6 +663,125 @@ struct CmxIrohClientSessionPoolTests {
         await background.close()
         await control.close()
     }
+
+    @Test
+    func ownerReleaseExplainsTheExactUnavailableRelayPrivatePathCycle() async throws {
+        let fixture = try PoolFixture()
+        let firstConnection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .privateNetwork
+        )
+        let replacementConnection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .relay(url: "https://relay.example.com/")
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [
+                .connection(firstConnection),
+                .connection(replacementConnection),
+            ]
+        )
+        let diagnosticLog = DiagnosticLog(capacity: 16)
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            diagnosticLog: diagnosticLog
+        )
+        let changes = await pool.selectedPathChanges()
+        var iterator = changes.makeAsyncIterator()
+        #expect(await iterator.next() != nil)
+        let factory = CmxIrohByteTransportFactory(sessionPool: pool)
+
+        let first = try factory.makeTransport(for: fixture.request)
+        try await first.connect()
+        #expect(await iterator.next() != nil)
+        #expect(await pool.selectedObservedPath() == .privateNetwork)
+
+        await first.close()
+        #expect(await iterator.next() != nil)
+        let unavailable = await pool.selectedObservedPath()
+
+        let replacement = try factory.makeTransport(for: fixture.request)
+        try await replacement.connect()
+        #expect(await iterator.next() != nil)
+        let relay = await pool.selectedObservedPath()
+
+        await replacementConnection.setObservedSelectedPath(.privateNetwork)
+        #expect(await iterator.next() != nil)
+        let privateNetwork = await pool.selectedObservedPath()
+
+        #expect([unavailable, relay, privateNetwork] == [
+            .unavailable,
+            .relay(url: "https://relay.example.com/"),
+            .privateNetwork,
+        ])
+
+        for _ in 0 ..< 1_000 {
+            if await diagnosticLog.processedCount() >= 4 { break }
+            await Task.yield()
+        }
+        let events = await diagnosticLog.snapshot().events
+        #expect(events.map(\.code) == [
+            .transportSessionLifecycle,
+            .transportSessionLifecycle,
+            .sessionClosed,
+            .transportSessionLifecycle,
+        ])
+        #expect(events.map(\.a) == [
+            DiagnosticSessionLifecycleKind.established.rawValue,
+            DiagnosticSessionLifecycleKind.controlOwnerReleased.rawValue,
+            DiagnosticTransportKind.iroh.rawValue,
+            DiagnosticSessionLifecycleKind.established.rawValue,
+        ])
+        #expect(events[0].b == Int(CmxTransportSessionPurpose.foregroundControl.rawValue))
+        #expect(events[1].b == Int(CmxTransportSessionPurpose.foregroundControl.rawValue))
+        #expect(events[2].b == DiagnosticFailureKind.none.rawValue)
+        #expect(events[0].c == events[1].c)
+        #expect(events[1].c == events[2].c)
+        #expect(events[3].c != events[2].c)
+
+        await replacement.close()
+    }
+
+    @Test
+    func mixedCaseBackgroundAliasCannotTearDownTheForegroundControlOwner() async throws {
+        let fixture = try PoolFixture()
+        let connection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            selectedPath: .privateNetwork
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [.connection(connection)]
+        )
+        let pool = try await fixture.pool(endpoint: endpoint, generation: 1)
+        let factory = CmxIrohByteTransportFactory(sessionPool: pool)
+        let foreground = try factory.makeTransport(for: fixture.request)
+        let backgroundRequest = CmxByteTransportRequest(
+            route: fixture.request.route,
+            expectedPeerDeviceID: fixture.request.expectedPeerDeviceID?.uppercased(),
+            authorizationMode: .transportAdmission,
+            sessionPurpose: .backgroundControl
+        )
+        let background = try factory.makeTransport(for: backgroundRequest)
+
+        try await foreground.connect()
+        let backgroundConnect = Task { try await background.connect() }
+        try #require(await waitForControlWaiter(pool, request: backgroundRequest))
+        backgroundConnect.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await backgroundConnect.value
+        }
+
+        #expect(await pool.selectedObservedPath() == .privateNetwork)
+        #expect(await connection.observedCloseCallCount() == 0)
+        #expect(await endpoint.observedDialedAddresses().count == 1)
+        await foreground.close()
+    }
 }
 
 private func waitForControlWaiter(
@@ -730,7 +849,8 @@ private struct PoolFixture {
     func pool(
         endpoint: any CmxIrohEndpoint,
         generation: UInt64,
-        contextProvider: (any CmxIrohClientContextProvider)? = nil
+        contextProvider: (any CmxIrohClientContextProvider)? = nil,
+        diagnosticLog: DiagnosticLog? = nil
     ) async throws -> CmxIrohClientSessionPool {
         let configuration = try CmxIrohEndpointConfiguration(
             secretKey: CmxIrohSecretKey(bytes: Data(repeating: 7, count: 32)),
@@ -747,7 +867,8 @@ private struct PoolFixture {
             supervisor: supervisor,
             contextProvider: contextProvider
                 ?? TestIrohClientContextProvider(context: context),
-            protocolConfiguration: .testApplicationLanes
+            protocolConfiguration: .testApplicationLanes,
+            diagnosticLog: diagnosticLog
         )
         await pool.activate(runtimeGeneration: generation)
         return pool

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -1253,6 +1253,7 @@ public final class MobileIrohRuntimeComposition:
             protocolConfiguration: Self.protocolConfiguration(
                 for: transportVerificationMode
             ),
+            diagnosticLog: diagnosticLog,
             offlinePolicyCache: offlinePolicies,
             networkPathSnapshot: networkPathSnapshot,
             lanFallback: { target, bindings, rendezvous in


### PR DESCRIPTION
## What changed
- correlate each admitted Iroh pool session with a process-local ID
- record its privacy-safe owner role and exact lifecycle exit reason
- distinguish intentional owner release, read/write failure, remote close, stale eviction, lane failure, runtime replacement, and explicit invalidation
- connect the production iOS diagnostic ring to the Iroh client session pool

## Why
A cmux 1.0.4 report repeatedly cycles selected path `unavailable -> relay -> private network`, but the old schema cannot identify which lifecycle owner removed the session. This closes that evidence gap without exporting endpoint IDs, routes, addresses, accounts, or raw errors. It does not add retry timing or change transport behavior.

## Verification
- regression test commit first: `303ecb8f07`
- `swift test` in `Packages/Shared/CmuxIrohTransport`: 399 tests passed
- `swift test` in `Packages/Shared/CMUXMobileCore`: 225 tests passed
- mixed-case background UUID aliases cannot close the foreground owner
- deterministic owner release produces and correlates the exact unavailable/relay/private cycle

The standalone macOS `swift test` for `ios/cmuxPackage` remains blocked by existing dependency manifests that declare macOS 10.13 while depending on macOS 14 packages; the normal app build is used for composition verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787045369&installation_id=133855650&pr_number=8471&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8471&signature=5f43121b6b7aee14872a8a0d1b0d33637c4653dc3dd17f846b4954bc14106172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add privacy-safe lifecycle diagnostics to the Iroh session pool to trace who closes a session and why, using a process-local session ID. This explains path flaps (unavailable → relay → private) without exposing peers, routes, or accounts, and does not change transport behavior.

- **New Features**
  - Added `transportSessionLifecycle` (`51`) event and extended `sessionClosed` to carry transport kind and a local correlation ID.
  - Introduced `DiagnosticSessionLifecycleKind` to classify owner-driven releases, read/write failures, remote close, stale eviction, lane failure, runtime deactivate/reconfigure, and explicit invalidation.
  - Session pool now emits lifecycle events on establish/close, correlating with `sessionClosed` via a positive, process-local ID and the owner `CmxTransportSessionPurpose`.
  - Plumbed `diagnosticLog` into `CmxIrohClientRuntime` and `CmxIrohClientSessionPool`; connected the iOS diagnostic ring.
  - Added tests that reproduce and attribute the unavailable → relay → private cycle and prevent mixed-case background aliases from tearing down the foreground owner.

<sup>Written for commit d0fe1321d41ba84932a2b4afec48040a9048455d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

