### PR TITLE
Test Iroh remote-close diagnostic correlation

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
@@ -215,7 +215,12 @@ struct CmxIrohClientSessionPoolTests {
                 .connection(secondConnection),
             ]
         )
-        let pool = try await fixture.pool(endpoint: endpoint, generation: 1)
+        let diagnosticLog = DiagnosticLog(capacity: 8)
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            diagnosticLog: diagnosticLog
+        )
         let factory = CmxIrohByteTransportFactory(sessionPool: pool)
         let first = try factory.makeTransport(for: fixture.request)
         try await first.connect()
@@ -228,6 +233,22 @@ struct CmxIrohClientSessionPoolTests {
         try await replacement.connect()
         #expect(await endpoint.observedDialedAddresses().count == 2)
         #expect(await secondConnection.observedCloseCallCount() == 0)
+
+        for _ in 0 ..< 1_000 {
+            if await diagnosticLog.processedCount() >= 4 { break }
+            await Task.yield()
+        }
+        let events = await diagnosticLog.snapshot().events
+        #expect(events.map(\.code) == [
+            .transportSessionLifecycle,
+            .transportSessionLifecycle,
+            .sessionClosed,
+            .transportSessionLifecycle,
+        ])
+        #expect(events[1].diagnosticSessionLifecycleKind == .remoteClosed)
+        #expect(events[1].diagnosticSessionPurpose == .foregroundControl)
+        #expect(events[1].diagnosticSessionID == events[2].diagnosticSessionID)
+        #expect(events[3].diagnosticSessionID != events[2].diagnosticSessionID)
         await replacement.close()
     }
 


### PR DESCRIPTION
Adds direct regression coverage that a remote peer closure emits `remoteClosed` for the foreground owner, pairs it with the matching `sessionClosed` event through one process-local session ID, and assigns a fresh ID after redial.

Verification: focused test passed; full `CmuxIrohTransport` suite passed (399 tests in 46 suites).

This is test-only follow-up coverage for the already merged session lifecycle diagnostics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787046028&installation_id=133855650&pr_number=8472&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8472&signature=2326195d735155df83a63499d63ce5dccf5052e10398881bf2c20da55534b0fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a focused test to verify remote-close diagnostic correlation in `CmuxIrohTransport`. It asserts `remoteClosed` is emitted for the foreground owner, correlates with `sessionClosed` via a single session ID, and that a fresh ID is assigned after redial.

<sup>Written for commit 2247d5a3e0bc9e0623ee69d450a0782211e9465f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

