### PR TITLE
Preserve PR metadata during passive sidebar transition

### DIFF
--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/SidebarGitMetadataService+Probe.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/SidebarGitMetadataService+Probe.swift
@@ -238,7 +238,9 @@ extension SidebarGitMetadataService {
             )
             return
         }
+        let pullRequestActivity = host?.pullRequestActivity ?? .disabled
         let shouldTrackPullRequests = sidebarPullRequestPollingEnabled
+        let shouldDiscardPullRequestProjection = !pullRequestActivity.acceptsPassiveReports
         let resolvedPullRequest: SidebarPullRequestBadge? = {
             guard shouldTrackPullRequests else { return nil }
             guard case .resolved(let pullRequest) = snapshot.pullRequest else { return nil }
@@ -405,27 +407,18 @@ extension SidebarGitMetadataService {
                     panelId: probeKey.panelId,
                     badge: nextBadge
                 )
-            } else if host.panelPullRequestBadge(
-                workspaceId: probeKey.workspaceId,
-                panelId: probeKey.panelId
-            ) != nil {
+            } else if shouldDiscardPullRequestProjection, previousPullRequestBadge != nil {
                 didApplyMaterialSidebarGitChange = true
                 host.clearPanelPullRequest(workspaceId: probeKey.workspaceId, panelId: probeKey.panelId)
             }
         case .notFound:
-            if host.panelPullRequestBadge(
-                workspaceId: probeKey.workspaceId,
-                panelId: probeKey.panelId
-            ) != nil {
+            if (shouldTrackPullRequests || shouldDiscardPullRequestProjection),
+               previousPullRequestBadge != nil {
                 didApplyMaterialSidebarGitChange = true
                 host.clearPanelPullRequest(workspaceId: probeKey.workspaceId, panelId: probeKey.panelId)
             }
         case .deferred, .unsupportedRepository, .transientFailure:
-            if !shouldTrackPullRequests,
-               host.panelPullRequestBadge(
-                   workspaceId: probeKey.workspaceId,
-                   panelId: probeKey.panelId
-               ) != nil {
+            if shouldDiscardPullRequestProjection, previousPullRequestBadge != nil {
                 didApplyMaterialSidebarGitChange = true
                 host.clearPanelPullRequest(workspaceId: probeKey.workspaceId, panelId: probeKey.panelId)
             }

--- a/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/ProbeApplyRaceTests.swift
+++ b/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/ProbeApplyRaceTests.swift
@@ -70,4 +70,49 @@ import CmuxGit
             $0.workspaceId == workspaceId && $0.panelId == panelId
         })
     }
+
+    @Test(.timeLimit(.minutes(1)))
+    func localProbeCompletingAfterPullRequestsBecomePassivePreservesExistingBadge() async throws {
+        let host = RecordingSidebarGitHost()
+        host.pullRequestActivity = .activePolling
+        let (workspaceId, panelId) = host.addWorkspace(panelDirectory: "/tmp/repo")
+        let badge = SidebarPullRequestBadge(
+            number: 9_001,
+            label: "PR",
+            url: URL(string: "https://github.com/manaflow-ai/cmux/pull/9001")!,
+            status: .open,
+            branch: "feature/passive-projection"
+        )
+        host.updatePanelPullRequest(workspaceId: workspaceId, panelId: panelId, badge: badge)
+        let clock = ManualGitPollClock()
+        let pullRequestProbing = RecordingPullRequestProbing()
+        let reader = GatedMetadataReader(
+            metadata: .repository(branch: "feature/passive-projection"),
+            gated: true
+        )
+        let service = makeService(
+            host: host,
+            reader: reader,
+            clock: clock,
+            pullRequestProbing: pullRequestProbing
+        )
+
+        service.scheduleInitialWorkspaceGitMetadataRefreshIfPossible(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            reason: "test"
+        )
+        await clock.waitForSleeper()
+        await clock.resumeNext()
+        #expect(await reader.waitForProbe(maxYields: 100_000))
+
+        host.pullRequestActivity = .passiveReportsOnly
+        await reader.openGate()
+
+        #expect(await waitUntil {
+            host.workspaces[0].state.panels[panelId]?.branch?.branch == "feature/passive-projection"
+        })
+        #expect(host.workspaces[0].state.panels[panelId]?.badge == badge)
+        #expect(pullRequestProbing.scheduledRefreshes.isEmpty)
+    }
 }


### PR DESCRIPTION
Follow-up to #8226 and #8175.

A runtime command-palette dogfood pass found that an in-flight local Git probe could clear an existing pull-request badge after the PR row changed from active polling to passive reports only. This preserves the projection in passive mode while retaining authoritative cleanup in disabled mode.

Regression proof:
- commit 1 adds the exact gated probe race and fails because PR #9001 becomes nil
- commit 2 fixes the lifecycle distinction and makes the same test pass

Validation:
- CmuxGit: 88/88
- CmuxSidebarGit: 46/46
- tagged Debug reload: issue-8175-passive-retention
- project wiring, workspace package grouping, Package.resolved policy, and diff checks pass

Final no-auth runtime/network verification is running against the tagged artifact; this PR must not be merged without explicit user approval.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787047568&installation_id=133855650&pr_number=8474&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8474&signature=6fe31f323d978fd6bbaa706aa0127b221c3428300a36510f0d6edd3335fa0ffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the sidebar pull request badge when PR polling switches from active to passive, preventing late local probes from clearing existing metadata. Cleanup now only happens when PR activity is disabled.

- **Bug Fixes**
  - Respect `pullRequestActivity.acceptsPassiveReports`: keep existing PR projection in `.passiveReportsOnly`, and clear only when disabled.
  - Added regression test to cover the probe race: `localProbeCompletingAfterPullRequestsBecomePassivePreservesExistingBadge`.

<sup>Written for commit 38ac278a3b9bf248a0826edbdb85a4156fa536cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing pull request badges when pull request updates switch to passive reporting.
  * Prevented unnecessary clearing of pull request information during git metadata refreshes.
* **Tests**
  * Added coverage to verify badges remain visible and no additional pull request checks are scheduled after switching to passive updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->