### PR TITLE
test(iroh): verify custom relay round trips

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveEnvironment.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveEnvironment.swift
@@ -1,7 +1,9 @@
 import Foundation
+@testable import CmuxIrohTransport
 
 enum CmxIrohCustomRelayLiveEnvironment {
     enum EnvironmentError: Error {
+        case invalid(String)
         case missing(String)
     }
 
@@ -20,6 +22,16 @@ enum CmxIrohCustomRelayLiveEnvironment {
             && environment["CMUX_IROH_CUSTOM_RELAY_STATIC_TOKEN"]?.isEmpty == false
     }
 
+    static var hasEndpointBoundTokenRelay: Bool {
+        [
+            "CMUX_IROH_CUSTOM_RELAY_BOUND_URL",
+            "CMUX_IROH_CUSTOM_RELAY_FIRST_SECRET_KEY_HEX",
+            "CMUX_IROH_CUSTOM_RELAY_FIRST_TOKEN",
+            "CMUX_IROH_CUSTOM_RELAY_SECOND_SECRET_KEY_HEX",
+            "CMUX_IROH_CUSTOM_RELAY_SECOND_TOKEN",
+        ].allSatisfy { environment[$0]?.isEmpty == false }
+    }
+
     static var timeout: TimeInterval {
         environment["CMUX_IROH_CUSTOM_RELAY_TIMEOUT"]
             .flatMap(TimeInterval.init) ?? 10
@@ -30,5 +42,23 @@ enum CmxIrohCustomRelayLiveEnvironment {
             throw EnvironmentError.missing(name)
         }
         return value
+    }
+
+    static func requiredSecretKey(_ name: String) throws -> CmxIrohSecretKey {
+        let value = try required(name)
+        guard value.utf8.count == 64 else {
+            throw EnvironmentError.invalid(name)
+        }
+        var bytes = Data(capacity: 32)
+        var index = value.startIndex
+        while index < value.endIndex {
+            let next = value.index(index, offsetBy: 2)
+            guard let byte = UInt8(value[index ..< next], radix: 16) else {
+                throw EnvironmentError.invalid(name)
+            }
+            bytes.append(byte)
+            index = next
+        }
+        return try CmxIrohSecretKey(bytes: bytes)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
@@ -9,6 +9,18 @@ import Testing
     .enabled(if: CmxIrohCustomRelayLiveEnvironment.isEnabled)
 )
 struct CmxIrohCustomRelayLiveTests {
+    private enum LiveTestError: Error {
+        case connectionTimedOut
+        case endpointClosed
+        case relayAddressTimedOut
+        case relayPathTimedOut
+    }
+
+    private struct ConnectionPair: Sendable {
+        let outgoing: any CmxIrohConnection
+        let incoming: any CmxIrohConnection
+    }
+
     @Test(.enabled(if: CmxIrohCustomRelayLiveEnvironment.hasNoTokenRelay))
     func unauthenticatedRelayUsesExactConfiguredURL() async throws {
         let relayURL = try CmxIrohCustomRelayLiveEnvironment.required(
@@ -55,5 +67,256 @@ struct CmxIrohCustomRelayLiveTests {
         )
 
         #expect(result == .reachable(relayURL: relayURL))
+    }
+
+    @Test(.enabled(if: CmxIrohCustomRelayLiveEnvironment.hasStaticTokenRelay))
+    func staticTokenRelayCarriesBidirectionalRoundTrip() async throws {
+        let relayURL = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_STATIC_URL"
+        )
+        let token = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_STATIC_TOKEN"
+        )
+        try await assertBidirectionalRoundTrip(
+            relayURL: relayURL,
+            firstAuthenticationToken: token,
+            secondAuthenticationToken: token
+        )
+    }
+
+    @Test(.enabled(if: CmxIrohCustomRelayLiveEnvironment.hasNoTokenRelay))
+    func unauthenticatedRelayCarriesBidirectionalRoundTrip() async throws {
+        let relayURL = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_NO_TOKEN_URL"
+        )
+        try await assertBidirectionalRoundTrip(
+            relayURL: relayURL,
+            firstAuthenticationToken: nil,
+            secondAuthenticationToken: nil
+        )
+    }
+
+    @Test(.enabled(if: CmxIrohCustomRelayLiveEnvironment.hasEndpointBoundTokenRelay))
+    func endpointBoundTokensCarryBidirectionalRoundTrip() async throws {
+        try await assertBidirectionalRoundTrip(
+            relayURL: try CmxIrohCustomRelayLiveEnvironment.required(
+                "CMUX_IROH_CUSTOM_RELAY_BOUND_URL"
+            ),
+            firstAuthenticationToken: try CmxIrohCustomRelayLiveEnvironment.required(
+                "CMUX_IROH_CUSTOM_RELAY_FIRST_TOKEN"
+            ),
+            secondAuthenticationToken: try CmxIrohCustomRelayLiveEnvironment.required(
+                "CMUX_IROH_CUSTOM_RELAY_SECOND_TOKEN"
+            ),
+            firstSecretKey: try CmxIrohCustomRelayLiveEnvironment.requiredSecretKey(
+                "CMUX_IROH_CUSTOM_RELAY_FIRST_SECRET_KEY_HEX"
+            ),
+            secondSecretKey: try CmxIrohCustomRelayLiveEnvironment.requiredSecretKey(
+                "CMUX_IROH_CUSTOM_RELAY_SECOND_SECRET_KEY_HEX"
+            )
+        )
+    }
+
+    private func assertBidirectionalRoundTrip(
+        relayURL: String,
+        firstAuthenticationToken: String?,
+        secondAuthenticationToken: String?,
+        firstSecretKey: CmxIrohSecretKey? = nil,
+        secondSecretKey: CmxIrohSecretKey? = nil
+    ) async throws {
+        let firstProfile = CmxIrohEndpointRelayProfile(
+            customProfile: try CmxIrohCustomRelayProfile(
+                relays: [
+                    CmxIrohCustomRelay(
+                        url: relayURL,
+                        authenticationToken: firstAuthenticationToken
+                    ),
+                ]
+            )
+        )
+        let secondProfile = CmxIrohEndpointRelayProfile(
+            customProfile: try CmxIrohCustomRelayProfile(
+                relays: [
+                    CmxIrohCustomRelay(
+                        url: relayURL,
+                        authenticationToken: secondAuthenticationToken
+                    ),
+                ]
+            )
+        )
+        let factory = CmxIrohLibEndpointFactory(
+            transportVerificationMode: .relayOnly
+        )
+        let alpn = Data("cmux/custom-relay-live/1".utf8)
+        let first = try await factory.bind(
+            configuration: CmxIrohEndpointConfiguration(
+                secretKey: try firstSecretKey ?? CmxIrohSecretKey(
+                    bytes: Data(repeating: 1, count: 32)
+                ),
+                alpns: [alpn],
+                relayProfile: firstProfile
+            )
+        )
+        let second = try await factory.bind(
+            configuration: CmxIrohEndpointConfiguration(
+                secretKey: try secondSecretKey ?? CmxIrohSecretKey(
+                    bytes: Data(repeating: 2, count: 32)
+                ),
+                alpns: [alpn],
+                relayProfile: secondProfile
+            )
+        )
+
+        do {
+            let firstAddress = try await relayAddress(
+                for: first,
+                relayURL: relayURL
+            )
+            let secondAddress = try await relayAddress(
+                for: second,
+                relayURL: relayURL
+            )
+            #expect(firstAddress.pathHints.map(\.value) == [relayURL])
+            #expect(secondAddress.pathHints.map(\.value) == [relayURL])
+
+            let connections = try await connectPair(
+                first: first,
+                second: second,
+                secondAddress: secondAddress,
+                alpn: alpn
+            )
+            let outgoingConnection = connections.outgoing
+            let incomingConnection = connections.incoming
+
+            try await outgoingConnection.setIncomingStreamLimits(
+                maximumBidirectionalStreamCount: 1,
+                maximumUnidirectionalStreamCount: 0
+            )
+            try await incomingConnection.setIncomingStreamLimits(
+                maximumBidirectionalStreamCount: 1,
+                maximumUnidirectionalStreamCount: 0
+            )
+
+            async let acceptedStream = incomingConnection.acceptBidirectionalStream()
+            let outgoingStream = try await outgoingConnection.openBidirectionalStream()
+            let incomingStream = try await acceptedStream
+            let request = Data("custom-relay-request".utf8)
+            try await outgoingStream.sendStream.send(request)
+            try await outgoingStream.sendStream.finish()
+            #expect(try await receiveAll(from: incomingStream.receiveStream) == request)
+
+            let response = Data("custom-relay-response".utf8)
+            try await incomingStream.sendStream.send(response)
+            try await incomingStream.sendStream.finish()
+            #expect(try await receiveAll(from: outgoingStream.receiveStream) == response)
+
+            #expect(
+                try await relayPath(
+                    for: outgoingConnection,
+                    relayURL: relayURL
+                ) == .relay(url: relayURL)
+            )
+            #expect(
+                try await relayPath(
+                    for: incomingConnection,
+                    relayURL: relayURL
+                ) == .relay(url: relayURL)
+            )
+
+            await outgoingConnection.close(errorCode: 0, reason: "live_test_complete")
+            await incomingConnection.close(errorCode: 0, reason: "live_test_complete")
+        } catch {
+            await first.close()
+            await second.close()
+            throw error
+        }
+        await first.close()
+        await second.close()
+    }
+
+    private func connectPair(
+        first: any CmxIrohEndpoint,
+        second: any CmxIrohEndpoint,
+        secondAddress: CmxIrohEndpointAddress,
+        alpn: Data
+    ) async throws -> ConnectionPair {
+        try await withThrowingTaskGroup(of: ConnectionPair.self) { group in
+            group.addTask {
+                async let acceptedConnection = second.accept()
+                let outgoingConnection = try await first.connect(
+                    to: secondAddress,
+                    alpn: alpn
+                )
+                let incomingConnection = try #require(await acceptedConnection)
+                return ConnectionPair(
+                    outgoing: outgoingConnection,
+                    incoming: incomingConnection
+                )
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(
+                    for: .seconds(CmxIrohCustomRelayLiveEnvironment.timeout)
+                )
+                // The FFI connect/accept futures do not currently unwind from
+                // Swift task cancellation alone. Closing both disposable live
+                // endpoints makes this external-network gate deterministically bounded.
+                await first.close()
+                await second.close()
+                throw LiveTestError.connectionTimedOut
+            }
+            defer { group.cancelAll() }
+            guard let pair = try await group.next() else {
+                throw LiveTestError.connectionTimedOut
+            }
+            return pair
+        }
+    }
+
+    private func relayAddress(
+        for endpoint: any CmxIrohEndpoint,
+        relayURL: String
+    ) async throws -> CmxIrohEndpointAddress {
+        let deadline = Date().addingTimeInterval(CmxIrohCustomRelayLiveEnvironment.timeout)
+        while Date() < deadline {
+            let address = await endpoint.address()
+            if address.pathHints.contains(where: {
+                $0.kind == .relayURL && $0.value == relayURL
+            }) {
+                return address
+            }
+            if !(await endpoint.isHealthy()) {
+                throw LiveTestError.endpointClosed
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw LiveTestError.relayAddressTimedOut
+    }
+
+    private func relayPath(
+        for connection: any CmxIrohConnection,
+        relayURL: String
+    ) async throws -> CmxIrohObservedConnectionPath {
+        let connection = try #require(
+            connection as? any CmxIrohConnectionPathInspecting
+        )
+        let deadline = Date().addingTimeInterval(CmxIrohCustomRelayLiveEnvironment.timeout)
+        while Date() < deadline {
+            let path = await connection.observedSelectedPath()
+            if path == .relay(url: relayURL) {
+                return path
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw LiveTestError.relayPathTimedOut
+    }
+
+    private func receiveAll(
+        from stream: any CmxIrohReceiveStream
+    ) async throws -> Data {
+        var result = Data()
+        while let chunk = try await stream.receive(maximumByteCount: 4_096) {
+            result.append(chunk)
+        }
+        return result
     }
 }


### PR DESCRIPTION
Adds opt-in live gates that:

- bind two production FFI endpoints in relay-only mode
- prove exact custom relay-map selection
- exchange request and response bytes over one bidirectional stream
- assert both selected paths are the configured relay
- support unauthenticated, shared static-token, and endpoint-bound per-device token providers
- close disposable endpoints on timeout so external failures are bounded

Verification:

- 46 focused Iroh transport tests pass
- 10 macOS Iroh settings tests pass
- 8 iOS Simulator Iroh settings tests pass on isolated iPhone 16 Pro / iOS 18.4
- user-provided EU relay selection passes
- full unauthenticated round trip times out, confirming that relay requires provider credentials despite advertising the route

To run authenticated endpoint-bound coverage, provide `CMUX_IROH_CUSTOM_RELAY_BOUND_URL`, `CMUX_IROH_CUSTOM_RELAY_FIRST_SECRET_KEY_HEX`, `CMUX_IROH_CUSTOM_RELAY_FIRST_TOKEN`, `CMUX_IROH_CUSTOM_RELAY_SECOND_SECRET_KEY_HEX`, and `CMUX_IROH_CUSTOM_RELAY_SECOND_TOKEN`, plus `CMUX_IROH_CUSTOM_RELAY_LIVE=1`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787059423&installation_id=133855650&pr_number=8482&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8482&signature=9fa4100a7ceb16bd408ec6b401a7dda60fb725fa64796d4d0aa408f28fedcc66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in live tests that verify custom relay round trips in `CmuxIrohTransport`. Tests assert exact relay selection and a bidirectional request/response over one stream across unauthenticated, static-token, and endpoint-bound modes.

- New Features
  - Relay-only live tests binding two endpoints via the configured custom relay.
  - Verify path hints and observed path match the exact relay URL.
  - Bidirectional stream round trip with request/response byte checks.
  - Deterministic timeouts with endpoint cleanup; strict hex parsing for endpoint-bound secret keys.

- Migration
  - Enable: `CMUX_IROH_CUSTOM_RELAY_LIVE=1` (optional `CMUX_IROH_CUSTOM_RELAY_TIMEOUT`, default 10s).
  - Static mode: `CMUX_IROH_CUSTOM_RELAY_STATIC_URL`, `CMUX_IROH_CUSTOM_RELAY_STATIC_TOKEN`.
  - Unauthenticated mode: `CMUX_IROH_CUSTOM_RELAY_NO_TOKEN_URL`.
  - Endpoint-bound mode: `CMUX_IROH_CUSTOM_RELAY_BOUND_URL`, `CMUX_IROH_CUSTOM_RELAY_FIRST_SECRET_KEY_HEX`, `CMUX_IROH_CUSTOM_RELAY_FIRST_TOKEN`, `CMUX_IROH_CUSTOM_RELAY_SECOND_SECRET_KEY_HEX`, `CMUX_IROH_CUSTOM_RELAY_SECOND_TOKEN`.

<sup>Written for commit b63de3891c4b21c0bf7a482dd524d046a792c21d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

