### PR TITLE
Add authenticated production Iroh release gate

### DIFF
--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -1,3 +1,4 @@
+import CMUXAuthCore
 import Foundation
 
 enum AuthEnvironment {
@@ -386,31 +387,91 @@ enum AuthEnvironment {
     }
 
     static var stackProjectID: String {
-        let environment = ProcessInfo.processInfo.environment
+        #if DEBUG
+        return resolvedStackProjectID(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: true
+        )
+        #else
+        return resolvedStackProjectID(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: false
+        )
+        #endif
+    }
+
+    /// Resolve the Stack channel for a macOS build. Debug defaults to the
+    /// development project, while `scripts/reload.sh --prod-auth` bakes an
+    /// explicit production override into the tagged app's launch environment.
+    /// Invalid values fail toward the build's normal channel.
+    static func resolvedStackAuthEnvironment(
+        environment: [String: String],
+        isDebugBuild: Bool
+    ) -> CMUXAuthEnvironment {
+        switch environment["CMUX_AUTH_ENVIRONMENT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() {
+        case "production":
+            return .production
+        case "development":
+            return .development
+        default:
+            return isDebugBuild ? .development : .production
+        }
+    }
+
+    static func resolvedStackProjectID(
+        environment: [String: String],
+        isDebugBuild: Bool
+    ) -> String {
         if let projectID = environment["CMUX_STACK_PROJECT_ID"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !projectID.isEmpty {
             return projectID
         }
-        #if DEBUG
-        return developmentStackProjectID
-        #else
-        return productionStackProjectID
-        #endif
+        switch resolvedStackAuthEnvironment(
+            environment: environment,
+            isDebugBuild: isDebugBuild
+        ) {
+        case .development:
+            return developmentStackProjectID
+        case .production:
+            return productionStackProjectID
+        }
     }
 
     static var stackPublishableClientKey: String {
-        let environment = ProcessInfo.processInfo.environment
+        #if DEBUG
+        return resolvedStackPublishableClientKey(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: true
+        )
+        #else
+        return resolvedStackPublishableClientKey(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: false
+        )
+        #endif
+    }
+
+    static func resolvedStackPublishableClientKey(
+        environment: [String: String],
+        isDebugBuild: Bool
+    ) -> String {
         if let clientKey = environment["CMUX_STACK_PUBLISHABLE_CLIENT_KEY"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !clientKey.isEmpty {
             return clientKey
         }
-        #if DEBUG
-        return developmentStackPublishableClientKey
-        #else
-        return productionStackPublishableClientKey
-        #endif
+        switch resolvedStackAuthEnvironment(
+            environment: environment,
+            isDebugBuild: isDebugBuild
+        ) {
+        case .development:
+            return developmentStackPublishableClientKey
+        case .production:
+            return productionStackPublishableClientKey
+        }
     }
 
     /// The website origin used for the after-sign-in handler.

--- a/Sources/Auth/DebugDogfoodCredentialResolver.swift
+++ b/Sources/Auth/DebugDogfoodCredentialResolver.swift
@@ -1,4 +1,5 @@
 #if DEBUG
+import Darwin
 import Foundation
 
 /// Resolves dogfood Stack credentials for the macOS DEBUG auto-sign-in path.
@@ -37,6 +38,8 @@ import Foundation
 /// `init`, so tests drive every precedence branch without touching the real
 /// filesystem or `~/.secrets`.
 struct DebugDogfoodCredentialResolver {
+    static let explicitCredentialsFileEnvironmentKey = "CMUX_AUTH_CREDENTIALS_FILE"
+
     /// A resolved email/password pair.
     ///
     /// Kept nested in this file under the file-organization carve-out for small,
@@ -49,12 +52,20 @@ struct DebugDogfoodCredentialResolver {
 
     /// The launch environment to read env-var credentials from.
     private let environment: [String: String]
+    /// A one-shot credentials file explicitly selected by release-gate tooling.
+    /// When present it is the only credential source, so ambient development
+    /// credentials cannot shadow a production test account.
+    private let explicitCredentialsFile: String?
     /// Ordered secret-file candidate paths (highest precedence first), already
     /// expanded to absolute paths by the caller.
     private let secretFilePaths: [String]
     /// Reads the contents of a secret file at the given path, or `nil` when the
     /// file is absent/unreadable. Injected so tests never read real files.
     private let readFile: (String) -> String?
+    /// Secure reader for the explicit one-shot file. The default opens with
+    /// `O_NOFOLLOW`, then verifies regular-file type, ownership, and 0600-or-
+    /// stricter permissions on the opened descriptor before reading.
+    private let readSecureFile: (String) -> String?
 
     /// Creates a resolver.
     ///
@@ -70,11 +81,16 @@ struct DebugDogfoodCredentialResolver {
         secretFilePaths: [String]? = nil,
         readFile: @escaping (String) -> String? = { path in
             try? String(contentsOfFile: path, encoding: .utf8)
-        }
+        },
+        readSecureFile: @escaping (String) -> String? = Self.readSecureCredentialsFile
     ) {
         self.environment = environment
+        self.explicitCredentialsFile = environment[Self.explicitCredentialsFileEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nonEmpty
         self.secretFilePaths = secretFilePaths ?? Self.defaultSecretFilePaths(environment: environment)
         self.readFile = readFile
+        self.readSecureFile = readSecureFile
     }
 
     /// The default ordered secret-file candidates, resolved against `HOME`.
@@ -116,6 +132,15 @@ struct DebugDogfoodCredentialResolver {
     /// Resolve the highest-precedence credential pair, or `nil` when none is
     /// available. See the type doc for the full precedence order.
     func resolve() -> ResolvedCredentials? {
+        if let explicitCredentialsFile {
+            guard let contents = readSecureFile(explicitCredentialsFile) else {
+                return nil
+            }
+            let parsed = Self.parseEnvFile(contents)
+            return credentials(in: parsed, for: .dogfood)
+                ?? credentials(in: parsed, for: .uitest)
+        }
+
         // Dogfood account wins over the agent (uitest) account everywhere, so
         // resolve ALL dogfood sources before ANY uitest source.
         for account in [Account.dogfood, .uitest] {
@@ -170,5 +195,30 @@ struct DebugDogfoodCredentialResolver {
         }
         return result
     }
+
+    /// Read an explicitly selected credentials file without following a final
+    /// symlink. Validation is performed on the opened descriptor, closing the
+    /// check/read race that path-based permission checks would introduce.
+    private static func readSecureCredentialsFile(_ path: String) -> String? {
+        guard path.hasPrefix("/") else { return nil }
+        let descriptor = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
+        guard descriptor >= 0 else { return nil }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+
+        var metadata = stat()
+        guard fstat(descriptor, &metadata) == 0,
+              (metadata.st_mode & S_IFMT) == S_IFREG,
+              metadata.st_uid == geteuid(),
+              (metadata.st_mode & 0o077) == 0,
+              let data = try? handle.readToEnd(),
+              let contents = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return contents
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
 }
 #endif

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -33,6 +33,18 @@ struct MacAuthComposition {
         defaults: UserDefaults = .standard
     ) {
         let bundleIdentifier = Bundle.main.bundleIdentifier
+        let resolvedAuthEnvironment = AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: environment,
+            isDebugBuild: Self.isDebugBuild
+        )
+        let stackProjectID = AuthEnvironment.resolvedStackProjectID(
+            environment: environment,
+            isDebugBuild: Self.isDebugBuild
+        )
+        let stackPublishableClientKey = AuthEnvironment.resolvedStackPublishableClientKey(
+            environment: environment,
+            isDebugBuild: Self.isDebugBuild
+        )
         let tokenStore = FallbackTokenStore(
             primary: KeychainStackTokenStore(
                 service: KeychainStackTokenStore.serviceName(bundleIdentifier: bundleIdentifier)
@@ -42,8 +54,8 @@ struct MacAuthComposition {
         self.tokenStore = tokenStore
 
         let stack = StackClientApp(
-            projectId: AuthEnvironment.stackProjectID,
-            publishableClientKey: AuthEnvironment.stackPublishableClientKey,
+            projectId: stackProjectID,
+            publishableClientKey: stackPublishableClientKey,
             baseUrl: AuthEnvironment.stackBaseURL.absoluteString,
             tokenStore: .custom(tokenStore),
             noAutomaticPrefetch: true
@@ -69,8 +81,8 @@ struct MacAuthComposition {
 
         let config = AuthConfig(
             stack: CMUXAuthConfig(
-                projectId: AuthEnvironment.stackProjectID,
-                publishableClientKey: AuthEnvironment.stackPublishableClientKey
+                projectId: stackProjectID,
+                publishableClientKey: stackPublishableClientKey
             ),
             magicLinkCallbackURL: AuthEnvironment.websiteOrigin
                 .appendingPathComponent("auth/callback", isDirectory: false)
@@ -94,11 +106,22 @@ struct MacAuthComposition {
         // `shouldStartAutoLogin` gate then fires unchanged. Compiled out of
         // release builds.
         let resolvedEnvironment = Self.environmentWithDogfoodAutoSignIn(environment)
+        let authProjectSwitched = Self.detectAuthProjectSwitch(
+            resolvedProjectID: stackProjectID,
+            buildDefaultProjectID: AuthEnvironment.resolvedStackProjectID(
+                environment: [:],
+                isDebugBuild: Self.isDebugBuild
+            ),
+            defaults: defaults
+        )
         let launch = AuthLaunchOptions(
             clearAuthRequested: resolvedEnvironment["CMUX_UITEST_CLEAR_AUTH"] == "1",
             mockDataEnabled: false,
             environment: resolvedEnvironment,
-            includesDevAuth: Self.includesDevAuth
+            includesDevAuth: Self.includesDevAuth(
+                resolvedAuthEnvironment: resolvedAuthEnvironment
+            ),
+            clearStaleAuthOnLaunch: authProjectSwitched
         )
 
         let anchor = AuthPresentationContextProvider()
@@ -157,12 +180,32 @@ struct MacAuthComposition {
             .appendingPathComponent(bundleIdentifier ?? "cmux", isDirectory: true)
     }
 
-    private static var includesDevAuth: Bool {
+    private static var isDebugBuild: Bool {
         #if DEBUG
         true
         #else
         false
         #endif
+    }
+
+    private static func includesDevAuth(
+        resolvedAuthEnvironment: CMUXAuthEnvironment
+    ) -> Bool {
+        isDebugBuild && resolvedAuthEnvironment == .development
+    }
+
+    nonisolated static let storedStackProjectIDKey = "cmux.auth.stackProjectID"
+
+    /// Keep cached identities and Stack tokens from crossing projects when one
+    /// tagged Debug bundle is rebuilt with `--prod-auth`, or switched back.
+    nonisolated static func detectAuthProjectSwitch(
+        resolvedProjectID: String,
+        buildDefaultProjectID: String,
+        defaults: UserDefaults
+    ) -> Bool {
+        let previous = defaults.string(forKey: storedStackProjectIDKey) ?? buildDefaultProjectID
+        defaults.set(resolvedProjectID, forKey: storedStackProjectIDKey)
+        return previous != resolvedProjectID
     }
 
     #if DEBUG

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -9,6 +9,51 @@ import Testing
 
 @Suite("Auth environment")
 struct AuthEnvironmentTests {
+    @Test("macOS production auth override selects the production Stack project")
+    func macOSProductionAuthOverrideSelectsProductionStackProject() {
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: ["CMUX_AUTH_ENVIRONMENT": " production "],
+            isDebugBuild: true
+        ) == .production)
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: ["CMUX_AUTH_ENVIRONMENT": "production"],
+            isDebugBuild: true
+        ) == "9790718f-14cd-4f7e-824d-eaf527a82b82")
+        #expect(AuthEnvironment.resolvedStackPublishableClientKey(
+            environment: ["CMUX_AUTH_ENVIRONMENT": "production"],
+            isDebugBuild: true
+        ) == "pck_kzj80gx4mh2jrzn1cx6y5e8jk0kwa01vkevh2p9zd4twr")
+    }
+
+    @Test("invalid macOS auth override fails toward the build channel")
+    func invalidMacOSAuthOverrideFailsTowardBuildChannel() {
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: ["CMUX_AUTH_ENVIRONMENT": "staging"],
+            isDebugBuild: true
+        ) == .development)
+        #expect(AuthEnvironment.resolvedStackAuthEnvironment(
+            environment: ["CMUX_AUTH_ENVIRONMENT": "staging"],
+            isDebugBuild: false
+        ) == .production)
+    }
+
+    @Test("explicit Stack values override the selected auth channel")
+    func explicitStackValuesOverrideSelectedAuthChannel() {
+        let environment = [
+            "CMUX_AUTH_ENVIRONMENT": "production",
+            "CMUX_STACK_PROJECT_ID": "test-project",
+            "CMUX_STACK_PUBLISHABLE_CLIENT_KEY": "test-key",
+        ]
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: environment,
+            isDebugBuild: true
+        ) == "test-project")
+        #expect(AuthEnvironment.resolvedStackPublishableClientKey(
+            environment: environment,
+            isDebugBuild: true
+        ) == "test-key")
+    }
+
     @Test("Iroh broker uses shared staging in debug without moving other APIs")
     func irohBrokerUsesSharedStagingInDebugWithoutMovingOtherAPIs() {
         let defaultURL = AuthEnvironment.resolvedIrohBrokerBaseURL(

--- a/cmuxTests/DebugDogfoodCredentialResolverTests.swift
+++ b/cmuxTests/DebugDogfoodCredentialResolverTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -185,6 +186,83 @@ import Testing
         #expect(parsed["CMUX_DOGFOOD_STACK_PASSWORD"] == "secret value")
         #expect(parsed["BLANK_AFTER"] == "1")
     }
+
+    @Test func explicitCredentialsFileIsExclusiveAndUsesSecureReader() {
+        let resolver = DebugDogfoodCredentialResolver(
+            environment: [
+                "CMUX_AUTH_CREDENTIALS_FILE": "/private/tmp/gate.env",
+                "CMUX_DOGFOOD_STACK_EMAIL": "ambient-dev@example.com",
+                "CMUX_DOGFOOD_STACK_PASSWORD": "ambient-dev-password",
+            ],
+            readSecureFile: { path in
+                #expect(path == "/private/tmp/gate.env")
+                return """
+                CMUX_UITEST_STACK_EMAIL=production@example.com
+                CMUX_UITEST_STACK_PASSWORD=production-password
+                """
+            }
+        )
+
+        #expect(resolver.resolve() == .init(
+            email: "production@example.com",
+            password: "production-password"
+        ))
+    }
+
+    @Test func unreadableExplicitCredentialsFileFailsClosedWithoutFallback() {
+        let resolver = DebugDogfoodCredentialResolver(
+            environment: [
+                "CMUX_AUTH_CREDENTIALS_FILE": "/private/tmp/insecure.env",
+                "CMUX_DOGFOOD_STACK_EMAIL": "ambient-dev@example.com",
+                "CMUX_DOGFOOD_STACK_PASSWORD": "ambient-dev-password",
+            ],
+            readSecureFile: { _ in nil }
+        )
+
+        #expect(resolver.resolve() == nil)
+    }
+
+    @Test func explicitCredentialsFileReaderAcceptsOnlyProtectedRegularFiles() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-auth-file-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let credentials = directory.appendingPathComponent("credentials.env")
+        try """
+        CMUX_UITEST_STACK_EMAIL=production@example.com
+        CMUX_UITEST_STACK_PASSWORD=production-password
+        """.write(to: credentials, atomically: false, encoding: .utf8)
+        #expect(chmod(credentials.path, 0o600) == 0)
+
+        let protectedResolver = DebugDogfoodCredentialResolver(environment: [
+            "CMUX_AUTH_CREDENTIALS_FILE": credentials.path,
+        ])
+        #expect(protectedResolver.resolve() == .init(
+            email: "production@example.com",
+            password: "production-password"
+        ))
+
+        #expect(chmod(credentials.path, 0o640) == 0)
+        let groupReadableResolver = DebugDogfoodCredentialResolver(environment: [
+            "CMUX_AUTH_CREDENTIALS_FILE": credentials.path,
+        ])
+        #expect(groupReadableResolver.resolve() == nil)
+
+        let symlink = directory.appendingPathComponent("credentials-link.env")
+        try FileManager.default.createSymbolicLink(
+            at: symlink,
+            withDestinationURL: credentials
+        )
+        let symlinkResolver = DebugDogfoodCredentialResolver(environment: [
+            "CMUX_AUTH_CREDENTIALS_FILE": symlink.path,
+        ])
+        #expect(symlinkResolver.resolve() == nil)
+    }
 }
 
 /// Integration coverage for the `MacAuthComposition` wrapper that feeds resolved
@@ -193,6 +271,28 @@ import Testing
 /// file" bug, so these tests drive the wrapper directly with injected file
 /// fakes.
 @Suite struct MacAuthCompositionDogfoodAutoSignInTests {
+    @Test func authProjectSwitchIsDetectedAndThenStabilizes() throws {
+        let suiteName = "cmuxTests.macAuthProjectSwitch.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(MacAuthComposition.detectAuthProjectSwitch(
+            resolvedProjectID: "production-project",
+            buildDefaultProjectID: "development-project",
+            defaults: defaults
+        ))
+        #expect(!MacAuthComposition.detectAuthProjectSwitch(
+            resolvedProjectID: "production-project",
+            buildDefaultProjectID: "development-project",
+            defaults: defaults
+        ))
+        #expect(MacAuthComposition.detectAuthProjectSwitch(
+            resolvedProjectID: "development-project",
+            buildDefaultProjectID: "development-project",
+            defaults: defaults
+        ))
+    }
+
     @Test func dogfoodFileWinsOverAgentEnvCredsOnDogMac() {
         // Dog-Mac scenario: agent (uitest) creds in the environment, human
         // dogfood creds only in the secret file. The build must come up as the

--- a/scripts/lib/dev-secrets.sh
+++ b/scripts/lib/dev-secrets.sh
@@ -183,9 +183,11 @@ cmux_dev_secrets_load() {
   if [[ -n "$explicit_file" ]]; then
     # An explicit one-shot file is exclusive. Never fall through to ambient
     # development credentials during a production release gate.
+    # shellcheck disable=SC2329
     cmux_dev_secrets__explicit_dogfood() {
       case "$1" in EMAIL) cmux_dev_secrets__read_key "$explicit_file" CMUX_DOGFOOD_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$explicit_file" CMUX_DOGFOOD_STACK_PASSWORD ;; esac
     }
+    # shellcheck disable=SC2329
     cmux_dev_secrets__explicit_uitest() {
       case "$1" in EMAIL) cmux_dev_secrets__read_key "$explicit_file" CMUX_UITEST_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$explicit_file" CMUX_UITEST_STACK_PASSWORD ;; esac
     }

--- a/scripts/lib/dev-secrets.sh
+++ b/scripts/lib/dev-secrets.sh
@@ -29,6 +29,35 @@
 #
 # Returns non-zero (and prints guidance) when no usable credentials are found.
 
+# Validate an explicitly selected credentials file before any caller bakes its
+# path into a tagged app or reads it. The file must be an absolute, regular,
+# non-symlink file owned by the current uid with no group/world permissions.
+cmux_dev_secrets_validate_file() {
+  local file="${1:-}" owner permissions
+  [[ "$file" == /* ]] || {
+    echo "error: credentials file path must be absolute" >&2
+    return 2
+  }
+  [[ -f "$file" && ! -L "$file" ]] || {
+    echo "error: credentials file must be a regular non-symlink file" >&2
+    return 2
+  }
+  owner="$(stat -f '%u' "$file" 2>/dev/null || true)"
+  permissions="$(stat -f '%Lp' "$file" 2>/dev/null || true)"
+  [[ "$owner" == "$(id -u)" ]] || {
+    echo "error: credentials file must be owned by the current user" >&2
+    return 2
+  }
+  [[ "$permissions" =~ ^[0-7]{3,4}$ ]] || {
+    echo "error: could not validate credentials file permissions" >&2
+    return 2
+  }
+  if (( (8#$permissions & 8#077) != 0 )); then
+    echo "error: credentials file must not grant group or world permissions (use chmod 600)" >&2
+    return 2
+  fi
+}
+
 # Read a single KEY=value out of a .env file without sourcing it (so we never
 # execute arbitrary secret-file contents). Mirrors DebugDogfoodCredentialResolver.
 # parseEnvFile: trims the line, skips blank/`#`-comment lines, trims the key and
@@ -91,9 +120,31 @@ cmux_dev_secrets__try_pair() {
 
 cmux_dev_secrets_load() {
   local agent_only=0
-  case "${1:-}" in
-    --agent) agent_only=1 ;;
-  esac
+  local explicit_file=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)
+        agent_only=1
+        shift
+        ;;
+      --credentials-file)
+        explicit_file="${2:-}"
+        [[ -n "$explicit_file" ]] || {
+          echo "error: --credentials-file requires a path" >&2
+          return 2
+        }
+        shift 2
+        ;;
+      *)
+        echo "error: unknown credential-loader option '$1'" >&2
+        return 2
+        ;;
+    esac
+  done
+
+  if [[ -n "$explicit_file" ]]; then
+    cmux_dev_secrets_validate_file "$explicit_file" || return $?
+  fi
 
   local home_dir="${HOME:-}"
   local dogfood_file="${home_dir}/.secrets/cmuxterm-dev.env"
@@ -129,7 +180,18 @@ cmux_dev_secrets_load() {
     case "$1" in EMAIL) cmux_dev_secrets__read_key "$agent_file" CMUX_UITEST_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$agent_file" CMUX_UITEST_STACK_PASSWORD ;; esac
   }
 
-  if [[ "$agent_only" -eq 1 ]]; then
+  if [[ -n "$explicit_file" ]]; then
+    # An explicit one-shot file is exclusive. Never fall through to ambient
+    # development credentials during a production release gate.
+    cmux_dev_secrets__explicit_dogfood() {
+      case "$1" in EMAIL) cmux_dev_secrets__read_key "$explicit_file" CMUX_DOGFOOD_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$explicit_file" CMUX_DOGFOOD_STACK_PASSWORD ;; esac
+    }
+    cmux_dev_secrets__explicit_uitest() {
+      case "$1" in EMAIL) cmux_dev_secrets__read_key "$explicit_file" CMUX_UITEST_STACK_EMAIL ;; PASSWORD) cmux_dev_secrets__read_key "$explicit_file" CMUX_UITEST_STACK_PASSWORD ;; esac
+    }
+    cmux_dev_secrets__try_pair email password cmux_dev_secrets__explicit_dogfood \
+      || cmux_dev_secrets__try_pair email password cmux_dev_secrets__explicit_uitest
+  elif [[ "$agent_only" -eq 1 ]]; then
     # Agent flow: only the shared agent (uitest) sources (steps 4 and 6).
     cmux_dev_secrets__try_pair email password cmux_dev_secrets__env_uitest \
       || cmux_dev_secrets__try_pair email password cmux_dev_secrets__agent_file_uitest
@@ -144,6 +206,10 @@ cmux_dev_secrets_load() {
   fi
 
   if [[ -z "$email" || -z "$password" ]]; then
+    if [[ -n "$explicit_file" ]]; then
+      echo "error: explicit credentials file does not contain a complete supported credential pair" >&2
+      return 2
+    fi
     cat >&2 <<EOF
 error: no dev sign-in credentials found.
 
@@ -158,9 +224,24 @@ EOF
     return 2
   fi
 
-  export CMUX_UITEST_STACK_EMAIL="$email"
-  export CMUX_UITEST_STACK_PASSWORD="$password"
-  # Email only; never echo the password.
-  echo "==> dev sign-in account: $CMUX_UITEST_STACK_EMAIL"
+  CMUX_UITEST_STACK_EMAIL="$email"
+  CMUX_UITEST_STACK_PASSWORD="$password"
+  if [[ -n "$explicit_file" ]]; then
+    # Keep the temporary production identity in shell variables only. It is
+    # added to the environment exclusively on the short-lived simctl launch;
+    # setup, minting, curl, and helper children must not inherit it or ambient
+    # development credentials.
+    export -n CMUX_UITEST_STACK_EMAIL CMUX_UITEST_STACK_PASSWORD
+    unset CMUX_DOGFOOD_STACK_EMAIL CMUX_DOGFOOD_STACK_PASSWORD
+  else
+    export CMUX_UITEST_STACK_EMAIL CMUX_UITEST_STACK_PASSWORD
+  fi
+  # Ordinary dogfood loads retain the existing email-only diagnostic. The
+  # one-shot production account is fully redacted.
+  if [[ -n "$explicit_file" ]]; then
+    echo "==> dev sign-in account: [redacted]"
+  else
+    echo "==> dev sign-in account: $CMUX_UITEST_STACK_EMAIL"
+  fi
   return 0
 }

--- a/scripts/lib/iroh-production-gate.test.mjs
+++ b/scripts/lib/iroh-production-gate.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const repositoryRoot = path.resolve(import.meta.dir, "../..");
+
+function fixtureDirectory() {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "cmux-prod-gate-test-"));
+  chmodSync(directory, 0o700);
+  return directory;
+}
+
+function run(command, args, environment = {}) {
+  return spawnSync(command, args, {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...environment },
+  });
+}
+
+test("explicit credentials file is exclusive and accepts either supported key pair", (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const credentialsFile = path.join(directory, "credentials.env");
+  writeFileSync(credentialsFile, [
+    "CMUX_UITEST_STACK_EMAIL=temporary@example.com",
+    "CMUX_UITEST_STACK_PASSWORD=temporary-password",
+    "",
+  ].join("\n"), { mode: 0o600 });
+  chmodSync(credentialsFile, 0o600);
+
+  const result = run("bash", ["-c", [
+    "source scripts/lib/dev-secrets.sh",
+    "cmux_dev_secrets_load --credentials-file \"$CREDENTIALS_FILE\"",
+    "! env | grep -Eq '^CMUX_(DOGFOOD|UITEST)_STACK_(EMAIL|PASSWORD)='",
+    "printf '%s\\n%s\\n' \"$CMUX_UITEST_STACK_EMAIL\" \"$CMUX_UITEST_STACK_PASSWORD\"",
+  ].join("; ")], {
+    CREDENTIALS_FILE: credentialsFile,
+    CMUX_DOGFOOD_STACK_EMAIL: "ambient@example.com",
+    CMUX_DOGFOOD_STACK_PASSWORD: "ambient-password",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, [
+    "==> dev sign-in account: [redacted]",
+    "temporary@example.com",
+    "temporary-password",
+    "",
+  ].join("\n"));
+  assert.doesNotMatch(result.stderr, /temporary@example|temporary-password|ambient@example|ambient-password/u);
+});
+
+test("explicit credentials file rejects permissive modes and symlinks", (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const credentialsFile = path.join(directory, "credentials.env");
+  writeFileSync(credentialsFile, "CMUX_UITEST_STACK_EMAIL=x\nCMUX_UITEST_STACK_PASSWORD=y\n", {
+    mode: 0o640,
+  });
+  chmodSync(credentialsFile, 0o640);
+  const symlink = path.join(directory, "credentials-link.env");
+  symlinkSync(credentialsFile, symlink);
+
+  for (const candidate of [credentialsFile, symlink]) {
+    const result = run("bash", ["-c", [
+      "source scripts/lib/dev-secrets.sh",
+      "cmux_dev_secrets_load --credentials-file \"$CREDENTIALS_FILE\"",
+    ].join("; ")], { CREDENTIALS_FILE: candidate });
+    assert.equal(result.status, 2);
+    assert.doesNotMatch(result.stderr, /temporary-password|ambient-password/u);
+  }
+});
+
+test("production release-gate flags fail before creating runtime state", () => {
+  const conflictingBase = run("bash", [
+    "scripts/run-iroh-release-gate.sh",
+    "--mode", "automatic",
+    "--tag", "prodtest",
+    "--production",
+    "--staging-base-url", "https://example.com",
+  ]);
+  assert.equal(conflictingBase.status, 2);
+  assert.match(conflictingBase.stderr, /cannot be combined/u);
+
+  const reusedBuild = run("bash", [
+    "scripts/run-iroh-release-gate.sh",
+    "--mode", "automatic",
+    "--tag", "prodtest",
+    "--production",
+    "--skip-build",
+  ]);
+  assert.equal(reusedBuild.status, 2);
+  assert.match(reusedBuild.stderr, /cannot reuse a build/u);
+
+  const productionEnvironmentWithoutProduction = run("bash", [
+    "scripts/run-iroh-release-gate.sh",
+    "--mode", "automatic",
+    "--tag", "prodtest",
+    "--stack-env-file", "/private/tmp/unused.env",
+  ]);
+  assert.equal(productionEnvironmentWithoutProduction.status, 2);
+  assert.match(productionEnvironmentWithoutProduction.stderr, /requires --production/u);
+});
+
+test("Mac reload documents production auth without accepting secret values", () => {
+  const result = run("bash", ["scripts/reload.sh", "--help"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /--prod-auth/u);
+  assert.match(result.stdout, /--credentials-file <path>/u);
+  assert.match(result.stdout, /credential values never enter argv/u);
+});

--- a/scripts/lib/temporary-stack-user.mjs
+++ b/scripts/lib/temporary-stack-user.mjs
@@ -48,7 +48,7 @@ function assertSecureDirectory(directory) {
   const absolute = path.resolve(directory);
   if (absolute !== directory) throw new Error("state directory must use an absolute normalized path");
   const metadata = lstatSync(directory);
-  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+  if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
     throw new Error("state directory must be a non-symlink directory");
   }
   if (metadata.uid !== process.getuid()) throw new Error("state directory must be owned by the current user");
@@ -86,7 +86,6 @@ function replaceSecureFile(file, contents) {
   const temporary = `${file}.tmp-${process.pid}-${randomUUID()}`;
   writeExclusiveSecureFile(temporary, contents);
   renameSync(temporary, file);
-  chmodSync(file, 0o600);
 }
 
 function requiredValue(values, key) {

--- a/scripts/lib/temporary-stack-user.mjs
+++ b/scripts/lib/temporary-stack-user.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env bun
+
+import { randomBytes, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
+const webRequire = createRequire(path.join(moduleDirectory, "../../web/package.json"));
+
+export function parseEnvFile(contents) {
+  const result = {};
+  for (const rawLine of contents.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const equals = line.indexOf("=");
+    if (equals <= 0) continue;
+    const key = line.slice(0, equals).trim();
+    let value = line.slice(equals + 1).trim();
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      try {
+        value = JSON.parse(value);
+      } catch {
+        value = value.slice(1, -1);
+      }
+    } else if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function assertSecureDirectory(directory) {
+  const absolute = path.resolve(directory);
+  if (absolute !== directory) throw new Error("state directory must use an absolute normalized path");
+  const metadata = lstatSync(directory);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new Error("state directory must be a non-symlink directory");
+  }
+  if (metadata.uid !== process.getuid()) throw new Error("state directory must be owned by the current user");
+  if ((metadata.mode & 0o077) !== 0) throw new Error("state directory must not grant group or world permissions");
+}
+
+export function assertSecureFile(file) {
+  const absolute = path.resolve(file);
+  if (absolute !== file) throw new Error("secret file must use an absolute normalized path");
+  assertSecureDirectory(path.dirname(file));
+  const metadata = lstatSync(file);
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error("secret file must be a regular non-symlink file");
+  }
+  if (metadata.uid !== process.getuid()) throw new Error("secret file must be owned by the current user");
+  if ((metadata.mode & 0o077) !== 0) throw new Error("secret file must not grant group or world permissions");
+}
+
+function writeExclusiveSecureFile(file, contents) {
+  assertSecureDirectory(path.dirname(file));
+  const descriptor = openSync(
+    file,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    writeFileSync(descriptor, contents, { encoding: "utf8" });
+  } finally {
+    closeSync(descriptor);
+  }
+  chmodSync(file, 0o600);
+}
+
+function replaceSecureFile(file, contents) {
+  const temporary = `${file}.tmp-${process.pid}-${randomUUID()}`;
+  writeExclusiveSecureFile(temporary, contents);
+  renameSync(temporary, file);
+  chmodSync(file, 0o600);
+}
+
+function requiredValue(values, key) {
+  const value = values[key]?.trim();
+  if (!value) throw new Error(`production Stack environment is missing ${key}`);
+  return value;
+}
+
+export function stackConfigurationFromEnvFile(environmentFile) {
+  assertSecureFile(environmentFile);
+  const values = parseEnvFile(readFileSync(environmentFile, "utf8"));
+  return {
+    projectId: requiredValue(values, "NEXT_PUBLIC_STACK_PROJECT_ID"),
+    publishableClientKey: requiredValue(values, "NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"),
+    secretServerKey: requiredValue(values, "STACK_SECRET_SERVER_KEY"),
+  };
+}
+
+function loadStackServerApp(configuration) {
+  const { StackServerApp } = webRequire("@stackframe/stack");
+  return new StackServerApp(configuration);
+}
+
+function credentialFileContents(email, password) {
+  return [
+    `CMUX_UITEST_STACK_EMAIL=${JSON.stringify(email)}`,
+    `CMUX_UITEST_STACK_PASSWORD=${JSON.stringify(password)}`,
+    "",
+  ].join("\n");
+}
+
+export async function createTemporaryStackUser({
+  stackApp,
+  stateFile,
+  credentialsFile,
+  now = () => new Date(),
+}) {
+  if (path.dirname(stateFile) !== path.dirname(credentialsFile)) {
+    throw new Error("state and credentials files must share one protected directory");
+  }
+  assertSecureDirectory(path.dirname(stateFile));
+  const email = `cmux-iroh-gate+${randomUUID()}@manaflow.ai`;
+  const password = randomBytes(24).toString("base64url");
+  let user;
+  try {
+    user = await stackApp.createUser({
+      primaryEmail: email,
+      primaryEmailVerified: true,
+      primaryEmailAuthEnabled: true,
+      password,
+      displayName: "cmux Iroh production gate",
+    });
+    const initialState = {
+      schemaVersion: 1,
+      userId: user.id,
+      email,
+      password,
+      accessToken: null,
+      refreshToken: null,
+      createdAt: now().toISOString(),
+    };
+    writeExclusiveSecureFile(stateFile, `${JSON.stringify(initialState)}\n`);
+
+    const session = await user.createSession({
+      expiresInMillis: 20 * 60 * 1000,
+      isImpersonation: true,
+    });
+    const { accessToken, refreshToken } = await session.getTokens();
+    if (!accessToken || !refreshToken) throw new Error("Stack did not return temporary session tokens");
+
+    replaceSecureFile(stateFile, `${JSON.stringify({
+      ...initialState,
+      accessToken,
+      refreshToken,
+    })}\n`);
+    writeExclusiveSecureFile(credentialsFile, credentialFileContents(email, password));
+    return { created: true };
+  } catch (error) {
+    rmSync(credentialsFile, { force: true });
+    let accountAbsent = user === undefined;
+    if (user) {
+      try {
+        await user.delete();
+        accountAbsent = (await stackApp.getUser(user.id)) === null;
+      } catch {
+        accountAbsent = false;
+      }
+    }
+    if (accountAbsent) {
+      rmSync(stateFile, { force: true });
+    } else if (!statExists(stateFile) && user) {
+      // Keep a minimal protected recovery record when account creation
+      // succeeded but session creation (or the first state write) failed.
+      // Cleanup can skip the unavailable account API tokens and still use the
+      // Stack admin client to delete this exact user.
+      writeExclusiveSecureFile(stateFile, `${JSON.stringify({
+        schemaVersion: 1,
+        userId: user.id,
+        email,
+        password,
+        accessToken: null,
+        refreshToken: null,
+        createdAt: now().toISOString(),
+      })}\n`);
+    }
+    throw error;
+  }
+}
+
+function statExists(file) {
+  try {
+    lstatSync(file);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function readState(stateFile) {
+  assertSecureFile(stateFile);
+  const state = JSON.parse(readFileSync(stateFile, "utf8"));
+  for (const key of ["userId", "email", "password"]) {
+    if (typeof state[key] !== "string" || state[key].length === 0) {
+      throw new Error(`temporary Stack state is missing ${key}`);
+    }
+  }
+  return state;
+}
+
+async function safeResponseErrorCode(response) {
+  try {
+    const body = await response.json();
+    if (typeof body?.error !== "string") return null;
+    const code = body.error.slice(0, 80);
+    return /^[a-z0-9_-]+$/iu.test(code) ? code : "server_error";
+  } catch {
+    return null;
+  }
+}
+
+function writeRecoveryReport(recoveryFile, report) {
+  mkdirSync(path.dirname(recoveryFile), { recursive: true, mode: 0o700 });
+  const parent = statSync(path.dirname(recoveryFile));
+  if (parent.uid !== process.getuid() || (parent.mode & 0o022) !== 0) {
+    throw new Error("cleanup report directory must be current-user-owned and non-writable by group/world");
+  }
+  rmSync(recoveryFile, { force: true });
+  writeExclusiveSecureFile(recoveryFile, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+export async function cleanupTemporaryStackUser({
+  stackApp,
+  stateFile,
+  credentialsFile,
+  recoveryFile,
+  apiBaseURL,
+  fetchImpl = fetch,
+  now = () => new Date(),
+}) {
+  const state = readState(stateFile);
+  let apiStatus = null;
+  let apiErrorCode = null;
+  let apiCleanupSucceeded = false;
+  if (typeof state.accessToken === "string" && state.accessToken.length > 0
+      && typeof state.refreshToken === "string" && state.refreshToken.length > 0) {
+    try {
+      const response = await fetchImpl(new URL("/api/account", apiBaseURL), {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${state.accessToken}`,
+          "x-stack-refresh-token": state.refreshToken,
+        },
+      });
+      apiStatus = response.status;
+      apiCleanupSucceeded = response.ok;
+      if (!response.ok) apiErrorCode = await safeResponseErrorCode(response);
+    } catch {
+      apiErrorCode = "network_error";
+    }
+  } else {
+    apiErrorCode = "temporary_session_unavailable";
+  }
+
+  let directCleanupAttempted = false;
+  let directCleanupSucceeded = false;
+  let accountAbsentAfterAPI = false;
+  try {
+    accountAbsentAfterAPI = (await stackApp.getUser(state.userId)) === null;
+  } catch {
+    accountAbsentAfterAPI = false;
+  }
+  let accountAbsent = accountAbsentAfterAPI;
+  if (!accountAbsent) {
+    directCleanupAttempted = true;
+    try {
+      const user = await stackApp.getUser(state.userId);
+      if (user) await user.delete();
+      accountAbsent = (await stackApp.getUser(state.userId)) === null;
+      directCleanupSucceeded = accountAbsent;
+    } catch {
+      directCleanupSucceeded = false;
+      accountAbsent = false;
+    }
+  }
+
+  // Direct deletion is a hygiene fallback, not evidence that the production
+  // account API worked. The release gate passes only when the API succeeded
+  // and its deletion was independently observable before the fallback.
+  const passed = apiCleanupSucceeded && accountAbsentAfterAPI;
+  const report = {
+    schemaVersion: 1,
+    passed,
+    apiCleanupSucceeded,
+    apiStatus,
+    apiErrorCode,
+    directCleanupAttempted,
+    directCleanupSucceeded,
+    accountAbsentAfterAPI,
+    accountAbsent,
+    manualRecoveryRequired: !accountAbsent,
+    completedAt: now().toISOString(),
+  };
+  writeRecoveryReport(recoveryFile, report);
+
+  if (accountAbsent) {
+    rmSync(credentialsFile, { force: true });
+    rmSync(stateFile, { force: true });
+  }
+  return report;
+}
+
+function parsedArguments(argv) {
+  const values = { command: argv[0] };
+  for (let index = 1; index < argv.length; index += 2) {
+    const option = argv[index];
+    const value = argv[index + 1];
+    if (!option?.startsWith("--") || !value) throw new Error(`invalid argument ${option ?? ""}`);
+    values[option.slice(2)] = value;
+  }
+  return values;
+}
+
+async function main() {
+  const args = parsedArguments(process.argv.slice(2));
+  for (const key of ["environment-file", "state-file", "credentials-file"]) {
+    if (!args[key]) throw new Error(`--${key} is required`);
+  }
+  const configuration = stackConfigurationFromEnvFile(args["environment-file"]);
+  const stackApp = loadStackServerApp(configuration);
+
+  if (args.command === "create") {
+    const result = await createTemporaryStackUser({
+      stackApp,
+      stateFile: args["state-file"],
+      credentialsFile: args["credentials-file"],
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  if (args.command === "cleanup") {
+    if (!args["api-base-url"] || !args["recovery-file"]) {
+      throw new Error("cleanup requires --api-base-url and --recovery-file");
+    }
+    const result = await cleanupTemporaryStackUser({
+      stackApp,
+      stateFile: args["state-file"],
+      credentialsFile: args["credentials-file"],
+      recoveryFile: args["recovery-file"],
+      apiBaseURL: args["api-base-url"],
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    if (!result.passed) process.exitCode = 1;
+    return;
+  }
+  throw new Error("command must be create or cleanup");
+}
+
+if (import.meta.main) {
+  main().catch(() => {
+    // Stack SDK errors can echo request fields. Keep command-line logs free of
+    // the temporary account identity, password, and tokens; recovery details
+    // live only in the protected state/report files.
+    process.stderr.write("error: temporary Stack user operation failed; inspect the protected recovery state\n");
+    process.exitCode = 1;
+  });
+}

--- a/scripts/lib/temporary-stack-user.test.mjs
+++ b/scripts/lib/temporary-stack-user.test.mjs
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  assertSecureFile,
+  cleanupTemporaryStackUser,
+  createTemporaryStackUser,
+  parseEnvFile,
+} from "./temporary-stack-user.mjs";
+
+function fixtureDirectory() {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "cmux-stack-user-test-"));
+  chmodSync(directory, 0o700);
+  return directory;
+}
+
+function temporaryUser(id = "user-1") {
+  return {
+    id,
+    async createSession() {
+      return {
+        async getTokens() {
+          return { accessToken: "access-token", refreshToken: "refresh-token" };
+        },
+      };
+    },
+    async delete() {},
+  };
+}
+
+test("parseEnvFile handles Vercel-style quoted values", () => {
+  assert.deepEqual(parseEnvFile('A="one\\ntwo"\nB=plain\nC=\'single\'\n'), {
+    A: "one\ntwo",
+    B: "plain",
+    C: "single",
+  });
+});
+
+test("create writes only protected state and credential files", async (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const stateFile = path.join(directory, "account.json");
+  const credentialsFile = path.join(directory, "credentials.env");
+  const user = temporaryUser();
+  const stackApp = {
+    async createUser(options) {
+      assert.equal(options.primaryEmailVerified, true);
+      assert.equal(options.primaryEmailAuthEnabled, true);
+      assert.match(options.primaryEmail, /^cmux-iroh-gate\+/u);
+      return user;
+    },
+  };
+
+  assert.deepEqual(await createTemporaryStackUser({ stackApp, stateFile, credentialsFile }), {
+    created: true,
+  });
+  assert.doesNotThrow(() => assertSecureFile(stateFile));
+  assert.doesNotThrow(() => assertSecureFile(credentialsFile));
+  const credentials = readFileSync(credentialsFile, "utf8");
+  assert.match(credentials, /CMUX_UITEST_STACK_EMAIL=/u);
+  assert.match(credentials, /CMUX_UITEST_STACK_PASSWORD=/u);
+  assert.doesNotMatch(credentials, /access-token|refresh-token/u);
+});
+
+test("cleanup API failure deletes directly but keeps the gate red", async (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const stateFile = path.join(directory, "account.json");
+  const credentialsFile = path.join(directory, "credentials.env");
+  const recoveryDirectory = path.join(directory, "recovery");
+  const recoveryFile = path.join(recoveryDirectory, "cleanup.json");
+  chmodSync(directory, 0o700);
+  const user = temporaryUser();
+  let present = true;
+  user.delete = async () => { present = false; };
+  const stackApp = {
+    async createUser() { return user; },
+    async getUser() { return present ? user : null; },
+  };
+  await createTemporaryStackUser({ stackApp, stateFile, credentialsFile });
+
+  const result = await cleanupTemporaryStackUser({
+    stackApp,
+    stateFile,
+    credentialsFile,
+    recoveryFile,
+    apiBaseURL: "https://cmux.com",
+    fetchImpl: async () => new Response(JSON.stringify({ error: "account_delete_failed" }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    }),
+  });
+
+  assert.equal(result.passed, false);
+  assert.equal(result.apiStatus, 500);
+  assert.equal(result.apiErrorCode, "account_delete_failed");
+  assert.equal(result.accountAbsentAfterAPI, false);
+  assert.equal(result.directCleanupSucceeded, true);
+  assert.equal(result.accountAbsent, true);
+  assert.equal(result.manualRecoveryRequired, false);
+  assert.doesNotMatch(readFileSync(recoveryFile, "utf8"), /access-token|refresh-token|@manaflow/u);
+  assert.throws(() => readFileSync(stateFile));
+  assert.throws(() => readFileSync(credentialsFile));
+});
+
+test("cleanup stays red when a successful API response did not delete the account", async (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const stateFile = path.join(directory, "account.json");
+  const credentialsFile = path.join(directory, "credentials.env");
+  const recoveryFile = path.join(directory, "cleanup.json");
+  const user = temporaryUser();
+  let present = true;
+  user.delete = async () => { present = false; };
+  const stackApp = {
+    async createUser() { return user; },
+    async getUser() { return present ? user : null; },
+  };
+  await createTemporaryStackUser({ stackApp, stateFile, credentialsFile });
+
+  const result = await cleanupTemporaryStackUser({
+    stackApp,
+    stateFile,
+    credentialsFile,
+    recoveryFile,
+    apiBaseURL: "https://cmux.com",
+    fetchImpl: async () => new Response(null, { status: 204 }),
+  });
+
+  assert.equal(result.apiCleanupSucceeded, true);
+  assert.equal(result.accountAbsentAfterAPI, false);
+  assert.equal(result.directCleanupSucceeded, true);
+  assert.equal(result.accountAbsent, true);
+  assert.equal(result.passed, false);
+});
+
+test("cleanup report replaces unstructured server errors with a safe code", async (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const stateFile = path.join(directory, "account.json");
+  const credentialsFile = path.join(directory, "credentials.env");
+  const recoveryFile = path.join(directory, "cleanup.json");
+  const user = temporaryUser();
+  let present = true;
+  user.delete = async () => { present = false; };
+  const stackApp = {
+    async createUser() { return user; },
+    async getUser() { return present ? user : null; },
+  };
+  await createTemporaryStackUser({ stackApp, stateFile, credentialsFile });
+
+  const result = await cleanupTemporaryStackUser({
+    stackApp,
+    stateFile,
+    credentialsFile,
+    recoveryFile,
+    apiBaseURL: "https://cmux.com",
+    fetchImpl: async () => new Response(JSON.stringify({
+      error: "deletion failed for temporary@example.com with token secret",
+    }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    }),
+  });
+
+  assert.equal(result.apiErrorCode, "server_error");
+  assert.doesNotMatch(readFileSync(recoveryFile, "utf8"), /temporary@example|token secret/u);
+});
+
+test("failed session creation preserves a direct-cleanup recovery record", async (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const stateFile = path.join(directory, "account.json");
+  const credentialsFile = path.join(directory, "credentials.env");
+  const recoveryFile = path.join(directory, "cleanup.json");
+  const user = temporaryUser();
+  user.createSession = async () => { throw new Error("session unavailable"); };
+  user.delete = async () => { throw new Error("delete unavailable"); };
+  const stackApp = {
+    async createUser() { return user; },
+    async getUser() { return user; },
+  };
+
+  await assert.rejects(
+    createTemporaryStackUser({ stackApp, stateFile, credentialsFile }),
+    /session unavailable/u,
+  );
+  assert.doesNotThrow(() => assertSecureFile(stateFile));
+
+  const result = await cleanupTemporaryStackUser({
+    stackApp,
+    stateFile,
+    credentialsFile,
+    recoveryFile,
+    apiBaseURL: "https://cmux.com",
+    fetchImpl: async () => { throw new Error("must not call account API without tokens"); },
+  });
+  assert.equal(result.apiErrorCode, "temporary_session_unavailable");
+  assert.equal(result.manualRecoveryRequired, true);
+  assert.doesNotThrow(() => assertSecureFile(stateFile));
+});
+
+test("cleanup preserves per-user recovery state when direct deletion fails", async (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const stateFile = path.join(directory, "account.json");
+  const credentialsFile = path.join(directory, "credentials.env");
+  const recoveryFile = path.join(directory, "cleanup.json");
+  const user = temporaryUser();
+  user.delete = async () => { throw new Error("unavailable"); };
+  const stackApp = {
+    async createUser() { return user; },
+    async getUser() { return user; },
+  };
+  await createTemporaryStackUser({ stackApp, stateFile, credentialsFile });
+
+  const result = await cleanupTemporaryStackUser({
+    stackApp,
+    stateFile,
+    credentialsFile,
+    recoveryFile,
+    apiBaseURL: "https://cmux.com",
+    fetchImpl: async () => { throw new Error("offline"); },
+  });
+
+  assert.equal(result.passed, false);
+  assert.equal(result.accountAbsent, false);
+  assert.equal(result.manualRecoveryRequired, true);
+  assert.doesNotThrow(() => assertSecureFile(stateFile));
+  assert.doesNotThrow(() => assertSecureFile(credentialsFile));
+});
+
+test("secure-file validation rejects group-readable credentials", (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const file = path.join(directory, "credentials.env");
+  writeFileSync(file, "secret", { mode: 0o640 });
+  chmodSync(file, 0o640);
+  assert.throws(() => assertSecureFile(file), /group or world/u);
+});

--- a/scripts/mobile-dev-launch.sh
+++ b/scripts/mobile-dev-launch.sh
@@ -34,6 +34,9 @@
 #   --iroh-release-gate <automatic|relayOnly|directOnly>
 #              simulator only: run the credential-free Iroh release-gate probe
 #              after sign-in and attach.
+#   --credentials-file <absolute-path>
+#              load one 0600 credential file exclusively. Intended for an
+#              isolated temporary production release-gate account.
 
 set -euo pipefail
 
@@ -47,6 +50,7 @@ ENSURE_MAC=0
 AGENT=0
 DETACH=0
 IROH_RELEASE_GATE_MODE=""
+AUTH_CREDENTIALS_FILE=""
 ATTACH_TTL_SECONDS="${CMUX_ATTACH_TTL_SECONDS:-600}"
 ATTACH_MINT_MAX_ATTEMPTS="${CMUX_ATTACH_MINT_MAX_ATTEMPTS:-20}"
 
@@ -70,6 +74,7 @@ while [[ $# -gt 0 ]]; do
     --agent) AGENT=1; shift ;;
     --detach) DETACH=1; shift ;;
     --iroh-release-gate) IROH_RELEASE_GATE_MODE="${2:-}"; shift 2 ;;
+    --credentials-file) AUTH_CREDENTIALS_FILE="${2:-}"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "error: unknown arg $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -113,7 +118,9 @@ source "$SCRIPT_DIR/lib/mobile-attach.sh"
 if ! cmux_attach_validate_dev_tag "$TAG"; then
   exit 2
 fi
-if [[ "$AGENT" -eq 1 ]]; then
+if [[ -n "$AUTH_CREDENTIALS_FILE" ]]; then
+  cmux_dev_secrets_load --credentials-file "$AUTH_CREDENTIALS_FILE" || exit $?
+elif [[ "$AGENT" -eq 1 ]]; then
   cmux_dev_secrets_load --agent || exit $?
 else
   cmux_dev_secrets_load || exit $?
@@ -177,8 +184,14 @@ if [[ "$ATTACH" -eq 1 ]]; then
   fi
 fi
 
-# Never print the attach URL (bearer credential); just whether auto-pair is on.
-echo "==> launching $BUNDLE_ID on $TARGET (signed in as $CMUX_UITEST_STACK_EMAIL${ATTACH_URL:+, auto-pairing})"
+# Never print the attach URL (bearer credential). One-shot production-account
+# identities are redacted too; ordinary dogfood launches retain their existing
+# account label so developers can detect accidental account selection.
+SIGN_IN_ACCOUNT_LABEL="$CMUX_UITEST_STACK_EMAIL"
+if [[ -n "$AUTH_CREDENTIALS_FILE" ]]; then
+  SIGN_IN_ACCOUNT_LABEL="[redacted]"
+fi
+echo "==> launching $BUNDLE_ID on $TARGET (signed in as $SIGN_IN_ACCOUNT_LABEL${ATTACH_URL:+, auto-pairing})"
 
 if [[ "$TARGET" == "simulator" ]]; then
   if [[ -n "$SIMULATOR_ID" ]]; then

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/mobile-attach.sh
 source "$SCRIPT_DIR/lib/mobile-attach.sh"
+# shellcheck source=scripts/lib/dev-secrets.sh
+source "$SCRIPT_DIR/lib/dev-secrets.sh"
 
 APP_NAME="cmux DEV"
 BUNDLE_ID="com.cmuxterm.app.debug"
@@ -21,6 +23,10 @@ CMUX_DEV_PORT_RANGE=""
 CMUX_DEV_ORIGIN=""
 CMUX_DEV_API_BASE_URL_VALUE=""
 CMUX_IROH_BROKER_BASE_URL_VALUE=""
+CMUX_AUTH_WWW_ORIGIN_VALUE=""
+CMUX_WWW_ORIGIN_VALUE=""
+PROD_AUTH=0
+AUTH_CREDENTIALS_FILE=""
 CLI_PATH=""
 NO_GLOBAL_CLI_LINKS="${CMUX_RELOAD_NO_GLOBAL_CLI_LINKS:-0}"
 # Matches CmuxStateDirectory (non-TCC ~/.local/state/cmux) where the app/CLI now
@@ -259,6 +265,12 @@ Options:
                          so macOS launches the freshly-built binary on cmd-click or --launch.
   --launch               Launch the app after building. Without this flag, the script
                          builds and prints the app path but does not open it.
+  --prod-auth            Point this tagged Debug build at production Stack auth,
+                         cmux APIs, and the production Iroh broker.
+  --credentials-file <path>
+                         Bake only the path to a current-user-owned 0600 auth file.
+                         The credential values never enter argv, Info.plist, or
+                         the long-lived Mac process environment.
   --name <app name>      Override app display/bundle name.
   --bundle-id <id>       Override bundle identifier.
   --derived-data <path>  Override derived data path.
@@ -492,6 +504,18 @@ while [[ $# -gt 0 ]]; do
       LAUNCH=1
       shift
       ;;
+    --prod-auth)
+      PROD_AUTH=1
+      shift
+      ;;
+    --credentials-file)
+      AUTH_CREDENTIALS_FILE="${2:-}"
+      if [[ -z "$AUTH_CREDENTIALS_FILE" ]]; then
+        echo "error: --credentials-file requires a value" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     --derived-data)
       DERIVED_DATA="${2:-}"
       if [[ -z "$DERIVED_DATA" ]]; then
@@ -531,6 +555,11 @@ if [[ -z "$TAG" ]]; then
   exit 1
 fi
 
+if [[ -n "$AUTH_CREDENTIALS_FILE" ]]; then
+  cmux_dev_secrets_validate_file "$AUTH_CREDENTIALS_FILE"
+  AUTH_CREDENTIALS_FILE="$(cd "$(dirname "$AUTH_CREDENTIALS_FILE")" && pwd -P)/$(basename "$AUTH_CREDENTIALS_FILE")"
+fi
+
 if [[ -n "$TAG" ]]; then
   if ! cmux_attach_validate_dev_tag "$TAG"; then
     exit 1
@@ -554,6 +583,14 @@ CMUX_DEV_PORT_END="$(choose_cmux_dev_port_end "$CMUX_DEV_PORT" "$CMUX_DEV_PORT_R
 CMUX_DEV_ORIGIN="http://localhost:${CMUX_DEV_PORT}"
 CMUX_DEV_API_BASE_URL_VALUE="$(cmux_attach_resolve_dev_api_base_url "$CMUX_DEV_ORIGIN")"
 CMUX_IROH_BROKER_BASE_URL_VALUE="${CMUX_IROH_BROKER_BASE_URL:-https://cmux-staging.vercel.app}"
+CMUX_AUTH_WWW_ORIGIN_VALUE="$CMUX_DEV_ORIGIN"
+CMUX_WWW_ORIGIN_VALUE="$CMUX_DEV_ORIGIN"
+if [[ "$PROD_AUTH" -eq 1 ]]; then
+  CMUX_DEV_API_BASE_URL_VALUE="${CMUX_DEV_API_BASE_URL:-https://cmux.com}"
+  CMUX_IROH_BROKER_BASE_URL_VALUE="${CMUX_IROH_BROKER_BASE_URL:-https://cmux.com}"
+  CMUX_AUTH_WWW_ORIGIN_VALUE="https://cmux.com"
+  CMUX_WWW_ORIGIN_VALUE="https://cmux.com"
+fi
 
 # Quiet logging: capture all noisy build output (xcodebuild, zig, codesign,
 # plistbuddy, etc.) to a single log file. On success we print only a one-line
@@ -966,10 +1003,17 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
       set_plist_env "$INFO_PLIST" CMUX_PORT_END "$CMUX_DEV_PORT_END"
       set_plist_env "$INFO_PLIST" CMUX_PORT_RANGE "$CMUX_DEV_PORT_RANGE"
       set_plist_env "$INFO_PLIST" PORT "$CMUX_DEV_PORT"
-      set_plist_env "$INFO_PLIST" CMUX_AUTH_WWW_ORIGIN "$CMUX_DEV_ORIGIN"
+      set_plist_env "$INFO_PLIST" CMUX_AUTH_WWW_ORIGIN "$CMUX_AUTH_WWW_ORIGIN_VALUE"
+      set_plist_env "$INFO_PLIST" CMUX_WWW_ORIGIN "$CMUX_WWW_ORIGIN_VALUE"
       set_plist_env "$INFO_PLIST" CMUX_API_BASE_URL "$CMUX_DEV_API_BASE_URL_VALUE"
       set_plist_env "$INFO_PLIST" CMUX_VM_API_BASE_URL "$CMUX_DEV_API_BASE_URL_VALUE"
       set_plist_env "$INFO_PLIST" CMUX_IROH_BROKER_BASE_URL "$CMUX_IROH_BROKER_BASE_URL_VALUE"
+      if [[ "$PROD_AUTH" -eq 1 ]]; then
+        set_plist_env "$INFO_PLIST" CMUX_AUTH_ENVIRONMENT production
+      fi
+      if [[ -n "$AUTH_CREDENTIALS_FILE" ]]; then
+        set_plist_env "$INFO_PLIST" CMUX_AUTH_CREDENTIALS_FILE "$AUTH_CREDENTIALS_FILE"
+      fi
       if [[ -S "$CMUXD_SOCKET" ]]; then
         for PID in $(lsof -t "$CMUXD_SOCKET" 2>/dev/null); do
           kill "$PID" 2>/dev/null || true
@@ -1107,11 +1151,18 @@ if [[ "$LAUNCH" -eq 1 ]]; then
     CMUX_PORT_END="$CMUX_DEV_PORT_END"
     CMUX_PORT_RANGE="$CMUX_DEV_PORT_RANGE"
     PORT="$CMUX_DEV_PORT"
-    CMUX_AUTH_WWW_ORIGIN="$CMUX_DEV_ORIGIN"
+    CMUX_AUTH_WWW_ORIGIN="$CMUX_AUTH_WWW_ORIGIN_VALUE"
+    CMUX_WWW_ORIGIN="$CMUX_WWW_ORIGIN_VALUE"
     CMUX_API_BASE_URL="$CMUX_DEV_API_BASE_URL_VALUE"
     CMUX_VM_API_BASE_URL="$CMUX_DEV_API_BASE_URL_VALUE"
     CMUX_IROH_BROKER_BASE_URL="$CMUX_IROH_BROKER_BASE_URL_VALUE"
   )
+  if [[ "$PROD_AUTH" -eq 1 ]]; then
+    TAG_LAUNCH_ENV+=(CMUX_AUTH_ENVIRONMENT=production)
+  fi
+  if [[ -n "$AUTH_CREDENTIALS_FILE" ]]; then
+    TAG_LAUNCH_ENV+=(CMUX_AUTH_CREDENTIALS_FILE="$AUTH_CREDENTIALS_FILE")
+  fi
 
   LAUNCH_CMD=()
   LAUNCH_RETRY_CMD=()

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -6,6 +6,7 @@ usage() {
 Usage: scripts/run-iroh-release-gate.sh --mode <automatic|relay-only|direct-only> --tag <tag>
        [--staging-base-url <url>] [--skip-build] [--keep-simulator]
        [--report-output <path>]
+       [--production [--stack-env-file <secure-path>]]
 
 Builds a tagged Mac app and an isolated iOS Simulator app, signs both into the
 same staging account, pairs only over Iroh, and verifies host status, terminal
@@ -13,6 +14,9 @@ input/output, one restored workspace rename, independent events, notification
 reconcile, chat sessions, artifact count, and the redacted selected path.
 
 Credentials resolve through scripts/lib/dev-secrets.sh and are never printed.
+`--production` creates a verified temporary production Stack account, runs the
+same gate against https://cmux.com, then deletes the account. Production account
+API cleanup failures fail the gate even when direct Stack cleanup succeeds.
 EOF
 }
 
@@ -22,12 +26,17 @@ STAGING_BASE_URL="${CMUX_IROH_RELEASE_GATE_BASE_URL:-https://cmux-staging.vercel
 SKIP_BUILD=0
 KEEP_SIMULATOR=0
 REPORT_OUTPUT=""
+PRODUCTION=0
+STACK_ENV_FILE=""
+BASE_URL_WAS_EXPLICIT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --mode) MODE="${2:-}"; shift 2 ;;
     --tag) TAG="${2:-}"; shift 2 ;;
-    --staging-base-url) STAGING_BASE_URL="${2:-}"; shift 2 ;;
+    --staging-base-url) STAGING_BASE_URL="${2:-}"; BASE_URL_WAS_EXPLICIT=1; shift 2 ;;
+    --production) PRODUCTION=1; shift ;;
+    --stack-env-file) STACK_ENV_FILE="${2:-}"; shift 2 ;;
     --skip-build) SKIP_BUILD=1; shift ;;
     --keep-simulator) KEEP_SIMULATOR=1; shift ;;
     --report-output) REPORT_OUTPUT="${2:-}"; shift 2 ;;
@@ -38,6 +47,21 @@ done
 
 [[ -n "$MODE" ]] || { echo "error: --mode is required" >&2; exit 2; }
 [[ -n "$TAG" ]] || { echo "error: --tag is required" >&2; exit 2; }
+if [[ "$PRODUCTION" -eq 1 && "$BASE_URL_WAS_EXPLICIT" -eq 1 ]]; then
+  echo "error: --production cannot be combined with --staging-base-url" >&2
+  exit 2
+fi
+if [[ "$PRODUCTION" -eq 0 && -n "$STACK_ENV_FILE" ]]; then
+  echo "error: --stack-env-file requires --production" >&2
+  exit 2
+fi
+if [[ "$PRODUCTION" -eq 1 && "$SKIP_BUILD" -eq 1 ]]; then
+  echo "error: --production cannot reuse a build because each run bakes a new protected credential-file path" >&2
+  exit 2
+fi
+if [[ "$PRODUCTION" -eq 1 ]]; then
+  STAGING_BASE_URL="https://cmux.com"
+fi
 
 case "$MODE" in
   automatic) RAW_MODE="automatic" ;;
@@ -57,6 +81,8 @@ cd "$REPO_ROOT"
 
 # shellcheck source=scripts/lib/mobile-attach.sh
 source "$SCRIPT_DIR/lib/mobile-attach.sh"
+# shellcheck source=scripts/lib/dev-secrets.sh
+source "$SCRIPT_DIR/lib/dev-secrets.sh"
 cmux_attach_validate_dev_tag "$TAG"
 
 SLUG="$(cmux_attach__slug "$TAG")"
@@ -69,22 +95,108 @@ SIMULATOR_ID=""
 REPORT_FILENAME="cmux-iroh-release-gate.json"
 REPORT_READY_NOTIFICATION="dev.cmux.ios.iroh-release-gate.report-ready"
 REPORT_WAITER_PID=""
+STATE_DIR=""
+PROD_ENV_FILE=""
+PROD_CREDENTIALS_FILE=""
+PROD_ACCOUNT_STATE_FILE=""
+PROD_RECOVERY_FILE=""
+VERCEL_DIR=""
 
 cleanup() {
+  local exit_code=$?
+  local cleanup_code=0
+  trap - EXIT INT TERM
+  set +e
   if [[ -n "$REPORT_WAITER_PID" ]]; then
     kill "$REPORT_WAITER_PID" >/dev/null 2>&1 || true
   fi
-  if [[ "$KEEP_SIMULATOR" -eq 1 ]]; then
-    return
+  # The helper commits protected recovery state immediately after Stack creates
+  # the user. Retry cleanup whenever that state exists, including a partial
+  # create whose session-token step failed.
+  if [[ -n "$PROD_ACCOUNT_STATE_FILE" && -e "$PROD_ACCOUNT_STATE_FILE" ]]; then
+    bun scripts/lib/temporary-stack-user.mjs cleanup \
+      --environment-file "$PROD_ENV_FILE" \
+      --state-file "$PROD_ACCOUNT_STATE_FILE" \
+      --credentials-file "$PROD_CREDENTIALS_FILE" \
+      --api-base-url "$STAGING_BASE_URL" \
+      --recovery-file "$PROD_RECOVERY_FILE" >/dev/null
+    cleanup_code=$?
+    if [[ "$cleanup_code" -ne 0 ]]; then
+      echo "error: production account cleanup gate failed; redacted report: $PROD_RECOVERY_FILE" >&2
+      exit_code=1
+    fi
+  fi
+  if [[ -n "$PROD_ENV_FILE" && "$PROD_ENV_FILE" == "$STATE_DIR/"* ]]; then
+    rm -f "$PROD_ENV_FILE"
+  fi
+  if [[ -n "$VERCEL_DIR" ]]; then
+    rm -rf "$VERCEL_DIR"
   fi
   defaults delete "$MAC_BUNDLE_ID" cmux.iroh.debug.transport-mode >/dev/null 2>&1 || true
   pkill -f "cmux DEV ${SLUG}.app/Contents/MacOS/cmux DEV" 2>/dev/null || true
-  if [[ -n "$SIMULATOR_ID" ]]; then
+  rm -rf "$HOME/Library/Application Support/cmux/$MAC_BUNDLE_ID"
+  security delete-generic-password -s "$MAC_BUNDLE_ID.auth" -a cmux-auth-access-token >/dev/null 2>&1 || true
+  security delete-generic-password -s "$MAC_BUNDLE_ID.auth" -a cmux-auth-refresh-token >/dev/null 2>&1 || true
+  if [[ "$KEEP_SIMULATOR" -ne 1 && -n "$SIMULATOR_ID" ]]; then
     xcrun simctl shutdown "$SIMULATOR_ID" >/dev/null 2>&1 || true
     xcrun simctl delete "$SIMULATOR_ID" >/dev/null 2>&1 || true
   fi
+  if [[ -n "$STATE_DIR" ]]; then
+    if [[ -e "$PROD_ACCOUNT_STATE_FILE" ]]; then
+      echo "error: temporary Stack user still exists; protected recovery state retained at $PROD_ACCOUNT_STATE_FILE" >&2
+      exit_code=1
+    else
+      rm -rf "$STATE_DIR"
+    fi
+  fi
+  exit "$exit_code"
 }
+
+handle_interrupt() {
+  exit 130
+}
+
+handle_termination() {
+  exit 143
+}
+
 trap cleanup EXIT
+trap handle_interrupt INT
+trap handle_termination TERM
+
+if [[ "$PRODUCTION" -eq 1 ]]; then
+  STATE_DIR="$(mktemp -d "${TMPDIR:-/private/tmp}/cmux-iroh-production-${SLUG}.XXXXXX")"
+  chmod 700 "$STATE_DIR"
+  PROD_ACCOUNT_STATE_FILE="$STATE_DIR/account.json"
+  PROD_CREDENTIALS_FILE="$STATE_DIR/credentials.env"
+  RECOVERY_DIR="${TMPDIR:-/private/tmp}/cmux-iroh-production-gate-recovery-$(id -u)"
+  mkdir -p "$RECOVERY_DIR"
+  chmod 700 "$RECOVERY_DIR"
+  PROD_RECOVERY_FILE="$RECOVERY_DIR/${SLUG}.json"
+
+  if [[ -n "$STACK_ENV_FILE" ]]; then
+    cmux_dev_secrets_validate_file "$STACK_ENV_FILE"
+    PROD_ENV_FILE="$STACK_ENV_FILE"
+  else
+    VERCEL_DIR="$STATE_DIR/vercel-project"
+    mkdir -p "$VERCEL_DIR"
+    chmod 700 "$VERCEL_DIR"
+    PROD_ENV_FILE="$STATE_DIR/vercel-production.env"
+    bunx vercel link --yes --project cmux --scope manaflow --cwd "$VERCEL_DIR"
+    bunx vercel env pull "$PROD_ENV_FILE" \
+      --environment production \
+      --yes \
+      --scope manaflow \
+      --cwd "$VERCEL_DIR"
+    chmod 600 "$PROD_ENV_FILE"
+  fi
+
+  bun scripts/lib/temporary-stack-user.mjs create \
+    --environment-file "$PROD_ENV_FILE" \
+    --state-file "$PROD_ACCOUNT_STATE_FILE" \
+    --credentials-file "$PROD_CREDENTIALS_FILE" >/dev/null
+  echo "==> temporary production Stack account ready (credentials redacted)"
+fi
 
 SIMULATOR_ID="$(SIMULATOR_NAME="$SIMULATOR_NAME" /usr/bin/python3 <<'PY'
 import json
@@ -121,15 +233,31 @@ xcrun simctl boot "$SIMULATOR_ID"
 xcrun simctl bootstatus "$SIMULATOR_ID" -b
 
 if [[ "$SKIP_BUILD" -ne 1 ]]; then
-  CMUX_DEV_API_BASE_URL="$STAGING_BASE_URL" \
-  CMUX_IROH_BROKER_BASE_URL="$STAGING_BASE_URL" \
-    ./scripts/reload.sh --tag "$TAG"
-  CMUX_DEV_API_BASE_URL="$STAGING_BASE_URL" \
-  CMUX_IROH_BROKER_BASE_URL="$STAGING_BASE_URL" \
-    ./ios/scripts/reload.sh \
-      --tag "$TAG" \
-      --simulator "$SIMULATOR_NAME" \
-      --no-launch
+  if [[ "$PRODUCTION" -eq 1 ]]; then
+    CMUX_DEV_API_BASE_URL="$STAGING_BASE_URL" \
+    CMUX_IROH_BROKER_BASE_URL="$STAGING_BASE_URL" \
+      ./scripts/reload.sh \
+        --tag "$TAG" \
+        --prod-auth \
+        --credentials-file "$PROD_CREDENTIALS_FILE"
+    CMUX_DEV_API_BASE_URL="$STAGING_BASE_URL" \
+    CMUX_IROH_BROKER_BASE_URL="$STAGING_BASE_URL" \
+      ./ios/scripts/reload.sh \
+        --tag "$TAG" \
+        --simulator "$SIMULATOR_NAME" \
+        --prod-auth \
+        --no-launch
+  else
+    CMUX_DEV_API_BASE_URL="$STAGING_BASE_URL" \
+    CMUX_IROH_BROKER_BASE_URL="$STAGING_BASE_URL" \
+      ./scripts/reload.sh --tag "$TAG"
+    CMUX_DEV_API_BASE_URL="$STAGING_BASE_URL" \
+    CMUX_IROH_BROKER_BASE_URL="$STAGING_BASE_URL" \
+      ./ios/scripts/reload.sh \
+        --tag "$TAG" \
+        --simulator "$SIMULATOR_NAME" \
+        --no-launch
+  fi
 else
   [[ -d "$IOS_APP" ]] || { echo "error: tagged iOS app is missing: $IOS_APP" >&2; exit 1; }
   xcrun simctl install "$SIMULATOR_ID" "$IOS_APP"
@@ -225,13 +353,18 @@ except subprocess.TimeoutExpired:
 PY
 REPORT_WAITER_PID=$!
 
+MOBILE_LAUNCH_ARGS=(
+  --tag "$TAG"
+  --simulator-id "$SIMULATOR_ID"
+  --ensure-mac
+  --detach
+  --iroh-release-gate "$RAW_MODE"
+)
+if [[ "$PRODUCTION" -eq 1 ]]; then
+  MOBILE_LAUNCH_ARGS+=(--credentials-file "$PROD_CREDENTIALS_FILE")
+fi
 CMUX_ATTACH_MINT_MAX_ATTEMPTS=120 \
-./scripts/mobile-dev-launch.sh \
-  --tag "$TAG" \
-  --simulator-id "$SIMULATOR_ID" \
-  --ensure-mac \
-  --detach \
-  --iroh-release-gate "$RAW_MODE" \
+./scripts/mobile-dev-launch.sh "${MOBILE_LAUNCH_ARGS[@]}" \
   2>&1 | sed -E \
     -e 's/^(==> dev sign-in account:).*/\1 [redacted]/' \
     -e 's/(signed in as )[^,)]+/\1[redacted]/'

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -134,9 +134,14 @@ cleanup() {
   fi
   defaults delete "$MAC_BUNDLE_ID" cmux.iroh.debug.transport-mode >/dev/null 2>&1 || true
   pkill -f "cmux DEV ${SLUG}.app/Contents/MacOS/cmux DEV" 2>/dev/null || true
-  rm -rf "$HOME/Library/Application Support/cmux/$MAC_BUNDLE_ID"
-  security delete-generic-password -s "$MAC_BUNDLE_ID.auth" -a cmux-auth-access-token >/dev/null 2>&1 || true
-  security delete-generic-password -s "$MAC_BUNDLE_ID.auth" -a cmux-auth-refresh-token >/dev/null 2>&1 || true
+  if [[ "$PRODUCTION" -eq 1 ]]; then
+    # Production uses a disposable account and must remove its local tokens.
+    # Staging keeps its tagged state so a failed gate remains inspectable and a
+    # later --skip-build run can reuse the same authenticated build.
+    rm -rf "$HOME/Library/Application Support/cmux/$MAC_BUNDLE_ID"
+    security delete-generic-password -s "$MAC_BUNDLE_ID.auth" -a cmux-auth-access-token >/dev/null 2>&1 || true
+    security delete-generic-password -s "$MAC_BUNDLE_ID.auth" -a cmux-auth-refresh-token >/dev/null 2>&1 || true
+  fi
   if [[ "$KEEP_SIMULATOR" -ne 1 && -n "$SIMULATOR_ID" ]]; then
     xcrun simctl shutdown "$SIMULATOR_ID" >/dev/null 2>&1 || true
     xcrun simctl delete "$SIMULATOR_ID" >/dev/null 2>&1 || true


### PR DESCRIPTION
Adds a reusable production-authenticated Iroh release gate with fail-closed temporary Stack account lifecycle, protected credentials, and verified account cleanup.

Verification:
- 36 focused Swift tests passed
- 40 Bun/shell tests passed
- tagged `irpg` macOS production-auth build passed and codesign verified

Full production E2E intentionally remains red until POSTHOG_PERSONAL_API_KEY is configured, because production account deletion correctly fails closed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787067733&installation_id=133855650&pr_number=8486&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8486&signature=4fc9725ecc2f267e198e26485c57439d332f73ce695bd34c92ea469b09487816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a production-authenticated Iroh release gate that provisions a one-off Stack user, runs the gate against https://cmux.com, verifies API-driven account deletion with a fail-closed fallback and redacted recovery. Also fixes the staging gate to preserve tagged state between runs; production runs wipe tokens.

- New Features
  - Production gate: `scripts/run-iroh-release-gate.sh --production` creates a temporary Stack user via `scripts/lib/temporary-stack-user.mjs` (using a secure Vercel env pull or `--stack-env-file`), runs the same checks used in staging, then deletes the account via the API and verifies deletion before falling back to direct removal. Cleanup runs on exit and writes a redacted recovery report if anything fails.
  - Secure credentials: Exclusive `--credentials-file` with strict 0600, owner-only, non-symlink checks in `scripts/lib/dev-secrets.sh`; the DEBUG resolver reads `CMUX_AUTH_CREDENTIALS_FILE` via a secure reader. Values stay out of argv, Info.plist, logs, and long-lived environments; launch output is redacted.
  - macOS auth environment: `CMUX_AUTH_ENVIRONMENT` selects development/production Stack keys and project ID; `--prod-auth` in `scripts/reload.sh` sets production origins and bakes `CMUX_AUTH_CREDENTIALS_FILE`. Project switches clear stale auth; dev auth UI appears only for DEBUG + development.
  - Temporary Stack user helper: `scripts/lib/temporary-stack-user.mjs` loads `NEXT_PUBLIC_*` and `STACK_SECRET_SERVER_KEY`, creates a user/session, writes protected state/credentials, and performs verified cleanup with safe-file utilities.
  - Tooling updates: `scripts/mobile-dev-launch.sh` supports `--credentials-file` and redacts account labels; `scripts/run-iroh-release-gate.sh` validates production flags, forbids build reuse, preserves staging gate state, and wipes local tokens only for production.

- Migration
  - Staging gate: scripts/run-iroh-release-gate.sh --mode automatic --tag <tag>
  - Production gate: scripts/run-iroh-release-gate.sh --mode automatic --tag <tag> --production [--stack-env-file <secure-0600-path>]
  - To pass the production cleanup check, ensure the production env has `POSTHOG_PERSONAL_API_KEY` configured; without it, the gate fails closed by design.

<sup>Written for commit 81285e9c34b83687b84738780096973d92f49e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime auth environment selection with production/development overrides and updated Stack auth configuration resolution.
  * Added support for loading credentials from a single explicit credentials file across dev/mobile/reload flows.
  * Introduced production-auth mode for reload and release-gate workflows, including temporary production account provisioning and cleanup.
* **Security**
  * Enforced strict credentials-file validation (absolute path, regular file, owner-only permissions, no symlinks) and ensured sensitive values aren’t logged or propagated.
* **Bug Fixes**
  * Improved detection/stabilization when the effective auth project changes, preventing incorrect stale-auth behavior.
* **Tests**
  * Added coverage for auth environment resolution, credentials-file exclusivity, and production-gate behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->