### PR TITLE
Add authenticated custom private Iroh paths

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohCustomPrivateAddress.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohCustomPrivateAddress.swift
@@ -1,0 +1,128 @@
+import Darwin
+import Foundation
+
+/// One canonical numeric address for a user-configured private path.
+///
+/// This value intentionally carries no port or identity. Dial-time policy joins
+/// it to the broker-authenticated Mac's current Iroh UDP port and EndpointID.
+public struct CmxIrohCustomPrivateAddress: Codable, Equatable, Hashable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case value
+        case family
+    }
+    public enum Family: String, Codable, Sendable {
+        case ipv4
+        case ipv6
+    }
+
+    /// Canonical numeric IPv4 or IPv6 text without brackets, a port, or a zone.
+    public let value: String
+    public let family: Family
+
+    /// Parses, canonicalizes, and validates one numeric private-path address.
+    ///
+    /// Hostnames, socket ports, loopback, multicast, link-local, wildcard, and
+    /// scoped IPv6 addresses are rejected. Globally shaped addresses remain
+    /// eligible because the authenticated Iroh handshake, not the coordinate,
+    /// proves the remote Mac.
+    public init(_ rawValue: String) throws {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.utf8.count <= 64,
+              !trimmed.contains("%"),
+              !trimmed.contains("["),
+              !trimmed.contains("]") else {
+            throw CmxIrohCustomPrivateAddressError.invalidAddress
+        }
+
+        let canonical: String
+        let family: Family
+        if let value = Self.canonicalIPv4(trimmed) {
+            canonical = value
+            family = .ipv4
+        } else if let value = Self.canonicalIPv6(trimmed) {
+            canonical = value
+            family = .ipv6
+        } else {
+            throw CmxIrohCustomPrivateAddressError.invalidAddress
+        }
+
+        do {
+            let profile = try CmxIrohNetworkProfileKey(
+                source: .customVPN,
+                profileID: String(repeating: "0", count: 64)
+            )
+            let observedAt = Date(timeIntervalSince1970: 0)
+            _ = try CmxIrohPathHint(
+                kind: .directAddress,
+                value: family == .ipv4 ? "\(canonical):1" : "[\(canonical)]:1",
+                source: .customVPN,
+                privacyScope: .privateNetwork,
+                observedAt: observedAt,
+                expiresAt: observedAt.addingTimeInterval(1),
+                networkProfile: profile
+            )
+        } catch {
+            throw CmxIrohCustomPrivateAddressError.invalidAddress
+        }
+
+        self.value = canonical
+        self.family = family
+    }
+
+    /// Builds the Iroh socket coordinate using an authenticated UDP port.
+    public func socketAddress(port: UInt16) -> String {
+        switch family {
+        case .ipv4: "\(value):\(port)"
+        case .ipv6: "[\(value)]:\(port)"
+        }
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedFamily = try container.decode(Family.self, forKey: .family)
+        try self.init(container.decode(String.self, forKey: .value))
+        guard family == decodedFamily else {
+            throw CmxIrohCustomPrivateAddressError.invalidAddress
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(value, forKey: .value)
+        try container.encode(family, forKey: .family)
+    }
+
+    private static func canonicalIPv4(_ rawValue: String) -> String? {
+        var address = in_addr()
+        guard rawValue.withCString({ inet_pton(AF_INET, $0, &address) }) == 1 else {
+            return nil
+        }
+        var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+        guard inet_ntop(AF_INET, &address, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else {
+            return nil
+        }
+        return Self.string(beforeNullIn: buffer)
+    }
+
+    private static func canonicalIPv6(_ rawValue: String) -> String? {
+        var address = in6_addr()
+        guard rawValue.withCString({ inet_pton(AF_INET6, $0, &address) }) == 1 else {
+            return nil
+        }
+        var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+        guard inet_ntop(AF_INET6, &address, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else {
+            return nil
+        }
+        return Self.string(beforeNullIn: buffer)
+    }
+
+    private static func string(beforeNullIn buffer: [CChar]) -> String {
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+}
+
+public enum CmxIrohCustomPrivateAddressError: Error, Equatable, Sendable {
+    case invalidAddress
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohCustomPrivatePathDraft.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohCustomPrivatePathDraft.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// Device-local settings input for one Mac's explicit private addresses.
 public struct CmxIrohCustomPrivatePathDraft: Equatable, Sendable {
+    /// Maximum numeric addresses accepted for one Mac on one device.
+    public static let maximumAddressCount = 8
+
     public let macDeviceID: String
     public let macDisplayName: String
     public let addresses: [String]

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohCustomPrivatePathDraft.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohCustomPrivatePathDraft.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Device-local settings input for one Mac's explicit private addresses.
+public struct CmxIrohCustomPrivatePathDraft: Equatable, Sendable {
+    public let macDeviceID: String
+    public let macDisplayName: String
+    public let addresses: [String]
+    public let isEnabled: Bool
+
+    public init(
+        macDeviceID: String,
+        macDisplayName: String,
+        addresses: [String],
+        isEnabled: Bool
+    ) {
+        self.macDeviceID = macDeviceID
+        self.macDisplayName = macDisplayName
+        self.addresses = addresses
+        self.isEnabled = isEnabled
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
@@ -24,6 +24,12 @@ public protocol CmxIrohSettingsControlling: AnyObject {
     /// Probes one custom relay without changing the active preference.
     func testIrohCustomRelay(id: String) async -> CmxIrohRelayTestResult
 
+    /// Persists one device-local custom private-path configuration.
+    func upsertIrohCustomPrivatePath(_ path: CmxIrohCustomPrivatePathDraft) async throws
+
+    /// Removes this device's custom private paths for one Mac.
+    func removeIrohCustomPrivatePath(macDeviceID: String) async throws
+
     /// Fetches the latest signed fleet and account preference.
     func refreshIrohSettings() async
 
@@ -38,6 +44,14 @@ public protocol CmxIrohSettingsControlling: AnyObject {
 }
 
 public extension CmxIrohSettingsControlling {
+    func upsertIrohCustomPrivatePath(_ path: CmxIrohCustomPrivatePathDraft) async throws {
+        throw CmxIrohSettingsControlError.unsupported
+    }
+
+    func removeIrohCustomPrivatePath(macDeviceID: String) async throws {
+        throw CmxIrohSettingsControlError.unsupported
+    }
+
     func irohDiagnosticReport() async -> DiagnosticReport {
         .empty
     }
@@ -47,4 +61,8 @@ public extension CmxIrohSettingsControlling {
     }
 
     func clearIrohDiagnosticReport() async {}
+}
+
+public enum CmxIrohSettingsControlError: Error, Equatable, Sendable {
+    case unsupported
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsSnapshot.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsSnapshot.swift
@@ -88,12 +88,46 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
         }
     }
 
+    /// A broker-authenticated Mac available for device-local path settings.
+    public struct PrivateNetworkMac: Identifiable, Equatable, Sendable {
+        public let id: String
+        public let displayName: String
+
+        public init(id: String, displayName: String) {
+            self.id = id
+            self.displayName = displayName
+        }
+    }
+
+    /// One device-local, per-Mac custom private-path configuration.
+    public struct CustomPrivateNetwork: Identifiable, Equatable, Sendable {
+        public var id: String { macDeviceID }
+        public let macDeviceID: String
+        public let macDisplayName: String
+        public let addresses: [String]
+        public let isEnabled: Bool
+
+        public init(
+            macDeviceID: String,
+            macDisplayName: String,
+            addresses: [String],
+            isEnabled: Bool
+        ) {
+            self.macDeviceID = macDeviceID
+            self.macDisplayName = macDisplayName
+            self.addresses = addresses
+            self.isEnabled = isEnabled
+        }
+    }
+
     public let runtimeStatus: RuntimeStatus
     /// Redacted selected-path attribution, independent from lifecycle status.
     public let selectedTransportPath: CmxIrohSelectedTransportPath
     public let preference: CmxIrohRelayPreferenceDraft
     public let managedRelays: [ManagedRelay]
     public let customRelays: [CustomRelay]
+    public let privateNetworkMacs: [PrivateNetworkMac]
+    public let customPrivateNetworks: [CustomPrivateNetwork]
     public let policySource: PolicySource
     public let policySequence: Int64?
     public let policyExpiresAt: Date?
@@ -113,6 +147,8 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
         preference: CmxIrohRelayPreferenceDraft,
         managedRelays: [ManagedRelay],
         customRelays: [CustomRelay],
+        privateNetworkMacs: [PrivateNetworkMac] = [],
+        customPrivateNetworks: [CustomPrivateNetwork] = [],
         policySource: PolicySource,
         policySequence: Int64? = nil,
         policyExpiresAt: Date? = nil,
@@ -125,6 +161,8 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
         self.preference = preference
         self.managedRelays = managedRelays
         self.customRelays = customRelays
+        self.privateNetworkMacs = privateNetworkMacs
+        self.customPrivateNetworks = customPrivateNetworks
         self.policySource = policySource
         self.policySequence = policySequence
         self.policyExpiresAt = policyExpiresAt

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohCustomPrivateAddressTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohCustomPrivateAddressTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import CMUXMobileCore
+
+@Test func customPrivateAddressCanonicalizesNumericIPOnly() throws {
+    let ipv4 = try CmxIrohCustomPrivateAddress("10.0.0.8")
+    #expect(ipv4.value == "10.0.0.8")
+    #expect(ipv4.family == .ipv4)
+    #expect(ipv4.socketAddress(port: 49_152) == "10.0.0.8:49152")
+
+    let ipv6 = try CmxIrohCustomPrivateAddress("fd00:0:0:0:0:0:0:8")
+    #expect(ipv6.value == "fd00::8")
+    #expect(ipv6.family == .ipv6)
+    #expect(ipv6.socketAddress(port: 49_152) == "[fd00::8]:49152")
+}
+
+@Test func customPrivateAddressRejectsCoordinatesAndUnsafeAddresses() {
+    for value in [
+        "private.example.com",
+        "10.0.0.8:49152",
+        "[fd00::8]:49152",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+        "::",
+        "169.254.1.2",
+        "fe80::1",
+        "ff02::1",
+        "fd00::1%en0",
+    ] {
+        #expect(
+            throws: CmxIrohCustomPrivateAddressError.invalidAddress,
+            Comment(rawValue: value)
+        ) {
+            _ = try CmxIrohCustomPrivateAddress(value)
+        }
+    }
+}
+
+@Test func customPrivateAddressDecodeRevalidatesFamily() throws {
+    let valid = Data(#"{"value":"10.0.0.8","family":"ipv4"}"#.utf8)
+    #expect(try JSONDecoder().decode(CmxIrohCustomPrivateAddress.self, from: valid).value
+        == "10.0.0.8")
+
+    let tampered = Data(#"{"value":"10.0.0.8","family":"ipv6"}"#.utf8)
+    #expect(throws: CmxIrohCustomPrivateAddressError.invalidAddress) {
+        _ = try JSONDecoder().decode(CmxIrohCustomPrivateAddress.self, from: tampered)
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+Policy.swift
@@ -170,6 +170,7 @@ extension CmxIrohClientRuntime {
                 networkPathSnapshot: networkPathSnapshot,
                 offlinePolicy: offlinePolicy,
                 lanFallback: lanFallback,
+                customPrivateFallback: customPrivateFallback,
                 now: now
             )
             registryContextProvider = provider

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime+RelayPolicy.swift
@@ -89,6 +89,7 @@ extension CmxIrohClientRuntime {
                 networkPathSnapshot: networkPathSnapshot,
                 offlinePolicy: offlinePolicy,
                 lanFallback: lanFallback,
+                customPrivateFallback: customPrivateFallback,
                 now: now
             )
             registryContextProvider = provider

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -17,6 +17,8 @@ public actor CmxIrohClientRuntime {
 
     /// Supplies local-link reachability only for one authenticated Mac tuple.
     public typealias LANFallbackProvider = CmxIrohRegistryContextProvider.LANFallbackProvider
+    public typealias CustomPrivateFallbackProvider =
+        CmxIrohRegistryContextProvider.CustomPrivateFallbackProvider
 
     /// Runs after a relay credential is installed on the exact active binding.
     public typealias RelayCredentialHandler = @Sendable (
@@ -73,6 +75,7 @@ public actor CmxIrohClientRuntime {
     let offlinePolicyCache: CmxIrohClientOfflinePolicyCache?
     let networkPathSnapshot: @Sendable () async throws -> CmxIrohNetworkPathSnapshot
     let lanFallback: LANFallbackProvider?
+    let customPrivateFallback: CustomPrivateFallbackProvider?
     let now: @Sendable () -> Date
     let handleBinding: BindingHandler
     let handleCachedBindings: CachedBindingsHandler
@@ -131,6 +134,7 @@ public actor CmxIrohClientRuntime {
             CmxIrohNetworkPathSnapshot(generation: 1, activeNetworkProfiles: [])
         },
         lanFallback: LANFallbackProvider? = nil,
+        customPrivateFallback: CustomPrivateFallbackProvider? = nil,
         now: @escaping @Sendable () -> Date = { Date() },
         handleBinding: @escaping BindingHandler = { _, _ in true },
         handleCachedBindings: @escaping CachedBindingsHandler = { _, _ in },
@@ -169,6 +173,7 @@ public actor CmxIrohClientRuntime {
         self.offlinePolicyCache = offlinePolicyCache
         self.networkPathSnapshot = networkPathSnapshot
         self.lanFallback = lanFallback
+        self.customPrivateFallback = customPrivateFallback
         self.now = now
         self.handleBinding = handleBinding
         self.handleCachedBindings = handleCachedBindings

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohCustomPrivatePathStore.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohCustomPrivatePathStore.swift
@@ -1,0 +1,307 @@
+public import CMUXMobileCore
+import CryptoKit
+public import Foundation
+
+/// Validated device-local settings for one authenticated Mac.
+public struct CmxIrohCustomPrivatePathConfiguration: Codable, Equatable, Sendable {
+    public let macDeviceID: String
+    public let macDisplayName: String
+    public let addresses: [CmxIrohCustomPrivateAddress]
+    public let isEnabled: Bool
+
+    public init(
+        macDeviceID: String,
+        macDisplayName: String,
+        addresses: [CmxIrohCustomPrivateAddress],
+        isEnabled: Bool
+    ) throws {
+        let canonicalDeviceID = cmxCanonicalDeviceID(
+            macDeviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        guard let uuid = UUID(uuidString: canonicalDeviceID),
+              uuid.uuidString.lowercased() == canonicalDeviceID,
+              !addresses.isEmpty,
+              addresses.count <= CmxIrohCustomPrivatePathStore.maximumAddressCount,
+              Set(addresses).count == addresses.count else {
+            throw CmxIrohCustomPrivatePathStoreError.invalidConfiguration
+        }
+        let displayName = macDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard displayName.utf8.count <= 128,
+              !displayName.unicodeScalars.contains(where: {
+                  $0.value < 0x20 || $0.value == 0x7f
+              }) else {
+            throw CmxIrohCustomPrivatePathStoreError.invalidConfiguration
+        }
+        self.macDeviceID = canonicalDeviceID
+        self.macDisplayName = displayName
+        self.addresses = addresses
+        self.isEnabled = isEnabled
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            macDeviceID: container.decode(String.self, forKey: .macDeviceID),
+            macDisplayName: container.decode(String.self, forKey: .macDisplayName),
+            addresses: container.decode(
+                [CmxIrohCustomPrivateAddress].self,
+                forKey: .addresses
+            ),
+            isEnabled: container.decode(Bool.self, forKey: .isEnabled)
+        )
+    }
+}
+
+/// Credential-free state used to compose private-path authorization.
+public struct CmxIrohCustomPrivatePathSnapshot: Equatable, Sendable {
+    public let generation: UInt64
+    public let configurations: [CmxIrohCustomPrivatePathConfiguration]
+    public let activeNetworkProfiles: Set<CmxIrohNetworkProfileKey>
+
+    public init(
+        generation: UInt64,
+        configurations: [CmxIrohCustomPrivatePathConfiguration],
+        activeNetworkProfiles: Set<CmxIrohNetworkProfileKey>
+    ) {
+        self.generation = generation
+        self.configurations = configurations
+        self.activeNetworkProfiles = activeNetworkProfiles
+    }
+
+    public static let unavailable = CmxIrohCustomPrivatePathSnapshot(
+        generation: 1,
+        configurations: [],
+        activeNetworkProfiles: []
+    )
+}
+
+/// One locally configured address plus its opaque active-profile authority.
+public struct CmxIrohCustomPrivatePathBootstrap: Equatable, Sendable {
+    public let address: CmxIrohCustomPrivateAddress
+    public let networkProfile: CmxIrohNetworkProfileKey
+
+    public init(
+        address: CmxIrohCustomPrivateAddress,
+        networkProfile: CmxIrohNetworkProfileKey
+    ) throws {
+        guard networkProfile.source == .customVPN else {
+            throw CmxIrohCustomPrivatePathStoreError.invalidConfiguration
+        }
+        self.address = address
+        self.networkProfile = networkProfile
+    }
+}
+
+/// Device-only, account-isolated persistence for explicit private addresses.
+///
+/// Addresses are non-secret routing preferences, so this store deliberately
+/// uses app-local defaults instead of Keychain. This keeps the transport's
+/// Keychain-stall degradation unchanged while preventing account or broker sync.
+public actor CmxIrohCustomPrivatePathStore {
+    struct Record: Codable {
+        let version: Int
+        let generation: UInt64
+        let configurations: [CmxIrohCustomPrivatePathConfiguration]
+    }
+
+    struct State {
+        var generation: UInt64
+        var configurations: [CmxIrohCustomPrivatePathConfiguration]
+    }
+
+    public static let maximumConfigurationCount = 64
+    public static let maximumAddressCount = 8
+    private static let recordVersion = 1
+    private static let maximumEncodedByteCount = 64 * 1_024
+
+    private let store: any CmxIrohInstallStateStoring
+    private var states: [String: State] = [:]
+
+    public init(
+        store: any CmxIrohInstallStateStoring = CmxIrohUserDefaultsInstallStateStore()
+    ) {
+        self.store = store
+    }
+
+    public func snapshot(accountID: String) throws -> CmxIrohCustomPrivatePathSnapshot {
+        let scope = try storageScope(accountID)
+        let state = try state(for: scope)
+        return try snapshot(state: state, scope: scope)
+    }
+
+    /// Loads current preferences, failing closed without disabling Iroh when
+    /// local settings are malformed or unavailable.
+    public func availableSnapshot(
+        accountID: String
+    ) -> CmxIrohCustomPrivatePathSnapshot {
+        (try? snapshot(accountID: accountID)) ?? .unavailable
+    }
+
+    public func upsert(
+        _ draft: CmxIrohCustomPrivatePathDraft,
+        accountID: String
+    ) throws -> CmxIrohCustomPrivatePathSnapshot {
+        let configuration = try Self.validatedConfiguration(draft)
+        let scope = try storageScope(accountID)
+        var state = try state(for: scope)
+        if let index = state.configurations.firstIndex(where: {
+            $0.macDeviceID == configuration.macDeviceID
+        }) {
+            state.configurations[index] = configuration
+        } else {
+            guard state.configurations.count < Self.maximumConfigurationCount else {
+                throw CmxIrohCustomPrivatePathStoreError.tooManyConfigurations
+            }
+            state.configurations.append(configuration)
+        }
+        state.configurations.sort { $0.macDeviceID < $1.macDeviceID }
+        state.generation = nextGeneration(state.generation)
+        try persist(state, scope: scope)
+        states[scope] = state
+        return try snapshot(state: state, scope: scope)
+    }
+
+    public func remove(
+        macDeviceID: String,
+        accountID: String
+    ) throws -> CmxIrohCustomPrivatePathSnapshot {
+        let canonical = cmxCanonicalDeviceID(
+            macDeviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        let scope = try storageScope(accountID)
+        var state = try state(for: scope)
+        guard state.configurations.contains(where: { $0.macDeviceID == canonical }) else {
+            throw CmxIrohCustomPrivatePathStoreError.missingConfiguration
+        }
+        state.configurations.removeAll { $0.macDeviceID == canonical }
+        state.generation = nextGeneration(state.generation)
+        try persist(state, scope: scope)
+        states[scope] = state
+        return try snapshot(state: state, scope: scope)
+    }
+
+    /// Returns paths only for the exact expected Mac and current account.
+    public func enabledPaths(
+        forMacDeviceID macDeviceID: String,
+        accountID: String
+    ) -> [CmxIrohCustomPrivatePathBootstrap] {
+        guard let scope = try? storageScope(accountID),
+              let state = try? state(for: scope),
+              let configuration = state.configurations.first(where: {
+                  $0.macDeviceID == cmxCanonicalDeviceID(macDeviceID)
+              }),
+              configuration.isEnabled,
+              let profile = try? profile(
+                  accountScope: scope,
+                  macDeviceID: configuration.macDeviceID
+              ) else { return [] }
+        return configuration.addresses.compactMap {
+            try? CmxIrohCustomPrivatePathBootstrap(
+                address: $0,
+                networkProfile: profile
+            )
+        }
+    }
+
+    private static func validatedConfiguration(
+        _ draft: CmxIrohCustomPrivatePathDraft
+    ) throws -> CmxIrohCustomPrivatePathConfiguration {
+        var addresses: [CmxIrohCustomPrivateAddress] = []
+        for value in draft.addresses {
+            let address = try CmxIrohCustomPrivateAddress(value)
+            if !addresses.contains(address) { addresses.append(address) }
+        }
+        return try CmxIrohCustomPrivatePathConfiguration(
+            macDeviceID: draft.macDeviceID,
+            macDisplayName: draft.macDisplayName,
+            addresses: addresses,
+            isEnabled: draft.isEnabled
+        )
+    }
+
+    private func storageScope(_ accountID: String) throws -> String {
+        try CmxIrohRelayStorageScope.account(
+            accountID,
+            prefix: "custom-private-paths"
+        )
+    }
+
+    private func state(for scope: String) throws -> State {
+        if let state = states[scope] { return state }
+        let loaded: State
+        if let encoded = store.string(forKey: scope) {
+            guard let data = Data(base64Encoded: encoded),
+                  data.count <= Self.maximumEncodedByteCount,
+                  let record = try? JSONDecoder().decode(Record.self, from: data),
+                  record.version == Self.recordVersion,
+                  record.generation > 0,
+                  record.configurations.count <= Self.maximumConfigurationCount,
+                  Set(record.configurations.map(\.macDeviceID)).count
+                    == record.configurations.count else {
+                throw CmxIrohCustomPrivatePathStoreError.invalidStoredConfiguration
+            }
+            loaded = State(
+                generation: record.generation,
+                configurations: record.configurations.sorted {
+                    $0.macDeviceID < $1.macDeviceID
+                }
+            )
+        } else {
+            loaded = State(generation: 1, configurations: [])
+        }
+        states[scope] = loaded
+        return loaded
+    }
+
+    private func persist(_ state: State, scope: String) throws {
+        let data = try JSONEncoder().encode(Record(
+            version: Self.recordVersion,
+            generation: state.generation,
+            configurations: state.configurations
+        ))
+        guard data.count <= Self.maximumEncodedByteCount else {
+            throw CmxIrohCustomPrivatePathStoreError.invalidConfiguration
+        }
+        store.set(data.base64EncodedString(), forKey: scope)
+    }
+
+    private func snapshot(
+        state: State,
+        scope: String
+    ) throws -> CmxIrohCustomPrivatePathSnapshot {
+        var profiles: Set<CmxIrohNetworkProfileKey> = []
+        for configuration in state.configurations
+        where configuration.isEnabled && !configuration.addresses.isEmpty {
+            profiles.insert(try profile(
+                accountScope: scope,
+                macDeviceID: configuration.macDeviceID
+            ))
+        }
+        return CmxIrohCustomPrivatePathSnapshot(
+            generation: state.generation,
+            configurations: state.configurations,
+            activeNetworkProfiles: profiles
+        )
+    }
+
+    private func profile(
+        accountScope: String,
+        macDeviceID: String
+    ) throws -> CmxIrohNetworkProfileKey {
+        let digest = SHA256.hash(
+            data: Data("custom-private-path-v1\0\(accountScope)\0\(macDeviceID)".utf8)
+        ).map { String(format: "%02x", $0) }.joined()
+        return try CmxIrohNetworkProfileKey(source: .customVPN, profileID: digest)
+    }
+
+    private func nextGeneration(_ current: UInt64) -> UInt64 {
+        current == .max ? 1 : current + 1
+    }
+}
+
+public enum CmxIrohCustomPrivatePathStoreError: Error, Equatable, Sendable {
+    case invalidConfiguration
+    case invalidStoredConfiguration
+    case tooManyConfigurations
+    case missingConfiguration
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohCustomPrivatePathStore.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohCustomPrivatePathStore.swift
@@ -1,6 +1,6 @@
 public import CMUXMobileCore
 import CryptoKit
-public import Foundation
+import Foundation
 
 /// Validated device-local settings for one authenticated Mac.
 public struct CmxIrohCustomPrivatePathConfiguration: Codable, Equatable, Sendable {
@@ -21,7 +21,7 @@ public struct CmxIrohCustomPrivatePathConfiguration: Codable, Equatable, Sendabl
         guard let uuid = UUID(uuidString: canonicalDeviceID),
               uuid.uuidString.lowercased() == canonicalDeviceID,
               !addresses.isEmpty,
-              addresses.count <= CmxIrohCustomPrivatePathStore.maximumAddressCount,
+              addresses.count <= CmxIrohCustomPrivatePathDraft.maximumAddressCount,
               Set(addresses).count == addresses.count else {
             throw CmxIrohCustomPrivatePathStoreError.invalidConfiguration
         }
@@ -110,7 +110,6 @@ public actor CmxIrohCustomPrivatePathStore {
     }
 
     public static let maximumConfigurationCount = 64
-    public static let maximumAddressCount = 8
     private static let recordVersion = 1
     private static let maximumEncodedByteCount = 64 * 1_024
 
@@ -290,13 +289,24 @@ public actor CmxIrohCustomPrivatePathStore {
     ) throws -> CmxIrohNetworkProfileKey {
         let digest = SHA256.hash(
             data: Data("custom-private-path-v1\0\(accountScope)\0\(macDeviceID)".utf8)
-        ).map { String(format: "%02x", $0) }.joined()
-        return try CmxIrohNetworkProfileKey(source: .customVPN, profileID: digest)
+        )
+        var encoded = [UInt8]()
+        encoded.reserveCapacity(SHA256.Digest.byteCount * 2)
+        for byte in digest {
+            encoded.append(Self.hexDigits[Int(byte >> 4)])
+            encoded.append(Self.hexDigits[Int(byte & 0x0f)])
+        }
+        return try CmxIrohNetworkProfileKey(
+            source: .customVPN,
+            profileID: String(decoding: encoded, as: UTF8.self)
+        )
     }
 
     private func nextGeneration(_ current: UInt64) -> UInt64 {
         current == .max ? 1 : current + 1
     }
+
+    private static let hexDigits = Array("0123456789abcdef".utf8)
 }
 
 public enum CmxIrohCustomPrivatePathStoreError: Error, Equatable, Sendable {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohNetworkPathSnapshotComposer.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohNetworkPathSnapshotComposer.swift
@@ -1,0 +1,39 @@
+public import CMUXMobileCore
+
+/// Assigns one process-monotonic generation to a platform path snapshot joined
+/// with device-local custom private-path preferences.
+public actor CmxIrohNetworkPathSnapshotComposer {
+    private struct Input: Equatable {
+        let platformGeneration: UInt64
+        let platformProfiles: Set<CmxIrohNetworkProfileKey>
+        let customGeneration: UInt64
+        let customProfiles: Set<CmxIrohNetworkProfileKey>
+    }
+
+    private var generation: UInt64 = 1
+    private var previousInput: Input?
+
+    public init() {}
+
+    public func compose(
+        platform: CmxIrohNetworkPathSnapshot,
+        custom: CmxIrohCustomPrivatePathSnapshot
+    ) -> CmxIrohNetworkPathSnapshot {
+        let input = Input(
+            platformGeneration: platform.generation,
+            platformProfiles: platform.activeNetworkProfiles,
+            customGeneration: custom.generation,
+            customProfiles: custom.activeNetworkProfiles
+        )
+        if let previousInput, previousInput != input {
+            generation = generation == .max ? 1 : generation + 1
+        }
+        previousInput = input
+        return CmxIrohNetworkPathSnapshot(
+            generation: generation,
+            activeNetworkProfiles: platform.activeNetworkProfiles.union(
+                custom.activeNetworkProfiles
+            )
+        )
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -8,6 +8,9 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         _ authenticatedBindings: [CmxIrohBrokerBindingMetadata],
         _ rendezvous: CmxIrohLANRendezvous
     ) async -> [CmxIrohPathHint]
+    public typealias CustomPrivateFallbackProvider = @Sendable (
+        _ expectedMacDeviceID: String
+    ) async -> [CmxIrohCustomPrivatePathBootstrap]
 
     let supervisor: CmxIrohEndpointSupervisor
     let broker: any CmxIrohRegistryServing
@@ -17,6 +20,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
     let networkPathSnapshot: (@Sendable () async throws -> CmxIrohNetworkPathSnapshot)?
     var offlinePolicy: CmxIrohClientOfflinePolicyContext?
     let lanFallback: LANFallbackProvider?
+    let customPrivateFallback: CustomPrivateFallbackProvider?
     let verifier: CmxIrohGrantVerifier
     let now: @Sendable () -> Date
     var grantCache: [CmxIrohPeerIdentity: CmxIrohRegistryGrantCache] = [:]
@@ -33,6 +37,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         activeNetworkProfiles: @escaping @Sendable () async -> Set<CmxIrohNetworkProfileKey>,
         offlinePolicy: CmxIrohClientOfflinePolicyContext? = nil,
         lanFallback: LANFallbackProvider? = nil,
+        customPrivateFallback: CustomPrivateFallbackProvider? = nil,
         verifier: CmxIrohGrantVerifier = CmxIrohGrantVerifier(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -45,6 +50,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         networkPathSnapshot = nil
         self.offlinePolicy = offlinePolicy
         self.lanFallback = lanFallback
+        self.customPrivateFallback = customPrivateFallback
         self.verifier = verifier
         self.now = now
     }
@@ -59,6 +65,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         networkPathSnapshot: @escaping @Sendable () async throws -> CmxIrohNetworkPathSnapshot,
         offlinePolicy: CmxIrohClientOfflinePolicyContext? = nil,
         lanFallback: LANFallbackProvider? = nil,
+        customPrivateFallback: CustomPrivateFallbackProvider? = nil,
         verifier: CmxIrohGrantVerifier = CmxIrohGrantVerifier(),
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
@@ -70,6 +77,7 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         self.networkPathSnapshot = networkPathSnapshot
         self.offlinePolicy = offlinePolicy
         self.lanFallback = lanFallback
+        self.customPrivateFallback = customPrivateFallback
         self.verifier = verifier
         self.now = now
     }
@@ -213,11 +221,15 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
         at clock: Date
     ) async throws -> CmxIrohClientContext {
         let targetIdentity = targetBinding.endpointID
-        let routeHints = authoritativePrivateRouteHints(
+        var routeHints = authoritativePrivateRouteHints(
             routeHints,
             targetBinding: targetBinding,
             at: clock
         )
+        routeHints.append(contentsOf: await customPrivateRouteHints(
+            targetBinding: targetBinding,
+            at: clock
+        ))
         let pathSnapshot = try await availableNetworkPathSnapshot(
             for: targetBinding.pathHints + routeHints,
             at: clock
@@ -280,6 +292,58 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             }
             return directPorts?.replacingPort(in: hint)
         }
+    }
+
+    /// Resolves explicit addresses only after broker discovery authenticated
+    /// this exact Mac tuple. The broker's current UDP port is authoritative;
+    /// the configured address contributes reachability only.
+    private func customPrivateRouteHints(
+        targetBinding: CmxIrohBrokerBinding,
+        at clock: Date
+    ) async -> [CmxIrohPathHint] {
+        guard let customPrivateFallback,
+              let directPorts = freshDirectPorts(
+                  targetBinding: targetBinding,
+                  at: clock
+              ) else { return [] }
+        let configured = await customPrivateFallback(targetBinding.deviceID)
+        var hints: [CmxIrohPathHint] = []
+        for path in configured.prefix(CmxAttachEndpoint.maximumIrohPathHintCount) {
+            let port: UInt16?
+            switch path.address.family {
+            case .ipv4: port = directPorts.ipv4
+            case .ipv6: port = directPorts.ipv6
+            }
+            guard let port,
+                  let hint = try? CmxIrohPathHint(
+                      kind: .directAddress,
+                      value: path.address.socketAddress(port: port),
+                      source: .customVPN,
+                      privacyScope: .privateNetwork,
+                      observedAt: clock,
+                      expiresAt: clock.addingTimeInterval(
+                          CmxIrohPathHint.maximumPrivateHintTTL
+                      ),
+                      networkProfile: path.networkProfile
+                  ),
+                  !hints.contains(hint) else { continue }
+            hints.append(hint)
+        }
+        return hints
+    }
+
+    private func freshDirectPorts(
+        targetBinding: CmxIrohBrokerBinding,
+        at clock: Date
+    ) -> CmxIrohDirectPorts? {
+        guard let lastSeenAt = CmxIrohISO8601Date.parse(targetBinding.lastSeenAt),
+              lastSeenAt <= clock.addingTimeInterval(
+                  CmxIrohPathHint.maximumObservationClockSkew
+              ),
+              lastSeenAt >= clock.addingTimeInterval(
+                  -CmxIrohPathHint.maximumPrivateHintTTL
+              ) else { return nil }
+        return targetBinding.directPorts
     }
 
     private func cachedPolicy(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomPrivatePathProviderTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomPrivatePathProviderTests.swift
@@ -1,0 +1,216 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+extension CmxIrohRegistryContextProviderTests {
+    @Test
+    func customPrivateAddressesUseAuthenticatedMacPortsAndIdentity() async throws {
+        let fixture = try RegistryFixture()
+        let profile = try CmxIrohNetworkProfileKey(
+            source: .customVPN,
+            profileID: opaqueProfileID("custom-private")
+        )
+        let recorder = try TestCustomPrivateFallbackRecorder(
+            paths: ["10.0.0.8", "fd00::8"].map {
+                try CmxIrohCustomPrivatePathBootstrap(
+                    address: CmxIrohCustomPrivateAddress($0),
+                    networkProfile: profile
+                )
+            }
+        )
+        let broker = TestIrohRegistryBroker(
+            discovery: try fixture.discovery(
+                targetHints: [],
+                targetDirectPorts: ["ipv4": 50_909, "ipv6": 54_750]
+            ),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = CmxIrohRegistryContextProvider(
+            supervisor: try await fixture.activeSupervisor(),
+            broker: broker,
+            localBindingExpectation: try fixture.localExpectation(),
+            managedRelayURLs: [fixture.relayURL],
+            networkPathSnapshot: {
+                CmxIrohNetworkPathSnapshot(
+                    generation: 7,
+                    activeNetworkProfiles: [profile]
+                )
+            },
+            customPrivateFallback: { deviceID in
+                await recorder.paths(for: deviceID)
+            },
+            now: { fixture.now }
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        #expect(await recorder.requestedDeviceIDs() == [fixture.acceptor.deviceID])
+        #expect(context.dialPlan.privateFallbackPaths.map(\.value) == [
+            "10.0.0.8:50909",
+            "[fd00::8]:54750",
+        ])
+        #expect(context.dialPlan.privateFallbackPaths.allSatisfy {
+            $0.source == .customVPN
+                && $0.privacyScope == .privateNetwork
+                && $0.networkProfile == profile
+        })
+        let authorization = try #require(context.privateFallbackAuthorization)
+        #expect(authorization.networkPathSnapshot.generation == 7)
+
+        await #expect(throws: CmxIrohRegistryContextError.targetDeviceMismatch) {
+            try await provider.context(for: fixture.request(
+                hints: [],
+                expectedPeerDeviceID: "123e4567-e89b-42d3-a456-426614174099"
+            ))
+        }
+        #expect(await recorder.requestedDeviceIDs() == [fixture.acceptor.deviceID])
+    }
+
+    @Test
+    func customPrivateAddressCannotGuessMissingOrStaleBrokerPort() async throws {
+        let fixture = try RegistryFixture()
+        let profile = try CmxIrohNetworkProfileKey(
+            source: .customVPN,
+            profileID: opaqueProfileID("custom-private")
+        )
+        let path = try CmxIrohCustomPrivatePathBootstrap(
+            address: CmxIrohCustomPrivateAddress("10.0.0.8"),
+            networkProfile: profile
+        )
+        let stale = fixture.now.addingTimeInterval(
+            -(CmxIrohPathHint.maximumPrivateHintTTL + 1)
+        )
+        let cases: [(String, [String: Int]?, Date?)] = [
+            ("missing", nil, nil),
+            ("wrong family", ["ipv6": 54_750], nil),
+            ("stale", ["ipv4": 50_909], stale),
+        ]
+
+        for (name, directPorts, lastSeenAt) in cases {
+            let broker = TestIrohRegistryBroker(
+                discovery: try fixture.discovery(
+                    targetHints: [],
+                    targetDirectPorts: directPorts,
+                    targetLastSeenAt: lastSeenAt
+                ),
+                pairGrantResponses: [try fixture.pairGrantResponse(
+                    issuedAt: fixture.nowSeconds,
+                    expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+                )]
+            )
+            let provider = CmxIrohRegistryContextProvider(
+                supervisor: try await fixture.activeSupervisor(),
+                broker: broker,
+                localBindingExpectation: try fixture.localExpectation(),
+                managedRelayURLs: [fixture.relayURL],
+                networkPathSnapshot: {
+                    CmxIrohNetworkPathSnapshot(
+                        generation: 7,
+                        activeNetworkProfiles: [profile]
+                    )
+                },
+                customPrivateFallback: { _ in [path] },
+                now: { fixture.now }
+            )
+
+            let context = try await provider.context(for: fixture.request(hints: []))
+
+            #expect(context.dialPlan.privateFallbackPaths.isEmpty, Comment(rawValue: name))
+            #expect(context.privateFallbackAuthorization == nil, Comment(rawValue: name))
+        }
+    }
+
+    @Test
+    func customPrivateConfigurationGenerationChangeRevokesAuthorization() async throws {
+        let fixture = try RegistryFixture()
+        let profile = try CmxIrohNetworkProfileKey(
+            source: .customVPN,
+            profileID: opaqueProfileID("custom-private")
+        )
+        let path = try CmxIrohCustomPrivatePathBootstrap(
+            address: CmxIrohCustomPrivateAddress("10.0.0.8"),
+            networkProfile: profile
+        )
+        let customState = TestCustomPrivateSnapshotState(
+            CmxIrohCustomPrivatePathSnapshot(
+                generation: 2,
+                configurations: [],
+                activeNetworkProfiles: [profile]
+            )
+        )
+        let composer = CmxIrohNetworkPathSnapshotComposer()
+        let broker = TestIrohRegistryBroker(
+            discovery: try fixture.discovery(
+                targetHints: [],
+                targetDirectPorts: ["ipv4": 50_909]
+            ),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = CmxIrohRegistryContextProvider(
+            supervisor: try await fixture.activeSupervisor(),
+            broker: broker,
+            localBindingExpectation: try fixture.localExpectation(),
+            managedRelayURLs: [fixture.relayURL],
+            networkPathSnapshot: {
+                await composer.compose(
+                    platform: CmxIrohNetworkPathSnapshot(
+                        generation: 11,
+                        activeNetworkProfiles: []
+                    ),
+                    custom: await customState.snapshot()
+                )
+            },
+            customPrivateFallback: { _ in [path] },
+            now: { fixture.now }
+        )
+        let context = try await provider.context(for: fixture.request(hints: []))
+        let authorization = try #require(context.privateFallbackAuthorization)
+
+        await customState.set(CmxIrohCustomPrivatePathSnapshot(
+            generation: 3,
+            configurations: [],
+            activeNetworkProfiles: []
+        ))
+
+        await #expect(throws: CmxIrohPrivateFallbackValidationError.generationChanged) {
+            try await provider.validatePrivateFallback(authorization)
+        }
+    }
+}
+
+private actor TestCustomPrivateFallbackRecorder {
+    private let configuredPaths: [CmxIrohCustomPrivatePathBootstrap]
+    private var deviceIDs: [String] = []
+
+    init(paths: [CmxIrohCustomPrivatePathBootstrap]) throws {
+        configuredPaths = paths
+    }
+
+    func paths(for deviceID: String) -> [CmxIrohCustomPrivatePathBootstrap] {
+        deviceIDs.append(deviceID)
+        return configuredPaths
+    }
+
+    func requestedDeviceIDs() -> [String] { deviceIDs }
+}
+
+private actor TestCustomPrivateSnapshotState {
+    private var value: CmxIrohCustomPrivatePathSnapshot
+
+    init(_ value: CmxIrohCustomPrivatePathSnapshot) {
+        self.value = value
+    }
+
+    func snapshot() -> CmxIrohCustomPrivatePathSnapshot { value }
+
+    func set(_ value: CmxIrohCustomPrivatePathSnapshot) {
+        self.value = value
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomPrivatePathStoreTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomPrivatePathStoreTests.swift
@@ -1,0 +1,172 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohCustomPrivatePathStoreTests {
+    private let macA = "123e4567-e89b-42d3-a456-426614174004"
+    private let macB = "123e4567-e89b-42d3-a456-426614174005"
+
+    @Test
+    func preferencesRemainDeviceLocalAccountScopedAndExactMacScoped() async throws {
+        let installState = CustomPrivatePathMemoryStore()
+        let store = CmxIrohCustomPrivatePathStore(store: installState)
+        let saved = try await store.upsert(
+            CmxIrohCustomPrivatePathDraft(
+                macDeviceID: macA.uppercased(),
+                macDisplayName: " Work Mac ",
+                addresses: ["10.0.0.8", "10.0.0.8", "fd00::8"],
+                isEnabled: true
+            ),
+            accountID: "account-a"
+        )
+
+        #expect(saved.generation == 2)
+        #expect(saved.configurations.count == 1)
+        #expect(saved.configurations[0].macDeviceID == macA)
+        #expect(saved.configurations[0].macDisplayName == "Work Mac")
+        #expect(saved.configurations[0].addresses.map(\.value) == ["10.0.0.8", "fd00::8"])
+        #expect(saved.activeNetworkProfiles.count == 1)
+        #expect(await store.enabledPaths(
+            forMacDeviceID: macA,
+            accountID: "account-a"
+        ).map(\.address.value) == ["10.0.0.8", "fd00::8"])
+        #expect(await store.enabledPaths(
+            forMacDeviceID: macB,
+            accountID: "account-a"
+        ).isEmpty)
+        #expect(await store.enabledPaths(
+            forMacDeviceID: macA,
+            accountID: "account-b"
+        ).isEmpty)
+
+        let restored = CmxIrohCustomPrivatePathStore(store: installState)
+        #expect(try await restored.snapshot(accountID: "account-a") == saved)
+    }
+
+    @Test
+    func disabledAndRemovedPreferencesRevokeProfileAuthority() async throws {
+        let store = CmxIrohCustomPrivatePathStore(
+            store: CustomPrivatePathMemoryStore()
+        )
+        _ = try await store.upsert(
+            CmxIrohCustomPrivatePathDraft(
+                macDeviceID: macA,
+                macDisplayName: "Work Mac",
+                addresses: ["10.0.0.8"],
+                isEnabled: false
+            ),
+            accountID: "account-a"
+        )
+        let disabled = try await store.snapshot(accountID: "account-a")
+        #expect(disabled.activeNetworkProfiles.isEmpty)
+        #expect(await store.enabledPaths(
+            forMacDeviceID: macA,
+            accountID: "account-a"
+        ).isEmpty)
+
+        let removed = try await store.remove(
+            macDeviceID: macA,
+            accountID: "account-a"
+        )
+        #expect(removed.generation == disabled.generation + 1)
+        #expect(removed.configurations.isEmpty)
+        #expect(removed.activeNetworkProfiles.isEmpty)
+    }
+
+    @Test
+    func invalidInputCannotEnterPersistence() async {
+        let store = CmxIrohCustomPrivatePathStore(
+            store: CustomPrivatePathMemoryStore()
+        )
+        for addresses in [
+            ["private.example.com"],
+            ["127.0.0.1"],
+            ["10.0.0.8:49152"],
+        ] {
+            await #expect(throws: CmxIrohCustomPrivateAddressError.invalidAddress) {
+                _ = try await store.upsert(
+                    CmxIrohCustomPrivatePathDraft(
+                        macDeviceID: macA,
+                        macDisplayName: "Work Mac",
+                        addresses: addresses,
+                        isEnabled: true
+                    ),
+                    accountID: "account-a"
+                )
+            }
+        }
+    }
+
+    @Test
+    func malformedDeviceLocalStateFailsClosed() async throws {
+        let installState = CustomPrivatePathMemoryStore()
+        let scope = try CmxIrohRelayStorageScope.account(
+            "account-a",
+            prefix: "custom-private-paths"
+        )
+        installState.set("not-base64", forKey: scope)
+        let store = CmxIrohCustomPrivatePathStore(store: installState)
+
+        #expect(await store.availableSnapshot(accountID: "account-a") == .unavailable)
+        #expect(await store.enabledPaths(
+            forMacDeviceID: macA,
+            accountID: "account-a"
+        ).isEmpty)
+    }
+
+    @Test
+    func composerChangesGenerationWhenEitherAuthorityChanges() async throws {
+        let platformProfile = try CmxIrohNetworkProfileKey(
+            source: .tailscale,
+            profileID: opaqueProfileID("platform")
+        )
+        let customProfile = try CmxIrohNetworkProfileKey(
+            source: .customVPN,
+            profileID: opaqueProfileID("custom")
+        )
+        let composer = CmxIrohNetworkPathSnapshotComposer()
+        let platform = CmxIrohNetworkPathSnapshot(
+            generation: 8,
+            activeNetworkProfiles: [platformProfile]
+        )
+        let custom = CmxIrohCustomPrivatePathSnapshot(
+            generation: 2,
+            configurations: [],
+            activeNetworkProfiles: [customProfile]
+        )
+
+        let first = await composer.compose(platform: platform, custom: custom)
+        let same = await composer.compose(platform: platform, custom: custom)
+        let changed = await composer.compose(
+            platform: platform,
+            custom: CmxIrohCustomPrivatePathSnapshot(
+                generation: 3,
+                configurations: [],
+                activeNetworkProfiles: []
+            )
+        )
+
+        #expect(first.generation == same.generation)
+        #expect(first.activeNetworkProfiles == [platformProfile, customProfile])
+        #expect(changed.generation == first.generation + 1)
+        #expect(changed.activeNetworkProfiles == [platformProfile])
+    }
+}
+
+private final class CustomPrivatePathMemoryStore:
+    CmxIrohInstallStateStoring,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var values: [String: String] = [:]
+
+    func string(forKey key: String) -> String? {
+        lock.withLock { values[key] }
+    }
+
+    func set(_ value: String?, forKey key: String) {
+        lock.withLock { values[key] = value }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohCustomPrivatePathEditor.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohCustomPrivatePathEditor.swift
@@ -14,6 +14,12 @@ struct MobileIrohCustomPrivatePathEditor: View {
     @State private var addressesText: String
     @State private var isEnabled: Bool
     @State private var isSaving = false
+    @State private var validation: Validation
+
+    struct Validation: Equatable {
+        let addresses: [String]
+        let canSave: Bool
+    }
 
     init(
         path: CmxIrohSettingsSnapshot.CustomPrivateNetwork?,
@@ -23,11 +29,15 @@ struct MobileIrohCustomPrivatePathEditor: View {
         existing = path
         self.availableMacs = availableMacs
         self.onSave = onSave
-        _selectedMacDeviceID = State(
-            initialValue: path?.macDeviceID ?? availableMacs.first?.id ?? ""
-        )
-        _addressesText = State(initialValue: path?.addresses.joined(separator: "\n") ?? "")
+        let selectedMacDeviceID = path?.macDeviceID ?? availableMacs.first?.id ?? ""
+        let addressesText = path?.addresses.joined(separator: "\n") ?? ""
+        _selectedMacDeviceID = State(initialValue: selectedMacDeviceID)
+        _addressesText = State(initialValue: addressesText)
         _isEnabled = State(initialValue: path?.isEnabled ?? false)
+        _validation = State(initialValue: Self.validate(
+            addressesText: addressesText,
+            selectedMacDeviceID: selectedMacDeviceID
+        ))
     }
 
     var body: some View {
@@ -103,24 +113,34 @@ struct MobileIrohCustomPrivatePathEditor: View {
                     Button(L10n.string("mobile.common.save", defaultValue: "Save")) {
                         save()
                     }
-                    .disabled(!isValid || isSaving)
+                    .disabled(!validation.canSave || isSaving)
                 }
             }
+            .onChange(of: addressesText) { _, _ in refreshValidation() }
+            .onChange(of: selectedMacDeviceID) { _, _ in refreshValidation() }
         }
     }
 
-    private var addresses: [String] {
-        addressesText
+    static func validate(
+        addressesText: String,
+        selectedMacDeviceID: String
+    ) -> Validation {
+        let addresses = addressesText
             .split(whereSeparator: { $0.isNewline })
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+        let canSave = !selectedMacDeviceID.isEmpty
+            && !addresses.isEmpty
+            && addresses.count <= CmxIrohCustomPrivatePathDraft.maximumAddressCount
+            && addresses.allSatisfy { (try? CmxIrohCustomPrivateAddress($0)) != nil }
+        return Validation(addresses: addresses, canSave: canSave)
     }
 
-    private var isValid: Bool {
-        !selectedMacDeviceID.isEmpty
-            && !addresses.isEmpty
-            && addresses.count <= 8
-            && addresses.allSatisfy { (try? CmxIrohCustomPrivateAddress($0)) != nil }
+    private func refreshValidation() {
+        validation = Self.validate(
+            addressesText: addressesText,
+            selectedMacDeviceID: selectedMacDeviceID
+        )
     }
 
     private func displayName(_ value: String) -> String {
@@ -130,13 +150,13 @@ struct MobileIrohCustomPrivatePathEditor: View {
     }
 
     private func save() {
-        guard isValid, !isSaving else { return }
+        guard validation.canSave, !isSaving else { return }
         let mac = availableMacs.first { $0.id == selectedMacDeviceID }
         let displayName = existing?.macDisplayName ?? mac?.displayName ?? ""
         let draft = CmxIrohCustomPrivatePathDraft(
             macDeviceID: selectedMacDeviceID,
             macDisplayName: displayName,
-            addresses: addresses,
+            addresses: validation.addresses,
             isEnabled: isEnabled
         )
         isSaving = true

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohCustomPrivatePathEditor.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohCustomPrivatePathEditor.swift
@@ -1,0 +1,149 @@
+#if os(iOS)
+import CMUXMobileCore
+import CmuxMobileSupport
+import SwiftUI
+
+@MainActor
+struct MobileIrohCustomPrivatePathEditor: View {
+    private let existing: CmxIrohSettingsSnapshot.CustomPrivateNetwork?
+    private let availableMacs: [CmxIrohSettingsSnapshot.PrivateNetworkMac]
+    private let onSave: (CmxIrohCustomPrivatePathDraft) async -> Bool
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedMacDeviceID: String
+    @State private var addressesText: String
+    @State private var isEnabled: Bool
+    @State private var isSaving = false
+
+    init(
+        path: CmxIrohSettingsSnapshot.CustomPrivateNetwork?,
+        availableMacs: [CmxIrohSettingsSnapshot.PrivateNetworkMac],
+        onSave: @escaping (CmxIrohCustomPrivatePathDraft) async -> Bool
+    ) {
+        existing = path
+        self.availableMacs = availableMacs
+        self.onSave = onSave
+        _selectedMacDeviceID = State(
+            initialValue: path?.macDeviceID ?? availableMacs.first?.id ?? ""
+        )
+        _addressesText = State(initialValue: path?.addresses.joined(separator: "\n") ?? "")
+        _isEnabled = State(initialValue: path?.isEnabled ?? false)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    if let existing {
+                        LabeledContent(
+                            L10n.string(
+                                "mobile.iroh.private.custom.mac",
+                                defaultValue: "Mac"
+                            ),
+                            value: displayName(existing.macDisplayName)
+                        )
+                    } else {
+                        Picker(
+                            L10n.string(
+                                "mobile.iroh.private.custom.mac",
+                                defaultValue: "Mac"
+                            ),
+                            selection: $selectedMacDeviceID
+                        ) {
+                            ForEach(availableMacs) { mac in
+                                Text(displayName(mac.displayName))
+                                    .tag(mac.id)
+                            }
+                        }
+                    }
+                }
+
+                Section {
+                    TextEditor(text: $addressesText)
+                        .frame(minHeight: 110)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .accessibilityIdentifier("MobileIrohCustomPrivateAddresses")
+                    Toggle(
+                        L10n.string(
+                            "mobile.iroh.private.custom.enabled",
+                            defaultValue: "Use These Addresses"
+                        ),
+                        isOn: $isEnabled
+                    )
+                } header: {
+                    Text(L10n.string(
+                        "mobile.iroh.private.custom.addresses",
+                        defaultValue: "Numeric IP Addresses"
+                    ))
+                } footer: {
+                    Text(L10n.string(
+                        "mobile.iroh.private.custom.addresses.footer",
+                        defaultValue: "Enter one IPv4 or IPv6 address per line, without a port. cmux combines it with the Mac's current broker-authenticated Iroh UDP port."
+                    ))
+                }
+            }
+            .navigationTitle(existing == nil
+                ? L10n.string(
+                    "mobile.iroh.private.custom.add",
+                    defaultValue: "Add Private Addresses"
+                )
+                : L10n.string(
+                    "mobile.iroh.private.custom.edit",
+                    defaultValue: "Edit Private Addresses"
+                ))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel")) {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(L10n.string("mobile.common.save", defaultValue: "Save")) {
+                        save()
+                    }
+                    .disabled(!isValid || isSaving)
+                }
+            }
+        }
+    }
+
+    private var addresses: [String] {
+        addressesText
+            .split(whereSeparator: { $0.isNewline })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private var isValid: Bool {
+        !selectedMacDeviceID.isEmpty
+            && !addresses.isEmpty
+            && addresses.count <= 8
+            && addresses.allSatisfy { (try? CmxIrohCustomPrivateAddress($0)) != nil }
+    }
+
+    private func displayName(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return L10n.string("mobile.iroh.private.custom.unnamedMac", defaultValue: "Mac")
+    }
+
+    private func save() {
+        guard isValid, !isSaving else { return }
+        let mac = availableMacs.first { $0.id == selectedMacDeviceID }
+        let displayName = existing?.macDisplayName ?? mac?.displayName ?? ""
+        let draft = CmxIrohCustomPrivatePathDraft(
+            macDeviceID: selectedMacDeviceID,
+            macDisplayName: displayName,
+            addresses: addresses,
+            isEnabled: isEnabled
+        )
+        isSaving = true
+        Task {
+            if await onSave(draft) { dismiss() }
+            isSaving = false
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohPrivateNetworksSection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohPrivateNetworksSection.swift
@@ -1,0 +1,105 @@
+#if os(iOS)
+import CMUXMobileCore
+import CmuxMobileSupport
+import SwiftUI
+
+@MainActor
+struct MobileIrohPrivateNetworksSection: View {
+    let configurations: [CmxIrohSettingsSnapshot.CustomPrivateNetwork]
+    let availableMacs: [CmxIrohSettingsSnapshot.PrivateNetworkMac]
+    let edit: (String) -> Void
+    let add: () -> Void
+    let setEnabled: (CmxIrohSettingsSnapshot.CustomPrivateNetwork, Bool) -> Void
+    let requestRemoval: (String) -> Void
+
+    var body: some View {
+        Section {
+            LabeledContent(
+                L10n.string("mobile.iroh.private.lan", defaultValue: "Local Network Discovery"),
+                value: L10n.string(
+                    "mobile.iroh.private.automatic",
+                    defaultValue: "Automatic"
+                )
+            )
+            LabeledContent(
+                L10n.string(
+                    "mobile.iroh.private.tailscale",
+                    defaultValue: "Tailscale Compatibility"
+                ),
+                value: L10n.string(
+                    "mobile.iroh.private.tailscale.active",
+                    defaultValue: "When Tailscale Is Active"
+                )
+            )
+
+            ForEach(configurations) { configuration in
+                HStack {
+                    Toggle(isOn: Binding(
+                        get: { configuration.isEnabled },
+                        set: { setEnabled(configuration, $0) }
+                    )) {
+                        VStack(alignment: .leading) {
+                            Text(displayName(configuration))
+                            Text(configuration.addresses.joined(separator: ", "))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                    }
+                    Menu {
+                        Button(L10n.string("mobile.common.edit", defaultValue: "Edit")) {
+                            edit(configuration.macDeviceID)
+                        }
+                        Button(
+                            L10n.string("mobile.common.remove", defaultValue: "Remove"),
+                            role: .destructive
+                        ) {
+                            requestRemoval(configuration.macDeviceID)
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                    .accessibilityLabel(
+                        L10n.string("mobile.common.actions", defaultValue: "Actions")
+                    )
+                }
+            }
+
+            Button(action: add) {
+                Label(
+                    L10n.string(
+                        "mobile.iroh.private.custom.add",
+                        defaultValue: "Add Private Addresses"
+                    ),
+                    systemImage: "plus"
+                )
+            }
+            .disabled(unconfiguredMacs.isEmpty)
+            .accessibilityIdentifier("MobileIrohAddCustomPrivatePath")
+        } header: {
+            Text(L10n.string("mobile.iroh.private", defaultValue: "Private Networks"))
+        } footer: {
+            Text(L10n.string(
+                "mobile.iroh.private.footer",
+                defaultValue: "Private addresses stay on this device and are fallback paths only. cmux pins the Mac's broker-authenticated Iroh EndpointID and current UDP port; an address never proves identity."
+            ))
+        }
+    }
+
+    var unconfiguredMacs: [CmxIrohSettingsSnapshot.PrivateNetworkMac] {
+        let configuredIDs = Set(configurations.map(\.macDeviceID))
+        return availableMacs.filter { !configuredIDs.contains($0.id) }
+    }
+
+    private func displayName(
+        _ configuration: CmxIrohSettingsSnapshot.CustomPrivateNetwork
+    ) -> String {
+        let trimmed = configuration.macDisplayName.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        return trimmed.isEmpty
+            ? L10n.string("mobile.iroh.private.custom.unnamedMac", defaultValue: "Mac")
+            : trimmed
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
@@ -76,6 +76,22 @@ final class MobileIrohSettingsModel {
         Task { testResults[id] = await controller.testIrohCustomRelay(id: id) }
     }
 
+    func upsertCustomPrivatePath(
+        _ path: CmxIrohCustomPrivatePathDraft
+    ) async -> Bool {
+        await mutateAndWait {
+            try await self.controller.upsertIrohCustomPrivatePath(path)
+        }
+    }
+
+    func removeCustomPrivatePath(macDeviceID: String) {
+        mutate {
+            try await self.controller.removeIrohCustomPrivatePath(
+                macDeviceID: macDeviceID
+            )
+        }
+    }
+
     func clearSaveError() {
         showsSaveError = false
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -9,6 +9,9 @@ struct MobileIrohSettingsView: View {
     @State private var showsCustomEditor = false
     @State private var editedCustomRelayID: String?
     @State private var pendingCustomRemovalID: String?
+    @State private var showsPrivatePathEditor = false
+    @State private var editedPrivatePathMacDeviceID: String?
+    @State private var pendingPrivatePathRemovalMacDeviceID: String?
 
     init(controller: any CmxIrohSettingsControlling) {
         _model = State(initialValue: MobileIrohSettingsModel(controller: controller))
@@ -91,23 +94,30 @@ struct MobileIrohSettingsView: View {
                 ))
             }
 
-            Section {
-                LabeledContent(
-                    L10n.string("mobile.iroh.private.iroh", defaultValue: "Iroh Private Paths"),
-                    value: L10n.string("mobile.iroh.private.automatic", defaultValue: "Automatic")
-                )
-                LabeledContent(
-                    L10n.string("mobile.iroh.private.tailscale", defaultValue: "Tailscale Compatibility"),
-                    value: L10n.string("mobile.iroh.private.automatic", defaultValue: "Automatic")
-                )
-            } header: {
-                Text(L10n.string("mobile.iroh.private", defaultValue: "Private Networks"))
-            } footer: {
-                Text(L10n.string(
-                    "mobile.iroh.private.footer",
-                    defaultValue: "Iroh discovers LAN and VPN paths after authenticating the Mac. Custom raw TCP routes are not accepted because they cannot prove the remote Mac."
-                ))
-            }
+            MobileIrohPrivateNetworksSection(
+                configurations: model.snapshot.customPrivateNetworks,
+                availableMacs: model.snapshot.privateNetworkMacs,
+                edit: { macDeviceID in
+                    editedPrivatePathMacDeviceID = macDeviceID
+                    showsPrivatePathEditor = true
+                },
+                add: {
+                    editedPrivatePathMacDeviceID = nil
+                    showsPrivatePathEditor = true
+                },
+                setEnabled: { configuration, isEnabled in
+                    let draft = CmxIrohCustomPrivatePathDraft(
+                        macDeviceID: configuration.macDeviceID,
+                        macDisplayName: configuration.macDisplayName,
+                        addresses: configuration.addresses,
+                        isEnabled: isEnabled
+                    )
+                    Task { _ = await model.upsertCustomPrivatePath(draft) }
+                },
+                requestRemoval: { macDeviceID in
+                    pendingPrivatePathRemovalMacDeviceID = macDeviceID
+                }
+            )
 
             #if DEBUG
             if let mode = model.snapshot.debugTransportVerificationMode {
@@ -142,6 +152,14 @@ struct MobileIrohSettingsView: View {
                 await model.upsertCustomRelay(relay, deviceSecret: secret)
             }
         }
+        .sheet(isPresented: $showsPrivatePathEditor) {
+            MobileIrohCustomPrivatePathEditor(
+                path: editedPrivatePath,
+                availableMacs: privatePathEditorMacs
+            ) { path in
+                await model.upsertCustomPrivatePath(path)
+            }
+        }
         .alert(
             L10n.string("mobile.iroh.saveFailed", defaultValue: "Could Not Save Networking Settings"),
             isPresented: Binding(
@@ -153,7 +171,7 @@ struct MobileIrohSettingsView: View {
         } message: {
             Text(L10n.string(
                 "mobile.iroh.saveFailed.message",
-                defaultValue: "Your previous networking configuration is still active. Check your account connection and values, then try again."
+                defaultValue: "Your previous networking configuration is still active. Check the values, then try again."
             ))
         }
         .confirmationDialog(
@@ -166,6 +184,26 @@ struct MobileIrohSettingsView: View {
             Button(L10n.string("mobile.common.remove", defaultValue: "Remove"), role: .destructive) {
                 if let id = pendingCustomRemovalID { model.removeCustomRelay(id: id) }
                 pendingCustomRemovalID = nil
+            }
+        }
+        .confirmationDialog(
+            L10n.string(
+                "mobile.iroh.private.custom.remove.confirm",
+                defaultValue: "Remove these private addresses?"
+            ),
+            isPresented: Binding(
+                get: { pendingPrivatePathRemovalMacDeviceID != nil },
+                set: { if !$0 { pendingPrivatePathRemovalMacDeviceID = nil } }
+            )
+        ) {
+            Button(
+                L10n.string("mobile.common.remove", defaultValue: "Remove"),
+                role: .destructive
+            ) {
+                if let macDeviceID = pendingPrivatePathRemovalMacDeviceID {
+                    model.removeCustomPrivatePath(macDeviceID: macDeviceID)
+                }
+                pendingPrivatePathRemovalMacDeviceID = nil
             }
         }
     }
@@ -217,6 +255,26 @@ struct MobileIrohSettingsView: View {
     private var editedCustomRelay: CmxIrohSettingsSnapshot.CustomRelay? {
         guard let editedCustomRelayID else { return nil }
         return model.snapshot.customRelays.first { $0.id == editedCustomRelayID }
+    }
+
+    private var editedPrivatePath: CmxIrohSettingsSnapshot.CustomPrivateNetwork? {
+        guard let editedPrivatePathMacDeviceID else { return nil }
+        return model.snapshot.customPrivateNetworks.first {
+            $0.macDeviceID == editedPrivatePathMacDeviceID
+        }
+    }
+
+    private var privatePathEditorMacs: [CmxIrohSettingsSnapshot.PrivateNetworkMac] {
+        if let editedPrivatePath {
+            return [.init(
+                id: editedPrivatePath.macDeviceID,
+                displayName: editedPrivatePath.macDisplayName
+            )]
+        }
+        let configuredIDs = Set(model.snapshot.customPrivateNetworks.map(\.macDeviceID))
+        return model.snapshot.privateNetworkMacs.filter {
+            !configuredIDs.contains($0.id)
+        }
     }
 
     private func customRelaySubtitle(_ relay: CmxIrohSettingsSnapshot.CustomRelay) -> String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -596,6 +596,153 @@
         }
       }
     },
+    "mobile.common.actions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Actions" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "操作" } }
+      }
+    },
+    "mobile.common.cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "キャンセル" } }
+      }
+    },
+    "mobile.common.edit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Edit" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "編集" } }
+      }
+    },
+    "mobile.common.remove" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "削除" } }
+      }
+    },
+    "mobile.common.save" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Save" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存" } }
+      }
+    },
+    "mobile.iroh.private" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Private Networks" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートネットワーク" } }
+      }
+    },
+    "mobile.iroh.private.automatic" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Automatic" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "自動" } }
+      }
+    },
+    "mobile.iroh.private.custom.add" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Add Private Addresses" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートアドレスを追加" } }
+      }
+    },
+    "mobile.iroh.private.custom.addresses" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Numeric IP Addresses" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "数値形式のIPアドレス" } }
+      }
+    },
+    "mobile.iroh.private.custom.addresses.footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter one IPv4 or IPv6 address per line, without a port. cmux combines it with the Mac's current broker-authenticated Iroh UDP port." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "IPv4またはIPv6アドレスをポートなしで1行に1つ入力してください。cmuxはそのアドレスを、ブローカーが認証したMacの現在のIroh UDPポートと組み合わせます。" } }
+      }
+    },
+    "mobile.iroh.private.custom.edit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Edit Private Addresses" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートアドレスを編集" } }
+      }
+    },
+    "mobile.iroh.private.custom.enabled" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Use These Addresses" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "これらのアドレスを使用" } }
+      }
+    },
+    "mobile.iroh.private.custom.mac" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Mac" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Mac" } }
+      }
+    },
+    "mobile.iroh.private.custom.remove.confirm" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove these private addresses?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "これらのプライベートアドレスを削除しますか？" } }
+      }
+    },
+    "mobile.iroh.private.custom.unnamedMac" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Mac" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Mac" } }
+      }
+    },
+    "mobile.iroh.private.footer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Private addresses stay on this device and are fallback paths only. cmux pins the Mac's broker-authenticated Iroh EndpointID and current UDP port; an address never proves identity." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートアドレスはこのデバイス内にのみ保存され、フォールバック経路としてのみ使用されます。cmuxはブローカーが認証したMacのIroh EndpointIDと現在のUDPポートを固定します。アドレス自体を本人確認には使用しません。" } }
+      }
+    },
+    "mobile.iroh.private.lan" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Local Network Discovery" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ローカルネットワーク検出" } }
+      }
+    },
+    "mobile.iroh.private.tailscale" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Tailscale Compatibility" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Tailscale互換性" } }
+      }
+    },
+    "mobile.iroh.private.tailscale.active" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "When Tailscale Is Active" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Tailscaleが有効な場合" } }
+      }
+    },
+    "mobile.iroh.saveFailed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Could Not Save Networking Settings" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ネットワーク設定を保存できませんでした" } }
+      }
+    },
+    "mobile.iroh.saveFailed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Your previous networking configuration is still active. Check the values, then try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "以前のネットワーク設定は引き続き有効です。入力内容を確認して、もう一度お試しください。" } }
+      }
+    },
     "mobile.iroh.diagnostics.clear" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohCustomPrivatePathEditorTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohCustomPrivatePathEditorTests.swift
@@ -1,0 +1,29 @@
+#if os(iOS)
+import CMUXMobileCore
+import Testing
+@testable import CmuxMobileShellUI
+
+@Test @MainActor
+func customPrivatePathEditorValidationUsesSharedAddressLimit() {
+    let addresses = (1 ... CmxIrohCustomPrivatePathDraft.maximumAddressCount)
+        .map { "10.0.0.\($0)" }
+    let valid = MobileIrohCustomPrivatePathEditor.validate(
+        addressesText: addresses.joined(separator: "\n"),
+        selectedMacDeviceID: "123e4567-e89b-42d3-a456-426614174004"
+    )
+    #expect(valid.canSave)
+    #expect(valid.addresses == addresses)
+
+    let tooMany = MobileIrohCustomPrivatePathEditor.validate(
+        addressesText: (addresses + ["10.0.0.9"]).joined(separator: "\n"),
+        selectedMacDeviceID: "123e4567-e89b-42d3-a456-426614174004"
+    )
+    #expect(!tooMany.canSave)
+
+    let noMac = MobileIrohCustomPrivatePathEditor.validate(
+        addressesText: "10.0.0.1",
+        selectedMacDeviceID: ""
+    )
+    #expect(!noMac.canSave)
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
@@ -89,6 +89,25 @@ struct MobileIrohSettingsModelTests {
         #expect(model.snapshot == .unavailable)
     }
 
+    @Test func customPrivatePathMutationsForwardExactMacScopedDraft() async {
+        let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
+        let model = MobileIrohSettingsModel(controller: controller)
+        let draft = CmxIrohCustomPrivatePathDraft(
+            macDeviceID: "123e4567-e89b-42d3-a456-426614174004",
+            macDisplayName: "Work Mac",
+            addresses: ["10.0.0.8", "fd00::8"],
+            isEnabled: true
+        )
+
+        #expect(await model.upsertCustomPrivatePath(draft))
+        #expect(controller.customPrivatePathUpserts == [draft])
+
+        model.removeCustomPrivatePath(macDeviceID: draft.macDeviceID)
+        await waitUntil {
+            controller.customPrivatePathRemovals == [draft.macDeviceID]
+        }
+    }
+
     @Test func observationLoadsSafeDiagnosticReportAndExportText() async {
         let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
         let report = diagnosticReport()
@@ -232,6 +251,8 @@ private final class MobileIrohSettingsControllerDouble:
     var exportData = Data()
     var diagnosticClearCount = 0
     var debugTransportModeMutations: [CmxIrohTransportVerificationMode] = []
+    var customPrivatePathUpserts: [CmxIrohCustomPrivatePathDraft] = []
+    var customPrivatePathRemovals: [String] = []
     var holdsDiagnosticReportReads = false
     private(set) var nextDiagnosticReportRequestID = 0
     private var pendingDiagnosticReportReads: [
@@ -268,6 +289,16 @@ private final class MobileIrohSettingsControllerDouble:
     }
     func removeIrohCustomRelay(id: String) async throws {}
     func testIrohCustomRelay(id: String) async -> CmxIrohRelayTestResult { .failed }
+
+    func upsertIrohCustomPrivatePath(
+        _ path: CmxIrohCustomPrivatePathDraft
+    ) async throws {
+        customPrivatePathUpserts.append(path)
+    }
+
+    func removeIrohCustomPrivatePath(macDeviceID: String) async throws {
+        customPrivatePathRemovals.append(macDeviceID)
+    }
 
     func refreshIrohSettings() async {}
 
@@ -306,6 +337,8 @@ private final class MobileIrohSettingsControllerDouble:
             preference: snapshot.preference,
             managedRelays: snapshot.managedRelays,
             customRelays: snapshot.customRelays,
+            privateNetworkMacs: snapshot.privateNetworkMacs,
+            customPrivateNetworks: snapshot.customPrivateNetworks,
             policySource: snapshot.policySource,
             policySequence: snapshot.policySequence,
             policyExpiresAt: snapshot.policyExpiresAt,

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -58,6 +58,7 @@ public final class MobileIrohRuntimeComposition:
         case unavailable
         case incompleteCustomRelay
         case missingCustomRelay
+        case unavailableCustomPrivatePath
     }
     typealias BrokerFactory = @Sendable (
         _ tokenSource: CmxIrohBrokerTokenSource
@@ -107,6 +108,8 @@ public final class MobileIrohRuntimeComposition:
     private let relayPolicyCache: CmxIrohRelayPolicyCache
     private let relayPreferenceStore: CmxIrohRelayPreferenceStore
     private let customRelayCredentials: CmxIrohCustomRelayCredentialStore
+    private let customPrivatePaths: CmxIrohCustomPrivatePathStore
+    private let networkPathSnapshotComposer: CmxIrohNetworkPathSnapshotComposer
     private let relayPolicyTrustRoot: CmxIrohRelayPolicyTrustRoot?
     private let endpointFactoryProvider:
         @MainActor (CmxIrohTransportVerificationMode) -> any CmxIrohEndpointFactory
@@ -257,6 +260,8 @@ public final class MobileIrohRuntimeComposition:
                     bundleIdentifier: bundleIdentifier
                 )
             ),
+            customPrivatePaths: CmxIrohCustomPrivatePathStore(store: installState),
+            networkPathSnapshotComposer: CmxIrohNetworkPathSnapshotComposer(),
             relayPolicyTrustRoot: Self.relayPolicyTrustRoot(
                 infoDictionary: infoDictionary
             ),
@@ -308,6 +313,9 @@ public final class MobileIrohRuntimeComposition:
         relayPolicyCache: CmxIrohRelayPolicyCache = CmxIrohRelayPolicyCache(),
         relayPreferenceStore: CmxIrohRelayPreferenceStore = CmxIrohRelayPreferenceStore(),
         customRelayCredentials: CmxIrohCustomRelayCredentialStore = CmxIrohCustomRelayCredentialStore(),
+        customPrivatePaths: CmxIrohCustomPrivatePathStore = CmxIrohCustomPrivatePathStore(),
+        networkPathSnapshotComposer: CmxIrohNetworkPathSnapshotComposer =
+            CmxIrohNetworkPathSnapshotComposer(),
         relayPolicyTrustRoot: CmxIrohRelayPolicyTrustRoot? = nil,
         endpointFactory: any CmxIrohEndpointFactory,
         endpointFactoryProvider: (
@@ -337,6 +345,8 @@ public final class MobileIrohRuntimeComposition:
         self.relayPolicyCache = relayPolicyCache
         self.relayPreferenceStore = relayPreferenceStore
         self.customRelayCredentials = customRelayCredentials
+        self.customPrivatePaths = customPrivatePaths
+        self.networkPathSnapshotComposer = networkPathSnapshotComposer
         self.relayPolicyTrustRoot = relayPolicyTrustRoot
         self.endpointFactoryProvider = endpointFactoryProvider ?? { _ in endpointFactory }
         self.transportVerificationMode = transportVerificationMode
@@ -1263,6 +1273,9 @@ public final class MobileIrohRuntimeComposition:
         let clock = now
         let activeRelayPolicyService = resolvedPolicyService
         let transportVerificationMode = transportVerificationMode
+        let customPrivatePaths = customPrivatePaths
+        let networkPathSnapshotComposer = networkPathSnapshotComposer
+        let platformNetworkPathSnapshot = networkPathSnapshot
         let runtime = try CmxIrohClientRuntime(
             factory: endpointFactoryProvider(transportVerificationMode),
             broker: broker,
@@ -1273,7 +1286,16 @@ public final class MobileIrohRuntimeComposition:
             ),
             diagnosticLog: diagnosticLog,
             offlinePolicyCache: offlinePolicies,
-            networkPathSnapshot: networkPathSnapshot,
+            networkPathSnapshot: {
+                let platform = try await platformNetworkPathSnapshot()
+                let custom = await customPrivatePaths.availableSnapshot(
+                    accountID: accountID
+                )
+                return await networkPathSnapshotComposer.compose(
+                    platform: platform,
+                    custom: custom
+                )
+            },
             lanFallback: { target, bindings, rendezvous in
                 guard let lanPeerDiscovery else { return [] }
                 switch await lanPeerDiscovery.discover(
@@ -1296,6 +1318,12 @@ public final class MobileIrohRuntimeComposition:
                 case .notFound, .policyDenied:
                     return []
                 }
+            },
+            customPrivateFallback: { expectedMacDeviceID in
+                await customPrivatePaths.enabledPaths(
+                    forMacDeviceID: expectedMacDeviceID,
+                    accountID: accountID
+                )
             },
             handleBinding: { [weak self] registration, discovery in
                 guard await self?.allowsPersistence(
@@ -1675,6 +1703,33 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
         } else {
             Optional<Set<String>>.none
         }
+        let privatePathSnapshot: CmxIrohCustomPrivatePathSnapshot
+        if let activeAccountID {
+            privatePathSnapshot = await customPrivatePaths.availableSnapshot(
+                accountID: activeAccountID
+            )
+        } else {
+            privatePathSnapshot = .unavailable
+        }
+        let liveMacs = await routeCatalog.liveMacCandidates(preferredTag: tag)
+        var privateNetworkMacsByID: [String: CmxIrohSettingsSnapshot.PrivateNetworkMac] = [:]
+        for mac in liveMacs {
+            let id = cmxCanonicalDeviceID(mac.deviceID)
+            if privateNetworkMacsByID[id] == nil {
+                privateNetworkMacsByID[id] = .init(
+                    id: id,
+                    displayName: mac.displayName ?? ""
+                )
+            }
+        }
+        for configuration in privatePathSnapshot.configurations {
+            if privateNetworkMacsByID[configuration.macDeviceID] == nil {
+                privateNetworkMacsByID[configuration.macDeviceID] = .init(
+                    id: configuration.macDeviceID,
+                    displayName: configuration.macDisplayName
+                )
+            }
+        }
         #if DEBUG
         let debugTransportVerificationMode: CmxIrohTransportVerificationMode? =
             debugDefaults == nil ? nil : transportVerificationMode
@@ -1702,6 +1757,22 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
                 configuration: configuration,
                 configuredCredentialIDs: configuredCredentialIDs
             ),
+            privateNetworkMacs: privateNetworkMacsByID.values.sorted {
+                if $0.displayName != $1.displayName {
+                    return $0.displayName.localizedCaseInsensitiveCompare(
+                        $1.displayName
+                    ) == .orderedAscending
+                }
+                return $0.id < $1.id
+            },
+            customPrivateNetworks: privatePathSnapshot.configurations.map {
+                CmxIrohSettingsSnapshot.CustomPrivateNetwork(
+                    macDeviceID: $0.macDeviceID,
+                    macDisplayName: $0.macDisplayName,
+                    addresses: $0.addresses.map(\.value),
+                    isEnabled: $0.isEnabled
+                )
+            },
             policySource: Self.settingsPolicySource(effective),
             policySequence: diagnostics?.policySequence,
             policyExpiresAt: diagnostics?.policyExpiresAt,
@@ -1847,6 +1918,32 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
         case .invalidProfile, .bindFailed, .endpointClosed, .timedOut:
             return .failed
         }
+    }
+
+    public func upsertIrohCustomPrivatePath(
+        _ path: CmxIrohCustomPrivatePathDraft
+    ) async throws {
+        guard let activeAccountID else {
+            throw SettingsError.unavailableCustomPrivatePath
+        }
+        _ = try await customPrivatePaths.upsert(
+            path,
+            accountID: activeAccountID
+        )
+        publishIrohSettingsUpdate()
+    }
+
+    public func removeIrohCustomPrivatePath(
+        macDeviceID: String
+    ) async throws {
+        guard let activeAccountID else {
+            throw SettingsError.unavailableCustomPrivatePath
+        }
+        _ = try await customPrivatePaths.remove(
+            macDeviceID: macDeviceID,
+            accountID: activeAccountID
+        )
+        publishIrohSettingsUpdate()
     }
 
     public func refreshIrohSettings() async {


### PR DESCRIPTION
Adds device-local, per-Mac custom IPv4/IPv6 fallback paths to the iOS Iroh settings.

Security properties:
- numeric addresses only, with unsafe local/multicast/wildcard coordinates rejected
- exact expected Mac device binding and broker-authenticated EndpointID remain authoritative
- the broker registration supplies the current family-specific Iroh UDP port
- path profiles and snapshot generations revoke stale authorization
- settings stay in app-local storage and never sync through the broker or account

Also corrects the private-network settings copy and preserves automatic LAN and Tailscale compatibility. English and Japanese localizations included.

Verification:
- CMUXMobileCore full Swift package tests passed
- CmuxIrohTransport full Swift package tests passed (414 tests, existing live-relay skips only)
- focused custom private-path tests passed (8)
- iOS settings model tests passed (9)
- isolated Simulator UI path passed: Settings > Iroh > Private Networks > Add Private Addresses, including disabled/enabled Save validation
- tagged macOS and isolated Simulator builds passed with tag irvpn

Residual verification gap: a true end-to-end custom VPN dial needs a separately reachable user-supplied private address and current Mac registration; composition and rejection behavior are covered in focused tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787068801&installation_id=133855650&pr_number=8487&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8487&signature=1bbd0c494b85b8d130b61de49dd731dceb7374e64488c8bd4ee05707f90b8229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds authenticated, device‑local custom private Iroh paths on iOS. Users can add per‑Mac numeric IPv4/IPv6 fallback addresses that are only used with the broker‑authenticated Mac’s EndpointID and current UDP port; LAN and Tailscale remain automatic.

- New Features
  - iOS UI: Private Networks section with add/edit per‑Mac addresses, enable toggle, validation, and EN/JA strings.
  - Strict validation: numeric IPs only; rejects hostnames, ports, loopback, multicast, link‑local, wildcard, and IPv6 zones; canonicalizes IPv4/IPv6.
  - Device‑local persistence: `CmxIrohCustomPrivatePathStore` (account‑scoped, no broker/account sync), limits 64 configs/8 addresses, generation revocation.
  - Transport integration: `CmxIrohClientRuntime`/`CmxIrohRegistryContextProvider` accept `customPrivateFallback`; path hints built only when broker discovery provides fresh family‑specific UDP ports; identity remains the broker EndpointID. `CmxIrohNetworkPathSnapshotComposer` merges platform and custom profiles and bumps generation on change.
  - Settings API: `CmxIrohSettingsControlling` adds upsert/remove; `CmxIrohSettingsSnapshot` adds `privateNetworkMacs` and `customPrivateNetworks`; model and views wired to persist, toggle, and remove.
  - Copy update: clearer private‑network text; automatic LAN and Tailscale compatibility preserved.

- Bug Fixes
  - Hardened bounds for custom‑path input and storage: max address text length, bracket/zone rejection, and capped encoded record size; malformed state fails closed.

<sup>Written for commit 9697d89703e32a64ab9b51cf38850abddde69356. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS settings to create, edit, enable/disable, and remove custom private network addresses per Mac.
  * Added support for numeric IPv4/IPv6 address validation with canonical formatting and correct socket address rendering.
  * Custom private paths are now included in settings snapshots and can affect connectivity and fallback routing.
* **Bug Fixes**
  * Invalid, stale, mismatched, or corrupted custom-private configurations fail safely without activating routes or authorization.  
* **Tests**
  * Added coverage for address validation, storage behavior, snapshot composition, and fallback handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->