### PR TITLE
Prove broker-bound Iroh relay round trip

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveEnvironment.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveEnvironment.swift
@@ -32,6 +32,14 @@ enum CmxIrohCustomRelayLiveEnvironment {
         ].allSatisfy { environment[$0]?.isEmpty == false }
     }
 
+    static var hasBrokerCredentials: Bool {
+        [
+            "CMUX_IROH_CUSTOM_RELAY_BROKER_URL",
+            "CMUX_IROH_CUSTOM_RELAY_ACCESS_TOKEN",
+            "CMUX_IROH_CUSTOM_RELAY_REFRESH_TOKEN",
+        ].allSatisfy { environment[$0]?.isEmpty == false }
+    }
+
     static var timeout: TimeInterval {
         environment["CMUX_IROH_CUSTOM_RELAY_TIMEOUT"]
             .flatMap(TimeInterval.init) ?? 10

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
@@ -1,3 +1,5 @@
+import CMUXMobileCore
+import CryptoKit
 import Foundation
 import Testing
 @testable import CmuxIrohTransport
@@ -14,6 +16,7 @@ struct CmxIrohCustomRelayLiveTests {
         case endpointClosed
         case relayAddressTimedOut
         case relayPathTimedOut
+        case streamRoundTripTimedOut
     }
 
     private struct ConnectionPair: Sendable {
@@ -117,6 +120,165 @@ struct CmxIrohCustomRelayLiveTests {
         )
     }
 
+    @Test(.enabled(if: CmxIrohCustomRelayLiveEnvironment.hasBrokerCredentials))
+    func brokerBoundTokensCarryBidirectionalRoundTrip() async throws {
+        let baseURL = try #require(URL(string: try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_BROKER_URL"
+        )))
+        let accessToken = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_ACCESS_TOKEN"
+        )
+        let refreshToken = try CmxIrohCustomRelayLiveEnvironment.required(
+            "CMUX_IROH_CUSTOM_RELAY_REFRESH_TOKEN"
+        )
+        let broker = try CmxIrohTrustBrokerClient(
+            baseURL: baseURL,
+            tokenSource: CmxIrohBrokerTokenSource(
+                accessToken: { accessToken },
+                refreshToken: { refreshToken }
+            )
+        )
+        try await revokeStaleLiveTestBindings(broker: broker)
+        let firstSecretKey = try randomSecretKey()
+        let secondSecretKey = try randomSecretKey()
+        var bindingIDs: [String] = []
+        var stage = "register first endpoint"
+
+        do {
+            print("Iroh live relay: \(stage)")
+            let first = try await register(
+                secretKey: firstSecretKey,
+                tag: "relay-live-first",
+                broker: broker
+            )
+            bindingIDs.append(first.bindingID)
+            stage = "register second endpoint"
+            print("Iroh live relay: \(stage)")
+            let second = try await register(
+                secretKey: secondSecretKey,
+                tag: "relay-live-second",
+                broker: broker
+            )
+            bindingIDs.append(second.bindingID)
+
+            stage = "mint first endpoint-bound token"
+            print("Iroh live relay: \(stage)")
+            let firstToken = try await broker.issueRelayToken(
+                bindingID: first.bindingID,
+                endpointID: first.endpointID
+            )
+            stage = "mint second endpoint-bound token"
+            print("Iroh live relay: \(stage)")
+            let secondToken = try await broker.issueRelayToken(
+                bindingID: second.bindingID,
+                endpointID: second.endpointID
+            )
+            let firstCredentials: [String: String] = Dictionary(
+                uniqueKeysWithValues: firstToken.credentials.map { ($0.relayURL, $0.token) }
+            )
+            let commonRelayURL = try #require(
+                secondToken.credentials.lazy
+                    .map(\.relayURL)
+                    .first(where: { firstCredentials[$0] != nil })
+            )
+            let firstAuthenticationToken = try #require(firstCredentials[commonRelayURL])
+            let secondAuthenticationToken = try #require(
+                secondToken.credentials.first(where: {
+                    $0.relayURL == commonRelayURL
+                })?.token
+            )
+
+            stage = "carry bidirectional relay-only stream"
+            print("Iroh live relay: \(stage)")
+            try await assertBidirectionalRoundTrip(
+                relayURL: commonRelayURL,
+                firstAuthenticationToken: firstAuthenticationToken,
+                secondAuthenticationToken: secondAuthenticationToken,
+                firstSecretKey: firstSecretKey,
+                secondSecretKey: secondSecretKey
+            )
+        } catch {
+            Issue.record("Iroh live relay failed while attempting to \(stage): \(error)")
+            await revoke(bindingIDs: bindingIDs, broker: broker)
+            throw error
+        }
+        await revoke(bindingIDs: bindingIDs, broker: broker)
+    }
+
+    private struct RegisteredEndpoint: Sendable {
+        let bindingID: String
+        let endpointID: CmxIrohPeerIdentity
+    }
+
+    private func register(
+        secretKey: CmxIrohSecretKey,
+        tag: String,
+        broker: CmxIrohTrustBrokerClient
+    ) async throws -> RegisteredEndpoint {
+        let privateKey = try Curve25519.Signing.PrivateKey(
+            rawRepresentation: secretKey.bytes
+        )
+        let endpointID = privateKey.publicKey.rawRepresentation
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let identity = try CmxIrohIdentityMaterial(
+            secretKey: secretKey,
+            generation: 1
+        )
+        let signer = try CmxIrohRegistrationSigner(
+            identity: identity,
+            endpointID: endpointID
+        )
+        let payload = try CmxIrohRegistrationPayload(
+            deviceID: UUID().uuidString.lowercased(),
+            appInstanceID: UUID().uuidString.lowercased(),
+            tag: tag,
+            platform: .ios,
+            endpointID: endpointID,
+            identityGeneration: identity.generation,
+            pairingEnabled: false,
+            capabilities: ["rpc", "terminal.streams"],
+            pathHints: []
+        )
+        let registration = try await broker.register(
+            prepared: signer.prepare(payload: payload),
+            signer: signer
+        )
+        #expect(registration.binding.endpointID.endpointID == endpointID)
+        return RegisteredEndpoint(
+            bindingID: registration.binding.bindingID,
+            endpointID: registration.binding.endpointID
+        )
+    }
+
+    private func randomSecretKey() throws -> CmxIrohSecretKey {
+        try CmxIrohSecretKey(bytes: Data((0 ..< 32).map { _ in UInt8.random(in: .min ... .max) }))
+    }
+
+    private func revoke(
+        bindingIDs: [String],
+        broker: CmxIrohTrustBrokerClient
+    ) async {
+        for bindingID in bindingIDs.reversed() {
+            do {
+                try await broker.revoke(bindingID: bindingID)
+            } catch {
+                Issue.record("Failed to revoke disposable live-test binding")
+            }
+        }
+    }
+
+    private func revokeStaleLiveTestBindings(
+        broker: CmxIrohTrustBrokerClient
+    ) async throws {
+        let staleBindingIDs = try await broker.discover().bindings
+            .filter { ["relay-live-first", "relay-live-second"].contains($0.tag) }
+            .map(\.bindingID)
+        for bindingID in staleBindingIDs {
+            try await broker.revoke(bindingID: bindingID)
+        }
+    }
+
     private func assertBidirectionalRoundTrip(
         relayURL: String,
         firstAuthenticationToken: String?,
@@ -157,6 +319,7 @@ struct CmxIrohCustomRelayLiveTests {
                 relayProfile: firstProfile
             )
         )
+        print("Iroh live relay: first endpoint bound")
         let second = try await factory.bind(
             configuration: CmxIrohEndpointConfiguration(
                 secretKey: try secondSecretKey ?? CmxIrohSecretKey(
@@ -166,16 +329,19 @@ struct CmxIrohCustomRelayLiveTests {
                 relayProfile: secondProfile
             )
         )
+        print("Iroh live relay: second endpoint bound")
 
         do {
             let firstAddress = try await relayAddress(
                 for: first,
                 relayURL: relayURL
             )
+            print("Iroh live relay: first relay address advertised")
             let secondAddress = try await relayAddress(
                 for: second,
                 relayURL: relayURL
             )
+            print("Iroh live relay: second relay address advertised")
             #expect(firstAddress.pathHints.map(\.value) == [relayURL])
             #expect(secondAddress.pathHints.map(\.value) == [relayURL])
 
@@ -185,30 +351,14 @@ struct CmxIrohCustomRelayLiveTests {
                 secondAddress: secondAddress,
                 alpn: alpn
             )
+            print("Iroh live relay: endpoint connection established")
             let outgoingConnection = connections.outgoing
             let incomingConnection = connections.incoming
 
-            try await outgoingConnection.setIncomingStreamLimits(
-                maximumBidirectionalStreamCount: 1,
-                maximumUnidirectionalStreamCount: 0
+            try await carryBoundedStreamRoundTrip(
+                outgoingConnection: outgoingConnection,
+                incomingConnection: incomingConnection
             )
-            try await incomingConnection.setIncomingStreamLimits(
-                maximumBidirectionalStreamCount: 1,
-                maximumUnidirectionalStreamCount: 0
-            )
-
-            async let acceptedStream = incomingConnection.acceptBidirectionalStream()
-            let outgoingStream = try await outgoingConnection.openBidirectionalStream()
-            let incomingStream = try await acceptedStream
-            let request = Data("custom-relay-request".utf8)
-            try await outgoingStream.sendStream.send(request)
-            try await outgoingStream.sendStream.finish()
-            #expect(try await receiveAll(from: incomingStream.receiveStream) == request)
-
-            let response = Data("custom-relay-response".utf8)
-            try await incomingStream.sendStream.send(response)
-            try await incomingStream.sendStream.finish()
-            #expect(try await receiveAll(from: outgoingStream.receiveStream) == response)
 
             #expect(
                 try await relayPath(
@@ -216,12 +366,14 @@ struct CmxIrohCustomRelayLiveTests {
                     relayURL: relayURL
                 ) == .relay(url: relayURL)
             )
+            print("Iroh live relay: outgoing path verified as relay")
             #expect(
                 try await relayPath(
                     for: incomingConnection,
                     relayURL: relayURL
                 ) == .relay(url: relayURL)
             )
+            print("Iroh live relay: incoming path verified as relay")
 
             await outgoingConnection.close(errorCode: 0, reason: "live_test_complete")
             await incomingConnection.close(errorCode: 0, reason: "live_test_complete")
@@ -232,6 +384,54 @@ struct CmxIrohCustomRelayLiveTests {
         }
         await first.close()
         await second.close()
+    }
+
+    private func carryBoundedStreamRoundTrip(
+        outgoingConnection: any CmxIrohConnection,
+        incomingConnection: any CmxIrohConnection
+    ) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await outgoingConnection.setIncomingStreamLimits(
+                    maximumBidirectionalStreamCount: 1,
+                    maximumUnidirectionalStreamCount: 0
+                )
+                print("Iroh live relay: outgoing stream limits configured")
+                try await incomingConnection.setIncomingStreamLimits(
+                    maximumBidirectionalStreamCount: 1,
+                    maximumUnidirectionalStreamCount: 0
+                )
+                print("Iroh live relay: incoming stream limits configured")
+
+                async let acceptedStream = incomingConnection.acceptBidirectionalStream()
+                print("Iroh live relay: waiting for incoming stream")
+                let outgoingStream = try await outgoingConnection.openBidirectionalStream()
+                print("Iroh live relay: outgoing stream created")
+                let request = Data("custom-relay-request".utf8)
+                try await outgoingStream.sendStream.send(request)
+                try await outgoingStream.sendStream.finish()
+                let incomingStream = try await acceptedStream
+                print("Iroh live relay: bidirectional stream opened")
+                #expect(try await self.receiveAll(from: incomingStream.receiveStream) == request)
+                print("Iroh live relay: request received")
+
+                let response = Data("custom-relay-response".utf8)
+                try await incomingStream.sendStream.send(response)
+                try await incomingStream.sendStream.finish()
+                #expect(try await self.receiveAll(from: outgoingStream.receiveStream) == response)
+                print("Iroh live relay: response received")
+            }
+            group.addTask {
+                try await ContinuousClock().sleep(
+                    for: .seconds(CmxIrohCustomRelayLiveEnvironment.timeout)
+                )
+                await outgoingConnection.close(errorCode: 1, reason: "live_test_timeout")
+                await incomingConnection.close(errorCode: 1, reason: "live_test_timeout")
+                throw LiveTestError.streamRoundTripTimedOut
+            }
+            defer { group.cancelAll() }
+            _ = try await group.next()
+        }
     }
 
     private func connectPair(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohCustomRelayLiveTests.swift
@@ -138,7 +138,7 @@ struct CmxIrohCustomRelayLiveTests {
                 refreshToken: { refreshToken }
             )
         )
-        try await revokeStaleLiveTestBindings(broker: broker)
+        let runTag = "relay-live-\(UUID().uuidString.lowercased())"
         let firstSecretKey = try randomSecretKey()
         let secondSecretKey = try randomSecretKey()
         var bindingIDs: [String] = []
@@ -148,7 +148,7 @@ struct CmxIrohCustomRelayLiveTests {
             print("Iroh live relay: \(stage)")
             let first = try await register(
                 secretKey: firstSecretKey,
-                tag: "relay-live-first",
+                tag: "\(runTag)-first",
                 broker: broker
             )
             bindingIDs.append(first.bindingID)
@@ -156,7 +156,7 @@ struct CmxIrohCustomRelayLiveTests {
             print("Iroh live relay: \(stage)")
             let second = try await register(
                 secretKey: secondSecretKey,
-                tag: "relay-live-second",
+                tag: "\(runTag)-second",
                 broker: broker
             )
             bindingIDs.append(second.bindingID)
@@ -173,8 +173,9 @@ struct CmxIrohCustomRelayLiveTests {
                 bindingID: second.bindingID,
                 endpointID: second.endpointID
             )
-            let firstCredentials: [String: String] = Dictionary(
-                uniqueKeysWithValues: firstToken.credentials.map { ($0.relayURL, $0.token) }
+            let firstCredentials = Dictionary(
+                firstToken.credentials.map { ($0.relayURL, $0.token) },
+                uniquingKeysWith: { _, latestToken in latestToken }
             )
             let commonRelayURL = try #require(
                 secondToken.credentials.lazy
@@ -265,17 +266,6 @@ struct CmxIrohCustomRelayLiveTests {
             } catch {
                 Issue.record("Failed to revoke disposable live-test binding")
             }
-        }
-    }
-
-    private func revokeStaleLiveTestBindings(
-        broker: CmxIrohTrustBrokerClient
-    ) async throws {
-        let staleBindingIDs = try await broker.discover().bindings
-            .filter { ["relay-live-first", "relay-live-second"].contains($0.tag) }
-            .map(\.bindingID)
-        for bindingID in staleBindingIDs {
-            try await broker.revoke(bindingID: bindingID)
         }
     }
 


### PR DESCRIPTION
## What

- registers two disposable endpoint identities through the staging trust-broker challenge flow
- mints independent endpoint-bound relay credentials
- requires a bidirectional relay-only Iroh stream over one exact server-provided relay URL
- verifies both observed paths are relay and revokes all disposable bindings
- bounds connection and stream phases so a live failure cannot hang the gate
- fixes the live harness ordering so the first byte is sent before awaiting the peer's lazily materialized QUIC stream

## Verification

- `swift test`: 408 tests passed
- staging live gate: passed in 4.496s with two fresh endpoint-bound JWTs
- post-run broker query: zero disposable bindings remained

Test-only; no app runtime or user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787069233&installation_id=133855650&pr_number=8488&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8488&signature=267f9d5a55b538847e96a23b5293ab7f11c5d3537df13793bc2af2330cfc87a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live test that proves a broker-bound Iroh relay can carry a bidirectional stream round trip over a single server-provided relay URL. Tightens timeouts and isolates each run so the gate never hangs.

- New Features
  - Registers two disposable endpoints via the staging trust-broker, mints endpoint-bound relay tokens, and verifies both paths are relay-only on the same URL.
  - Adds bounded stream round trip with incoming stream limits and a deadline; force-closes connections on timeout.
  - Isolates each live run with a unique tag and auto-revokes stale and post-run bindings. Supports broker env vars: CMUX_IROH_CUSTOM_RELAY_BROKER_URL, CMUX_IROH_CUSTOM_RELAY_ACCESS_TOKEN, CMUX_IROH_CUSTOM_RELAY_REFRESH_TOKEN.

- Bug Fixes
  - Fixes live harness ordering so the first byte is sent before awaiting the peer’s lazily materialized QUIC stream.

<sup>Written for commit 1b403a76f8fc134f4693a1dbf288458245925653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added live coverage for broker-credential–bound custom relay token flows.
  * Added end-to-end bidirectional relay round-trip validation using credentials issued at runtime.
  * Introduced timeout handling and progress reporting for streamed request/response exchanges.
  * Enhanced cleanup by revoking temporary relay bindings on both success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->