### PR TITLE
Gate Iroh rollout on Tailscale version skew

### DIFF
--- a/.github/workflows/iroh-release-gate.yml
+++ b/.github/workflows/iroh-release-gate.yml
@@ -22,7 +22,38 @@ permissions:
   contents: read
 
 jobs:
+  tailscale-version-skew:
+    name: Tailscale version-skew compatibility
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    timeout-minutes: 75
+    env:
+      CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_15 }}
+      CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
+      CMUX_SKIP_ZIG_BUILD: "1"
+      SWIFT_BACKTRACE: "interactive=no,timeout=0s,symbolicate=off,color=no"
+      CMUX_XCODEBUILD_NONINTERACTIVE_POST_TEST_TIMEOUT_SECONDS: "45"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Select Xcode
+        run: ./scripts/select-ci-xcode.sh
+
+      - name: Download pre-built GhosttyKit
+        run: ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Install Rust
+        run: ./scripts/install-rust-ci.sh
+
+      - name: Run deterministic version-skew gate
+        run: ./scripts/ci/run-iroh-tailscale-compatibility-gate.sh
+
   simulator-e2e:
+    needs: tailscale-version-skew
     strategy:
       fail-fast: false
       matrix:

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1011,8 +1011,7 @@ final class MobileHostService {
             let transport = CmxNetworkByteTransport(acceptedConnection: connection)
             await Self.acceptTransport(
                 transport,
-                authorization: MobileHostTransportAuthorizationPolicy
-                    .legacyPrivateNetworkListener,
+                authorization: .legacyPrivateNetworkListener,
                 isCurrent: {
                     await MobileHostService.shared.canAcceptConnection(
                         generation: generation

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1011,7 +1011,8 @@ final class MobileHostService {
             let transport = CmxNetworkByteTransport(acceptedConnection: connection)
             await Self.acceptTransport(
                 transport,
-                authorization: .stackBearer,
+                authorization: MobileHostTransportAuthorizationPolicy
+                    .legacyPrivateNetworkListener,
                 isCurrent: {
                     await MobileHostService.shared.canAcceptConnection(
                         generation: generation

--- a/Sources/Mobile/MobileHostTransportAuthorization.swift
+++ b/Sources/Mobile/MobileHostTransportAuthorization.swift
@@ -16,6 +16,14 @@ enum MobileHostConnectionAuthorizationContext: Equatable, Sendable {
     case irohAdmission(CmxIrohAdmittedPeer)
 }
 
+/// One policy authority for transports accepted by the legacy private-network
+/// listener. Keeping this separate from Iroh admission makes version-skew
+/// coverage exercise the same authorization choice as the production listener.
+enum MobileHostTransportAuthorizationPolicy {
+    static let legacyPrivateNetworkListener: MobileHostConnectionAuthorizationContext =
+        .stackBearer
+}
+
 
 enum MobileHostEventTransport: String, Equatable, Sendable {
     case control = "control_v1"

--- a/Sources/Mobile/MobileHostTransportAuthorization.swift
+++ b/Sources/Mobile/MobileHostTransportAuthorization.swift
@@ -16,12 +16,12 @@ enum MobileHostConnectionAuthorizationContext: Equatable, Sendable {
     case irohAdmission(CmxIrohAdmittedPeer)
 }
 
-/// One policy authority for transports accepted by the legacy private-network
-/// listener. Keeping this separate from Iroh admission makes version-skew
-/// coverage exercise the same authorization choice as the production listener.
-enum MobileHostTransportAuthorizationPolicy {
-    static let legacyPrivateNetworkListener: MobileHostConnectionAuthorizationContext =
-        .stackBearer
+extension MobileHostConnectionAuthorizationContext {
+    /// One policy authority for transports accepted by the legacy
+    /// private-network listener. Keeping this separate from Iroh admission
+    /// makes version-skew coverage exercise the same authorization choice as
+    /// the production listener.
+    static let legacyPrivateNetworkListener: Self = .stackBearer
 }
 
 

--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -251,8 +251,7 @@ struct IrohTailscaleVersionSkewMacGateTests {
             authorizeRequest: { request in
                 await MobileHostService.connectionAuthorizationError(
                     for: request,
-                    authorization: MobileHostTransportAuthorizationPolicy
-                        .legacyPrivateNetworkListener,
+                    authorization: .legacyPrivateNetworkListener,
                     stackAuthorization: { decoded in
                         await stackAuthorization.record(decoded)
                         guard decoded.auth?.stackAccessToken == "legacy-stack-token" else {
@@ -300,7 +299,7 @@ struct IrohTailscaleVersionSkewMacGateTests {
 
     @Test func testLegacyCompatibilityPolicyCannotBecomeIrohAdmission() {
         #expect(
-            MobileHostTransportAuthorizationPolicy.legacyPrivateNetworkListener
+            MobileHostConnectionAuthorizationContext.legacyPrivateNetworkListener
                 == .stackBearer
         )
     }

--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -225,9 +225,13 @@ extension MobileHostAuthorizationTests {
         #expect(error.code == "unauthorized")
         #expect(await recorder.count() == 1)
     }
+}
 
+@MainActor
+@Suite(.serialized)
+struct IrohTailscaleVersionSkewMacGateTests {
     @Test func testReleasedIOSWireFrameRemainsAcceptedByLegacyTCPAuthorization() async throws {
-        let legacyFrame = Data(
+        let legacyPayload = Data(
             #"""
             {
               "id": "legacy-workspace-list",
@@ -237,31 +241,132 @@ extension MobileHostAuthorizationTests {
             }
             """#.utf8
         )
-        let request: MobileHostRPCRequest
-        switch MobileHostRPCEnvelope.decodeRequest(legacyFrame) {
-        case .success(let decoded):
-            request = decoded
-        case .failure(let error):
-            Issue.record("Legacy iOS frame did not decode: \(error.code)")
+        let transport = LegacyIOSCompatibilityByteTransport()
+        let stackAuthorization = LegacyStackAuthorizationRecorder()
+        let session = MobileHostConnection(
+            id: UUID(),
+            transport: transport,
+            firstFrameTimeoutNanoseconds: 0,
+            idleTimeoutNanoseconds: 0,
+            authorizeRequest: { request in
+                await MobileHostService.connectionAuthorizationError(
+                    for: request,
+                    authorization: MobileHostTransportAuthorizationPolicy
+                        .legacyPrivateNetworkListener,
+                    stackAuthorization: { decoded in
+                        await stackAuthorization.record(decoded)
+                        guard decoded.auth?.stackAccessToken == "legacy-stack-token" else {
+                            return .failure(MobileHostRPCError(
+                                code: "unauthorized",
+                                message: "Legacy Stack bearer was not preserved"
+                            ))
+                        }
+                        return nil
+                    }
+                )
+            },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { request in
+                .ok([
+                    "method": request.method,
+                    "authorization": "stack_bearer",
+                ])
+            },
+            onClose: { _ in }
+        )
+        let runTask = Task { await session.run() }
+        await transport.enqueue(try MobileSyncFrameCodec.encodeFrame(legacyPayload))
+
+        var responseBuffer = await transport.waitForSentBuffer()
+        let responsePayloads = try MobileSyncFrameCodec.decodeFrames(from: &responseBuffer)
+        let responsePayload = try #require(responsePayloads.first)
+        let response = try #require(
+            JSONSerialization.jsonObject(
+                with: responsePayload
+            ) as? [String: Any]
+        )
+        let result = try #require(response["result"] as? [String: Any])
+
+        #expect(response["id"] as? String == "legacy-workspace-list")
+        #expect(response["ok"] as? Bool == true)
+        #expect(result["method"] as? String == "workspace.list")
+        #expect(result["authorization"] as? String == "stack_bearer")
+        #expect(await stackAuthorization.invocationCount() == 1)
+        #expect(await stackAuthorization.lastToken() == "legacy-stack-token")
+
+        await transport.finishReceiving()
+        await runTask.value
+    }
+
+    @Test func testLegacyCompatibilityPolicyCannotBecomeIrohAdmission() {
+        #expect(
+            MobileHostTransportAuthorizationPolicy.legacyPrivateNetworkListener
+                == .stackBearer
+        )
+    }
+
+    @Test func testLegacyCompatibilityRouteIsNumericTailscaleAndNeverLoopback() throws {
+        let snapshot = MobileRouteResolver().routes(
+            port: 58_465,
+            tailscaleHosts: [
+                "127.0.0.1",
+                "work-mac.tailnet.ts.net",
+                "100.71.210.41",
+            ]
+        )
+        let tailscaleRoutes = snapshot.routes.filter { $0.kind == .tailscale }
+
+        #expect(tailscaleRoutes.count == 1)
+        guard case let .hostPort(host, port) = tailscaleRoutes.first?.endpoint else {
+            Issue.record("Expected a numeric Tailscale compatibility route")
             return
         }
+        #expect(host == "100.71.210.41")
+        #expect(port == 58_465)
+        #expect(host != "127.0.0.1")
+    }
 
-        let result = await MobileHostService.connectionAuthorizationError(
-            for: request,
-            authorization: .stackBearer,
-            stackAuthorization: { decoded in
-                guard decoded.auth?.stackAccessToken == "legacy-stack-token" else {
-                    return .failure(MobileHostRPCError(
-                        code: "unauthorized",
-                        message: "Legacy Stack bearer was not preserved"
-                    ))
-                }
-                return nil
-            }
+    @Test func testStableExplicitSettingStartsIrohAndLegacyCompatibilityListener() throws {
+        let suiteName = "IrohTailscaleVersionSkewMacGateTests.Current.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: MobileHostService.listeningEnabledDefaultsKey)
+
+        let enabled = MobileHostService.isListeningEnabled(
+            defaults: defaults,
+            buildFlavor: .stable
+        )
+        let plan = MobileHostService.startupPlan(
+            legacyListenerEnabled: enabled,
+            legacyListenerRunning: false
         )
 
-        #expect(result == nil)
+        #expect(plan.activatesIroh)
+        #expect(plan.startsLegacyListener)
     }
+
+    @Test func testStableHistoricalSettingStartsIrohAndLegacyCompatibilityListener() throws {
+        let suiteName = "IrohTailscaleVersionSkewMacGateTests.Historical.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: "cmuxMobilePairingHostEnabled")
+
+        let enabled = MobileHostService.isListeningEnabled(
+            defaults: defaults,
+            buildFlavor: .stable
+        )
+        let plan = MobileHostService.startupPlan(
+            legacyListenerEnabled: enabled,
+            legacyListenerRunning: false
+        )
+
+        #expect(plan.activatesIroh)
+        #expect(plan.startsLegacyListener)
+    }
+}
+
+@MainActor
+extension MobileHostAuthorizationTests {
 
     @Test func testIrohAdmittedStatusIncludesIdentityWhileTCPPublicStatusDoesNot() async throws {
         let request = MobileHostRPCRequest(
@@ -369,4 +474,78 @@ private actor MobileHostIrohPersistenceGate {
         continuation?.resume()
         continuation = nil
     }
+}
+
+/// In-memory framed transport for the released-iOS compatibility contract.
+/// It deliberately has no host, port, loopback socket, or Iroh endpoint, so the
+/// test can only pass through the explicitly selected legacy authorization lane.
+private actor LegacyIOSCompatibilityByteTransport: CmxByteTransport {
+    private var receiveQueue: [Data?] = []
+    private var receiveWaiter: CheckedContinuation<Data?, Never>?
+    private var sentBuffer: Data?
+    private var sentWaiters: [CheckedContinuation<Data, Never>] = []
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? {
+        if !receiveQueue.isEmpty {
+            return receiveQueue.removeFirst()
+        }
+        return await withCheckedContinuation { receiveWaiter = $0 }
+    }
+
+    func send(_ data: Data) async throws {
+        if sentBuffer == nil {
+            sentBuffer = data
+        } else {
+            sentBuffer?.append(data)
+        }
+        guard let sentBuffer else { return }
+        let waiters = sentWaiters
+        sentWaiters.removeAll(keepingCapacity: false)
+        for waiter in waiters {
+            waiter.resume(returning: sentBuffer)
+        }
+    }
+
+    func close() async {
+        receiveWaiter?.resume(returning: nil)
+        receiveWaiter = nil
+    }
+
+    func enqueue(_ data: Data) {
+        if let receiveWaiter {
+            self.receiveWaiter = nil
+            receiveWaiter.resume(returning: data)
+        } else {
+            receiveQueue.append(data)
+        }
+    }
+
+    func finishReceiving() {
+        if let receiveWaiter {
+            self.receiveWaiter = nil
+            receiveWaiter.resume(returning: nil)
+        } else {
+            receiveQueue.append(nil)
+        }
+    }
+
+    func waitForSentBuffer() async -> Data {
+        if let sentBuffer {
+            return sentBuffer
+        }
+        return await withCheckedContinuation { sentWaiters.append($0) }
+    }
+}
+
+private actor LegacyStackAuthorizationRecorder {
+    private var tokens: [String?] = []
+
+    func record(_ request: MobileHostRPCRequest) {
+        tokens.append(request.auth?.stackAccessToken)
+    }
+
+    func invocationCount() -> Int { tokens.count }
+    func lastToken() -> String? { tokens.last ?? nil }
 }

--- a/scripts/ci/run-iroh-tailscale-compatibility-gate.sh
+++ b/scripts/ci/run-iroh-tailscale-compatibility-gate.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+result_root="${CMUX_TAILSCALE_COMPAT_RESULT_ROOT:-${RUNNER_TEMP:-/tmp}/cmux-iroh-tailscale-compatibility}"
+derived_data="$result_root/app-host-derived"
+result_bundle="$result_root/app-host.xcresult"
+source_packages="${CMUX_TAILSCALE_COMPAT_SOURCE_PACKAGES:-$repo_root/.ci-source-packages}"
+swift_scratch_root="$result_root/swift-build"
+
+mkdir -p "$result_root" "$source_packages"
+rm -rf "$result_bundle"
+rm -rf "$swift_scratch_root"
+rm -f "$result_root"/*.log
+
+run_app_host_gate() {
+  rm -rf "$result_bundle"
+  (
+    cd "$repo_root"
+    scripts/ci/xcodebuild_noninteractive.py \
+      xcodebuild \
+      -project cmux.xcodeproj \
+      -scheme cmux-unit \
+      -configuration Debug \
+      -destination "platform=macOS" \
+      -derivedDataPath "$derived_data" \
+      -clonedSourcePackagesDirPath "$source_packages" \
+      -resultBundlePath "$result_bundle" \
+      COMPILER_INDEX_STORE_ENABLE=NO \
+      -only-testing:cmuxTests/IrohTailscaleVersionSkewMacGateTests \
+      test
+  )
+
+  python3 - "$result_bundle" <<'PY'
+import json
+import subprocess
+import sys
+
+result_bundle = sys.argv[1]
+summary = json.loads(
+    subprocess.check_output(
+        [
+            "xcrun",
+            "xcresulttool",
+            "get",
+            "test-results",
+            "summary",
+            "--path",
+            result_bundle,
+            "--compact",
+        ]
+    )
+)
+expected = 5
+observed = int(summary.get("totalTestCount", 0))
+passed = int(summary.get("passedTests", 0))
+failed = int(summary.get("failedTests", 0))
+if summary.get("result") != "Passed" or observed != expected or passed != expected or failed:
+    raise SystemExit(
+        "Mac compatibility gate did not execute exactly five passing tests: "
+        f"result={summary.get('result')} total={observed} passed={passed} failed={failed}"
+    )
+print("Mac compatibility gate: 5/5 passed")
+PY
+}
+
+run_package_gate() {
+  local package_path="$1"
+  local filter="$2"
+  local expected_count="$3"
+  shift 3
+  local scratch_path="$swift_scratch_root/$(basename "$package_path")"
+
+  local list_output
+  list_output="$(
+    swift test list \
+      --package-path "$repo_root/$package_path" \
+      --scratch-path "$scratch_path"
+  )"
+  local expected_test
+  for expected_test in "$@"; do
+    if ! grep -Fqx "$expected_test" <<<"$list_output"; then
+      echo "Missing compatibility-gate test: $expected_test" >&2
+      exit 1
+    fi
+  done
+
+  local output_file="$result_root/$(basename "$package_path").log"
+  swift test \
+    --package-path "$repo_root/$package_path" \
+    --scratch-path "$scratch_path" \
+    --filter "$filter" 2>&1 | tee "$output_file"
+
+  if ! grep -Eq \
+    "Test run with ${expected_count} tests? in [0-9]+ suites? passed" \
+    "$output_file"; then
+    echo "Expected exactly $expected_count passing tests from $package_path" >&2
+    exit 1
+  fi
+}
+
+run_app_host_gate
+
+run_package_gate \
+  Packages/iOS/CmuxMobileShell \
+  'ReconnectRouteSelectionTests/(legacyMacWithoutIrohFailsClosedInsteadOfSendingBearerOverTCP|legacySavedMacWithoutPublishedIrohIsRetainedAndRequestsMacUpdate|rejectedIrohReconnectNeverDowngradesToRawTailscale|storedReconnectPinsIrohAndExcludesRawFallbacks|switchToLegacySavedMacUpgradesFromRegistryWithoutRescan)' \
+  5 \
+  'CmuxMobileShellTests.ReconnectRouteSelectionTests/legacyMacWithoutIrohFailsClosedInsteadOfSendingBearerOverTCP()' \
+  'CmuxMobileShellTests.ReconnectRouteSelectionTests/legacySavedMacWithoutPublishedIrohIsRetainedAndRequestsMacUpdate()' \
+  'CmuxMobileShellTests.ReconnectRouteSelectionTests/rejectedIrohReconnectNeverDowngradesToRawTailscale()' \
+  'CmuxMobileShellTests.ReconnectRouteSelectionTests/storedReconnectPinsIrohAndExcludesRawFallbacks()' \
+  'CmuxMobileShellTests.ReconnectRouteSelectionTests/switchToLegacySavedMacUpgradesFromRegistryWithoutRescan()'
+
+run_package_gate \
+  Packages/iOS/CmuxMobileRPC \
+  'MobileCoreRPCClientTests/(admittedIrohRequestCarriesNoStackOrAttachCredential|hostStatusProbeNeverSendsStackTokenOnUntrustedRoute)' \
+  2 \
+  'CmuxMobileRPCTests.MobileCoreRPCClientTests/admittedIrohRequestCarriesNoStackOrAttachCredential()' \
+  'CmuxMobileRPCTests.MobileCoreRPCClientTests/hostStatusProbeNeverSendsStackTokenOnUntrustedRoute()'
+
+run_package_gate \
+  Packages/iOS/CmuxMobileShellModel \
+  'MobileShellRouteAuthPolicyTests/allowsStackAuthOnlyForLoopbackRoutes' \
+  1 \
+  'CmuxMobileShellModelTests.MobileShellRouteAuthPolicyTests/allowsStackAuthOnlyForLoopbackRoutes()'
+
+echo "Iroh/Tailscale version-skew compatibility gate passed"


### PR DESCRIPTION
## Contract

- Released iOS clients keep using the explicit Mac private-network listener with Stack bearer authorization.
- Current iOS retains a Tailscale-only saved Mac and upgrades it to Iroh when the authenticated registry publishes an Iroh route.
- Current iOS never downgrades a rejected or missing Iroh route to raw Tailscale and never sends a bearer on raw private-network probes.
- Current iOS to an older Mac without authenticated Iroh remains unavailable by design.

## Implementation

The Mac legacy listener and its compatibility test share one production authorization policy. The released wire-frame fixture now traverses the complete framing, connection, authorization, and response lifecycle through an in-memory transport with no loopback or Iroh escape route.

The Iroh release workflow now blocks all automatic, relay-only, and direct-only simulator lanes on a deterministic compatibility gate. The script validates exact test identities and exact pass counts so renamed, skipped, or accidentally broad filters cannot pass silently.

## Verification

- run-iroh-tailscale-compatibility-gate.sh: 5 Mac compatibility tests, 5 route-selection tests, 2 RPC credential-containment tests, and 1 loopback auth-policy test passed
- bash -n scripts/ci/run-iroh-tailscale-compatibility-gate.sh
- git diff --check
- workflow YAML parsed with Ruby Psych

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787071072&installation_id=133855650&pr_number=8490&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8490&signature=0ea8c75102e17a978e121674d1259954641d1fe824685c18230fa0b04194e276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the Iroh rollout behind a Tailscale version-skew check and unifies the legacy Mac listener under one authorization policy to keep released iOS clients safe and compatible.

- **New Features**
  - Adds deterministic `tailscale-version-skew` CI in `.github/workflows/iroh-release-gate.yml` that runs `scripts/ci/run-iroh-tailscale-compatibility-gate.sh` and blocks `simulator-e2e`; the gate validates exact test identities and pass counts across macOS and iOS packages.
  - Introduces `MobileHostConnectionAuthorizationContext.legacyPrivateNetworkListener` as an alias of `.stackBearer` and switches the legacy listener to it; tests confirm released iOS frames keep the Stack bearer, the policy cannot become Iroh admission, the compatibility route uses numeric Tailscale (never loopback), and stable settings start both Iroh and the legacy listener without downgrades or bearer on raw probes.

<sup>Written for commit 226dca213ce62493dce37b685346e966d89b94cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization handling for connections accepted through the legacy private-network listener.
  * Preserved stack-based authorization during legacy iOS compatibility flows.

* **Tests**
  * Added compatibility checks for version skew, routing, listener behavior, authorization, and stable settings.
  * Added automated validation across macOS and iOS compatibility test suites.

* **Chores**
  * Added a release gate that blocks simulator end-to-end tests until compatibility checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->