### PR TITLE
Normalize production Iroh gate temporary paths

### DIFF
--- a/scripts/lib/iroh-production-gate.test.mjs
+++ b/scripts/lib/iroh-production-gate.test.mjs
@@ -133,7 +133,12 @@ while [[ $# -gt 0 ]]; do
 done
 [[ -n "$state_file" ]]
 state_directory="$(dirname "$state_file")"
-printf '%s\n%s\n' "$state_file" "$(stat -f '%Lp' "$state_directory")" > "$CMUX_TEST_CAPTURE_FILE"
+if [[ "$(uname)" == "Darwin" ]]; then
+  mode="$(stat -f '%Lp' "$state_directory")"
+else
+  mode="$(stat -c '%a' "$state_directory")"
+fi
+printf '%s\n%s\n' "$state_file" "$mode" > "$CMUX_TEST_CAPTURE_FILE"
 exit 73
 `, { mode: 0o755 });
   chmodSync(fakeBun, 0o755);

--- a/scripts/lib/iroh-production-gate.test.mjs
+++ b/scripts/lib/iroh-production-gate.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import {
   chmodSync,
   mkdtempSync,
+  mkdirSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -109,6 +111,54 @@ test("production release-gate flags fail before creating runtime state", () => {
   ]);
   assert.equal(productionEnvironmentWithoutProduction.status, 2);
   assert.match(productionEnvironmentWithoutProduction.stderr, /requires --production/u);
+});
+
+test("production release gate gives its account helper a normalized protected state directory", (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+
+  const fakeBin = path.join(directory, "bin");
+  mkdirSync(fakeBin, { mode: 0o700 });
+  const captureFile = path.join(directory, "captured-state.txt");
+  const fakeBun = path.join(fakeBin, "bun");
+  writeFileSync(fakeBun, `#!/usr/bin/env bash
+set -euo pipefail
+state_file=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--state-file" ]]; then
+    state_file="\${2:-}"
+    break
+  fi
+  shift
+done
+[[ -n "$state_file" ]]
+state_directory="$(dirname "$state_file")"
+printf '%s\n%s\n' "$state_file" "$(stat -f '%Lp' "$state_directory")" > "$CMUX_TEST_CAPTURE_FILE"
+exit 73
+`, { mode: 0o755 });
+  chmodSync(fakeBun, 0o755);
+
+  const stackEnvironment = path.join(directory, "stack.env");
+  writeFileSync(stackEnvironment, "unused=true\n", { mode: 0o600 });
+  chmodSync(stackEnvironment, 0o600);
+
+  const result = run("bash", [
+    "scripts/run-iroh-release-gate.sh",
+    "--mode", "automatic",
+    "--tag", "prodtmp",
+    "--production",
+    "--stack-env-file", stackEnvironment,
+  ], {
+    CMUX_TEST_CAPTURE_FILE: captureFile,
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    TMPDIR: `${directory}/`,
+  });
+
+  assert.equal(result.status, 73, result.stderr);
+  const [stateFile, mode] = readFileSync(captureFile, "utf8").trimEnd().split("\n");
+  assert.equal(stateFile, path.resolve(stateFile));
+  assert.equal(path.dirname(stateFile).startsWith(`${directory}/`), true);
+  assert.equal(mode, "700");
 });
 
 test("Mac reload documents production auth without accepting secret values", () => {

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -174,11 +174,12 @@ if [[ "$PRODUCTION" -eq 1 ]]; then
   # spelling once so every protected path given to the account helper is
   # absolute and syntactically normalized without changing symlink identity.
   TEMPORARY_ROOT="$(cd -L "${TMPDIR:-/private/tmp}" && pwd -L)"
-  STATE_DIR="$(mktemp -d "$TEMPORARY_ROOT/cmux-iroh-production-${SLUG}.XXXXXX")"
+  TEMPORARY_PREFIX="${TEMPORARY_ROOT%/}"
+  STATE_DIR="$(mktemp -d "$TEMPORARY_PREFIX/cmux-iroh-production-${SLUG}.XXXXXX")"
   chmod 700 "$STATE_DIR"
   PROD_ACCOUNT_STATE_FILE="$STATE_DIR/account.json"
   PROD_CREDENTIALS_FILE="$STATE_DIR/credentials.env"
-  RECOVERY_DIR="$TEMPORARY_ROOT/cmux-iroh-production-gate-recovery-$(id -u)"
+  RECOVERY_DIR="$TEMPORARY_PREFIX/cmux-iroh-production-gate-recovery-$(id -u)"
   mkdir -p "$RECOVERY_DIR"
   chmod 700 "$RECOVERY_DIR"
   PROD_RECOVERY_FILE="$RECOVERY_DIR/${SLUG}.json"

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -170,11 +170,15 @@ trap handle_interrupt INT
 trap handle_termination TERM
 
 if [[ "$PRODUCTION" -eq 1 ]]; then
-  STATE_DIR="$(mktemp -d "${TMPDIR:-/private/tmp}/cmux-iroh-production-${SLUG}.XXXXXX")"
+  # macOS normally exports TMPDIR with a trailing slash. Resolve its logical
+  # spelling once so every protected path given to the account helper is
+  # absolute and syntactically normalized without changing symlink identity.
+  TEMPORARY_ROOT="$(cd -L "${TMPDIR:-/private/tmp}" && pwd -L)"
+  STATE_DIR="$(mktemp -d "$TEMPORARY_ROOT/cmux-iroh-production-${SLUG}.XXXXXX")"
   chmod 700 "$STATE_DIR"
   PROD_ACCOUNT_STATE_FILE="$STATE_DIR/account.json"
   PROD_CREDENTIALS_FILE="$STATE_DIR/credentials.env"
-  RECOVERY_DIR="${TMPDIR:-/private/tmp}/cmux-iroh-production-gate-recovery-$(id -u)"
+  RECOVERY_DIR="$TEMPORARY_ROOT/cmux-iroh-production-gate-recovery-$(id -u)"
   mkdir -p "$RECOVERY_DIR"
   chmod 700 "$RECOVERY_DIR"
   PROD_RECOVERY_FILE="$RECOVERY_DIR/${SLUG}.json"


### PR DESCRIPTION
## Summary
- reproduce macOS trailing-slash `TMPDIR` through the real production-gate entrypoint
- normalize the temporary root before deriving protected state and recovery paths
- preserve the state directory's owner-only `0700` permissions

## Verification
- `bun test scripts/lib/iroh-production-gate.test.mjs scripts/lib/temporary-stack-user.test.mjs` (13 passed)
- `bash -n scripts/run-iroh-release-gate.sh`
- regression commit `138fca12f4` fails on the doubled path before fix commit `f689256011`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787071799&installation_id=133855650&pr_number=8491&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8491&signature=69c94e4672987ed67cc4e528b87f8048617839e89d257d93b8730872beecdcb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes temp paths in the Iroh production gate to prevent doubled paths on macOS and keep temp dirs secure. The account helper now always receives an absolute, normalized state path.

- **Bug Fixes**
  - Normalize the root temp dir once (`cd -L … && pwd -L`), trim trailing slash, and derive all temp paths from it; preserves symlink identity and fixes macOS issues.
  - Always pass an absolute, normalized protected state path to the account helper; tests now verify the path and `0700` permissions portably on macOS and Linux.

<sup>Written for commit a0070ca6429b70481017e3a7ce63b336d2f36a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

