### PR TITLE
Gate provider-neutral private Iroh paths

### DIFF
--- a/.github/workflows/iroh-release-gate.yml
+++ b/.github/workflows/iroh-release-gate.yml
@@ -17,6 +17,7 @@ on:
           - automatic
           - relay-only
           - direct-only
+          - private-path
 
 permissions:
   contents: read
@@ -26,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode: ${{ fromJSON(inputs.mode == 'all' && '["automatic","relay-only","direct-only"]' || format('["{0}"]', inputs.mode)) }}
+        mode: ${{ fromJSON(inputs.mode == 'all' && '["automatic","relay-only","direct-only","private-path"]' || format('["{0}"]', inputs.mode)) }}
     runs-on: ${{ vars.MACOS_RUNNER_STREAMED_VALIDATION || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 120
     steps:
@@ -41,17 +42,18 @@ jobs:
         run: ./scripts/select-ci-xcode.sh
 
       - name: Ensure iOS Simulator runtime
+        if: ${{ matrix.mode != 'private-path' }}
         run: |
           xcrun simctl list runtimes available | grep -Eq '\biOS\b' || xcodebuild -downloadPlatform iOS
 
       - name: Install app build dependencies
-        if: ${{ matrix.mode != 'direct-only' }}
+        if: ${{ matrix.mode == 'automatic' || matrix.mode == 'relay-only' }}
         run: |
           ./scripts/install-zig-ci.sh
           ./scripts/download-prebuilt-ghosttykit.sh || ./scripts/ensure-ghosttykit.sh
 
       - name: Materialize isolated staging account
-        if: ${{ matrix.mode != 'direct-only' }}
+        if: ${{ matrix.mode == 'automatic' || matrix.mode == 'relay-only' }}
         env:
           CMUX_DOGFOOD_STACK_EMAIL: ${{ secrets.CMUX_DOGFOOD_STACK_EMAIL }}
           CMUX_DOGFOOD_STACK_PASSWORD: ${{ secrets.CMUX_DOGFOOD_STACK_PASSWORD }}
@@ -73,6 +75,7 @@ jobs:
             automatic) TAG=irgaut ;;
             relay-only) TAG=irgrel ;;
             direct-only) TAG=irgdir ;;
+            private-path) TAG=irgprv ;;
           esac
           ./scripts/run-iroh-release-gate.sh \
             --mode "${{ matrix.mode }}" \

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPrivatePathTransportGateTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPrivatePathTransportGateTests.swift
@@ -1,0 +1,548 @@
+import CMUXMobileCore
+import CryptoKit
+import Darwin
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// Release-gate coverage for the provider-neutral custom-private-path contract.
+///
+/// The successful case traverses a real non-loopback host interface. It proves
+/// the app contract without claiming that CI owns an external VPN tunnel.
+@Suite(.serialized)
+struct CmxIrohPrivatePathTransportGateTests {
+    private enum GateError: Error {
+        case connectionTimedOut
+        case noPrivateIPv4Interface
+        case portAllocationFailed
+    }
+
+    @Test
+    func brokerAuthorizedCustomAddressCarriesPrivateRPC() async throws {
+        let now = Date()
+        let fixture = try RegistryFixture(now: now)
+        let ipAddress = try privateIPv4Address()
+        let port = try availableUDPPort(ipAddress: ipAddress)
+        let profile = try privateNetworkProfile(id: "release-gate")
+        let customPath = try CmxIrohCustomPrivatePathBootstrap(
+            address: CmxIrohCustomPrivateAddress(ipAddress),
+            networkProfile: profile
+        )
+        let clientSupervisor = try await realClientSupervisor(fixture: fixture)
+        let serverEndpoint = try await realServerEndpoint(
+            fixture: fixture,
+            ipAddress: ipAddress,
+            port: port
+        )
+
+        do {
+            let clientEndpoint = try await clientSupervisor.activeEndpoint()
+            #expect(await clientEndpoint.identity() == fixture.initiator.endpointID)
+            #expect(await serverEndpoint.identity() == fixture.acceptor.endpointID)
+
+            let discovery = try fixture.discovery(
+                targetHints: [],
+                targetDirectPorts: ["ipv4": Int(port)],
+                targetLastSeenAt: now
+            )
+            let broker = TestIrohRegistryBroker(
+                discovery: discovery,
+                pairGrantResponses: [try fixture.pairGrantResponse(
+                    issuedAt: fixture.nowSeconds,
+                    expiresAt: fixture.nowSeconds + 300
+                )]
+            )
+            let provider = CmxIrohRegistryContextProvider(
+                supervisor: clientSupervisor,
+                broker: broker,
+                localBindingExpectation: try fixture.localExpectation(),
+                managedRelayURLs: [fixture.relayURL],
+                networkPathSnapshot: {
+                    CmxIrohNetworkPathSnapshot(
+                        generation: 1,
+                        activeNetworkProfiles: [profile]
+                    )
+                },
+                customPrivateFallback: { deviceID in
+                    guard CmxIrohDeviceID(deviceID)
+                        == CmxIrohDeviceID(fixture.acceptor.deviceID) else { return [] }
+                    return [customPath]
+                },
+                now: { now }
+            )
+            let context = try await provider.context(for: fixture.request(hints: []))
+            #expect(context.dialPlan.publicPaths.isEmpty)
+            #expect(context.dialPlan.privateFallbackPaths.map(\.value) == [
+                "\(ipAddress):\(port)",
+            ])
+            #expect(context.dialPlan.privateFallbackPaths.allSatisfy {
+                $0.source == .customVPN
+                    && $0.privacyScope == .privateNetwork
+                    && $0.networkProfile == profile
+            })
+            #expect(context.credential.kind == .pairGrant)
+
+            let authorizer = admissionController(
+                fixture: fixture,
+                broker: broker,
+                discovery: discovery,
+                now: now
+            )
+            let clientSession = try CmxIrohClientSession(
+                endpoint: clientEndpoint,
+                targetIdentity: fixture.acceptor.endpointID,
+                dialPlan: context.dialPlan,
+                credential: context.credential,
+                privateFallbackAuthorization: context.privateFallbackAuthorization,
+                privateFallbackValidator: provider
+            )
+            let serverSession = try await connect(
+                clientSession: clientSession,
+                serverEndpoint: serverEndpoint,
+                authorizer: authorizer
+            )
+
+            let admittedPeer = try await serverSession.admittedPeerContext()
+            #expect(admittedPeer.endpointID == fixture.initiator.endpointID)
+            #expect(try await selectedPrivatePath(clientSession))
+
+            let request = Data(
+                #"{"jsonrpc":"2.0","id":1,"method":"cmux.privatePath.probe"}"#.utf8
+            )
+            try await clientSession.sendControl(request)
+            #expect(try await serverSession.receiveControl(maximumByteCount: 4_096) == request)
+
+            let response = Data(
+                #"{"jsonrpc":"2.0","id":1,"result":{"path":"private_network"}}"#.utf8
+            )
+            try await serverSession.sendControl(response)
+            #expect(try await clientSession.receiveControl(maximumByteCount: 4_096) == response)
+
+            await clientSession.close()
+            await serverSession.close()
+        } catch {
+            await clientSupervisor.deactivate()
+            await serverEndpoint.close()
+            throw error
+        }
+        await clientSupervisor.deactivate()
+        await serverEndpoint.close()
+    }
+
+    @Test
+    func wrongEndpointIdentityCannotUseTheLivePrivateCoordinate() async throws {
+        let now = Date()
+        let fixture = try RegistryFixture(now: now)
+        let ipAddress = try privateIPv4Address()
+        let port = try availableUDPPort(ipAddress: ipAddress)
+        let clientSupervisor = try await realClientSupervisor(fixture: fixture)
+        let serverEndpoint = try await realServerEndpoint(
+            fixture: fixture,
+            ipAddress: ipAddress,
+            port: port
+        )
+        let clientEndpoint = try await clientSupervisor.activeEndpoint()
+        let hint = try privateHint(
+            ipAddress: ipAddress,
+            port: port,
+            profile: privateNetworkProfile(id: "wrong-identity"),
+            now: now
+        )
+        let wrongIdentity = try peerIdentity(secretByte: 8)
+
+        do {
+            #expect(wrongIdentity != fixture.acceptor.endpointID)
+            #expect(try await connectionIsRejected(
+                endpoint: clientEndpoint,
+                address: CmxIrohEndpointAddress(
+                    identity: wrongIdentity,
+                    pathHints: [hint]
+                )
+            ))
+        } catch {
+            await clientSupervisor.deactivate()
+            await serverEndpoint.close()
+            throw error
+        }
+
+        await clientSupervisor.deactivate()
+        await serverEndpoint.close()
+    }
+
+    @Test
+    func brokerWrongPortCannotReachTheLivePrivateEndpoint() async throws {
+        let now = Date()
+        let fixture = try RegistryFixture(now: now)
+        let ipAddress = try privateIPv4Address()
+        let serverPort = try availableUDPPort(ipAddress: ipAddress)
+        let wrongPort = try differentAvailableUDPPort(
+            ipAddress: ipAddress,
+            excluding: serverPort
+        )
+        let profile = try privateNetworkProfile(id: "wrong-port")
+        let customPath = try CmxIrohCustomPrivatePathBootstrap(
+            address: CmxIrohCustomPrivateAddress(ipAddress),
+            networkProfile: profile
+        )
+        let clientSupervisor = try await realClientSupervisor(fixture: fixture)
+        let serverEndpoint = try await realServerEndpoint(
+            fixture: fixture,
+            ipAddress: ipAddress,
+            port: serverPort
+        )
+
+        do {
+            let discovery = try fixture.discovery(
+                targetHints: [],
+                targetDirectPorts: ["ipv4": Int(wrongPort)],
+                targetLastSeenAt: now
+            )
+            let broker = TestIrohRegistryBroker(
+                discovery: discovery,
+                pairGrantResponses: [try fixture.pairGrantResponse(
+                    issuedAt: fixture.nowSeconds,
+                    expiresAt: fixture.nowSeconds + 300
+                )]
+            )
+            let provider = CmxIrohRegistryContextProvider(
+                supervisor: clientSupervisor,
+                broker: broker,
+                localBindingExpectation: try fixture.localExpectation(),
+                managedRelayURLs: [fixture.relayURL],
+                networkPathSnapshot: {
+                    CmxIrohNetworkPathSnapshot(
+                        generation: 1,
+                        activeNetworkProfiles: [profile]
+                    )
+                },
+                customPrivateFallback: { _ in [customPath] },
+                now: { now }
+            )
+            let context = try await provider.context(for: fixture.request(hints: []))
+            let clientEndpoint = try await clientSupervisor.activeEndpoint()
+
+            #expect(context.dialPlan.privateFallbackPaths.map(\.value) == [
+                "\(ipAddress):\(wrongPort)",
+            ])
+            #expect(try await connectionIsRejected(
+                endpoint: clientEndpoint,
+                address: CmxIrohEndpointAddress(
+                    identity: fixture.acceptor.endpointID,
+                    pathHints: context.dialPlan.privateFallbackPaths
+                )
+            ))
+        } catch {
+            await clientSupervisor.deactivate()
+            await serverEndpoint.close()
+            throw error
+        }
+
+        await clientSupervisor.deactivate()
+        await serverEndpoint.close()
+    }
+
+    @Test
+    func inactiveCustomRouteFailsBeforeDial() async throws {
+        let now = Date()
+        let fixture = try RegistryFixture(now: now)
+        let ipAddress = try privateIPv4Address()
+        let port = try availableUDPPort(ipAddress: ipAddress)
+        let profile = try privateNetworkProfile(id: "inactive-route")
+        let customPath = try CmxIrohCustomPrivatePathBootstrap(
+            address: CmxIrohCustomPrivateAddress(ipAddress),
+            networkProfile: profile
+        )
+        let clientSupervisor = try await realClientSupervisor(fixture: fixture)
+        let broker = TestIrohRegistryBroker(
+            discovery: try fixture.discovery(
+                targetHints: [],
+                targetDirectPorts: ["ipv4": Int(port)],
+                targetLastSeenAt: now
+            ),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 300
+            )]
+        )
+        let provider = CmxIrohRegistryContextProvider(
+            supervisor: clientSupervisor,
+            broker: broker,
+            localBindingExpectation: try fixture.localExpectation(),
+            managedRelayURLs: [fixture.relayURL],
+            networkPathSnapshot: {
+                CmxIrohNetworkPathSnapshot(
+                    generation: 2,
+                    activeNetworkProfiles: []
+                )
+            },
+            customPrivateFallback: { _ in [customPath] },
+            now: { now }
+        )
+
+        do {
+            let context = try await provider.context(for: fixture.request(hints: []))
+            #expect(context.dialPlan.publicPaths.isEmpty)
+            #expect(context.dialPlan.privateFallbackPaths.isEmpty)
+            #expect(context.privateFallbackAuthorization == nil)
+            let endpoint = try await clientSupervisor.activeEndpoint()
+            let session = try CmxIrohClientSession(
+                endpoint: endpoint,
+                targetIdentity: fixture.acceptor.endpointID,
+                dialPlan: context.dialPlan,
+                credential: context.credential,
+                privateFallbackAuthorization: context.privateFallbackAuthorization,
+                privateFallbackValidator: provider
+            )
+            await #expect(throws: CmxIrohRegistryContextError.dialPlanUnavailable) {
+                try await session.connect()
+            }
+            await session.close()
+        } catch {
+            await clientSupervisor.deactivate()
+            throw error
+        }
+        await clientSupervisor.deactivate()
+    }
+
+    private func realClientSupervisor(
+        fixture: RegistryFixture
+    ) async throws -> CmxIrohEndpointSupervisor {
+        let configuration = try CmxIrohEndpointConfiguration(
+            secretKey: CmxIrohSecretKey(bytes: Data((0 ..< 32).map(UInt8.init))),
+            alpns: [CmxIrohProtocolConfiguration.cmuxMobileV1.alpn],
+            managedRelayURLs: [fixture.relayURL],
+            relays: []
+        )
+        let supervisor = CmxIrohEndpointSupervisor(
+            factory: CmxIrohLibEndpointFactory(transportVerificationMode: .directOnly),
+            configuration: configuration
+        )
+        _ = try await supervisor.activate()
+        return supervisor
+    }
+
+    private func realServerEndpoint(
+        fixture: RegistryFixture,
+        ipAddress: String,
+        port: UInt16
+    ) async throws -> any CmxIrohEndpoint {
+        let configuration = try CmxIrohEndpointConfiguration(
+            secretKey: CmxIrohSecretKey(bytes: Data(repeating: 9, count: 32)),
+            alpns: [CmxIrohProtocolConfiguration.cmuxMobileV1.alpn],
+            bindPolicy: .required(CmxIrohBindAddress(ipAddress: ipAddress, port: port)),
+            managedRelayURLs: [fixture.relayURL],
+            relays: []
+        )
+        return try await CmxIrohLibEndpointFactory(
+            transportVerificationMode: .directOnly
+        ).bind(configuration: configuration)
+    }
+
+    private func admissionController(
+        fixture: RegistryFixture,
+        broker: TestIrohRegistryBroker,
+        discovery: CmxIrohDiscoveryResponse,
+        now: Date
+    ) -> CmxIrohAdmissionController {
+        let onlineRegistry = CmxIrohOnlineAdmissionRegistry(
+            broker: broker,
+            keys: discovery.grantVerificationKeys,
+            acceptor: fixture.acceptor,
+            managedRelayURLs: [fixture.relayURL],
+            clock: FixedOnlineAdmissionClock(now: now)
+        )
+        return CmxIrohAdmissionController(
+            acceptor: fixture.acceptor,
+            pairingEnabled: true,
+            offlineSessions: CmxIrohOfflinePairingSessions(pairingEnabled: true),
+            onlineRegistry: onlineRegistry,
+            now: { now }
+        )
+    }
+
+    private func connect(
+        clientSession: CmxIrohClientSession,
+        serverEndpoint: any CmxIrohEndpoint,
+        authorizer: CmxIrohAdmissionController
+    ) async throws -> CmxIrohServerSession {
+        try await withThrowingTaskGroup(of: CmxIrohServerSession.self) { group in
+            group.addTask {
+                async let serverSession = self.acceptAndAdmit(
+                    endpoint: serverEndpoint,
+                    authorizer: authorizer
+                )
+                try await clientSession.connect()
+                return try await serverSession
+            }
+            group.addTask {
+                // This is a bounded release-gate deadline, not state polling.
+                try await ContinuousClock().sleep(for: .seconds(20))
+                await clientSession.close()
+                await serverEndpoint.close()
+                throw GateError.connectionTimedOut
+            }
+            defer { group.cancelAll() }
+            let session: CmxIrohServerSession? = try await group.next()
+            guard let session else { throw GateError.connectionTimedOut }
+            return session
+        }
+    }
+
+    private func acceptAndAdmit(
+        endpoint: any CmxIrohEndpoint,
+        authorizer: CmxIrohAdmissionController
+    ) async throws -> CmxIrohServerSession {
+        let connection = try #require(try await endpoint.accept())
+        let session = try CmxIrohServerSession(
+            connection: connection,
+            authorizer: authorizer
+        )
+        _ = try await session.admit()
+        return session
+    }
+
+    private func selectedPrivatePath(
+        _ session: CmxIrohClientSession
+    ) async throws -> Bool {
+        let paths = await session.observedSelectedPathChanges()
+        return try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await path in paths {
+                    switch path {
+                    case .privateNetwork: return true
+                    case .direct, .relay: return false
+                    case .unavailable: continue
+                    }
+                }
+                return false
+            }
+            group.addTask {
+                // This is a bounded release-gate deadline, not state polling.
+                try await ContinuousClock().sleep(for: .seconds(10))
+                throw GateError.connectionTimedOut
+            }
+            defer { group.cancelAll() }
+            let selectedPathIsPrivate: Bool? = try await group.next()
+            guard let selectedPathIsPrivate else { throw GateError.connectionTimedOut }
+            return selectedPathIsPrivate
+        }
+    }
+
+    private func connectionIsRejected(
+        endpoint: any CmxIrohEndpoint,
+        address: CmxIrohEndpointAddress
+    ) async throws -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    let connection = try await endpoint.connect(
+                        to: address,
+                        alpn: CmxIrohProtocolConfiguration.cmuxMobileV1.alpn
+                    )
+                    await connection.close(errorCode: 1, reason: "gate_unexpected_connection")
+                    return false
+                } catch {
+                    return true
+                }
+            }
+            group.addTask {
+                // A closed endpoint makes the wrong-coordinate deadline deterministic.
+                try? await ContinuousClock().sleep(for: .seconds(5))
+                await endpoint.close()
+                return true
+            }
+            let rejected = await group.next() ?? false
+            group.cancelAll()
+            return rejected
+        }
+    }
+
+    private func privateIPv4Address() throws -> String {
+        let addresses = try CmxIrohSystemLANInterfaceSnapshotProvider().interfaceAddresses()
+        guard let address = addresses.first(where: {
+            $0.family == .ipv4
+                && CmxIrohIPAddressScope(socketAddress: "\($0.ipAddress):1").isPrivate
+                && (try? CmxIrohCustomPrivateAddress($0.ipAddress)) != nil
+        }) else {
+            throw GateError.noPrivateIPv4Interface
+        }
+        return address.ipAddress
+    }
+
+    private func availableUDPPort(ipAddress: String) throws -> UInt16 {
+        let descriptor = Darwin.socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+        guard descriptor >= 0 else { throw currentPOSIXError() }
+        defer { Darwin.close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        guard ipAddress.withCString({ inet_pton(AF_INET, $0, &address.sin_addr) }) == 1 else {
+            throw GateError.noPrivateIPv4Interface
+        }
+        let bound = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0 else { throw currentPOSIXError() }
+
+        var addressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let readAddress = withUnsafeMutablePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.getsockname(descriptor, $0, &addressLength)
+            }
+        }
+        guard readAddress == 0 else { throw currentPOSIXError() }
+        return UInt16(bigEndian: address.sin_port)
+    }
+
+    private func differentAvailableUDPPort(
+        ipAddress: String,
+        excluding excluded: UInt16
+    ) throws -> UInt16 {
+        for _ in 0 ..< 8 {
+            let candidate = try availableUDPPort(ipAddress: ipAddress)
+            if candidate != excluded { return candidate }
+        }
+        throw GateError.portAllocationFailed
+    }
+
+    private func privateNetworkProfile(id: String) throws -> CmxIrohNetworkProfileKey {
+        try CmxIrohNetworkProfileKey(
+            source: .customVPN,
+            profileID: opaqueProfileID(id)
+        )
+    }
+
+    private func privateHint(
+        ipAddress: String,
+        port: UInt16,
+        profile: CmxIrohNetworkProfileKey,
+        now: Date
+    ) throws -> CmxIrohPathHint {
+        try CmxIrohPathHint(
+            kind: .directAddress,
+            value: "\(ipAddress):\(port)",
+            source: .customVPN,
+            privacyScope: .privateNetwork,
+            observedAt: now,
+            expiresAt: now.addingTimeInterval(60),
+            networkProfile: profile
+        )
+    }
+
+    private func peerIdentity(secretByte: UInt8) throws -> CmxIrohPeerIdentity {
+        let key = try Curve25519.Signing.PrivateKey(
+            rawRepresentation: Data(repeating: secretByte, count: 32)
+        )
+        let endpointID = key.publicKey.rawRepresentation.map {
+            String(format: "%02x", $0)
+        }.joined()
+        return try CmxIrohPeerIdentity(endpointID: endpointID)
+    }
+
+    private func currentPOSIXError() -> POSIXError {
+        POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPrivatePathTransportGateTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPrivatePathTransportGateTests.swift
@@ -11,6 +11,11 @@ import Testing
 /// the app contract without claiming that CI owns an external VPN tunnel.
 @Suite(.serialized)
 struct CmxIrohPrivatePathTransportGateTests {
+    private struct BoundServer {
+        let endpoint: any CmxIrohEndpoint
+        let port: UInt16
+    }
+
     private enum GateError: Error {
         case connectionTimedOut
         case noPrivateIPv4Interface
@@ -22,18 +27,18 @@ struct CmxIrohPrivatePathTransportGateTests {
         let now = Date()
         let fixture = try RegistryFixture(now: now)
         let ipAddress = try privateIPv4Address()
-        let port = try availableUDPPort(ipAddress: ipAddress)
         let profile = try privateNetworkProfile(id: "release-gate")
         let customPath = try CmxIrohCustomPrivatePathBootstrap(
             address: CmxIrohCustomPrivateAddress(ipAddress),
             networkProfile: profile
         )
         let clientSupervisor = try await realClientSupervisor(fixture: fixture)
-        let serverEndpoint = try await realServerEndpoint(
+        let server = try await realServerEndpoint(
             fixture: fixture,
-            ipAddress: ipAddress,
-            port: port
+            ipAddress: ipAddress
         )
+        let serverEndpoint = server.endpoint
+        let port = server.port
 
         do {
             let clientEndpoint = try await clientSupervisor.activeEndpoint()
@@ -134,13 +139,13 @@ struct CmxIrohPrivatePathTransportGateTests {
         let now = Date()
         let fixture = try RegistryFixture(now: now)
         let ipAddress = try privateIPv4Address()
-        let port = try availableUDPPort(ipAddress: ipAddress)
         let clientSupervisor = try await realClientSupervisor(fixture: fixture)
-        let serverEndpoint = try await realServerEndpoint(
+        let server = try await realServerEndpoint(
             fixture: fixture,
-            ipAddress: ipAddress,
-            port: port
+            ipAddress: ipAddress
         )
+        let serverEndpoint = server.endpoint
+        let port = server.port
         let clientEndpoint = try await clientSupervisor.activeEndpoint()
         let hint = try privateHint(
             ipAddress: ipAddress,
@@ -174,7 +179,12 @@ struct CmxIrohPrivatePathTransportGateTests {
         let now = Date()
         let fixture = try RegistryFixture(now: now)
         let ipAddress = try privateIPv4Address()
-        let serverPort = try availableUDPPort(ipAddress: ipAddress)
+        let server = try await realServerEndpoint(
+            fixture: fixture,
+            ipAddress: ipAddress
+        )
+        let serverEndpoint = server.endpoint
+        let serverPort = server.port
         let wrongPort = try differentAvailableUDPPort(
             ipAddress: ipAddress,
             excluding: serverPort
@@ -185,11 +195,6 @@ struct CmxIrohPrivatePathTransportGateTests {
             networkProfile: profile
         )
         let clientSupervisor = try await realClientSupervisor(fixture: fixture)
-        let serverEndpoint = try await realServerEndpoint(
-            fixture: fixture,
-            ipAddress: ipAddress,
-            port: serverPort
-        )
 
         do {
             let discovery = try fixture.discovery(
@@ -319,6 +324,27 @@ struct CmxIrohPrivatePathTransportGateTests {
         )
         _ = try await supervisor.activate()
         return supervisor
+    }
+
+    private func realServerEndpoint(
+        fixture: RegistryFixture,
+        ipAddress: String
+    ) async throws -> BoundServer {
+        var lastError: (any Error)?
+        for _ in 0 ..< 8 {
+            let port = try availableUDPPort(ipAddress: ipAddress)
+            do {
+                let endpoint = try await realServerEndpoint(
+                    fixture: fixture,
+                    ipAddress: ipAddress,
+                    port: port
+                )
+                return BoundServer(endpoint: endpoint, port: port)
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? GateError.portAllocationFailed
     }
 
     private func realServerEndpoint(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPrivatePathTransportGateTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPrivatePathTransportGateTests.swift
@@ -25,7 +25,11 @@ struct CmxIrohPrivatePathTransportGateTests {
     @Test
     func brokerAuthorizedCustomAddressCarriesPrivateRPC() async throws {
         let now = Date()
-        let fixture = try RegistryFixture(now: now)
+        let fixture = try RegistryFixture(
+            now: now,
+            initiatorSecretKey: Data(repeating: 1, count: 32),
+            acceptorSecretKey: Data(repeating: 10, count: 32)
+        )
         let ipAddress = try privateIPv4Address()
         let profile = try privateNetworkProfile(id: "release-gate")
         let customPath = try CmxIrohCustomPrivatePathBootstrap(
@@ -137,7 +141,11 @@ struct CmxIrohPrivatePathTransportGateTests {
     @Test
     func wrongEndpointIdentityCannotUseTheLivePrivateCoordinate() async throws {
         let now = Date()
-        let fixture = try RegistryFixture(now: now)
+        let fixture = try RegistryFixture(
+            now: now,
+            initiatorSecretKey: Data(repeating: 2, count: 32),
+            acceptorSecretKey: Data(repeating: 11, count: 32)
+        )
         let ipAddress = try privateIPv4Address()
         let clientSupervisor = try await realClientSupervisor(fixture: fixture)
         let server = try await realServerEndpoint(
@@ -155,20 +163,15 @@ struct CmxIrohPrivatePathTransportGateTests {
         )
         let wrongIdentity = try peerIdentity(secretByte: 8)
 
-        do {
-            #expect(wrongIdentity != fixture.acceptor.endpointID)
-            #expect(try await connectionIsRejected(
-                endpoint: clientEndpoint,
-                address: CmxIrohEndpointAddress(
-                    identity: wrongIdentity,
-                    pathHints: [hint]
-                )
-            ))
-        } catch {
-            await clientSupervisor.deactivate()
-            await serverEndpoint.close()
-            throw error
-        }
+        #expect(wrongIdentity != fixture.acceptor.endpointID)
+        let outcome = await connectionAttemptOutcome(
+            endpoint: clientEndpoint,
+            address: CmxIrohEndpointAddress(
+                identity: wrongIdentity,
+                pathHints: [hint]
+            )
+        )
+        #expect(outcome == .observationElapsed || outcome == .remoteIdentityMismatch)
 
         await clientSupervisor.deactivate()
         await serverEndpoint.close()
@@ -177,7 +180,11 @@ struct CmxIrohPrivatePathTransportGateTests {
     @Test
     func brokerWrongPortCannotReachTheLivePrivateEndpoint() async throws {
         let now = Date()
-        let fixture = try RegistryFixture(now: now)
+        let fixture = try RegistryFixture(
+            now: now,
+            initiatorSecretKey: Data(repeating: 3, count: 32),
+            acceptorSecretKey: Data(repeating: 12, count: 32)
+        )
         let ipAddress = try privateIPv4Address()
         let server = try await realServerEndpoint(
             fixture: fixture,
@@ -229,13 +236,14 @@ struct CmxIrohPrivatePathTransportGateTests {
             #expect(context.dialPlan.privateFallbackPaths.map(\.value) == [
                 "\(ipAddress):\(wrongPort)",
             ])
-            #expect(try await connectionIsRejected(
+            let outcome = await connectionAttemptOutcome(
                 endpoint: clientEndpoint,
                 address: CmxIrohEndpointAddress(
                     identity: fixture.acceptor.endpointID,
                     pathHints: context.dialPlan.privateFallbackPaths
                 )
-            ))
+            )
+            #expect(outcome == .observationElapsed || outcome == .dialFailed)
         } catch {
             await clientSupervisor.deactivate()
             await serverEndpoint.close()
@@ -313,7 +321,7 @@ struct CmxIrohPrivatePathTransportGateTests {
         fixture: RegistryFixture
     ) async throws -> CmxIrohEndpointSupervisor {
         let configuration = try CmxIrohEndpointConfiguration(
-            secretKey: CmxIrohSecretKey(bytes: Data((0 ..< 32).map(UInt8.init))),
+            secretKey: CmxIrohSecretKey(bytes: fixture.privateKey.rawRepresentation),
             alpns: [CmxIrohProtocolConfiguration.cmuxMobileV1.alpn],
             managedRelayURLs: [fixture.relayURL],
             relays: []
@@ -353,7 +361,7 @@ struct CmxIrohPrivatePathTransportGateTests {
         port: UInt16
     ) async throws -> any CmxIrohEndpoint {
         let configuration = try CmxIrohEndpointConfiguration(
-            secretKey: CmxIrohSecretKey(bytes: Data(repeating: 9, count: 32)),
+            secretKey: CmxIrohSecretKey(bytes: fixture.acceptorSecretKey),
             alpns: [CmxIrohProtocolConfiguration.cmuxMobileV1.alpn],
             bindPolicy: .required(CmxIrohBindAddress(ipAddress: ipAddress, port: port)),
             managedRelayURLs: [fixture.relayURL],
@@ -454,11 +462,11 @@ struct CmxIrohPrivatePathTransportGateTests {
         }
     }
 
-    private func connectionIsRejected(
+    private func connectionAttemptOutcome(
         endpoint: any CmxIrohEndpoint,
         address: CmxIrohEndpointAddress
-    ) async throws -> Bool {
-        await withTaskGroup(of: Bool.self) { group in
+    ) async -> ConnectionAttemptOutcome {
+        await withTaskGroup(of: ConnectionAttemptOutcome.self) { group in
             group.addTask {
                 do {
                     let connection = try await endpoint.connect(
@@ -466,21 +474,36 @@ struct CmxIrohPrivatePathTransportGateTests {
                         alpn: CmxIrohProtocolConfiguration.cmuxMobileV1.alpn
                     )
                     await connection.close(errorCode: 1, reason: "gate_unexpected_connection")
-                    return false
+                    return .connected
+                } catch CmxIrohLibError.remoteIdentityMismatch {
+                    return .remoteIdentityMismatch
                 } catch {
-                    return true
+                    return .dialFailed
                 }
             }
             group.addTask {
-                // A closed endpoint makes the wrong-coordinate deadline deterministic.
+                // Iroh rejects an unknown cryptographic EndpointID before a
+                // connection exists, so a wrong live coordinate can remain pending.
+                // The same release-gate suite proves an authorized private
+                // coordinate carries bidirectional RPC, so this is not the only
+                // evidence used to assess network health.
                 try? await ContinuousClock().sleep(for: .seconds(5))
-                await endpoint.close()
-                return true
+                return .observationElapsed
             }
-            let rejected = await group.next() ?? false
+            let outcome = await group.next() ?? .observationElapsed
             group.cancelAll()
-            return rejected
+            if outcome == .observationElapsed {
+                await endpoint.close()
+            }
+            return outcome
         }
+    }
+
+    private enum ConnectionAttemptOutcome: Equatable, Sendable {
+        case connected
+        case remoteIdentityMismatch
+        case dialFailed
+        case observationElapsed
     }
 
     private func privateIPv4Address() throws -> String {

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderTests.swift
@@ -356,6 +356,7 @@ enum TestNetworkPathStateError: Error {
 
 struct RegistryFixture: Sendable {
     let privateKey: Curve25519.Signing.PrivateKey
+    let acceptorSecretKey: Data
     let key: CmxIrohGrantVerificationKey
     let initiator: CmxIrohGrantPeer
     let acceptor: CmxIrohGrantPeer
@@ -363,14 +364,19 @@ struct RegistryFixture: Sendable {
     let nowSeconds: Int64
     let relayURL = "https://use1-1.relay.lawrence.cmux.iroh.link/"
 
-    init(now: Date = Date(timeIntervalSince1970: 1_800_000_000)) throws {
+    init(
+        now: Date = Date(timeIntervalSince1970: 1_800_000_000),
+        initiatorSecretKey: Data = Data((0 ..< 32).map(UInt8.init)),
+        acceptorSecretKey: Data = Data(repeating: 9, count: 32)
+    ) throws {
         self.now = now
+        self.acceptorSecretKey = acceptorSecretKey
         nowSeconds = Int64(now.timeIntervalSince1970.rounded(.down))
         privateKey = try Curve25519.Signing.PrivateKey(
-            rawRepresentation: Data((0 ..< 32).map(UInt8.init))
+            rawRepresentation: initiatorSecretKey
         )
         let targetKey = try Curve25519.Signing.PrivateKey(
-            rawRepresentation: Data(repeating: 9, count: 32)
+            rawRepresentation: acceptorSecretKey
         )
         initiator = CmxIrohGrantPeer(
             bindingID: "123e4567-e89b-42d3-a456-426614174001",

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderTests.swift
@@ -359,11 +359,13 @@ struct RegistryFixture: Sendable {
     let key: CmxIrohGrantVerificationKey
     let initiator: CmxIrohGrantPeer
     let acceptor: CmxIrohGrantPeer
-    let now = Date(timeIntervalSince1970: 1_800_000_000)
-    let nowSeconds: Int64 = 1_800_000_000
+    let now: Date
+    let nowSeconds: Int64
     let relayURL = "https://use1-1.relay.lawrence.cmux.iroh.link/"
 
-    init() throws {
+    init(now: Date = Date(timeIntervalSince1970: 1_800_000_000)) throws {
+        self.now = now
+        nowSeconds = Int64(now.timeIntervalSince1970.rounded(.down))
         privateKey = try Curve25519.Signing.PrivateKey(
             rawRepresentation: Data((0 ..< 32).map(UInt8.init))
         )

--- a/scripts/lib/mobile-attach.test.mjs
+++ b/scripts/lib/mobile-attach.test.mjs
@@ -500,11 +500,12 @@ test("release gate grants asynchronous Iroh publication a bounded startup window
   );
 });
 
-test("release gate assigns direct-only to the Simulator transport proof", () => {
+test("release gate assigns each mode to its transport proof", () => {
   const cases = [
     ["automatic", "app-rpc"],
     ["relay-only", "app-rpc"],
     ["direct-only", "simulator-direct-transport"],
+    ["private-path", "host-private-path-transport"],
   ];
 
   for (const [mode, expectedPlan] of cases) {

--- a/scripts/lib/mobile-attach.test.mjs
+++ b/scripts/lib/mobile-attach.test.mjs
@@ -522,6 +522,21 @@ test("release gate assigns each mode to its transport proof", () => {
   }
 });
 
+test("private-path plan ignores the unrelated staging base URL", () => {
+  const result = run("bash", [
+    "scripts/run-iroh-release-gate.sh",
+    "--mode",
+    "private-path",
+    "--tag",
+    "plan-private",
+    "--staging-base-url",
+    "not-a-network-url",
+    "--print-plan",
+  ]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "host-private-path-transport");
+});
+
 test("mobile launch accepts an explicit no-attach override", () => {
   const result = run("bash", [
     "scripts/mobile-dev-launch.sh",

--- a/scripts/run-iroh-private-path-transport-gate.sh
+++ b/scripts/run-iroh-private-path-transport-gate.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-iroh-private-path-transport-gate.sh --tag <tag>
+       [--skip-build] [--report-output <path>]
+
+Runs two real relay-disabled Iroh endpoints across a non-loopback private host
+interface. The gate requires broker-authorized custom numeric route selection,
+exact EndpointID admission, bidirectional RPC bytes, and fail-closed wrong
+identity, wrong port, and inactive-route cases.
+
+This proves cmux's provider-neutral private-path contract. It does not claim
+that the runner owns or traverses an external VPN tunnel.
+EOF
+}
+
+TAG=""
+SKIP_BUILD=0
+REPORT_OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag) TAG="${2:-}"; shift 2 ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --report-output) REPORT_OUTPUT="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$TAG" ]] || { echo "error: --tag is required" >&2; exit 2; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=scripts/lib/mobile-attach.sh
+source "$SCRIPT_DIR/lib/mobile-attach.sh"
+cmux_attach_validate_dev_tag "$TAG"
+
+SLUG="$(cmux_attach__slug "$TAG")"
+DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData/cmux-iroh-private-path-$SLUG"
+RESULT_BUNDLE="$DERIVED_DATA/CmuxIrohPrivatePathTransportGate.xcresult"
+XCODEBUILD_ACTION="test"
+if [[ "$SKIP_BUILD" -eq 1 ]]; then
+  XCODEBUILD_ACTION="test-without-building"
+fi
+rm -rf "$RESULT_BUNDLE"
+
+(
+  cd "$REPO_ROOT/Packages/Shared/CmuxIrohTransport"
+  python3 "$REPO_ROOT/scripts/ci/run_with_timeout.py" \
+    --timeout-seconds 600 \
+    -- xcodebuild \
+      -scheme CmuxIrohTransport \
+      -destination "platform=macOS" \
+      -derivedDataPath "$DERIVED_DATA" \
+      -resultBundlePath "$RESULT_BUNDLE" \
+      "$XCODEBUILD_ACTION" \
+      -only-testing:CmuxIrohTransportTests/CmxIrohPrivatePathTransportGateTests
+)
+
+RESULT_BUNDLE="$RESULT_BUNDLE" /usr/bin/python3 <<'PY'
+import json
+import os
+import subprocess
+
+summary = json.loads(subprocess.check_output([
+    "xcrun", "xcresulttool", "get", "test-results", "summary",
+    "--path", os.environ["RESULT_BUNDLE"], "--compact",
+]))
+if summary.get("result") != "Passed":
+    raise SystemExit(
+        f"private-path transport test result was {summary.get('result')}, expected Passed"
+    )
+total = int(summary.get("totalTestCount", 0))
+passed = int(summary.get("passedTests", 0))
+failed = int(summary.get("failedTests", 0))
+if total != 4 or passed != 4 or failed != 0:
+    raise SystemExit(
+        f"private-path transport gate total={total} passed={passed} failed={failed}"
+    )
+PY
+
+REPORT_JSON='{"bidirectionalRPCVerified":true,"brokerGrantVerified":true,"brokerPortAuthoritative":true,"coverage":"host_private_interface_contract","customAddressInjected":true,"endpointIdentityVerified":true,"externalVPNVerified":false,"inactiveRouteRejected":true,"passed":true,"relayMode":"disabled","routeKind":"iroh","routeSource":"custom_vpn","schemaVersion":3,"selectedPathClass":"private_network","wrongIdentityRejected":true,"wrongPortRejected":true}'
+printf '%s\n' "$REPORT_JSON"
+if [[ -n "$REPORT_OUTPUT" ]]; then
+  mkdir -p "$(dirname "$REPORT_OUTPUT")"
+  REPORT_OUTPUT="$REPORT_OUTPUT" REPORT_JSON="$REPORT_JSON" /usr/bin/python3 <<'PY'
+import json
+import os
+
+with open(os.environ["REPORT_OUTPUT"], "w", encoding="utf-8") as handle:
+    json.dump(json.loads(os.environ["REPORT_JSON"]), handle, sort_keys=True)
+    handle.write("\n")
+PY
+fi
+
+echo "==> Iroh private-path transport gate passed"

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/run-iroh-release-gate.sh --mode <automatic|relay-only|direct-only> --tag <tag>
+Usage: scripts/run-iroh-release-gate.sh --mode <automatic|relay-only|direct-only|private-path> --tag <tag>
        [--staging-base-url <url>] [--skip-build] [--keep-simulator]
        [--report-output <path>] [--print-plan]
        [--production [--stack-env-file <secure-path>]]
@@ -11,7 +11,9 @@ Usage: scripts/run-iroh-release-gate.sh --mode <automatic|relay-only|direct-only
 Automatic and relay-only build a tagged Mac app plus an isolated iOS Simulator
 app, sign both into the same staging account, pair only over Iroh, and verify
 the app RPC surface. Direct-only runs a deterministic two-Iroh-endpoint proof
-inside an isolated iOS Simulator with relays disabled.
+inside an isolated iOS Simulator with relays disabled. Private-path runs a
+provider-neutral broker-authorized custom-route proof across a non-loopback
+private host interface with relays disabled.
 
 Credentials resolve through scripts/lib/dev-secrets.sh and are never printed.
 `--production` creates a verified temporary production Stack account, runs the
@@ -69,8 +71,14 @@ case "$MODE" in
   automatic) RAW_MODE="automatic"; GATE_PLAN="app-rpc" ;;
   relay-only) RAW_MODE="relayOnly"; GATE_PLAN="app-rpc" ;;
   direct-only) RAW_MODE="directOnly"; GATE_PLAN="simulator-direct-transport" ;;
+  private-path) RAW_MODE=""; GATE_PLAN="host-private-path-transport" ;;
   *) echo "error: invalid mode '$MODE'" >&2; exit 2 ;;
 esac
+
+if [[ "$PRODUCTION" -eq 1 && "$GATE_PLAN" == "host-private-path-transport" ]]; then
+  echo "error: private-path proves the host transport contract and has no production environment" >&2
+  exit 2
+fi
 
 case "$STAGING_BASE_URL" in
   https://*) ;;
@@ -98,6 +106,13 @@ if [[ "$GATE_PLAN" == "simulator-direct-transport" ]]; then
   [[ "$KEEP_SIMULATOR" -eq 1 ]] && DIRECT_GATE_ARGUMENTS+=(--keep-simulator)
   [[ -n "$REPORT_OUTPUT" ]] && DIRECT_GATE_ARGUMENTS+=(--report-output "$REPORT_OUTPUT")
   exec "$SCRIPT_DIR/run-iroh-direct-transport-gate.sh" "${DIRECT_GATE_ARGUMENTS[@]}"
+fi
+
+if [[ "$GATE_PLAN" == "host-private-path-transport" ]]; then
+  PRIVATE_GATE_ARGUMENTS=(--tag "$TAG")
+  [[ "$SKIP_BUILD" -eq 1 ]] && PRIVATE_GATE_ARGUMENTS+=(--skip-build)
+  [[ -n "$REPORT_OUTPUT" ]] && PRIVATE_GATE_ARGUMENTS+=(--report-output "$REPORT_OUTPUT")
+  exec "$SCRIPT_DIR/run-iroh-private-path-transport-gate.sh" "${PRIVATE_GATE_ARGUMENTS[@]}"
 fi
 
 SLUG="$(cmux_attach__slug "$TAG")"

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -80,10 +80,12 @@ if [[ "$PRODUCTION" -eq 1 && "$GATE_PLAN" == "host-private-path-transport" ]]; t
   exit 2
 fi
 
-case "$STAGING_BASE_URL" in
-  https://*) ;;
-  *) echo "error: --staging-base-url must use https" >&2; exit 2 ;;
-esac
+if [[ "$GATE_PLAN" != "host-private-path-transport" ]]; then
+  case "$STAGING_BASE_URL" in
+    https://*) ;;
+    *) echo "error: --staging-base-url must use https" >&2; exit 2 ;;
+  esac
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
Proves cmux’s custom private-path contract with real relay-disabled Iroh endpoints.

The gate requires a broker-authoritative numeric private route, exact EndpointID, signed pair-grant admission, selected private-network path, and bidirectional RPC bytes. Wrong identity, wrong port, and inactive profile cases fail closed.

The redacted artifact explicitly records `externalVPNVerified: false`; this does not claim an external VPN tunnel was exercised.

Verification:
- `swift test --filter CmxIrohPrivatePathTransportGateTests` (4/4)
- `./scripts/run-iroh-private-path-transport-gate.sh --tag irpriv --report-output /tmp/cmux-iroh-private-path-report.json`
- `./scripts/run-iroh-release-gate.sh --mode private-path --tag irpriv --skip-build --report-output /tmp/cmux-iroh-private-wrapper-report.json`
- `node --test scripts/lib/mobile-attach.test.mjs` (29/29)
- `bun test scripts/lib/iroh-production-gate.test.mjs` (5/5)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787074083&installation_id=133855650&pr_number=8492&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8492&signature=892c73f6f22904be8b1ee1e76ef94943e214876d89dcda8de2804801c198934d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider‑neutral private‑path release gate for Iroh with relays disabled to validate custom private routes on a real host interface. Enforces broker‑authorized numeric route, exact EndpointID, signed pair‑grant, bidirectional RPC, and classifies failure outcomes for wrong identity/port and inactive routes.

- **New Features**
  - CI: add `private-path` mode to `.github/workflows/iroh-release-gate.yml` and `scripts/run-iroh-release-gate.sh`.
  - Transport test: add `CmxIrohPrivatePathTransportGateTests` to prove private path selection and RPC, and classify rejections as identity mismatch, dial failed, or observation elapsed.
  - Tooling: add `scripts/run-iroh-private-path-transport-gate.sh` that runs the gate and emits a JSON report with `externalVPNVerified: false`.
  - Update `scripts/lib/mobile-attach.test.mjs` to map `private-path` to `host-private-path-transport` and verify `--staging-base-url` is ignored in `private-path`; allow injected clock in the registry fixture.

- **Bug Fixes**
  - Workflow: skip iOS Simulator runtime for `private-path`; limit app deps and staging account materialization to `automatic`/`relay-only`; map `private-path` tag to `irgprv`.
  - Release-gate: block `--production` for `private-path` and ignore `--staging-base-url` in `private-path`; route to `host-private-path-transport`.
  - Gate runner: validate `xcresult` summary (expects 4/4 passed) and write a stricter report, keeping `externalVPNVerified: false`.

<sup>Written for commit b51d82d42e692e07d2adbf9f23949f050b2575f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `private-path` transport mode to release-gate workflows and gate commands, including updated matrix handling and dispatch logic.
  * Introduced a dedicated macOS private-path transport gate runner with generated pass/fail reporting.

* **Tests**
  * Added comprehensive private-path LAN release-gate integration coverage, including dial-plan selection, contract success paths, and multiple rejection/failure scenarios.

* **Bug Fixes**
  * Tightened staging/setup and tagging behavior for `private-path`, and ensured iOS simulator runtime installation is skipped when not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->