### PR TITLE
Fix Iroh release-gate readiness race

### DIFF
--- a/scripts/lib/mobile-attach.sh
+++ b/scripts/lib/mobile-attach.sh
@@ -158,7 +158,7 @@ cmux_attach_mac_socket_ready() {
 # 0 if the Mac is ready to mint a usable target-specific ticket, 1 otherwise.
 # Never force-kills a running app by default.
 cmux_attach_ensure_mac() {
-  local tag="$1" repo_root="${2:-}" target="${3:?attach target is required}" sock app slug _i
+  local tag="$1" repo_root="${2:-}" target="${3:?attach target is required}" sock app slug mint_attempts _i
   sock="$(cmux_attach_socket_path "$tag")"
   app="$(cmux_attach_mac_app_path "$tag")"
   slug="$(cmux_attach__slug "$tag")"
@@ -199,7 +199,21 @@ cmux_attach_ensure_mac() {
   # binds /tmp/cmux-debug-<slug>.sock without extra env.
   open -g "$app" >/dev/null 2>&1 || open "$app" >/dev/null 2>&1 || true
   for _i in $(seq 1 60); do
-    [[ -S "$sock" ]] && return 0
+    if [[ -S "$sock" ]]; then
+      if [[ -z "$repo_root" ]]; then
+        return 0
+      fi
+      mint_attempts="${CMUX_ATTACH_MINT_MAX_ATTEMPTS:-20}"
+      if [[ -n "$(cmux_attach_mint_url "$tag" 60 "$repo_root" "$target" "$mint_attempts")" ]]; then
+        return 0
+      fi
+      if [[ "$target" == "physical_device" ]]; then
+        echo "warning: tagged Mac app for '$tag' launched, but no trusted Iroh ticket became ready." >&2
+      else
+        echo "warning: tagged Mac app for '$tag' launched, but its iOS pairing ticket did not become ready." >&2
+      fi
+      return 1
+    fi
     sleep 0.2
   done
   echo "warning: tagged Mac socket $sock did not appear after launch; auto-pair unavailable (signing in only)." >&2

--- a/scripts/lib/mobile-attach.test.mjs
+++ b/scripts/lib/mobile-attach.test.mjs
@@ -171,6 +171,67 @@ async function mintAttachURL(target, payload, maxAttempts = 1) {
   }
 }
 
+async function ensureMacAfterRelaunch() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cmux-mobile-ready-test-"));
+  const socketPath = path.join(tempRoot, "mobile.sock");
+  const appPath = path.join(tempRoot, "cmux DEV ready.app");
+  const callCounterPath = path.join(tempRoot, "call-count");
+  fs.mkdirSync(appPath);
+
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+
+  try {
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        [
+          'source "$1"',
+          'cmux_attach_enable_pairing_host() { :; }',
+          'cmux_attach_socket_path() { printf "%s" "$CMUX_TEST_SOCKET"; }',
+          'cmux_attach_mac_app_path() { printf "%s" "$CMUX_TEST_APP"; }',
+          'cmux_attach__slug() { printf "ready"; }',
+          'cmux_attach_mint_url() {',
+          '  count="$(cat "$CMUX_TEST_CALL_COUNTER" 2>/dev/null || printf 0)"',
+          '  count="$((count + 1))"',
+          '  printf "%s" "$count" > "$CMUX_TEST_CALL_COUNTER"',
+          '  if [[ "$count" -ge 2 ]]; then printf "cmux-ios-dev://attach?v=2&kind=iroh"; return 0; fi',
+          '  return 1',
+          '}',
+          'pkill() { return 0; }',
+          'open() { return 0; }',
+          'sleep() { return 0; }',
+          'CMUX_ATTACH_ALLOW_RELAUNCH=1 cmux_attach_ensure_mac "ready" "$2" physical_device',
+        ].join("\n"),
+        "mobile-attach-test",
+        validator,
+        tempRoot,
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CMUX_TEST_APP: appPath,
+          CMUX_TEST_CALL_COUNTER: callCounterPath,
+          CMUX_TEST_SOCKET: socketPath,
+        },
+      },
+    );
+    result.callCount = fs.existsSync(callCounterPath)
+      ? Number.parseInt(fs.readFileSync(callCounterPath, "utf8"), 10)
+      : 0;
+    return result;
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
 function attachPayload(kind) {
   return {
     attach_url: `cmux-ios-dev://attach?v=2&kind=${kind}`,
@@ -473,6 +534,12 @@ test("physical-device mint retries transient empty responses", async () => {
   );
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, payload.attach_url);
+  assert.equal(result.callCount, 2);
+});
+
+test("Mac readiness is revalidated after a tagged relaunch", async () => {
+  const result = await ensureMacAfterRelaunch();
+  assert.equal(result.status, 0, result.stderr);
   assert.equal(result.callCount, 2);
 });
 

--- a/scripts/run-iroh-release-gate.sh
+++ b/scripts/run-iroh-release-gate.sh
@@ -368,8 +368,9 @@ fi
 # tag is uniquely owned by this driver, and the exact executable is now absent,
 # so remove only this validated tag's socket before relaunching.
 cmux_attach_remove_stale_socket "$TAG"
-CMUX_ATTACH_ALLOW_RELAUNCH=1 cmux_attach_ensure_mac \
-  "$TAG" "$REPO_ROOT" simulator_injection
+CMUX_ATTACH_ALLOW_RELAUNCH=1 \
+CMUX_ATTACH_MINT_MAX_ATTEMPTS=120 \
+cmux_attach_ensure_mac "$TAG" "$REPO_ROOT" physical_device
 
 # Wait for the app's atomic report-write signal. Python owns the simulator
 # notifyutil child so its timeout is bounded without polling the filesystem.


### PR DESCRIPTION
## Summary
- revalidate ticket minting after launching or relaunching the tagged Mac
- require the release gate to observe a trusted Iroh route before launching iOS
- preserve a red-then-green behavioral regression test

## Verification
- `node --test scripts/lib/mobile-attach.test.mjs` (30/30)
- `bash -n scripts/lib/mobile-attach.sh scripts/run-iroh-release-gate.sh`
- `git diff --check`

The previous current-main hosted run failed automatic and relay-only because the Mac debug socket appeared before broker registration could mint a trusted Iroh ticket.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787075234&installation_id=133855650&pr_number=8493&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8493&signature=1b227a07a3325e1a275498efe14dcc30f7bbfcecfb510f2b7d4c8ed130922ce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release-gate readiness race by waiting for a trusted Iroh ticket after the tagged Mac app launches or relaunches. This prevents the gate from proceeding when only the debug socket exists.

- **Bug Fixes**
  - Revalidate minting in `cmux_attach_ensure_mac` before reporting Mac ready; add bounded retries via `CMUX_ATTACH_MINT_MAX_ATTEMPTS`.
  - In `scripts/run-iroh-release-gate.sh`, require a trusted route before proceeding and set `CMUX_ATTACH_MINT_MAX_ATTEMPTS=120`; switch to `physical_device`.
  - Add regression test to confirm readiness is rechecked after relaunch and that transient empty mints are retried.

<sup>Written for commit 259b4e6822add37f2ad965395876230c8ad979a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Mac app readiness checks after relaunches.
  - Attach operations now wait for a usable connection ticket before reporting success.
  - Added clearer failure handling and target-specific warnings when attachment setup cannot complete.
  - Improved reliability for physical-device attachment workflows, including configurable retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->