### PR TITLE
feat(iroh): stream artifacts over peer-bound lanes

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactLaneDescriptor.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactLaneDescriptor.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// An opaque, short-lived capability for one authorized Iroh artifact transfer.
+public struct ChatArtifactLaneDescriptor: Codable, Equatable, Sendable {
+    /// Opaque capability presented in the Iroh artifact-lane header.
+    public let resourceID: String
+    /// File size captured when the Mac authorized the transfer.
+    public let totalSize: Int64
+    /// Time after which the Mac refuses new lane claims.
+    public let expiresAt: Date
+
+    public init(resourceID: String, totalSize: Int64, expiresAt: Date) {
+        self.resourceID = resourceID
+        self.totalSize = totalSize
+        self.expiresAt = expiresAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case resourceID = "resource_id"
+        case totalSize = "total_size"
+        case expiresAt = "expires_at"
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactLaneDescriptorTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactLaneDescriptorTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("ChatArtifactLaneDescriptor")
+struct ChatArtifactLaneDescriptorTests {
+    @Test
+    func roundTripsOnlyOpaqueTransferMetadata() throws {
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "artifact:opaque-capability",
+            totalSize: 42,
+            expiresAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let coding = ChatWireCoding()
+
+        let data = try coding.encode(descriptor)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+
+        #expect(object["resource_id"] as? String == descriptor.resourceID)
+        #expect(object["total_size"] as? Int == 42)
+        #expect(object["expires_at"] as? String == "2023-11-14T22:13:20Z")
+        #expect(object["path"] == nil)
+        #expect(try coding.decode(ChatArtifactLaneDescriptor.self, from: data) == descriptor)
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
@@ -17,6 +17,13 @@ struct CmxIrohServerSessionTests {
             buffer: terminalHeader + Data("terminal-payload".utf8)
         )
         let terminalSend = TestIrohSendStream()
+        let artifactID = try CmxIrohResourceID("artifact:admitted-preview")
+        let artifactHeader = try fixture.headerCodec.encode(
+            CmxIrohStreamHeader(lane: .artifact(resourceID: artifactID, offset: 4))
+        )
+        let artifactReceive = TestIrohReceiveStream(
+            buffer: artifactHeader + Data("artifact-payload".utf8)
+        )
         let connection = TestIrohConnection(
             remoteIdentity: fixture.peerID,
             bidirectionalStreams: [
@@ -24,6 +31,10 @@ struct CmxIrohServerSessionTests {
                 CmxIrohBidirectionalStream(
                     receiveStream: terminalReceive,
                     sendStream: terminalSend
+                ),
+                CmxIrohBidirectionalStream(
+                    receiveStream: artifactReceive,
+                    sendStream: TestIrohSendStream()
                 ),
             ],
             eventRecorder: events
@@ -54,12 +65,23 @@ struct CmxIrohServerSessionTests {
             try await inbound.stream.receiveStream.receive(maximumByteCount: 64)
                 == Data("terminal-payload".utf8)
         )
+        let artifact = try await session.acceptBidirectionalLane()
+        #expect(artifact.lane == .artifact(resourceID: artifactID, offset: 4))
+        #expect(
+            try await artifact.stream.receiveStream.receive(maximumByteCount: 64)
+                == Data("artifact-payload".utf8)
+        )
         let acknowledgements = await fixture.controlSend.observedSentBuffers()
         let acceptedPending = try #require(acknowledgements.first)
         let serverReady = try #require(acknowledgements.dropFirst().first)
         #expect(acknowledgements.count == 2)
         #expect(try CmxIrohAdmissionAckCodec().decodePrefix(acceptedPending) == .accepted)
         #expect(serverReady == admissionFrame(status: 3))
+        try await session.sendControl(Data("control-after-artifact".utf8))
+        #expect(
+            await fixture.controlSend.observedSentBuffers().last
+                == Data("control-after-artifact".utf8)
+        )
         #expect(await connection.observedCloseCallCount() == 0)
     }
 

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileArtifactLaneConnection.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileArtifactLaneConnection.swift
@@ -1,0 +1,17 @@
+public import CMUXMobileCore
+public import Foundation
+
+/// One independently cancellable raw artifact lane.
+public protocol MobileArtifactLaneConnection: Sendable {
+    /// Reads at most the requested byte count, or nil after clean EOF.
+    func receive(maximumByteCount: Int) async throws -> Data?
+    /// Aborts the lane and releases transport resources.
+    func close() async
+}
+
+/// Opens an artifact lane on the RPC client's already-admitted Iroh peer.
+public typealias MobileArtifactLaneProvider = @Sendable (
+    _ request: CmxByteTransportRequest,
+    _ resourceID: String,
+    _ offset: UInt64
+) async throws -> any MobileArtifactLaneConnection

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -122,6 +122,27 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         await session.prepareIndependentServerEvents()
     }
 
+    /// Opens an artifact lane bound to this client's immutable admitted route.
+    public func openArtifactLane(
+        resourceID: String,
+        offset: UInt64
+    ) async throws -> any MobileArtifactLaneConnection {
+        guard route.kind == .iroh,
+              let provider = runtime.artifactLaneProvider else {
+            throw MobileShellConnectionError.connectionClosed
+        }
+        let admission = try lifecycleGate.beginArtifactLaneAdmission()
+        let connection = try await provider(
+            transportRequest,
+            resourceID,
+            offset
+        )
+        return try await lifecycleGate.finishArtifactLaneAdmission(
+            admission,
+            connection: connection
+        )
+    }
+
     /// Build a JSON-RPC request frame with the given method and params.
     /// - Parameters:
     ///   - method: The RPC method name.

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCClientLifecycleGate.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCClientLifecycleGate.swift
@@ -8,6 +8,10 @@ final class MobileRPCClientLifecycleGate: Sendable {
         fileprivate let revision: UInt64
     }
 
+    struct ArtifactLaneAdmission: Sendable {
+        fileprivate let revision: UInt64
+    }
+
     private struct State: Sendable {
         var retired = false
         var revision: UInt64 = 0
@@ -76,6 +80,29 @@ final class MobileRPCClientLifecycleGate: Sendable {
             throw MobileShellConnectionError.connectionClosed
         }
         return stream
+    }
+
+    func beginArtifactLaneAdmission() throws -> ArtifactLaneAdmission {
+        try state.withLock { state in
+            guard !state.retired else {
+                throw MobileShellConnectionError.connectionClosed
+            }
+            return ArtifactLaneAdmission(revision: state.revision)
+        }
+    }
+
+    func finishArtifactLaneAdmission(
+        _ admission: ArtifactLaneAdmission,
+        connection: any MobileArtifactLaneConnection
+    ) async throws -> any MobileArtifactLaneConnection {
+        let accepted = state.withLock { state in
+            !state.retired && state.revision == admission.revision
+        }
+        guard accepted else {
+            await connection.close()
+            throw MobileShellConnectionError.connectionClosed
+        }
+        return connection
     }
 
     func retire() {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
@@ -42,6 +42,8 @@ public protocol MobileSyncRuntime: Sendable {
     /// Optional source for one independent, sequence-aware terminal lane per
     /// mounted surface. A nil provider preserves control/event delivery.
     var terminalLaneProvider: MobileTerminalLaneProvider? { get }
+    /// Optional source for low-priority raw artifact bytes on an admitted Iroh peer.
+    var artifactLaneProvider: MobileArtifactLaneProvider? { get }
     /// Bounded deadline, in nanoseconds, for the render-grid liveness
     /// watchdog's subscription probe (an idempotent `mobile.events.subscribe`
     /// re-assert). A healthy idle terminal legitimately pushes no events, so
@@ -54,6 +56,7 @@ public protocol MobileSyncRuntime: Sendable {
 public extension MobileSyncRuntime {
     var independentEventByteStreamProvider: CmxIndependentEventByteStreamProvider? { nil }
     var terminalLaneProvider: MobileTerminalLaneProvider? { nil }
+    var artifactLaneProvider: MobileArtifactLaneProvider? { nil }
 
     /// Returns a cached Stack access token for best-effort status probes.
     var stackAccessTokenForStatusProvider: @Sendable () async -> String? {

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCClientLifecycleGateTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCClientLifecycleGateTests.swift
@@ -45,6 +45,55 @@ struct MobileRPCClientLifecycleGateTests {
 
         #expect(!invokedFactory)
     }
+
+    @Test
+    func retirementDuringArtifactOpenClosesTheStaleLane() async throws {
+        let gate = MobileRPCClientLifecycleGate()
+        let connection = RecordingArtifactLaneConnection()
+        let admission = try gate.beginArtifactLaneAdmission()
+
+        gate.retire()
+
+        do {
+            _ = try await gate.finishArtifactLaneAdmission(
+                admission,
+                connection: connection
+            )
+            Issue.record("stale artifact lane should be rejected")
+        } catch MobileShellConnectionError.connectionClosed {
+            // Expected.
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+        #expect(await connection.closeCount() == 1)
+    }
+
+    @Test
+    func retiredGateRejectsArtifactOpenBeforeProviderInvocation() {
+        let gate = MobileRPCClientLifecycleGate()
+        gate.retire()
+
+        do {
+            _ = try gate.beginArtifactLaneAdmission()
+            Issue.record("retired gate should reject artifact admission")
+        } catch MobileShellConnectionError.connectionClosed {
+            // Expected.
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+}
+
+private actor RecordingArtifactLaneConnection: MobileArtifactLaneConnection {
+    private var observedCloseCount = 0
+
+    func receive(maximumByteCount _: Int) async throws -> Data? { nil }
+
+    func close() async {
+        observedCloseCount += 1
+    }
+
+    func closeCount() -> Int { observedCloseCount }
 }
 
 private actor SuspendedLifecycleCloseTransport: CmxByteTransport {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileArtifactLaneFetchLoop.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileArtifactLaneFetchLoop.swift
@@ -1,0 +1,118 @@
+internal import CmuxAgentChat
+internal import CmuxMobileRPC
+internal import Foundation
+
+enum MobileArtifactLaneFetchError: Error, Equatable {
+    case invalidDescriptor
+    case failedBeforeFirstByte
+    case failedAfterFirstByte
+}
+
+/// Converts one raw Iroh artifact lane into the existing chunk/backpressure seam.
+struct MobileArtifactLaneFetchLoop: Sendable {
+    private static let maximumReceiveByteCount = 64 * 1_024
+
+    func run(
+        descriptor: ChatArtifactLaneDescriptor,
+        connection: any MobileArtifactLaneConnection,
+        collectsData: Bool,
+        progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?,
+        onChunk: @Sendable (_ chunk: ChatArtifactChunk) async throws -> Void
+    ) async throws -> Data {
+        do {
+            let result = try await runOpenConnection(
+                descriptor: descriptor,
+                connection: connection,
+                collectsData: collectsData,
+                progress: progress,
+                onChunk: onChunk
+            )
+            await connection.close()
+            return result
+        } catch {
+            await connection.close()
+            throw error
+        }
+    }
+
+    private func runOpenConnection(
+        descriptor: ChatArtifactLaneDescriptor,
+        connection: any MobileArtifactLaneConnection,
+        collectsData: Bool,
+        progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?,
+        onChunk: @Sendable (_ chunk: ChatArtifactChunk) async throws -> Void
+    ) async throws -> Data {
+        guard descriptor.totalSize >= 0 else {
+            throw MobileArtifactLaneFetchError.invalidDescriptor
+        }
+        var result = Data()
+        if collectsData,
+           descriptor.totalSize > 0,
+           descriptor.totalSize <= Int64(Int.max) {
+            result.reserveCapacity(Int(descriptor.totalSize))
+        }
+        var offset: Int64 = 0
+        var finalChunk: ChatArtifactChunk?
+        while true {
+            try Task.checkCancellation()
+            let data: Data?
+            do {
+                data = try await connection.receive(
+                    maximumByteCount: Self.maximumReceiveByteCount
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                throw offset == 0
+                    ? MobileArtifactLaneFetchError.failedBeforeFirstByte
+                    : MobileArtifactLaneFetchError.failedAfterFirstByte
+            }
+            guard let data else {
+                if descriptor.totalSize == 0, offset == 0 {
+                    let chunk = ChatArtifactChunk(
+                        data: Data(),
+                        offset: 0,
+                        totalSize: 0,
+                        eof: true
+                    )
+                    progress?(0, 0)
+                    try await onChunk(chunk)
+                    return result
+                }
+                guard offset == descriptor.totalSize else {
+                    throw offset == 0
+                        ? MobileArtifactLaneFetchError.failedBeforeFirstByte
+                        : MobileArtifactLaneFetchError.failedAfterFirstByte
+                }
+                if let finalChunk {
+                    try await onChunk(finalChunk)
+                }
+                return result
+            }
+            guard finalChunk == nil,
+                  !data.isEmpty,
+                  Int64(data.count) <= descriptor.totalSize - offset else {
+                throw offset == 0
+                    ? MobileArtifactLaneFetchError.failedBeforeFirstByte
+                    : MobileArtifactLaneFetchError.failedAfterFirstByte
+            }
+            let chunkOffset = offset
+            offset += Int64(data.count)
+            let chunk = ChatArtifactChunk(
+                data: data,
+                offset: chunkOffset,
+                totalSize: descriptor.totalSize,
+                eof: offset == descriptor.totalSize
+            )
+            if collectsData {
+                result.append(data)
+            }
+            progress?(offset, descriptor.totalSize)
+            if chunk.eof {
+                finalChunk = chunk
+            } else {
+                try await onChunk(chunk)
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
@@ -416,9 +416,11 @@ public actor MobileChatEventSource: ChatEventSource {
                 // authorized RPC can safely restart from offset zero.
             } catch is CancellationError {
                 throw CancellationError()
-            } catch {
+            } catch MobileArtifactLaneFetchError.failedAfterFirstByte {
                 // Once the lane exposed bytes, mixing in an RPC restart could
                 // splice two file versions into one preview.
+                throw ChatArtifactError.macUnreachable
+            } catch MobileArtifactLaneFetchError.invalidDescriptor {
                 throw ChatArtifactError.macUnreachable
             }
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
@@ -20,6 +20,8 @@ public actor MobileChatEventSource: ChatEventSource {
     public nonisolated let supportsTerminalArtifactList: Bool
     /// Whether the connected Mac supports session-wide artifact gallery pages.
     public nonisolated let supportsArtifactGallery: Bool
+    /// Whether raw artifact bytes may use a peer-bound Iroh application lane.
+    public nonisolated let supportsArtifactLane: Bool
 
     /// Creates the adapter.
     ///
@@ -29,13 +31,15 @@ public actor MobileChatEventSource: ChatEventSource {
         supportsArtifacts: Bool = false,
         supportsArtifactGallery: Bool = false,
         supportsArtifactFolders: Bool = false,
-        supportsTerminalArtifactList: Bool = false
+        supportsTerminalArtifactList: Bool = false,
+        supportsArtifactLane: Bool = false
     ) {
         self.client = client
         self.supportsArtifacts = supportsArtifacts
         self.supportsArtifactGallery = supportsArtifactGallery
         self.supportsArtifactFolders = supportsArtifactFolders
         self.supportsTerminalArtifactList = supportsTerminalArtifactList
+        self.supportsArtifactLane = supportsArtifactLane
     }
 
     /// Lists chat-capable agent sessions the Mac knows about.
@@ -355,12 +359,79 @@ public actor MobileChatEventSource: ChatEventSource {
             let request = try MobileCoreRPCClient.requestData(method: method, params: params)
             let result = try await client.sendRequest(request)
             return try coding.decode(T.self, from: result)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             throw Self.artifactError(from: error)
         }
     }
 
     func fetchArtifactChunks(
+        method: String,
+        stringParams: [String: String],
+        collectsData: Bool,
+        progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?,
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws -> Data {
+        if supportsArtifactLane {
+            let descriptor: ChatArtifactLaneDescriptor
+            let connection: any MobileArtifactLaneConnection
+            do {
+                var descriptorParams: [String: Any] = stringParams
+                descriptorParams["transport"] = "iroh_artifact_v1"
+                descriptor = try await artifactCall(
+                    method: method,
+                    params: descriptorParams
+                )
+                guard descriptor.totalSize >= 0 else {
+                    throw MobileArtifactLaneFetchError.invalidDescriptor
+                }
+                connection = try await client.openArtifactLane(
+                    resourceID: descriptor.resourceID,
+                    offset: 0
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // Descriptor mint/open failed before any lane byte was exposed.
+                // Preserve compatibility by using the existing RPC path.
+                return try await fetchArtifactChunksOverRPC(
+                    method: method,
+                    stringParams: stringParams,
+                    collectsData: collectsData,
+                    progress: progress,
+                    onChunk: onChunk
+                )
+            }
+            do {
+                return try await MobileArtifactLaneFetchLoop().run(
+                    descriptor: descriptor,
+                    connection: connection,
+                    collectsData: collectsData,
+                    progress: progress,
+                    onChunk: onChunk
+                )
+            } catch MobileArtifactLaneFetchError.failedBeforeFirstByte {
+                // No consumer-visible bytes were delivered, so the legacy
+                // authorized RPC can safely restart from offset zero.
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // Once the lane exposed bytes, mixing in an RPC restart could
+                // splice two file versions into one preview.
+                throw ChatArtifactError.macUnreachable
+            }
+        }
+        return try await fetchArtifactChunksOverRPC(
+            method: method,
+            stringParams: stringParams,
+            collectsData: collectsData,
+            progress: progress,
+            onChunk: onChunk
+        )
+    }
+
+    private func fetchArtifactChunksOverRPC(
         method: String,
         stringParams: [String: String],
         collectsData: Bool,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+AgentChat.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+AgentChat.swift
@@ -31,7 +31,8 @@ extension MobileShellComposite {
             supportsArtifacts: supportsChatArtifacts,
             supportsArtifactGallery: supportsChatArtifactGallery,
             supportsArtifactFolders: supportsChatArtifactFolders,
-            supportsTerminalArtifactList: supportsTerminalArtifactList
+            supportsTerminalArtifactList: supportsTerminalArtifactList,
+            supportsArtifactLane: supportsIrohArtifactLane
         )
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Capabilities.swift
@@ -26,6 +26,9 @@ extension MobileShellComposite {
     }
     /// Whether the Mac supports terminal artifact scan/stat/fetch/thumbnail RPCs.
     public var supportsTerminalArtifacts: Bool { supportedHostCapabilities.contains(Self.terminalArtifactCapability) }
+    public var supportsIrohArtifactLane: Bool {
+        supportedHostCapabilities.contains(Self.irohArtifactLaneCapability)
+    }
     /// Whether the Mac supports terminal-scoped directory listing.
     public var supportsTerminalArtifactList: Bool {
         supportedHostCapabilities.contains(Self.terminalArtifactListCapability)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -97,6 +97,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     static let chatArtifactCapability = "chat.artifact.v1"
     static let chatArtifactGalleryCapability = "chat.artifact.gallery.v1"
     static let terminalArtifactCapability = "terminal.artifact.v1"
+    static let irohArtifactLaneCapability = "iroh.artifact_lane.v1"
     static let dogfoodFeedbackCapability = "dogfood.v1"
     static let workspaceGroupsCapability = "workspace.groups.v1"
     private static let terminalOutputCapabilityTimeoutNanoseconds: UInt64 = 750_000_000

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactLaneFetchLoopTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactLaneFetchLoopTests.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxAgentChat
 import CmuxMobileRPC
 import Foundation
@@ -176,6 +177,140 @@ struct MobileArtifactLaneFetchLoopTests {
             ) { _ in }
         }
         #expect(await connection.snapshot().closeCount == 1)
+    }
+
+    @Test
+    func eventSourcePreservesConsumerErrorAfterLaneBytes() async throws {
+        let connection = ArtifactLaneConnectionScript(steps: [
+            .bytes(Data("not utf8".utf8)),
+            .eof,
+        ])
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "consumer-error-resource",
+            totalSize: 8,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+        let transport = ArtifactDescriptorTransport(descriptor: descriptor)
+        let runtime = ArtifactAdapterRuntime(
+            transportFactory: ArtifactDescriptorTransportFactory(transport: transport),
+            artifactLaneProvider: { _, _, _ in connection }
+        )
+        let route = try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(endpointID: String(repeating: "a", count: 64)),
+                pathHints: []
+            )
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "workspace",
+            terminalID: "terminal",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(30)
+        )
+        let client = MobileCoreRPCClient(runtime: runtime, route: route, ticket: ticket)
+        defer { Task { await client.disconnect() } }
+        let source = MobileChatEventSource(
+            client: client,
+            supportsArtifacts: true,
+            supportsArtifactLane: true
+        )
+
+        do {
+            try await source.artifactFetch(sessionID: "session", path: "artifact.txt") { _ in
+                throw ArtifactConsumerSentinel.malformedText
+            }
+            Issue.record("consumer error should escape the artifact transport adapter")
+        } catch ArtifactConsumerSentinel.malformedText {
+            // Expected. The preview layer needs this exact error to choose its binary fallback.
+        } catch {
+            Issue.record("unexpected rewritten error: \(error)")
+        }
+        #expect(await connection.snapshot().closeCount == 1)
+    }
+}
+
+private enum ArtifactConsumerSentinel: Error {
+    case malformedText
+}
+
+private struct ArtifactAdapterRuntime: MobileSyncRuntime {
+    let transportFactory: any CmxByteTransportFactory
+    let artifactLaneProvider: MobileArtifactLaneProvider?
+    let stackAccessTokenProvider: @Sendable () async throws -> String = { "test-token" }
+    let stackAccessTokenForceRefresher: @Sendable () async throws -> String = { "test-token" }
+    let rpcRequestTimeoutNanoseconds: UInt64 = 5_000_000_000
+    let now: @Sendable () -> Date = Date.init
+    let supportedRouteKinds: [CmxAttachTransportKind] = [.iroh]
+    let pairingRequestTimeoutNanoseconds: UInt64 = 5_000_000_000
+    let supportsServerPushEvents = false
+    let livenessProbeTimeoutNanoseconds: UInt64 = 1_000_000_000
+}
+
+private struct ArtifactDescriptorTransportFactory: CmxByteTransportFactory {
+    let transport: ArtifactDescriptorTransport
+
+    func makeTransport(for _: CmxAttachRoute) throws -> any CmxByteTransport {
+        transport
+    }
+}
+
+private actor ArtifactDescriptorTransport: CmxByteTransport {
+    private let descriptor: ChatArtifactLaneDescriptor
+    private var pendingFrames: [Data] = []
+    private var receiveWaiters: [CheckedContinuation<Data?, Never>] = []
+    private var isClosed = false
+
+    init(descriptor: ChatArtifactLaneDescriptor) {
+        self.descriptor = descriptor
+    }
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? {
+        if !pendingFrames.isEmpty {
+            return pendingFrames.removeFirst()
+        }
+        if isClosed { return nil }
+        return await withCheckedContinuation { receiveWaiters.append($0) }
+    }
+
+    func send(_ data: Data) async throws {
+        var buffer = data
+        for payload in try MobileSyncFrameCodec.decodeFrames(from: &buffer) {
+            let request = try #require(
+                JSONSerialization.jsonObject(with: payload) as? [String: Any]
+            )
+            let id = try #require(request["id"] as? String)
+            let encodedDescriptor = try ChatWireCoding().encode(descriptor)
+            let result = try #require(
+                JSONSerialization.jsonObject(with: encodedDescriptor) as? [String: Any]
+            )
+            let response = try JSONSerialization.data(withJSONObject: [
+                "id": id,
+                "ok": true,
+                "result": result,
+            ])
+            deliver(try MobileSyncFrameCodec.encodeFrame(response))
+        }
+    }
+
+    func close() async {
+        isClosed = true
+        let waiters = receiveWaiters
+        receiveWaiters.removeAll()
+        for waiter in waiters { waiter.resume(returning: nil) }
+    }
+
+    private func deliver(_ frame: Data) {
+        guard !receiveWaiters.isEmpty else {
+            pendingFrames.append(frame)
+            return
+        }
+        receiveWaiters.removeFirst().resume(returning: frame)
     }
 }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactLaneFetchLoopTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactLaneFetchLoopTests.swift
@@ -1,0 +1,241 @@
+import CmuxAgentChat
+import CmuxMobileRPC
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+@Suite
+struct MobileArtifactLaneFetchLoopTests {
+    @Test
+    func convertsRawBytesIntoExactBackpressuredChunks() async throws {
+        let connection = ArtifactLaneConnectionScript(steps: [
+            .bytes(Data("abc".utf8)),
+            .bytes(Data("de".utf8)),
+        ])
+        let recorder = ArtifactLaneChunkRecorder()
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "opaque-resource",
+            totalSize: 5,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+
+        let data = try await MobileArtifactLaneFetchLoop().run(
+            descriptor: descriptor,
+            connection: connection,
+            collectsData: true,
+            progress: nil
+        ) { chunk in
+            await recorder.record(chunk)
+        }
+
+        #expect(data == Data("abcde".utf8))
+        #expect(await recorder.chunks() == [
+            ChatArtifactChunk(data: Data("abc".utf8), offset: 0, totalSize: 5, eof: false),
+            ChatArtifactChunk(data: Data("de".utf8), offset: 3, totalSize: 5, eof: true),
+        ])
+        let snapshot = await connection.snapshot()
+        #expect(snapshot.maximumByteCounts == [64 * 1_024, 64 * 1_024, 64 * 1_024])
+        #expect(snapshot.closeCount == 1)
+    }
+
+    @Test
+    func emitsOneEmptyEOFChunkForZeroByteArtifact() async throws {
+        let connection = ArtifactLaneConnectionScript(steps: [.eof])
+        let recorder = ArtifactLaneChunkRecorder()
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "empty-resource",
+            totalSize: 0,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+
+        let data = try await MobileArtifactLaneFetchLoop().run(
+            descriptor: descriptor,
+            connection: connection,
+            collectsData: true,
+            progress: nil
+        ) { chunk in
+            await recorder.record(chunk)
+        }
+
+        #expect(data.isEmpty)
+        #expect(await recorder.chunks() == [
+            ChatArtifactChunk(data: Data(), offset: 0, totalSize: 0, eof: true),
+        ])
+        #expect(await connection.snapshot().closeCount == 1)
+    }
+
+    @Test
+    func classifiesFailureBeforeFirstByteForSafeRPCFallback() async {
+        let connection = ArtifactLaneConnectionScript(steps: [.failure])
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "unstarted-resource",
+            totalSize: 8,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+
+        await #expect(throws: MobileArtifactLaneFetchError.failedBeforeFirstByte) {
+            _ = try await MobileArtifactLaneFetchLoop().run(
+                descriptor: descriptor,
+                connection: connection,
+                collectsData: false,
+                progress: nil
+            ) { _ in }
+        }
+        #expect(await connection.snapshot().closeCount == 1)
+    }
+
+    @Test
+    func classifiesFailureAfterBytesToPreventMixedTransportData() async {
+        let connection = ArtifactLaneConnectionScript(steps: [
+            .bytes(Data("abc".utf8)),
+            .failure,
+        ])
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "partial-resource",
+            totalSize: 8,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+
+        await #expect(throws: MobileArtifactLaneFetchError.failedAfterFirstByte) {
+            _ = try await MobileArtifactLaneFetchLoop().run(
+                descriptor: descriptor,
+                connection: connection,
+                collectsData: false,
+                progress: nil
+            ) { _ in }
+        }
+        #expect(await connection.snapshot().closeCount == 1)
+    }
+
+    @Test
+    func rejectsAnOverrunAfterDeliveredBytesAsNonFallbackFailure() async {
+        let connection = ArtifactLaneConnectionScript(steps: [
+            .bytes(Data("abc".utf8)),
+            .bytes(Data("def".utf8)),
+        ])
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "overrun-resource",
+            totalSize: 5,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+
+        await #expect(throws: MobileArtifactLaneFetchError.failedAfterFirstByte) {
+            _ = try await MobileArtifactLaneFetchLoop().run(
+                descriptor: descriptor,
+                connection: connection,
+                collectsData: false,
+                progress: nil
+            ) { _ in }
+        }
+        #expect(await connection.snapshot().closeCount == 1)
+    }
+
+    @Test
+    func rejectsBytesAfterTheDeclaredSizeBeforeReportingFinalEOF() async {
+        let connection = ArtifactLaneConnectionScript(steps: [
+            .bytes(Data("abcde".utf8)),
+            .bytes(Data("x".utf8)),
+        ])
+        let recorder = ArtifactLaneChunkRecorder()
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "trailing-byte-resource",
+            totalSize: 5,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+
+        await #expect(throws: MobileArtifactLaneFetchError.failedAfterFirstByte) {
+            _ = try await MobileArtifactLaneFetchLoop().run(
+                descriptor: descriptor,
+                connection: connection,
+                collectsData: false,
+                progress: nil
+            ) { chunk in
+                await recorder.record(chunk)
+            }
+        }
+        #expect(await recorder.chunks().isEmpty)
+        #expect(await connection.snapshot().closeCount == 1)
+    }
+
+    @Test
+    func propagatesCancellationAndClosesTheLane() async {
+        let connection = ArtifactLaneConnectionScript(steps: [.cancelled])
+        let descriptor = ChatArtifactLaneDescriptor(
+            resourceID: "cancelled-resource",
+            totalSize: 5,
+            expiresAt: Date().addingTimeInterval(30)
+        )
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await MobileArtifactLaneFetchLoop().run(
+                descriptor: descriptor,
+                connection: connection,
+                collectsData: false,
+                progress: nil
+            ) { _ in }
+        }
+        #expect(await connection.snapshot().closeCount == 1)
+    }
+}
+
+private actor ArtifactLaneConnectionScript: MobileArtifactLaneConnection {
+    enum Step: Sendable {
+        case bytes(Data)
+        case eof
+        case failure
+        case cancelled
+    }
+
+    struct Snapshot: Sendable {
+        let maximumByteCounts: [Int]
+        let closeCount: Int
+    }
+
+    private var steps: [Step]
+    private var maximumByteCounts: [Int] = []
+    private var closeCount = 0
+
+    init(steps: [Step]) {
+        self.steps = steps
+    }
+
+    func receive(maximumByteCount: Int) async throws -> Data? {
+        maximumByteCounts.append(maximumByteCount)
+        guard !steps.isEmpty else { return nil }
+        switch steps.removeFirst() {
+        case let .bytes(data):
+            return data
+        case .eof:
+            return nil
+        case .failure:
+            throw ArtifactLaneScriptError.failed
+        case .cancelled:
+            throw CancellationError()
+        }
+    }
+
+    func close() async {
+        closeCount += 1
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(maximumByteCounts: maximumByteCounts, closeCount: closeCount)
+    }
+}
+
+private actor ArtifactLaneChunkRecorder {
+    private var values: [ChatArtifactChunk] = []
+
+    func record(_ chunk: ChatArtifactChunk) {
+        values.append(chunk)
+    }
+
+    func chunks() -> [ChatArtifactChunk] {
+        values
+    }
+}
+
+private enum ArtifactLaneScriptError: Error {
+    case failed
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceCapabilityTests.swift
@@ -14,13 +14,16 @@ import Testing
         ]
         #expect(!store.supportsChatArtifactFolders)
         #expect(!store.supportsTerminalArtifactList)
+        #expect(!store.supportsIrohArtifactLane)
 
         store.supportedHostCapabilities.formUnion([
             "chat.artifact.folders.v1",
             "terminal.artifact.list.v1",
+            "iroh.artifact_lane.v1",
         ])
         #expect(store.supportsChatArtifactFolders)
         #expect(store.supportsTerminalArtifactList)
+        #expect(store.supportsIrohArtifactLane)
     }
 
     @Test func workspaceMutationCapabilitiesAreVersionAndTicketGated() async throws {

--- a/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
+++ b/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
@@ -1,4 +1,6 @@
+import CmuxAgentChat
 import CmuxIrohTransport
+import Darwin
 import Foundation
 import OSLog
 
@@ -21,7 +23,7 @@ protocol MobileHostIrohArtifactLaneHandling: Sendable {
     ) async -> Bool
 }
 
-/// Safe production default until artifact preview installs a resource owner.
+/// Safe fallback for hosts that do not install an artifact resource owner.
 struct MobileHostIrohRejectingArtifactLaneHandler: MobileHostIrohArtifactLaneHandling {
     func handleArtifactLane(
         resourceID: CmxIrohResourceID,
@@ -33,6 +35,265 @@ struct MobileHostIrohRejectingArtifactLaneHandler: MobileHostIrohArtifactLaneHan
     }
 }
 
+/// Runtime-scoped, peer-bound capabilities minted only after control-RPC authorization.
+actor MobileHostIrohArtifactTransferRegistry {
+    enum Error: Swift.Error, Equatable {
+        case unavailable
+        case invalidFile
+        case capacityExceeded
+        case unknownResource
+        case expired
+        case peerMismatch
+        case invalidOffset
+        case alreadyInUse
+        case resumeLimitExceeded
+    }
+
+    struct Lease: Equatable, Sendable {
+        let id: UUID
+        let resourceID: CmxIrohResourceID
+        let canonicalPath: String
+        let identity: MobileHostIrohArtifactFileIdentity
+        let offset: UInt64
+        let totalSize: Int64
+    }
+
+    private struct Entry: Sendable {
+        let peer: CmxIrohAdmittedPeer
+        let canonicalPath: String
+        let identity: MobileHostIrohArtifactFileIdentity
+        let expiresAt: Date
+        var activeLeaseID: UUID?
+        var remainingClaims: Int
+    }
+
+    private static let maximumEntryCount = 128
+    private static let maximumSerialClaimCount = 8
+    private static let defaultTimeToLive: TimeInterval = 5 * 60
+
+    private let timeToLive: TimeInterval
+    private let now: @Sendable () -> Date
+    private let resourceID: @Sendable () throws -> CmxIrohResourceID
+    private var entries: [CmxIrohResourceID: Entry] = [:]
+
+    init(
+        timeToLive: TimeInterval = defaultTimeToLive,
+        now: @escaping @Sendable () -> Date = Date.init,
+        resourceID: @escaping @Sendable () throws -> CmxIrohResourceID = {
+            let token = (UUID().uuidString + UUID().uuidString)
+                .replacingOccurrences(of: "-", with: "")
+                .lowercased()
+            return try CmxIrohResourceID("artifact:\(token)")
+        }
+    ) {
+        self.timeToLive = max(1, timeToLive)
+        self.now = now
+        self.resourceID = resourceID
+    }
+
+    func issue(
+        canonicalPath: String,
+        peer: CmxIrohAdmittedPeer
+    ) throws -> ChatArtifactLaneDescriptor {
+        let currentTime = now()
+        pruneExpired(at: currentTime)
+        guard entries.count < Self.maximumEntryCount else {
+            throw Error.capacityExceeded
+        }
+        let resolvedPath = URL(fileURLWithPath: canonicalPath)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .path
+        let identity = try MobileHostIrohArtifactFileIdentity.snapshot(path: resolvedPath)
+        guard identity.size >= 0 else { throw Error.invalidFile }
+        let capability = try resourceID()
+        guard entries[capability] == nil else { throw Error.capacityExceeded }
+        let expiresAt = currentTime.addingTimeInterval(timeToLive)
+        entries[capability] = Entry(
+            peer: peer,
+            canonicalPath: resolvedPath,
+            identity: identity,
+            expiresAt: expiresAt,
+            activeLeaseID: nil,
+            remainingClaims: Self.maximumSerialClaimCount
+        )
+        return ChatArtifactLaneDescriptor(
+            resourceID: capability.value,
+            totalSize: identity.size,
+            expiresAt: expiresAt
+        )
+    }
+
+    func claim(
+        resourceID: CmxIrohResourceID,
+        offset: UInt64,
+        peer: CmxIrohAdmittedPeer
+    ) throws -> Lease {
+        let currentTime = now()
+        guard var entry = entries[resourceID] else { throw Error.unknownResource }
+        guard entry.expiresAt > currentTime else {
+            entries[resourceID] = nil
+            throw Error.expired
+        }
+        guard entry.peer == peer else { throw Error.peerMismatch }
+        guard offset <= UInt64(entry.identity.size) else { throw Error.invalidOffset }
+        guard entry.activeLeaseID == nil else { throw Error.alreadyInUse }
+        guard entry.remainingClaims > 0 else { throw Error.resumeLimitExceeded }
+        let leaseID = UUID()
+        entry.activeLeaseID = leaseID
+        entry.remainingClaims -= 1
+        entries[resourceID] = entry
+        return Lease(
+            id: leaseID,
+            resourceID: resourceID,
+            canonicalPath: entry.canonicalPath,
+            identity: entry.identity,
+            offset: offset,
+            totalSize: entry.identity.size
+        )
+    }
+
+    func release(_ lease: Lease) {
+        guard var entry = entries[lease.resourceID],
+              entry.activeLeaseID == lease.id else { return }
+        entry.activeLeaseID = nil
+        entries[lease.resourceID] = entry
+    }
+
+    private func pruneExpired(at currentTime: Date) {
+        entries = entries.filter { _, entry in
+            entry.activeLeaseID != nil || entry.expiresAt > currentTime
+        }
+    }
+}
+
+struct MobileHostIrohArtifactFileIdentity: Equatable, Sendable {
+    let device: UInt64
+    let inode: UInt64
+    let size: Int64
+    let modifiedSeconds: Int64
+    let modifiedNanoseconds: Int64
+
+    static func snapshot(path: String) throws -> Self {
+        let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: path))
+        defer { try? handle.close() }
+        return try snapshot(fileDescriptor: handle.fileDescriptor)
+    }
+
+    static func snapshot(fileDescriptor: Int32) throws -> Self {
+        var value = stat()
+        guard fstat(fileDescriptor, &value) == 0,
+              (value.st_mode & S_IFMT) == S_IFREG else {
+            throw MobileHostIrohArtifactTransferRegistry.Error.invalidFile
+        }
+        return Self(
+            device: UInt64(value.st_dev),
+            inode: UInt64(value.st_ino),
+            size: Int64(value.st_size),
+            modifiedSeconds: Int64(value.st_mtimespec.tv_sec),
+            modifiedNanoseconds: Int64(value.st_mtimespec.tv_nsec)
+        )
+    }
+}
+
+/// Concrete Mac owner for low-priority raw artifact bytes.
+struct MobileHostIrohArtifactLaneHandler: MobileHostIrohArtifactLaneHandling {
+    private static let chunkByteCount = 64 * 1_024
+    // noq transmits larger priorities first. Keep artifact bytes below terminal
+    // streams (default 0) and server events (50).
+    private static let streamPriority: Int32 = -10
+    private static let streamFailureCode: UInt64 = 6
+
+    let registry: MobileHostIrohArtifactTransferRegistry
+
+    func handleArtifactLane(
+        resourceID: CmxIrohResourceID,
+        offset: UInt64,
+        stream: CmxIrohBidirectionalStream,
+        peer: CmxIrohAdmittedPeer
+    ) async -> Bool {
+        let lease: MobileHostIrohArtifactTransferRegistry.Lease
+        do {
+            lease = try await registry.claim(
+                resourceID: resourceID,
+                offset: offset,
+                peer: peer
+            )
+        } catch {
+            return false
+        }
+
+        do {
+            let handle = try FileHandle(
+                forReadingFrom: URL(fileURLWithPath: lease.canonicalPath)
+            )
+            defer { try? handle.close() }
+            guard try MobileHostIrohArtifactFileIdentity.snapshot(
+                fileDescriptor: handle.fileDescriptor
+            ) == lease.identity else {
+                throw MobileHostIrohArtifactTransferRegistry.Error.invalidFile
+            }
+            try handle.seek(toOffset: lease.offset)
+            try await stream.sendStream.setPriority(Self.streamPriority)
+            await stream.receiveStream.stop(errorCode: 0)
+            while !Task.isCancelled,
+                  let data = try handle.read(upToCount: Self.chunkByteCount),
+                  !data.isEmpty {
+                try await stream.sendStream.send(data)
+            }
+            try Task.checkCancellation()
+            guard try MobileHostIrohArtifactFileIdentity.snapshot(
+                fileDescriptor: handle.fileDescriptor
+            ) == lease.identity else {
+                throw MobileHostIrohArtifactTransferRegistry.Error.invalidFile
+            }
+            try await stream.sendStream.finish()
+        } catch is CancellationError {
+            await stream.sendStream.reset(errorCode: 0)
+            await stream.receiveStream.stop(errorCode: 0)
+        } catch {
+            await stream.sendStream.reset(errorCode: Self.streamFailureCode)
+            await stream.receiveStream.stop(errorCode: Self.streamFailureCode)
+        }
+        await registry.release(lease)
+        return true
+    }
+}
+
+/// Separate credits prevent terminal fan-out from starving one artifact lane.
+struct MobileHostIrohApplicationLaneQuota {
+    enum LaneClass {
+        case terminal
+        case artifact
+    }
+
+    static let maximumTerminalCount = 4
+    static let maximumArtifactCount = 1
+
+    private var terminalIDs: Set<UUID> = []
+    private var artifactIDs: Set<UUID> = []
+
+    var terminalCount: Int { terminalIDs.count }
+    var artifactCount: Int { artifactIDs.count }
+
+    mutating func reserve(_ id: UUID, laneClass: LaneClass) -> Bool {
+        switch laneClass {
+        case .terminal:
+            guard terminalIDs.count < Self.maximumTerminalCount else { return false }
+            terminalIDs.insert(id)
+        case .artifact:
+            guard artifactIDs.count < Self.maximumArtifactCount else { return false }
+            artifactIDs.insert(id)
+        }
+        return true
+    }
+
+    mutating func release(_ id: UUID) {
+        terminalIDs.remove(id)
+        artifactIDs.remove(id)
+    }
+}
+
 /// Sole Mac-side accept owner for post-admission Iroh application streams.
 ///
 /// Terminal lanes route a validated surface UUID to sequence-framed PTY output
@@ -40,7 +301,12 @@ struct MobileHostIrohRejectingArtifactLaneHandler: MobileHostIrohArtifactLaneHan
 /// registration seam and otherwise reset. Every task is owned by this admitted
 /// session and cancelled when the control connection or runtime generation ends.
 actor MobileHostIrohApplicationLaneRouter {
-    static let maximumConcurrentLaneCount: UInt64 = 4
+    static let maximumConcurrentTerminalLaneCount =
+        UInt64(MobileHostIrohApplicationLaneQuota.maximumTerminalCount)
+    static let maximumConcurrentArtifactLaneCount =
+        UInt64(MobileHostIrohApplicationLaneQuota.maximumArtifactCount)
+    static let maximumConcurrentLaneCount =
+        maximumConcurrentTerminalLaneCount + maximumConcurrentArtifactLaneCount
 
     enum InputFrameError: Error, Equatable {
         case invalidLength
@@ -60,6 +326,7 @@ actor MobileHostIrohApplicationLaneRouter {
     private let session: CmxIrohAdmittedServerSession
     private let artifactHandler: any MobileHostIrohArtifactLaneHandling
     private var laneTasks: [UUID: Task<Void, Never>] = [:]
+    private var laneQuota = MobileHostIrohApplicationLaneQuota()
     private var stopped = false
 
     init(
@@ -107,6 +374,7 @@ actor MobileHostIrohApplicationLaneRouter {
         stopped = true
         let tasks = Array(laneTasks.values)
         laneTasks.removeAll()
+        laneQuota = MobileHostIrohApplicationLaneQuota()
         for task in tasks { task.cancel() }
         for task in tasks { await task.value }
     }
@@ -115,11 +383,21 @@ actor MobileHostIrohApplicationLaneRouter {
         _ lane: CmxIrohLane,
         stream: CmxIrohBidirectionalStream
     ) async {
-        guard laneTasks.count < Int(Self.maximumConcurrentLaneCount) else {
-            await Self.reject(stream, errorCode: ErrorCode.quotaExceeded)
+        let laneClass: MobileHostIrohApplicationLaneQuota.LaneClass
+        switch lane {
+        case .terminal:
+            laneClass = .terminal
+        case .artifact:
+            laneClass = .artifact
+        case .control, .serverEvents:
+            await Self.reject(stream, errorCode: ErrorCode.unsupportedResource)
             return
         }
         let id = UUID()
+        guard laneQuota.reserve(id, laneClass: laneClass) else {
+            await Self.reject(stream, errorCode: ErrorCode.quotaExceeded)
+            return
+        }
         let peer = session.peer
         let artifactHandler = artifactHandler
         let task = Task { [weak self] in
@@ -150,6 +428,7 @@ actor MobileHostIrohApplicationLaneRouter {
 
     private func laneDidFinish(_ id: UUID) {
         laneTasks[id] = nil
+        laneQuota.release(id)
     }
 
     private nonisolated static func handleTerminalLane(

--- a/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
+++ b/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
@@ -36,6 +36,11 @@ struct MobileHostIrohRejectingArtifactLaneHandler: MobileHostIrohArtifactLaneHan
     }
 }
 
+enum MobileHostIrohArtifactTransferIssueFailure: Equatable, Sendable {
+    case fileNotFound
+    case unavailable
+}
+
 /// Runtime-scoped, peer-bound capabilities minted only after control-RPC authorization.
 actor MobileHostIrohArtifactTransferRegistry {
     enum Error: Swift.Error, Equatable {
@@ -48,6 +53,16 @@ actor MobileHostIrohArtifactTransferRegistry {
         case invalidOffset
         case alreadyInUse
         case resumeLimitExceeded
+
+        var issueFailure: MobileHostIrohArtifactTransferIssueFailure {
+            switch self {
+            case .invalidFile:
+                .fileNotFound
+            case .unavailable, .capacityExceeded, .unknownResource, .expired,
+                 .peerMismatch, .invalidOffset, .alreadyInUse, .resumeLimitExceeded:
+                .unavailable
+            }
+        }
     }
 
     struct Lease: Equatable, Sendable {

--- a/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
+++ b/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
@@ -1,6 +1,7 @@
 import CmuxAgentChat
 import CmuxIrohTransport
 import Darwin
+import Dispatch
 import Foundation
 import OSLog
 
@@ -196,6 +197,96 @@ struct MobileHostIrohArtifactFileIdentity: Equatable, Sendable {
     }
 }
 
+/// Random-access file reader backed by DispatchIO so a slow file system never
+/// blocks Swift's cooperative executor. Cancelling a lane stops pending I/O.
+private final class MobileHostIrohArtifactDispatchReader: @unchecked Sendable {
+    private static let queue = DispatchQueue(
+        label: "dev.cmux.mobile-host-iroh-artifact-read",
+        qos: .utility
+    )
+
+    private let fileDescriptor: Int32
+    private let channel: DispatchIO
+
+    init(path: String) throws {
+        let fileDescriptor = Darwin.open(path, O_RDONLY | O_CLOEXEC)
+        guard fileDescriptor >= 0 else {
+            throw MobileHostIrohArtifactTransferRegistry.Error.invalidFile
+        }
+        self.fileDescriptor = fileDescriptor
+        self.channel = DispatchIO(
+            type: .random,
+            fileDescriptor: fileDescriptor,
+            queue: Self.queue
+        ) { _ in
+            _ = Darwin.close(fileDescriptor)
+        }
+        channel.setLimit(lowWater: 1)
+    }
+
+    func snapshot() throws -> MobileHostIrohArtifactFileIdentity {
+        try MobileHostIrohArtifactFileIdentity.snapshot(fileDescriptor: fileDescriptor)
+    }
+
+    func read(offset: UInt64, maximumByteCount: Int) async throws -> Data {
+        guard offset <= UInt64(Int64.max), maximumByteCount > 0 else {
+            throw MobileHostIrohArtifactTransferRegistry.Error.invalidOffset
+        }
+        try Task.checkCancellation()
+        let channel = channel
+        let data = try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Data, any Error>) in
+                let result = MobileHostIrohArtifactDispatchReadResult(
+                    continuation: continuation
+                )
+                channel.read(
+                    offset: off_t(offset),
+                    length: maximumByteCount,
+                    queue: Self.queue
+                ) { done, bytes, errorCode in
+                    result.receive(done: done, bytes: bytes, errorCode: errorCode)
+                }
+            }
+        } onCancel: {
+            channel.close(flags: .stop)
+        }
+        try Task.checkCancellation()
+        return data
+    }
+
+    func close() {
+        channel.close()
+    }
+}
+
+/// DispatchIO may deliver one read through several callbacks on its serial queue.
+private final class MobileHostIrohArtifactDispatchReadResult: @unchecked Sendable {
+    private let continuation: CheckedContinuation<Data, any Error>
+    private var data = Data()
+    private var didResume = false
+
+    init(continuation: CheckedContinuation<Data, any Error>) {
+        self.continuation = continuation
+    }
+
+    func receive(done: Bool, bytes: DispatchData?, errorCode: Int32) {
+        guard !didResume else { return }
+        if let bytes {
+            data.append(contentsOf: bytes)
+        }
+        guard done else { return }
+        didResume = true
+        if errorCode == 0 {
+            continuation.resume(returning: data)
+        } else {
+            continuation.resume(
+                throwing: POSIXError(POSIXErrorCode(rawValue: errorCode) ?? .EIO)
+            )
+        }
+    }
+}
+
 /// Concrete Mac owner for low-priority raw artifact bytes.
 struct MobileHostIrohArtifactLaneHandler: MobileHostIrohArtifactLaneHandling {
     private static let chunkByteCount = 64 * 1_024
@@ -224,27 +315,35 @@ struct MobileHostIrohArtifactLaneHandler: MobileHostIrohArtifactLaneHandling {
         }
 
         do {
-            let handle = try FileHandle(
-                forReadingFrom: URL(fileURLWithPath: lease.canonicalPath)
-            )
-            defer { try? handle.close() }
-            guard try MobileHostIrohArtifactFileIdentity.snapshot(
-                fileDescriptor: handle.fileDescriptor
-            ) == lease.identity else {
+            let reader = try MobileHostIrohArtifactDispatchReader(path: lease.canonicalPath)
+            defer { reader.close() }
+            guard try reader.snapshot() == lease.identity else {
                 throw MobileHostIrohArtifactTransferRegistry.Error.invalidFile
             }
-            try handle.seek(toOffset: lease.offset)
             try await stream.sendStream.setPriority(Self.streamPriority)
             await stream.receiveStream.stop(errorCode: 0)
-            while !Task.isCancelled,
-                  let data = try handle.read(upToCount: Self.chunkByteCount),
-                  !data.isEmpty {
+            let totalSize = UInt64(lease.totalSize)
+            var readOffset = lease.offset
+            while readOffset < totalSize {
+                try Task.checkCancellation()
+                let remainingByteCount = totalSize - readOffset
+                let readByteCount = Int(min(
+                    UInt64(Self.chunkByteCount),
+                    remainingByteCount
+                ))
+                let data = try await reader.read(
+                    offset: readOffset,
+                    maximumByteCount: readByteCount
+                )
+                guard !data.isEmpty else {
+                    throw MobileHostIrohArtifactTransferRegistry.Error.invalidFile
+                }
+                try Task.checkCancellation()
                 try await stream.sendStream.send(data)
+                readOffset += UInt64(data.count)
             }
             try Task.checkCancellation()
-            guard try MobileHostIrohArtifactFileIdentity.snapshot(
-                fileDescriptor: handle.fileDescriptor
-            ) == lease.identity else {
+            guard try reader.snapshot() == lease.identity else {
                 throw MobileHostIrohArtifactTransferRegistry.Error.invalidFile
             }
             try await stream.sendStream.finish()

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -202,12 +202,19 @@ extension MobileHostIrohRuntime {
                 let eventWriter = MobileHostIrohServerEventWriter(
                     session: session
                 )
-                let laneRouter = MobileHostIrohApplicationLaneRouter(session: session)
+                let artifactTransfers = MobileHostIrohArtifactTransferRegistry()
+                let laneRouter = MobileHostIrohApplicationLaneRouter(
+                    session: session,
+                    artifactHandler: MobileHostIrohArtifactLaneHandler(
+                        registry: artifactTransfers
+                    )
+                )
                 let connectionSupervisor = CmxIrohAdmittedConnectionSupervisor(
                     runControl: {
                         await MobileHostService.acceptTransport(
                             session.controlTransport,
                             authorization: .irohAdmission(session.peer),
+                            artifactTransfers: artifactTransfers,
                             independentEventWriter: eventWriter,
                             isCurrent: isCurrent
                         )

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 extension MobileHostService {
+    nonisolated static let irohArtifactLaneCapability = "iroh.artifact_lane.v1"
+
     /// The single source of truth for the capabilities advertised to mobile
     /// clients via `mobile.host.status`. Every status path (the public-status
     /// cache, the network status gate, and `TerminalController`'s

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -251,9 +251,17 @@ final class MobileHostService {
     /// the display name or the device id, so this reply is where a freshly
     /// paired phone learns what to call this Mac, which paired-Mac record owns
     /// the connection, and which app instance owns its routes.
-    nonisolated static func identityStatusPayload(routes: [CmxAttachRoute], now: Date = Date()) -> [String: Any] {
+    nonisolated static func identityStatusPayload(
+        routes: [CmxAttachRoute],
+        additionalCapabilities: Set<String> = [],
+        now: Date = Date()
+    ) -> [String: Any] {
         var payload = publicStatusPayload(routes: [], now: now)
         payload["routes"] = routes.mobileHostJSONObjects(for: .authenticated, at: now)
+        if !additionalCapabilities.isEmpty {
+            payload["capabilities"] = mobileHostCapabilities
+                + additionalCapabilities.sorted()
+        }
         payload["terminal_theme_revision_epoch"] = terminalThemeRevisionEpoch
         payload["mac_device_id"] = MobileHostIdentity.deviceID()
         payload["mac_instance_tag"] = MobileHostIdentity.instanceTag()
@@ -1024,6 +1032,7 @@ final class MobileHostService {
     nonisolated static func acceptTransport(
         _ transport: any CmxByteTransport,
         authorization: MobileHostConnectionAuthorizationContext,
+        artifactTransfers: MobileHostIrohArtifactTransferRegistry? = nil,
         independentEventWriter: (any MobileHostIndependentEventWriting)? = nil,
         isCurrent: @escaping @Sendable () async -> Bool
     ) async {
@@ -1063,12 +1072,19 @@ final class MobileHostService {
                     return await Self.connectionStatusResult(
                         for: request,
                         authorization: authorization,
+                        supportsArtifactLane: artifactTransfers != nil,
                         stackStatus: { request in
                             await MobileHostService.networkStatusResult(for: request)
                         }
                     )
                 }
-                let result = await TerminalController.shared.mobileHostHandleRPC(request)
+                let result = await TerminalController.shared.mobileHostHandleRPC(
+                    request,
+                    executionContext: MobileHostRPCExecutionContext(
+                        authorization: authorization,
+                        artifactTransfers: artifactTransfers
+                    )
+                )
                 await MobileHostService.shared.recordCreatedResourcesIfNeeded(
                     request: request,
                     result: result
@@ -1118,13 +1134,19 @@ final class MobileHostService {
     nonisolated static func connectionStatusResult(
         for request: MobileHostRPCRequest,
         authorization: MobileHostConnectionAuthorizationContext,
+        supportsArtifactLane: Bool = false,
         stackStatus: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult
     ) async -> MobileHostRPCResult {
         switch authorization {
         case .stackBearer:
             return await stackStatus(request)
         case .irohAdmission:
-            return MobileHostPublicStatusCache.result(includeIdentity: true)
+            return MobileHostPublicStatusCache.result(
+                includeIdentity: true,
+                additionalCapabilities: supportsArtifactLane
+                    ? Set([irohArtifactLaneCapability])
+                    : Set()
+            )
         }
     }
 

--- a/Sources/Mobile/MobileHostTransportAuthorization.swift
+++ b/Sources/Mobile/MobileHostTransportAuthorization.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxAgentChat
 import CmuxAuthRuntime
 import CmuxIrohTransport
 import CmuxMobileTransport
@@ -22,6 +23,25 @@ extension MobileHostConnectionAuthorizationContext {
     /// makes version-skew coverage exercise the same authorization choice as
     /// the production listener.
     static let legacyPrivateNetworkListener: Self = .stackBearer
+}
+
+/// Immutable trust context carried from transport admission into RPC dispatch.
+struct MobileHostRPCExecutionContext: Sendable {
+    let authorization: MobileHostConnectionAuthorizationContext
+    let artifactTransfers: MobileHostIrohArtifactTransferRegistry?
+
+    func issueArtifactTransfer(
+        canonicalPath: String
+    ) async throws -> ChatArtifactLaneDescriptor {
+        guard case let .irohAdmission(peer) = authorization,
+              let artifactTransfers else {
+            throw MobileHostIrohArtifactTransferRegistry.Error.unavailable
+        }
+        return try await artifactTransfers.issue(
+            canonicalPath: canonicalPath,
+            peer: peer
+        )
+    }
 }
 
 
@@ -267,13 +287,19 @@ enum MobileHostPublicStatusCache {
         return irohRoute != nil
     }
 
-    static func result(includeIdentity: Bool = false) -> MobileHostRPCResult {
+    static func result(
+        includeIdentity: Bool = false,
+        additionalCapabilities: Set<String> = []
+    ) -> MobileHostRPCResult {
         lock.lock()
         let cachedRoutes = mergedRoutesLocked()
         lock.unlock()
         return .ok(
             includeIdentity
-                ? MobileHostService.identityStatusPayload(routes: cachedRoutes)
+                ? MobileHostService.identityStatusPayload(
+                    routes: cachedRoutes,
+                    additionalCapabilities: additionalCapabilities
+                )
                 : MobileHostService.publicStatusPayload(routes: cachedRoutes)
         )
     }

--- a/Sources/TerminalController+MobileChat.swift
+++ b/Sources/TerminalController+MobileChat.swift
@@ -29,7 +29,11 @@ extension TerminalController {
 
     /// Routes one `mobile.chat.*` method to its handler (single dispatch
     /// case in `mobileHostHandleRPC` keeps the god-file growth flat).
-    func v2MobileChatDispatch(method: String, params: [String: Any]) async -> V2CallResult {
+    func v2MobileChatDispatch(
+        method: String,
+        params: [String: Any],
+        executionContext: MobileHostRPCExecutionContext? = nil
+    ) async -> V2CallResult {
         switch method {
         case "mobile.chat.sessions":
             return await v2MobileChatSessions(params: params)
@@ -46,7 +50,10 @@ extension TerminalController {
         case "mobile.chat.artifact.stat":
             return await v2MobileChatArtifactStat(params: params)
         case "mobile.chat.artifact.fetch":
-            return await v2MobileChatArtifactFetch(params: params)
+            return await v2MobileChatArtifactFetch(
+                params: params,
+                executionContext: executionContext
+            )
         case "mobile.chat.artifact.thumbnail":
             return await v2MobileChatArtifactThumbnail(params: params)
         case "mobile.chat.artifact.list":

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -129,7 +129,7 @@ extension TerminalController {
                         code: "unsupported_transport",
                         message: String(
                             localized: "mobile.chat.artifact.error.irohTransportUnavailable",
-                            defaultValue: "Iroh artifact transfer requires an authenticated Iroh session."
+                            defaultValue: "Artifact transfer requires an authenticated session."
                         ),
                         data: nil
                     )

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -111,7 +111,10 @@ extension TerminalController {
         }
     }
 
-    func v2MobileChatArtifactFetch(params: [String: Any]) async -> V2CallResult {
+    func v2MobileChatArtifactFetch(
+        params: [String: Any],
+        executionContext: MobileHostRPCExecutionContext? = nil
+    ) async -> V2CallResult {
         let resolution = await mobileChatArtifactResolution(params: params, operation: .file)
         guard case .success(let resolved) = resolution else {
             return resolution.failureResult
@@ -120,6 +123,23 @@ extension TerminalController {
         let length = ChatArtifactTransferPolicy.defaultPolicy
             .clampedChunkLength(v2Int(params, "length"))
         do {
+            if v2RawString(params, "transport") == "iroh_artifact_v1" {
+                guard let executionContext else {
+                    return .err(
+                        code: "unsupported_transport",
+                        message: String(
+                            localized: "mobile.chat.artifact.error.irohTransportUnavailable",
+                            defaultValue: "Iroh artifact transfer requires an authenticated Iroh session."
+                        ),
+                        data: nil
+                    )
+                }
+                return .ok(ChatArtifactWire.payload(
+                    try await executionContext.issueArtifactTransfer(
+                        canonicalPath: resolved.canonicalPath
+                    )
+                ) ?? [:])
+            }
             let chunk = try await Task.detached {
                 try ArtifactByteReader().fetch(path: resolved.canonicalPath, offset: offset, length: length)
             }.value

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -144,6 +144,23 @@ extension TerminalController {
                 try ArtifactByteReader().fetch(path: resolved.canonicalPath, offset: offset, length: length)
             }.value
             return .ok(ChatArtifactWire.payload(chunk) ?? [:])
+        } catch let error as MobileHostIrohArtifactTransferRegistry.Error {
+            switch error.issueFailure {
+            case .fileNotFound:
+                debugLogMobileChatArtifactDenial(
+                    code: "file_not_found",
+                    reason: "descriptor-file-invalid",
+                    path: resolved.requestedPath
+                )
+                return mobileChatArtifactError(.fileNotFound, path: resolved.requestedPath)
+            case .unavailable:
+                debugLogMobileChatArtifactDenial(
+                    code: "unavailable",
+                    reason: "descriptor-issue-failed",
+                    path: resolved.requestedPath
+                )
+                return mobileChatArtifactError(.unavailable, path: resolved.requestedPath)
+            }
         } catch ArtifactByteReader.Error.fileNotFound {
             debugLogMobileChatArtifactDenial(
                 code: "file_not_found", reason: "stat-failed", path: resolved.requestedPath
@@ -321,6 +338,7 @@ extension TerminalController {
         case forbidden
         case fileNotFound
         case unsupportedMedia
+        case unavailable
     }
 
     private func mobileChatArtifactError(
@@ -363,6 +381,15 @@ extension TerminalController {
                     defaultValue: "This file type cannot be previewed."
                 ),
                 data: ["path": path]
+            )
+        case .unavailable:
+            return .err(
+                code: "unavailable",
+                message: String(
+                    localized: "mobile.chat.artifact.error.transferUnavailable",
+                    defaultValue: "Artifact transfer is temporarily unavailable."
+                ),
+                data: nil
             )
         }
     }

--- a/Sources/TerminalController+MobileTerminalArtifacts.swift
+++ b/Sources/TerminalController+MobileTerminalArtifacts.swift
@@ -23,14 +23,21 @@ extension TerminalController {
         return trimmed?.isEmpty == false ? trimmed : nil
     }
 
-    func v2MobileTerminalArtifactDispatch(method: String, params: [String: Any]) async -> V2CallResult {
+    func v2MobileTerminalArtifactDispatch(
+        method: String,
+        params: [String: Any],
+        executionContext: MobileHostRPCExecutionContext? = nil
+    ) async -> V2CallResult {
         switch method {
         case "mobile.terminal.artifact.scan":
             return await v2MobileTerminalArtifactScan(params: params)
         case "mobile.terminal.artifact.stat":
             return await v2MobileTerminalArtifactStat(params: params)
         case "mobile.terminal.artifact.fetch":
-            return await v2MobileTerminalArtifactFetch(params: params)
+            return await v2MobileTerminalArtifactFetch(
+                params: params,
+                executionContext: executionContext
+            )
         case "mobile.terminal.artifact.thumbnail":
             return await v2MobileTerminalArtifactThumbnail(params: params)
         case "mobile.terminal.artifact.list":
@@ -111,7 +118,10 @@ extension TerminalController {
         }
     }
 
-    func v2MobileTerminalArtifactFetch(params: [String: Any]) async -> V2CallResult {
+    func v2MobileTerminalArtifactFetch(
+        params: [String: Any],
+        executionContext: MobileHostRPCExecutionContext? = nil
+    ) async -> V2CallResult {
         let resolution = await mobileTerminalArtifactContext(params: params, requiresPath: true)
         guard case .success(let context) = resolution else {
             return resolution.failureResult
@@ -120,6 +130,26 @@ extension TerminalController {
         let length = ChatArtifactTransferPolicy.defaultPolicy
             .clampedChunkLength(v2Int(params, "length"))
         do {
+            if v2RawString(params, "transport") == "iroh_artifact_v1" {
+                guard let executionContext else {
+                    return .err(
+                        code: "unsupported_transport",
+                        message: String(
+                            localized: "mobile.chat.artifact.error.irohTransportUnavailable",
+                            defaultValue: "Iroh artifact transfer requires an authenticated Iroh session."
+                        ),
+                        data: nil
+                    )
+                }
+                let canonicalPath = try await Task.detached(priority: .utility) {
+                    try context.authorizedRead { _, canonicalPath in canonicalPath }
+                }.value
+                return TerminalArtifactWire.result(
+                    try await executionContext.issueArtifactTransfer(
+                        canonicalPath: canonicalPath
+                    )
+                )
+            }
             let chunk = try await Task.detached(priority: .utility) {
                 try context.authorizedRead { reader, canonicalPath in
                     try reader.fetch(path: canonicalPath, offset: offset, length: length)

--- a/Sources/TerminalController+MobileTerminalArtifacts.swift
+++ b/Sources/TerminalController+MobileTerminalArtifacts.swift
@@ -136,7 +136,7 @@ extension TerminalController {
                         code: "unsupported_transport",
                         message: String(
                             localized: "mobile.chat.artifact.error.irohTransportUnavailable",
-                            defaultValue: "Iroh artifact transfer requires an authenticated Iroh session."
+                            defaultValue: "Artifact transfer requires an authenticated session."
                         ),
                         data: nil
                     )

--- a/Sources/TerminalController+MobileTerminalArtifacts.swift
+++ b/Sources/TerminalController+MobileTerminalArtifacts.swift
@@ -156,6 +156,13 @@ extension TerminalController {
                 }
             }.value
             return TerminalArtifactWire.result(chunk)
+        } catch let error as MobileHostIrohArtifactTransferRegistry.Error {
+            switch error.issueFailure {
+            case .fileNotFound:
+                return mobileTerminalArtifactError(.fileNotFound, path: context.requestedPath)
+            case .unavailable:
+                return mobileTerminalArtifactError(.unavailable, path: context.requestedPath)
+            }
         } catch TerminalArtifactReadContext.Error.forbidden {
             debugLogMobileTerminalArtifactDenial(op: "fetch", path: context.requestedPath)
             return mobileTerminalArtifactError(.forbidden, path: context.requestedPath)
@@ -277,6 +284,7 @@ extension TerminalController {
         case forbidden
         case fileNotFound
         case unsupportedMedia
+        case unavailable
     }
 
     private func debugLogMobileTerminalArtifactDenial(op: String, path: String?) {
@@ -325,6 +333,15 @@ extension TerminalController {
                     defaultValue: "This file type cannot be previewed."
                 ),
                 data: path.map { ["path": $0] }
+            )
+        case .unavailable:
+            return .err(
+                code: "unavailable",
+                message: String(
+                    localized: "mobile.chat.artifact.error.transferUnavailable",
+                    defaultValue: "Artifact transfer is temporarily unavailable."
+                ),
+                data: nil
             )
         }
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -13793,7 +13793,10 @@ class TerminalController {
     // MARK: - Mobile Host V2 Methods
 
     @MainActor
-    func mobileHostHandleRPC(_ request: MobileHostRPCRequest) async -> MobileHostRPCResult {
+    func mobileHostHandleRPC(
+        _ request: MobileHostRPCRequest,
+        executionContext: MobileHostRPCExecutionContext? = nil
+    ) async -> MobileHostRPCResult {
         // The mobile data-plane RPC speaks `MobileHostRPCRequest` /
         // `MobileHostRPCResult` and dispatches directly to the app-side
         // `v2Mobile*` bodies. It deliberately does NOT route through the v2
@@ -13830,7 +13833,11 @@ class TerminalController {
         case "mobile.terminal.mouse", "terminal.mouse":
             result = v2MobileTerminalMouse(params: request.params)
         case let method where method.hasPrefix("mobile.terminal.artifact."):
-            result = await v2MobileTerminalArtifactDispatch(method: method, params: request.params)
+            result = await v2MobileTerminalArtifactDispatch(
+                method: method,
+                params: request.params,
+                executionContext: executionContext
+            )
         case "workspace.action":
             result = v2MobileWorkspaceAction(params: request.params)
         case "workspace.move":
@@ -13838,7 +13845,11 @@ class TerminalController {
         case "workspace.group.action", "workspace.group.create":
             result = request.method == "workspace.group.create" ? v2MobileWorkspaceGroupCreate(params: request.params) : v2MobileWorkspaceGroupAction(params: request.params)
         case let method where method.hasPrefix("mobile.chat."):
-            result = await v2MobileChatDispatch(method: method, params: request.params)
+            result = await v2MobileChatDispatch(
+                method: method,
+                params: request.params,
+                executionContext: executionContext
+            )
         case "workspace.close":
             result = v2MobileWorkspaceClose(params: request.params)
         case "workspace.group.collapse":

--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -455,6 +455,21 @@ extension MobileHostAuthorizationTests {
         )
     }
 
+    @Test func testIrohArtifactDescriptorFailuresPreserveFileAndCapacitySemantics() {
+        #expect(
+            MobileHostIrohArtifactTransferRegistry.Error.invalidFile.issueFailure
+                == .fileNotFound
+        )
+        #expect(
+            MobileHostIrohArtifactTransferRegistry.Error.unavailable.issueFailure
+                == .unavailable
+        )
+        #expect(
+            MobileHostIrohArtifactTransferRegistry.Error.capacityExceeded.issueFailure
+                == .unavailable
+        )
+    }
+
     @Test func testIrohArtifactCapabilityIsOpaquePeerBoundAndSeriallyResumable() async throws {
         let fixture = try MobileHostIrohArtifactFixture(contents: Data("abcdef".utf8))
         defer { fixture.remove() }

--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxAgentChat
 import CmuxIrohTransport
 import CmuxMobileRPC
 import Foundation
@@ -435,6 +436,119 @@ extension MobileHostAuthorizationTests {
         )
     }
 
+    @Test func testIrohArtifactCapabilityIsOpaquePeerBoundAndSeriallyResumable() async throws {
+        let fixture = try MobileHostIrohArtifactFixture(contents: Data("abcdef".utf8))
+        defer { fixture.remove() }
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let resourceID = try CmxIrohResourceID(
+            "artifact:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        )
+        let registry = MobileHostIrohArtifactTransferRegistry(
+            timeToLive: 60,
+            now: { now },
+            resourceID: { resourceID }
+        )
+        let peer = try irohPeer(endpointCharacter: "a")
+        let otherPeer = try irohPeer(endpointCharacter: "b")
+
+        let descriptor = try await registry.issue(
+            canonicalPath: fixture.path,
+            peer: peer
+        )
+
+        #expect(descriptor.resourceID == resourceID.value)
+        #expect(descriptor.totalSize == 6)
+        #expect(descriptor.expiresAt == now.addingTimeInterval(60))
+        #expect(!descriptor.resourceID.contains(fixture.path))
+        await #expect(throws: MobileHostIrohArtifactTransferRegistry.Error.peerMismatch) {
+            try await registry.claim(
+                resourceID: resourceID,
+                offset: 2,
+                peer: otherPeer
+            )
+        }
+
+        let lease = try await registry.claim(
+            resourceID: resourceID,
+            offset: 2,
+            peer: peer
+        )
+        #expect(lease.offset == 2)
+        #expect(lease.totalSize == 6)
+        await #expect(throws: MobileHostIrohArtifactTransferRegistry.Error.alreadyInUse) {
+            try await registry.claim(
+                resourceID: resourceID,
+                offset: 3,
+                peer: peer
+            )
+        }
+        await registry.release(lease)
+
+        let resumed = try await registry.claim(
+            resourceID: resourceID,
+            offset: 4,
+            peer: peer
+        )
+        #expect(resumed.offset == 4)
+        await registry.release(resumed)
+    }
+
+    @Test func testIrohArtifactHandlerStreamsAuthorizedOffsetAtLowPriority() async throws {
+        let fixture = try MobileHostIrohArtifactFixture(contents: Data("abcdef".utf8))
+        defer { fixture.remove() }
+        let resourceID = try CmxIrohResourceID(
+            "artifact:abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        )
+        let registry = MobileHostIrohArtifactTransferRegistry(
+            timeToLive: 60,
+            now: Date.init,
+            resourceID: { resourceID }
+        )
+        let peer = try irohPeer(endpointCharacter: "c")
+        _ = try await registry.issue(canonicalPath: fixture.path, peer: peer)
+        let send = RecordingMobileHostIrohArtifactSendStream()
+        let receive = RecordingMobileHostIrohArtifactReceiveStream()
+        let handler = MobileHostIrohArtifactLaneHandler(registry: registry)
+
+        let didTakeOwnership = await handler.handleArtifactLane(
+            resourceID: resourceID,
+            offset: 2,
+            stream: CmxIrohBidirectionalStream(
+                receiveStream: receive,
+                sendStream: send
+            ),
+            peer: peer
+        )
+
+        #expect(didTakeOwnership)
+        #expect(await send.payload() == Data("cdef".utf8))
+        #expect(await send.priorities() == [10])
+        #expect(await send.finishCount() == 1)
+        #expect(await receive.stopCodes() == [0])
+    }
+
+    @Test func testIrohApplicationLaneQuotasReserveArtifactCapacity() {
+        #expect(MobileHostIrohApplicationLaneRouter.maximumConcurrentTerminalLaneCount == 4)
+        #expect(MobileHostIrohApplicationLaneRouter.maximumConcurrentArtifactLaneCount == 1)
+        #expect(MobileHostIrohApplicationLaneRouter.maximumConcurrentLaneCount == 5)
+    }
+
+    private func irohPeer(
+        endpointCharacter: Character,
+        generation: Int = 1
+    ) throws -> CmxIrohAdmittedPeer {
+        CmxIrohAdmittedPeer(peer: CmxIrohGrantPeer(
+            bindingID: "123e4567-e89b-42d3-a456-426614174001",
+            deviceID: "123e4567-e89b-42d3-a456-426614174002",
+            tag: "test",
+            platform: .ios,
+            endpointID: try CmxIrohPeerIdentity(
+                endpointID: String(repeating: String(endpointCharacter), count: 64)
+            ),
+            identityGeneration: generation
+        ))
+    }
+
     func irohAdmissionContext() throws -> MobileHostConnectionAuthorizationContext {
         let endpointID = try CmxIrohPeerIdentity(
             endpointID: String(repeating: "a", count: 64)
@@ -449,6 +563,67 @@ extension MobileHostAuthorizationTests {
         )
         return .irohAdmission(CmxIrohAdmittedPeer(peer: peer))
     }
+}
+
+private struct MobileHostIrohArtifactFixture {
+    let directory: URL
+    let path: String
+
+    init(contents: Data) throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-iroh-artifact-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let file = directory.appendingPathComponent("private-preview.bin")
+        try contents.write(to: file, options: .atomic)
+        self.directory = directory
+        self.path = file.path
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+private actor RecordingMobileHostIrohArtifactSendStream: CmxIrohSendStream {
+    private var chunks: [Data] = []
+    private var observedPriorities: [Int32] = []
+    private var observedFinishCount = 0
+
+    func send(_ data: Data) {
+        chunks.append(data)
+    }
+
+    func finish() {
+        observedFinishCount += 1
+    }
+
+    func reset(errorCode _: UInt64) {}
+
+    func setPriority(_ priority: Int32) {
+        observedPriorities.append(priority)
+    }
+
+    func payload() -> Data {
+        chunks.reduce(into: Data()) { $0.append($1) }
+    }
+
+    func priorities() -> [Int32] { observedPriorities }
+    func finishCount() -> Int { observedFinishCount }
+}
+
+private actor RecordingMobileHostIrohArtifactReceiveStream: CmxIrohReceiveStream {
+    private var observedStopCodes: [UInt64] = []
+
+    func receive(maximumByteCount _: Int) -> Data? { nil }
+
+    func stop(errorCode: UInt64) {
+        observedStopCodes.append(errorCode)
+    }
+
+    func stopCodes() -> [UInt64] { observedStopCodes }
 }
 
 private actor MobileHostIrohPersistenceGate {

--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -378,22 +378,41 @@ extension MobileHostAuthorizationTests {
         let admitted = await MobileHostService.connectionStatusResult(
             for: request,
             authorization: try irohAdmissionContext(),
+            supportsArtifactLane: true,
             stackStatus: { _ in .ok(["routes": []]) }
         )
         guard case let .ok(admittedPayload as [String: Any]) = admitted else {
             return #expect(Bool(false), "Admitted Iroh status must return an object")
         }
         #expect(admittedPayload["mac_device_id"] is String)
+        let admittedCapabilities = try #require(admittedPayload["capabilities"] as? [String])
+        #expect(admittedCapabilities.contains(MobileHostService.irohArtifactLaneCapability))
+
+        let admittedWithoutHandler = await MobileHostService.connectionStatusResult(
+            for: request,
+            authorization: try irohAdmissionContext(),
+            supportsArtifactLane: false,
+            stackStatus: { _ in .ok(["routes": []]) }
+        )
+        guard case let .ok(unownedPayload as [String: Any]) = admittedWithoutHandler else {
+            return #expect(Bool(false), "Admitted Iroh status must return an object")
+        }
+        let unownedCapabilities = try #require(unownedPayload["capabilities"] as? [String])
+        #expect(!unownedCapabilities.contains(MobileHostService.irohArtifactLaneCapability))
 
         let tcp = await MobileHostService.connectionStatusResult(
             for: request,
             authorization: .stackBearer,
-            stackStatus: { _ in .ok(["routes": []]) }
+            stackStatus: { _ in
+                .ok(MobileHostService.publicStatusPayload(routes: []))
+            }
         )
         guard case let .ok(tcpPayload as [String: Any]) = tcp else {
             return #expect(Bool(false), "TCP status must return an object")
         }
         #expect(tcpPayload["mac_device_id"] == nil)
+        let tcpCapabilities = try #require(tcpPayload["capabilities"] as? [String])
+        #expect(!tcpCapabilities.contains(MobileHostService.irohArtifactLaneCapability))
     }
 
     @Test func testIrohTerminalLaneInputFramingSurvivesQUICChunkBoundaries() throws {
@@ -440,12 +459,13 @@ extension MobileHostAuthorizationTests {
         let fixture = try MobileHostIrohArtifactFixture(contents: Data("abcdef".utf8))
         defer { fixture.remove() }
         let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let clock = MobileHostIrohArtifactTestClock(now: now)
         let resourceID = try CmxIrohResourceID(
             "artifact:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
         )
         let registry = MobileHostIrohArtifactTransferRegistry(
             timeToLive: 60,
-            now: { now },
+            now: { clock.now },
             resourceID: { resourceID }
         )
         let peer = try irohPeer(endpointCharacter: "a")
@@ -491,6 +511,39 @@ extension MobileHostAuthorizationTests {
         )
         #expect(resumed.offset == 4)
         await registry.release(resumed)
+
+        let unknownResource = try CmxIrohResourceID(
+            "artifact:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        )
+        await #expect(throws: MobileHostIrohArtifactTransferRegistry.Error.unknownResource) {
+            try await registry.claim(
+                resourceID: unknownResource,
+                offset: 0,
+                peer: peer
+            )
+        }
+
+        let separateSessionRegistry = MobileHostIrohArtifactTransferRegistry(
+            timeToLive: 60,
+            now: { clock.now },
+            resourceID: { resourceID }
+        )
+        await #expect(throws: MobileHostIrohArtifactTransferRegistry.Error.unknownResource) {
+            try await separateSessionRegistry.claim(
+                resourceID: resourceID,
+                offset: 0,
+                peer: peer
+            )
+        }
+
+        clock.advance(by: 61)
+        await #expect(throws: MobileHostIrohArtifactTransferRegistry.Error.expired) {
+            try await registry.claim(
+                resourceID: resourceID,
+                offset: 0,
+                peer: peer
+            )
+        }
     }
 
     @Test func testIrohArtifactHandlerStreamsAuthorizedOffsetAtLowPriority() async throws {
@@ -522,15 +575,72 @@ extension MobileHostAuthorizationTests {
 
         #expect(didTakeOwnership)
         #expect(await send.payload() == Data("cdef".utf8))
-        #expect(await send.priorities() == [10])
+        #expect(await send.priorities() == [-10])
         #expect(await send.finishCount() == 1)
         #expect(await receive.stopCodes() == [0])
+    }
+
+    @Test func testIrohArtifactHandlerResetsIfFileChangesDuringTransfer() async throws {
+        let fixture = try MobileHostIrohArtifactFixture(contents: Data("abcdef".utf8))
+        defer { fixture.remove() }
+        let resourceID = try CmxIrohResourceID(
+            "artifact:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+        )
+        let registry = MobileHostIrohArtifactTransferRegistry(
+            timeToLive: 60,
+            now: Date.init,
+            resourceID: { resourceID }
+        )
+        let peer = try irohPeer(endpointCharacter: "d")
+        _ = try await registry.issue(canonicalPath: fixture.path, peer: peer)
+        let send = MutatingMobileHostIrohArtifactSendStream(path: fixture.path)
+        let receive = RecordingMobileHostIrohArtifactReceiveStream()
+
+        let didTakeOwnership = await MobileHostIrohArtifactLaneHandler(
+            registry: registry
+        ).handleArtifactLane(
+            resourceID: resourceID,
+            offset: 0,
+            stream: CmxIrohBidirectionalStream(
+                receiveStream: receive,
+                sendStream: send
+            ),
+            peer: peer
+        )
+
+        #expect(didTakeOwnership)
+        #expect(await send.finishCount() == 0)
+        #expect(await send.resetCodes() == [6])
+        #expect(await receive.stopCodes() == [0, 6])
     }
 
     @Test func testIrohApplicationLaneQuotasReserveArtifactCapacity() {
         #expect(MobileHostIrohApplicationLaneRouter.maximumConcurrentTerminalLaneCount == 4)
         #expect(MobileHostIrohApplicationLaneRouter.maximumConcurrentArtifactLaneCount == 1)
         #expect(MobileHostIrohApplicationLaneRouter.maximumConcurrentLaneCount == 5)
+
+        var quota = MobileHostIrohApplicationLaneQuota()
+        let terminalIDs = (0..<5).map { _ in UUID() }
+        for id in terminalIDs.prefix(4) {
+            let didReserve = quota.reserve(id, laneClass: .terminal)
+            #expect(didReserve)
+        }
+        let didReserveFifthTerminal = quota.reserve(terminalIDs[4], laneClass: .terminal)
+        #expect(!didReserveFifthTerminal)
+        let artifactID = UUID()
+        let didReserveArtifact = quota.reserve(artifactID, laneClass: .artifact)
+        #expect(didReserveArtifact)
+        let didReserveSecondArtifact = quota.reserve(UUID(), laneClass: .artifact)
+        #expect(!didReserveSecondArtifact)
+        #expect(quota.terminalCount == 4)
+        #expect(quota.artifactCount == 1)
+
+        quota.release(terminalIDs[0])
+        let didReuseTerminalCredit = quota.reserve(terminalIDs[4], laneClass: .terminal)
+        #expect(didReuseTerminalCredit)
+        quota.release(artifactID)
+        let didReuseArtifactCredit = quota.reserve(UUID(), laneClass: .artifact)
+        #expect(didReuseArtifactCredit)
     }
 
     private func irohPeer(
@@ -587,6 +697,25 @@ private struct MobileHostIrohArtifactFixture {
     }
 }
 
+private final class MobileHostIrohArtifactTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+
+    init(now: Date) {
+        value = now
+    }
+
+    var now: Date {
+        lock.withLock { value }
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.withLock {
+            value = value.addingTimeInterval(interval)
+        }
+    }
+}
+
 private actor RecordingMobileHostIrohArtifactSendStream: CmxIrohSendStream {
     private var chunks: [Data] = []
     private var observedPriorities: [Int32] = []
@@ -624,6 +753,39 @@ private actor RecordingMobileHostIrohArtifactReceiveStream: CmxIrohReceiveStream
     }
 
     func stopCodes() -> [UInt64] { observedStopCodes }
+}
+
+private actor MutatingMobileHostIrohArtifactSendStream: CmxIrohSendStream {
+    private let path: String
+    private var didMutate = false
+    private var observedFinishCount = 0
+    private var observedResetCodes: [UInt64] = []
+
+    init(path: String) {
+        self.path = path
+    }
+
+    func send(_: Data) throws {
+        guard !didMutate else { return }
+        didMutate = true
+        guard let handle = FileHandle(forWritingAtPath: path) else { return }
+        defer { try? handle.close() }
+        try handle.truncate(atOffset: 0)
+        try handle.write(contentsOf: Data("changed-size".utf8))
+    }
+
+    func finish() {
+        observedFinishCount += 1
+    }
+
+    func reset(errorCode: UInt64) {
+        observedResetCodes.append(errorCode)
+    }
+
+    func setPriority(_: Int32) {}
+
+    func finishCount() -> Int { observedFinishCount }
+    func resetCodes() -> [UInt64] { observedResetCodes }
 }
 
 private actor MobileHostIrohPersistenceGate {

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -77,6 +77,13 @@ struct cmuxApp: App {
                     surfaceID: surfaceUUID,
                     cursor: cursor
                 )
+            },
+            artifactLaneProvider: { request, resourceID, offset in
+                try await iroh.openArtifactLane(
+                    for: request,
+                    resourceID: resourceID,
+                    offset: offset
+                )
             }
         )
 

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRuntime.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRuntime.swift
@@ -32,6 +32,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
     public var supportsServerPushEvents: Bool
     public var independentEventByteStreamProvider: CmxIndependentEventByteStreamProvider?
     public var terminalLaneProvider: MobileTerminalLaneProvider?
+    public var artifactLaneProvider: MobileArtifactLaneProvider?
 
     /// Builds the production access-token provider over an injected
     /// ``TokenProviding`` (the app-root ``AuthCoordinator``), honoring the DEBUG
@@ -140,7 +141,8 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         now: @escaping @Sendable () -> Date = Date.init,
         supportsServerPushEvents: Bool = true,
         independentEventByteStreamProvider: CmxIndependentEventByteStreamProvider? = nil,
-        terminalLaneProvider: MobileTerminalLaneProvider? = nil
+        terminalLaneProvider: MobileTerminalLaneProvider? = nil,
+        artifactLaneProvider: MobileArtifactLaneProvider? = nil
     ) {
         self.supportedRouteKinds = supportedRouteKinds
         self.transportFactory = transportFactory
@@ -154,6 +156,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         self.supportsServerPushEvents = supportsServerPushEvents
         self.independentEventByteStreamProvider = independentEventByteStreamProvider
         self.terminalLaneProvider = terminalLaneProvider
+        self.artifactLaneProvider = artifactLaneProvider
     }
 
     public init(
@@ -167,7 +170,8 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         now: @escaping @Sendable () -> Date = Date.init,
         supportsServerPushEvents: Bool = true,
         independentEventByteStreamProvider: CmxIndependentEventByteStreamProvider? = nil,
-        terminalLaneProvider: MobileTerminalLaneProvider? = nil
+        terminalLaneProvider: MobileTerminalLaneProvider? = nil,
+        artifactLaneProvider: MobileArtifactLaneProvider? = nil
     ) {
         self.supportedRouteKinds = transportFactory.supportedKinds
         self.transportFactory = transportFactory
@@ -180,6 +184,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         self.supportsServerPushEvents = supportsServerPushEvents
         self.independentEventByteStreamProvider = independentEventByteStreamProvider
         self.terminalLaneProvider = terminalLaneProvider
+        self.artifactLaneProvider = artifactLaneProvider
         self.now = now
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohArtifactLane.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohArtifactLane.swift
@@ -1,0 +1,27 @@
+import CmuxIrohTransport
+import CmuxMobileRPC
+import Foundation
+
+/// iOS adapter that exposes only the readable half of an Iroh artifact stream.
+actor MobileIrohArtifactLane: MobileArtifactLaneConnection {
+    private let stream: CmxIrohBidirectionalStream
+    private var closed = false
+
+    init(stream: CmxIrohBidirectionalStream) {
+        self.stream = stream
+    }
+
+    func receive(maximumByteCount: Int) async throws -> Data? {
+        guard !closed else { return nil }
+        return try await stream.receiveStream.receive(
+            maximumByteCount: max(1, maximumByteCount)
+        )
+    }
+
+    func close() async {
+        guard !closed else { return }
+        closed = true
+        await stream.receiveStream.stop(errorCode: 0)
+        await stream.sendStream.reset(errorCode: 0)
+    }
+}

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -1,6 +1,7 @@
 import CMUXMobileCore
 import CmuxAuthRuntime
 public import CmuxIrohTransport
+import CmuxMobileRPC
 import CmuxMobileShell
 import CmuxMobileTransport
 import CryptoKit
@@ -518,6 +519,29 @@ public final class MobileIrohRuntimeComposition:
             priority: priority
         )
         return MobileIrohTerminalLane(stream: stream)
+    }
+
+    /// Opens a low-priority raw artifact lane for an opaque Mac-issued capability.
+    public func openArtifactLane(
+        for request: CmxByteTransportRequest,
+        resourceID: String,
+        offset: UInt64,
+        priority: Int32 = -10
+    ) async throws -> any MobileArtifactLaneConnection {
+        let capability = try CmxIrohResourceID(resourceID)
+        let stream = try await openBidirectionalLane(
+            for: request,
+            lane: .artifact(resourceID: capability, offset: offset),
+            priority: priority
+        )
+        do {
+            try await stream.sendStream.finish()
+            return MobileIrohArtifactLane(stream: stream)
+        } catch {
+            await stream.sendStream.reset(errorCode: 0)
+            await stream.receiveStream.stop(errorCode: 0)
+            throw error
+        }
     }
 
     /// Starts the one server-event byte stream on the pooled admitted connection.
@@ -1604,7 +1628,7 @@ public final class MobileIrohRuntimeComposition:
             alpn: CmxIrohProtocolConfiguration.cmuxMobileV1.alpn,
             maximumHeaderByteCount: CmxIrohProtocolConfiguration.cmuxMobileV1
                 .maximumHeaderByteCount,
-            maximumConcurrentClientApplicationLaneCount: 4,
+            maximumConcurrentClientApplicationLaneCount: 5,
             allowsNATTraversalAfterAdmission: mode.allowsNATTraversalAfterAdmission
         )
     }


### PR DESCRIPTION
## Summary
- add an opaque, peer-bound Iroh artifact descriptor and session-scoped transfer registry
- stream chat and terminal artifacts over a low-priority application lane with separate quota, replay limits, file-identity checks, and lifecycle ownership
- advertise the capability only for admitted Iroh sessions and retain RPC fallback before the first artifact byte

## Verification
- `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -derivedDataPath /tmp/cmux-artln-rebase-mac -destination platform=macOS -only-testing:cmuxTests/MobileHostAuthorizationTests CMUX_SKIP_ZIG_BUILD=1 test` (82 passed)
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileArtifactLaneFetchLoopTests` (7 passed)
- `swift test --package-path Packages/iOS/CmuxMobileRPC --filter MobileRPCClientLifecycleGateTests` (4 passed)
- `swift test --package-path Packages/Shared/CmuxIrohTransport --filter CmxIrohServerSessionTests.acceptedControlPreservesPayloadAndUnlocksIndependentLanes` (1 passed)
- `swift test --package-path Packages/Shared/CmuxAgentChat --filter ChatArtifactLaneDescriptorTests` (1 passed)
- `./ios/scripts/reload.sh --tag artln --simulator cmux-artln-12277 --no-launch --no-setup` (isolated Simulator build succeeded)
- `git diff --check origin/main...HEAD` and Localizable.xcstrings JSON validation passed

## Residual risk
No physical-device or real-relay artifact preview was exercised. Evidence covers an isolated full iOS composition build, focused fetch/lifecycle tests, and an admitted in-memory Iroh session with independent lanes. Standalone `swift test` for `ios/cmuxPackage` is blocked before source compilation by its existing macOS 10.13 manifest default versus dependencies requiring macOS 14; the full Simulator composition build covers that source instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787076093&installation_id=133855650&pr_number=8494&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8494&signature=7e6a71800b6443d2880cb1be4b97e9e177bb139db0661e42babbd3990b1ef155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams chat and terminal artifacts over a low‑priority Iroh lane using peer‑bound, opaque capabilities, with file‑integrity checks, class‑based quotas (4 terminal + 1 artifact), and safe RPC fallback before the first byte. Descriptor issuance now classifies failures (file not found vs temporarily unavailable) with localized errors, and the `iroh.artifact_lane.v1` capability is advertised only when the handler is installed; the legacy RPC path remains unchanged.

- **New Features**
  - Added `ChatArtifactLaneDescriptor` and a session‑scoped `MobileHostIrohArtifactTransferRegistry` (TTL, peer binding, serial resume limit, capacity guard, file‑identity snapshot).
  - Implemented Mac handler `MobileHostIrohArtifactLaneHandler` with low‑priority sends, EOF/reset behavior, integrity rechecks, and per‑class quotas; router reserves artifact capacity and raises concurrent lanes to 5; admitted status includes `iroh.artifact_lane.v1` only when the handler is present.
  - Exposed client APIs (`MobileArtifactLaneConnection`, `MobileArtifactLaneProvider`, `MobileCoreRPCClient.openArtifactLane`) and iOS wiring (`cmuxApp`, `MobileIrohRuntimeComposition`); `MobileArtifactLaneFetchLoop` turns raw bytes into back‑pressured `ChatArtifactChunk`s, and `MobileChatEventSource` prefers the lane with safe pre‑byte RPC fallback.
  - Added `transport: "iroh_artifact_v1"` support in fetch RPCs to mint opaque descriptors; improved localized messages for transfer availability.

- **Bug Fixes**
  - Preserved artifact consumer errors after lane bytes and propagated cancellation; lanes close cleanly on cancel/reset, and RPC fallback is used only when no lane bytes were delivered.
  - Made Mac artifact file reads cancellable via DispatchIO to avoid blocking; rechecked identity before and after streaming to prevent mixed previews.
  - Classified descriptor issue failures (file-not-found vs unavailable) and surfaced precise, localized errors without exposing paths.

<sup>Written for commit 309c9fcd9a002c155edb230a7982b9be7d56c678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated iroh artifact lanes for chat and terminal, using short-lived lane descriptors and streamed chunk delivery with accurate progress/EOF behavior.
  * Introduced mobile APIs to open, receive, and close artifact lanes at a given offset, gated by `iroh.artifact_lane.v1` capability.
  * Implemented an artifact lease/transfer registry plus separate quota-based admission for terminal vs artifact lanes.
  * Updated host capability/status reporting to include artifact-lane support when available.
* **Bug Fixes**
  * Improved lifecycle cleanup and error handling, including reliable early fallback to legacy RPC.
* **Tests**
  * Expanded coverage for lane streaming semantics, cancellation, admission lifecycle, quota/leasing, and handler reset scenarios.
* **Documentation**
  * Added new localized user messages for unavailable authenticated iroh transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->