### PR TITLE
cmuxTests: make CLI mock control sockets headless-robust; refresh vm-new expectations

### DIFF
--- a/cmuxTests/CLIGenericHookPersistenceTests.swift
+++ b/cmuxTests/CLIGenericHookPersistenceTests.swift
@@ -314,7 +314,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "CMUX_CLI_SENTRY_DISABLED": "1",
         ]
 
-        startDetachedMockServer(listenerFD: listenerFD, state: state, connectionCount: 128) { line in
+        startDetachedMockServer(listenerFD: listenerFD, state: state) { line in
             guard let payload = self.jsonObject(line) else {
                 return "OK"
             }
@@ -582,7 +582,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         ]
 
         func runHermesHook(_ subcommand: String, input: String) -> ProcessRunResult {
-            let serverHandled = startAgentHookMockServer(listenerFD: listenerFD, state: state, surfaceId: surfaceId, connectionCount: 4)
+            let serverHandled = startAgentHookMockServer(listenerFD: listenerFD, state: state, surfaceId: surfaceId)
             let result = runProcess(
                 executablePath: cliPath,
                 arguments: ["hooks", "hermes-agent", subcommand],
@@ -1373,7 +1373,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "GROK_HOME": grokHome.path,
         ]
 
-        startDetachedAgentHookMockServer(listenerFD: listenerFD, state: state, surfaceId: surfaceId, connectionCount: 80)
+        startDetachedAgentHookMockServer(listenerFD: listenerFD, state: state, surfaceId: surfaceId)
 
         func runGrokHook(_ subcommand: String, input: String) -> ProcessRunResult {
             let result = runProcess(

--- a/cmuxTests/CLIGrokNotificationNoiseTests.swift
+++ b/cmuxTests/CLIGrokNotificationNoiseTests.swift
@@ -173,7 +173,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             "GROK_HOME": grokHome.path,
         ]
 
-        startDetachedAgentHookMockServer(listenerFD: listenerFD, state: state, surfaceId: surfaceId, connectionCount: 128)
+        startDetachedAgentHookMockServer(listenerFD: listenerFD, state: state, surfaceId: surfaceId)
         return GrokNoiseContext(
             cliPath: cliPath,
             socketPath: socketPath,

--- a/cmuxTests/CLIMockSocketServerSupport.swift
+++ b/cmuxTests/CLIMockSocketServerSupport.swift
@@ -1,6 +1,114 @@
 import XCTest
 import Darwin
 
+/// Coordinates mock control-socket accept loops that share a listener FD.
+///
+/// Many CLI tests open a *fresh* mock server for every hook invocation but reuse
+/// the same bound listener FD across those invocations. Each new server must
+/// supersede the previous one, otherwise a leftover accept loop lingers on the
+/// shared FD and can steal the next hook's connection — fulfilling the previous
+/// (already-satisfied) expectation and leaving the current one hanging until the
+/// 5s wait times out.
+///
+/// The loops run on raw `Thread`s rather than GCD queues on purpose: a blocking
+/// `accept()` parked on a GCD worker ties that worker up for the whole test, and
+/// a test that spins up a server per hook quickly drains the shared GCD pool that
+/// `runProcess` needs for its stdout/stderr readers and exit waiter — which then
+/// looks exactly like the CLI hanging.
+final class CLIMockAcceptLoopRegistry: @unchecked Sendable {
+    static let shared = CLIMockAcceptLoopRegistry()
+
+    private let lock = NSLock()
+    private struct Handle { let stopWriteFD: Int32; let done: DispatchSemaphore }
+    private var current: [Int32: Handle] = [:]
+
+    /// Starts a poll-based accept loop on `listenerFD`, superseding any previous
+    /// loop registered for the same FD (it is signalled to stop and joined before
+    /// the new loop begins accepting). Each accepted connection is handed to its
+    /// own raw thread via `onConnection`.
+    func start(
+        listenerFD: Int32,
+        onConnection: @escaping @Sendable (Int32) -> Void,
+        onListenerClosed: @escaping @Sendable () -> Void
+    ) {
+        lock.lock()
+        let previous = current[listenerFD]
+        lock.unlock()
+        if let previous {
+            var one: UInt8 = 1
+            _ = Darwin.write(previous.stopWriteFD, &one, 1)
+            _ = previous.done.wait(timeout: .now() + 2)
+        }
+
+        var stopFDs: [Int32] = [-1, -1]
+        _ = pipe(&stopFDs)
+        let stopReadFD = stopFDs[0]
+        let stopWriteFD = stopFDs[1]
+        let done = DispatchSemaphore(value: 0)
+
+        lock.lock()
+        current[listenerFD] = Handle(stopWriteFD: stopWriteFD, done: done)
+        lock.unlock()
+
+        let thread = Thread {
+            defer {
+                // Deregister before closing the pipe FDs so a later server on a
+                // reused FD number never writes a stop byte into an unrelated
+                // descriptor.
+                self.lock.lock()
+                if self.current[listenerFD]?.done === done {
+                    self.current[listenerFD] = nil
+                }
+                self.lock.unlock()
+                Darwin.close(stopReadFD)
+                Darwin.close(stopWriteFD)
+                done.signal()
+            }
+            while true {
+                var fds = [
+                    pollfd(fd: listenerFD, events: Int16(POLLIN), revents: 0),
+                    pollfd(fd: stopReadFD, events: Int16(POLLIN), revents: 0),
+                ]
+                let ready = Darwin.poll(&fds, 2, -1)
+                if ready < 0 {
+                    if errno == EINTR { continue }
+                    onListenerClosed()
+                    return
+                }
+                if (fds[1].revents & Int16(POLLIN)) != 0 {
+                    // Superseded by a newer server on the same FD.
+                    return
+                }
+                let listenerEvents = fds[0].revents
+                if (listenerEvents & Int16(POLLIN)) != 0 {
+                    var clientAddr = sockaddr_un()
+                    var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+                    let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                            Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                        }
+                    }
+                    if clientFD < 0 {
+                        if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK { continue }
+                        onListenerClosed()
+                        return
+                    }
+                    let handlerThread = Thread { onConnection(clientFD) }
+                    handlerThread.stackSize = 1 << 20
+                    handlerThread.start()
+                    continue
+                }
+                if (listenerEvents & Int16(POLLERR | POLLHUP | POLLNVAL)) != 0 {
+                    onListenerClosed()
+                    return
+                }
+            }
+        }
+        thread.stackSize = 1 << 20
+        thread.start()
+    }
+}
+
 extension CMUXOpenCommandTests {
     func openTypedDiffSession(payload: [String: Any], cliPath: String) throws -> String {
         let source = try XCTUnwrap(payload["sessionSource"] as? [String: Any])
@@ -101,10 +209,19 @@ extension CLINotifyProcessIntegrationRegressionTests {
         }
     }
 
+    // The bundled CLI opens a dedicated short-lived control connection for the
+    // `system.top` agent-process lookup in addition to its main hook connection.
+    // Headless (piped stdin/stdout with no controlling TTY) that lookup always
+    // fires because caller-TTY resolution can't succeed, so every hook invocation
+    // needs at least two accepted connections. Default to a small pool with margin
+    // so the extra connection is always serviced instead of starving on a
+    // single-accept mock.
+    static let defaultMockConnectionCount = 4
+
     func startMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
-        connectionCount: Int = 1,
+        connectionCount: Int = CLINotifyProcessIntegrationRegressionTests.defaultMockConnectionCount,
         fulfillWhen: (@Sendable (String) -> Bool)? = nil,
         handler: @escaping @Sendable (String) -> String
     ) -> XCTestExpectation {
@@ -121,18 +238,71 @@ extension CLINotifyProcessIntegrationRegressionTests {
     func startMockServerAllowingNoResponse(
         listenerFD: Int32,
         state: MockSocketServerState,
-        connectionCount: Int = 1,
+        connectionCount: Int = CLINotifyProcessIntegrationRegressionTests.defaultMockConnectionCount,
         fulfillWhen: (@Sendable (String) -> Bool)? = nil,
         handler: @escaping @Sendable (String) -> String?
     ) -> XCTestExpectation {
+        // `connectionCount` is retained for source compatibility but no longer
+        // caps how many connections are serviced: a single accept loop dispatches
+        // every incoming connection to its own handler, so the CLI's extra
+        // `system.top` control connection is always answered.
+        _ = connectionCount
         let handled = expectation(description: "cli mock socket handled")
         let fulfillmentGate = MockSocketFulfillmentGate()
-        for _ in 0..<max(1, connectionCount) {
-            DispatchQueue.global(qos: .userInitiated).async {
-                func fulfillOnce() {
-                    fulfillmentGate.fulfill(handled)
+        CLIMockAcceptLoopRegistry.shared.start(listenerFD: listenerFD, onConnection: { clientFD in
+            defer {
+                Darwin.close(clientFD)
+                fulfillmentGate.fulfill(handled)
+            }
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    return
                 }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
 
+                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    pending.removeSubrange(0...newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    state.append(line)
+                    if fulfillWhen?(line) == true {
+                        fulfillmentGate.fulfill(handled)
+                    }
+                    guard let responsePayload = handler(line) else { continue }
+                    let response = responsePayload + "\n"
+                    _ = response.withCString { ptr in
+                        Darwin.write(clientFD, ptr, strlen(ptr))
+                    }
+                }
+            }
+        }, onListenerClosed: {
+            // Unblock the waiter if the listener is torn down before any client
+            // connected (matches the previous accept-failure fulfillment).
+            fulfillmentGate.fulfill(handled)
+        })
+        return handled
+    }
+
+    /// Runs a mock control-socket accept loop on a dedicated raw thread (NOT a GCD
+    /// queue). Each accepted connection is handled on its own raw thread.
+    ///
+    /// This deliberately avoids `DispatchQueue.global()`: a blocking `accept()`
+    /// parked on a GCD worker ties that worker up for the whole test, and a test
+    /// that opens a fresh server per hook quickly exhausts the shared GCD pool —
+    /// which then starves the `runProcess` stdout/stderr readers and exit waiter,
+    /// making the CLI look like it hung. Raw threads keep the GCD pool free.
+    static func runMockAcceptLoop(
+        listenerFD: Int32,
+        onConnection: @escaping @Sendable (Int32) -> Void,
+        onListenerClosed: (@Sendable () -> Void)? = nil
+    ) {
+        let thread = Thread {
+            while true {
                 var clientAddr = sockaddr_un()
                 var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
                 let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
@@ -140,88 +310,50 @@ extension CLINotifyProcessIntegrationRegressionTests {
                         Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
                     }
                 }
-                guard clientFD >= 0 else {
-                    fulfillOnce()
+                if clientFD < 0 {
+                    if errno == EINTR { continue }
+                    onListenerClosed?()
                     return
                 }
-                defer {
-                    Darwin.close(clientFD)
-                    fulfillOnce()
-                }
-
-                var pending = Data()
-                var buffer = [UInt8](repeating: 0, count: 4096)
-                while true {
-                    let count = Darwin.read(clientFD, &buffer, buffer.count)
-                    if count < 0 {
-                        if errno == EINTR { continue }
-                        return
-                    }
-                    if count == 0 { return }
-                    pending.append(buffer, count: count)
-
-                    while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                        let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                        pending.removeSubrange(0...newlineRange.lowerBound)
-                        guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                        state.append(line)
-                        if fulfillWhen?(line) == true {
-                            fulfillOnce()
-                        }
-                        guard let responsePayload = handler(line) else { continue }
-                        let response = responsePayload + "\n"
-                        _ = response.withCString { ptr in
-                            Darwin.write(clientFD, ptr, strlen(ptr))
-                        }
-                    }
-                }
+                let handlerThread = Thread { onConnection(clientFD) }
+                handlerThread.stackSize = 1 << 20
+                handlerThread.start()
             }
         }
-        return handled
+        thread.stackSize = 1 << 20
+        thread.start()
     }
 
     func startDetachedMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
-        connectionCount: Int = 1,
+        connectionCount: Int = CLINotifyProcessIntegrationRegressionTests.defaultMockConnectionCount,
         handler: @escaping @Sendable (String) -> String
     ) {
-        for _ in 0..<max(1, connectionCount) {
-            DispatchQueue.global(qos: .userInitiated).async {
-                var clientAddr = sockaddr_un()
-                var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
-                let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
-                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                        Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
-                    }
-                }
-                guard clientFD >= 0 else {
+        // See `runMockAcceptLoop`: a single raw-thread accept loop services every
+        // connection, so `connectionCount` no longer bounds the server.
+        _ = connectionCount
+        Self.runMockAcceptLoop(listenerFD: listenerFD) { clientFD in
+            defer { Darwin.close(clientFD) }
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
                     return
                 }
-                defer {
-                    Darwin.close(clientFD)
-                }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
 
-                var pending = Data()
-                var buffer = [UInt8](repeating: 0, count: 4096)
-                while true {
-                    let count = Darwin.read(clientFD, &buffer, buffer.count)
-                    if count < 0 {
-                        if errno == EINTR { continue }
-                        return
-                    }
-                    if count == 0 { return }
-                    pending.append(buffer, count: count)
-
-                    while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                        let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                        pending.removeSubrange(0...newlineRange.lowerBound)
-                        guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                        state.append(line)
-                        let response = handler(line) + "\n"
-                        _ = response.withCString { ptr in
-                            Darwin.write(clientFD, ptr, strlen(ptr))
-                        }
+                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    pending.removeSubrange(0...newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    state.append(line)
+                    let response = handler(line) + "\n"
+                    _ = response.withCString { ptr in
+                        Darwin.write(clientFD, ptr, strlen(ptr))
                     }
                 }
             }

--- a/cmuxTests/CLIMockSocketServerSupport.swift
+++ b/cmuxTests/CLIMockSocketServerSupport.swift
@@ -1,73 +1,157 @@
 import XCTest
 import Darwin
 
-/// Coordinates mock control-socket accept loops that share a listener FD.
+/// A one-shot latch, safe to race on from several mock-server threads.
 ///
-/// Many CLI tests open a *fresh* mock server for every hook invocation but reuse
-/// the same bound listener FD across those invocations. Each new server must
-/// supersede the previous one, otherwise a leftover accept loop lingers on the
-/// shared FD and can steal the next hook's connection — fulfilling the previous
-/// (already-satisfied) expectation and leaving the current one hanging until the
-/// 5s wait times out.
+/// Mock servers answer more than one connection per hook, but the test waits on a
+/// single expectation, so exactly one of those threads may signal it.
+final class CLIMockOnceFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var claimed = false
+
+    /// Returns true for the first caller only.
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !claimed else { return false }
+        claimed = true
+        return true
+    }
+
+    /// Fulfills `expectation` on the first call and ignores every later one.
+    func fulfill(_ expectation: XCTestExpectation) {
+        guard claim() else { return }
+        expectation.fulfill()
+    }
+}
+
+/// Reads newline-framed requests from `clientFD` and writes back each response
+/// `respond` returns, until the peer closes the connection or a write fails.
+/// Returning nil from `respond` consumes the request without answering it.
+///
+/// The caller owns `clientFD` and is responsible for closing it.
+func cliMockServeLineFramedConnection(
+    clientFD: Int32,
+    respond: (String) -> String?
+) {
+    var pending = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let count = Darwin.read(clientFD, &buffer, buffer.count)
+        if count < 0 {
+            if errno == EINTR { continue }
+            return
+        }
+        if count == 0 { return }
+        pending.append(buffer, count: count)
+
+        while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+            let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+            pending.removeSubrange(0...newlineRange.lowerBound)
+            guard let line = String(data: lineData, encoding: .utf8) else { continue }
+            guard let responsePayload = respond(line) else { continue }
+            guard cliMockWriteAll(responsePayload + "\n", to: clientFD) else { return }
+        }
+    }
+}
+
+/// Writes `string` to `fd` in full, retrying short writes and interrupted or
+/// would-block writes. Returns false once the peer is gone.
+func cliMockWriteAll(_ string: String, to fd: Int32) -> Bool {
+    let bytes = Array(string.utf8)
+    var offset = 0
+    while offset < bytes.count {
+        let written = bytes.withUnsafeBytes { buffer -> Int in
+            guard let base = buffer.baseAddress else { return 0 }
+            return Darwin.write(fd, base.advanced(by: offset), bytes.count - offset)
+        }
+        if written > 0 {
+            offset += written
+            continue
+        }
+        if written == 0 { return false }
+        if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK { continue }
+        return false
+    }
+    return true
+}
+
+/// Owns the mock control-socket accept loops, keyed by listener FD.
+///
+/// Many CLI tests open a *fresh* mock server for every hook invocation while
+/// reusing one bound listener FD. Each new server must supersede the previous one,
+/// otherwise a leftover accept loop lingers on the shared FD and can steal the
+/// next hook's connection — fulfilling the previous (already-satisfied)
+/// expectation and leaving the current one hanging until its 5s wait times out.
 ///
 /// The loops run on raw `Thread`s rather than GCD queues on purpose: a blocking
-/// `accept()` parked on a GCD worker ties that worker up for the whole test, and
-/// a test that spins up a server per hook quickly drains the shared GCD pool that
+/// accept parked on a GCD worker ties that worker up for the whole test, and a
+/// test that spins up a server per hook quickly drains the shared GCD pool that
 /// `runProcess` needs for its stdout/stderr readers and exit waiter — which then
 /// looks exactly like the CLI hanging.
+///
+/// Each loop waits on both its listener FD and a private stop pipe, because
+/// closing a descriptor does not wake a thread already parked in `poll`/`accept`
+/// on Darwin. Without the stop pipe a loop would block until the test process
+/// exits, leaking its thread. Call ``stopAll(file:line:)`` from test teardown.
 final class CLIMockAcceptLoopRegistry: @unchecked Sendable {
     static let shared = CLIMockAcceptLoopRegistry()
 
-    private let lock = NSLock()
-    private struct Handle { let stopWriteFD: Int32; let done: DispatchSemaphore }
-    private var current: [Int32: Handle] = [:]
+    private final class Loop {
+        let stopReadFD: Int32
+        let stopWriteFD: Int32
+        let done = DispatchSemaphore(value: 0)
 
-    /// Starts a poll-based accept loop on `listenerFD`, superseding any previous
-    /// loop registered for the same FD (it is signalled to stop and joined before
-    /// the new loop begins accepting). Each accepted connection is handed to its
-    /// own raw thread via `onConnection`.
+        init(stopReadFD: Int32, stopWriteFD: Int32) {
+            self.stopReadFD = stopReadFD
+            self.stopWriteFD = stopWriteFD
+        }
+    }
+
+    /// Guards `loops` and serializes whole start/stop sequences so two concurrent
+    /// starts on one FD can't both observe the same predecessor and then both run
+    /// (two loops on one listener is exactly the connection-stealing bug). Loop
+    /// threads never take this lock — they only signal `done` — so holding it
+    /// across the stop-and-join cannot deadlock.
+    private let lock = NSLock()
+    private var loops: [Int32: Loop] = [:]
+
+    /// Starts a poll-based accept loop on `listenerFD`, superseding any loop
+    /// already registered for that FD (the old loop is signalled and joined before
+    /// the new one starts accepting). Each accepted connection is handed to its own
+    /// raw thread via `onConnection`, which owns and must close that FD.
     func start(
         listenerFD: Int32,
         onConnection: @escaping @Sendable (Int32) -> Void,
-        onListenerClosed: @escaping @Sendable () -> Void
+        onListenerClosed: @escaping @Sendable () -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) {
         lock.lock()
-        let previous = current[listenerFD]
-        lock.unlock()
-        if let previous {
-            var one: UInt8 = 1
-            _ = Darwin.write(previous.stopWriteFD, &one, 1)
-            _ = previous.done.wait(timeout: .now() + 2)
-        }
+        defer { lock.unlock() }
+
+        retireLoopLocked(listenerFD: listenerFD, file: file, line: line)
 
         var stopFDs: [Int32] = [-1, -1]
-        _ = pipe(&stopFDs)
-        let stopReadFD = stopFDs[0]
-        let stopWriteFD = stopFDs[1]
-        let done = DispatchSemaphore(value: 0)
-
-        lock.lock()
-        current[listenerFD] = Handle(stopWriteFD: stopWriteFD, done: done)
-        lock.unlock()
+        guard pipe(&stopFDs) == 0 else {
+            // Without a stop pipe the loop could never be superseded or reaped, so
+            // starting one would reintroduce the stealing bug and leak a thread.
+            XCTFail(
+                "Failed to create mock server stop pipe: \(String(cString: strerror(errno)))",
+                file: file,
+                line: line
+            )
+            return
+        }
+        let loop = Loop(stopReadFD: stopFDs[0], stopWriteFD: stopFDs[1])
+        loops[listenerFD] = loop
 
         let thread = Thread {
-            defer {
-                // Deregister before closing the pipe FDs so a later server on a
-                // reused FD number never writes a stop byte into an unrelated
-                // descriptor.
-                self.lock.lock()
-                if self.current[listenerFD]?.done === done {
-                    self.current[listenerFD] = nil
-                }
-                self.lock.unlock()
-                Darwin.close(stopReadFD)
-                Darwin.close(stopWriteFD)
-                done.signal()
-            }
+            defer { loop.done.signal() }
             while true {
                 var fds = [
                     pollfd(fd: listenerFD, events: Int16(POLLIN), revents: 0),
-                    pollfd(fd: stopReadFD, events: Int16(POLLIN), revents: 0),
+                    pollfd(fd: loop.stopReadFD, events: Int16(POLLIN), revents: 0),
                 ]
                 let ready = Darwin.poll(&fds, 2, -1)
                 if ready < 0 {
@@ -76,7 +160,7 @@ final class CLIMockAcceptLoopRegistry: @unchecked Sendable {
                     return
                 }
                 if (fds[1].revents & Int16(POLLIN)) != 0 {
-                    // Superseded by a newer server on the same FD.
+                    // Superseded, or reaped at teardown.
                     return
                 }
                 let listenerEvents = fds[0].revents
@@ -106,6 +190,45 @@ final class CLIMockAcceptLoopRegistry: @unchecked Sendable {
         }
         thread.stackSize = 1 << 20
         thread.start()
+    }
+
+    /// Stops and joins the loop registered for `listenerFD`, if any.
+    func stop(listenerFD: Int32, file: StaticString = #filePath, line: UInt = #line) {
+        lock.lock()
+        defer { lock.unlock() }
+        retireLoopLocked(listenerFD: listenerFD, file: file, line: line)
+    }
+
+    /// Stops and joins every registered loop. Call from test teardown so no accept
+    /// thread outlives the test that started it.
+    func stopAll(file: StaticString = #filePath, line: UInt = #line) {
+        lock.lock()
+        defer { lock.unlock() }
+        // Snapshot the keys: retiring a loop removes it from `loops`.
+        for listenerFD in Array(loops.keys) {
+            retireLoopLocked(listenerFD: listenerFD, file: file, line: line)
+        }
+    }
+
+    /// Signals the loop to exit, waits for it, then closes its stop pipe. The
+    /// registry owns the pipe FDs for the loop's whole life: the loop never closes
+    /// them, so a stop byte can never land in an unrelated descriptor that reused
+    /// the number. Must be called with `lock` held.
+    private func retireLoopLocked(listenerFD: Int32, file: StaticString, line: UInt) {
+        guard let loop = loops.removeValue(forKey: listenerFD) else { return }
+        var one: UInt8 = 1
+        _ = Darwin.write(loop.stopWriteFD, &one, 1)
+        if loop.done.wait(timeout: .now() + 5) == .timedOut {
+            // A loop that ignored its stop byte is still parked on the listener and
+            // will steal a later connection; that has to be loud, not silent.
+            XCTFail(
+                "Mock server accept loop for fd \(listenerFD) did not stop within 5s",
+                file: file,
+                line: line
+            )
+        }
+        Darwin.close(loop.stopReadFD)
+        Darwin.close(loop.stopWriteFD)
     }
 }
 
@@ -196,89 +319,51 @@ extension CMUXOpenCommandTests {
 }
 
 extension CLINotifyProcessIntegrationRegressionTests {
-    private final class MockSocketFulfillmentGate: @unchecked Sendable {
-        private let lock = NSLock()
-        private var didFulfill = false
-
-        func fulfill(_ expectation: XCTestExpectation) {
-            lock.lock()
-            defer { lock.unlock() }
-            guard !didFulfill else { return }
-            didFulfill = true
-            expectation.fulfill()
-        }
-    }
-
-    // The bundled CLI opens a dedicated short-lived control connection for the
-    // `system.top` agent-process lookup in addition to its main hook connection.
-    // Headless (piped stdin/stdout with no controlling TTY) that lookup always
-    // fires because caller-TTY resolution can't succeed, so every hook invocation
-    // needs at least two accepted connections. Default to a small pool with margin
-    // so the extra connection is always serviced instead of starving on a
-    // single-accept mock.
-    static let defaultMockConnectionCount = 4
-
+    /// Serves the mock control socket until the listener is torn down, fulfilling
+    /// `handled` once the first connection is done (or once the listener goes away
+    /// before anything connected).
+    ///
+    /// One accept loop services every connection the CLI opens. That matters
+    /// headless: with piped stdio and no controlling TTY the CLI can't resolve its
+    /// caller by TTY, so it always falls back to a `system.top` lookup on a second,
+    /// short-lived connection. A mock that answers only one connection starves that
+    /// lookup, and the hook stalls or routes to the wrong surface.
     func startMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
-        connectionCount: Int = CLINotifyProcessIntegrationRegressionTests.defaultMockConnectionCount,
         fulfillWhen: (@Sendable (String) -> Bool)? = nil,
         handler: @escaping @Sendable (String) -> String
     ) -> XCTestExpectation {
         startMockServerAllowingNoResponse(
             listenerFD: listenerFD,
             state: state,
-            connectionCount: connectionCount,
             fulfillWhen: fulfillWhen
         ) { line in
             handler(line)
         }
     }
 
+    /// Like ``startMockServer(listenerFD:state:fulfillWhen:handler:)``, but a nil
+    /// return from `handler` records the request and sends no reply.
     func startMockServerAllowingNoResponse(
         listenerFD: Int32,
         state: MockSocketServerState,
-        connectionCount: Int = CLINotifyProcessIntegrationRegressionTests.defaultMockConnectionCount,
         fulfillWhen: (@Sendable (String) -> Bool)? = nil,
         handler: @escaping @Sendable (String) -> String?
     ) -> XCTestExpectation {
-        // `connectionCount` is retained for source compatibility but no longer
-        // caps how many connections are serviced: a single accept loop dispatches
-        // every incoming connection to its own handler, so the CLI's extra
-        // `system.top` control connection is always answered.
-        _ = connectionCount
         let handled = expectation(description: "cli mock socket handled")
-        let fulfillmentGate = MockSocketFulfillmentGate()
+        let fulfillmentGate = CLIMockOnceFlag()
         CLIMockAcceptLoopRegistry.shared.start(listenerFD: listenerFD, onConnection: { clientFD in
             defer {
                 Darwin.close(clientFD)
                 fulfillmentGate.fulfill(handled)
             }
-            var pending = Data()
-            var buffer = [UInt8](repeating: 0, count: 4096)
-            while true {
-                let count = Darwin.read(clientFD, &buffer, buffer.count)
-                if count < 0 {
-                    if errno == EINTR { continue }
-                    return
+            cliMockServeLineFramedConnection(clientFD: clientFD) { line in
+                state.append(line)
+                if fulfillWhen?(line) == true {
+                    fulfillmentGate.fulfill(handled)
                 }
-                if count == 0 { return }
-                pending.append(buffer, count: count)
-
-                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                    pending.removeSubrange(0...newlineRange.lowerBound)
-                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                    state.append(line)
-                    if fulfillWhen?(line) == true {
-                        fulfillmentGate.fulfill(handled)
-                    }
-                    guard let responsePayload = handler(line) else { continue }
-                    let response = responsePayload + "\n"
-                    _ = response.withCString { ptr in
-                        Darwin.write(clientFD, ptr, strlen(ptr))
-                    }
-                }
+                return handler(line)
             }
         }, onListenerClosed: {
             // Unblock the waiter if the listener is torn down before any client
@@ -288,85 +373,28 @@ extension CLINotifyProcessIntegrationRegressionTests {
         return handled
     }
 
-    /// Runs a mock control-socket accept loop on a dedicated raw thread (NOT a GCD
-    /// queue). Each accepted connection is handled on its own raw thread.
-    ///
-    /// This deliberately avoids `DispatchQueue.global()`: a blocking `accept()`
-    /// parked on a GCD worker ties that worker up for the whole test, and a test
-    /// that opens a fresh server per hook quickly exhausts the shared GCD pool —
-    /// which then starves the `runProcess` stdout/stderr readers and exit waiter,
-    /// making the CLI look like it hung. Raw threads keep the GCD pool free.
-    static func runMockAcceptLoop(
-        listenerFD: Int32,
-        onConnection: @escaping @Sendable (Int32) -> Void,
-        onListenerClosed: (@Sendable () -> Void)? = nil
-    ) {
-        let thread = Thread {
-            while true {
-                var clientAddr = sockaddr_un()
-                var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
-                let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
-                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                        Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
-                    }
-                }
-                if clientFD < 0 {
-                    if errno == EINTR { continue }
-                    onListenerClosed?()
-                    return
-                }
-                let handlerThread = Thread { onConnection(clientFD) }
-                handlerThread.stackSize = 1 << 20
-                handlerThread.start()
-            }
-        }
-        thread.stackSize = 1 << 20
-        thread.start()
-    }
-
+    /// A mock server with no expectation to wait on, for tests that drive many
+    /// hooks and assert on `state` afterwards.
     func startDetachedMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
-        connectionCount: Int = CLINotifyProcessIntegrationRegressionTests.defaultMockConnectionCount,
         handler: @escaping @Sendable (String) -> String
     ) {
-        // See `runMockAcceptLoop`: a single raw-thread accept loop services every
-        // connection, so `connectionCount` no longer bounds the server.
-        _ = connectionCount
-        Self.runMockAcceptLoop(listenerFD: listenerFD) { clientFD in
+        CLIMockAcceptLoopRegistry.shared.start(listenerFD: listenerFD, onConnection: { clientFD in
             defer { Darwin.close(clientFD) }
-            var pending = Data()
-            var buffer = [UInt8](repeating: 0, count: 4096)
-            while true {
-                let count = Darwin.read(clientFD, &buffer, buffer.count)
-                if count < 0 {
-                    if errno == EINTR { continue }
-                    return
-                }
-                if count == 0 { return }
-                pending.append(buffer, count: count)
-
-                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                    pending.removeSubrange(0...newlineRange.lowerBound)
-                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                    state.append(line)
-                    let response = handler(line) + "\n"
-                    _ = response.withCString { ptr in
-                        Darwin.write(clientFD, ptr, strlen(ptr))
-                    }
-                }
+            cliMockServeLineFramedConnection(clientFD: clientFD) { line in
+                state.append(line)
+                return handler(line)
             }
-        }
+        }, onListenerClosed: {})
     }
 
     func startAgentHookMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
-        surfaceId: String,
-        connectionCount: Int
+        surfaceId: String
     ) -> XCTestExpectation {
-        startMockServer(listenerFD: listenerFD, state: state, connectionCount: connectionCount) { line in
+        startMockServer(listenerFD: listenerFD, state: state) { line in
             self.agentHookMockResponse(line: line, surfaceId: surfaceId)
         }
     }
@@ -374,10 +402,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
     func startDetachedAgentHookMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
-        surfaceId: String,
-        connectionCount: Int
+        surfaceId: String
     ) {
-        startDetachedMockServer(listenerFD: listenerFD, state: state, connectionCount: connectionCount) { line in
+        startDetachedMockServer(listenerFD: listenerFD, state: state) { line in
             self.agentHookMockResponse(line: line, surfaceId: surfaceId)
         }
     }

--- a/cmuxTests/CLINotifyClaudeForkOfForkRegressionTests.swift
+++ b/cmuxTests/CLINotifyClaudeForkOfForkRegressionTests.swift
@@ -27,13 +27,12 @@ extension CLINotifyProcessIntegrationRegressionTests {
             activeTurnId: "fork-parent-turn"
         )
 
-        // One detached server pool covers both CLI invocations. Starting a second
-        // expectation-backed server on the same listener would race its accept
-        // workers against the first call's leftover workers and time out.
+        // One detached server covers both CLI invocations. An expectation-backed
+        // server per invocation would supersede this one mid-scenario, so keep the
+        // single long-lived server and assert on the recorded commands instead.
         startForkOfForkSurfaceServer(
             context: context,
-            surfaceIds: [forkParentSurfaceId, context.surfaceId],
-            connectionCount: 16
+            surfaceIds: [forkParentSurfaceId, context.surfaceId]
         )
 
         let start = runForkOfForkHook(
@@ -136,10 +135,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
 
     private func startForkOfForkSurfaceServer(
         context: ForkOfForkContext,
-        surfaceIds: [String],
-        connectionCount: Int
+        surfaceIds: [String]
     ) {
-        startDetachedMockServer(listenerFD: context.listenerFD, state: context.state, connectionCount: connectionCount) { line in
+        startDetachedMockServer(listenerFD: context.listenerFD, state: context.state) { line in
             guard let payload = self.jsonObject(line),
                   let id = payload["id"] as? String,
                   let method = payload["method"] as? String else {

--- a/cmuxTests/CLINotifyClaudeHookWorkspaceRoutingTests.swift
+++ b/cmuxTests/CLINotifyClaudeHookWorkspaceRoutingTests.swift
@@ -138,10 +138,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        // connectionCount 2: the deferred feed telemetry (the pre-fix regression this
-        // test guards against) arrives on a second socket connection, which must be
-        // accepted and drained for the feed.push absence assertion to be falsifiable.
-        let serverHandled = startMockServer(listenerFD: listenerFD, state: state, connectionCount: 2) { line in
+        // The deferred feed telemetry (the pre-fix regression this test guards
+        // against) arrives on a second socket connection, which must be accepted and
+        // drained for the feed.push absence assertion to be falsifiable. The mock
+        // server answers every connection the CLI opens, so that is covered.
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
             guard let payload = self.jsonObject(line) else { return "OK" }
             guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
                 return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -8719,44 +8719,36 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         context: ClaudeHookContext,
         connectionLimit: Int
     ) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            var accepted = 0
-            while accepted < connectionLimit {
-                var clientAddr = sockaddr_un()
-                var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
-                let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
-                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                        Darwin.accept(context.listenerFD, sockaddrPtr, &clientAddrLen)
-                    }
-                }
-                if clientFD < 0 {
+        // `connectionLimit` is retained for source compatibility; a single
+        // raw-thread accept loop now services every connection (see
+        // `runMockAcceptLoop`), which keeps blocking accept()s off the GCD pool
+        // that runProcess needs for its stdout/stderr readers and exit waiter.
+        _ = connectionLimit
+        let listenerFD = context.listenerFD
+        let state = context.state
+        let mockResponse: @Sendable (String) -> String = { line in
+            self.agentHookMockResponse(line: line, context: context)
+        }
+        Self.runMockAcceptLoop(listenerFD: listenerFD) { clientFD in
+            defer { Darwin.close(clientFD) }
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
                     if errno == EINTR { continue }
                     return
                 }
-                accepted += 1
-
-                DispatchQueue.global(qos: .userInitiated).async {
-                    defer { Darwin.close(clientFD) }
-                    var pending = Data()
-                    var buffer = [UInt8](repeating: 0, count: 4096)
-                    while true {
-                        let count = Darwin.read(clientFD, &buffer, buffer.count)
-                        if count < 0 {
-                            if errno == EINTR { continue }
-                            return
-                        }
-                        if count == 0 { return }
-                        pending.append(buffer, count: count)
-                        while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                            let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                            pending.removeSubrange(0...newlineRange.lowerBound)
-                            guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                            context.state.append(line)
-                            let response = self.agentHookMockResponse(line: line, context: context) + "\n"
-                            _ = response.withCString { ptr in
-                                Darwin.write(clientFD, ptr, strlen(ptr))
-                            }
-                        }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    pending.removeSubrange(0...newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    state.append(line)
+                    let response = mockResponse(line) + "\n"
+                    _ = response.withCString { ptr in
+                        Darwin.write(clientFD, ptr, strlen(ptr))
                     }
                 }
             }
@@ -9432,7 +9424,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
             .appendingPathComponent("cmux-spawn-id-e2e-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tmpDir) }
-        let socketPath = tmpDir.appendingPathComponent("sock").path
+        // Bind the control socket under a short /tmp path. The AF_UNIX sun_path
+        // limit is 104 bytes, and this machine's temporary directory alone is long
+        // enough that a socket nested under `tmpDir` overflows it; keep HOME pointed
+        // at tmpDir but give the socket a short, dedicated path.
+        let socketPath = makeSocketPath("tmuxenv")
         let listenerFD = try bindUnixSocket(at: socketPath)
         defer { Darwin.close(listenerFD); unlink(socketPath) }
         let state = MockSocketServerState()

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -7,6 +7,14 @@ import Darwin
 #endif
 
 final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
+    override func tearDown() {
+        // The mock servers park an accept loop on the test's listener FD, and
+        // closing that FD does not wake a thread already blocked in poll/accept.
+        // Reap the loops here so none of them outlives the test that started it.
+        CLIMockAcceptLoopRegistry.shared.stopAll()
+        super.tearDown()
+    }
+
     func testClaudeClearSessionStartMarksWorkspaceRunning() throws {
         let context = try makeClaudeHookContext(name: "claude-clear-running")
         defer { context.cleanup() }
@@ -309,7 +317,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     func testCodexStopReadsOversizedFinalTranscriptLine() throws {
         let context = try makeClaudeHookContext(name: "codex-oversized-final-transcript")
         defer { context.cleanup() }
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let turnId = "oversized-final-turn"
         let transcriptURL = context.root.appendingPathComponent("oversized-final-codex-session.jsonl")
@@ -374,7 +382,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         _ = try runGit(["commit", "-m", "initial"])
         let initialCommit = try runGit(["rev-parse", "HEAD"])
 
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
         let sessionId = "codex-last-turn-session"
         let sessionStart = runCodexHook(
             context: context,
@@ -790,7 +798,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         standardInput: String,
         extraEnvironment: [String: String] = [:]
     ) -> ProcessRunResult {
-        let serverHandled = startMockServer(listenerFD: context.listenerFD, state: context.state, connectionCount: 4) { line in
+        let serverHandled = startMockServer(listenerFD: context.listenerFD, state: context.state) { line in
             guard let payload = self.jsonObject(line) else {
                 return "OK"
             }
@@ -1700,7 +1708,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let sessionId = "same-process-session"
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let parentPrompt = runCodexHook(
             context: context,
@@ -1787,7 +1795,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let sessionId = "notification-lifecycle-session"
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let prompt = runCodexHook(
             context: context,
@@ -1846,7 +1854,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let newSessionId = "stale-idle-stop-new"
         let oldEnvironment = codexLaunchEnvironment(context: context, sessionId: oldSessionId)
         let newEnvironment = codexLaunchEnvironment(context: context, sessionId: newSessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let oldPrompt = runCodexHook(
             context: context,
@@ -1906,7 +1914,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         let newSessionId = "stale-idle-notification-new"
         let oldEnvironment = codexLaunchEnvironment(context: context, sessionId: oldSessionId)
         let newEnvironment = codexLaunchEnvironment(context: context, sessionId: newSessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let oldPrompt = runCodexHook(
             context: context,
@@ -1964,7 +1972,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let sessionId = "legacy-stop-turn-stack-session"
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+        startAgentHookMockServerAccepting(context: context)
 
         let parentPrompt = runCodexHook(
             context: context,
@@ -2025,7 +2033,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let sessionId = "generic-turn-stack-session"
         let launchEnvironment = agentLaunchEnvironment(context: context, kind: "gemini", executable: "/usr/local/bin/gemini")
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+        startAgentHookMockServerAccepting(context: context)
 
         let parentPrompt = runAgentHook(
             context: context,
@@ -2100,7 +2108,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let sessionId = "mixed-anonymous-depth-session"
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let parentPrompt = runCodexHook(
             context: context,
@@ -2205,7 +2213,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let sessionId = "anonymous-depth-turn-stop-session"
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+        startAgentHookMockServerAccepting(context: context)
 
         let parentPrompt = runCodexHook(
             context: context,
@@ -2272,7 +2280,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             eventType: "turn_aborted"
         )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let interruptedPrompt = runCodexHook(
             context: context,
@@ -2324,7 +2332,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             #"{"type":"event_msg","payload":{"type":"task_started","turn_id":"old-turn"}}"#,
         ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let oldPrompt = runCodexHook(
             context: context,
@@ -2391,7 +2399,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             eventType: "turn_complete"
         )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let parentPrompt = runCodexHook(
             context: context,
@@ -2489,7 +2497,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             #"{"type":"event_msg","payload":{"type":"turn_aborted","turn_id":"child-turn"}}"#,
         ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let parentPrompt = runCodexHook(
             context: context,
@@ -2566,7 +2574,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             .write(to: stateURL, options: .atomic)
 
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let childPromptStart = context.state.commands.count
         let childPrompt = runCodexHook(
@@ -2637,7 +2645,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             .write(to: stateURL, options: .atomic)
 
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let childPromptStart = context.state.commands.count
         let childPrompt = runCodexHook(
@@ -2707,7 +2715,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             .write(to: stateURL, options: .atomic)
 
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let childPromptStart = context.state.commands.count
         let childPrompt = runCodexHook(
@@ -2770,7 +2778,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             .write(to: stateURL, options: .atomic)
 
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+        startAgentHookMockServerAccepting(context: context)
 
         let childPrompt = runCodexHook(
             context: context,
@@ -2849,7 +2857,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             .write(to: stateURL, options: .atomic)
 
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 64)
+        startAgentHookMockServerAccepting(context: context)
 
         let childStopStart = context.state.commands.count
         let childStop = runCodexHook(
@@ -2937,7 +2945,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             .write(to: stateURL, options: .atomic)
 
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let childPromptStart = context.state.commands.count
         let childPrompt = runCodexHook(
@@ -2986,7 +2994,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             eventType: "turn_aborted"
         )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+        startAgentHookMockServerAccepting(context: context)
 
         let oldPrompt = runCodexHook(
             context: context,
@@ -3051,7 +3059,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             eventType: "turn_aborted"
         )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+        startAgentHookMockServerAccepting(context: context)
 
         let oldPrompt = runCodexHook(
             context: context,
@@ -3115,7 +3123,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             eventType: "turn_aborted"
         )
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let oldPrompt = runCodexHook(
             context: context,
@@ -3187,7 +3195,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             .write(to: stateURL, options: .atomic)
 
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 32)
+        startAgentHookMockServerAccepting(context: context)
 
         let currentStopStart = context.state.commands.count
         let currentStop = runCodexHook(
@@ -3216,7 +3224,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
 
         let sessionId = "unseen-turn-stop-session"
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 48)
+        startAgentHookMockServerAccepting(context: context)
 
         let oldPrompt = runCodexHook(
             context: context,
@@ -3262,7 +3270,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         defer { context.cleanup() }
 
         let sessionId = "managed-child-session"
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 16)
+        startAgentHookMockServerAccepting(context: context)
         let result = runCodexHook(
             context: context,
             subcommand: "stop",
@@ -3304,7 +3312,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             #"{"type":"response_item","payload":{"type":"message","role":"user","content":"<subagent_notification>old child finished</subagent_notification>"}}"#,
         ].joined(separator: "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
 
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 24)
+        startAgentHookMockServerAccepting(context: context)
         let launchEnvironment = codexLaunchEnvironment(context: context, sessionId: sessionId)
 
         let prompt = runCodexHook(
@@ -3357,7 +3365,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         try JSONSerialization.data(withJSONObject: store, options: [.prettyPrinted])
             .write(to: stateURL, options: .atomic)
 
-        startAgentHookMockServerAccepting(context: context, connectionLimit: 16)
+        startAgentHookMockServerAccepting(context: context)
         let result = runCodexHook(
             context: context,
             subcommand: "session-end",
@@ -8715,44 +8723,21 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
-    private func startAgentHookMockServerAccepting(
-        context: ClaudeHookContext,
-        connectionLimit: Int
-    ) {
-        // `connectionLimit` is retained for source compatibility; a single
-        // raw-thread accept loop now services every connection (see
-        // `runMockAcceptLoop`), which keeps blocking accept()s off the GCD pool
-        // that runProcess needs for its stdout/stderr readers and exit waiter.
-        _ = connectionLimit
-        let listenerFD = context.listenerFD
+    /// Serves this context's agent-hook mock socket for the rest of the test. One
+    /// accept loop answers every connection, including the CLI's extra `system.top`
+    /// lookup connection, and the registry reaps the loop at teardown.
+    private func startAgentHookMockServerAccepting(context: ClaudeHookContext) {
         let state = context.state
         let mockResponse: @Sendable (String) -> String = { line in
             self.agentHookMockResponse(line: line, context: context)
         }
-        Self.runMockAcceptLoop(listenerFD: listenerFD) { clientFD in
+        CLIMockAcceptLoopRegistry.shared.start(listenerFD: context.listenerFD, onConnection: { clientFD in
             defer { Darwin.close(clientFD) }
-            var pending = Data()
-            var buffer = [UInt8](repeating: 0, count: 4096)
-            while true {
-                let count = Darwin.read(clientFD, &buffer, buffer.count)
-                if count < 0 {
-                    if errno == EINTR { continue }
-                    return
-                }
-                if count == 0 { return }
-                pending.append(buffer, count: count)
-                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                    pending.removeSubrange(0...newlineRange.lowerBound)
-                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                    state.append(line)
-                    let response = mockResponse(line) + "\n"
-                    _ = response.withCString { ptr in
-                        Darwin.write(clientFD, ptr, strlen(ptr))
-                    }
-                }
+            cliMockServeLineFramedConnection(clientFD: clientFD) { line in
+                state.append(line)
+                return mockResponse(line)
             }
-        }
+        }, onListenerClosed: {})
     }
 
     private func agentHookMockResponse(line: String, context: ClaudeHookContext) -> String {
@@ -8798,7 +8783,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         standardInput: String,
         extraEnvironment: [String: String] = [:]
     ) -> ProcessRunResult {
-        let serverHandled = startMockServer(listenerFD: context.listenerFD, state: context.state, connectionCount: 4) { line in
+        let serverHandled = startMockServer(listenerFD: context.listenerFD, state: context.state) { line in
             guard let payload = self.jsonObject(line) else {
                 return "OK"
             }

--- a/cmuxTests/CLISSHPTYAttachSessionLostRespawnTests.swift
+++ b/cmuxTests/CLISSHPTYAttachSessionLostRespawnTests.swift
@@ -327,8 +327,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
 
         let socketHandled = startMockServer(
             listenerFD: listenerFD,
-            state: state,
-            connectionCount: 2
+            state: state
         ) { line in
             guard let payload = self.jsonObject(line),
                   let id = payload["id"] as? String,

--- a/cmuxTests/VMDefaultCloudCommandTests.swift
+++ b/cmuxTests/VMDefaultCloudCommandTests.swift
@@ -39,7 +39,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                         "image": "snapshot-default",
                     ]
                 )
-            case "vm.ssh_info":
+            case "vm.ssh_info", "vm.attach_info":
                 let params = payload["params"] as? [String: Any] ?? [:]
                 XCTAssertEqual(params["id"] as? String, vmID)
                 return self.v2Response(
@@ -153,7 +153,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             state.commands.compactMap { self.jsonObject($0)?["method"] as? String },
             [
                 "vm.create",
-                "vm.ssh_info",
+                "vm.attach_info",
                 "workspace.list",
                 "workspace.create",
                 "workspace.rename",
@@ -272,7 +272,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                         "image": "snapshot-default",
                     ]
                 )
-            case "vm.ssh_info":
+            case "vm.ssh_info", "vm.attach_info":
                 return self.v2Response(
                     id: id,
                     ok: true,
@@ -409,7 +409,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             state.commands.compactMap { self.jsonObject($0)?["method"] as? String },
             [
                 "vm.create",
-                "vm.ssh_info",
+                "vm.attach_info",
                 "workspace.list",
                 "workspace.action",
                 "workspace.action",
@@ -459,7 +459,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                         "image": "snapshot-default",
                     ]
                 )
-            case "vm.ssh_info":
+            case "vm.ssh_info", "vm.attach_info":
                 return self.v2Response(
                     id: id,
                     ok: true,
@@ -568,7 +568,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             state.commands.compactMap { self.jsonObject($0)?["method"] as? String },
             [
                 "vm.create",
-                "vm.ssh_info",
+                "vm.attach_info",
                 "workspace.list",
                 "workspace.create",
                 "workspace.rename",

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -6192,9 +6192,13 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         connectionLimit: Int,
         handler: @escaping @Sendable (String) -> String
     ) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            var accepted = 0
-            while accepted < connectionLimit {
+        // `connectionLimit` is retained for source compatibility; a single
+        // raw-thread accept loop services every connection so blocking accept()s
+        // stay off the GCD pool that runProcess relies on (see runMockServer).
+        _ = connectionLimit
+        let writeAll = self.writeAll
+        let acceptThread = Thread {
+            while true {
                 var clientAddr = sockaddr_un()
                 var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
                 let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
@@ -6206,9 +6210,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                     if errno == EINTR { continue }
                     return
                 }
-                accepted += 1
-
-                DispatchQueue.global(qos: .userInitiated).async {
+                let handlerThread = Thread {
                     defer { Darwin.close(clientFD) }
                     var pending = Data()
                     var buffer = [UInt8](repeating: 0, count: 4096)
@@ -6227,11 +6229,27 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                             pending.removeSubrange(0...newlineRange.lowerBound)
                             guard let line = String(data: lineData, encoding: .utf8) else { continue }
                             state.append(line)
-                            guard self.writeAll(handler(line) + "\n", to: clientFD) else { return }
+                            guard writeAll(handler(line) + "\n", clientFD) else { return }
                         }
                     }
                 }
+                handlerThread.stackSize = 1 << 20
+                handlerThread.start()
             }
+        }
+        acceptThread.stackSize = 1 << 20
+        acceptThread.start()
+    }
+
+    private final class MockOnceFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var claimed = false
+        func claim() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if claimed { return false }
+            claimed = true
+            return true
         }
     }
 
@@ -6241,26 +6259,27 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         onHandled: @escaping @Sendable () -> Void,
         handler: @escaping @Sendable (String) -> String
     ) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            var clientAddr = sockaddr_un()
-            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
-            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
-                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
-                }
-            }
-            guard clientFD >= 0 else {
-                onHandled()
-                return
-            }
+        // The bundled CLI opens a dedicated short-lived control connection for its
+        // `system.top` agent-process lookup on top of the main hook connection.
+        // Headless (piped stdio, no controlling TTY) that lookup always fires, so a
+        // single-accept mock starves the extra connection and the CLI stalls or
+        // falls back to unresolved routing.
+        //
+        // A single raw-thread accept loop dispatches every connection to its own
+        // raw-thread handler. Raw threads (not GCD) are deliberate: a blocking
+        // accept() parked on a GCD worker ties it up for the whole test, and tests
+        // that open a server per hook exhaust the shared GCD pool that runProcess
+        // uses for its stdout/stderr readers and exit waiter — which then looks
+        // like the CLI hung. `onHandled` fires once, after the first connection.
+        let handledOnce = MockOnceFlag()
+        let writeAll = self.writeAll
+        CLIMockAcceptLoopRegistry.shared.start(listenerFD: listenerFD, onConnection: { clientFD in
             defer {
                 Darwin.close(clientFD)
-                onHandled()
+                if handledOnce.claim() { onHandled() }
             }
-
             var pending = Data()
             var buffer = [UInt8](repeating: 0, count: 4096)
-
             while true {
                 let count = Darwin.read(clientFD, &buffer, buffer.count)
                 if count < 0 {
@@ -6275,10 +6294,12 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                     pending.removeSubrange(0...newlineRange.lowerBound)
                     guard let line = String(data: lineData, encoding: .utf8) else { continue }
                     state.append(line)
-                    guard self.writeAll(handler(line) + "\n", to: clientFD) else { return }
+                    guard writeAll(handler(line) + "\n", clientFD) else { return }
                 }
             }
-        }
+        }, onListenerClosed: {
+            if handledOnce.claim() { onHandled() }
+        })
     }
 
     private func writeAll(_ string: String, to fd: Int32) -> Bool {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -3615,6 +3615,14 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 }
 
 final class CLINotifyProcessIntegrationTests: XCTestCase {
+    override func tearDown() {
+        // The mock servers park an accept loop on the test's listener FD, and
+        // closing that FD does not wake a thread already blocked in poll/accept.
+        // Reap the loops here so none of them outlives the test that started it.
+        CLIMockAcceptLoopRegistry.shared.stopAll()
+        super.tearDown()
+    }
+
     private struct ProcessRunResult {
         let status: Int32
         let stdout: String
@@ -4337,7 +4345,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             unlink(socketPath)
         }
 
-        startMockServerAccepting(listenerFD: listenerFD, state: state, connectionLimit: 6) { line in
+        startMockServerAccepting(listenerFD: listenerFD, state: state) { line in
             guard let data = line.data(using: .utf8),
                   let payload = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                   let id = payload["id"] as? String else {
@@ -6186,116 +6194,45 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         return handled
     }
 
+    /// Serves the mock socket for the rest of the test with no expectation to wait
+    /// on. The registry's single accept loop answers every connection and is reaped
+    /// at teardown.
     private func startMockServerAccepting(
         listenerFD: Int32,
         state: MockSocketServerState,
-        connectionLimit: Int,
         handler: @escaping @Sendable (String) -> String
     ) {
-        // `connectionLimit` is retained for source compatibility; a single
-        // raw-thread accept loop services every connection so blocking accept()s
-        // stay off the GCD pool that runProcess relies on (see runMockServer).
-        _ = connectionLimit
-        let writeAll = self.writeAll
-        let acceptThread = Thread {
-            while true {
-                var clientAddr = sockaddr_un()
-                var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
-                let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
-                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                        Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
-                    }
-                }
-                if clientFD < 0 {
-                    if errno == EINTR { continue }
-                    return
-                }
-                let handlerThread = Thread {
-                    defer { Darwin.close(clientFD) }
-                    var pending = Data()
-                    var buffer = [UInt8](repeating: 0, count: 4096)
-
-                    while true {
-                        let count = Darwin.read(clientFD, &buffer, buffer.count)
-                        if count < 0 {
-                            if errno == EINTR { continue }
-                            return
-                        }
-                        if count == 0 { return }
-                        pending.append(buffer, count: count)
-
-                        while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                            let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                            pending.removeSubrange(0...newlineRange.lowerBound)
-                            guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                            state.append(line)
-                            guard writeAll(handler(line) + "\n", clientFD) else { return }
-                        }
-                    }
-                }
-                handlerThread.stackSize = 1 << 20
-                handlerThread.start()
+        CLIMockAcceptLoopRegistry.shared.start(listenerFD: listenerFD, onConnection: { clientFD in
+            defer { Darwin.close(clientFD) }
+            cliMockServeLineFramedConnection(clientFD: clientFD) { line in
+                state.append(line)
+                return handler(line)
             }
-        }
-        acceptThread.stackSize = 1 << 20
-        acceptThread.start()
+        }, onListenerClosed: {})
     }
 
-    private final class MockOnceFlag: @unchecked Sendable {
-        private let lock = NSLock()
-        private var claimed = false
-        func claim() -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            if claimed { return false }
-            claimed = true
-            return true
-        }
-    }
-
+    /// Serves the mock control socket, calling `onHandled` once — after the first
+    /// connection finishes, or if the listener goes away before anything connected.
+    ///
+    /// The registry's accept loop answers every connection the CLI opens. Headless
+    /// that is required, not just generous: with piped stdio and no controlling TTY
+    /// the CLI always falls back to a `system.top` lookup on a second, short-lived
+    /// connection, and a mock that answers only one starves it.
     private func runMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
         onHandled: @escaping @Sendable () -> Void,
         handler: @escaping @Sendable (String) -> String
     ) {
-        // The bundled CLI opens a dedicated short-lived control connection for its
-        // `system.top` agent-process lookup on top of the main hook connection.
-        // Headless (piped stdio, no controlling TTY) that lookup always fires, so a
-        // single-accept mock starves the extra connection and the CLI stalls or
-        // falls back to unresolved routing.
-        //
-        // A single raw-thread accept loop dispatches every connection to its own
-        // raw-thread handler. Raw threads (not GCD) are deliberate: a blocking
-        // accept() parked on a GCD worker ties it up for the whole test, and tests
-        // that open a server per hook exhaust the shared GCD pool that runProcess
-        // uses for its stdout/stderr readers and exit waiter — which then looks
-        // like the CLI hung. `onHandled` fires once, after the first connection.
-        let handledOnce = MockOnceFlag()
-        let writeAll = self.writeAll
+        let handledOnce = CLIMockOnceFlag()
         CLIMockAcceptLoopRegistry.shared.start(listenerFD: listenerFD, onConnection: { clientFD in
             defer {
                 Darwin.close(clientFD)
                 if handledOnce.claim() { onHandled() }
             }
-            var pending = Data()
-            var buffer = [UInt8](repeating: 0, count: 4096)
-            while true {
-                let count = Darwin.read(clientFD, &buffer, buffer.count)
-                if count < 0 {
-                    if errno == EINTR { continue }
-                    return
-                }
-                if count == 0 { return }
-                pending.append(buffer, count: count)
-
-                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                    pending.removeSubrange(0...newlineRange.lowerBound)
-                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                    state.append(line)
-                    guard writeAll(handler(line) + "\n", clientFD) else { return }
-                }
+            cliMockServeLineFramedConnection(clientFD: clientFD) { line in
+                state.append(line)
+                return handler(line)
             }
         }, onListenerClosed: {
             if handledOnce.claim() { onHandled() }
@@ -6303,25 +6240,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
     }
 
     private func writeAll(_ string: String, to fd: Int32) -> Bool {
-        let bytes = Array(string.utf8)
-        var offset = 0
-        while offset < bytes.count {
-            let written = bytes.withUnsafeBytes { buffer in
-                Darwin.write(fd, buffer.baseAddress!.advanced(by: offset), bytes.count - offset)
-            }
-            if written > 0 {
-                offset += written
-                continue
-            }
-            if written == 0 {
-                return false
-            }
-            if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK {
-                continue
-            }
-            return false
-        }
-        return true
+        cliMockWriteAll(string, to: fd)
     }
 
     private func v2Response(


### PR DESCRIPTION
## What this fixes

Pre-existing `cmuxTests` failures that only reproduce under a local headless `xcodebuild test` (they pass in CI, which is currently paused). None of this is product behavior — it's test-harness robustness plus a couple of stale expectations. Proven pre-existing: on a clean `origin/main` checkout these same tests fail.

**1 — CLI mock control sockets are headless-fragile (the big cluster).** The notify-process integration tests spin up a mock control socket and drive the bundled CLI through it. Headless, the CLI has no controlling TTY, so its hook routing always opens a *second, dedicated* control connection (`resolveAgentProcessTerminalBinding`) — which the single-connection mock never serviced, so it stalled 2s and fell back to wrong routing / empty output past the 5s process timeout. Fix: a poll-based, raw-thread accept loop per listener FD (off the shared GCD pool that `runProcess` needs for its stdout/exit readers), with a per-FD registry that supersedes a prior loop so a leftover accept can't steal the next hook's connection. This unblocks the multi-hook grok/antigravity/hermes tests. (`CLIMockSocketServerSupport.swift`, `WorkspaceRemoteConnectionTests.swift`, `CLINotifyProcessIntegrationRegressionTests.swift`)

**2 — `vm new` expectations were stale.** The product creates VM workspaces with `forceSSH: false` → `vm.attach_info`; three tests still expected the older `vm.ssh_info` sequence. Refreshed the mock case + expected method order. (`VMDefaultCloudCommandTests.swift`)

**3 — AF_UNIX socket path overflow.** The tmux-compat-env test built a nested socket under `/var/folders/...` that exceeds the 104-byte `sun_path` limit → bind assert. Moved it to a short `/tmp` path. (`CLINotifyProcessIntegrationRegressionTests.swift`)

## Scope / honesty

Test-only; no product changes. This is incremental — it fixes the dominant, systematic headless mechanism (~20 tests) with real fixes, **no `XCTSkip`s**. A deeper long-tail remains in these suites (TTY-dependent PTY-resize tests, a codex nested-stop visible-mutation suppression path, a static-link helper-linkage invariant, real-home-dir isolation); those need product-level or build-settings changes and are deliberately left for focused follow-ups rather than faked green.

Run locally with `SWIFT_BACKTRACE=enable=no` + a `timeout` so a crash fails fast instead of hanging on the interactive backtracer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787079788&installation_id=133855650&pr_number=8495&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8495&signature=23e3e237e016244b259fcb60f97c0670c138242a65b09a4545c939b024269696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CLI mock control sockets headless-robust with a single, lifecycle-owned accept loop per listener that services all connections and shuts down cleanly. Also refresh `vm new` tests to expect `vm.attach_info` and bind long AF_UNIX socket paths under `/tmp`.

- **Bug Fixes**
  - Added a poll-based accept loop per listener FD on raw Threads; a registry supersedes prior loops and holds a lock across retire-and-start to prevent double loops and stolen connections.
  - The registry owns a private stop pipe; loops are signaled and joined, and both suites call `stopAll()` in `tearDown` (closing the FD doesn’t wake `poll`/`accept` on Darwin).
  - Ensures the extra headless `system.top` connection is handled; updated `vm new` from `vm.ssh_info` to `vm.attach_info`; bound a control socket under `/tmp` to fit the 104-byte `sun_path` limit.

- **Refactors**
  - Consolidated socket I/O into `cliMockServeLineFramedConnection` and `cliMockWriteAll`; added `CLIMockOnceFlag` for one-shot expectations.
  - Removed `connectionCount`/`connectionLimit` from test servers; mocks now answer every connection.

<sup>Written for commit 4a11af6f08b0415a9cf00102aa1ce352f5783a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

