### PR TITLE
docs: correct Iroh relay catalog source

### DIFF
--- a/docs/iroh-app-transport-architecture.md
+++ b/docs/iroh-app-transport-architecture.md
@@ -109,7 +109,9 @@ The fork must expose cancellation for an in-progress connect. Closing a QUIC con
 
 ## Relay fleet and preferences
 
-`CMUX_RELAY_CATALOG_JSON` is the server-owned managed fleet. Every catalog has a strictly increasing sequence and at most sixteen unique credential-free HTTPS origins. The backend rejects sequence rollback and same-sequence content changes. It signs a five-minute policy with an Ed25519 key whose public half is pinned by clients. A cached policy remains usable only until its signed expiry. Invalid, expired, rolled-back, or unverifiable policy fails closed to direct Iroh paths.
+`config/iroh/managed-relay-catalog.json` is the committed, server-owned source of truth for the managed fleet. `web/tools/generate-managed-iroh-relay-catalog.ts` validates it and writes the generated TypeScript consumed by the web API and presence worker. Build checks reject generated-file drift. Managed relay URLs do not come from deployment environment variables, and signing keys and relay credentials never enter the catalog or generated files.
+
+Every catalog has a strictly increasing sequence and at most sixteen unique credential-free HTTPS origins. The backend rejects sequence rollback and same-sequence content changes. It signs a five-minute policy with an Ed25519 key whose public half is pinned by clients. A cached policy remains usable only until its signed expiry. Invalid, expired, rolled-back, or unverifiable policy fails closed to direct Iroh paths. Fleet rotations are add-before-remove: bump the sequence and add relays, regenerate and deploy both server consumers, wait at least one signed-policy lifetime, then bump the sequence again before regenerating, deploying, and removing the retired relays. A stable relay ID never changes meaning in place.
 
 The server may add, remove, or replace relays without a client update. A remote `EndpointAddr` contains only the remote endpoint's advertised home relay or relays, validated against the signed fleet. Fleet configuration and remote reachability remain separate wire fields.
 


### PR DESCRIPTION
Documents the committed managed relay catalog and its generated TypeScript consumers as the source of truth.

Also records the add-before-remove fleet rotation sequence and removes the stale deployment environment variable reference.

Verification:
- `bun web/tools/generate-managed-iroh-relay-catalog.ts --check`
- `git diff --check`
- no remaining `CMUX_RELAY_CATALOG_JSON` references

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787082974&installation_id=133855650&pr_number=8496&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8496&signature=90dd58cd712997a517d6dc0dc1593ea35a1bde4e9e86fc478e228bcb1514eb51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Iroh transport docs to state the committed `config/iroh/managed-relay-catalog.json` (and generated TypeScript) is the source of truth for the managed relay fleet. Removes the `CMUX_RELAY_CATALOG_JSON` reference, documents validation/build checks via `web/tools/generate-managed-iroh-relay-catalog.ts`, and clarifies sequence rules and add-before-remove fleet rotation.

<sup>Written for commit bc8991359dabacf7a2aff5b383aac71cc3ae3d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the managed relay catalog as the authoritative source for relay fleet configuration.
  * Documented catalog validation, generated outputs, and build checks that detect configuration drift.
  * Clarified that relay URLs are not deployment environment settings and that sensitive credentials are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->