### PR TITLE
Dedupe Iroh selected-path diagnostics

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLog.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticLog.swift
@@ -129,7 +129,10 @@ public final class DiagnosticLog: Sendable {
     /// This is the hot-path API. It only yields the value onto the buffered
     /// stream; the actual ring write happens on the internal drain task. A burst
     /// past the consumer's pace drops the oldest pending events (per
-    /// `.bufferingNewest`), never the caller.
+    /// `.bufferingNewest`), never the caller. Repeated
+    /// ``DiagnosticEventCode/selectedPathChanged`` values for the same redacted
+    /// path class are consumed but not retained, so observer wakeups cannot be
+    /// mistaken for transport changes.
     ///
     /// - Parameter event: The event to record.
     public nonisolated func record(_ event: DiagnosticEvent) {
@@ -328,6 +331,7 @@ public final class DiagnosticLog: Sendable {
         private var head = 0
         private var filled = 0
         private var totalProcessed = 0
+        private var selectedPathKind: DiagnosticPathKind?
         private let capacity: Int
         private let buildStamp: String
         private let role: DiagnosticRuntimeRole
@@ -353,12 +357,16 @@ public final class DiagnosticLog: Sendable {
         }
 
         func append(_ event: DiagnosticEvent) {
+            totalProcessed += 1
+            if let nextPathKind = event.diagnosticPathKind {
+                guard nextPathKind != selectedPathKind else { return }
+                selectedPathKind = nextPathKind
+            }
             slots[head] = event
             head = (head + 1) % capacity
             if filled < capacity {
                 filled += 1
             }
-            totalProcessed += 1
         }
 
         func count() -> Int {
@@ -374,6 +382,7 @@ public final class DiagnosticLog: Sendable {
             head = 0
             filled = 0
             totalProcessed = 0
+            selectedPathKind = nil
             self.anchorWallNanos = anchorWallNanos
             self.anchorMonotonicNanos = anchorMonotonicNanos
         }

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -69,6 +69,50 @@ import Testing
         #expect(lines[3] == "3000,7,7,,10,20,")
     }
 
+    @Test func duplicateSelectedPathNotificationsDoNotExportFalseChanges() async {
+        let log = DiagnosticLog(capacity: 16)
+        log.record(DiagnosticEvent(
+            code: .selectedPathChanged,
+            tNanos: 1_000,
+            a: DiagnosticPathKind.relay.rawValue
+        ))
+        log.record(DiagnosticEvent(
+            code: .transportSessionLifecycle,
+            tNanos: 2_000,
+            a: DiagnosticSessionLifecycleKind.established.rawValue,
+            b: Int(CmxTransportSessionPurpose.foregroundControl.rawValue),
+            c: 1
+        ))
+        log.record(DiagnosticEvent(
+            code: .selectedPathChanged,
+            tNanos: 3_000,
+            a: DiagnosticPathKind.relay.rawValue
+        ))
+        log.record(DiagnosticEvent(
+            code: .selectedPathChanged,
+            tNanos: 4_000,
+            a: DiagnosticPathKind.privateNetwork.rawValue
+        ))
+        log.record(DiagnosticEvent(
+            code: .selectedPathChanged,
+            tNanos: 5_000,
+            a: DiagnosticPathKind.privateNetwork.rawValue
+        ))
+        await waitForProcessed(log, 5)
+
+        let report = await log.snapshot()
+        #expect(report.events.map(\.code) == [
+            .selectedPathChanged,
+            .transportSessionLifecycle,
+            .selectedPathChanged,
+        ])
+        #expect(report.events.compactMap(\.diagnosticPathKind) == [
+            .relay,
+            .privateNetwork,
+        ])
+        #expect(report.events[1].diagnosticSessionLifecycleKind == .established)
+    }
+
     @Test func ringEvictionDropsOldest() async {
         let log = DiagnosticLog(capacity: 3)
         // Drain each event before recording the next so eviction is governed


### PR DESCRIPTION
## Summary

- retain a selected-path diagnostic only when the redacted path class changes
- preserve transport-session lifecycle rows between duplicate path notifications
- reset selected-path diagnostic state when a diagnostic session is cleared

## Verification

- regression test fails on the test-only commit `4a5060a47a` because duplicate relay/private notifications are exported
- `swift test --package-path Packages/Shared/CMUXMobileCore --filter duplicateSelectedPathNotificationsDoNotExportFalseChanges`
- `swift test --package-path Packages/Shared/CMUXMobileCore` (230 tests)
- tagged cloud build `irpded`, run https://github.com/manaflow-ai/cmux/actions/runs/29702843263

## Scope

This removes diagnostic noise only. It does not infer socket churn or suppress genuine unavailable, relay, private-network, or session-lifecycle transitions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787085801&installation_id=133855650&pr_number=8497&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8497&signature=869b1a46cce922b868ab204e24bf63cc0c838f2e10b25fa5ee432298d38bbf35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce noise in Iroh path diagnostics by deduping consecutive selected-path updates. Prevents exporting false changes while keeping session lifecycle rows intact.

- **Bug Fixes**
  - Emit `selectedPathChanged` only when the redacted path kind actually changes.
  - Preserve transport-session lifecycle events between duplicate path notifications.
  - Reset selected-path dedupe state when a diagnostic session is cleared.
  - Add unit test to ensure duplicates are dropped and lifecycle events remain.

<sup>Written for commit aa3a6d403a49548b61ee0079dcdf7a48b06d0b06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate diagnostic path notifications from appearing as false changes in exported diagnostic reports.
  * Preserved accurate path classifications and session lifecycle details in diagnostic event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->