### PR TITLE
Preserve secure Tailscale pairings across staggered Iroh upgrades

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxByteTransportRequest.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxByteTransportRequest.swift
@@ -2,6 +2,9 @@
 public enum CmxTransportAuthorizationMode: Equatable, Sendable {
     /// RPC requests must add a Stack bearer on an approved transport.
     case stackBearer
+    /// A pairing established before Iroh may send a Stack bearer only to the
+    /// exact Tailscale peer captured by this persisted compatibility grant.
+    case legacyTailscaleBearer(CmxLegacyTailscaleAuthorizationEvidence)
     /// The transport handshake admitted this exact peer and account binding.
     case transportAdmission
 }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxLegacyTailscaleAuthorizationEvidence.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxLegacyTailscaleAuthorizationEvidence.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Invalid input for a persisted pre-Iroh Tailscale compatibility grant.
+public enum CmxLegacyTailscaleAuthorizationEvidenceError: Error, Equatable, Sendable {
+    /// The Mac device identifier was empty or surrounded by whitespace.
+    case invalidMacDeviceID
+    /// The host was not a numeric Tailscale peer address.
+    case invalidHost
+    /// The port fell outside `1...65535`.
+    case invalidPort(Int)
+}
+
+/// A narrow capability allowing one pre-Iroh pairing to keep using its exact
+/// plaintext Tailscale route while both sides move through a staggered update.
+///
+/// This value is transport evidence, not route discovery. It authorizes only
+/// one canonical Mac device ID, numeric Tailscale peer address, and TCP port.
+public struct CmxLegacyTailscaleAuthorizationEvidence: Equatable, Sendable {
+    /// The canonical paired Mac device identifier.
+    public let macDeviceID: String
+    /// The canonical numeric Tailscale peer address.
+    public let host: String
+    /// The exact legacy mobile listener port.
+    public let port: Int
+
+    /// Validates and canonicalizes one persisted compatibility grant.
+    public init(macDeviceID: String, host: String, port: Int) throws {
+        let trimmedDeviceID = macDeviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedDeviceID.isEmpty, trimmedDeviceID == macDeviceID else {
+            throw CmxLegacyTailscaleAuthorizationEvidenceError.invalidMacDeviceID
+        }
+        guard let peerAddress = CmxTailscalePeerAddress(host) else {
+            throw CmxLegacyTailscaleAuthorizationEvidenceError.invalidHost
+        }
+        guard (1 ... 65_535).contains(port) else {
+            throw CmxLegacyTailscaleAuthorizationEvidenceError.invalidPort(port)
+        }
+
+        self.macDeviceID = cmxCanonicalDeviceID(macDeviceID)
+        self.host = peerAddress.value
+        self.port = port
+    }
+
+    /// Whether a request still names the exact peer captured by this grant.
+    public func authorizes(macDeviceID: String?, host: String, port: Int) -> Bool {
+        guard let macDeviceID,
+              cmxCanonicalDeviceID(macDeviceID) == self.macDeviceID,
+              let peerAddress = CmxTailscalePeerAddress(host) else {
+            return false
+        }
+        return peerAddress.value == self.host && port == self.port
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxLegacyTailscaleAuthorizationEvidenceTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxLegacyTailscaleAuthorizationEvidenceTests.swift
@@ -1,0 +1,81 @@
+import Testing
+@testable import CMUXMobileCore
+
+@Suite struct CmxLegacyTailscaleAuthorizationEvidenceTests {
+    @Test func canonicalizesUUIDAndNumericIPv6() throws {
+        let evidence = try CmxLegacyTailscaleAuthorizationEvidence(
+            macDeviceID: "F4EC647C-9FA1-4B7F-8AB6-4261A8129738",
+            host: "fd7a:115c:a1e0:0:0:0:0:1234",
+            port: 58_465
+        )
+
+        #expect(evidence.macDeviceID == "f4ec647c-9fa1-4b7f-8ab6-4261a8129738")
+        #expect(evidence.host == "fd7a:115c:a1e0::1234")
+        #expect(evidence.port == 58_465)
+        #expect(evidence.authorizes(
+            macDeviceID: "F4EC647C-9FA1-4B7F-8AB6-4261A8129738",
+            host: "fd7a:115c:a1e0::1234",
+            port: 58_465
+        ))
+    }
+
+    @Test func rejectsNonPeerInputs() {
+        #expect(throws: CmxLegacyTailscaleAuthorizationEvidenceError.invalidMacDeviceID) {
+            _ = try CmxLegacyTailscaleAuthorizationEvidence(
+                macDeviceID: " mac-1",
+                host: "100.71.210.41",
+                port: 58_465
+            )
+        }
+        #expect(throws: CmxLegacyTailscaleAuthorizationEvidenceError.invalidHost) {
+            _ = try CmxLegacyTailscaleAuthorizationEvidence(
+                macDeviceID: "mac-1",
+                host: "work-mac.tailnet.ts.net",
+                port: 58_465
+            )
+        }
+        #expect(throws: CmxLegacyTailscaleAuthorizationEvidenceError.invalidHost) {
+            _ = try CmxLegacyTailscaleAuthorizationEvidence(
+                macDeviceID: "mac-1",
+                host: "192.168.1.20",
+                port: 58_465
+            )
+        }
+        #expect(throws: CmxLegacyTailscaleAuthorizationEvidenceError.invalidPort(0)) {
+            _ = try CmxLegacyTailscaleAuthorizationEvidence(
+                macDeviceID: "mac-1",
+                host: "100.71.210.41",
+                port: 0
+            )
+        }
+    }
+
+    @Test func authorizesOnlyExactCanonicalBinding() throws {
+        let evidence = try CmxLegacyTailscaleAuthorizationEvidence(
+            macDeviceID: "mac-1",
+            host: "100.71.210.41",
+            port: 58_465
+        )
+
+        #expect(evidence.authorizes(
+            macDeviceID: "mac-1",
+            host: "100.71.210.41",
+            port: 58_465
+        ))
+        #expect(!evidence.authorizes(
+            macDeviceID: "mac-2",
+            host: "100.71.210.41",
+            port: 58_465
+        ))
+        #expect(!evidence.authorizes(
+            macDeviceID: "mac-1",
+            host: "100.71.210.42",
+            port: 58_465
+        ))
+        #expect(!evidence.authorizes(
+            macDeviceID: "mac-1",
+            host: "100.71.210.41",
+            port: 58_466
+        ))
+    }
+}

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
@@ -6,6 +6,24 @@ public import Foundation
 /// Auth tokens are never persisted, only enough to re-mint a fresh attach
 /// ticket via the StackAuth-authenticated manual host flow on next launch.
 public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
+    /// Persisted compatibility grants are intentionally absent. They may move
+    /// only through the local SQLite grant table, never Codable state, account
+    /// backup, logs, or another device.
+    private enum CodingKeys: String, CodingKey {
+        case macDeviceID
+        case displayName
+        case routes
+        case instanceTag
+        case createdAt
+        case lastSeenAt
+        case isActive
+        case stackUserID
+        case teamID
+        case customName
+        case customColor
+        case customIcon
+    }
+
     /// Stable identifier of the paired Mac device.
     public var macDeviceID: String
     /// Human-readable name of the Mac, if the pairing payload supplied one.
@@ -16,6 +34,11 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
     /// `nil` means an older host has not established instance-level authority;
     /// route refresh then requires one unambiguous route-advertising instance.
     public var instanceTag: String?
+    /// Exact raw Tailscale routes this iPhone had already trusted before the
+    /// Iroh migration. This local-only compatibility capability is never
+    /// created for new or cloud-restored pairings and is revoked once the Mac
+    /// publishes an authenticated Iroh identity.
+    public var legacyTailscaleRoutes: [CmxAttachRoute]? = nil
     /// When this pairing was first recorded.
     public var createdAt: Date
     /// When this pairing was last refreshed or used.
@@ -104,7 +127,8 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
         customName: String? = nil,
         customColor: String? = nil,
         customIcon: String? = nil,
-        instanceTag: String? = nil
+        instanceTag: String? = nil,
+        legacyTailscaleRoutes: [CmxAttachRoute]? = nil
     ) {
         self.macDeviceID = macDeviceID
         self.displayName = displayName
@@ -118,5 +142,6 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
         self.customColor = customColor
         self.customIcon = customIcon
         self.instanceTag = instanceTag
+        self.legacyTailscaleRoutes = legacyTailscaleRoutes
     }
 }

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Records.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Records.swift
@@ -170,6 +170,15 @@ extension MobilePairedMacStore {
             .text(fromOwnerKey),
         ])
         try exec("""
+            UPDATE legacy_tailscale_route_grants
+            SET owner_key = ?
+            WHERE mac_device_id = ? AND owner_key = ?;
+        """, binding: [
+            .text(toOwnerKey),
+            .text(macDeviceID),
+            .text(fromOwnerKey),
+        ])
+        try exec("""
             DELETE FROM paired_macs
             WHERE mac_device_id = ? AND owner_key = ?;
         """, binding: [
@@ -241,6 +250,10 @@ extension MobilePairedMacStore {
 
         return try rows.map { row in
             let routes = try fetchRoutes(macDeviceID: row.macDeviceID, ownerKey: row.ownerKey)
+            let legacyTailscaleRoutes = try fetchLegacyTailscaleRoutes(
+                macDeviceID: row.macDeviceID,
+                ownerKey: row.ownerKey
+            )
             return MobilePairedMac(
                 macDeviceID: row.macDeviceID,
                 displayName: row.displayName,
@@ -253,9 +266,48 @@ extension MobilePairedMacStore {
                 customName: row.customName,
                 customColor: row.customColor,
                 customIcon: row.customIcon,
-                instanceTag: row.instanceTag
+                instanceTag: row.instanceTag,
+                legacyTailscaleRoutes: legacyTailscaleRoutes.isEmpty
+                    ? nil
+                    : legacyTailscaleRoutes
             )
         }
+    }
+
+    func fetchLegacyTailscaleRoutes(
+        macDeviceID: String,
+        ownerKey: String
+    ) throws -> [CmxAttachRoute] {
+        var statement: OpaquePointer?
+        defer { sqlite3_finalize(statement) }
+        let result = sqlite3_prepare_v2(
+            db,
+            """
+            SELECT endpoint_json
+            FROM legacy_tailscale_route_grants
+            WHERE mac_device_id = ? AND owner_key = ?
+            ORDER BY id ASC;
+            """,
+            -1,
+            &statement,
+            nil
+        )
+        guard result == SQLITE_OK else {
+            throw MobilePairedMacStoreError.prepareFailed(result, lastErrorMessage())
+        }
+        try bind(statement: statement, parameters: [.text(macDeviceID), .text(ownerKey)])
+        let decoder = JSONDecoder()
+        var routes: [CmxAttachRoute] = []
+        while sqlite3_step(statement) == SQLITE_ROW {
+            guard let json = Self.readNullableText(statement, column: 0),
+                  let data = json.data(using: .utf8),
+                  let route = try? decoder.decode(CmxAttachRoute.self, from: data),
+                  route.kind == .tailscale else {
+                continue
+            }
+            routes.append(route)
+        }
+        return routes
     }
 
     func fetchRoutes(macDeviceID: String, ownerKey: String) throws -> [CmxAttachRoute] {

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
@@ -14,7 +14,7 @@ let pairedMacStoreLog = Logger(subsystem: "com.cmuxterm.app", category: "PairedM
 /// inject it as `any MobilePairedMacStoring`.
 public actor MobilePairedMacStore: MobilePairedMacStoring {
     /// The schema version this build creates and migrates to.
-    public static let currentSchemaVersion: Int32 = 7
+    public static let currentSchemaVersion: Int32 = 8
 
     private let dbPath: String
     // `nonisolated(unsafe)` only so the (Swift 6 nonisolated) `deinit` can close
@@ -112,7 +112,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV5()
                 try migrateToV6()
                 try migrateToV7()
-                try setUserVersion(7)
+                try migrateToV8()
+                try setUserVersion(8)
             }
         case 1:
             try transaction {
@@ -122,7 +123,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV5()
                 try migrateToV6()
                 try migrateToV7()
-                try setUserVersion(7)
+                try migrateToV8()
+                try setUserVersion(8)
             }
         case 2:
             try transaction {
@@ -131,7 +133,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV5()
                 try migrateToV6()
                 try migrateToV7()
-                try setUserVersion(7)
+                try migrateToV8()
+                try setUserVersion(8)
             }
         case 3:
             try transaction {
@@ -139,27 +142,36 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV5()
                 try migrateToV6()
                 try migrateToV7()
-                try setUserVersion(7)
+                try migrateToV8()
+                try setUserVersion(8)
             }
         case 4:
             try transaction {
                 try migrateToV5()
                 try migrateToV6()
                 try migrateToV7()
-                try setUserVersion(7)
+                try migrateToV8()
+                try setUserVersion(8)
             }
         case 5:
             try transaction {
                 try migrateToV6()
                 try migrateToV7()
-                try setUserVersion(7)
+                try migrateToV8()
+                try setUserVersion(8)
             }
         case 6:
             try transaction {
                 try migrateToV7()
-                try setUserVersion(7)
+                try migrateToV8()
+                try setUserVersion(8)
             }
         case 7:
+            try transaction {
+                try migrateToV8()
+                try setUserVersion(8)
+            }
+        case 8:
             break
         default:
             // A newer build wrote a higher schema version. Schema migrations are
@@ -401,6 +413,53 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         try exec("CREATE INDEX IF NOT EXISTS idx_macs_stack_user ON paired_macs(stack_user_id);")
         try exec("CREATE INDEX IF NOT EXISTS idx_macs_team ON paired_macs(stack_user_id, team_id);")
         try exec("CREATE INDEX IF NOT EXISTS idx_routes_device ON mac_routes(mac_device_id, owner_key);")
+    }
+
+    /// v8: preserve only the exact raw Tailscale destinations that this local
+    /// installation used before Iroh shipped. The table is deliberately absent
+    /// from account backup, so a new install, a second phone, or a restored row
+    /// cannot acquire this bearer-carrying compatibility capability.
+    ///
+    /// Rows that already contain Iroh are excluded. Once Iroh is persisted,
+    /// ``upsertRecord`` deletes any remaining grants and never recreates them.
+    private func migrateToV8() throws {
+        try exec("""
+            CREATE TABLE legacy_tailscale_route_grants (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                endpoint_json TEXT NOT NULL,
+                UNIQUE (mac_device_id, owner_key, endpoint_json),
+                FOREIGN KEY (mac_device_id, owner_key)
+                    REFERENCES paired_macs(mac_device_id, owner_key)
+                    ON DELETE CASCADE
+            );
+        """)
+        try exec("""
+            INSERT OR IGNORE INTO legacy_tailscale_route_grants (
+                mac_device_id, owner_key, endpoint_json
+            )
+            SELECT routes.mac_device_id, routes.owner_key, routes.endpoint_json
+            FROM mac_routes routes
+            WHERE routes.kind = 'tailscale'
+              AND EXISTS (
+                SELECT 1 FROM paired_macs macs
+                WHERE macs.mac_device_id = routes.mac_device_id
+                  AND macs.owner_key = routes.owner_key
+                  AND macs.stack_user_id IS NOT NULL
+                  AND macs.stack_user_id <> ''
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM mac_routes iroh
+                WHERE iroh.mac_device_id = routes.mac_device_id
+                  AND iroh.owner_key = routes.owner_key
+                  AND iroh.kind = 'iroh'
+              );
+        """)
+        try exec("""
+            CREATE INDEX idx_legacy_tailscale_grants_device
+            ON legacy_tailscale_route_grants(mac_device_id, owner_key);
+        """)
     }
 
     /// Column names defined on `table` (via `PRAGMA table_info`), used to make
@@ -668,6 +727,15 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 lastSeenAt: now,
                 isActive: shouldMarkActive
             )
+            if routesToPersist.contains(where: { $0.kind == .iroh }) {
+                try exec(
+                    """
+                    DELETE FROM legacy_tailscale_route_grants
+                    WHERE mac_device_id = ? AND owner_key = ?;
+                    """,
+                    binding: [.text(macDeviceID), .text(ownerKey)]
+                )
+            }
             if existing != nil, let selectedUnclaimed,
                selectedUnclaimed.ownerKey != ownerKey {
                 try exec(

--- a/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacStoreTests.swift
@@ -100,6 +100,179 @@ import Testing
         #expect(!stored.routes.contains { $0.id == "tailscale-old" })
     }
 
+    @Test func v8MigrationGrandfathersOnlyTailscaleOnlyLocalPairings() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+        let tailscale = try tailscaleRoute(host: "100.64.0.20")
+
+        try seedVersionSevenDatabase(at: databaseURL, routes: [tailscale])
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        let mac = try #require(await store.activeMac(stackUserID: "user-1"))
+
+        #expect(mac.legacyTailscaleRoutes == [tailscale])
+    }
+
+    @Test func v8MigrationDoesNotGrantRowsThatAlreadyHaveIroh() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+
+        try seedVersionSevenDatabase(
+            at: databaseURL,
+            routes: [
+                try tailscaleRoute(host: "100.64.0.21"),
+                try irohRoute(),
+            ]
+        )
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        let mac = try #require(await store.activeMac(stackUserID: "user-1"))
+
+        #expect(mac.legacyTailscaleRoutes == nil)
+    }
+
+    @Test func v8MigrationDoesNotGrantAnonymousPairings() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+
+        try seedVersionSevenDatabase(
+            at: databaseURL,
+            routes: [try tailscaleRoute(host: "100.64.0.25")],
+            stackUserID: nil
+        )
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        let mac = try #require(await store.activeMac(stackUserID: nil))
+
+        #expect(mac.stackUserID == nil)
+        #expect(mac.legacyTailscaleRoutes == nil)
+    }
+
+    @Test func freshAndRestoredRowsCannotMintLegacyTailscaleCapability() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tailscale = try tailscaleRoute(host: "100.64.0.22")
+
+        try await store.upsert(
+            macDeviceID: "legacy-mac",
+            displayName: "Legacy Mac",
+            routes: [tailscale],
+            markActive: true,
+            stackUserID: "user-1",
+            now: Date()
+        )
+        let mac = try #require(await store.activeMac(stackUserID: "user-1"))
+
+        #expect(mac.legacyTailscaleRoutes == nil)
+    }
+
+    @Test func routeRefreshCannotRewriteGrandfatheredDestination() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+        let original = try tailscaleRoute(host: "100.64.0.23")
+        let replacement = try tailscaleRoute(host: "100.64.0.24")
+
+        try seedVersionSevenDatabase(at: databaseURL, routes: [original])
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        _ = try await store.loadAll(stackUserID: "user-1")
+        try await store.upsert(
+            macDeviceID: "legacy-mac",
+            displayName: "Legacy Mac",
+            routes: [replacement],
+            markActive: true,
+            stackUserID: "user-1",
+            now: Date()
+        )
+        let mac = try #require(await store.activeMac(stackUserID: "user-1"))
+
+        #expect(mac.routes == [replacement])
+        #expect(mac.legacyTailscaleRoutes == [original])
+    }
+
+    @Test func authenticatedIrohPublicationRevokesGrandfatheredDestination() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+        let tailscale = try tailscaleRoute(host: "100.64.0.25")
+
+        try seedVersionSevenDatabase(at: databaseURL, routes: [tailscale])
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        #expect(try await store.activeMac(stackUserID: "user-1")?.legacyTailscaleRoutes == [tailscale])
+        try await store.upsert(
+            macDeviceID: "legacy-mac",
+            displayName: "Upgraded Mac",
+            routes: [tailscale, try irohRoute()],
+            markActive: true,
+            stackUserID: "user-1",
+            now: Date()
+        )
+
+        #expect(try await store.activeMac(stackUserID: "user-1")?.legacyTailscaleRoutes == nil)
+    }
+
+    @Test func grandfatheredCapabilitySurvivesLocalTeamScopeClaim() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+        let original = try tailscaleRoute(host: "100.64.0.26")
+        let refreshed = try tailscaleRoute(host: "100.64.0.27")
+
+        try seedVersionSevenDatabase(at: databaseURL, routes: [original])
+        let store = try MobilePairedMacStore(databaseURL: databaseURL)
+        _ = try await store.loadAll(stackUserID: "user-1")
+        try await store.upsert(
+            macDeviceID: "legacy-mac",
+            displayName: "Claimed Mac",
+            routes: [refreshed],
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date()
+        )
+
+        let claimed = try #require(
+            await store.activeMac(stackUserID: "user-1", teamID: "team-a")
+        )
+        #expect(claimed.routes == [refreshed])
+        #expect(claimed.legacyTailscaleRoutes == [original])
+    }
+
+    @Test func codableRepresentationNeverExportsLocalCompatibilityCapability() throws {
+        let route = try tailscaleRoute(host: "100.64.0.28")
+        let mac = MobilePairedMac(
+            macDeviceID: "legacy-mac",
+            displayName: "Legacy Mac",
+            routes: [route],
+            createdAt: Date(timeIntervalSince1970: 1),
+            lastSeenAt: Date(timeIntervalSince1970: 2),
+            isActive: true,
+            stackUserID: "user-1",
+            legacyTailscaleRoutes: [route]
+        )
+
+        let encoded = try JSONEncoder().encode(mac)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        let decoded = try JSONDecoder().decode(MobilePairedMac.self, from: encoded)
+
+        #expect(object["legacyTailscaleRoutes"] == nil)
+        #expect(decoded.legacyTailscaleRoutes == nil)
+    }
+
     @Test func markingActiveDeactivatesPreviousWithinScope() async throws {
         let (store, directory) = try makeStore()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -483,6 +656,91 @@ import Testing
         let visible = try await store.loadAll(stackUserID: "user-1", teamID: "team-a")
         #expect(visible.filter(\.isActive).map(\.macDeviceID) == ["team-mac"])
         #expect(try await store.activeMac(stackUserID: "user-1", teamID: "team-a")?.macDeviceID == "team-mac")
+    }
+
+    private func tailscaleRoute(host: String) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "tailscale-\(host)",
+            kind: .tailscale,
+            endpoint: .hostPort(host: host, port: 58_465)
+        )
+    }
+
+    private func irohRoute() throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(
+                    endpointID: String(repeating: "a", count: 64)
+                ),
+                pathHints: []
+            )
+        )
+    }
+
+    private func seedVersionSevenDatabase(
+        at databaseURL: URL,
+        routes: [CmxAttachRoute],
+        stackUserID: String? = "user-1"
+    ) throws {
+        let ownerKey = "\(stackUserID ?? "")\u{1F}\u{1F}"
+        let stackUserValue = stackUserID.map(sqlQuoted) ?? "NULL"
+        var database: OpaquePointer?
+        #expect(sqlite3_open(databaseURL.path, &database) == SQLITE_OK)
+        defer { sqlite3_close(database) }
+        let schema = """
+            CREATE TABLE paired_macs (
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                display_name TEXT,
+                stack_user_id TEXT,
+                team_id TEXT,
+                created_at REAL NOT NULL,
+                last_seen_at REAL NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 0,
+                custom_name TEXT,
+                custom_color TEXT,
+                custom_icon TEXT,
+                instance_tag TEXT,
+                PRIMARY KEY (mac_device_id, owner_key)
+            );
+            CREATE TABLE mac_routes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                endpoint_json TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (mac_device_id, owner_key)
+                    REFERENCES paired_macs(mac_device_id, owner_key)
+                    ON DELETE CASCADE
+            );
+            INSERT INTO paired_macs VALUES (
+                'legacy-mac', \(sqlQuoted(ownerKey)), 'Legacy Mac',
+                \(stackUserValue), NULL, 0, 0, 1, NULL, NULL, NULL, NULL
+            );
+            PRAGMA user_version = 7;
+        """
+        #expect(sqlite3_exec(database, schema, nil, nil, nil) == SQLITE_OK)
+        for route in routes {
+            let jsonData = try JSONEncoder().encode(route)
+            let json = try #require(String(data: jsonData, encoding: .utf8))
+            let insert = """
+                INSERT INTO mac_routes (
+                    mac_device_id, owner_key, route_id, kind, endpoint_json, priority
+                ) VALUES (
+                    'legacy-mac', \(sqlQuoted(ownerKey)), \(sqlQuoted(route.id)),
+                    \(sqlQuoted(route.kind.rawValue)), \(sqlQuoted(json)), \(route.priority)
+                );
+            """
+            #expect(sqlite3_exec(database, insert, nil, nil, nil) == SQLITE_OK)
+        }
+    }
+
+    private func sqlQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "''"))'"
     }
 
 }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -31,6 +31,9 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     ///   - ticket: The attach ticket authorizing requests.
     ///   - allowsStackAuthFallback: When `true`, falls back to a Stack Auth token
     ///     on routes that allow it once the attach ticket no longer covers a request.
+    ///   - legacyTailscaleAuthorizationEvidence: Exact local capability retained
+    ///     only for a pairing that predates Iroh. Mismatched evidence is ignored,
+    ///     leaving the raw Tailscale route fail-closed.
     ///   - transportConnectObserver: Optional synchronous sink for privacy-safe
     ///     transport dial lifecycle events. The observer must return immediately.
     public init(
@@ -38,6 +41,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         route: CmxAttachRoute,
         ticket: CmxAttachTicket,
         allowsStackAuthFallback: Bool = false,
+        legacyTailscaleAuthorizationEvidence: CmxLegacyTailscaleAuthorizationEvidence? = nil,
         connectAttemptRegistry: MobileRPCConnectAttemptRegistry = MobileRPCConnectAttemptRegistry(),
         stackTokenGate: RPCStackTokenGate? = nil,
         stackTokenForceRefreshGate: RPCStackTokenGate? = nil,
@@ -50,10 +54,27 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         self.runtime = runtime
         self.route = route
         self.ticket = ticket
+        let authorizationMode: CmxTransportAuthorizationMode
+        if route.kind == .iroh {
+            authorizationMode = .transportAdmission
+        } else if route.kind == .tailscale,
+                  case let .hostPort(host, port) = route.endpoint,
+                  let legacyTailscaleAuthorizationEvidence,
+                  legacyTailscaleAuthorizationEvidence.authorizes(
+                      macDeviceID: ticket.macDeviceID,
+                      host: host,
+                      port: port
+                  ) {
+            authorizationMode = .legacyTailscaleBearer(
+                legacyTailscaleAuthorizationEvidence
+            )
+        } else {
+            authorizationMode = .stackBearer
+        }
         let transportRequest = CmxByteTransportRequest(
             route: route,
             expectedPeerDeviceID: ticket.macDeviceID,
-            authorizationMode: route.kind == .iroh ? .transportAdmission : .stackBearer,
+            authorizationMode: authorizationMode,
             sessionPurpose: sessionPurpose
         )
         self.transportRequest = transportRequest
@@ -235,7 +256,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             // account, so retrying with a fresh token of THIS account cannot
             // help and would only weaken the same-account gate; it surfaces as
             // `.rpcError("account_mismatch", _)`, not `.authorizationFailed`.
-            guard transportRequest.authorizationMode == .stackBearer,
+            guard transportUsesStackBearer,
                   case .authorizationFailed = error else { throw error }
             try await forceRefreshStackTokenForRetry(deadline: deadline)
             // Re-run with retry disabled so a fresh token that is still rejected
@@ -385,7 +406,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             // expiry), so they never reach this branch.
             if !ticket.isExpired(at: runtime.now()) {
                 auth["attach_token"] = attachToken
-            } else if !allowsStackAuthFallback || !MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) {
+            } else if !canSendStackBearer {
                 throw MobileShellConnectionError.attachTicketExpired
             }
         }
@@ -399,8 +420,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         // supplementary route/workspace context.
         let shouldSendStackAuth = requestNeedsAuth
         if shouldSendStackAuth {
-            guard allowsStackAuthFallback,
-                  MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) else {
+            guard canSendStackBearer else {
                 throw MobileShellConnectionError.insecureManualRoute
             }
             do {
@@ -430,8 +450,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         }
         if !requestNeedsAuth,
            isHostStatusRequest(request),
-           allowsStackAuthFallback,
-           MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) {
+           canSendStackBearer {
             let stackAccessToken: String?
             if let hostStatusStackToken {
                 stackAccessToken = hostStatusStackToken
@@ -469,6 +488,38 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     private func stackAccessToken(deadline: RPCRequestDeadline) async throws -> String {
         try await stackTokenGate.token(timeoutNanoseconds: try deadline.remainingNanoseconds()) { [runtime] in
             try await runtime.stackAccessTokenProvider()
+        }
+    }
+
+    private var transportUsesStackBearer: Bool {
+        switch transportRequest.authorizationMode {
+        case .stackBearer, .legacyTailscaleBearer:
+            true
+        case .transportAdmission:
+            false
+        }
+    }
+
+    /// One authorization decision shared by every token-send site. Generic
+    /// plaintext routes remain restricted to loopback; the legacy mode is valid
+    /// only while its immutable device/IP/port evidence still matches.
+    private var canSendStackBearer: Bool {
+        switch transportRequest.authorizationMode {
+        case .stackBearer:
+            return allowsStackAuthFallback
+                && MobileShellRouteAuthPolicy.routeAllowsStackAuth(route)
+        case let .legacyTailscaleBearer(evidence):
+            guard route.kind == .tailscale,
+                  case let .hostPort(host, port) = route.endpoint else {
+                return false
+            }
+            return evidence.authorizes(
+                macDeviceID: ticket.macDeviceID,
+                host: host,
+                port: port
+            )
+        case .transportAdmission:
+            return false
         }
     }
 

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientTests.swift
@@ -487,4 +487,111 @@ import Testing
         _ = try? await task.value
     }
 
+    @Test func exactLegacyTailscaleEvidenceCarriesStackBearer() async throws {
+        let macDeviceID = "123e4567-e89b-42d3-a456-426614174004"
+        let route = try hostPortRoute(
+            kind: .tailscale,
+            host: "100.64.0.5",
+            port: 58_465
+        )
+        let evidence = try CmxLegacyTailscaleAuthorizationEvidence(
+            macDeviceID: macDeviceID,
+            host: "100.64.0.5",
+            port: 58_465
+        )
+        let transport = QueuedCancellationProbeTransport()
+        let capture = TransportRequestCapture()
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: IntentRecordingTransportFactory(
+                transport: transport,
+                capture: capture
+            ),
+            stackAccessToken: "legacy-stack-token"
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: macDeviceID,
+            macDisplayName: "Legacy Mac",
+            routes: [route],
+            expiresAt: nil,
+            authToken: nil
+        )
+        let client = MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            legacyTailscaleAuthorizationEvidence: evidence
+        )
+        let request = try MobileCoreRPCClient.requestData(method: "workspace.list")
+
+        let task = Task { try await client.sendRequest(request) }
+        let sent = try await transport.waitForSentRequestCount(1)
+
+        let frame = try #require(sent.first)
+        #expect(frame.stackAccessToken == "legacy-stack-token")
+        #expect(frame.attachToken == nil)
+        #expect(
+            capture.request()?.authorizationMode
+                == .legacyTailscaleBearer(evidence)
+        )
+        task.cancel()
+        await transport.releaseFirstSend()
+        _ = try? await task.value
+    }
+
+    @Test func mismatchedLegacyTailscaleEvidenceFailsBeforeFetchingBearer() async throws {
+        let route = try hostPortRoute(
+            kind: .tailscale,
+            host: "100.64.0.6",
+            port: 58_465
+        )
+        let evidence = try CmxLegacyTailscaleAuthorizationEvidence(
+            macDeviceID: "123e4567-e89b-42d3-a456-426614174004",
+            host: "100.64.0.5",
+            port: 58_465
+        )
+        let transport = QueuedCancellationProbeTransport()
+        let capture = TransportRequestCapture()
+        let stackTokenRequested = AsyncFlag()
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: IntentRecordingTransportFactory(
+                transport: transport,
+                capture: capture
+            ),
+            stackAccessTokenProvider: {
+                await stackTokenRequested.set()
+                return "must-not-cross-mismatched-route"
+            }
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "123e4567-e89b-42d3-a456-426614174004",
+            macDisplayName: "Legacy Mac",
+            routes: [route],
+            expiresAt: nil,
+            authToken: nil
+        )
+        let client = MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            legacyTailscaleAuthorizationEvidence: evidence
+        )
+        let request = try MobileCoreRPCClient.requestData(method: "workspace.list")
+
+        do {
+            _ = try await client.sendRequest(request)
+            Issue.record("Expected mismatched legacy route to fail closed")
+        } catch MobileShellConnectionError.insecureManualRoute {
+        } catch {
+            Issue.record("Expected insecureManualRoute, got \(error)")
+        }
+
+        #expect(!(await stackTokenRequested.isSet()))
+        #expect(capture.request() == nil)
+        #expect(try await transport.sentRequests().isEmpty)
+    }
+
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -379,14 +379,15 @@ extension MobileShellComposite {
     /// Reconnects an already-paired Mac through its full route set.
     ///
     /// This path is used only when the set contains an authenticated Iroh peer
-    /// route. `connect(ticket:)` pins the pairing to Iroh, so an admission or
-    /// revocation failure cannot downgrade to raw Tailscale/custom-network RPC.
-    /// The synthetic ticket names the already-paired device; it is never used to
-    /// discover or create a new pairing.
+    /// route or an exact locally grandfathered Tailscale route. Iroh pins the
+    /// pairing and removes raw fallbacks; the Tailscale exception is bound to
+    /// the previously paired device, address, and port. The synthetic ticket
+    /// names the already-paired device and never creates a new pairing.
     func connectStoredMacRoutes(
         name: String,
         routes: [CmxAttachRoute],
         pairedMacDeviceID: String,
+        legacyTailscaleRoutes: [CmxAttachRoute] = [],
         ifStillCurrent: (() -> Bool)? = nil
     ) async {
         let ticket: CmxAttachTicket
@@ -398,6 +399,7 @@ extension MobileShellComposite {
             )
             _ = try await connect(
                 ticket: ticket,
+                legacyTailscaleRoutes: legacyTailscaleRoutes,
                 pairedMacDeviceID: pairedMacDeviceID,
                 ifStillCurrent: ifStillCurrent
             )
@@ -421,63 +423,19 @@ extension MobileShellComposite {
         name: String,
         routes: [CmxAttachRoute],
         pairedMacDeviceID: String,
+        legacyTailscaleRoutes: [CmxAttachRoute] = [],
         recordsPairingAttempt: Bool = false,
         ifStillCurrent: (() -> Bool)? = nil
     ) async -> Bool {
-        guard ifStillCurrent?() ?? true else { return false }
-        let supportedKinds = runtime?.supportedRouteKinds ?? []
-        let pinnedRoutes = Self.storedReconnectRoutes(
-            routes,
-            supportedKinds: supportedKinds,
-            preferNonLoopback: Self.prefersNonLoopbackRoutes
-        )
-        guard let firstRoute = pinnedRoutes.first else { return false }
-
-        if firstRoute.kind == .iroh {
-            await connectStoredMacRoutes(
-                name: name,
-                routes: pinnedRoutes,
-                pairedMacDeviceID: pairedMacDeviceID,
-                ifStillCurrent: ifStillCurrent
-            )
-        } else {
-            let candidates = Self.reconnectHostPortRoutes(
-                pinnedRoutes,
-                supportedKinds: supportedKinds,
-                preferNonLoopback: Self.prefersNonLoopbackRoutes
-            ).filter { MobileShellRouteAuthPolicy.normalizedManualHost($0.host) != nil }
-            for route in candidates {
-                guard ifStillCurrent?() ?? true else { return false }
-                if recordsPairingAttempt {
-                    await connectManualHost(
-                        name: name,
-                        host: route.host,
-                        port: route.port,
-                        pairedMacDeviceID: pairedMacDeviceID,
-                        recordsPairingAttempt: true,
-                        ifStillCurrent: ifStillCurrent
-                    )
-                } else {
-                    await connectStoredMacHost(
-                        name: name,
-                        host: route.host,
-                        port: route.port,
-                        pairedMacDeviceID: pairedMacDeviceID,
-                        ifStillCurrent: ifStillCurrent
-                    )
-                }
-                if connectionState == .connected,
-                   remoteClient != nil,
-                   foregroundMacDeviceID == pairedMacDeviceID {
-                    break
-                }
-            }
-        }
-
-        return (ifStillCurrent?() ?? true)
-            && connectionState == .connected
-            && remoteClient != nil
-            && foregroundMacDeviceID == pairedMacDeviceID
+        (await connectStoredMacOutcome(
+            name: name,
+            routes: routes,
+            pairedMacDeviceID: pairedMacDeviceID,
+            instanceTag: nil,
+            legacyTailscaleRoutes: legacyTailscaleRoutes,
+            recordsPairingAttempt: recordsPairingAttempt,
+            ifStillCurrent: ifStillCurrent
+        )).didConnect
     }
 
     func connectStoredMacHost(
@@ -509,6 +467,7 @@ extension MobileShellComposite {
         routes: [CmxAttachRoute],
         pairedMacDeviceID: String,
         instanceTag: String?,
+        legacyTailscaleRoutes: [CmxAttachRoute] = [],
         automaticReconnectAccountID: String? = nil,
         recordsPairingAttempt: Bool = false,
         ifStillCurrent: (() -> Bool)? = nil
@@ -518,6 +477,7 @@ extension MobileShellComposite {
             routes: routes,
             pairedMacDeviceID: pairedMacDeviceID,
             instanceTag: instanceTag,
+            legacyTailscaleRoutes: legacyTailscaleRoutes,
             automaticReconnectAccountID: automaticReconnectAccountID,
             recordsPairingAttempt: recordsPairingAttempt,
             ifStillCurrent: ifStillCurrent
@@ -529,6 +489,7 @@ extension MobileShellComposite {
         routes: [CmxAttachRoute],
         pairedMacDeviceID: String,
         instanceTag: String?,
+        legacyTailscaleRoutes: [CmxAttachRoute] = [],
         automaticReconnectAccountID: String? = nil,
         recordsPairingAttempt: Bool = false,
         ifStillCurrent: (() -> Bool)? = nil
@@ -540,6 +501,7 @@ extension MobileShellComposite {
             instanceTagExpectation: MobileMacInstanceTagAuthority.expectation(
                 storedInstanceTag: instanceTag
             ),
+            legacyTailscaleRoutes: legacyTailscaleRoutes,
             automaticReconnectAccountID: automaticReconnectAccountID,
             recordsPairingAttempt: recordsPairingAttempt,
             ifStillCurrent: ifStillCurrent
@@ -554,6 +516,7 @@ extension MobileShellComposite {
         routes: [CmxAttachRoute],
         pairedMacDeviceID: String,
         instanceTagExpectation: MobileMacInstanceTagExpectation,
+        legacyTailscaleRoutes: [CmxAttachRoute] = [],
         automaticReconnectAccountID: String? = nil,
         recordsPairingAttempt: Bool = false,
         ifStillCurrent: (() -> Bool)? = nil
@@ -569,7 +532,14 @@ extension MobileShellComposite {
 
         var outcome: StoredMacReconnectOutcome = .failed(.unknown)
 
-        if firstRoute.kind == .iroh {
+        let hasAuthorizedLegacyTailscaleRoute = pinnedRoutes.contains { route in
+            Self.legacyTailscaleAuthorizationEvidence(
+                for: route,
+                macDeviceID: pairedMacDeviceID,
+                persistedRoutes: legacyTailscaleRoutes
+            ) != nil
+        }
+        if firstRoute.kind == .iroh || hasAuthorizedLegacyTailscaleRoute {
             do {
                 let ticket = try Self.storedMacTicket(
                     name: name,
@@ -578,6 +548,7 @@ extension MobileShellComposite {
                 )
                 let noThrowFailure = try await connect(
                     ticket: ticket,
+                    legacyTailscaleRoutes: legacyTailscaleRoutes,
                     pairedMacDeviceID: pairedMacDeviceID,
                     instanceTagExpectation: instanceTagExpectation,
                     ifStillCurrent: ifStillCurrent

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -55,6 +55,37 @@ struct ReconnectRefreshSnapshot: Sendable {
 
 @MainActor
 extension MobileShellComposite {
+    /// Resolves one immutable pre-Iroh capability for an exact raw Tailscale
+    /// route. Fresh registry/manual routes cannot create this evidence; they
+    /// must match a route retained by the local schema migration.
+    static func legacyTailscaleAuthorizationEvidence(
+        for route: CmxAttachRoute,
+        macDeviceID: String,
+        persistedRoutes: [CmxAttachRoute]
+    ) -> CmxLegacyTailscaleAuthorizationEvidence? {
+        guard route.kind == .tailscale,
+              case let .hostPort(host, port) = route.endpoint else {
+            return nil
+        }
+        for persistedRoute in persistedRoutes where persistedRoute.kind == .tailscale {
+            guard case let .hostPort(persistedHost, persistedPort) = persistedRoute.endpoint,
+                  let evidence = try? CmxLegacyTailscaleAuthorizationEvidence(
+                      macDeviceID: macDeviceID,
+                      host: persistedHost,
+                      port: persistedPort
+                  ),
+                  evidence.authorizes(
+                      macDeviceID: macDeviceID,
+                      host: host,
+                      port: port
+                  ) else {
+                continue
+            }
+            return evidence
+        }
+        return nil
+    }
+
     /// Supported routes for reconnecting an already-paired Mac.
     ///
     /// Unlike the legacy host/port helper, this preserves Iroh peer routes. Once

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1889,12 +1889,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             let localHasIroh = localRoutes.contains { $0.kind == .iroh }
             let localCanConnectSecurely = localHasIroh
                 || localRoutes.contains { $0.kind == .debugLoopback }
+                || localRoutes.contains { route in
+                    Self.legacyTailscaleAuthorizationEvidence(
+                        for: route,
+                        macDeviceID: mac.macDeviceID,
+                        persistedRoutes: mac.legacyTailscaleRoutes ?? []
+                    ) != nil
+                }
             let isLegacyPrivateNetworkPairing = !mac.routes.contains { $0.kind == .iroh }
                 && mac.routes.contains { $0.kind == .tailscale }
 
-            // New clients never send a Stack bearer directly over a raw
-            // Tailscale/TCP route. Such a saved route is a migration hint only;
-            // consult the authenticated registry for the Mac's Iroh identity.
+            // Raw Tailscale/TCP is bearer-capable only for an exact local route
+            // grandfathered during the v7-to-v8 migration. Every fresh, changed,
+            // restored, or registry route remains a hint for discovering Iroh.
             if localCanConnectSecurely {
                 attemptedAutomaticIroh = attemptedAutomaticIroh || localHasIroh
                 lastDialOutcome = await connectStoredMacOutcome(
@@ -1902,6 +1909,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     routes: localRoutes,
                     pairedMacDeviceID: mac.macDeviceID,
                     instanceTag: mac.instanceTag,
+                    legacyTailscaleRoutes: mac.legacyTailscaleRoutes ?? [],
                     automaticReconnectAccountID: scope.userID,
                     ifStillCurrent: { [weak self] in
                         self?.storedMacReconnectGeneration == generation
@@ -1924,6 +1932,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         routes: refreshedRoutes,
                         pairedMacDeviceID: mac.macDeviceID,
                         instanceTag: mac.instanceTag,
+                        legacyTailscaleRoutes: mac.legacyTailscaleRoutes ?? [],
                         automaticReconnectAccountID: scope.userID,
                         ifStillCurrent: { [weak self] in
                             self?.storedMacReconnectGeneration == generation
@@ -2387,6 +2396,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let localHasIroh = candidateRoutes.contains { $0.kind == .iroh }
         let localCanConnectSecurely = localHasIroh
             || candidateRoutes.contains { $0.kind == .debugLoopback }
+            || candidateRoutes.contains { route in
+                Self.legacyTailscaleAuthorizationEvidence(
+                    for: route,
+                    macDeviceID: refreshedTarget.macDeviceID,
+                    persistedRoutes: refreshedTarget.legacyTailscaleRoutes ?? []
+                ) != nil
+            }
         let isLegacyPrivateNetworkPairing = !refreshedTarget.routes.contains { $0.kind == .iroh }
             && refreshedTarget.routes.contains { $0.kind == .tailscale }
         var refreshOutcome = ReconnectRouteRefreshOutcome.inconclusive
@@ -2397,6 +2413,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 routes: candidateRoutes,
                 pairedMacDeviceID: macDeviceID,
                 instanceTag: refreshedTarget.instanceTag,
+                legacyTailscaleRoutes: refreshedTarget.legacyTailscaleRoutes ?? [],
                 recordsPairingAttempt: true,
                 ifStillCurrent: { [weak self] in
                     self?.isCurrentMacSwitchAttempt(switchAttemptID) == true
@@ -2428,6 +2445,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         routes: refreshedRoutes,
                         pairedMacDeviceID: macDeviceID,
                         instanceTag: refreshedTarget.instanceTag,
+                        legacyTailscaleRoutes: refreshedTarget.legacyTailscaleRoutes ?? [],
                         recordsPairingAttempt: true,
                         ifStillCurrent: { [weak self] in
                             self?.isCurrentMacSwitchAttempt(switchAttemptID) == true
@@ -2558,6 +2576,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             routes: candidateRoutes,
             pairedMacDeviceID: previousActive.macDeviceID,
             instanceTag: previousActive.instanceTag,
+            legacyTailscaleRoutes: previousActive.legacyTailscaleRoutes ?? [],
             ifStillCurrent: isRestoreCurrent
         )
         let restoreScopeIsCurrent = await isScopeCurrent(restoreScope)
@@ -3156,6 +3175,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let firstRoute = pinnedRoutes.first else { return nil }
         let ticket: CmxAttachTicket
         let route: CmxAttachRoute
+        let legacyTailscaleAuthorizationEvidence: CmxLegacyTailscaleAuthorizationEvidence?
         do {
             if firstRoute.kind == .iroh {
                 ticket = try Self.storedMacTicket(
@@ -3164,6 +3184,26 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     pairedMacDeviceID: mac.macDeviceID
                 )
                 route = firstRoute
+                legacyTailscaleAuthorizationEvidence = nil
+            } else if let authorizedLegacyRoute = pinnedRoutes.first(where: { candidate in
+                Self.legacyTailscaleAuthorizationEvidence(
+                    for: candidate,
+                    macDeviceID: mac.macDeviceID,
+                    persistedRoutes: mac.legacyTailscaleRoutes ?? []
+                ) != nil
+            }) {
+                ticket = try Self.storedMacTicket(
+                    name: mac.displayName ?? mac.macDeviceID,
+                    routes: [authorizedLegacyRoute],
+                    pairedMacDeviceID: mac.macDeviceID
+                )
+                route = authorizedLegacyRoute
+                legacyTailscaleAuthorizationEvidence = Self
+                    .legacyTailscaleAuthorizationEvidence(
+                        for: authorizedLegacyRoute,
+                        macDeviceID: mac.macDeviceID,
+                        persistedRoutes: mac.legacyTailscaleRoutes ?? []
+                    )
             } else {
                 guard let (host, port) = Self.firstReconnectHostPortRoute(
                     pinnedRoutes,
@@ -3188,6 +3228,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 }) ?? supportedRoutes.first(where: { $0.kind != .debugLoopback })
                     ?? supportedRoutes.first else { return nil }
                 route = selectedRoute
+                legacyTailscaleAuthorizationEvidence = nil
             }
         } catch {
             mobileShellLog.warning(
@@ -3200,6 +3241,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             route: route,
             ticket: ticket,
             allowsStackAuthFallback: MobileShellRouteAuthPolicy.routeAllowsStackAuth(route),
+            legacyTailscaleAuthorizationEvidence: legacyTailscaleAuthorizationEvidence,
             connectAttemptRegistry: connectAttemptRegistry,
             stackTokenGate: stackTokenGate,
             stackTokenForceRefreshGate: stackTokenForceRefreshGate,
@@ -4901,6 +4943,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func connect(
         ticket: CmxAttachTicket,
         allowsStackAuthFallback: Bool? = nil,
+        legacyTailscaleRoutes: [CmxAttachRoute] = [],
         pairedMacDeviceID: String? = nil,
         instanceTagExpectation: MobileMacInstanceTagExpectation = .adopt,
         ifStillCurrent: (() -> Bool)? = nil
@@ -4950,21 +4993,28 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
 
         let workspaceListRequests = try Self.initialWorkspaceListRequests(for: ticket)
-        // Stack auth is now the authorization gate for every request. Decide the
-        // fallback per attempted route so an untrusted fallback route cannot
-        // disable auth for a trusted Tailscale/loopback/iroh route.
+        // Stack auth gates plaintext requests. Decide its transport authority
+        // per attempted route so a generic fallback cannot inherit loopback or
+        // grandfathered-Tailscale bearer permission.
         let routeAllowsStackAuthFallbackOverride = allowsStackAuthFallback
         let connectionAttemptStartedAt = pairingAttemptStartedAt
         var lastError: (any Error)?
         routeLoop: for route in supportedRoutes {
             activeRoute = route
             mobileShellLog.info("pairing trying route kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)")
+            let legacyTailscaleAuthorizationEvidence = Self
+                .legacyTailscaleAuthorizationEvidence(
+                    for: route,
+                    macDeviceID: ticket.macDeviceID,
+                    persistedRoutes: legacyTailscaleRoutes
+                )
             let client = MobileCoreRPCClient(
                 runtime: runtime,
                 route: route,
                 ticket: ticket,
                 allowsStackAuthFallback: routeAllowsStackAuthFallbackOverride
                     ?? MobileShellRouteAuthPolicy.routeAllowsStackAuth(route),
+                legacyTailscaleAuthorizationEvidence: legacyTailscaleAuthorizationEvidence,
                 connectAttemptRegistry: connectAttemptRegistry,
                 stackTokenGate: stackTokenGate,
                 stackTokenForceRefreshGate: stackTokenForceRefreshGate,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
@@ -3,6 +3,7 @@ import CmuxMobilePairedMac
 import CmuxMobileRPC
 import CmuxMobileShellModel
 import Foundation
+import SQLite3
 import Testing
 @testable import CmuxMobileShell
 
@@ -97,6 +98,45 @@ extension ReconnectRouteSelectionTests {
 
         #expect(!(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1")))
         #expect(factory.attemptedKinds().isEmpty)
+    }
+
+    @Test func preIrohPairingContinuesOverItsExactTailscaleRouteAfterIOSUpgrade() async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(router: router, box: box)
+        let runtime = LivenessTestRuntime(
+            transportFactory: factory,
+            now: { clock.now },
+            supportedRouteKinds: [.iroh, .tailscale]
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let databaseURL = directory.appendingPathComponent("paired-macs.sqlite3")
+        try seedVersionSevenPairing(
+            at: databaseURL,
+            route: tailscale(),
+            stackUserID: "user-1"
+        )
+        let pairedStore = try MobilePairedMacStore(databaseURL: databaseURL)
+        let store = MobileShellComposite(
+            runtime: runtime,
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "iroh-tailscale-upgrade-\(UUID().uuidString)"
+            )!
+        )
+        await store.loadPairedMacs()
+
+        #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(store.connectionState == .connected)
+        #expect(factory.attemptedKinds() == [.tailscale])
+        #expect(store.activeRoute?.kind == .tailscale)
     }
 
     @Test func reconnectUsesSingleRegistrySnapshotToRescueNonActiveMacWithNoLocalRoutes() async throws {
@@ -1136,6 +1176,65 @@ extension ReconnectRouteSelectionTests {
             ),
             priority: -10_000
         )
+    }
+
+    private func seedVersionSevenPairing(
+        at databaseURL: URL,
+        route: CmxAttachRoute,
+        stackUserID: String
+    ) throws {
+        let ownerKey = "\(stackUserID)\u{1F}\u{1F}"
+        let routeData = try JSONEncoder().encode(route)
+        let routeJSON = try #require(String(data: routeData, encoding: .utf8))
+        var database: OpaquePointer?
+        #expect(sqlite3_open(databaseURL.path, &database) == SQLITE_OK)
+        defer { sqlite3_close(database) }
+        let seed = """
+            CREATE TABLE paired_macs (
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                display_name TEXT,
+                stack_user_id TEXT,
+                team_id TEXT,
+                created_at REAL NOT NULL,
+                last_seen_at REAL NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 0,
+                custom_name TEXT,
+                custom_color TEXT,
+                custom_icon TEXT,
+                instance_tag TEXT,
+                PRIMARY KEY (mac_device_id, owner_key)
+            );
+            CREATE TABLE mac_routes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                endpoint_json TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (mac_device_id, owner_key)
+                    REFERENCES paired_macs(mac_device_id, owner_key)
+                    ON DELETE CASCADE
+            );
+            INSERT INTO paired_macs VALUES (
+                'test-mac', \(sqlQuoted(ownerKey)), 'Test Mac',
+                \(sqlQuoted(stackUserID)), NULL, 0, 0, 1,
+                NULL, NULL, NULL, NULL
+            );
+            INSERT INTO mac_routes (
+                mac_device_id, owner_key, route_id, kind, endpoint_json, priority
+            ) VALUES (
+                'test-mac', \(sqlQuoted(ownerKey)), \(sqlQuoted(route.id)),
+                'tailscale', \(sqlQuoted(routeJSON)), \(route.priority)
+            );
+            PRAGMA user_version = 7;
+        """
+        #expect(sqlite3_exec(database, seed, nil, nil, nil) == SQLITE_OK)
+    }
+
+    private func sqlQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "''"))'"
     }
 
     private func makeMigrationShell(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
@@ -136,6 +136,16 @@ extension ReconnectRouteSelectionTests {
         #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
         #expect(store.connectionState == .connected)
         #expect(factory.attemptedKinds() == [.tailscale])
+        #expect(
+            factory.attemptedAuthorizationModes()
+                == [.legacyTailscaleBearer(
+                    try CmxLegacyTailscaleAuthorizationEvidence(
+                        macDeviceID: "test-mac",
+                        host: "100.82.214.112",
+                        port: 50_906
+                    )
+                )]
+        )
         #expect(store.activeRoute?.kind == .tailscale)
     }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests+Support.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests+Support.swift
@@ -173,6 +173,7 @@ final class KindRecordingTransportFactory: CmxByteTransportFactory, @unchecked S
     private let failingKinds: Set<CmxAttachTransportKind>
     private let lock = NSLock()
     private var kinds: [CmxAttachTransportKind] = []
+    private var authorizationModes: [CmxTransportAuthorizationMode] = []
 
     init(
         router: LivenessHostRouter,
@@ -186,6 +187,22 @@ final class KindRecordingTransportFactory: CmxByteTransportFactory, @unchecked S
 
     func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
         lock.withLock { kinds.append(route.kind) }
+        return try makeRecordedTransport(for: route)
+    }
+
+    func makeTransport(
+        for request: CmxByteTransportRequest
+    ) throws -> any CmxByteTransport {
+        lock.withLock {
+            kinds.append(request.route.kind)
+            authorizationModes.append(request.authorizationMode)
+        }
+        return try makeRecordedTransport(for: request.route)
+    }
+
+    private func makeRecordedTransport(
+        for route: CmxAttachRoute
+    ) throws -> any CmxByteTransport {
         if failingKinds.contains(route.kind) {
             throw RouteRecordingTransportError.routeFailed
         }
@@ -196,5 +213,9 @@ final class KindRecordingTransportFactory: CmxByteTransportFactory, @unchecked S
 
     func attemptedKinds() -> [CmxAttachTransportKind] {
         lock.withLock { kinds }
+    }
+
+    func attemptedAuthorizationModes() -> [CmxTransportAuthorizationMode] {
+        lock.withLock { authorizationModes }
     }
 }

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransport.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransport.swift
@@ -40,8 +40,8 @@ public enum CmxNetworkByteTransportError: Error, Equatable, Sendable {
     case authorizationIntentRequired
     /// The request's authorization mode cannot be served by plaintext TCP.
     case unsupportedAuthorizationMode(CmxTransportAuthorizationMode)
-    /// The OS could not provide cryptographic Tailscale peer authorization, so
-    /// plaintext TCP cannot carry the Stack bearer token.
+    /// The exact legacy peer, live Tailscale-range tunnel, and effective
+    /// connection endpoints could not all be proven.
     case tailscaleAuthorizationUnavailable
     /// An operation was attempted before the connection became ready.
     case notConnected
@@ -86,6 +86,7 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
     let callbackQueue: DispatchQueue
     let maximumReceiveLength: Int
     let connectTimeoutNanoseconds: UInt64
+    let tailscaleBinding: CmxTailscaleTransportBinding?
     private var state: TransportState = .idle
     private var connectContinuations: [UUID: CheckedContinuation<Void, any Error>] = [:]
     private var receiveContinuation: (id: UUID, continuation: CheckedContinuation<Data?, any Error>)?
@@ -95,6 +96,8 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
     private var cancelledOperationIDs: Set<UUID> = []
     private var connectTimeoutTimer: (any DispatchSourceTimer)?
     private var remoteDidClose = false
+    private var tailscalePathRevision: UInt64 = 0
+    private var tailscaleAuthorizationInvalidated = false
 
     public init(
         host: String,
@@ -129,6 +132,7 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
         )
         self.maximumReceiveLength = maximumReceiveLength
         self.connectTimeoutNanoseconds = max(1, connectTimeoutNanoseconds)
+        tailscaleBinding = nil
     }
 
     public init(
@@ -158,6 +162,7 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
         )
         maximumReceiveLength = Self.defaultMaximumReceiveLength
         connectTimeoutNanoseconds = Self.defaultConnectTimeoutNanoseconds
+        tailscaleBinding = nil
     }
 
     public init(
@@ -174,6 +179,47 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
         )
         self.maximumReceiveLength = maximumReceiveLength
         self.connectTimeoutNanoseconds = max(1, connectTimeoutNanoseconds)
+        tailscaleBinding = nil
+    }
+
+    init(
+        request: CmxByteTransportRequest,
+        preparedTailscaleRoute: CmxPreparedTailscaleRoute,
+        tailscaleRouteAuthority: any CmxTailscaleRouteAuthorizing,
+        maximumReceiveLength: Int,
+        connectTimeoutNanoseconds: UInt64 = CmxNetworkByteTransport.defaultConnectTimeoutNanoseconds
+    ) throws {
+        guard maximumReceiveLength > 0 else {
+            throw CmxNetworkByteTransportError.invalidMaximumReceiveLength(maximumReceiveLength)
+        }
+        guard preparedTailscaleRoute.proof.request == request else {
+            throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+        }
+        guard let nwPort = NWEndpoint.Port(
+            rawValue: UInt16(exactly: preparedTailscaleRoute.proof.peerPort) ?? 0
+        ), nwPort != .any else {
+            throw CmxNetworkByteTransportError.invalidPort(preparedTailscaleRoute.proof.peerPort)
+        }
+
+        let tcpOptions = NWProtocolTCP.Options()
+        tcpOptions.noDelay = true
+        let parameters = NWParameters(tls: nil, tcp: tcpOptions)
+        parameters.requiredInterface = preparedTailscaleRoute.requiredInterface
+        connection = NWConnection(
+            host: preparedTailscaleRoute.proof.peerAddress.nwHost,
+            port: nwPort,
+            using: parameters
+        )
+        callbackQueue = DispatchQueue(
+            label: "dev.cmux.mobile.tailscale-network-byte-transport.\(UUID().uuidString)"
+        )
+        self.maximumReceiveLength = maximumReceiveLength
+        self.connectTimeoutNanoseconds = max(1, connectTimeoutNanoseconds)
+        tailscaleBinding = CmxTailscaleTransportBinding(
+            request: request,
+            preparedRoute: preparedTailscaleRoute,
+            authority: tailscaleRouteAuthority
+        )
     }
 
     /// Opens the connection, awaiting `ready` or failing on error/timeout.
@@ -260,6 +306,12 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
                 }
                 Task { await self.handleConnectionEvent(event) }
             }
+            if tailscaleBinding != nil {
+                connection.pathUpdateHandler = { [weak self] path in
+                    guard let self else { return }
+                    Task { await self.handleTailscalePathUpdate(path) }
+                }
+            }
             connection.start(queue: callbackQueue)
         case .connecting:
             connectContinuations[operationID] = continuation
@@ -276,6 +328,12 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
         switch event {
         case .ready:
             guard !isTerminal else {
+                return
+            }
+            do {
+                try await validateTailscaleAuthorizationForCurrentPath()
+            } catch {
+                failTransport(.tailscaleAuthorizationUnavailable)
                 return
             }
             cancelConnectTimeout()
@@ -458,11 +516,24 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
             return
         }
 
-        beginSend(
-            data,
-            operationID: operationID,
-            continuation: continuation
-        )
+        do {
+            try await performAuthorizedWrite(
+                authorization: {
+                    try await validateTailscaleAuthorizationForCurrentPath()
+                },
+                beginWrite: {
+                    beginSend(
+                        data,
+                        operationID: operationID,
+                        continuation: continuation
+                    )
+                }
+            )
+        } catch {
+            let transportError = CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+            continuation.resume(throwing: transportError)
+            failTransport(transportError)
+        }
     }
 
     private func beginSend(
@@ -603,6 +674,58 @@ public actor CmxNetworkByteTransport: CmxByteTransport {
             return
         }
         failTransport(.connectionTimedOut)
+    }
+
+    private func handleTailscalePathUpdate(_ path: NWPath) async {
+        guard tailscaleBinding != nil, !isTerminal else { return }
+        tailscalePathRevision = tailscalePathRevision == .max ? 1 : tailscalePathRevision + 1
+        do {
+            try await validateTailscaleAuthorization(path: path)
+        } catch {
+            tailscaleAuthorizationInvalidated = true
+            failTransport(.tailscaleAuthorizationUnavailable)
+        }
+    }
+
+    private func validateTailscaleAuthorizationForCurrentPath() async throws {
+        guard tailscaleBinding != nil else { return }
+        guard let path = connection.currentPath else {
+            throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+        }
+        let revision = tailscalePathRevision
+        try await validateTailscaleAuthorization(path: path)
+        // The authority call yields this actor. Reject any connection-path
+        // update that interleaved before the synchronous send boundary.
+        guard revision == tailscalePathRevision else {
+            throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+        }
+    }
+
+    private func validateTailscaleAuthorization(path: NWPath) async throws {
+        guard let binding = tailscaleBinding else { return }
+        guard !tailscaleAuthorizationInvalidated,
+              binding.request == binding.preparedRoute.proof.request,
+              connection.parameters.requiredInterface == binding.preparedRoute.requiredInterface else {
+            throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+        }
+        do {
+            try await binding.authority.validate(
+                proof: binding.preparedRoute.proof,
+                connectionPath: path
+            )
+        } catch {
+            throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+        }
+    }
+
+    /// The single legacy bearer-write boundary. Authorization completes before
+    /// Network.framework receives the send request.
+    func performAuthorizedWrite(
+        authorization: () async throws -> Void,
+        beginWrite: () -> Void
+    ) async rethrows {
+        try await authorization()
+        beginWrite()
     }
 
     private var isTerminal: Bool {

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransportFactory.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkByteTransportFactory.swift
@@ -5,6 +5,7 @@ public struct CmxNetworkByteTransportFactory: CmxRouteAwareByteTransportFactory 
     public var supportedKinds: [CmxAttachTransportKind]
     public var maximumReceiveLength: Int
     public var connectTimeoutNanoseconds: UInt64
+    private let tailscaleRouteAuthority: any CmxTailscaleRouteAuthorizing
 
     public init(
         supportedKinds: [CmxAttachTransportKind] = [.tailscale, .debugLoopback],
@@ -14,6 +15,19 @@ public struct CmxNetworkByteTransportFactory: CmxRouteAwareByteTransportFactory 
         self.supportedKinds = supportedKinds
         self.maximumReceiveLength = maximumReceiveLength
         self.connectTimeoutNanoseconds = max(1, connectTimeoutNanoseconds)
+        tailscaleRouteAuthority = CmxSystemTailscaleRouteAuthority()
+    }
+
+    init(
+        supportedKinds: [CmxAttachTransportKind] = [.tailscale, .debugLoopback],
+        maximumReceiveLength: Int = CmxNetworkByteTransport.defaultMaximumReceiveLength,
+        connectTimeoutNanoseconds: UInt64 = CmxNetworkByteTransport.defaultConnectTimeoutNanoseconds,
+        tailscaleRouteAuthority: any CmxTailscaleRouteAuthorizing
+    ) {
+        self.supportedKinds = supportedKinds
+        self.maximumReceiveLength = maximumReceiveLength
+        self.connectTimeoutNanoseconds = max(1, connectTimeoutNanoseconds)
+        self.tailscaleRouteAuthority = tailscaleRouteAuthority
     }
 
     public func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
@@ -35,8 +49,8 @@ public struct CmxNetworkByteTransportFactory: CmxRouteAwareByteTransportFactory 
         )
     }
 
-    /// Preserves authorization intent so plaintext routes fail closed unless
-    /// they are local simulator loopback.
+    /// Preserves authorization intent so generic plaintext Tailscale routes
+    /// fail closed and only an exact persisted compatibility grant can dial.
     public func makeTransport(
         for request: CmxByteTransportRequest
     ) throws -> any CmxByteTransport {
@@ -48,19 +62,31 @@ public struct CmxNetworkByteTransportFactory: CmxRouteAwareByteTransportFactory 
         guard case let .hostPort(host, port) = route.endpoint else {
             throw CmxNetworkByteTransportError.unsupportedEndpoint(route.endpoint)
         }
-        guard request.authorizationMode == .stackBearer else {
-            throw CmxNetworkByteTransportError.unsupportedAuthorizationMode(
-                request.authorizationMode
-            )
-        }
-
         switch route.kind {
         case .tailscale:
-            // Network.framework exposes only a generic packet-tunnel interface.
-            // It cannot prove that the tunnel belongs to Tailscale's authenticated
-            // control plane, so plaintext TCP must never carry a Stack bearer.
-            throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+            guard case let .legacyTailscaleBearer(evidence) = request.authorizationMode else {
+                // A generic Stack bearer never opts into the legacy risk.
+                throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+            }
+            guard evidence.authorizes(
+                macDeviceID: request.expectedPeerDeviceID,
+                host: host,
+                port: port
+            ) else {
+                throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+            }
+            return CmxPreparingTailscaleByteTransport(
+                request: request,
+                tailscaleRouteAuthority: tailscaleRouteAuthority,
+                maximumReceiveLength: maximumReceiveLength,
+                connectTimeoutNanoseconds: connectTimeoutNanoseconds
+            )
         case .debugLoopback:
+            guard request.authorizationMode == .stackBearer else {
+                throw CmxNetworkByteTransportError.unsupportedAuthorizationMode(
+                    request.authorizationMode
+                )
+            }
             guard CmxLoopbackHost().matches(route) else {
                 throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
             }

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxPreparingTailscaleByteTransport.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxPreparingTailscaleByteTransport.swift
@@ -1,0 +1,110 @@
+internal import CMUXMobileCore
+import Foundation
+
+/// Defers the actor-isolated route proof until `connect()` while preserving the
+/// synchronous transport-factory contract. The proven interface is set on
+/// `NWParameters` before Network.framework starts the connection.
+actor CmxPreparingTailscaleByteTransport: CmxByteTransport {
+    private let request: CmxByteTransportRequest
+    private let tailscaleRouteAuthority: any CmxTailscaleRouteAuthorizing
+    private let maximumReceiveLength: Int
+    private let connectTimeoutNanoseconds: UInt64
+    private var preparationTask: Task<any CmxByteTransport, any Error>?
+    private var transport: (any CmxByteTransport)?
+    private var isClosed = false
+
+    init(
+        request: CmxByteTransportRequest,
+        tailscaleRouteAuthority: any CmxTailscaleRouteAuthorizing,
+        maximumReceiveLength: Int,
+        connectTimeoutNanoseconds: UInt64
+    ) {
+        self.request = request
+        self.tailscaleRouteAuthority = tailscaleRouteAuthority
+        self.maximumReceiveLength = maximumReceiveLength
+        self.connectTimeoutNanoseconds = connectTimeoutNanoseconds
+    }
+
+    func connect() async throws {
+        let transport = try await preparedTransport()
+        try await transport.connect()
+    }
+
+    func receive() async throws -> Data? {
+        guard let transport else {
+            throw isClosed
+                ? CmxNetworkByteTransportError.alreadyClosed
+                : CmxNetworkByteTransportError.notConnected
+        }
+        return try await transport.receive()
+    }
+
+    func send(_ data: Data) async throws {
+        guard let transport else {
+            throw isClosed
+                ? CmxNetworkByteTransportError.alreadyClosed
+                : CmxNetworkByteTransportError.notConnected
+        }
+        try await transport.send(data)
+    }
+
+    func close() async {
+        guard !isClosed else { return }
+        isClosed = true
+        preparationTask?.cancel()
+        if let transport {
+            await transport.close()
+        }
+    }
+
+    private func preparedTransport() async throws -> any CmxByteTransport {
+        guard !isClosed else {
+            throw CmxNetworkByteTransportError.alreadyClosed
+        }
+        if let transport {
+            return transport
+        }
+
+        let task: Task<any CmxByteTransport, any Error>
+        if let preparationTask {
+            task = preparationTask
+        } else {
+            let request = request
+            let authority = tailscaleRouteAuthority
+            let maximumReceiveLength = maximumReceiveLength
+            let connectTimeoutNanoseconds = connectTimeoutNanoseconds
+            task = Task {
+                do {
+                    let prepared = try await authority.prepare(request: request)
+                    try Task.checkCancellation()
+                    return try CmxNetworkByteTransport(
+                        request: request,
+                        preparedTailscaleRoute: prepared,
+                        tailscaleRouteAuthority: authority,
+                        maximumReceiveLength: maximumReceiveLength,
+                        connectTimeoutNanoseconds: connectTimeoutNanoseconds
+                    )
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    throw CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable
+                }
+            }
+            preparationTask = task
+        }
+
+        do {
+            let preparedTransport = try await task.value
+            guard !isClosed else {
+                await preparedTransport.close()
+                throw CmxNetworkByteTransportError.alreadyClosed
+            }
+            transport = preparedTransport
+            preparationTask = nil
+            return preparedTransport
+        } catch {
+            preparationTask = nil
+            throw error
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleRouteAuthority.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleRouteAuthority.swift
@@ -1,0 +1,239 @@
+internal import CMUXMobileCore
+import Darwin
+import Foundation
+@preconcurrency import Network
+
+struct CmxPreparedTailscaleRoute: Sendable {
+    let proof: CmxTailscaleRouteProof
+    let requiredInterface: NWInterface
+}
+
+protocol CmxTailscaleRouteAuthorizing: Sendable {
+    func prepare(request: CmxByteTransportRequest) async throws -> CmxPreparedTailscaleRoute
+    func validate(proof: CmxTailscaleRouteProof, connectionPath: NWPath) async throws
+}
+
+actor CmxSystemTailscaleRouteAuthority: CmxTailscaleRouteAuthorizing {
+    private struct PathState: Sendable {
+        var generation: UInt64 = 0
+        var path: NWPath?
+    }
+
+    private struct ObservedPath: Sendable {
+        let generation: UInt64
+        let path: NWPath
+    }
+
+    private var pathState = PathState()
+    private let monitor: NWPathMonitor
+
+    init() {
+        let monitor = NWPathMonitor()
+        self.monitor = monitor
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self else { return }
+            Task { await self.observe(path) }
+        }
+        // Network.framework requires a callback queue. The callback immediately
+        // enters this actor, which is the sole owner of mutable path state.
+        monitor.start(
+            queue: DispatchQueue(
+                label: "dev.cmux.mobile.tailscale-route-authority"
+            )
+        )
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    func prepare(request: CmxByteTransportRequest) throws -> CmxPreparedTailscaleRoute {
+        let observed = observedPath()
+        let snapshot = Self.authoritySnapshot(
+            generation: observed.generation,
+            path: observed.path
+        )
+        let proof = try CmxTailscaleRouteProofValidator().prepare(
+            request: request,
+            snapshot: snapshot
+        )
+        guard let interface = observed.path.availableInterfaces.first(where: {
+            $0.name == proof.interface.name && $0.index == proof.interface.index
+        }) else {
+            throw CmxTailscaleRouteProofError.tailscaleInterfaceUnavailable
+        }
+        return CmxPreparedTailscaleRoute(proof: proof, requiredInterface: interface)
+    }
+
+    func validate(proof: CmxTailscaleRouteProof, connectionPath: NWPath) throws {
+        let observed = observedPath()
+        let authoritySnapshot = Self.authoritySnapshot(
+            generation: observed.generation,
+            path: observed.path
+        )
+        let connectionSnapshot = Self.connectionPathSnapshot(connectionPath)
+        try CmxTailscaleRouteProofValidator().validate(
+            proof: proof,
+            authoritySnapshot: authoritySnapshot,
+            connectionPath: connectionSnapshot
+        )
+    }
+
+    private func observedPath() -> ObservedPath {
+        let currentPath = monitor.currentPath
+        // `currentPath` can advance before the callback reaches this actor.
+        // Record that transition synchronously so a write cannot reuse the old
+        // authority generation during that callback window.
+        if pathState.path == nil || pathState.path != currentPath {
+            pathState.generation = Self.nextGeneration(after: pathState.generation)
+            pathState.path = currentPath
+        }
+        return ObservedPath(generation: pathState.generation, path: currentPath)
+    }
+
+    private func observe(_ path: NWPath) {
+        if pathState.path != path {
+            pathState.generation = Self.nextGeneration(after: pathState.generation)
+            pathState.path = path
+        }
+    }
+
+    private static func nextGeneration(after generation: UInt64) -> UInt64 {
+        generation == .max ? 1 : generation + 1
+    }
+
+    private static func authoritySnapshot(
+        generation: UInt64,
+        path: NWPath
+    ) -> CmxTailscaleAuthoritySnapshot {
+        CmxTailscaleAuthoritySnapshot(
+            generation: generation,
+            pathSatisfied: path.status == .satisfied,
+            availableInterfaces: Set(path.availableInterfaces.map {
+                CmxNetworkInterfaceIdentity(name: $0.name, index: $0.index)
+            }),
+            systemInterfaces: CmxSystemInterfaceSnapshotReader().read()
+        )
+    }
+
+    private static func connectionPathSnapshot(
+        _ path: NWPath
+    ) -> CmxTailscaleConnectionPathSnapshot {
+        let localAddress: CmxTailscaleIPAddress?
+        if let localEndpoint = path.localEndpoint {
+            localAddress = address(from: localEndpoint)
+        } else {
+            localAddress = nil
+        }
+
+        let remoteAddress: CmxTailscaleIPAddress?
+        let remotePort: Int?
+        if let remoteEndpoint = path.remoteEndpoint,
+           case let .hostPort(_, port) = remoteEndpoint {
+            remoteAddress = address(from: remoteEndpoint)
+            remotePort = Int(port.rawValue)
+        } else {
+            remoteAddress = nil
+            remotePort = nil
+        }
+
+        return CmxTailscaleConnectionPathSnapshot(
+            isSatisfied: path.status == .satisfied,
+            availableInterfaces: Set(path.availableInterfaces.map {
+                CmxNetworkInterfaceIdentity(name: $0.name, index: $0.index)
+            }),
+            localAddress: localAddress,
+            remoteAddress: remoteAddress,
+            remotePort: remotePort
+        )
+    }
+
+    private static func address(from endpoint: NWEndpoint) -> CmxTailscaleIPAddress? {
+        guard case let .hostPort(host, _) = endpoint else { return nil }
+        switch host {
+        case let .ipv4(address):
+            return CmxTailscaleIPAddress(family: .ipv4, bytes: address.rawValue)
+        case let .ipv6(address):
+            return CmxTailscaleIPAddress(family: .ipv6, bytes: address.rawValue)
+        case .name:
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+}
+
+private struct CmxSystemInterfaceSnapshotReader {
+    private struct Builder {
+        let identity: CmxNetworkInterfaceIdentity
+        var isUp: Bool
+        var isRunning: Bool
+        var addresses: Set<CmxTailscaleIPAddress>
+    }
+
+    func read() -> [CmxTailscaleInterfaceSnapshot] {
+        var interfaces: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&interfaces) == 0, let first = interfaces else {
+            return []
+        }
+        defer { freeifaddrs(interfaces) }
+
+        var builders: [CmxNetworkInterfaceIdentity: Builder] = [:]
+        var pointer: UnsafeMutablePointer<ifaddrs>? = first
+        while let current = pointer {
+            defer { pointer = current.pointee.ifa_next }
+            guard let nameCString = current.pointee.ifa_name else { continue }
+            let name = String(cString: nameCString)
+            let index = Int(if_nametoindex(nameCString))
+            guard index > 0 else { continue }
+
+            let identity = CmxNetworkInterfaceIdentity(name: name, index: index)
+            let flags = current.pointee.ifa_flags
+            var builder = builders[identity] ?? Builder(
+                identity: identity,
+                isUp: false,
+                isRunning: false,
+                addresses: []
+            )
+            builder.isUp = builder.isUp || (flags & UInt32(IFF_UP)) != 0
+            builder.isRunning = builder.isRunning || (flags & UInt32(IFF_RUNNING)) != 0
+            if let address = current.pointee.ifa_addr,
+               let ipAddress = ipAddress(from: address) {
+                builder.addresses.insert(ipAddress)
+            }
+            builders[identity] = builder
+        }
+
+        return builders.values.map { builder in
+            CmxTailscaleInterfaceSnapshot(
+                identity: builder.identity,
+                isUp: builder.isUp,
+                isRunning: builder.isRunning,
+                addresses: builder.addresses
+            )
+        }
+    }
+
+    private func ipAddress(
+        from address: UnsafeMutablePointer<sockaddr>
+    ) -> CmxTailscaleIPAddress? {
+        switch Int32(address.pointee.sa_family) {
+        case AF_INET:
+            var value = UnsafeRawPointer(address)
+                .assumingMemoryBound(to: sockaddr_in.self)
+                .pointee
+                .sin_addr
+            let bytes = withUnsafeBytes(of: &value) { Data($0) }
+            return CmxTailscaleIPAddress(family: .ipv4, bytes: bytes)
+        case AF_INET6:
+            var value = UnsafeRawPointer(address)
+                .assumingMemoryBound(to: sockaddr_in6.self)
+                .pointee
+                .sin6_addr
+            let bytes = withUnsafeBytes(of: &value) { Data($0) }
+            return CmxTailscaleIPAddress(family: .ipv6, bytes: bytes)
+        default:
+            return nil
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleRouteProof.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleRouteProof.swift
@@ -1,0 +1,240 @@
+internal import CMUXMobileCore
+import Darwin
+import Foundation
+@preconcurrency import Network
+
+enum CmxTailscaleRouteProofError: Error, Equatable, Sendable {
+    case unsupportedRouteKind
+    case unsupportedAuthorizationMode
+    case authorizationEvidenceMismatch
+    case unsupportedEndpoint
+    case nonNumericPeer
+    case peerOutsideTailscaleRange
+    case peerIsLocalDevice
+    case pathUnavailable
+    case tailscaleInterfaceUnavailable
+    case ambiguousTailscaleInterfaces
+    case routeGenerationChanged
+    case interfaceChanged
+    case connectionPathUnavailable
+    case localEndpointMismatch
+    case remoteEndpointMismatch
+    case remotePortMismatch
+}
+
+struct CmxTailscaleIPAddress: Hashable, Sendable {
+    enum Family: Sendable {
+        case ipv4
+        case ipv6
+    }
+
+    let family: Family
+    let bytes: Data
+
+    init?(_ rawHost: String) {
+        let trimmed = rawHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let host: String
+        if trimmed.hasPrefix("["), trimmed.hasSuffix("]"), trimmed.count > 2 {
+            host = String(trimmed.dropFirst().dropLast())
+        } else {
+            host = trimmed
+        }
+
+        if let address = IPv4Address(host) {
+            family = .ipv4
+            bytes = address.rawValue
+        } else if let address = IPv6Address(host) {
+            family = .ipv6
+            bytes = address.rawValue
+        } else {
+            return nil
+        }
+    }
+
+    init?(family: Family, bytes: Data) {
+        switch family {
+        case .ipv4:
+            guard bytes.count == MemoryLayout<in_addr>.size else { return nil }
+        case .ipv6:
+            guard bytes.count == MemoryLayout<in6_addr>.size else { return nil }
+        }
+        self.family = family
+        self.bytes = bytes
+    }
+
+    var nwHost: NWEndpoint.Host {
+        switch family {
+        case .ipv4:
+            return .ipv4(IPv4Address(bytes)!)
+        case .ipv6:
+            return .ipv6(IPv6Address(bytes)!)
+        }
+    }
+
+    var isTailscaleAddress: Bool {
+        let octets = [UInt8](bytes)
+        switch family {
+        case .ipv4:
+            return octets.count == 4 && octets[0] == 100 && (octets[1] & 0xC0) == 64
+        case .ipv6:
+            return octets.starts(with: [0xFD, 0x7A, 0x11, 0x5C, 0xA1, 0xE0])
+        }
+    }
+
+    var isTailscalePeerAddress: Bool {
+        guard isTailscaleAddress else { return false }
+        guard family == .ipv4 else { return true }
+        let octets = [UInt8](bytes)
+        // Tailscale reserves these service ranges. They cannot identify a peer
+        // Mac and may terminate locally, so a bearer route must never target them.
+        if octets[0] == 100, octets[1] == 100,
+           octets[2] == 0 || octets[2] == 100 {
+            return false
+        }
+        if octets[0] == 100, octets[1] == 115,
+           octets[2] == 92 || octets[2] == 93 {
+            return false
+        }
+        return true
+    }
+}
+
+struct CmxNetworkInterfaceIdentity: Hashable, Sendable {
+    let name: String
+    let index: Int
+}
+
+struct CmxTailscaleInterfaceSnapshot: Equatable, Sendable {
+    let identity: CmxNetworkInterfaceIdentity
+    let isUp: Bool
+    let isRunning: Bool
+    let addresses: Set<CmxTailscaleIPAddress>
+
+    var tailnetAddresses: Set<CmxTailscaleIPAddress> {
+        Set(addresses.filter(\.isTailscaleAddress))
+    }
+}
+
+struct CmxTailscaleAuthoritySnapshot: Equatable, Sendable {
+    let generation: UInt64
+    let pathSatisfied: Bool
+    let availableInterfaces: Set<CmxNetworkInterfaceIdentity>
+    let systemInterfaces: [CmxTailscaleInterfaceSnapshot]
+}
+
+struct CmxTailscaleConnectionPathSnapshot: Equatable, Sendable {
+    let isSatisfied: Bool
+    let availableInterfaces: Set<CmxNetworkInterfaceIdentity>
+    let localAddress: CmxTailscaleIPAddress?
+    let remoteAddress: CmxTailscaleIPAddress?
+    let remotePort: Int?
+}
+
+struct CmxTailscaleRouteProof: Equatable, Sendable {
+    let request: CmxByteTransportRequest
+    let peerAddress: CmxTailscaleIPAddress
+    let peerPort: Int
+    let interface: CmxNetworkInterfaceIdentity
+    let selfAddresses: Set<CmxTailscaleIPAddress>
+    let generation: UInt64
+}
+
+struct CmxTailscaleRouteProofValidator {
+    func prepare(
+        request: CmxByteTransportRequest,
+        snapshot: CmxTailscaleAuthoritySnapshot
+    ) throws -> CmxTailscaleRouteProof {
+        guard request.route.kind == .tailscale else {
+            throw CmxTailscaleRouteProofError.unsupportedRouteKind
+        }
+        guard case let .legacyTailscaleBearer(evidence) = request.authorizationMode else {
+            throw CmxTailscaleRouteProofError.unsupportedAuthorizationMode
+        }
+        guard case let .hostPort(host, port) = request.route.endpoint else {
+            throw CmxTailscaleRouteProofError.unsupportedEndpoint
+        }
+        guard evidence.authorizes(
+            macDeviceID: request.expectedPeerDeviceID,
+            host: host,
+            port: port
+        ) else {
+            throw CmxTailscaleRouteProofError.authorizationEvidenceMismatch
+        }
+        guard let peerAddress = CmxTailscaleIPAddress(host) else {
+            throw CmxTailscaleRouteProofError.nonNumericPeer
+        }
+        guard peerAddress.isTailscalePeerAddress else {
+            throw CmxTailscaleRouteProofError.peerOutsideTailscaleRange
+        }
+        guard snapshot.pathSatisfied else {
+            throw CmxTailscaleRouteProofError.pathUnavailable
+        }
+
+        let candidates = tailscaleInterfaceCandidates(in: snapshot)
+        guard !candidates.isEmpty else {
+            throw CmxTailscaleRouteProofError.tailscaleInterfaceUnavailable
+        }
+        guard candidates.count == 1, let candidate = candidates.first else {
+            throw CmxTailscaleRouteProofError.ambiguousTailscaleInterfaces
+        }
+        guard !candidate.tailnetAddresses.contains(peerAddress) else {
+            throw CmxTailscaleRouteProofError.peerIsLocalDevice
+        }
+
+        return CmxTailscaleRouteProof(
+            request: request,
+            peerAddress: peerAddress,
+            peerPort: port,
+            interface: candidate.identity,
+            selfAddresses: candidate.tailnetAddresses,
+            generation: snapshot.generation
+        )
+    }
+
+    func validate(
+        proof: CmxTailscaleRouteProof,
+        authoritySnapshot: CmxTailscaleAuthoritySnapshot,
+        connectionPath: CmxTailscaleConnectionPathSnapshot
+    ) throws {
+        guard authoritySnapshot.generation == proof.generation else {
+            throw CmxTailscaleRouteProofError.routeGenerationChanged
+        }
+        guard authoritySnapshot.pathSatisfied else {
+            throw CmxTailscaleRouteProofError.pathUnavailable
+        }
+        let candidates = tailscaleInterfaceCandidates(in: authoritySnapshot)
+        guard candidates.count == 1,
+              let candidate = candidates.first,
+              candidate.identity == proof.interface,
+              candidate.tailnetAddresses == proof.selfAddresses else {
+            throw CmxTailscaleRouteProofError.interfaceChanged
+        }
+        guard connectionPath.isSatisfied,
+              connectionPath.availableInterfaces.contains(proof.interface) else {
+            throw CmxTailscaleRouteProofError.connectionPathUnavailable
+        }
+        guard let localAddress = connectionPath.localAddress,
+              proof.selfAddresses.contains(localAddress) else {
+            throw CmxTailscaleRouteProofError.localEndpointMismatch
+        }
+        guard connectionPath.remoteAddress == proof.peerAddress else {
+            throw CmxTailscaleRouteProofError.remoteEndpointMismatch
+        }
+        guard connectionPath.remotePort == proof.peerPort else {
+            throw CmxTailscaleRouteProofError.remotePortMismatch
+        }
+    }
+
+    private func tailscaleInterfaceCandidates(
+        in snapshot: CmxTailscaleAuthoritySnapshot
+    ) -> [CmxTailscaleInterfaceSnapshot] {
+        snapshot.systemInterfaces.filter { interface in
+            interface.identity.name.hasPrefix("utun") &&
+                interface.identity.index > 0 &&
+                interface.isUp &&
+                interface.isRunning &&
+                snapshot.availableInterfaces.contains(interface.identity) &&
+                !interface.tailnetAddresses.isEmpty
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleTransportBinding.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxTailscaleTransportBinding.swift
@@ -1,0 +1,7 @@
+internal import CMUXMobileCore
+
+struct CmxTailscaleTransportBinding: Sendable {
+    let request: CmxByteTransportRequest
+    let preparedRoute: CmxPreparedTailscaleRoute
+    let authority: any CmxTailscaleRouteAuthorizing
+}

--- a/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxNetworkByteTransportFactorySecurityTests.swift
+++ b/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxNetworkByteTransportFactorySecurityTests.swift
@@ -1,6 +1,29 @@
 import CMUXMobileCore
+import Network
 import Testing
 @testable import CmuxMobileTransport
+
+private enum RejectingTailscaleAuthorityError: Error {
+    case rejected
+}
+
+private actor RejectingTailscaleAuthority: CmxTailscaleRouteAuthorizing {
+    private(set) var preparationCount = 0
+
+    func prepare(
+        request _: CmxByteTransportRequest
+    ) throws -> CmxPreparedTailscaleRoute {
+        preparationCount += 1
+        throw RejectingTailscaleAuthorityError.rejected
+    }
+
+    func validate(
+        proof _: CmxTailscaleRouteProof,
+        connectionPath _: NWPath
+    ) throws {
+        throw RejectingTailscaleAuthorityError.rejected
+    }
+}
 
 @Suite struct CmxTransportFactorySecurityTests {
     @Test func buildsLoopbackTransportWithExplicitAuthorizationIntent() throws {
@@ -86,4 +109,86 @@ import Testing
             _ = try factory.makeTransport(for: request)
         }
     }
+
+    @Test func preparesExactGrandfatheredTailscaleGrantAtConnectBoundary() async throws {
+        let request = try legacyTailscaleRequest()
+        let authority = RejectingTailscaleAuthority()
+        let factory = CmxNetworkByteTransportFactory(
+            tailscaleRouteAuthority: authority
+        )
+
+        let transport = try factory.makeTransport(for: request)
+        #expect(transport is CmxPreparingTailscaleByteTransport)
+        #expect(await authority.preparationCount == 0)
+
+        await #expect(throws: CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable) {
+            try await transport.connect()
+        }
+        #expect(await authority.preparationCount == 1)
+    }
+
+    @Test func rejectsEveryGrandfatheredGrantSubstitutionBeforeDial() throws {
+        let validRequest = try legacyTailscaleRequest()
+        let validEvidence = try CmxLegacyTailscaleAuthorizationEvidence(
+            macDeviceID: "mac-1",
+            host: "100.71.210.41",
+            port: 58_465
+        )
+        let factory = CmxNetworkByteTransportFactory()
+
+        let deviceSubstitution = CmxByteTransportRequest(
+            route: validRequest.route,
+            expectedPeerDeviceID: "mac-2",
+            authorizationMode: .legacyTailscaleBearer(validEvidence)
+        )
+        #expect(throws: CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable) {
+            _ = try factory.makeTransport(for: deviceSubstitution)
+        }
+
+        let hostSubstitution = CmxByteTransportRequest(
+            route: try CmxAttachRoute(
+                id: "tailscale",
+                kind: .tailscale,
+                endpoint: .hostPort(host: "100.71.210.42", port: 58_465)
+            ),
+            expectedPeerDeviceID: "mac-1",
+            authorizationMode: .legacyTailscaleBearer(validEvidence)
+        )
+        #expect(throws: CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable) {
+            _ = try factory.makeTransport(for: hostSubstitution)
+        }
+
+        let portSubstitution = CmxByteTransportRequest(
+            route: try CmxAttachRoute(
+                id: "tailscale",
+                kind: .tailscale,
+                endpoint: .hostPort(host: "100.71.210.41", port: 58_466)
+            ),
+            expectedPeerDeviceID: "mac-1",
+            authorizationMode: .legacyTailscaleBearer(validEvidence)
+        )
+        #expect(throws: CmxNetworkByteTransportError.tailscaleAuthorizationUnavailable) {
+            _ = try factory.makeTransport(for: portSubstitution)
+        }
+    }
+}
+
+private func legacyTailscaleRequest() throws -> CmxByteTransportRequest {
+    let host = "100.71.210.41"
+    let port = 58_465
+    return CmxByteTransportRequest(
+        route: try CmxAttachRoute(
+            id: "tailscale",
+            kind: .tailscale,
+            endpoint: .hostPort(host: host, port: port)
+        ),
+        expectedPeerDeviceID: "mac-1",
+        authorizationMode: .legacyTailscaleBearer(
+            try CmxLegacyTailscaleAuthorizationEvidence(
+                macDeviceID: "mac-1",
+                host: host,
+                port: port
+            )
+        )
+    )
 }

--- a/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxTailscaleRouteProofTests.swift
+++ b/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxTailscaleRouteProofTests.swift
@@ -1,0 +1,226 @@
+import CMUXMobileCore
+import Testing
+@testable import CmuxMobileTransport
+
+private let tailscaleInterface = CmxNetworkInterfaceIdentity(name: "utun4", index: 22)
+
+@Suite struct CmxTailscaleRouteProofTests {
+    @Test func rejectsGenericBearerAndMismatchedLegacyEvidence() throws {
+        let genericBearer = try tailscaleRequest(
+            host: "100.71.210.41",
+            authorizationMode: .stackBearer
+        )
+        let mismatchedEvidence = try CmxLegacyTailscaleAuthorizationEvidence(
+            macDeviceID: "mac-2",
+            host: "100.71.210.41",
+            port: 58_465
+        )
+        let mismatch = try tailscaleRequest(
+            host: "100.71.210.41",
+            authorizationMode: .legacyTailscaleBearer(mismatchedEvidence)
+        )
+        let snapshot = authoritySnapshot(generation: 1)
+
+        #expect(throws: CmxTailscaleRouteProofError.unsupportedAuthorizationMode) {
+            _ = try CmxTailscaleRouteProofValidator().prepare(
+                request: genericBearer,
+                snapshot: snapshot
+            )
+        }
+        #expect(throws: CmxTailscaleRouteProofError.authorizationEvidenceMismatch) {
+            _ = try CmxTailscaleRouteProofValidator().prepare(
+                request: mismatch,
+                snapshot: snapshot
+            )
+        }
+    }
+
+    @Test func rejectsWhenNoUnambiguousLiveTailscaleInterfaceExists() throws {
+        let request = try tailscaleRequest(host: "100.71.210.41")
+        let noTailscale = CmxTailscaleAuthoritySnapshot(
+            generation: 1,
+            pathSatisfied: true,
+            availableInterfaces: [CmxNetworkInterfaceIdentity(name: "en0", index: 15)],
+            systemInterfaces: [
+                interface(name: "en0", index: 15, addresses: ["192.168.1.10"])
+            ]
+        )
+        let second = CmxNetworkInterfaceIdentity(name: "utun5", index: 23)
+        let ambiguous = CmxTailscaleAuthoritySnapshot(
+            generation: 1,
+            pathSatisfied: true,
+            availableInterfaces: [tailscaleInterface, second],
+            systemInterfaces: [
+                interface(name: "utun4", index: 22, addresses: ["100.70.231.80"]),
+                interface(name: "utun5", index: 23, addresses: ["100.68.1.2"]),
+            ]
+        )
+
+        #expect(throws: CmxTailscaleRouteProofError.tailscaleInterfaceUnavailable) {
+            _ = try CmxTailscaleRouteProofValidator().prepare(
+                request: request,
+                snapshot: noTailscale
+            )
+        }
+        #expect(throws: CmxTailscaleRouteProofError.ambiguousTailscaleInterfaces) {
+            _ = try CmxTailscaleRouteProofValidator().prepare(
+                request: request,
+                snapshot: ambiguous
+            )
+        }
+    }
+
+    @Test func validatesExactInterfaceBoundIPv4AndIPv6Peers() throws {
+        let snapshot = authoritySnapshot(generation: 41)
+        let ipv4 = try tailscaleRequest(host: "100.71.210.41")
+        let ipv4Proof = try CmxTailscaleRouteProofValidator().prepare(
+            request: ipv4,
+            snapshot: snapshot
+        )
+        try CmxTailscaleRouteProofValidator().validate(
+            proof: ipv4Proof,
+            authoritySnapshot: snapshot,
+            connectionPath: connectionPath()
+        )
+
+        let ipv6 = try tailscaleRequest(host: "fd7a:115c:a1e0::1234")
+        let ipv6Proof = try CmxTailscaleRouteProofValidator().prepare(
+            request: ipv6,
+            snapshot: snapshot
+        )
+        try CmxTailscaleRouteProofValidator().validate(
+            proof: ipv6Proof,
+            authoritySnapshot: snapshot,
+            connectionPath: connectionPath(remoteAddress: "fd7a:115c:a1e0::1234")
+        )
+
+        #expect(ipv4Proof.interface == tailscaleInterface)
+        #expect(ipv4Proof.request.expectedPeerDeviceID == "mac-1")
+    }
+
+    @Test func rejectsGenerationInterfaceAndEffectiveEndpointSubstitution() throws {
+        let request = try tailscaleRequest(host: "100.71.210.41")
+        let snapshot = authoritySnapshot(generation: 41)
+        let proof = try CmxTailscaleRouteProofValidator().prepare(
+            request: request,
+            snapshot: snapshot
+        )
+        let replacement = CmxNetworkInterfaceIdentity(name: "utun5", index: 23)
+
+        #expect(throws: CmxTailscaleRouteProofError.routeGenerationChanged) {
+            try CmxTailscaleRouteProofValidator().validate(
+                proof: proof,
+                authoritySnapshot: authoritySnapshot(generation: 42),
+                connectionPath: connectionPath()
+            )
+        }
+        #expect(throws: CmxTailscaleRouteProofError.connectionPathUnavailable) {
+            try CmxTailscaleRouteProofValidator().validate(
+                proof: proof,
+                authoritySnapshot: snapshot,
+                connectionPath: CmxTailscaleConnectionPathSnapshot(
+                    isSatisfied: true,
+                    availableInterfaces: [replacement],
+                    localAddress: CmxTailscaleIPAddress("100.70.231.80"),
+                    remoteAddress: CmxTailscaleIPAddress("100.71.210.41"),
+                    remotePort: 58_465
+                )
+            )
+        }
+        #expect(throws: CmxTailscaleRouteProofError.remoteEndpointMismatch) {
+            try CmxTailscaleRouteProofValidator().validate(
+                proof: proof,
+                authoritySnapshot: snapshot,
+                connectionPath: connectionPath(remoteAddress: "100.71.210.42")
+            )
+        }
+        #expect(throws: CmxTailscaleRouteProofError.remotePortMismatch) {
+            try CmxTailscaleRouteProofValidator().validate(
+                proof: proof,
+                authoritySnapshot: snapshot,
+                connectionPath: connectionPath(remotePort: 58_466)
+            )
+        }
+    }
+
+    @Test func authorizationFailureCannotReachSendBoundary() async throws {
+        let transport = try CmxNetworkByteTransport(host: "127.0.0.1", port: 58_465)
+        var didBeginWrite = false
+
+        await #expect(throws: CmxTailscaleRouteProofError.routeGenerationChanged) {
+            try await transport.performAuthorizedWrite(
+                authorization: {
+                    throw CmxTailscaleRouteProofError.routeGenerationChanged
+                },
+                beginWrite: {
+                    didBeginWrite = true
+                }
+            )
+        }
+        #expect(!didBeginWrite)
+    }
+}
+
+private func tailscaleRequest(
+    host: String,
+    authorizationMode: CmxTransportAuthorizationMode? = nil
+) throws -> CmxByteTransportRequest {
+    let port = 58_465
+    let mode = try authorizationMode ?? .legacyTailscaleBearer(
+        CmxLegacyTailscaleAuthorizationEvidence(
+            macDeviceID: "mac-1",
+            host: host,
+            port: port
+        )
+    )
+    return CmxByteTransportRequest(
+        route: try CmxAttachRoute(
+            id: "tailscale",
+            kind: .tailscale,
+            endpoint: .hostPort(host: host, port: port)
+        ),
+        expectedPeerDeviceID: "mac-1",
+        authorizationMode: mode
+    )
+}
+
+private func authoritySnapshot(generation: UInt64) -> CmxTailscaleAuthoritySnapshot {
+    CmxTailscaleAuthoritySnapshot(
+        generation: generation,
+        pathSatisfied: true,
+        availableInterfaces: [tailscaleInterface],
+        systemInterfaces: [
+            interface(
+                name: tailscaleInterface.name,
+                index: tailscaleInterface.index,
+                addresses: ["100.70.231.80", "fd7a:115c:a1e0::6c36:e750"]
+            )
+        ]
+    )
+}
+
+private func interface(
+    name: String,
+    index: Int,
+    addresses: [String]
+) -> CmxTailscaleInterfaceSnapshot {
+    CmxTailscaleInterfaceSnapshot(
+        identity: CmxNetworkInterfaceIdentity(name: name, index: index),
+        isUp: true,
+        isRunning: true,
+        addresses: Set(addresses.compactMap(CmxTailscaleIPAddress.init))
+    )
+}
+
+private func connectionPath(
+    remoteAddress: String = "100.71.210.41",
+    remotePort: Int = 58_465
+) -> CmxTailscaleConnectionPathSnapshot {
+    CmxTailscaleConnectionPathSnapshot(
+        isSatisfied: true,
+        availableInterfaces: [tailscaleInterface],
+        localAddress: CmxTailscaleIPAddress("100.70.231.80"),
+        remoteAddress: CmxTailscaleIPAddress(remoteAddress),
+        remotePort: remotePort
+    )
+}


### PR DESCRIPTION
## Summary
- migrate only authenticated local v7 Tailscale pairings into a non-exportable compatibility grant
- bind compatibility traffic to the exact Mac, IP, port, live Tailscale-range utun path, and effective endpoints
- revoke the compatibility path as soon as an authenticated Iroh route is published
- preserve the grant through legitimate local scope changes while keeping restored, anonymous, fresh, and generic raw routes fail-closed

## Verification
- regression-only commit: df219b097e
- CMUXMobileCore: 232 tests passed
- CmuxMobilePairedMac: 29 tests passed
- CmuxMobileTransport: 40 tests passed
- CmuxMobileRPC: 106 tests passed
- CmuxMobileShell: 616 tests passed
- tagged macOS cloud build: run 29703564981
- isolated iOS Simulator build, auto-pair, workspace sync: passed on 13327B5C-325F-4C6F-BF8C-C36AA3EBC14A

## Residual risk
A physical iPhone Tailscale path is not exercised here. Apple does not expose a cryptographic VPN-provider identity, so the compatibility path fails closed unless the exact Tailscale-range address is carried by one live utun interface and the connection endpoints still match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787087841&installation_id=133855650&pr_number=8498&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8498&signature=f1581dc646407e2ff30759322b291d0328048672abdb3e0c2553acbeffbb39fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep existing Tailscale pairings working during staggered Iroh upgrades without weakening security. Adds a strict, local-only grant that allows a Stack bearer over Tailscale only to the exact pre-Iroh peer, and prefers Iroh as soon as it is available.

- **New Features**
  - Added `legacyTailscaleBearer` and `CmxLegacyTailscaleAuthorizationEvidence` (binds Mac device ID, numeric Tailscale IP, TCP port; canonicalizes and validates inputs).
  - Proved and enforced Tailscale bindings via `CmxTailscaleRouteAuthority` and `CmxTailscaleRouteProof` (must match live `utun` interface and connection endpoints; plaintext fails closed on any mismatch).
  - Updated `CmxNetworkByteTransportFactory` to prepare a proven interface using `CmxPreparingTailscaleByteTransport`; threaded evidence through `MobileCoreRPCClient` and `MobileShellComposite` to use the legacy path only for the exact pre-Iroh route and switch to Iroh when available.

- **Migration**
  - Bumped `MobilePairedMacStore` to schema v8: grandfathered only authenticated, local v7 Tailscale routes into a non-exportable local grant (not Codable, not backed up, not synced).
  - Moved grants on ownership changes; excluded restored, anonymous, fresh, and generic routes so they fail closed.
  - Added tests across `CMUXMobileCore`, `CmuxMobileTransport`, `CmuxMobileRPC`, and `CmuxMobileShell` for migration, proof, and reconnect behavior.

<sup>Written for commit cc0b2111da02907e433188bf2ea68b21c4ff3377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reconnecting to legacy Tailscale routes for compatible paired Macs.
  * Added strict authorization matching for device, host, and port details.
  * Added live Tailscale path and interface validation before and during connections.
  * Added database migration support to preserve eligible legacy routes while revoking them when newer secure routes are established.

* **Bug Fixes**
  * Prevented mismatched or invalid legacy routes from connecting.
  * Ensured authorization failures stop network activity before data is sent.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->