### PR TITLE
Inherit Ghostty font in cmux-tui web

### DIFF
--- a/cmux-tui/bindings/typescript/src/protocol/events.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/events.ts
@@ -184,6 +184,8 @@ export interface TerminalColors {
   cursor_style?: "block" | "underline" | "bar" | null;
   /** Protocol v6 additive extension. Older servers omit this field. */
   cursor_blink?: boolean | null;
+  /** Protocol v7 additive extension inherited from Ghostty. */
+  font_family?: string | null;
 }
 
 /** Initial base64 VT replay for an attached PTY surface. */

--- a/cmux-tui/bindings/typescript/src/protocol/render.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/render.ts
@@ -52,6 +52,8 @@ export interface RenderDeltaEvent {
   size?: Size;
   default_fg?: ColorHex;
   default_bg?: ColorHex;
+  /** Protocol v7 additive extension updated when Ghostty's configured font changes. */
+  font_family?: string | null;
   scrollback_rows?: number;
   rows: RenderRow[];
 }

--- a/cmux-tui/bindings/typescript/src/protocol/render.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/render.ts
@@ -37,6 +37,8 @@ export interface RenderStateEvent {
   cursor: RenderCursor;
   default_fg: ColorHex;
   default_bg: ColorHex;
+  /** Protocol v7 additive extension inherited from Ghostty. */
+  font_family?: string | null;
   scrollback_rows: number;
   rows: RenderRow[];
 }

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -537,6 +537,7 @@ pub struct Mux {
     browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
     cell_pixels: Mutex<(u16, u16)>,
     default_colors: Mutex<DefaultColors>,
+    terminal_font_family: Mutex<Option<String>>,
     sidebar_plugin: Mutex<SidebarPluginRuntime>,
     agent_records: Mutex<HashMap<SurfaceId, AgentRecord>>,
     surface_notifications: Mutex<HashMap<SurfaceId, SurfaceNotification>>,
@@ -600,6 +601,7 @@ impl Mux {
             browser_runtime: Mutex::new(None),
             cell_pixels: Mutex::new((8, 16)),
             default_colors: Mutex::new(DefaultColors::default()),
+            terminal_font_family: Mutex::new(None),
             sidebar_plugin: Mutex::new(SidebarPluginRuntime::default()),
             agent_records: Mutex::new(HashMap::new()),
             surface_notifications: Mutex::new(HashMap::new()),
@@ -1906,6 +1908,18 @@ impl Mux {
             surface.set_default_colors(colors);
             self.emit(MuxEvent::SurfaceOutput(surface.id));
         }
+    }
+
+    pub fn terminal_font_family(&self) -> Option<String> {
+        self.terminal_font_family.lock().unwrap().clone()
+    }
+
+    pub fn set_terminal_font_family(&self, font_family: Option<String>) {
+        let font_family = font_family.and_then(|value| {
+            let value = value.trim();
+            (!value.is_empty()).then(|| value.to_string())
+        });
+        *self.terminal_font_family.lock().unwrap() = font_family;
     }
 
     /// Resize a surface and broadcast the final clamped size when it actually

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1919,7 +1919,21 @@ impl Mux {
             let value = value.trim();
             (!value.is_empty()).then(|| value.to_string())
         });
-        *self.terminal_font_family.lock().unwrap() = font_family;
+        {
+            let mut current = self.terminal_font_family.lock().unwrap();
+            if *current == font_family {
+                return;
+            }
+            *current = font_family;
+        }
+        let colors = self.default_colors();
+        let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();
+        for surface in surfaces {
+            // Reuse the appearance stream already consumed by byte clients,
+            // while the rebuilt render frame carries the font delta below.
+            surface.set_default_colors(colors);
+            self.emit(MuxEvent::SurfaceOutput(surface.id));
+        }
     }
 
     /// Resize a surface and broadcast the final clamped size when it actually

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -538,6 +538,7 @@ pub struct Mux {
     cell_pixels: Mutex<(u16, u16)>,
     default_colors: Mutex<DefaultColors>,
     terminal_font_family: Mutex<Option<String>>,
+    terminal_font_generation: AtomicU64,
     sidebar_plugin: Mutex<SidebarPluginRuntime>,
     agent_records: Mutex<HashMap<SurfaceId, AgentRecord>>,
     surface_notifications: Mutex<HashMap<SurfaceId, SurfaceNotification>>,
@@ -602,6 +603,7 @@ impl Mux {
             cell_pixels: Mutex::new((8, 16)),
             default_colors: Mutex::new(DefaultColors::default()),
             terminal_font_family: Mutex::new(None),
+            terminal_font_generation: AtomicU64::new(0),
             sidebar_plugin: Mutex::new(SidebarPluginRuntime::default()),
             agent_records: Mutex::new(HashMap::new()),
             surface_notifications: Mutex::new(HashMap::new()),
@@ -1914,6 +1916,16 @@ impl Mux {
         self.terminal_font_family.lock().unwrap().clone()
     }
 
+    pub(crate) fn terminal_font_generation(&self) -> u64 {
+        self.terminal_font_generation.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn terminal_font_snapshot(&self) -> (u64, Option<String>) {
+        let font_family = self.terminal_font_family.lock().unwrap().clone();
+        let generation = self.terminal_font_generation.load(Ordering::Acquire);
+        (generation, font_family)
+    }
+
     pub fn set_terminal_font_family(&self, font_family: Option<String>) {
         let font_family = font_family.and_then(|value| {
             let value = value.trim();
@@ -1925,6 +1937,7 @@ impl Mux {
                 return;
             }
             *current = font_family;
+            self.terminal_font_generation.fetch_add(1, Ordering::Release);
         }
         let colors = self.default_colors();
         let surfaces = self.state.lock().unwrap().surfaces.values().cloned().collect::<Vec<_>>();

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -2346,22 +2346,30 @@ fn render_state_json(
 struct RenderClientState {
     size: (u16, u16),
     default_colors: (Rgb, Rgb),
+    font_family: Option<String>,
     scrollback_rows: u32,
 }
 
 impl RenderClientState {
-    fn new(frame: &SurfaceRenderFrame) -> Self {
+    fn new(frame: &SurfaceRenderFrame, font_family: Option<String>) -> Self {
         Self {
             size: frame.frame.size,
             default_colors: frame.frame.default_colors,
+            font_family,
             scrollback_rows: frame.scrollback_rows,
         }
     }
 
-    fn delta_json(&mut self, surface: SurfaceId, frame: &SurfaceRenderFrame) -> Value {
+    fn delta_json(
+        &mut self,
+        surface: SurfaceId,
+        frame: &SurfaceRenderFrame,
+        font_family: Option<&str>,
+    ) -> Value {
         let size_changed = self.size != frame.frame.size;
         let foreground_changed = self.default_colors.1 != frame.frame.default_colors.1;
         let background_changed = self.default_colors.0 != frame.frame.default_colors.0;
+        let font_changed = self.font_family.as_deref() != font_family;
         let scrollback_changed = self.scrollback_rows != frame.scrollback_rows;
         let full = size_changed
             || foreground_changed
@@ -2388,11 +2396,15 @@ impl RenderClientState {
         if background_changed {
             value["default_bg"] = json!(rgb_hex(frame.frame.default_colors.0));
         }
+        if font_changed {
+            value["font_family"] = json!(font_family);
+        }
         if scrollback_changed {
             value["scrollback_rows"] = json!(frame.scrollback_rows);
         }
         self.size = frame.frame.size;
         self.default_colors = frame.frame.default_colors;
+        self.font_family = font_family.map(str::to_string);
         self.scrollback_rows = frame.scrollback_rows;
         value
     }
@@ -3511,14 +3523,15 @@ fn handle_command(
                         if worker_committed.recv().is_err() {
                             return;
                         }
-                        let mut state = RenderClientState::new(&attach.initial);
+                        let mut state = RenderClientState::new(&attach.initial, font_family);
                         while writer.is_open()
                             && outbound_stream.is_open()
                             && !lifecycle.is_canceled()
                         {
                             let value = match attach.stream.recv_timeout(STREAM_DISCONNECT_POLL) {
                                 Ok(RenderAttachFrame::Frame(frame)) => {
-                                    state.delta_json(surface_id, &frame)
+                                    let font_family = mux.terminal_font_family();
+                                    state.delta_json(surface_id, &frame, font_family.as_deref())
                                 }
                                 Ok(RenderAttachFrame::ScrollChanged { offset, at_bottom }) => {
                                     json!({

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -2364,12 +2364,13 @@ impl RenderClientState {
         &mut self,
         surface: SurfaceId,
         frame: &SurfaceRenderFrame,
-        font_family: Option<&str>,
+        font_family_update: Option<Option<String>>,
     ) -> Value {
         let size_changed = self.size != frame.frame.size;
         let foreground_changed = self.default_colors.1 != frame.frame.default_colors.1;
         let background_changed = self.default_colors.0 != frame.frame.default_colors.0;
-        let font_changed = self.font_family.as_deref() != font_family;
+        let font_changed =
+            font_family_update.as_ref().is_some_and(|font_family| self.font_family != *font_family);
         let scrollback_changed = self.scrollback_rows != frame.scrollback_rows;
         let full = size_changed
             || foreground_changed
@@ -2397,14 +2398,16 @@ impl RenderClientState {
             value["default_bg"] = json!(rgb_hex(frame.frame.default_colors.0));
         }
         if font_changed {
-            value["font_family"] = json!(font_family);
+            value["font_family"] = json!(font_family_update.as_ref().unwrap());
         }
         if scrollback_changed {
             value["scrollback_rows"] = json!(frame.scrollback_rows);
         }
         self.size = frame.frame.size;
         self.default_colors = frame.frame.default_colors;
-        self.font_family = font_family.map(str::to_string);
+        if let Some(font_family) = font_family_update {
+            self.font_family = font_family;
+        }
         self.scrollback_rows = frame.scrollback_rows;
         value
     }
@@ -3493,7 +3496,7 @@ fn handle_command(
                         return Err(error.into());
                     }
                 };
-                let font_family = mux.terminal_font_family();
+                let (font_generation, font_family) = mux.terminal_font_snapshot();
                 if let Err(error) = writer.send_initial(
                     &render_state_json(surface_id, &attach.initial, font_family.as_deref()),
                     &outbound_stream,
@@ -3524,14 +3527,22 @@ fn handle_command(
                             return;
                         }
                         let mut state = RenderClientState::new(&attach.initial, font_family);
+                        let mut font_generation = font_generation;
                         while writer.is_open()
                             && outbound_stream.is_open()
                             && !lifecycle.is_canceled()
                         {
                             let value = match attach.stream.recv_timeout(STREAM_DISCONNECT_POLL) {
                                 Ok(RenderAttachFrame::Frame(frame)) => {
-                                    let font_family = mux.terminal_font_family();
-                                    state.delta_json(surface_id, &frame, font_family.as_deref())
+                                    let current_generation = mux.terminal_font_generation();
+                                    let font_family_update =
+                                        (current_generation != font_generation).then(|| {
+                                            let (generation, font_family) =
+                                                mux.terminal_font_snapshot();
+                                            font_generation = generation;
+                                            font_family
+                                        });
+                                    state.delta_json(surface_id, &frame, font_family_update)
                                 }
                                 Ok(RenderAttachFrame::ScrollChanged { offset, at_bottom }) => {
                                     json!({

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -2238,7 +2238,7 @@ fn color_hex(color: Option<Rgb>) -> Option<String> {
     color.map(|color| format!("#{:02x}{:02x}{:02x}", color.r, color.g, color.b))
 }
 
-fn terminal_colors_json(colors: TerminalColors) -> Value {
+fn terminal_colors_json(colors: TerminalColors, font_family: Option<&str>) -> Value {
     let cursor_style = colors.cursor_style.map(|style| match style {
         ghostty_vt::CursorShape::Bar => "bar",
         ghostty_vt::CursorShape::Underline => "underline",
@@ -2261,6 +2261,7 @@ fn terminal_colors_json(colors: TerminalColors) -> Value {
         "palette": palette,
         "cursor_style": cursor_style,
         "cursor_blink": colors.cursor_blink,
+        "font_family": font_family,
     })
 }
 
@@ -2323,7 +2324,11 @@ fn render_cursor_json(frame: &SurfaceRenderFrame) -> Value {
     })
 }
 
-fn render_state_json(surface: SurfaceId, frame: &SurfaceRenderFrame) -> Value {
+fn render_state_json(
+    surface: SurfaceId,
+    frame: &SurfaceRenderFrame,
+    font_family: Option<&str>,
+) -> Value {
     let (cols, rows) = frame.frame.size;
     json!({
         "event": "render-state",
@@ -2332,6 +2337,7 @@ fn render_state_json(surface: SurfaceId, frame: &SurfaceRenderFrame) -> Value {
         "cursor": render_cursor_json(frame),
         "default_fg": rgb_hex(frame.frame.default_colors.1),
         "default_bg": rgb_hex(frame.frame.default_colors.0),
+        "font_family": font_family,
         "scrollback_rows": frame.scrollback_rows,
         "rows": render_rows_json(frame, 0..rows),
     })
@@ -3475,9 +3481,11 @@ fn handle_command(
                         return Err(error.into());
                     }
                 };
-                if let Err(error) = writer
-                    .send_initial(&render_state_json(surface_id, &attach.initial), &outbound_stream)
-                {
+                let font_family = mux.terminal_font_family();
+                if let Err(error) = writer.send_initial(
+                    &render_state_json(surface_id, &attach.initial, font_family.as_deref()),
+                    &outbound_stream,
+                ) {
                     handle_attach_send_error(&lifecycle, &error);
                     rollback_failed_attach(
                         mux,
@@ -3749,7 +3757,10 @@ fn handle_command(
                     "cols": attach.cols,
                     "rows": attach.rows,
                     "data": base64::engine::general_purpose::STANDARD.encode(attach.replay),
-                    "colors": terminal_colors_json(attach.colors),
+                    "colors": terminal_colors_json(
+                        attach.colors,
+                        mux.terminal_font_family().as_deref(),
+                    ),
                 }),
                 &outbound_stream,
             ) {
@@ -3811,11 +3822,18 @@ fn handle_command(
                                     "cols": cols,
                                     "rows": rows,
                                     "replay": base64::engine::general_purpose::STANDARD.encode(replay),
-                                    "colors": terminal_colors_json(*colors),
+                                    "colors": terminal_colors_json(
+                                        *colors,
+                                        mux.terminal_font_family().as_deref(),
+                                    ),
                                 })
                             }
                             AttachFrame::ColorsChanged(colors) => {
-                                let mut value = terminal_colors_json(*colors);
+                                let font_family = mux.terminal_font_family();
+                                let mut value = terminal_colors_json(
+                                    *colors,
+                                    font_family.as_deref(),
+                                );
                                 value["event"] = json!("colors-changed");
                                 value["surface"] = json!(surface_id);
                                 value

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -632,6 +632,7 @@ fn control_socket_attach_vt_state_includes_effective_colors() {
             "palette": {"4": "#112233"},
             "cursor_style": "bar",
             "cursor_blink": false,
+            "font_family": null,
         })
     );
 
@@ -767,6 +768,7 @@ fn control_socket_attach_stream_receives_merged_colors_changed() {
             "palette": {},
             "cursor_style": "bar",
             "cursor_blink": false,
+            "font_family": null,
         })
     );
 

--- a/cmux-tui/crates/cmux-tui-core/tests/pty.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/pty.rs
@@ -1149,6 +1149,35 @@ fn render_attach_headless_fans_one_frame_to_render_and_byte_consumers() {
     );
     assert!(output.is_some(), "byte attachment stopped while render attachment was active");
 
+    mux.set_terminal_font_family(Some("JetBrains Mono".to_string()));
+    let font_delta = wait_for(
+        || {
+            while let Some(value) = read_json_line(&mut render_reader) {
+                if value["event"] == "render-delta" && value["font_family"] == "JetBrains Mono" {
+                    return Some(value);
+                }
+            }
+            None
+        },
+        Duration::from_secs(5),
+    )
+    .expect("render font delta");
+    assert_eq!(font_delta["font_family"], "JetBrains Mono");
+
+    let font_colors = wait_for(
+        || {
+            while let Some(value) = read_json_line(&mut byte_reader) {
+                if value["event"] == "colors-changed" && value["font_family"] == "JetBrains Mono" {
+                    return Some(value);
+                }
+            }
+            None
+        },
+        Duration::from_secs(5),
+    )
+    .expect("byte font appearance update");
+    assert_eq!(font_colors["font_family"], "JetBrains Mono");
+
     mux.close_surface(surface.id);
     cmux_tui_core::server::cleanup(&sock_path);
 }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -999,6 +999,7 @@ pub struct Config {
     pub theme: Theme,
     pub theme_overrides: ThemeOverrides,
     pub terminal_defaults: DefaultColors,
+    pub terminal_font_family: Option<String>,
     pub cursor_style: Option<CursorShape>,
     pub cursor_blink: Option<bool>,
     pub chrome: ChromeMode,
@@ -1045,8 +1046,10 @@ pub struct SidebarPluginConfig {
 pub fn load() -> Config {
     let mut config = Config::default();
 
-    let defaults = ghostty_defaults();
+    let ghostty = ghostty_defaults();
+    let defaults = ghostty.colors;
     config.terminal_defaults = defaults;
+    config.terminal_font_family = ghostty.font_family;
     if let Some(bg) = defaults.selection_bg {
         config.theme.selection_bg = Color::Rgb(bg.r, bg.g, bg.b);
         config.theme_overrides.selection = true;
@@ -1352,16 +1355,28 @@ fn parse_color(s: &str) -> Option<Color> {
 
 /// The user's relevant Ghostty settings with Ghostty's application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
-fn ghostty_defaults() -> DefaultColors {
+#[derive(Default)]
+struct GhosttyDefaults {
+    colors: DefaultColors,
+    font_family: Option<String>,
+}
+
+fn ghostty_defaults() -> GhosttyDefaults {
     let parsed = resolved_ghostty_defaults()
         .or_else(|| {
             let text = platform::ghostty_config_paths()
                 .iter()
                 .find_map(|path| std::fs::read_to_string(path).ok())?;
-            Some(parse_ghostty_defaults(&text))
+            Some(GhosttyDefaults {
+                colors: parse_ghostty_defaults(&text),
+                font_family: parse_ghostty_font_family(&text),
+            })
         })
         .unwrap_or_default();
-    resolve_ghostty_application_defaults(parsed)
+    GhosttyDefaults {
+        colors: resolve_ghostty_application_defaults(parsed.colors),
+        font_family: parsed.font_family,
+    }
 }
 
 fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultColors {
@@ -1373,11 +1388,13 @@ fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultC
 /// Ask Ghostty to resolve its configuration so cmux-tui inherits precisely the
 /// same theme-loading behavior as the graphical terminal. A failed or slow
 /// invocation is deliberately ignored; startup then uses the file fallback.
-fn resolved_ghostty_defaults() -> Option<DefaultColors> {
-    platform::ghostty_binary_paths()
-        .iter()
-        .find_map(|path| run_ghostty_show_config(path))
-        .map(|text| parse_resolved_ghostty_defaults(&text))
+fn resolved_ghostty_defaults() -> Option<GhosttyDefaults> {
+    platform::ghostty_binary_paths().iter().find_map(|path| run_ghostty_show_config(path)).map(
+        |text| GhosttyDefaults {
+            colors: parse_resolved_ghostty_defaults(&text),
+            font_family: parse_ghostty_font_family(&text),
+        },
+    )
 }
 
 fn run_ghostty_show_config(path: &Path) -> Option<String> {
@@ -1451,6 +1468,22 @@ fn parse_resolved_ghostty_defaults(text: &str) -> DefaultColors {
         apply_ghostty_default(&mut defaults, key.trim(), value.trim());
     }
     defaults
+}
+
+fn parse_ghostty_font_family(text: &str) -> Option<String> {
+    text.lines().find_map(|line| {
+        let (key, value) = line.trim().split_once('=')?;
+        if key.trim() != "font-family" {
+            return None;
+        }
+        let value = value.trim();
+        let value = value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .unwrap_or(value)
+            .trim();
+        (!value.is_empty()).then(|| value.to_string())
+    })
 }
 
 fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
@@ -1604,6 +1637,17 @@ mod tests {
     }
 
     #[test]
+    fn parses_first_nonempty_ghostty_font_family_as_primary_face() {
+        assert_eq!(
+            parse_ghostty_font_family(
+                "font-family = \"Berkeley Mono\"\nfont-family = Symbols Nerd Font\n",
+            ),
+            Some("Berkeley Mono".to_string())
+        );
+        assert_eq!(parse_ghostty_font_family("font-family = \"\"\n"), None);
+    }
+
+    #[test]
     fn parses_ghostty_terminal_colors_and_palette_with_later_valid_entry_wins() {
         let defaults = parse_ghostty_defaults(
             "foreground = #010203\n\
@@ -1718,6 +1762,7 @@ mod tests {
             SurfaceOptions { command: Some(vec!["/bin/cat".to_string()]), ..Default::default() },
         );
         mux.set_default_colors(defaults);
+        mux.set_terminal_font_family(Some("Berkeley Mono".to_string()));
         let surface = mux.new_workspace(None, Some((20, 4))).unwrap();
         surface.try_with_terminal(|term| term.vt_write(b"\x1b[31mR")).unwrap();
         // Re-applying through the mux exercises the existing-surface path and
@@ -1742,6 +1787,7 @@ mod tests {
         assert_eq!(state["event"], "render-state");
         assert_eq!(state["default_fg"], "#010203");
         assert_eq!(state["default_bg"], "#131415");
+        assert_eq!(state["font_family"], "Berkeley Mono");
         assert_eq!(state["cursor"]["color"], "#c0c1b5");
         assert_eq!(state["cursor"]["style"], "bar");
         assert_eq!(state["cursor"]["blink"], false);

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -1471,10 +1471,11 @@ fn parse_resolved_ghostty_defaults(text: &str) -> DefaultColors {
 }
 
 fn parse_ghostty_font_family(text: &str) -> Option<String> {
-    text.lines().find_map(|line| {
-        let (key, value) = line.trim().split_once('=')?;
+    let mut primary = None;
+    for line in text.lines() {
+        let Some((key, value)) = line.trim().split_once('=') else { continue };
         if key.trim() != "font-family" {
-            return None;
+            continue;
         }
         let value = value.trim();
         let value = value
@@ -1482,8 +1483,13 @@ fn parse_ghostty_font_family(text: &str) -> Option<String> {
             .and_then(|value| value.strip_suffix('"'))
             .unwrap_or(value)
             .trim();
-        (!value.is_empty()).then(|| value.to_string())
-    })
+        if value.is_empty() {
+            primary = None;
+        } else if primary.is_none() {
+            primary = Some(value.to_string());
+        }
+    }
+    primary
 }
 
 fn apply_ghostty_default(defaults: &mut DefaultColors, key: &str, value: &str) {
@@ -1645,6 +1651,10 @@ mod tests {
             Some("Berkeley Mono".to_string())
         );
         assert_eq!(parse_ghostty_font_family("font-family = \"\"\n"), None);
+        assert_eq!(
+            parse_ghostty_font_family("font-family = Old\nfont-family = \"\"\nfont-family = New\n",),
+            Some("New".to_string())
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -240,6 +240,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     // Headless sessions have no host terminal to query, so seed the mux from
     // Ghostty's config before any protocol client can create a surface.
     mux.set_default_colors(config.terminal_defaults);
+    mux.set_terminal_font_family(config.terminal_font_family.clone());
     mux.configure_sidebar_plugin(config.sidebar.plugin.clone());
     let websocket_server = match ws_addr {
         Some(addr) => {

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -296,6 +296,7 @@ impl Session {
 
     pub fn apply_config(&self, config: &crate::config::Config) {
         if let Session::Local(mux) = self {
+            mux.set_terminal_font_family(config.terminal_font_family.clone());
             mux.update_surface_options(|options| {
                 crate::config::apply_browser_to_surface_options(config, options);
             });

--- a/cmux-tui/frontends/web/src/components/RenderTerminal.tsx
+++ b/cmux-tui/frontends/web/src/components/RenderTerminal.tsx
@@ -3,6 +3,7 @@ import type { CmuxClient, Id, RenderRow } from "cmux/browser";
 import { useRenderTerminal } from "../hooks/useRenderTerminal";
 import { t } from "../i18n";
 import { runPresentation } from "../lib/renderStyles";
+import { terminalFontStack } from "../lib/terminalFont";
 import { TerminalFrame } from "./TerminalFrame";
 
 interface RenderTerminalProps {
@@ -61,6 +62,7 @@ export function RenderTerminal({
   const defaultFg = model?.defaultFg ?? "var(--terminal-foreground)";
   const defaultBg = model?.defaultBg ?? "var(--terminal-background)";
   const cols = model?.size.cols ?? 0;
+  const fontFamily = terminalFontStack(model?.fontFamily);
   const gridStyle = {
     width: `calc(var(--render-cell-width) * ${cols})`,
     height: `calc(var(--render-cell-height) * ${rows.length})`,
@@ -83,7 +85,14 @@ export function RenderTerminal({
     >
       <div
         className="terminal-host render-terminal-host"
-        ref={terminalRef}
+        ref={(host) => {
+          terminalRef(host);
+          if (model?.fontFamily) {
+            host?.closest<HTMLElement>(".app-shell")?.style
+              .setProperty("--terminal-font-family", fontFamily);
+          }
+        }}
+        style={{ "--terminal-font-family": fontFamily } as CSSProperties}
       >
         <div
           className={`render-scroll${history.active ? " history" : " live"}`}

--- a/cmux-tui/frontends/web/src/components/RenderTerminal.tsx
+++ b/cmux-tui/frontends/web/src/components/RenderTerminal.tsx
@@ -1,4 +1,4 @@
-import { memo, type CSSProperties } from "react";
+import { memo, useCallback, useLayoutEffect, useRef, type CSSProperties } from "react";
 import type { CmuxClient, Id, RenderRow } from "cmux/browser";
 import { useRenderTerminal } from "../hooks/useRenderTerminal";
 import { t } from "../i18n";
@@ -63,6 +63,15 @@ export function RenderTerminal({
   const defaultBg = model?.defaultBg ?? "var(--terminal-background)";
   const cols = model?.size.cols ?? 0;
   const fontFamily = terminalFontStack(model?.fontFamily);
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const bindTerminalRef = useCallback((host: HTMLDivElement | null) => {
+    hostRef.current = host;
+    terminalRef(host);
+  }, [terminalRef]);
+  useLayoutEffect(() => {
+    hostRef.current?.closest<HTMLElement>(".app-shell")?.style
+      .setProperty("--terminal-font-family", fontFamily);
+  }, [fontFamily]);
   const gridStyle = {
     width: `calc(var(--render-cell-width) * ${cols})`,
     height: `calc(var(--render-cell-height) * ${rows.length})`,
@@ -85,13 +94,7 @@ export function RenderTerminal({
     >
       <div
         className="terminal-host render-terminal-host"
-        ref={(host) => {
-          terminalRef(host);
-          if (model?.fontFamily) {
-            host?.closest<HTMLElement>(".app-shell")?.style
-              .setProperty("--terminal-font-family", fontFamily);
-          }
-        }}
+        ref={bindTerminalRef}
         style={{ "--terminal-font-family": fontFamily } as CSSProperties}
       >
         <div

--- a/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useAttachedTerminal.ts
@@ -21,6 +21,7 @@ import {
   colorsToPaletteSequence,
   colorsToSelectionThemePatch,
 } from "../lib/terminalColors";
+import { fallbackTerminalFontStack, terminalFontStack } from "../lib/terminalFont";
 import { terminalTheme } from "../lib/terminalTheme";
 import { tryLoadWebglRenderer } from "../lib/webglRenderer";
 
@@ -50,7 +51,7 @@ export function useAttachedTerminal({
       allowProposedApi: true,
       convertEol: false,
       disableStdin: true,
-      fontFamily: 'Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace',
+      fontFamily: fallbackTerminalFontStack,
       fontSize: 13,
       lineHeight: 1.15,
       theme: baseTheme,
@@ -107,6 +108,9 @@ export function useAttachedTerminal({
         stage?.style.setProperty("--surface-background", colors.bg);
       } else {
         stage?.style.removeProperty("--surface-background");
+      }
+      if (colors?.font_family !== undefined) {
+        terminal.options.fontFamily = terminalFontStack(colors.font_family);
       }
       const dynamicSequence = colorsToDynamicColorSequence(colors);
       if (dynamicSequence !== null) await writeTerminal(dynamicSequence);

--- a/cmux-tui/frontends/web/src/hooks/useRenderTerminal.ts
+++ b/cmux-tui/frontends/web/src/hooks/useRenderTerminal.ts
@@ -323,6 +323,7 @@ export function useRenderTerminal({
 
     const observer = new ResizeObserver(sendResize);
     observer.observe(host);
+    if (probe !== null) observer.observe(probe);
     window.visualViewport?.addEventListener("resize", sendResize);
     window.visualViewport?.addEventListener("scroll", sendResize);
     void document.fonts?.ready.then(() => {

--- a/cmux-tui/frontends/web/src/lib/renderModel.ts
+++ b/cmux-tui/frontends/web/src/lib/renderModel.ts
@@ -68,7 +68,7 @@ export function applyDelta(model: RenderModel, delta: RenderDeltaEvent): RenderM
     cursor: { ...delta.cursor },
     defaultFg: delta.default_fg ?? model.defaultFg,
     defaultBg: delta.default_bg ?? model.defaultBg,
-    fontFamily: model.fontFamily,
+    fontFamily: delta.font_family === undefined ? model.fontFamily : delta.font_family,
     scrollbackRows: delta.scrollback_rows ?? model.scrollbackRows,
     rows,
   };

--- a/cmux-tui/frontends/web/src/lib/renderModel.ts
+++ b/cmux-tui/frontends/web/src/lib/renderModel.ts
@@ -12,6 +12,7 @@ export interface RenderModel {
   cursor: RenderCursor;
   defaultFg: string;
   defaultBg: string;
+  fontFamily: string | null;
   scrollbackRows: number;
   rows: readonly RenderRow[];
 }
@@ -36,6 +37,7 @@ export function applySnapshot(snapshot: RenderStateEvent): RenderModel {
     cursor: { ...snapshot.cursor },
     defaultFg: snapshot.default_fg,
     defaultBg: snapshot.default_bg,
+    fontFamily: snapshot.font_family ?? null,
     scrollbackRows: snapshot.scrollback_rows,
     rows: normalizeRows(snapshot.rows, snapshot.size.rows),
   };
@@ -66,6 +68,7 @@ export function applyDelta(model: RenderModel, delta: RenderDeltaEvent): RenderM
     cursor: { ...delta.cursor },
     defaultFg: delta.default_fg ?? model.defaultFg,
     defaultBg: delta.default_bg ?? model.defaultBg,
+    fontFamily: model.fontFamily,
     scrollbackRows: delta.scrollback_rows ?? model.scrollbackRows,
     rows,
   };

--- a/cmux-tui/frontends/web/src/lib/terminalFont.ts
+++ b/cmux-tui/frontends/web/src/lib/terminalFont.ts
@@ -1,0 +1,10 @@
+export const fallbackTerminalFontStack = 'Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace';
+
+/** Build a CSS-safe family stack from server-owned Ghostty appearance metadata. */
+export function terminalFontStack(fontFamily: string | null | undefined): string {
+  const family = fontFamily?.trim();
+  if (family === undefined || family.length === 0 || /[\u0000-\u001f\u007f]/u.test(family)) {
+    return fallbackTerminalFontStack;
+  }
+  return `${JSON.stringify(family)}, ${fallbackTerminalFontStack}`;
+}

--- a/cmux-tui/frontends/web/src/styles.css
+++ b/cmux-tui/frontends/web/src/styles.css
@@ -176,7 +176,7 @@ button { color: inherit; touch-action: manipulation; }
 .render-cursor-block.unfocused { border: 1px solid currentColor; background: transparent; }
 .render-cursor-blink { animation: render-cursor-blink 1s steps(1, end) infinite; }
 .render-input { position: absolute; z-index: -1; top: 0; left: 0; width: 1px; height: 1px; padding: 0; border: 0; opacity: 0; resize: none; }
-.render-metric-probe { position: absolute; visibility: hidden; top: -1000px; left: -1000px; white-space: pre; }
+.render-metric-probe { position: absolute; display: inline-block; visibility: hidden; top: -1000px; left: -1000px; white-space: pre; }
 .back-to-live { position: absolute; z-index: 12; right: 8px; bottom: 8px; padding: 5px 8px; border: 1px solid var(--border-active); background: var(--status-bg); color: var(--status-active-fg); font-size: 11px; cursor: pointer; }
 .scrollback-status { position: absolute; z-index: 11; top: 50%; left: 50%; padding: 5px 8px; transform: translate(-50%, -50%); background: var(--status-bg); color: var(--status-dim); font-size: 11px; pointer-events: none; }
 .terminal-empty { display: grid; place-items: center; height: 100%; color: var(--status-dim); font-size: 12px; }

--- a/cmux-tui/frontends/web/src/styles.css
+++ b/cmux-tui/frontends/web/src/styles.css
@@ -27,6 +27,7 @@
   --terminal-background: #272822;
   --terminal-foreground: #d0d0d0;
   --terminal-cursor: #87afd7;
+  --terminal-font-family: Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   --ansi-black: #000000;
   --ansi-red: #cd0000;
   --ansi-green: #00cd00;
@@ -45,7 +46,7 @@
   --ansi-bright-white: #ffffff;
   color: var(--terminal-foreground);
   background: var(--terminal-background);
-  font-family: Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-family: var(--terminal-font-family);
   font-size: 12px;
   line-height: var(--tui-cell-height);
   font-synthesis: none;
@@ -79,7 +80,7 @@ button { color: inherit; touch-action: manipulation; }
 .pairing-code span, .pairing-code small { color: var(--status-dim); font-size: 12px; }
 .pairing-code strong { color: var(--border-active); font-size: 28px; letter-spacing: .12em; }
 
-.app-shell { display: grid; grid-template: minmax(0, 1fr) var(--tui-cell-height) / var(--tui-sidebar-width) minmax(0, 1fr); width: 100%; height: 100%; background: var(--terminal-background); }
+.app-shell { display: grid; grid-template: minmax(0, 1fr) var(--tui-cell-height) / var(--tui-sidebar-width) minmax(0, 1fr); width: 100%; height: 100%; background: var(--terminal-background); font-family: var(--terminal-font-family); }
 .mobile-toolbar, .drawer-backdrop, .extra-keys { display: none; }
 .sidebar, .mobile-toolbar, .tab-bar, .status-bar, .extra-keys,
 .pane-side, .pane-bottom, .pane-corner, .pane-rule { user-select: none; -webkit-user-select: none; }
@@ -147,7 +148,7 @@ button { color: inherit; touch-action: manipulation; }
 .terminal-stage { position: relative; width: 100%; height: 100%; min-width: 0; min-height: 0; padding: 0; background: var(--surface-background, var(--terminal-background)); overflow: hidden; user-select: none; -webkit-user-select: none; }
 .terminal-host { width: 100%; height: 100%; }
 .terminal-host .xterm { height: 100%; }
-.render-terminal-host { position: relative; overflow: hidden; background: var(--surface-background, var(--terminal-background)); font-family: Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace; font-size: 12px; line-height: var(--tui-cell-height); }
+.render-terminal-host { position: relative; overflow: hidden; background: var(--surface-background, var(--terminal-background)); font-family: var(--terminal-font-family); font-size: 12px; line-height: var(--tui-cell-height); }
 .render-scroll { position: absolute; inset: 0; overscroll-behavior: contain; scrollbar-color: var(--status-dim) transparent; }
 .render-scroll.live { overflow: hidden; }
 .render-scroll.history { overflow: auto; }

--- a/cmux-tui/frontends/web/test/render-model.test.ts
+++ b/cmux-tui/frontends/web/test/render-model.test.ts
@@ -40,6 +40,15 @@ function delta(overrides: Partial<RenderDeltaEvent> = {}): RenderDeltaEvent {
 }
 
 describe("render model", () => {
+  it("preserves the Ghostty font family from the initial render state", () => {
+    const initial = applySnapshot({
+      ...snapshot(),
+      font_family: "Berkeley Mono",
+    } as RenderStateEvent & { font_family: string });
+
+    expect(initial).toMatchObject({ fontFamily: "Berkeley Mono" });
+  });
+
   it("indexes snapshot and dirty rows by row number even when events list them out of order", () => {
     const initial = applySnapshot(snapshot([row(1, "two"), row(0, "one")]));
     const updated = applyDelta(initial, delta({ rows: [row(1, "TWO"), row(0, "ONE")] }));

--- a/cmux-tui/frontends/web/test/render-model.test.ts
+++ b/cmux-tui/frontends/web/test/render-model.test.ts
@@ -49,6 +49,15 @@ describe("render model", () => {
     expect(initial).toMatchObject({ fontFamily: "Berkeley Mono" });
   });
 
+  it("applies and clears live Ghostty font-family deltas", () => {
+    const initial = applySnapshot({ ...snapshot(), font_family: "Berkeley Mono" });
+    const updated = applyDelta(initial, delta({ font_family: "JetBrains Mono" }));
+    const cleared = applyDelta(updated, delta({ font_family: null }));
+
+    expect(updated.fontFamily).toBe("JetBrains Mono");
+    expect(cleared.fontFamily).toBeNull();
+  });
+
   it("indexes snapshot and dirty rows by row number even when events list them out of order", () => {
     const initial = applySnapshot(snapshot([row(1, "two"), row(0, "one")]));
     const updated = applyDelta(initial, delta({ rows: [row(1, "TWO"), row(0, "ONE")] }));

--- a/cmux-tui/frontends/web/test/render-terminal-sizing.test.tsx
+++ b/cmux-tui/frontends/web/test/render-terminal-sizing.test.tsx
@@ -12,6 +12,7 @@ vi.mock("../src/lib/attachRecovery", () => ({
 }));
 
 let hostWidth = 800;
+let metricWidth = 10;
 
 class TestStream {
   private index = 0;
@@ -37,12 +38,12 @@ function Harness({ client }: { client: CmuxClient }) {
       Object.defineProperty(node, "clientHeight", { configurable: true, get: () => 480 });
       const probe = node.querySelector<HTMLElement>("[data-render-probe]")!;
       probe.getBoundingClientRect = () => ({
-        width: 10,
+        width: metricWidth,
         height: 20,
         x: 0,
         y: 0,
         top: 0,
-        right: 10,
+        right: metricWidth,
         bottom: 20,
         left: 0,
         toJSON: () => ({}),
@@ -68,6 +69,7 @@ describe("render terminal sizing", () => {
   afterEach(() => {
     globalThis.ResizeObserver = originalResizeObserver;
     hostWidth = 800;
+    metricWidth = 10;
     recoveryDelay = 60_000;
   });
 
@@ -175,6 +177,50 @@ describe("render terminal sizing", () => {
     await new Promise((resolve) => setTimeout(resolve, 150));
 
     expect(client.resizeSurface).toHaveBeenCalledTimes(1);
+  });
+
+  it("remeasures and refits when the rendered font changes the cell probe", async () => {
+    let resizeCallback: ResizeObserverCallback | null = null;
+    const observed = new Set<Element>();
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe(target: Element) { observed.add(target); }
+      unobserve() {}
+      disconnect() {}
+    };
+    const cursor: RenderCursor = {
+      x: 0,
+      y: 0,
+      style: "bar",
+      blink: true,
+      visible: true,
+      color: null,
+    };
+    const client = {
+      attachSurface: vi.fn(async () => new TestStream([{
+        event: "render-state",
+        surface: 7,
+        size: { cols: 100, rows: 30 },
+        cursor,
+        default_fg: "#f8f8f2",
+        default_bg: "#272822",
+        scrollback_rows: 0,
+        rows: [],
+      }])),
+      resizeSurface: vi.fn(async () => ({ accepted: true, reservation_id: null })),
+      releaseSurfaceSize: vi.fn(async () => ({})),
+    } as unknown as CmuxClient;
+
+    const view = render(<Harness client={client} />);
+    const probe = view.container.querySelector("[data-render-probe]")!;
+    await waitFor(() => expect(client.resizeSurface).toHaveBeenCalledWith(7, 80, 24));
+    expect(observed.has(probe)).toBe(true);
+
+    metricWidth = 16;
+    resizeCallback!([], {} as ResizeObserver);
+    await waitFor(() => expect(client.resizeSurface).toHaveBeenLastCalledWith(7, 50, 24));
   });
 
   it("releases sizing when the render consumer terminates", async () => {

--- a/cmux-tui/frontends/web/test/render-terminal.test.tsx
+++ b/cmux-tui/frontends/web/test/render-terminal.test.tsx
@@ -8,6 +8,7 @@ import { RenderTerminal } from "../src/components/RenderTerminal";
 const renderHook = vi.hoisted(() => ({
   focused: true,
   historyActive: false,
+  terminalRef: vi.fn(),
   sendKey: vi.fn(),
   sendText: vi.fn(),
 }));
@@ -28,7 +29,7 @@ const model = {
 
 vi.mock("../src/hooks/useRenderTerminal", () => ({
   useRenderTerminal: () => ({
-    terminalRef: () => undefined,
+    terminalRef: renderHook.terminalRef,
     focused: renderHook.focused,
     foreignSize: null,
     model,
@@ -47,6 +48,7 @@ vi.mock("../src/hooks/useRenderTerminal", () => ({
 beforeEach(() => {
   renderHook.focused = true;
   renderHook.historyActive = false;
+  renderHook.terminalRef.mockClear();
   renderHook.sendKey.mockClear();
   renderHook.sendText.mockClear();
 });
@@ -60,6 +62,18 @@ describe("RenderTerminal DOM grid", () => {
     expect(container.querySelector<HTMLElement>(".render-terminal-host")?.style
       .getPropertyValue("--terminal-font-family"))
       .toBe('"Berkeley Mono \\"Retina\\"", Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace');
+  });
+
+  it("keeps the terminal host callback stable across render frames", () => {
+    const view = render(
+      <RenderTerminal client={{ protocol: 7 } as CmuxClient} surface={7} active error={null} onError={vi.fn()} />,
+    );
+
+    expect(renderHook.terminalRef).toHaveBeenCalledTimes(1);
+    view.rerender(
+      <RenderTerminal client={{ protocol: 7 } as CmuxClient} surface={7} active error={null} onError={vi.fn()} />,
+    );
+    expect(renderHook.terminalRef).toHaveBeenCalledTimes(1);
   });
 
   it("renders one absolute row per model row, authoritative run width, and server cursor geometry", () => {

--- a/cmux-tui/frontends/web/test/render-terminal.test.tsx
+++ b/cmux-tui/frontends/web/test/render-terminal.test.tsx
@@ -12,18 +12,19 @@ const renderHook = vi.hoisted(() => ({
   sendText: vi.fn(),
 }));
 
-const model: RenderModel = {
+const model = {
   surface: 7,
   size: { cols: 4, rows: 2 },
   cursor: { x: 2, y: 1, style: "bar", blink: true, visible: true, color: null },
   defaultFg: "#eeeeee",
   defaultBg: "#111111",
+  fontFamily: 'Berkeley Mono "Retina"',
   scrollbackRows: 10,
   rows: [
     { row: 0, runs: [{ text: "界", fg: null, bg: null, attrs: renderAttrs.bold, width_hint: 2 }] },
     { row: 1, runs: [{ text: "ok  ", fg: "#00ff00", bg: null, attrs: 0, underline: "dashed" }] },
   ],
-};
+} satisfies RenderModel & { fontFamily: string };
 
 vi.mock("../src/hooks/useRenderTerminal", () => ({
   useRenderTerminal: () => ({
@@ -51,6 +52,16 @@ beforeEach(() => {
 });
 
 describe("RenderTerminal DOM grid", () => {
+  it("applies the server font family as a quoted CSS stack", () => {
+    const { container } = render(
+      <RenderTerminal client={{ protocol: 7 } as CmuxClient} surface={7} active error={null} onError={vi.fn()} />,
+    );
+
+    expect(container.querySelector<HTMLElement>(".render-terminal-host")?.style
+      .getPropertyValue("--terminal-font-family"))
+      .toBe('"Berkeley Mono \\"Retina\\"", Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace');
+  });
+
   it("renders one absolute row per model row, authoritative run width, and server cursor geometry", () => {
     const { container } = render(
       <RenderTerminal client={{ protocol: 7 } as CmuxClient} surface={7} active error={null} onError={vi.fn()} />,

--- a/cmux-tui/frontends/web/test/terminal-colors.test.ts
+++ b/cmux-tui/frontends/web/test/terminal-colors.test.ts
@@ -5,6 +5,16 @@ import {
   colorsToPaletteSequence,
   colorsToSelectionThemePatch,
 } from "../src/lib/terminalColors";
+import { fallbackTerminalFontStack, terminalFontStack } from "../src/lib/terminalFont";
+
+describe("terminal font family", () => {
+  it("quotes arbitrary family names and rejects control characters", () => {
+    expect(terminalFontStack('Berkeley Mono "Retina"')).toBe(
+      '"Berkeley Mono \\"Retina\\"", Menlo, "SFMono-Regular", Consolas, "Liberation Mono", monospace',
+    );
+    expect(terminalFontStack("bad\nfont")).toBe(fallbackTerminalFontStack);
+  });
+});
 
 describe("effective terminal colors", () => {
   it("returns no patch when an older server omits colors", () => {

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -691,12 +691,13 @@ object{
   size?:object{cols:uint16,rows:uint16},
   default_fg?:ColorHex,
   default_bg?:ColorHex,
+  font_family?:string|null,
   scrollback_rows?:uint32,
   rows:array<Row>
 }
 ```
 
-Meaning: One coalesced render frame. The cursor is always present; `rows` contains dirty replacements unless `full:true`. `size` is present if and only if the surface resized, and every resize is a full viewport replacement. See [`render.md`](render.md#render-delta).
+Meaning: One coalesced render frame. The cursor is always present; `rows` contains dirty replacements unless `full:true`. `size` is present if and only if the surface resized, every resize is a full viewport replacement, and `font_family` is present when config reload changes or clears it. See [`render.md`](render.md#render-delta).
 
 ### vt-state
 

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -664,6 +664,7 @@ object{
   cursor:Cursor,
   default_fg:ColorHex,
   default_bg:ColorHex,
+  font_family:string|null,
   scrollback_rows:uint32,
   rows:array<Row>
 }
@@ -723,12 +724,13 @@ object{
     selection_fg:ColorHex|null,
     palette?:object{[index:string]:ColorHex},
     cursor_style:"block"|"underline"|"bar"|null,
-    cursor_blink:boolean|null
+    cursor_blink:boolean|null,
+    font_family:string|null
   }
 }
 ```
 
-Meaning: Initial VT replay for an attached PTY surface. Replaying `data` into a fresh Ghostty VT terminal with the supplied cell size reproduces current state. `colors` is captured with the replay and reports the surface's effective foreground, background, and cursor colors, including active OSC 10/11/12 overrides. Protocol v7 adds sparse `palette`, whose decimal string keys identify authored OSC 4 overrides; omitted indexes retain the frontend theme palette, and older servers omit the field. The additive protocol-v6 `cursor_style` and `cursor_blink` fields report the surface's current DECSCUSR-derived cursor state when available, then fall back to the session's Ghostty `cursor-style` and `cursor-style-blink` defaults. A field is `null` when the server cannot determine it; the current server does not track selection colors, so `selection_bg` and `selection_fg` are `null`. Ghostty's VT replay formatter does not emit DECSCUSR, so attach clients must apply the cursor metadata instead of inferring shape or blink from `data`.
+Meaning: Initial VT replay for an attached PTY surface. Replaying `data` into a fresh Ghostty VT terminal with the supplied cell size reproduces current state. `colors` is captured with the replay and reports the surface's effective foreground, background, cursor colors, and resolved primary Ghostty font family. Protocol v7 adds sparse `palette`, whose decimal string keys identify authored OSC 4 overrides; omitted indexes retain the frontend theme palette, and older servers omit the field. The additive protocol-v6 `cursor_style` and `cursor_blink` fields report the surface's current DECSCUSR-derived cursor state when available, then fall back to the session's Ghostty `cursor-style` and `cursor-style-blink` defaults. A field is `null` when the server cannot determine it; the current server does not track selection colors, so `selection_bg` and `selection_fg` are `null`. Ghostty's VT replay formatter does not emit DECSCUSR, so attach clients must apply the cursor metadata instead of inferring shape or blink from `data`.
 
 Example:
 
@@ -802,11 +804,12 @@ object{
   selection_fg:ColorHex|null,
   palette?:object{[index:string]:ColorHex},
   cursor_style:"block"|"underline"|"bar"|null,
-  cursor_blink:boolean|null
+  cursor_blink:boolean|null,
+  font_family:string|null
 }
 ```
 
-Meaning: The session defaults or a surface's live OSC palette state changed. Each live PTY byte-attach stream receives the effective colors for its surface. Active per-surface OSC 10/11/12 overrides remain authoritative; protocol-v7 sparse `palette` entries replace authored OSC 4 indexes while omitted indexes retain the frontend theme palette. Live palette events omit cursor metadata so the frontend preserves its current cursor; default-color events include authoritative cursor state. Protocol v7 requires the explicit `surface` subject id so multiple attach streams on one connection can be routed without implicit stream state. Protocol-v6 payloads omit `surface` and `palette`; v6 clients remain compatible because the new fields are additive. The current server emits `null` for both selection fields because it cannot query the terminal's OSC 17/19 selection-color state.
+Meaning: The session defaults or a surface's live OSC palette state changed. Each live PTY byte-attach stream receives the effective colors and primary Ghostty font family for its surface. Active per-surface OSC 10/11/12 overrides remain authoritative; protocol-v7 sparse `palette` entries replace authored OSC 4 indexes while omitted indexes retain the frontend theme palette. Live palette events omit cursor metadata so the frontend preserves its current cursor; default-color events include authoritative cursor state. Protocol v7 requires the explicit `surface` subject id so multiple attach streams on one connection can be routed without implicit stream state. Protocol-v6 payloads omit `surface` and `palette`; v6 clients remain compatible because the new fields are additive. The current server emits `null` for both selection fields because it cannot query the terminal's OSC 17/19 selection-color state.
 
 Example:
 

--- a/cmux-tui/spec/render.md
+++ b/cmux-tui/spec/render.md
@@ -142,6 +142,7 @@ object{
   size?:object{cols:uint16,rows:uint16},
   default_fg?:ColorHex,
   default_bg?:ColorHex,
+  font_family?:string|null,
   scrollback_rows?:uint32,
   rows:array<Row>
 }
@@ -151,7 +152,7 @@ The cursor is always present, including cursor-only frames where `rows` is empty
 
 `size` is present if and only if the surface resized. A resize always sends `full:true` and every viewport row at the new size. This full replacement is required because Ghostty may reflow content and invalidate every old row index. `full:true` may also be used without `size` when a palette/default-color change or engine full-damage state requires a complete repaint.
 
-When `full:true`, `rows` contains exactly the complete current viewport. Optional `default_fg` and `default_bg` are present only when that default changed. `scrollback_rows` is present only when the count changed. Runs still carry resolved RGB, so any palette change that affects visible cells must dirty those rows or cause a full delta.
+When `full:true`, `rows` contains exactly the complete current viewport. Optional `default_fg` and `default_bg` are present only when that default changed. `font_family` is present when a config reload changes or clears the session's primary Ghostty font family. `scrollback_rows` is present only when the count changed. Runs still carry resolved RGB, so any palette change that affects visible cells must dirty those rows or cause a full delta.
 
 `scroll-changed` carries viewport offset/at-bottom metadata; it does not carry cells and does not replace a delta. If scrolling changes visible content, the render stream also supplies the resulting dirty or full rows in an ordered `render-delta`. The two events need not be adjacent because frame coalescing may include other terminal mutations.
 

--- a/cmux-tui/spec/render.md
+++ b/cmux-tui/spec/render.md
@@ -109,12 +109,13 @@ object{
   cursor:Cursor,
   default_fg:ColorHex,
   default_bg:ColorHex,
+  font_family:string|null,
   scrollback_rows:uint32,
   rows:array<Row>
 }
 ```
 
-`rows` is a complete snapshot of the current viewport and contains exactly `size.rows` entries. This draft uses `size.rows` for the numeric height because a JSON object cannot also use `rows` as the row-array key. `scrollback_rows` is the current number of retained rows above the live screen; the initial event does not inline scrollback.
+`rows` is a complete snapshot of the current viewport and contains exactly `size.rows` entries. This draft uses `size.rows` for the numeric height because a JSON object cannot also use `rows` as the row-array key. `scrollback_rows` is the current number of retained rows above the live screen; the initial event does not inline scrollback. `font_family` is the session's primary resolved Ghostty `font-family`, or `null` when unavailable.
 
 Example:
 


### PR DESCRIPTION
Summary:
- resolve the primary Ghostty font-family with session appearance defaults
- send it in render and byte attachment metadata
- apply a sanitized CSS font stack to terminal DOM and app chrome

Verification:
- cargo test -p cmux-tui-core -p cmux-tui, clean fleet Mac
- TypeScript binding tests, 40 passed
- web build and tests, 153 passed
- agent-browser live WebSocket check: Courier New applied to app and terminal; Monokai #272822 covered app, sidebar, border, and terminal

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787097368&installation_id=133855650&pr_number=8503&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8503&signature=302e69f077e8d85b45884586c570726d004ca6ef63b2ec1306f2051f5f0a5ad4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inherit Ghostty’s primary font in the `cmux-tui` web client and terminal for consistent typography with the user’s Ghostty setup. The server resolves and streams the font; the web applies a safe CSS stack across the app and terminal and refits when metrics change.

- New Features
  - Protocol v7: optional `font_family` on `render-state`/`render-delta`; included in attach `colors` and `colors-changed`.
  - Server (`cmux-tui-core`/`cmux-tui`): resolve Ghostty `font-family` via `ghostty --show-config` or config files; seed on startup and on config apply; store with a generation and broadcast deltas; include in render and byte streams; emit `null` when unavailable.
  - Web (`frontends/web`): `terminalFontStack` with quoting/sanitization and a fallback; set `--terminal-font-family` on the app shell and render host; plumb to `xterm` `fontFamily`; observe the metric probe with `ResizeObserver` to remeasure and resize on font changes.
  - Docs/Tests: update `spec/events.md` and `spec/render.md`; add tests for quoting/sanitization, CSS var propagation, live font deltas, and refit on metric changes.

- Migration
  - Additive, optional fields; older servers/clients remain compatible. The web falls back to a monospace stack when `font_family` is missing.

<sup>Written for commit 97819610019902db5f599c69497f9ce22b372b6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using the configured terminal font family across terminal sessions and web interfaces.
  * Font changes now update active terminals automatically without requiring a restart.
  * Rendered terminal sizing reflows when font metrics change.
  * Font information is included in terminal state and live updates.

* **Documentation**
  * Updated protocol documentation to describe terminal font metadata and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->