### PR TITLE
Fix three browser bugs surfaced by repairing the Browser test suites

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -3267,9 +3267,11 @@ final class WindowBrowserPortal: NSObject {
                     return
                 }
             }
-            if preserveVisibleDuringTransientDetach(reason: "anchorWindowMismatch") {
-                return
-            }
+            // Only an anchor that is still parented somewhere (the drag/reparent
+            // churn above) earns keeping the slot on screen. An anchor with no
+            // superview, or one that moved to another window, is not coming back
+            // on its own, so hide the slot while recovery retries run instead of
+            // leaving it rendering over whatever pane now owns that space.
             if scheduleTransientDetachRecovery(reason: "anchorWindowMismatch") {
                 hideContainerView(reason: "anchorWindowMismatch")
                 return

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4048,7 +4048,14 @@ final class BrowserPanel: Panel, ObservableObject {
             BrowserToolbarAccessorySpacingDebugSettings.key: BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing,
             BrowserProfilePopoverDebugSettings.horizontalPaddingKey: BrowserProfilePopoverDebugSettings.defaultHorizontalPadding,
             BrowserProfilePopoverDebugSettings.verticalPaddingKey: BrowserProfilePopoverDebugSettings.defaultVerticalPadding,
-            BrowserThemeSettings.modeKey: BrowserThemeSettings.defaultMode.rawValue,
+            // The theme mode deliberately has no registered fallback. Registration
+            // writes into the process-wide registration domain, which every
+            // `UserDefaults` reads through, so the mode key would always resolve to
+            // a value and `BrowserThemeSettings.mode(defaults:)` could no longer tell
+            // "never chosen" from "chosen as system" — which is what lets it migrate
+            // the legacy `browserForcedDarkModeEnabled` toggle. The accessor already
+            // falls back to `defaultMode`, and the SwiftUI binding carries its own
+            // default, so nothing needs the registered value.
         ])
 
         let resolvedThemeMode = BrowserThemeSettings.mode(defaults: defaults)
@@ -4364,6 +4371,10 @@ final class BrowserPanel: Panel, ObservableObject {
             hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
             currentURL = initialRequest.url
             shouldRenderWebView = renderInitialNavigation
+            // A panel born with a URL is never `.newTab`: seed the state here
+            // because the deferred path returns without a visibility or
+            // navigation transition to refresh it later.
+            refreshWebViewLifecycleState()
             guard renderInitialNavigation else { return }
             if let url = initialRequest.url,
                insecureHTTPBypassHostOnce == nil,
@@ -4383,6 +4394,10 @@ final class BrowserPanel: Panel, ObservableObject {
             hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
             currentURL = url
             shouldRenderWebView = renderInitialNavigation
+            // A panel born with a URL is never `.newTab`: seed the state here
+            // because the deferred path returns without a visibility or
+            // navigation transition to refresh it later.
+            refreshWebViewLifecycleState()
             guard renderInitialNavigation else { return }
             if adoptedPrewarmedWebView {
                 // Already navigated while hidden; record for recovery paths.

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1855,6 +1855,39 @@ final class BrowserDeveloperToolsShortcutDefaultsTests: XCTestCase {
 
 @MainActor
 final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
+    /// The terminal background the browser paints under a page is opaque: the
+    /// terminal color is composited over the window background at the Ghostty
+    /// opacity so blank/loading regions never show window gray through the page.
+    /// Blend it here rather than asking the product for the answer, so a panel
+    /// that ignores the notification (or drops the opacity) still fails.
+    private func expectedUnderPageBackgroundColor(
+        terminalColor: NSColor,
+        opacity: CGFloat
+    ) throws -> NSColor {
+        let terminal = try XCTUnwrap(terminalColor.usingColorSpace(.sRGB))
+        let base = try XCTUnwrap(NSColor.windowBackgroundColor.usingColorSpace(.sRGB))
+        return NSColor(
+            srgbRed: terminal.redComponent * opacity + base.redComponent * (1 - opacity),
+            green: terminal.greenComponent * opacity + base.greenComponent * (1 - opacity),
+            blue: terminal.blueComponent * opacity + base.blueComponent * (1 - opacity),
+            alpha: 1.0
+        )
+    }
+
+    /// Compares two colors channel-wise. WebKit stores `underPageBackgroundColor`
+    /// with 8-bit channels, so the tolerance has to clear one quantization step.
+    private func assertColorsMatch(
+        _ actual: NSColor,
+        _ expected: NSColor,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.redComponent, expected.redComponent, accuracy: 0.005, file: file, line: line)
+        XCTAssertEqual(actual.greenComponent, expected.greenComponent, accuracy: 0.005, file: file, line: line)
+        XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.005, file: file, line: line)
+        XCTAssertEqual(actual.alphaComponent, expected.alphaComponent, accuracy: 0.005, file: file, line: line)
+    }
+
     func testBrowserPanelEnablesInspectableWebViewAndDeveloperExtras() {
         let panel = BrowserPanel(workspaceId: UUID())
         let developerExtras = panel.webView.configuration.preferences.value(forKey: "developerExtrasEnabled") as? Bool
@@ -1865,7 +1898,7 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
         }
     }
 
-    func testBrowserPanelRefreshesUnderPageBackgroundColorWhenGhosttyBackgroundChanges() {
+    func testBrowserPanelRefreshesUnderPageBackgroundColorWhenGhosttyBackgroundChanges() throws {
         let panel = BrowserPanel(workspaceId: UUID())
         let updatedColor = NSColor(srgbRed: 0.18, green: 0.29, blue: 0.44, alpha: 1.0)
         let updatedOpacity = 0.57
@@ -1879,16 +1912,12 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
             ]
         )
 
-        guard let actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB),
-              let expected = updatedColor.withAlphaComponent(updatedOpacity).usingColorSpace(.sRGB) else {
-            XCTFail("Expected sRGB-convertible under-page background colors")
-            return
-        }
-
-        XCTAssertEqual(actual.redComponent, expected.redComponent, accuracy: 0.005)
-        XCTAssertEqual(actual.greenComponent, expected.greenComponent, accuracy: 0.005)
-        XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.005)
-        XCTAssertEqual(actual.alphaComponent, expected.alphaComponent, accuracy: 0.005)
+        let actual = try XCTUnwrap(panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB))
+        let expected = try expectedUnderPageBackgroundColor(
+            terminalColor: updatedColor,
+            opacity: updatedOpacity
+        )
+        assertColorsMatch(actual, expected)
     }
 
     func testBrowserPanelStartsAsNewTabWithoutLoadingAboutBlank() {
@@ -1936,7 +1965,9 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
         XCTAssertNil(panel.webView.appearance)
     }
 
-    func testBrowserPanelRefreshesUnderPageBackgroundColorWithGhosttyOpacity() {
+    /// Same refresh, but with the opacity boxed as `NSNumber` the way the
+    /// Ghostty notification carries it.
+    func testBrowserPanelRefreshesUnderPageBackgroundColorWithGhosttyOpacity() throws {
         let panel = BrowserPanel(workspaceId: UUID())
         let updatedColor = NSColor(srgbRed: 0.18, green: 0.29, blue: 0.44, alpha: 1.0)
 
@@ -1949,16 +1980,12 @@ final class BrowserDeveloperToolsConfigurationTests: XCTestCase {
             ]
         )
 
-        guard let actual = panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB),
-              let expected = updatedColor.withAlphaComponent(0.57).usingColorSpace(.sRGB) else {
-            XCTFail("Expected sRGB-convertible under-page background colors")
-            return
-        }
-
-        XCTAssertEqual(actual.redComponent, expected.redComponent, accuracy: 0.005)
-        XCTAssertEqual(actual.greenComponent, expected.greenComponent, accuracy: 0.005)
-        XCTAssertEqual(actual.blueComponent, expected.blueComponent, accuracy: 0.005)
-        XCTAssertEqual(actual.alphaComponent, expected.alphaComponent, accuracy: 0.005)
+        let actual = try XCTUnwrap(panel.webView.underPageBackgroundColor?.usingColorSpace(.sRGB))
+        let expected = try expectedUnderPageBackgroundColor(
+            terminalColor: updatedColor,
+            opacity: 0.57
+        )
+        assertColorsMatch(actual, expected)
     }
 }
 
@@ -2681,13 +2708,25 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
-            if panel.preferredURLStringForOmnibar() == url.absoluteString && !panel.isLoading {
+            // Check the web view's own URL, not the omnibar string. The panel
+            // publishes the destination URL as soon as a navigation is requested
+            // and only raises `isLoading` once WebKit reports the provisional
+            // navigation, so the omnibar already reads as the target while
+            // `isLoading` is still false — a window in which this would return
+            // before the page had loaded at all. WebKit sets `webView.url` when
+            // the navigation commits, so it cannot be satisfied early.
+            if panel.webView.url?.absoluteString == url.absoluteString,
+               !panel.webView.isLoading,
+               !panel.isLoading {
                 return
             }
         }
 
         XCTFail(
-            "Timed out waiting for browser panel to load \(url.absoluteString). Current=\(panel.preferredURLStringForOmnibar() ?? "nil") loading=\(panel.isLoading)",
+            "Timed out waiting for browser panel to load \(url.absoluteString). "
+                + "Live=\(panel.webView.url?.absoluteString ?? "nil") "
+                + "Omnibar=\(panel.preferredURLStringForOmnibar() ?? "nil") "
+                + "webViewLoading=\(panel.webView.isLoading) panelLoading=\(panel.isLoading)",
             file: file,
             line: line
         )

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -341,6 +341,27 @@ final class BrowserHiddenWebViewDiscardManagerTests: XCTestCase {
 
 @MainActor
 final class BrowserPanelVisualAutomationRestoreHostTests: XCTestCase {
+    /// Waits until the panel is settled enough to be discarded.
+    ///
+    /// Waiting on `webView.isLoading` alone is not enough: `BrowserPanel` keeps its
+    /// own `isLoading` set for a minimum indicator duration after WebKit finishes so
+    /// the spinner cannot flicker on a fast navigation, and the discard gate refuses
+    /// while it is set. Wait for the same condition the gate reads.
+    private func waitForBrowserPanelLoadingToSettle(
+        _ panel: BrowserPanel,
+        timeout: TimeInterval = 5.0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while panel.isLoading || panel.webView.isLoading {
+            if Date() >= deadline { break }
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for the page to finish loading", file: file, line: line)
+        XCTAssertFalse(panel.isLoading, "Timed out waiting for the panel loading flag to clear", file: file, line: line)
+    }
+
     func testRestoredDiscardedHiddenWebViewGetsRestoreHostBeforeOffscreenCapture() {
         let discardedAt = Date(timeIntervalSince1970: 400)
         let panel = BrowserPanel(
@@ -350,16 +371,15 @@ final class BrowserPanelVisualAutomationRestoreHostTests: XCTestCase {
         )
         defer { panel.close() }
 
-        let deadline = Date().addingTimeInterval(1.0)
-        while panel.webView.isLoading,
-              RunLoop.main.run(mode: .default, before: deadline),
-              Date() < deadline {}
-        XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for about:blank to finish loading")
+        waitForBrowserPanelLoadingToSettle(panel)
 
         panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
         let originalWebView = panel.webView
 
-        XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
+        XCTAssertTrue(
+            panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt),
+            "Discard refused; blockers: \(panel.webViewLifecycleTopPayload()["discard_blockers"] ?? "unknown")"
+        )
         XCTAssertFalse(panel.webView === originalWebView)
         XCTAssertNil(panel.webView.superview)
         XCTAssertFalse(panel.hasBackgroundPreloadHost)
@@ -376,13 +396,30 @@ final class BrowserPanelVisualAutomationRestoreHostTests: XCTestCase {
     }
 }
 
+/// Creates a throwaway browser profile and deletes it when the test ends.
+///
+/// `createProfile` writes the profile into the shared `UserDefaults` and marks it
+/// last-used, and that selection outlives the process. Left behind, the profile
+/// stays the ambient choice for every later panel built without an explicit
+/// profile, so unrelated suites silently get a profile-scoped website data store
+/// instead of the default one. Deleting the profile also restores the last-used
+/// selection to the built-in default.
 @MainActor
-private func makeTemporaryBrowserPanelProfile(named prefix: String) throws -> BrowserProfileDefinition {
-    try XCTUnwrap(
+private func makeTemporaryBrowserPanelProfile(
+    named prefix: String,
+    cleanUpWith testCase: XCTestCase
+) throws -> BrowserProfileDefinition {
+    let profile = try XCTUnwrap(
         BrowserProfileStore.shared.createProfile(
             named: "\(prefix)-\(UUID().uuidString)"
         )
     )
+    testCase.addTeardownBlock {
+        await MainActor.run {
+            _ = BrowserProfileStore.shared.deleteProfile(id: profile.id)
+        }
+    }
+    return profile
 }
 
 final class BrowserPanelChromeBackgroundColorTests: XCTestCase {
@@ -937,7 +974,7 @@ final class BrowserPanelOmnibarPillBackgroundColorTests: XCTestCase {
 @MainActor
 final class BrowserPanelProfileIsolationTests: XCTestCase {
     func testStaleDidFinishDoesNotRecordVisitIntoSwitchedProfileHistory() throws {
-        let alternateProfile = try makeTemporaryBrowserPanelProfile(named: "Switched")
+        let alternateProfile = try makeTemporaryBrowserPanelProfile(named: "Switched", cleanUpWith: self)
         let defaultStore = BrowserHistoryStore.shared
         let alternateStore = BrowserProfileStore.shared.historyStore(for: alternateProfile.id)
         defaultStore.clearHistory()
@@ -3905,6 +3942,12 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             hiddenDisplayCount,
             "Revealing an existing portal-hosted browser should refresh WebKit presentation immediately"
         )
+        // A tab/workspace visibility change hides and reveals the slot without
+        // taking the web view out of the window, so it must not cycle WebKit's
+        // `_exitInWindow`/`_enterInWindow` pair. Cycling them fires visibilitychange
+        // and can reload the page or break an attached inspector, which is what
+        // broke the DevTools pane across workspace switch round-trips. The reveal
+        // still has to refresh presentation, asserted above.
         XCTAssertEqual(
             webView.reattachRenderingStateCount,
             hiddenReattachCount,

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -836,6 +836,25 @@ final class BrowserOmnibarNativeFieldRegistryWindowSelectionTests: XCTestCase {
 final class BrowserPortalOmnibarSuggestionsTests: XCTestCase {
     func testPortalSuggestionsOverlayPassesHitTestingOutsidePopupFrame() {
         let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 420, height: 260))
+        // The suggestions overlay is a SwiftUI hosting view, and SwiftUI only builds
+        // the content that answers a hit test once the view is in a window and has
+        // been through a layout/display pass. Host the slot in a window so the
+        // overlay reports real hits instead of nil for every point.
+        let window = NSWindow(
+            contentRect: slot.frame,
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = slot
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            window.contentView = nil
+            window.orderOut(nil)
+            window.close()
+        }
+
         let item = OmnibarSuggestion.search(engineName: "Google", query: "news")
         let popupFrame = CGRect(
             x: 40,
@@ -859,6 +878,9 @@ final class BrowserPortalOmnibarSuggestionsTests: XCTestCase {
             )
         )
         slot.layoutSubtreeIfNeeded()
+        slot.displayIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        slot.layoutSubtreeIfNeeded()
 
         let overlay = slot.subviews.first {
             String(describing: type(of: $0)).contains("OmnibarSuggestionsHostingView")
@@ -866,13 +888,29 @@ final class BrowserPortalOmnibarSuggestionsTests: XCTestCase {
         XCTAssertNotNil(overlay)
         guard let overlay else { return }
 
+        // The overlay is pinned to the slot with constraints, so it only has a
+        // usable coordinate space once layout has run. Hit-testing a zero-sized
+        // overlay would report "outside the popup" for every point, including
+        // points that must hit.
+        XCTAssertEqual(overlay.bounds.size, slot.bounds.size, "Overlay must fill the slot before hit-testing")
+
         XCTAssertNil(overlay.hitTest(NSPoint(x: 8, y: 8)))
 
+        // `popupFrame` is in the overlay's own top-left space, while `hitTest`
+        // takes a point in the superview's space. Convert through AppKit rather
+        // than flipping by hand: the overlay is a flipped hosting view inside an
+        // unflipped slot, so the two spaces disagree about y and a hand-rolled
+        // flip lands outside the popup.
         let insideTopLeftPoint = NSPoint(x: popupFrame.midX, y: popupFrame.midY)
-        let insidePoint = overlay.isFlipped
+        let overlayLocalPoint = overlay.isFlipped
             ? insideTopLeftPoint
             : NSPoint(x: insideTopLeftPoint.x, y: overlay.bounds.height - insideTopLeftPoint.y)
-        XCTAssertNotNil(overlay.hitTest(insidePoint))
+        let insidePoint = overlay.convert(overlayLocalPoint, to: overlay.superview)
+        XCTAssertNotNil(
+            overlay.hitTest(insidePoint),
+            "isFlipped=\(overlay.isFlipped) bounds=\(overlay.bounds) popup=\(popupFrame) "
+                + "point=\(insidePoint) inWindow=\(overlay.window != nil) subviews=\(overlay.subviews.count)"
+        )
     }
 }
 


### PR DESCRIPTION
## Three real bugs the tests were catching

These suites had drifted red, and fixing them surfaced genuine product defects — not test noise. Proven pre-existing: the baseline measurement ran on a worktree byte-identical to clean `main`.

**1 — A restored deferred tab keeps the wrong lifecycle state.** `init`'s deferred path returns before any transition runs, so the tab held the `.newTab` default instead of its restored state. Seeded it in `init`. Safe: `refreshWebViewLifecycleState()` is the product's own idempotent recompute and every input it reads is initialized by that point.

**2 — The legacy forced-dark-mode migration never ran, so upgraders silently lost the setting.** `register(defaults:)` writes the *process-wide* registration domain, so `browserThemeMode` always resolved and `mode(defaults:)` took its early return instead of migrating. Removed the redundant registration. The evidence is the tell: the suite **passes alone but fails in a batch** — alone, no panel has registered the fallback. The accessor already defaults to `.system` and `@AppStorage` carries its own default, and the only test asserting a registered fallback checks `searchEngineKey`, not `modeKey`.

**3 — A stale portal slot could render over the wrong pane.** The `isOffWindowReparent` branch already distinguished a still-parented anchor from an orphaned one, but the next line preserved the slot *unconditionally*, so the orphaned case never reached hide-while-retrying.

## Test-side fixes (each root-caused, not adjusted to fit)

- **Stale expectations predating product changes**, dated via `git log`: under-page colour asserts predate #3166 (the actual values decode *exactly* as compositing over `windowBackgroundColor`); a discard-delay test expected clamping while its own sibling proves above-max is *ignored*; a portal reveal test (2026-03-11) still demanded the `_exitInWindow`/`_enterInWindow` cycling that #2621 deliberately removed to stop DevTools breaking across workspace switches.
- **Waits on the wrong edge**: discard tests watched `webView.isLoading` while the gate also reads the panel's `isLoading` (held 350ms by the anti-flicker floor); `waitForBrowserPanel` accepted the optimistically-published omnibar URL and could return *before the load started*.
- **Persisted profile pollution**: the host's real defaults hold 26 leftover test profiles that no test in the repo ever deletes, so a profile-less panel adopts one. Pinned the default profile in the affected suite and made the helper clean up after itself.
- **Host SIGSEGV eliminated**: an unguarded `NSWindow` + `close()` under ARC over-released, crashing teardown in `XCTMemoryChecker`. It was silently swallowing ~20 tests — fixing it took one batch from 34 to **54** tests.

No `XCTSkip` anywhere.

## Result

**9 failing suites → 2. 18 failing tests → 2.** 53 of 55 in-scope suites green, zero host crashes. The 7 repaired suites run **54 tests, 0 failures**.

## Known-remaining (left visibly red rather than papered over)

- `BrowserPanelDiffViewerSchemeTests.testDiffViewerSchemeLoadsSameOriginModuleFromAllowlist` — dynamic ES-module `import()` over the `cmux-diff-viewer://` custom scheme fails. Load, registration, allowlisting, decompression and MIME all check out; leading suspicion is CSP `script-src 'self'` not resolving for a custom-scheme origin. That matters in production (this is the post-restart fallback path) and wants a `securitypolicyviolation` probe before anyone changes product code.
- `BrowserSessionHistoryRestoreTests.testBackDuringProvisionalNavigationDoesNotDesyncPublishedURLFromRenderedPage` — needs back-availability *during* a provisional navigation, but `canGoBack` derives from WebKit's, which only updates at commit. That's a genuine product design question, not a timing artifact.

Also worth passing on: `GhosttyBackgroundThemeTests` / `PanelAppearanceBackgroundTests` fail **identically on clean `main`** (verified by stashing and rebuilding: byte-for-byte `Executed 69 tests, with 30 failures`) — same #3166 colour staleness, out of scope here, and the same one-line composite fix applies.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787110002&installation_id=133855650&pr_number=8506&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8506&signature=1c372e9779adf50f3cf5801a10e227ac24630bf49be686f860d791f8980acd57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three browser bugs surfaced while repairing the Browser test suites: correct tab lifecycle on deferred restore, run the legacy theme migration, and hide orphaned portal slots. Result: failing suites drop from 9 to 2 (18 tests to 2) and host crashes are gone; the 7 repaired suites now run 54 tests with 0 failures.

- **Bug Fixes**
  - Seed lifecycle state during deferred restore so a tab created with a URL isn’t left as `.newTab`.
  - Remove registration for `BrowserThemeSettings.modeKey` so the legacy `browserForcedDarkModeEnabled` migration runs; accessor already defaults to `.system`.
  - Hide a portal slot when its anchor is orphaned; let recovery retries run instead of rendering over the wrong pane.

- **Test Fixes**
  - Composite under-page background over `NSColor.windowBackgroundColor`; add helper with 8-bit tolerance.
  - Treat out-of-range hidden discard delay as invalid and fall back to default; honor the maximum when in range.
  - Wait for both `panel.isLoading` and `webView.isLoading`; `waitForBrowserPanel` now checks committed `webView.url`.
  - Isolate profile state: pin built-in default, clean up temporary profiles, and restore last-used after tests.
  - Prevent teardown SIGSEGV by setting `NSWindow.isReleasedWhenClosed = false` in tests.
  - Assert portal reveal does not cycle WebKit `_exitInWindow`/`_enterInWindow`.
  - Make omnibar suggestions hit-testing reliable by hosting in a window, running layout/display, and converting coordinates via AppKit.

<sup>Written for commit f821f7878438632f82b8ced5bb8272a0dd00e93d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when browser panels are moved between windows or lose their anchor, preventing stale visible content.
  - Preserved detection of unset browser theme preferences so legacy forced-dark-mode settings migrate correctly.
  - Fixed browser panels opened with a URL so they immediately enter the correct lifecycle state instead of appearing as new tabs.
  - Improved browser loading and refresh behavior, including more accurate page color rendering and readiness detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->