### PR TITLE
Fix sendability warning blocking the Swift warning budget

### DIFF
--- a/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
+++ b/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
@@ -94,7 +94,10 @@ actor MobileHostIrohArtifactTransferRegistry {
 
     init(
         timeToLive: TimeInterval = defaultTimeToLive,
-        now: @escaping @Sendable () -> Date = Date.init,
+        // A closure literal, not `Date.init`: unapplied initializer references
+        // are not inferred @Sendable, and converting one trips the strict
+        // sendability warning that the zero-warning budget rejects.
+        now: @escaping @Sendable () -> Date = { Date() },
         resourceID: @escaping @Sendable () throws -> CmxIrohResourceID = {
             let token = (UUID().uuidString + UUID().uuidString)
                 .replacingOccurrences(of: "-", with: "")


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/8494 defaulted MobileHostIrohApplicationLaneRouter's clock parameter to `Date.init`. Unapplied initializer references are not inferred `@Sendable`, so converting one to `@Sendable () -> Date` emits the strict-concurrency warning, and `Validate Swift warning budget` (actual=1, budget=0) now fails every ci.yml run dispatched since that merge — including every branch's merge gate (first seen on https://github.com/manaflow-ai/cmux/actions/runs/29708830707). Main's last green CI predates the merge.

Replacing the default with a closure literal `{ Date() }` is inferred `@Sendable` and behaves identically. No callers pass `now` explicitly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787110553&installation_id=133855650&pr_number=8508&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8508&signature=f86abe8270d5735c461ead157b0efcc3172ed5ae0b7ab9c1d3934ecddba17958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a strict-concurrency warning by changing the default `now` parameter from `Date.init` to `{ Date() }`, which is inferred `@Sendable`. This clears the single warning blocking the zero-warning CI gate; behavior is unchanged and no callers pass `now`.

<sup>Written for commit 3023a9c5868489365ef8525cc7e2b38565defbae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when initializing artifact transfers by resolving a concurrency-related initialization issue.
  * No changes to application behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->