### PR TITLE
cmuxTests: expect composited terminal colours, and the menu flag the grouping test needs

### DIFF
--- a/cmuxTests/CmuxConfigNewWorkspaceMenuTests.swift
+++ b/cmuxTests/CmuxConfigNewWorkspaceMenuTests.swift
@@ -271,27 +271,32 @@ struct CmuxConfigNewWorkspaceMenuTests {
         let (store, root) = try loadStore(globalJSON: twoLayoutConfig(defaultActionID: "review-layout"))
         defer { try? FileManager.default.removeItem(at: root) }
 
-        try withNewWorkspaceContextMenu(store: store) { menu in
-            let layoutsHeader = String(localized: "menu.newWorkspace.layoutsHeader", defaultValue: "Layouts")
-            let headerIndex = try #require(menu.items.firstIndex { $0.title == layoutsHeader })
-            let saveTitle = String(localized: "menu.newWorkspace.saveWorkspaceAsLayout", defaultValue: "Save Workspace as Layout…")
-            let saveIndex = try #require(menu.items.firstIndex { $0.title == saveTitle })
-            let newWorkspaceIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newWorkspace.configID))
-            let agentChatIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newAgentChat.configID))
-            let reviewIndex = try #require(firstContextMenuIndex(menu, actionID: "review-layout"))
-            let devIndex = try #require(firstContextMenuIndex(menu, actionID: "dev-layout"))
+        // Agent chat is behind a default-off flag, and this test is about where
+        // the create entries sit relative to the Layouts section rather than
+        // about that default, so turn it on to get the item into the menu.
+        try withAgentChatUIFlag(true) {
+            try withNewWorkspaceContextMenu(store: store) { menu in
+                let layoutsHeader = String(localized: "menu.newWorkspace.layoutsHeader", defaultValue: "Layouts")
+                let headerIndex = try #require(menu.items.firstIndex { $0.title == layoutsHeader })
+                let saveTitle = String(localized: "menu.newWorkspace.saveWorkspaceAsLayout", defaultValue: "Save Workspace as Layout…")
+                let saveIndex = try #require(menu.items.firstIndex { $0.title == saveTitle })
+                let newWorkspaceIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newWorkspace.configID))
+                let agentChatIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newAgentChat.configID))
+                let reviewIndex = try #require(firstContextMenuIndex(menu, actionID: "review-layout"))
+                let devIndex = try #require(firstContextMenuIndex(menu, actionID: "dev-layout"))
 
-            #expect(newWorkspaceIndex < headerIndex)
-            #expect(agentChatIndex < headerIndex)
-            #expect(headerIndex < reviewIndex)
-            #expect(headerIndex < devIndex)
-            #expect(reviewIndex < saveIndex)
-            #expect(devIndex < saveIndex)
-            let layoutRange = (headerIndex + 1)..<saveIndex
-            let nonLayoutIDs = menu.items[layoutRange].compactMap(contextMenuActionID).filter {
-                $0 != "review-layout" && $0 != "dev-layout"
+                #expect(newWorkspaceIndex < headerIndex)
+                #expect(agentChatIndex < headerIndex)
+                #expect(headerIndex < reviewIndex)
+                #expect(headerIndex < devIndex)
+                #expect(reviewIndex < saveIndex)
+                #expect(devIndex < saveIndex)
+                let layoutRange = (headerIndex + 1)..<saveIndex
+                let nonLayoutIDs = menu.items[layoutRange].compactMap(contextMenuActionID).filter {
+                    $0 != "review-layout" && $0 != "dev-layout"
+                }
+                #expect(nonLayoutIDs.isEmpty)
             }
-            #expect(nonLayoutIDs.isEmpty)
         }
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2577,69 +2577,119 @@ struct TerminalKeyboardCopyModeCursorSwiftTests {
 }
 
 
+/// Blends `foreground` over `base` the way src-over compositing does.
+///
+/// cmux composites terminal background colors over the window background, so a
+/// configured opacity ends up in the RGB blend and the resulting color is
+/// opaque. The arithmetic is written out here on purpose: calling the app's own
+/// resolver to build the expectation would make these assertions agree with the
+/// product by construction and they could never catch a compositing regression.
+private func expectedCompositeOverWindowBackground(
+    foreground: NSColor,
+    opacity: CGFloat,
+    base: NSColor = .windowBackgroundColor
+) throws -> (red: CGFloat, green: CGFloat, blue: CGFloat) {
+    let foregroundSRGB = try XCTUnwrap(foreground.usingColorSpace(.sRGB))
+    let baseSRGB = try XCTUnwrap(base.usingColorSpace(.sRGB))
+    let alpha = max(0.0, min(opacity, 1.0))
+    return (
+        red: foregroundSRGB.redComponent * alpha + baseSRGB.redComponent * (1 - alpha),
+        green: foregroundSRGB.greenComponent * alpha + baseSRGB.greenComponent * (1 - alpha),
+        blue: foregroundSRGB.blueComponent * alpha + baseSRGB.blueComponent * (1 - alpha)
+    )
+}
+
+private func assertOpaqueColor(
+    _ actual: NSColor,
+    equals expected: (red: CGFloat, green: CGFloat, blue: CGFloat),
+    file: StaticString = #filePath,
+    line: UInt = #line
+) throws {
+    let srgb = try XCTUnwrap(
+        actual.usingColorSpace(.sRGB),
+        "Expected sRGB-convertible color",
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(srgb.redComponent, expected.red, accuracy: 0.005, file: file, line: line)
+    XCTAssertEqual(srgb.greenComponent, expected.green, accuracy: 0.005, file: file, line: line)
+    XCTAssertEqual(srgb.blueComponent, expected.blue, accuracy: 0.005, file: file, line: line)
+    XCTAssertEqual(srgb.alphaComponent, 1.0, accuracy: 0.005, file: file, line: line)
+}
+
 final class GhosttyBackgroundThemeTests: XCTestCase {
-    func testColorClampsOpacity() {
+    func testColorClampsOpacity() throws {
         let base = NSColor(srgbRed: 0.10, green: 0.20, blue: 0.30, alpha: 1.0)
 
+        // An opacity below zero clamps to 0, so none of `base` survives the
+        // blend and the result is the window background it composites onto.
+        // Without the clamp the negative weight would push the channels out of
+        // range instead.
         let lowerClamped = GhosttyBackgroundTheme.color(backgroundColor: base, opacity: -2.0)
-        XCTAssertEqual(lowerClamped.alphaComponent, 0.0, accuracy: 0.0001)
+        try assertOpaqueColor(
+            lowerClamped,
+            equals: try expectedCompositeOverWindowBackground(foreground: base, opacity: 0.0)
+        )
 
+        // An opacity above one clamps to 1, so `base` covers the window
+        // background completely.
         let upperClamped = GhosttyBackgroundTheme.color(backgroundColor: base, opacity: 5.0)
-        XCTAssertEqual(upperClamped.alphaComponent, 1.0, accuracy: 0.0001)
+        try assertOpaqueColor(
+            upperClamped,
+            equals: try expectedCompositeOverWindowBackground(foreground: base, opacity: 1.0)
+        )
     }
 
-    func testColorFromNotificationUsesBackgroundAndOpacity() {
-        let fallbackColor = NSColor.black
-        let fallbackOpacity = 1.0
+    func testColorFromNotificationUsesBackgroundAndOpacity() throws {
+        let notificationColor = NSColor(srgbRed: 0.18, green: 0.29, blue: 0.44, alpha: 1.0)
         let notification = Notification(
             name: .ghosttyDefaultBackgroundDidChange,
             object: nil,
             userInfo: [
-                GhosttyNotificationKey.backgroundColor: NSColor(srgbRed: 0.18, green: 0.29, blue: 0.44, alpha: 1.0),
+                GhosttyNotificationKey.backgroundColor: notificationColor,
                 GhosttyNotificationKey.backgroundOpacity: NSNumber(value: 0.57),
             ]
         )
 
+        // The fallbacks differ from the payload, so a color built from them
+        // instead would fail these assertions.
         let actual = GhosttyBackgroundTheme.color(
             from: notification,
-            fallbackColor: fallbackColor,
-            fallbackOpacity: fallbackOpacity
+            fallbackColor: .black,
+            fallbackOpacity: 1.0
         )
-        guard let srgb = actual.usingColorSpace(.sRGB) else {
-            XCTFail("Expected sRGB-convertible color")
-            return
-        }
 
-        XCTAssertEqual(srgb.redComponent, 0.18, accuracy: 0.005)
-        XCTAssertEqual(srgb.greenComponent, 0.29, accuracy: 0.005)
-        XCTAssertEqual(srgb.blueComponent, 0.44, accuracy: 0.005)
-        XCTAssertEqual(srgb.alphaComponent, 0.57, accuracy: 0.005)
+        try assertOpaqueColor(
+            actual,
+            equals: try expectedCompositeOverWindowBackground(
+                foreground: notificationColor,
+                opacity: 0.57
+            )
+        )
     }
 
-    func testColorFromNotificationFallsBackWhenPayloadMissing() {
+    func testColorFromNotificationFallsBackWhenPayloadMissing() throws {
         let fallbackColor = NSColor(srgbRed: 0.12, green: 0.34, blue: 0.56, alpha: 1.0)
-        let fallbackOpacity = 0.42
         let notification = Notification(name: .ghosttyDefaultBackgroundDidChange)
 
         let actual = GhosttyBackgroundTheme.color(
             from: notification,
             fallbackColor: fallbackColor,
-            fallbackOpacity: fallbackOpacity
+            fallbackOpacity: 0.42
         )
-        guard let srgb = actual.usingColorSpace(.sRGB) else {
-            XCTFail("Expected sRGB-convertible color")
-            return
-        }
 
-        XCTAssertEqual(srgb.redComponent, 0.12, accuracy: 0.005)
-        XCTAssertEqual(srgb.greenComponent, 0.34, accuracy: 0.005)
-        XCTAssertEqual(srgb.blueComponent, 0.56, accuracy: 0.005)
-        XCTAssertEqual(srgb.alphaComponent, 0.42, accuracy: 0.005)
+        try assertOpaqueColor(
+            actual,
+            equals: try expectedCompositeOverWindowBackground(
+                foreground: fallbackColor,
+                opacity: 0.42
+            )
+        )
     }
 }
 
 final class PanelAppearanceBackgroundTests: XCTestCase {
-    func testTransparentGhosttyOpacityUsesClearContentBackground() {
+    func testTransparentGhosttyOpacityUsesClearContentBackground() throws {
         var config = GhosttyConfig()
         config.backgroundColor = NSColor(srgbRed: 0.10, green: 0.20, blue: 0.30, alpha: 1.0)
         config.backgroundOpacity = 0.42
@@ -2649,7 +2699,17 @@ final class PanelAppearanceBackgroundTests: XCTestCase {
 
         XCTAssertTrue(appearance.usesClearContentBackground)
         XCTAssertFalse(appearance.drawsContentBackground)
-        XCTAssertEqual(appearance.backgroundColor.alphaComponent, 0.42, accuracy: 0.0001)
+        // The panel fill is the configured color composited over the window
+        // background, so the 0.42 opacity shows up in the blend and the fill
+        // itself is opaque. The transparency the test is named for comes from
+        // the clear content background below.
+        try assertOpaqueColor(
+            appearance.backgroundColor,
+            equals: try expectedCompositeOverWindowBackground(
+                foreground: config.backgroundColor,
+                opacity: 0.42
+            )
+        )
         XCTAssertEqual(appearance.contentBackgroundColor.alphaComponent, 0.0, accuracy: 0.0001)
     }
 


### PR DESCRIPTION
## What this fixes

11 test failures across the Cmux/Ghostty suites. Both causes are stale test expectations — the product is right in each case, and the call was made with dating evidence rather than by matching whatever the code does now.

**1 — Terminal background colours expect pre-composite values (10 failures).** #3166 made `compositedTerminalColor` blend the terminal colour over `windowBackgroundColor` and return `alpha: 1`; these asserts still expect the old `withAlphaComponent` values. The asserts date to #667 (2026-03-01), genuinely before #3166 (2026-04-27) — `git blame` misleadingly points at a later file-reorg commit, so this needed a pickaxe (`git log -S`) to establish. Confirmed arithmetically: solving `0.18*0.57 + bg*0.43 = 0.5326` gives `bg = 1.0`, and all nine observed values decode as exact src-over. Opacity matters here because `chromeColorScheme` derives a luminance from the result, which is only meaningful once opaque.

The tests now recompute the expected blend independently. Two off-main attempts at this asserted `GhosttyBackgroundTheme.color == WindowAppearanceSnapshot.compositedTerminalColor` — but the former forwards to the latter, so it agrees by construction and can never fail. **Mutation-tested instead:** reverting the product to the pre-#3166 `withAlphaComponent` turns all nine red (16 failures). A tautological assert would have stayed green.

**2 — Menu-grouping test needs a flag that ships off (1 failure).** #7709 (the test) landed 09:24 UTC; #7705 (the flag, default-off) landed 14:29 UTC the same day — the flag PR landed second and didn't pick up the concurrent PR's new test. The test now enables the flag it depends on.

Tests only; no product changes. No `XCTSkip`.

## Verified (by name)

```
Test Suite 'GhosttyBackgroundThemeTests' passed — Executed 3 tests, with 0 failures
Test Suite 'PanelAppearanceBackgroundTests' passed — Executed 6 tests, with 0 failures
Test Suite 'GhosttyConfigTests'          passed — Executed 59 tests, with 0 failures
✔ Suite CmuxConfigNewWorkspaceMenuTests passed
```

## Left red on purpose (15 failures, all pre-existing)

Proven pre-existing without a rebuild: `CJKIMEInputTests.swift`, `GhosttyPhysicalInputFocusReassertionTests.swift`, `GhosttyTerminalView.swift` and `TerminalSurface+Renderer.swift` are unchanged vs `main`, and the `CmuxWebViewKeyEquivalentTests` region of `BrowserConfigTests.swift` is byte-identical across 1306 lines. Same test + same product ⇒ pre-existing. Skipping them would be faking green, so they stay visible, with a starting point for whoever takes them:

- **`CmuxWebViewKeyEquivalentTests` (3)** — the two omnibar arrow *restore* tests build a window no user path produces, and shortcut routing declines it for three independent reasons. `focusedBrowserOmnibarField` returns nil, so the arrow is force-dispatched to the web view and `performKeyEquivalent` returns true, which matches the observed signature (the assertion above it passes, the field editor stays empty). The three unmet preconditions: `preferredMainWindowContextForShortcutRouting` bails at `event_context_required_no_fallback`, because the probe window has a real `windowNumber` but no `cmux.main.<uuid>` identifier and no registered context; `workspace.browserPanel(for: panelId)` can never resolve a fresh `UUID()` that belongs to no workspace; and the tracked panel id is never set, because the `.browserDidFocusAddressBar` observer is registered `queue: .main` and so runs after the key event. Fixing only the first leaves the test red. The gate looks deliberate rather than accidental — it verifies the tracked panel actually lives in the event window's selected workspace before stealing an arrow key, and loosening it would widen shortcut routing across windows and stale workspaces. So the fix belongs in the test setup: register a real main window and use a real browser panel, then focus the omnibar through the same call Cmd+L makes.
- **`GhosttyKeyEquivalentRegressionTests` (8)** — not diagnosed. These five tests share the same window-construction flaw as above, but I could not establish from reading which branch declines Cmd+V in the three paste tests, so I am not guessing at a mechanism. One of the eight is likely the stale-Kitty-keyboard test, which spawns a real PTY and waits on two 5-second markers; the recorded suite time of ~11 s for six tests is about what two exhausted deadlines cost.
- **`GhosttyBackquoteRegressionTests` (1)** — a separate cause, not the routing one. Its only entry point is `GhosttyNSView.keyDown(with:)`; it never calls `performKeyEquivalent` and never reaches shortcut routing or omnibar code. Since exactly one of its three assertions fails, the observer fired and the surface is alive, which narrows it to `pressText` or `pressUnshiftedCodepoint`. Two candidates fit, and reading cannot separate them: AppKit routing Shift+ESC through `insertText:` rather than `cancelOperation:`, which skips the ESC→`~` repair in `textForKeyEvent` and sends nil text; or `unshiftedCodepointFromEvent` asking the active keyboard layout for key code 50, which is not `0x60` on a non-US layout. The product file here is byte-identical to the commit that introduced the test green, so whatever changed is outside it.

- **`GhosttyPhysicalInputFocusReassertionTests` (3)** — all three die in the shared `focusTerminal` helper at `debugDesiredFocusState()` while `isSurfaceViewFirstResponder()` passes. `allowsTerminalKeyboardFocus` (returns `?? true` with no coordinator) and `hasUsableFocusGeometry` (360x240) are ruled out; unresolved.

`GhosttyConfigTests`' theme test is **not** in that list: it failed once on a cold host at load 34, then passed solo and in a re-run of the identical batch (11.28s → 0.33s). Measuring the CLI directly shows 0.04s, clean exit, 48KB output, and a probe disproved the pipe-deadlock theory. It's a load-sensitive wall-clock gate, not a defect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787113595&installation_id=133855650&pr_number=8509&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8509&signature=453cb8b94c17e0dc0d151c71de2737248357af30b49c87a6b1489b694116d960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 13 failing tests by expecting composited, opaque terminal background colors, using the build’s deep-link scheme, and enabling a required menu flag in tests. No product changes.

- **Bug Fixes**
  - Terminal/Ghostty tests now compute expected colors via src-over compositing over the window background and assert opaque sRGB; adds helpers and covers opacity clamping, notification payload vs fallback, and transparent panel fill.
  - Deep-link tests use `AuthEnvironment.callbackScheme` instead of hard-coding `cmux`, covering `cmux-dev://` too.
  - New workspace menu test enables the agent-chat UI flag to include the item and verify ordering.

<sup>Written for commit f849ee79ec1563a2d2f0af226db42c1e4aa40145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened background-opacity checks to verify accurate color blending and opaque composited results.
  * Expanded coverage for opacity clamping, notification-based background colors, missing payload fallbacks, and transparent panel backgrounds.
  * Updated workspace menu coverage to account for the agent chat option and clarify layout ordering expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->