### PR TITLE
Fix the file-open working directory keeping a trailing slash (and the test-window over-release hiding it)

### DIFF
--- a/Sources/AppDelegate+CmuxSSHURL.swift
+++ b/Sources/AppDelegate+CmuxSSHURL.swift
@@ -207,7 +207,12 @@ struct TerminalDefaultFileOpenRequest: Equatable {
         }
 
         self.fileURL = standardizedURL
-        self.workingDirectory = standardizedURL.deletingLastPathComponent().path(percentEncoded: false)
+        // `path(percentEncoded:)` keeps a directory URL's trailing slash, so the parent of
+        // "/tmp/scripts/run.command" came back as "/tmp/scripts/". That string becomes the
+        // workspace's working directory, which the window title renders via {activeDirectory}
+        // and which directory comparisons match on, so the stray slash is user visible. `path`
+        // reports the same decoded path without it and still reports "/" for a file at the root.
+        self.workingDirectory = standardizedURL.deletingLastPathComponent().path
         self.initialInput = "\(Self.shellSingleQuoted(standardizedURL.path(percentEncoded: false)))\n"
     }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2059,6 +2059,9 @@ final class BrowserPanelWebViewLifecycleTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the close() below would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        realHostWindow.isReleasedWhenClosed = false
         defer {
             realHostWindow.contentView = nil
             realHostWindow.close()

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1041,6 +1041,22 @@ final class TerminalOffscreenStartupTests: XCTestCase {
         XCTAssertGreaterThan(panel.surface.debugRuntimeSurfaceCreateAttemptCountForTesting(), 0)
     }
 
+    /// Bounded poll on the main run loop. The first runtime-surface creation for a surface
+    /// waits on the Claude command shim install, which hops through a detached Task and a
+    /// main-actor continuation, so the attempt lands a turn or more after init returns. The
+    /// invariant these tests guard is that the attempt needs no window attach, not that it
+    /// happens synchronously inside init.
+    private func waitUntil(timeout: TimeInterval = 5.0, condition: () -> Bool) -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + timeout
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            if condition() {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        return condition()
+    }
+
     func testInitialInputSurfaceAttemptsRuntimeCreationBeforeWindowAttachment() {
         let panel = TerminalPanel(
             workspaceId: UUID(),
@@ -1051,9 +1067,9 @@ final class TerminalOffscreenStartupTests: XCTestCase {
             panel.surface.debugHasHeadlessStartupWindowForTesting(),
             "Restored auto-resume input should bootstrap through a hidden window rather than waiting for a user-focused portal."
         )
-        XCTAssertGreaterThan(
-            panel.surface.debugRuntimeSurfaceCreateAttemptCountForTesting(),
-            0,
+        XCTAssertNil(panel.surface.uiWindow, "The runtime must start without any real window attach.")
+        XCTAssertTrue(
+            waitUntil { panel.surface.debugRuntimeSurfaceCreateAttemptCountForTesting() > 0 },
             "Restored auto-resume input must start the terminal runtime without waiting for a window attach."
         )
     }
@@ -1068,9 +1084,9 @@ final class TerminalOffscreenStartupTests: XCTestCase {
             panel.surface.debugHasHeadlessStartupWindowForTesting(),
             "Command-launched offscreen terminals should bootstrap through a hidden window rather than waiting for a user-focused portal."
         )
-        XCTAssertGreaterThan(
-            panel.surface.debugRuntimeSurfaceCreateAttemptCountForTesting(),
-            0,
+        XCTAssertNil(panel.surface.uiWindow, "The runtime must start without any real window attach.")
+        XCTAssertTrue(
+            waitUntil { panel.surface.debugRuntimeSurfaceCreateAttemptCountForTesting() > 0 },
             "Offscreen command-launched terminals must start the runtime without waiting for a window attach."
         )
     }

--- a/cmuxTests/TerminalNotificationOpenPanelFallbackTests.swift
+++ b/cmuxTests/TerminalNotificationOpenPanelFallbackTests.swift
@@ -38,6 +38,9 @@ struct TerminalNotificationOpenPanelFallbackTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the close() below would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
         window.makeKeyAndOrderFront(nil)
 
@@ -106,6 +109,9 @@ struct TerminalNotificationOpenPanelFallbackTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the close() below would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
         window.makeKeyAndOrderFront(nil)
 

--- a/cmuxTests/WindowKeyDownReplayGuardTests.swift
+++ b/cmuxTests/WindowKeyDownReplayGuardTests.swift
@@ -80,6 +80,9 @@ struct WindowKeyDownReplayGuardTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the callers' close() would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
         window.contentView = container
 
@@ -96,6 +99,9 @@ struct WindowKeyDownReplayGuardTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the callers' close() would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
         window.contentView = container
 
@@ -113,6 +119,9 @@ struct WindowKeyDownReplayGuardTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the callers' close() would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
         window.contentView = container
 

--- a/cmuxTests/WindowTitleTemplateTests.swift
+++ b/cmuxTests/WindowTitleTemplateTests.swift
@@ -198,6 +198,9 @@ struct WindowTitleTemplateTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the close() below would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         manager.window = window
         defer {
             manager.window = nil
@@ -244,6 +247,9 @@ struct WindowTitleTemplateTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the close() below would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         manager.window = window
         defer {
             manager.window = nil
@@ -323,6 +329,9 @@ struct WindowTitleTemplateTests {
             backing: .buffered,
             defer: false
         )
+        // AppKit defaults to isReleasedWhenClosed, so the close() below would release a
+        // window ARC still owns and the over-release lands in a later autorelease pool drain.
+        window.isReleasedWhenClosed = false
         manager.window = window
         defer {
             manager.window = nil


### PR DESCRIPTION
## The bug

Open a file from a terminal and the workspace's working directory comes out with a trailing slash: `/tmp/scripts/run.command` yields `"/tmp/scripts/"` instead of `"/tmp/scripts"`. `path(percentEncoded:)` preserves a directory URL's trailing slash, and `deletingLastPathComponent()` produces a directory URL.

That value becomes the workspace working directory — which the window title renders through `{activeDirectory}`, and which directory comparisons match on — so the stray slash is user-visible. Switched to `.path`, which reports the same decoded path without it.

**Verified rather than assumed:** `.path` strips the trailing slash, still returns `"/"` for a file at the root, and decodes percent-literals identically. The test already expects `directory.path`, and the repo uses `.path` for parent directories elsewhere.

## The bigger find: the suite was reporting a fake green

`WindowKeyDownReplayGuardTests` printed `Test run with 0 tests in 1 suite passed` — **after 3 host restarts**. Nine `NSWindow` creation sites across 4 test files used AppKit's default `isReleasedWhenClosed = true` and then `close()`d under ARC, over-releasing the window; teardown crashed in `objc_release` inside `objc_autoreleasePoolPop` and took whole suites down with it while still printing a verdict. Fixed to the repo's existing convention (`isReleasedWhenClosed = false`, which `trackTestWindow` already follows).

The effect is large: one batch went from **3 tests actually running with 6 host restarts** to **53 tests across all 8 suites with 0 restarts**. An A/B (patched vs unpatched, same base) confirms this **un-hid** failures rather than causing them — the honest count went from "7 failing" to 9 once the crash stopped swallowing tests.

## One stale test assumption

Two offscreen-startup tests demanded a runtime-create attempt *inside* `TerminalPanel.init`. The Claude-shim install gate (added later) defers the first attempt through a detached Task and a main-actor continuation, so `return (false, nil)` always won — unpassable as written. Rather than assume the product regressed, this asserts the invariant still holds: `uiWindow` stays nil, and it bounded-polls for the attempt using the repo's `waitUntil` convention.

No `XCTSkip`/`XCTSkipIf` — none was warranted.

## Verified (by name, 0 host restarts everywhere)

| suite | before | after |
|---|---|---|
| `TerminalDefaultFileOpenRequestTests` | 4 tests, **2 failures** | **4 tests, 0 failures** |
| `TerminalOffscreenStartupTests` | 27 tests, **5 failures** | **27 tests, 3 failures** |
| `WindowKeyDownReplayGuardTests` | **0 tests "passed"**, 3 restarts | **6 tests**, 1 real failure |
| `WindowTitleTemplateTests` | passed (crashed others) | 12 tests passed |
| `TerminalNotificationOpenPanelFallbackTests` | passed (crashed others) | 2 tests passed |

Baseline: 55 suites in scope (31 `XCTestCase` + 24 swift-testing); 48 passed, 9 fail after the crash fix stopped hiding two of them.

## Left red on purpose (9 tests / 6 suites)

Not skipped, because none is proven unfixable: `TerminalOffscreenStartupTests` ×3 (`MobileHostService` never publishes routes in 200 polls — smells environmental, but that is an unconfirmed guess and shouldn't be trusted), `TerminalNotificationClearAllTests` ×4, `TerminalNotificationDirectInteractionTests` ×3, `TerminalSearchOverlayMouseReleaseTests` ×2, `WindowTerminalHostViewTests` ×1, `PortalHitTestingPerformanceTests` ×1, `WindowKeyDownReplayGuardTests` ×1, `TitlebarControlsSizingPolicyTests` ×1. The `TerminalOffscreenStartupTests` and `WindowKeyDownReplayGuardTests` remainders reproduce on the `main` base, so they are pre-existing.

## Harness notes for anyone running these locally

- `SWIFT_BACKTRACE=enable=no` does **not** reach the test host (`testmanagerd` spawns it, not your shell) — use **`TEST_RUNNER_SWIFT_BACKTRACE=enable=no`**, or every crash wedges ~2 minutes on the interactive backtracer.
- Several suites are declared `@Suite("display name")` and never print their type name, so a log analyzer keyed on type names will report them as "never ran" when they passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787114605&installation_id=133855650&pr_number=8510&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8510&signature=2a5a47ff16d0f22ef03ebbb0a3e037f9c2e0d958430b201918d17df3f3a84dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the working directory path when opening a file and stabilize terminal/window tests. This removes stray slashes in titles and stops test-host crashes that hid failures.

- **Bug Fixes**
  - File open: use `.path` for the parent directory in `TerminalDefaultFileOpenRequest` to drop trailing slashes while keeping root "/"; fixes `{activeDirectory}` titles and directory comparisons.
  - Tests: set `isReleasedWhenClosed = false` on AppKit test windows (WindowKeyDownReplayGuard, WindowTitleTemplate, Notification fallback, Ghostty config) to prevent over-releases; update offscreen-startup tests to assert `uiWindow` stays nil and poll for the first runtime creation attempt.

<sup>Written for commit a62b7599d3d3338da370718e3d3951d52c789677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

