### PR TITLE
Normalize CLI shim paths in shell integrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,6 +954,7 @@ jobs:
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
           python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
+          python3 tests/test_shell_cli_shim_path_normalization.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_claude_hook_stop_last_assistant.py

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -240,7 +240,11 @@ _cmux_path_prepend_unique_directory() {
 _cmux_install_cli_command_shim() {
     local command_name="$1"
     local wrapper_path="$2"
-    local shim_root="${TMPDIR:-/tmp}/cmux-cli-shims/${CMUX_SURFACE_ID:-$$}"
+    local tmp_root="${TMPDIR:-/tmp}"
+    while [[ "$tmp_root" == */ ]]; do
+        tmp_root="${tmp_root%/}"
+    done
+    local shim_root="$tmp_root/cmux-cli-shims/${CMUX_SURFACE_ID:-$$}"
     local shim_path="$shim_root/$command_name"
     local escaped_wrapper="$wrapper_path"
 

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -268,7 +268,11 @@ _cmux_path_prepend_unique_directory() {
 _cmux_install_cli_command_shim() {
     local command_name="$1"
     local wrapper_path="$2"
-    local shim_root="${TMPDIR:-/tmp}/cmux-cli-shims/${CMUX_SURFACE_ID:-$$}"
+    local tmp_root="${TMPDIR:-/tmp}"
+    while [[ "$tmp_root" == */ ]]; do
+        tmp_root="${tmp_root%/}"
+    done
+    local shim_root="$tmp_root/cmux-cli-shims/${CMUX_SURFACE_ID:-$$}"
     local shim_path="$shim_root/$command_name"
     local escaped_wrapper="$wrapper_path"
 

--- a/Resources/shell-integration/fish/config.fish
+++ b/Resources/shell-integration/fish/config.fish
@@ -165,6 +165,7 @@ if test "$_cmux_integration_enabled" != 0
         if set -q TMPDIR; and test -n "$TMPDIR"
             set tmp_root "$TMPDIR"
         end
+        set tmp_root (string replace -r '/+$' '' -- "$tmp_root")
         set -l surface_component "$fish_pid"
         if set -q CMUX_SURFACE_ID; and test -n "$CMUX_SURFACE_ID"
             set surface_component "$CMUX_SURFACE_ID"

--- a/tests/test_shell_cli_shim_path_normalization.py
+++ b/tests/test_shell_cli_shim_path_normalization.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Regression coverage for duplicate cmux CLI shim entries in PATH."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHELL_INTEGRATION_ROOT = REPO_ROOT / "Resources" / "shell-integration"
+
+
+def _write_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _prepare_bundle(root: Path) -> tuple[Path, dict[str, Path]]:
+    resources = root / "bundle" / "Resources"
+    integration_root = resources / "shell-integration"
+    fish_root = integration_root / "fish"
+    bin_root = resources / "bin"
+    fish_root.mkdir(parents=True)
+    bin_root.mkdir(parents=True)
+
+    integrations = {
+        "zsh": integration_root / "cmux-zsh-integration.zsh",
+        "bash": integration_root / "cmux-bash-integration.bash",
+        "fish": fish_root / "config.fish",
+    }
+    shutil.copy2(SHELL_INTEGRATION_ROOT / "cmux-zsh-integration.zsh", integrations["zsh"])
+    shutil.copy2(SHELL_INTEGRATION_ROOT / "cmux-bash-integration.bash", integrations["bash"])
+    shutil.copy2(SHELL_INTEGRATION_ROOT / "fish" / "config.fish", integrations["fish"])
+    _write_executable(bin_root / "cmux-claude-wrapper")
+    return integration_root, integrations
+
+
+def _run_shell(
+    shell_name: str,
+    executable: str,
+    integration_root: Path,
+    integration: Path,
+    temporary_root: Path,
+    normalized_shim_root: Path,
+) -> subprocess.CompletedProcess[str]:
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CMUX")}
+    env.update(
+        {
+            # macOS normally exports TMPDIR with this trailing slash.
+            "TMPDIR": f"{temporary_root}/",
+            "PATH": f"{normalized_shim_root}:/usr/bin:/bin",
+            "CMUX_SURFACE_ID": "path-normalization-surface",
+            "CMUX_SHELL_INTEGRATION": "1",
+            "CMUX_SHELL_INTEGRATION_DIR": str(integration_root),
+            "CMUX_TEST_INTEGRATION": str(integration),
+            "CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION": "0",
+            "CMUX_SOCKET_PATH": "",
+            "GHOSTTY_RESOURCES_DIR": "",
+        }
+    )
+
+    if shell_name == "zsh":
+        command = [
+            executable,
+            "-f",
+            "-c",
+            'source "$CMUX_TEST_INTEGRATION" >/dev/null 2>&1; '
+            'printf "root=%s\\n" "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}"; '
+            'printf "path=%s\\n" "$PATH"',
+        ]
+    elif shell_name == "bash":
+        command = [
+            executable,
+            "--noprofile",
+            "--norc",
+            "-c",
+            'source "$CMUX_TEST_INTEGRATION" >/dev/null 2>&1; '
+            'printf "root=%s\\n" "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}"; '
+            'printf "path=%s\\n" "$PATH"',
+        ]
+    else:
+        command = [
+            executable,
+            "--no-config",
+            "-c",
+            'source "$CMUX_TEST_INTEGRATION" >/dev/null 2>&1; '
+            'printf "root=%s\\n" "$CMUX_CLAUDE_WRAPPER_SHIM_ROOT"; '
+            'printf "path=%s\\n" (string join : $PATH)',
+        ]
+
+    return subprocess.run(
+        command,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_shell_cli_shim_path_is_normalized() -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-shim-path-normalization-") as td:
+        root = Path(td)
+        integration_root, integrations = _prepare_bundle(root)
+        temporary_root = root / "temporary"
+        normalized_shim_root = (
+            temporary_root / "cmux-cli-shims" / "path-normalization-surface"
+        )
+        normalized_shim_root.mkdir(parents=True)
+
+        tested_shells: list[str] = []
+        for shell_name in ("zsh", "bash", "fish"):
+            executable = shutil.which(shell_name)
+            if executable is None:
+                continue
+            tested_shells.append(shell_name)
+            proc = _run_shell(
+                shell_name,
+                executable,
+                integration_root,
+                integrations[shell_name],
+                temporary_root,
+                normalized_shim_root,
+            )
+            debug = (
+                f"\nshell={shell_name} exit={proc.returncode}"
+                f"\n--- stdout ---\n{proc.stdout}"
+                f"\n--- stderr ---\n{proc.stderr}"
+            )
+            assert proc.returncode == 0, "shell integration failed" + debug
+
+            output = dict(
+                line.split("=", 1)
+                for line in proc.stdout.splitlines()
+                if "=" in line
+            )
+            expected = str(normalized_shim_root)
+            assert output.get("root") == expected, (
+                "cmux exported a non-normalized CLI shim root" + debug
+            )
+
+            path_entries = output.get("path", "").split(":")
+            matching_entries = [
+                entry for entry in path_entries if os.path.normpath(entry) == expected
+            ]
+            assert matching_entries == [expected], (
+                "cmux left duplicate equivalent CLI shim directories in PATH" + debug
+            )
+
+        assert {"zsh", "bash"}.issubset(tested_shells), (
+            f"required test shells were unavailable: tested {tested_shells!r}"
+        )
+
+
+if __name__ == "__main__":
+    test_shell_cli_shim_path_is_normalized()
+    print("PASS: shell integrations keep one normalized cmux CLI shim PATH entry")


### PR DESCRIPTION
## Summary

- normalize trailing slashes in `TMPDIR` before constructing per-surface CLI shim paths
- keep zsh, bash, and fish shell integrations consistent
- add a behavior-level regression that reproduces Swift's normalized PATH entry followed by shell integration startup

## Root cause

macOS normally exports `TMPDIR` with a trailing slash. The app creates the CLI shim directory through Foundation URL standardization, while the shell integrations appended another slash directly. Because their PATH helper compares raw strings, the normalized and double-slash spellings were both retained even though they refer to the same directory.

## User impact

Shell startup now exports one normalized cmux CLI shim directory instead of duplicate equivalent PATH entries.

## Validation

- `python3 tests/test_shell_cli_shim_path_normalization.py`
- `python3 tests/test_issue_6714_zsh_shim_noclobber.py`
- `python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py`
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`
- `fish -n Resources/shell-integration/fish/config.fish`

`./scripts/reload.sh --tag fix-cli-shim-path` could not enter compilation locally because the machine has only Command Line Tools selected and no full Xcode installation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787120111&installation_id=133855650&pr_number=8511&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8511&signature=2be98900d94896d78a4a5d3b91f3d2cb6b9ec43344a30dc97da761e80b9c28b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize CLI shim paths in shell integrations to prevent duplicate PATH entries when `TMPDIR` includes trailing slashes. Shell startup now exports a single, consistent shim directory across zsh, bash, and fish.

- **Bug Fixes**
  - Trim trailing slashes from `TMPDIR` before building the shim root in zsh, bash, and fish.
  - Keep PATH unique by constructing one normalized shim directory.
  - Add regression test `tests/test_shell_cli_shim_path_normalization.py` and enable it in CI.

<sup>Written for commit 4643d03267b5108b74ddd3a14161e53fcdc2662f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell CLI shim path handling when the temporary directory includes trailing slashes.
  * Prevented duplicate equivalent shim entries from being added to `PATH`.

* **Tests**
  * Added regression coverage across supported shell integrations to verify normalized shim paths and `PATH` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->