### PR TITLE
Fix Settings and main window zombies under AeroSpace

### DIFF
--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -65,6 +65,11 @@ final class SettingsWindowPresenter: NSObject {
     /// (and the window's identifier removed) in `settingsWindowWillClose` so
     /// a closed window can never absorb a future open request.
     private var settingsWindow: NSWindow?
+    /// Retains each AppKit window controller through its close callback. The
+    /// identity map matters because `show()` may re-enter from another
+    /// `willClose` observer and install a replacement before teardown of the
+    /// closing window has finished.
+    private var windowControllers: [ObjectIdentifier: ReleasingWindowController] = [:]
     // Navigation-delivery state is internal (not private) because its
     // behavior lives in SettingsWindowNavigationDelivery.swift (split for
     // the file-length budget); no type outside the presenter touches it.
@@ -339,6 +344,7 @@ final class SettingsWindowPresenter: NSObject {
             name: NSWindow.willCloseNotification,
             object: window
         )
+        installWindowController(for: window)
         settingsWindow = window
     }
 
@@ -346,6 +352,9 @@ final class SettingsWindowPresenter: NSObject {
         let window = windowFactory(self)
         window.identifier = NSUserInterfaceItemIdentifier(Self.windowIdentifier)
         window.isReleasedWhenClosed = false
+        // Do not expose a close-time transform surface that tiling window
+        // managers can retain as an empty workspace node.
+        window.animationBehavior = .none
         window.isRestorable = false
         window.minSize = Self.minimumSize
         window.contentMinSize = Self.minimumSize
@@ -370,6 +379,7 @@ final class SettingsWindowPresenter: NSObject {
             name: NSWindow.willCloseNotification,
             object: window
         )
+        installWindowController(for: window)
         settingsWindow = window
         isContentReadyForNavigation = false
         return window
@@ -450,6 +460,7 @@ final class SettingsWindowPresenter: NSObject {
             object: window
         )
         window.identifier = nil
+        retireWindowController(for: window)
         if settingsWindow === window {
             settingsWindow = nil
             isContentReadyForNavigation = false
@@ -462,20 +473,28 @@ final class SettingsWindowPresenter: NSObject {
             let window = notification.object as? NSWindow,
             window === settingsWindow
         else { return }
-        NotificationCenter.default.removeObserver(
-            self,
-            name: NSWindow.willCloseNotification,
-            object: window
-        )
         // A closed window must never be rediscovered by an open request, and
         // its SwiftUI tree must be released with it so it cannot linger
         // half-alive (the #4964 blank-reopen / #5321 lingering-window
         // classes). The next show() builds a fresh window from scratch.
-        window.identifier = nil
-        settingsWindow = nil
-        isContentReadyForNavigation = false
+        strip(window)
         window.contentViewController = nil
         window.contentView = nil
+    }
+
+    private func installWindowController(for window: NSWindow) {
+        let key = ObjectIdentifier(window)
+        guard windowControllers[key] == nil else { return }
+        windowControllers[key] = ReleasingWindowController(window: window)
+    }
+
+    private func retireWindowController(for window: NSWindow) {
+        let key = ObjectIdentifier(window)
+        guard let controller = windowControllers[key] else { return }
+        DispatchQueue.main.async { [weak self, weak controller] in
+            guard let self, self.windowControllers[key] === controller else { return }
+            self.windowControllers.removeValue(forKey: key)
+        }
     }
 
     // Multi-monitor recovery + diagnostics live in SettingsWindowGeometry.swift.

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -65,10 +65,10 @@ final class SettingsWindowPresenter: NSObject {
     /// (and the window's identifier removed) in `settingsWindowWillClose` so
     /// a closed window can never absorb a future open request.
     private var settingsWindow: NSWindow?
-    /// Retains each AppKit window controller through its close callback. The
-    /// identity map matters because `show()` may re-enter from another
-    /// `willClose` observer and install a replacement before teardown of the
-    /// closing window has finished.
+    /// Retains each AppKit window controller until presenter teardown begins.
+    /// The identity map matters because `show()` may re-enter from another
+    /// `willClose` observer and install a replacement while the closing
+    /// window is still unwinding.
     private var windowControllers: [ObjectIdentifier: ReleasingWindowController] = [:]
     // Navigation-delivery state is internal (not private) because its
     // behavior lives in SettingsWindowNavigationDelivery.swift (split for
@@ -489,12 +489,7 @@ final class SettingsWindowPresenter: NSObject {
     }
 
     private func retireWindowController(for window: NSWindow) {
-        let key = ObjectIdentifier(window)
-        guard let controller = windowControllers[key] else { return }
-        DispatchQueue.main.async { [weak self, weak controller] in
-            guard let self, self.windowControllers[key] === controller else { return }
-            self.windowControllers.removeValue(forKey: key)
-        }
+        windowControllers.removeValue(forKey: ObjectIdentifier(window))
     }
 
     // Multi-monitor recovery + diagnostics live in SettingsWindowGeometry.swift.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -579,7 +579,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private final class MainWindowController: NSWindowController, NSWindowDelegate {
+    private final class MainWindowController: ReleasingWindowController {
         var onClose: (() -> Void)?
         var shouldClose: (() -> Bool)?
 
@@ -593,7 +593,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         #endif
 
-        func windowWillClose(_ notification: Notification) {
+        override func managedWindowWillClose(_ window: NSWindow) {
             onClose?()
         }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -111,6 +111,15 @@ private func debugCommandPaletteResponderSummary(_ responder: NSResponder?) -> S
 #endif
 
 @MainActor
+final class WeakWindowReference {
+    weak var window: NSWindow?
+
+    init(_ window: NSWindow? = nil) {
+        self.window = window
+    }
+}
+
+@MainActor
 private final class WindowCommandPaletteOverlayController: NSObject {
     private weak var window: NSWindow?
     private let containerView = CommandPaletteOverlayContainerView(frame: .zero)
@@ -848,7 +857,8 @@ struct ContentView: View {
     @State private var lastSidebarSelectionIndex: Int? = nil
     @State private var titlebarText: String = ""
     @State private var isFullScreen: Bool = false
-    @State private var observedWindow: NSWindow?
+    @State private var observedWindowReference = WeakWindowReference()
+    private var observedWindow: NSWindow? { observedWindowReference.window }
     @State private var sidebarRenderWorkerClient: RenderWorkerClient?
     @StateObject private var fullscreenControlsViewModel = TitlebarControlsViewModel()
     @StateObject private var fileExplorerStore = FileExplorerStore()
@@ -1684,7 +1694,7 @@ struct ContentView: View {
                     debugSource: "titlebar.hiddenNewWorkspace"
                 )
             },
-            observedWindow: observedWindow,
+            observedWindowReference: observedWindowReference,
             selection: $sidebarSelectionState.selection,
             selectedTabIds: $selectedTabIds, lastSidebarSelectionIndex: $lastSidebarSelectionIndex, sidebarRenderWorkerClient: $sidebarRenderWorkerClient
         )
@@ -3252,7 +3262,7 @@ struct ContentView: View {
         // Track this window for fullscreen notifications
         if observedWindow !== window {
             DispatchQueue.main.async {
-                observedWindow = window
+                observedWindowReference = WeakWindowReference(window)
                 isFullScreen = window.styleMask.contains(.fullScreen)
                 let availableWidth = window.contentView?.bounds.width ?? window.contentLayoutRect.width
                 clampSidebarWidthIfNeeded(availableWidth: availableWidth)
@@ -10401,7 +10411,7 @@ struct VerticalTabsSidebar: View, Equatable {
     // precedent.
     static func == (lhs: VerticalTabsSidebar, rhs: VerticalTabsSidebar) -> Bool {
         lhs.windowId == rhs.windowId
-            && lhs.observedWindow === rhs.observedWindow
+            && lhs.observedWindowReference.window === rhs.observedWindowReference.window
             && lhs.updateViewModel === rhs.updateViewModel
             && lhs.fileExplorerState === rhs.fileExplorerState
     }
@@ -10412,7 +10422,8 @@ struct VerticalTabsSidebar: View, Equatable {
     let onSendFeedback: () -> Void
     let onToggleSidebar: () -> Void
     let onNewTab: () -> Void
-    let observedWindow: NSWindow?
+    let observedWindowReference: WeakWindowReference
+    var observedWindow: NSWindow? { observedWindowReference.window }
     @EnvironmentObject var tabManager: TabManager
     // Observe the coalesced unread projection instead of the notification store
     // so notification churn (terminal/agent activity) no longer reconstructs

--- a/cmuxTests/ClosedMainWindowRoutingTests.swift
+++ b/cmuxTests/ClosedMainWindowRoutingTests.swift
@@ -186,6 +186,7 @@ struct WindowZombieRegressionTests {
         #expect(reference?.window == nil)
         #expect(releasedWindow == nil)
     }
+
     @Test("Closed Settings window is fully retired")
     func closedSettingsWindowIsFullyRetired() async {
         _ = NSApplication.shared

--- a/cmuxTests/ClosedMainWindowRoutingTests.swift
+++ b/cmuxTests/ClosedMainWindowRoutingTests.swift
@@ -166,6 +166,26 @@ struct ClosedMainWindowRoutingTests {
 @MainActor
 @Suite("Window zombie regressions", .serialized)
 struct WindowZombieRegressionTests {
+    @Test("SwiftUI window state does not own its native window")
+    func swiftUIWindowStateDoesNotOwnItsNativeWindow() {
+        weak var releasedWindow: NSWindow?
+        var reference: WeakWindowReference?
+
+        autoreleasepool {
+            var window: NSWindow? = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            releasedWindow = window
+            reference = WeakWindowReference(window)
+            window = nil
+        }
+
+        #expect(reference?.window == nil)
+        #expect(releasedWindow == nil)
+    }
     @Test("Closed Settings window is fully retired")
     func closedSettingsWindowIsFullyRetired() async {
         _ = NSApplication.shared

--- a/cmuxTests/ClosedMainWindowRoutingTests.swift
+++ b/cmuxTests/ClosedMainWindowRoutingTests.swift
@@ -206,8 +206,12 @@ struct WindowZombieRegressionTests {
             closingWindow?.close()
             closingWindow = nil
         }
-        await settleWindowLifecycle()
+        let didRetireWindow = await settleWindowLifecycle {
+            releasedWindow == nil
+                && (closingWindowNumber.map { !isWindowServerWindowAlive($0) } ?? true)
+        }
 
+        #expect(didRetireWindow)
         #expect(releasedWindow == nil)
         #expect(closingWindowNumber != nil)
         if let closingWindowNumber {
@@ -254,8 +258,12 @@ struct WindowZombieRegressionTests {
             closingWindow?.close()
             closingWindow = nil
         }
-        await settleWindowLifecycle()
+        let didRetireWindow = await settleWindowLifecycle {
+            releasedWindow == nil
+                && (closingWindowNumber.map { !isWindowServerWindowAlive($0) } ?? true)
+        }
 
+        #expect(didRetireWindow)
         #expect(releasedWindow?.windowController == nil)
         #expect(releasedWindow?.contentViewController == nil)
         #expect(releasedWindow?.contentView == nil)
@@ -279,11 +287,17 @@ struct WindowZombieRegressionTests {
         }
     }
 
-    private func settleWindowLifecycle() async {
-        for _ in 0..<5 {
+    private func settleWindowLifecycle(
+        until condition: () async -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while !(await condition()) {
+            guard clock.now < deadline else { return false }
             await Task.yield()
-            try? await Task.sleep(for: .milliseconds(200))
+            try? await clock.sleep(for: .milliseconds(50))
         }
+        return true
     }
 
     private func isWindowServerWindowAlive(_ windowNumber: Int) -> Bool {

--- a/cmuxTests/ClosedMainWindowRoutingTests.swift
+++ b/cmuxTests/ClosedMainWindowRoutingTests.swift
@@ -162,3 +162,116 @@ struct ClosedMainWindowRoutingTests {
         #expect(app.focusMainWindow(windowId: windowCId))
     }
 }
+
+@MainActor
+@Suite("Window zombie regressions", .serialized)
+struct WindowZombieRegressionTests {
+    @Test("Closed Settings window is fully retired")
+    func closedSettingsWindowIsFullyRetired() async {
+        _ = NSApplication.shared
+        closeSettingsWindows()
+        defer { closeSettingsWindows() }
+
+        var closingWindowNumber: Int?
+        weak var releasedWindow: NSWindow?
+        autoreleasepool {
+            let presenter = SettingsWindowPresenter()
+            presenter.show()
+            var closingWindow = settingsWindow()
+            #expect(closingWindow != nil)
+            guard closingWindow != nil else { return }
+            closingWindowNumber = closingWindow?.windowNumber
+            releasedWindow = closingWindow
+            closingWindow?.close()
+            closingWindow = nil
+        }
+        await settleWindowLifecycle()
+
+        #expect(releasedWindow == nil)
+        #expect(closingWindowNumber != nil)
+        if let closingWindowNumber {
+            #expect(!isWindowServerWindowAlive(closingWindowNumber))
+        }
+    }
+
+    @Test("Closed detached main window is fully retired")
+    func closedDetachedMainWindowIsFullyRetired() async {
+        _ = NSApplication.shared
+        let previousAppDelegate = AppDelegate.shared
+        let app = AppDelegate()
+        AppDelegate.shared = app
+        let previousConfirmationHandler = app.debugCloseMainWindowConfirmationHandler
+        app.debugCloseMainWindowConfirmationHandler = { _ in true }
+        var survivorWindowId: UUID?
+        weak var releasedWindow: NSWindow?
+        defer {
+            if let leakedWindow = releasedWindow {
+                leakedWindow.windowController?.window = nil
+                leakedWindow.delegate = nil
+                leakedWindow.contentViewController = nil
+                leakedWindow.contentView = nil
+                leakedWindow.orderOut(nil)
+            }
+            if let survivorWindowId,
+               let survivor = app.windowForMainWindowId(survivorWindowId) {
+                survivor.close()
+            }
+            app.debugCloseMainWindowConfirmationHandler = previousConfirmationHandler
+            TerminalController.shared.setActiveTabManager(nil)
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        survivorWindowId = app.createMainWindow(shouldActivate: false)
+        let closingWindowId = app.createMainWindow(shouldActivate: false)
+        var closingWindow = app.windowForMainWindowId(closingWindowId)
+        #expect(closingWindow != nil)
+        guard closingWindow != nil else { return }
+        let closingWindowNumber = closingWindow?.windowNumber
+        releasedWindow = closingWindow
+
+        autoreleasepool {
+            closingWindow?.close()
+            closingWindow = nil
+        }
+        await settleWindowLifecycle()
+
+        #expect(releasedWindow?.windowController == nil)
+        #expect(releasedWindow?.contentViewController == nil)
+        #expect(releasedWindow?.contentView == nil)
+        #expect(closingWindowNumber != nil)
+        if let closingWindowNumber {
+            #expect(!isWindowServerWindowAlive(closingWindowNumber))
+        }
+    }
+
+    private func settingsWindow() -> NSWindow? {
+        NSApp.windows.first {
+            $0.identifier?.rawValue == "cmux.settings" && $0.isVisible
+        }
+    }
+
+    private func closeSettingsWindows() {
+        for window in NSApp.windows where window.identifier?.rawValue == "cmux.settings" {
+            window.orderOut(nil)
+            window.identifier = nil
+            window.close()
+        }
+    }
+
+    private func settleWindowLifecycle() async {
+        for _ in 0..<5 {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(200))
+        }
+    }
+
+    private func isWindowServerWindowAlive(_ windowNumber: Int) -> Bool {
+        guard let windows = CGWindowListCopyWindowInfo(
+            .optionIncludingWindow,
+            CGWindowID(windowNumber)
+        ) as? [[CFString: Any]] else {
+            return false
+        }
+        return !windows.isEmpty
+    }
+}

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -150,7 +150,7 @@ final class SidebarLazyLayoutScaleTests {
             onSendFeedback: {},
             onToggleSidebar: {},
             onNewTab: {},
-            observedWindow: nil,
+            observedWindowReference: WeakWindowReference(),
             selection: .constant(.tabs),
             selectedTabIds: .constant([]),
             lastSidebarSelectionIndex: .constant(nil),


### PR DESCRIPTION


https://github.com/user-attachments/assets/71a9358b-a82c-4dfa-b248-8e2800826571

## Summary

- give Settings and main windows explicit `ReleasingWindowController` ownership so close teardown clears their AppKit content/controller relationships
- disable Settings close animation and retire presenter-owned controllers by window identity, including reentrant close/open churn
- replace strong SwiftUI `NSWindow` state in `ContentView` and the workspace sidebar with a weak reference so a detached main window can deallocate instead of remaining in WindowServer
- add WindowServer-backed regression coverage for Settings and detached main window retirement, plus a weak-reference ownership test

## Root cause

AeroSpace exposed two cmux lifecycle leaks. Settings had no durable `NSWindowController` owner during close. Main windows did clear their controller, but the SwiftUI tree retained the native window through `@State` and the sidebar snapshot. The accessibility window disappeared while the WindowServer surface remained, so AeroSpace kept or re-tiled the empty node.

## Verification

- `WindowZombieRegressionTests`: 3 passed
- `ReleasingWindowControllerTests`: 2 passed
- `SettingsWindowOpenRegressionTests`: 5 passed
- `./scripts/lint-pbxproj-test-wiring.sh`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-aerospace-zombies`
- live AeroSpace 0.20.3-Beta verification on macOS 26.5.1:
  - Settings open/close repeated 3 times; every closed window ID disappeared from AeroSpace
  - second main window closed; its ID disappeared from both AeroSpace and `CGWindowList`
  - switched AeroSpace workspace away and back; neither closed window returned

The build used the repository's `CMUX_SKIP_ZIG_BUILD=1` helper path because the local Xcode 26/Zig helper link currently fails on macOS system symbols; the cmux app target built successfully.

## Localization

No user-facing strings changed. `Resources/Localizable.xcstrings` and both web message catalogs parse successfully and have no diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787130452&installation_id=133855650&pr_number=8513&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8513&signature=a44804f783c1a026a80dc2e626f3f75379bc6658ff4d56be218060ddfa90e591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zombie windows under AeroSpace by fully releasing Settings and detached main windows on close. Closed windows now deallocate and their WindowServer surfaces are removed, preventing re-tiling.

- **Bug Fixes**
  - Settings: retain a ReleasingWindowController per window (identity map), install on create, retire on teardown; disable close animation; clear window identifier; strip controller/content references during close.
  - Main: make MainWindowController extend ReleasingWindowController to guarantee cleanup on close.
  - SwiftUI: replace strong NSWindow state with WeakWindowReference in ContentView and the sidebar so detached windows can deallocate.
  - Tests: add WindowServer-backed regression tests for Settings and detached main windows, plus a weak-reference ownership test.

<sup>Written for commit 41d71917c9ce188345c6cd916a22fce8ca5c17fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lifecycle handling so closed Settings and main windows are fully retired and deallocated (no “zombie” lingering/reappearing).
  - Enhanced cleanup to ensure SwiftUI content for closed windows is released promptly.
  - Improved tracking by using weak window references to avoid unintended window retention.
- **Tests**
  - Added regression coverage to verify window deallocation and window-server removal after closing Settings and detached main windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->