### PR TITLE
fix(surface): reject unresolvable surface_id instead of closing the caller's surface

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4667,7 +4667,14 @@ struct CMUXCLI {
             let csWsFlag = optionValue(commandArgs, name: "--workspace")
             let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowId)
             let workspaceArg = csWsFlag ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-            let surfaceRaw = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel") ?? (csWsFlag == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+            // An explicit but empty --surface/--panel (e.g. `--surface "$VAR"` where
+            // VAR is unset) must be a hard error, not a silent degrade to the focused
+            // surface. Only an *omitted* flag may fall back to $CMUX_SURFACE_ID.
+            let explicitSurfaceFlag = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel")
+            if let explicitSurfaceFlag, explicitSurfaceFlag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw CLIError(message: "close-surface: --surface was given an empty value (omit --surface to close the focused surface)")
+            }
+            let surfaceRaw = explicitSurfaceFlag ?? (csWsFlag == nil && windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
             var params: [String: Any] = [:]
             let winId = try normalizeWindowHandle(windowRaw, client: client)
             if let winId { params["window_id"] = winId }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4665,6 +4665,18 @@ struct CMUXCLI {
 
         case "close-surface":
             let csWsFlag = optionValue(commandArgs, name: "--workspace")
+            // An explicit but empty --workspace/--window (e.g. `--workspace "$VAR"`
+            // where VAR is unset) must be a hard error, not a silent degrade to the
+            // focused workspace/window — the same self-decapitation footgun as an
+            // empty --surface. Only an *omitted* flag may fall back to the caller's
+            // focused context. Guard the explicit flags (not the resolved override).
+            if let csWsFlag, csWsFlag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw CLIError(message: "close-surface: --workspace was given an empty value (omit --workspace to use the focused workspace)")
+            }
+            if let windowFlag = optionValue(commandArgs, name: "--window"),
+               windowFlag.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                throw CLIError(message: "close-surface: --window was given an empty value (omit --window to use the focused window)")
+            }
             let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowId)
             let workspaceArg = csWsFlag ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             // An explicit but empty --surface/--panel (e.g. `--surface "$VAR"` where

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -596,7 +596,20 @@ extension ControlCommandCoordinator {
         guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
-        let resolution = context?.controlSurfaceClose(routing: routing, surfaceID: uuid(params, "surface_id"))
+        // An explicitly-supplied surface_id that fails to resolve (an unknown/stale
+        // `kind:N` ref, or a value that is neither a UUID nor a live handle) must be a
+        // hard error — never a silent fallback to the focused surface, which would
+        // close the *caller's own* surface (self-decapitation). Only an *omitted*
+        // surface_id is allowed to fall through to the focused-surface default.
+        let surfaceID = uuid(params, "surface_id")
+        if surfaceID == nil, let requested = string(params, "surface_id") {
+            return .err(
+                code: "not_found",
+                message: "Surface not found",
+                data: .object(["surface_id": .string(requested)])
+            )
+        }
+        let resolution = context?.controlSurfaceClose(routing: routing, surfaceID: surfaceID)
             ?? .tabManagerUnavailable
         switch resolution {
         case .tabManagerUnavailable:

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -596,17 +596,23 @@ extension ControlCommandCoordinator {
         guard context?.controlSurfaceRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
-        // An explicitly-supplied surface_id that fails to resolve (an unknown/stale
-        // `kind:N` ref, or a value that is neither a UUID nor a live handle) must be a
-        // hard error — never a silent fallback to the focused surface, which would
-        // close the *caller's own* surface (self-decapitation). Only an *omitted*
-        // surface_id is allowed to fall through to the focused-surface default.
+        // A surface_id that is *present but fails to resolve* — an unknown/stale
+        // `kind:N` ref, a UUID/handle with no live surface, an empty or
+        // whitespace-only string, or a non-string/junk value — must be a hard error,
+        // never a silent fallback to the focused surface, which would close the
+        // *caller's own* surface (self-decapitation). Only an *omitted* (or JSON
+        // `null`) surface_id may fall through to the focused-surface default.
+        //
+        // Presence is detected with `hasNonNull`, NOT the trimming `string()` helper:
+        // `string()` normalises "" / "   " to nil, so an explicit empty-string
+        // surface_id from a raw-socket client would otherwise look identical to an
+        // omitted one and re-open the self-decapitation hole for that value.
         let surfaceID = uuid(params, "surface_id")
-        if surfaceID == nil, let requested = string(params, "surface_id") {
+        if surfaceID == nil, hasNonNull(params, "surface_id") {
             return .err(
                 code: "not_found",
                 message: "Surface not found",
-                data: .object(["surface_id": .string(requested)])
+                data: .object(["surface_id": .string(rawString(params, "surface_id") ?? "")])
             )
         }
         let resolution = context?.controlSurfaceClose(routing: routing, surfaceID: surfaceID)

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -1478,6 +1478,42 @@ final class TerminalControllerSocketSecurityTests {
         _ = try XCTUnwrap(workspace.panels[other.id])
     }
 
+    @Test func testV2SurfaceCloseRejectsEmptyStringSurfaceIdAndPreservesFocusedSurface() throws {
+        let manager = TabManager()
+        defer {
+            manager.tabs.forEach { $0.teardownAllPanels() }
+            TerminalController.shared.setActiveTabManager(nil)
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        // Two surfaces; the SECOND is focused — the stand-in for the caller's own tab.
+        let other = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: false))
+        let focused = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true))
+        TerminalController.shared.setActiveTabManager(manager)
+
+        // A raw-socket client sending an explicit *empty-string* surface_id must NOT
+        // silently degrade to the focused surface. `string()` normalises "" to nil, so
+        // the coordinator has to detect presence via `hasNonNull` rather than the
+        // trimming `string()` helper — otherwise "" reopens the self-decapitation hole
+        // that the unresolvable-ref guard closes for non-empty values.
+        let response = try handleV2Request(
+            method: "surface.close",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": ""
+            ]
+        )
+
+        // Hard error, not a silent close.
+        XCTAssertEqual(response["ok"] as? Bool, false, "Unexpected JSON-RPC response: \(response)")
+        let error = try XCTUnwrap(response["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "not_found")
+        // Neither the caller's focused surface nor the other surface may be closed.
+        _ = try XCTUnwrap(workspace.panels[focused.id])
+        _ = try XCTUnwrap(workspace.panels[other.id])
+    }
+
     @Test func testBrowserOpenSplitDoesNotExternallyOpenDiffViewerWhenBrowserDisabled() throws {
         let defaults = UserDefaults.standard
         let previousBrowserDisabled = defaults.object(forKey: BrowserAvailabilitySettings.disabledKey)

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -1445,6 +1445,39 @@ final class TerminalControllerSocketSecurityTests {
         )
     }
 
+    // Regression: `surface.close` with an explicitly-supplied but UNRESOLVABLE surface_id (a well-formed
+    // but stale `kind:N` ref) must be a hard error — it must NOT fall back to closing the focused surface,
+    // which is the *caller's own* surface (self-decapitation). Only an OMITTED surface_id may default to
+    // the focused surface. Before the fix, `uuid(params,"surface_id")` returned nil for the stale ref and
+    // the resolver's `?? focusedPanelId` fallback closed the caller's tab and reported ok:true.
+    @Test func testV2SurfaceCloseRejectsUnresolvableSurfaceIdAndPreservesFocusedSurface() throws {
+        defer { TerminalController.shared.setActiveTabManager(nil) }
+
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        // Two surfaces; the SECOND is focused — it is the stand-in for the caller's own tab.
+        let other = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: false))
+        let focused = try XCTUnwrap(workspace.newTerminalSurface(inPane: pane, focus: true))
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let response = try handleV2Request(
+            method: "surface.close",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": "surface:99999"  // well-formed ref, but no such surface -> must not resolve
+            ]
+        )
+
+        // Hard error, not a silent close.
+        XCTAssertEqual(response["ok"] as? Bool, false, "Unexpected JSON-RPC response: \(response)")
+        let error = try XCTUnwrap(response["error"] as? [String: Any])
+        XCTAssertEqual(error["code"] as? String, "not_found")
+        // The caller's own focused surface — and the other surface — must still be alive (not decapitated).
+        _ = try XCTUnwrap(workspace.panels[focused.id])
+        _ = try XCTUnwrap(workspace.panels[other.id])
+    }
+
     @Test func testBrowserOpenSplitDoesNotExternallyOpenDiffViewerWhenBrowserDisabled() throws {
         let defaults = UserDefaults.standard
         let previousBrowserDisabled = defaults.object(forKey: BrowserAvailabilitySettings.disabledKey)

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -1451,9 +1451,12 @@ final class TerminalControllerSocketSecurityTests {
     // the focused surface. Before the fix, `uuid(params,"surface_id")` returned nil for the stale ref and
     // the resolver's `?? focusedPanelId` fallback closed the caller's tab and reported ok:true.
     @Test func testV2SurfaceCloseRejectsUnresolvableSurfaceIdAndPreservesFocusedSurface() throws {
-        defer { TerminalController.shared.setActiveTabManager(nil) }
-
         let manager = TabManager()
+        defer {
+            manager.tabs.forEach { $0.teardownAllPanels() }
+            TerminalController.shared.setActiveTabManager(nil)
+        }
+
         let workspace = try XCTUnwrap(manager.selectedWorkspace)
         let pane = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
         // Two surfaces; the SECOND is focused — it is the stand-in for the caller's own tab.


### PR DESCRIPTION
## Summary

`cmux close-surface --surface <id>` can close the **caller's own surface** when the supplied id doesn't resolve. For an agent driving the CLI from inside its own cmux tab, this silently closes that tab — the command prints `OK` and the session is gone. It's the destructive analog of focus-stealing: an unattended CLI whose default target degrades to "whoever called me".

## Repro

From inside a tab whose `$CMUX_SURFACE_ID` is surface **A**, with another surface **B** in the workspace:

```sh
cmux close-surface --surface surface:99999   # a well-formed but non-existent ref
# -> prints OK, and closes surface A (the caller), not an error
```

Also reachable via an explicit-empty value, e.g. `cmux close-surface --surface "$VAR"` where `VAR` is unset.

## Root cause

The V2 `surface.close` resolver, `TerminalController+ControlSurfaceContext2.swift:408`:

```swift
guard let surfaceId = surfaceID ?? ws.focusedPanelId else { return .noFocusedSurface }
```

`surfaceID` arrives here already collapsed to `nil` for a well-formed-but-unresolvable `kind:N` ref: `uuid(params, "surface_id")` (`ControlCommandCoordinator+Surface.swift`) calls `handles.uuid(forRef:)`, which returns `nil` for an unknown ref (`ControlHandleRegistry.swift`). The `?? ws.focusedPanelId` fallback then **cannot distinguish "no surface requested" from "a surface was requested but did not resolve"** — both become the focused surface, so a *failed resolution silently closes the caller's tab*.

Note: a **live UUID** (from `--id-format both`) round-trips and closes the correct target; a **stale-but-valid UUID** already yields the app-side `surfaceNotFound`. The self-close vectors are specifically (1) an unresolvable `kind:N` ref and (2) an explicit-empty `--surface`. An **omitted** `--surface` correctly defaulting to `$CMUX_SURFACE_ID` is by design and is preserved.

## Fix

Two guards enforcing one principle — *an explicitly-supplied target that doesn't resolve is a hard error; an omitted target still defaults to the focused surface*:

- **Server** (`ControlCommandCoordinator+Surface.swift`, client-agnostic — catches any V2 socket client): in `surfaceClose()`, if `uuid(params, "surface_id")` is `nil` but `string(params, "surface_id")` still carries a value, return `.err(code: "not_found")` instead of falling through to `controlSurfaceClose(surfaceID: nil)`.
- **CLI** (`CLI/cmux.swift`): an explicit empty `--surface`/`--panel` throws a `CLIError` instead of degrading to `$CMUX_SURFACE_ID`.

Both preserve the intended default (omitted → focused surface). The server guard reuses the existing `not_found` error shape (no new enum case), and the shared V2 resolver means every socket client — CLI, Python socket tests, agents — inherits the fix rather than patching one entrypoint (per `cmux-shared-behavior`).

## Test

Two-commit red/green (per the regression-test policy):
- **Commit 1** adds the failing test to the already-wired `cmuxTests/TerminalControllerSocketSecurityTests.swift`: drive `handleV2Request("surface.close")` against a live `TabManager` with two surfaces (the second focused), pass a stale `surface:99999` ref, assert a hard `not_found` error **and** that both surfaces (the focused caller included) survive.
- **Commit 2** adds the fix.

## Verification status (please confirm on CI / a macOS runner)

I could **not** run the full macOS app-target build locally (my environment's `xcodebuild` was unusable for a full app build). What I did verify:

- The `CmuxControlSocket` package (the server-side guard) **compiles clean** via `swift build`.
- The CLI guard uses only existing, idiomatic APIs (`optionValue`, `CLIError(message:)`, `trimmingCharacters`) in an already-`throws` context.
- The regression test uses only APIs already exercised by the adjacent `testV2SurfaceCloseCommandsRecordRecentlyClosedHistory` test.

The full app build + `cmuxTests` run (i.e. the red→green proof) should be confirmed by CI / dogfood before merge.

## Out of scope (noted, deliberately not changed)

The CLI injects the caller's `CMUX_WORKSPACE_ID` as `workspace_id`, which outranks `surface_id` in routing — so a `--surface <UUID>` targeting a *different* workspace fails `not_found` (the "silent no-op" symptom for a cross-workspace UUID) rather than resolving cross-workspace. That's a separate routing question; this PR keeps the self-close fix minimal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787159347&installation_model_id=21920&pr_number=8518&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8518&signature=ec92f3ca12decd523fcebdc8b656f11db798f1c77563d3e92a83ea5199d5bd91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents accidental self-close when `surface.close` is called with an unresolvable or empty `surface_id`. Now returns `not_found` and preserves the caller’s tab; the CLI errors on empty identity flags instead of degrading to focus.

- **Bug Fixes**
  - Server (`CmuxControlSocket`): `surfaceClose()` returns `not_found` when `surface_id` is present but unresolvable (stale ref/unknown UUID), empty/whitespace, or junk; only an omitted/null id falls back to the focused surface.
  - CLI: Rejects explicit empty values for `--surface`/`--panel` and `--workspace`/`--window`; omitting flags still defaults to `$CMUX_SURFACE_ID` or the focused context.
  - Tests: Added regression tests for unresolvable and empty-string `surface_id`; verifies no surfaces are closed.

<sup>Written for commit 1649d358ef2fea8ee14572f3b9b3221cf672b950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `surface.close` now returns a hard `not_found` error when an explicitly provided `surface_id` is empty, invalid, or can’t be resolved—without falling back or closing other surfaces.
  * Prevented close requests from accidentally closing the currently focused surface.
  * Environment-based surface targeting remains available only when the surface flag isn’t provided.
  * The `close-surface` CLI now rejects empty `--workspace`, `--window`, and `--surface/--panel` values.
* **Tests**
  * Added regression coverage for unresolved and empty `surface_id` behavior, ensuring surfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->