### PR TITLE
Persist per-tab terminal font zoom across app restarts

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -154,7 +154,7 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// every runtime startup path uses the same immutable workspace port range.
     let portOrdinal: Int
     let surfaceContext: ghostty_surface_context_e
-    let configTemplate: CmuxSurfaceConfigTemplate?
+    public let configTemplate: CmuxSurfaceConfigTemplate?
     let workingDirectory: String?
 
     /// The command to run instead of the default shell, if any.

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1378,6 +1378,9 @@ enum SurfaceResumeBindingScriptStore {
 
 struct SessionTerminalPanelSnapshot: Codable, Sendable {
     var workingDirectory: String?
+    /// Unscaled base font size in points at capture time, so per-tab zoom survives relaunch.
+    /// Nil means unknown (legacy snapshots or a dead surface); restore uses the runtime default.
+    var fontSize: Float?
     var scrollback: String?
     var agent: SessionRestorableAgentSnapshot?
     var tmuxStartCommand: String?
@@ -1392,6 +1395,7 @@ struct SessionTerminalPanelSnapshot: Codable, Sendable {
 
     init(
         workingDirectory: String? = nil,
+        fontSize: Float? = nil,
         scrollback: String? = nil,
         agent: SessionRestorableAgentSnapshot? = nil,
         tmuxStartCommand: String? = nil,
@@ -1403,6 +1407,7 @@ struct SessionTerminalPanelSnapshot: Codable, Sendable {
         wasAgentRunning: Bool? = nil
     ) {
         self.workingDirectory = workingDirectory
+        self.fontSize = fontSize
         self.scrollback = scrollback
         self.agent = agent
         self.tmuxStartCommand = tmuxStartCommand

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -563,12 +563,19 @@ extension Workspace {
                 includeScrollback: includeScrollback,
                 allowFallbackScrollback: shouldPersistScrollback || allowDebugFallbackScrollback || hasRestoredScrollbackFallback
             )
-            // Runtime zoom lives only in the live surface; a hibernated/dead surface
-            // falls back to the lineage-seeded points so the zoom survives capture.
+            // Persist font size only for explicit zoom (runtime-adjusted surface
+            // or zoomed creation template); tabs at the config default persist
+            // nothing, so config font-size changes still apply across restarts.
+            let creationFontBasePoints: Float? = {
+                guard let points = terminalPanel.surface.configTemplate?.fontSize,
+                      points > 0 else { return nil }
+                return points
+            }()
             let capturedFontBasePoints: Float? = {
                 guard let surface = terminalPanel.surface.surface,
-                      let runtimePoints = cmuxCurrentSurfaceFontSizePoints(surface) else {
-                    return terminalInheritanceFontPointsByPanelId[panelId]
+                      let runtimePoints = cmuxCurrentSurfaceFontSizePoints(surface),
+                      ghostty_surface_font_size_adjusted(surface) else {
+                    return creationFontBasePoints
                 }
                 return CmuxSurfaceConfigTemplate.baseFontSize(
                     fromRuntimePoints: runtimePoints,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -563,8 +563,21 @@ extension Workspace {
                 includeScrollback: includeScrollback,
                 allowFallbackScrollback: shouldPersistScrollback || allowDebugFallbackScrollback || hasRestoredScrollbackFallback
             )
+            // Runtime zoom lives only in the live surface; a hibernated/dead surface
+            // falls back to the lineage-seeded points so the zoom survives capture.
+            let capturedFontBasePoints: Float? = {
+                guard let surface = terminalPanel.surface.surface,
+                      let runtimePoints = cmuxCurrentSurfaceFontSizePoints(surface) else {
+                    return terminalInheritanceFontPointsByPanelId[panelId]
+                }
+                return CmuxSurfaceConfigTemplate.baseFontSize(
+                    fromRuntimePoints: runtimePoints,
+                    percent: GlobalFontMagnification.storedPercent
+                )
+            }()
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: directory,
+                fontSize: capturedFontBasePoints,
                 scrollback: resolvedScrollback,
                 agent: effectiveRestorableAgent,
                 tmuxStartCommand: restorableTmuxStartCommand,
@@ -1472,7 +1485,8 @@ extension Workspace {
                 runtimeSpawnPolicy: .pacedSessionRestore,
                 remotePTYSessionID: restoredRemotePTYSessionID,
                 suppressWorkspaceRemoteStartupCommand: suppressWorkspaceRemoteStartupCommand,
-                restoredSurfaceId: reusableSurfaceId
+                restoredSurfaceId: reusableSurfaceId,
+                restoredFontBasePoints: snapshot.terminal?.fontSize
             ) else {
                 if let replayFileURL { try? FileManager.default.removeItem(at: replayFileURL) }
                 return nil
@@ -7141,6 +7155,7 @@ final class Workspace: Identifiable, ObservableObject {
         remotePTYSessionID: String? = nil,
         suppressWorkspaceRemoteStartupCommand: Bool = false,
         restoredSurfaceId: UUID? = nil,
+        restoredFontBasePoints: Float? = nil,
         inheritWorkingDirectoryFallback: Bool = false,
         workingDirectoryFallbackSourcePanelId: UUID? = nil,
         allowTextBoxFocusDefault: Bool = true
@@ -7159,6 +7174,7 @@ final class Workspace: Identifiable, ObservableObject {
             remotePTYSessionID: remotePTYSessionID,
             suppressWorkspaceRemoteStartupCommand: suppressWorkspaceRemoteStartupCommand,
             restoredSurfaceId: restoredSurfaceId,
+            restoredFontBasePoints: restoredFontBasePoints,
             inheritWorkingDirectoryFallback: inheritWorkingDirectoryFallback,
             workingDirectoryFallbackSourcePanelId: workingDirectoryFallbackSourcePanelId,
             allowTextBoxFocusDefault: allowTextBoxFocusDefault
@@ -7182,6 +7198,7 @@ final class Workspace: Identifiable, ObservableObject {
         remotePTYSessionID: String? = nil,
         suppressWorkspaceRemoteStartupCommand: Bool = false,
         restoredSurfaceId: UUID? = nil,
+        restoredFontBasePoints: Float? = nil,
         inheritWorkingDirectoryFallback: Bool = false,
         workingDirectoryFallbackSourcePanelId: UUID? = nil,
         allowTextBoxFocusDefault: Bool = true
@@ -7230,6 +7247,7 @@ final class Workspace: Identifiable, ObservableObject {
             remotePTYSessionID: remotePTYSessionID,
             suppressWorkspaceRemoteStartupCommand: suppressWorkspaceRemoteStartupCommand,
             restoredSurfaceId: restoredSurfaceId,
+            restoredFontBasePoints: restoredFontBasePoints,
             inheritWorkingDirectoryFallback: inheritWorkingDirectoryFallback,
             workingDirectoryFallbackSourcePanelId: workingDirectoryFallbackSourcePanelId,
             allowTextBoxFocusDefault: allowTextBoxFocusDefault
@@ -7251,6 +7269,7 @@ final class Workspace: Identifiable, ObservableObject {
         remotePTYSessionID: String?,
         suppressWorkspaceRemoteStartupCommand: Bool,
         restoredSurfaceId: UUID?,
+        restoredFontBasePoints: Float?,
         inheritWorkingDirectoryFallback: Bool,
         workingDirectoryFallbackSourcePanelId: UUID?,
         allowTextBoxFocusDefault: Bool
@@ -7260,6 +7279,12 @@ final class Workspace: Identifiable, ObservableObject {
         let previousHostedView = focusedTerminalPanel?.hostedView
 
         var inheritedConfig = inheritedTerminalConfig(inPane: paneId)
+        if let restoredFontBasePoints, restoredFontBasePoints > 0 {
+            // A restored tab keeps its own persisted zoom, not the pane's inherited one.
+            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
+            template.fontSize = restoredFontBasePoints
+            inheritedConfig = template
+        }
         let requestedInitialCommand = initialCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitInitialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
         let remoteTerminalStartupCommand = suppressWorkspaceRemoteStartupCommand ? nil : remoteTerminalStartupCommand()

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -519,6 +519,44 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNil(decoded.forwardHistoryURLStrings)
     }
 
+    @MainActor
+    func testWorkspaceSessionSnapshotRestoresTerminalFontSize() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        XCTAssertNotNil(snapshot.panels.first { $0.id == panelId }?.terminal)
+
+        // Inject the persisted zoom through JSON so this test compiles (and fails)
+        // on a build that predates the terminal snapshot fontSize field.
+        let data = try JSONEncoder().encode(snapshot)
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        var panels = try XCTUnwrap(object["panels"] as? [[String: Any]])
+        let index = try XCTUnwrap(panels.firstIndex { $0["terminal"] != nil })
+        var terminal = try XCTUnwrap(panels[index]["terminal"] as? [String: Any])
+        terminal["fontSize"] = 5.5
+        panels[index]["terminal"] = terminal
+        object["panels"] = panels
+        let mutated = try JSONSerialization.data(withJSONObject: object)
+        let zoomedSnapshot = try JSONDecoder().decode(SessionWorkspaceSnapshot.self, from: mutated)
+
+        let restored = Workspace()
+        let idMap = restored.restoreSessionSnapshot(zoomedSnapshot)
+        let restoredPanelId = idMap[panelId] ?? panelId
+
+        let seededPoints = try XCTUnwrap(restored.terminalInheritanceFontPointsByPanelId[restoredPanelId])
+        XCTAssertEqual(seededPoints, 5.5, accuracy: 0.01)
+
+        // The restored zoom must also survive the next capture even without a
+        // live surface to probe (under tests the runtime probe has nothing to read).
+        let recaptured = restored.sessionSnapshot(includeScrollback: false)
+        let recapturedData = try JSONEncoder().encode(recaptured)
+        let recapturedObject = try XCTUnwrap(JSONSerialization.jsonObject(with: recapturedData) as? [String: Any])
+        let recapturedPanels = try XCTUnwrap(recapturedObject["panels"] as? [[String: Any]])
+        let recapturedTerminal = try XCTUnwrap(recapturedPanels.first { $0["terminal"] != nil }?["terminal"] as? [String: Any])
+        let recapturedFontSize = try XCTUnwrap(recapturedTerminal["fontSize"] as? Double)
+        XCTAssertEqual(recapturedFontSize, 5.5, accuracy: 0.01)
+    }
+
     func testScrollbackReplayEnvironmentWritesReplayFile() {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-scrollback-replay-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

- What changed? `SessionTerminalPanelSnapshot` gains an optional `fontSize` field holding the surface's unscaled base font points, mirroring how browser panels persist `pageZoom`. Capture reads the live surface via `cmuxCurrentSurfaceFontSizePoints` and normalizes against the global font magnification, falling back to the lineage-seeded points for hibernated or dead surfaces. Restore threads the value through `newTerminalSurface` into the surface config template, so a restored tab keeps its own zoom instead of inheriting the pane's. Legacy snapshots decode with `fontSize` nil and keep the previous behavior.
- Why? Fixes #8515: per-tab terminal zoom (Cmd+= / Cmd+-) resets to the default on every relaunch. Zoom already survives a pane split via runtime inheritance, but never a restart, because the terminal snapshot had no font-size field.

## Testing

- Two-commit red/green structure per the regression test policy: the first commit adds only the test, the second adds the fix. The test injects `fontSize` through JSON so it compiles against pre-fix code and fails on behavior rather than on build.
- Local run on macOS 26 (Apple Silicon, Xcode 26.6): `xcodebuild test -scheme cmux-unit -only-testing:cmuxTests/SessionPersistenceTests`. The new test fails at the seeding assertion on the test-only commit and passes on the fix commit. 133 of 142 suite tests pass; the 9 failing Hermes agent resume tests fail identically on a tree without this change (pre-existing local environment failures, not related).
- Manual verification in a tagged Debug build (`reload.sh --tag font-zoom`): zoomed several terminal tabs down and up, quit and relaunched, each tab restored at its own zoom and untouched tabs restored at the default. Split-pane zoom inheritance is unchanged.

## Demo Video

- Video URL or attachment: none attached; happy to record one if useful.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787159742&installation_model_id=21920&pr_number=8519&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8519&signature=afd9ed4dfe105fae6e10faff80801a6d9ac2f9817310a6138398ac49af770072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists per-tab terminal font zoom across app restarts so each tab restores its own font size instead of inheriting the pane’s. Only explicitly zoomed tabs persist size; tabs at the config default keep following config after restart. Fixes #8515.

- **Bug Fixes**
  - Added optional `fontSize` to `SessionTerminalPanelSnapshot` to store unscaled base points; backward compatible when nil.
  - Capture saves size only when zoom was adjusted at runtime or seeded by a zoomed template, normalizing against global magnification and falling back to lineage points if needed.
  - Restore threads the saved size into the surface config template so the tab keeps its zoom after relaunch.

<sup>Written for commit 7bba17a2cf0b7df9dba2b976b48c55b1f053f1d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal tabs now persist and restore each tab’s own font size and zoom settings across save, restore, and reload.
  * Session restore continues to apply the correct font size even when the terminal surface is not available for runtime probing.
* **Tests**
  * Added coverage to verify injected/persisted terminal font size is honored during restore and reflected in subsequent session snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
