### PR TITLE
[PERF] pr-poller: stop re-downloading every repo's full PR list on each poll (unchanged branches now 304 properly)

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -50,6 +50,16 @@ public actor GitHubPullRequestRequestCoordinator {
     private var rateLimitRetryDateByAuthorizationFingerprint: [Data: Date] = [:]
     private var rateLimitAuthorizationFingerprintsInInsertionOrder: [Data] = []
 
+    /// Creates a coordinator with the default shared-transport configuration.
+    ///
+    /// Exposed so callers in other modules can supply their own instance to
+    /// `PullRequestProbeService(requestCoordinator:)`. The session and cache
+    /// tuning knobs stay internal (tests reach that initializer through
+    /// `@testable import`), keeping the public surface to a plain default.
+    public convenience init() {
+        self.init(session: nil)
+    }
+
     init(
         session: URLSession? = nil,
         maximumCachedResponseCount: Int = 128,

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -12,7 +12,7 @@ private func githubAuthorizationFingerprint(for authHeader: String) -> Data {
 /// coalescing, and a bounded transport pool. Keeping these concerns here
 /// prevents per-window pollers from independently consuming the same GitHub
 /// rate-limit pool.
-actor GitHubPullRequestRequestCoordinator {
+public actor GitHubPullRequestRequestCoordinator {
     private static let maximumConcurrentTransportCount = 3
     private static let maximumRateLimitIdentityCount = 32
 

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
@@ -8,8 +8,9 @@ extension PullRequestProbeService {
     /// Repositories are fetched concurrently. A repository whose cached entry is
     /// fresh (younger than ``repoCacheLifetime``) and already covers every
     /// candidate branch is served from cache when `allowCachedResults` permits;
-    /// otherwise the recent-PRs pages are fetched and any still-unresolved
-    /// branches get targeted per-branch lookups.
+    /// otherwise each candidate branch is resolved with a targeted per-branch
+    /// `head={owner}:{branch}` lookup, which keeps the response small and its
+    /// ETag stable so the coordinator's `If-None-Match` cache stays effective.
     ///
     /// - Parameters:
     ///   - repoDirectoriesBySlug: Repositories to fetch (slug → representative directory).
@@ -81,7 +82,7 @@ extension PullRequestProbeService {
     }
 
     /// Fetches one repository: serve from cache when permitted and complete,
-    /// else page the recent PRs and per-branch-look-up any leftover branches.
+    /// else resolve every candidate branch with a per-branch `head=` lookup.
     nonisolated func repoFetchResult(
         repoSlug: String,
         candidateBranches: Set<String>,
@@ -126,61 +127,22 @@ extension PullRequestProbeService {
         }
 
         let fetchTimestamp = Date()
-        var page = 1
-        var fetchedPageCount = 0
-        var allPullRequests: [GitHubPullRequestProbeItem] = []
-
-        while page <= Self.repoPageLimit {
-            let endpoint = "repos/\(repoSlug)/pulls?state=all&sort=updated&direction=desc&per_page=\(Self.repoPageSize)&page=\(page)"
-            guard let response = await performRequest(
-                endpoint: endpoint,
-                authHeader: authHeader
-            ) else {
-                debugLog("workspace.prRefresh.repo.fail repo=\(repoSlug) page=\(page) status=nil")
-                return .transientFailure
-            }
-
-            guard response.statusCode == 200,
-                  let pullRequests = Self.decodeJSON([WorkspacePullRequestRESTItem].self, from: response.data) else {
-                debugLog("workspace.prRefresh.repo.fail repo=\(repoSlug) page=\(page) status=\(response.statusCode)")
-                return .transientFailure
-            }
-
-            fetchedPageCount += 1
-            allPullRequests.append(contentsOf: pullRequests.map(Self.probeItem))
-            if pullRequests.count < Self.repoPageSize {
-                break
-            }
-            page += 1
-        }
-
-        let recentWindowEntry = WorkspacePullRequestRepoCacheEntry(
+        let baseEntry = WorkspacePullRequestRepoCacheEntry(
             fetchedAt: fetchTimestamp,
-            pullRequestsByBranch: Self.pullRequestMapByNormalizedBranch(from: allPullRequests)
+            pullRequestsByBranch: [:]
         )
-        let unresolvedBranches = Self.unresolvedBranches(
-            normalizedCandidateBranches,
-            in: recentWindowEntry
+        let lookupOutcome = await branchLookupOutcome(
+            repoSlug: repoSlug,
+            candidateBranches: normalizedCandidateBranches.sorted(),
+            baseEntry: baseEntry,
+            refreshedAt: fetchTimestamp,
+            authHeader: authHeader
         )
-        let lookupOutcome: WorkspacePullRequestBranchLookupOutcome
-        if unresolvedBranches.isEmpty {
-            lookupOutcome = WorkspacePullRequestBranchLookupOutcome(
-                cacheEntry: recentWindowEntry,
-                transientBranches: []
-            )
-        } else {
-            lookupOutcome = await branchLookupOutcome(
-                repoSlug: repoSlug,
-                candidateBranches: unresolvedBranches,
-                baseEntry: recentWindowEntry,
-                refreshedAt: fetchTimestamp,
-                authHeader: authHeader
-            )
-        }
         debugLog(
-            "workspace.prRefresh.repo.success repo=\(repoSlug) pages=\(fetchedPageCount) " +
+            "workspace.prRefresh.repo.perBranch repo=\(repoSlug) " +
+            "branchLookups=\(normalizedCandidateBranches.count) " +
             "branches=\(lookupOutcome.cacheEntry.pullRequestsByBranch.count) " +
-            "branchLookups=\(unresolvedBranches.count) transient=\(lookupOutcome.transientBranches.count)"
+            "transient=\(lookupOutcome.transientBranches.count)"
         )
         return .success(
             lookupOutcome.cacheEntry,
@@ -285,6 +247,13 @@ extension PullRequestProbeService {
         ) else {
             debugLog("workspace.prRefresh.branch.fail repo=\(repoSlug) branch=\(branch) status=nil")
             return .transientFailure
+        }
+
+        if response.statusCode == 404 {
+            debugLog(
+                "workspace.prRefresh.branch.notFound repo=\(repoSlug) branch=\(branch)"
+            )
+            return .notFound
         }
 
         guard response.statusCode == 200,

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
@@ -55,7 +55,7 @@ extension PullRequestProbeService {
                         repoSlug: repoSlug,
                         candidateBranches: candidateBranchesByRepo[repoSlug] ?? [],
                         cachedEntry: cacheBySlug[repoSlug],
-                        useCachedRecentWindow: allowCachedResults
+                        useFreshCache: allowCachedResults
                             && (cacheBySlug[repoSlug].map {
                                 now.timeIntervalSince($0.fetchedAt) < Self.repoCacheLifetime
                             } ?? false),
@@ -87,14 +87,14 @@ extension PullRequestProbeService {
         repoSlug: String,
         candidateBranches: Set<String>,
         cachedEntry: WorkspacePullRequestRepoCacheEntry?,
-        useCachedRecentWindow: Bool,
+        useFreshCache: Bool,
         authHeader: String
     ) async -> WorkspacePullRequestRepoFetchResult {
         let normalizedCandidateBranches = Set(
             candidateBranches.compactMap(GitMetadataService.normalizedBranchName)
         )
 
-        if useCachedRecentWindow,
+        if useFreshCache,
            let cachedEntry {
             let unresolvedBranches = Self.unresolvedBranches(
                 normalizedCandidateBranches,
@@ -249,14 +249,21 @@ extension PullRequestProbeService {
             return .transientFailure
         }
 
-        // A 404 here is repo-level, not branch-level: the pulls list endpoint
-        // returns `200 []` for a branch with no matching PR, so a 404 means the
-        // repo was renamed/deleted or is no longer visible to this credential
-        // (auth failures surface as 401/403 and are handled by the coordinator).
-        // Resolving `.notFound` folds the branch into `knownAbsentBranches` so it
-        // stops re-polling on the fast loop; a cache-bypassing refresh
-        // (branchChange/shellPrompt/commandHint) or cache eviction clears that,
-        // so regained access is picked up on the next non-cached pass.
+        // A 404 on this `head=` lookup is repo-level, not branch-level: the pulls
+        // list endpoint returns `200 []` (handled below as `.notFound`) for a
+        // branch with no matching PR, so a 404 means the repo is not readable
+        // under this credential right now — renamed, deleted, or not visible.
+        // That last case is not necessarily permanent: GitHub also returns 404
+        // (rather than 403) when a token is missing a scope or SSO authorization
+        // for a private repo, to avoid disclosing the repo's existence. We still
+        // resolve `.notFound` so the branch folds into `knownAbsentBranches` and
+        // stops re-polling on the fast loop, but that suppression is bounded: it
+        // only applies while a cache entry stays fresh (`< repoCacheLifetime`).
+        // The cold path rebuilds with an empty known-absent set, and a
+        // cache-bypassing refresh (branchChange/shellPrompt/commandHint) or cache
+        // eviction clears it sooner — so a transiently-inaccessible repo (or
+        // regained access) re-resolves within one cache window instead of being
+        // hidden. The `200 []` no-PR case below shares this same bounded backoff.
         if response.statusCode == 404 {
             debugLog(
                 "workspace.prRefresh.branch.notFound repo=\(repoSlug) branch=\(branch)"
@@ -279,6 +286,8 @@ extension PullRequestProbeService {
         if let preferredPullRequest = Self.preferredPullRequest(from: matchingPullRequests) {
             return .found(preferredPullRequest)
         }
+        // `200` with no PR matching this branch's head: same `.notFound` /
+        // bounded known-absent backoff as the repo-level 404 above.
         return .notFound
     }
 

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
@@ -249,6 +249,14 @@ extension PullRequestProbeService {
             return .transientFailure
         }
 
+        // A 404 here is repo-level, not branch-level: the pulls list endpoint
+        // returns `200 []` for a branch with no matching PR, so a 404 means the
+        // repo was renamed/deleted or is no longer visible to this credential
+        // (auth failures surface as 401/403 and are handled by the coordinator).
+        // Resolving `.notFound` folds the branch into `knownAbsentBranches` so it
+        // stops re-polling on the fast loop; a cache-bypassing refresh
+        // (branchChange/shellPrompt/commandHint) or cache eviction clears that,
+        // so regained access is picked up on the next non-cached pass.
         if response.statusCode == 404 {
             debugLog(
                 "workspace.prRefresh.branch.notFound repo=\(repoSlug) branch=\(branch)"

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
@@ -41,28 +41,19 @@ public struct PullRequestProbeService: Sendable {
     ///
     /// - Parameters:
     ///   - commandRunner: Runs `gh auth token`; tests pass a fake.
+    ///   - requestCoordinator: Shared GitHub transport/cache/backoff policy.
+    ///     Defaults to a process-scoped coordinator; injected (like
+    ///     `commandRunner`) so tests can supply one backed by a stub
+    ///     `URLSession` without contacting GitHub.
     ///   - debugLog: Optional diagnostics sink; defaults to a no-op.
     public init(
         commandRunner: any CommandRunning = CommandRunner(),
+        requestCoordinator: GitHubPullRequestRequestCoordinator? = nil,
         debugLog: @escaping @Sendable (String) -> Void = { _ in }
     ) {
         self.commandRunner = commandRunner
         self.authHeaderCache = GitHubAuthHeaderCache()
-        self.requestCoordinator = GitHubPullRequestRequestCoordinator()
-        self.debugLog = debugLog
-    }
-
-    /// Test seam: injects a request coordinator (typically one backed by a stub
-    /// `URLSession`) so the network fetch layer can be exercised deterministically
-    /// without contacting GitHub.
-    init(
-        commandRunner: any CommandRunning,
-        requestCoordinator: GitHubPullRequestRequestCoordinator,
-        debugLog: @escaping @Sendable (String) -> Void = { _ in }
-    ) {
-        self.commandRunner = commandRunner
-        self.authHeaderCache = GitHubAuthHeaderCache()
-        self.requestCoordinator = requestCoordinator
+        self.requestCoordinator = requestCoordinator ?? GitHubPullRequestRequestCoordinator()
         self.debugLog = debugLog
     }
 

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
@@ -52,14 +52,26 @@ public struct PullRequestProbeService: Sendable {
         self.debugLog = debugLog
     }
 
+    /// Test seam: injects a request coordinator (typically one backed by a stub
+    /// `URLSession`) so the network fetch layer can be exercised deterministically
+    /// without contacting GitHub.
+    init(
+        commandRunner: any CommandRunning,
+        requestCoordinator: GitHubPullRequestRequestCoordinator,
+        debugLog: @escaping @Sendable (String) -> Void = { _ in }
+    ) {
+        self.commandRunner = commandRunner
+        self.authHeaderCache = GitHubAuthHeaderCache()
+        self.requestCoordinator = requestCoordinator
+        self.debugLog = debugLog
+    }
+
     // MARK: Tuning constants
 
     /// How long a fetched repo cache entry satisfies periodic refreshes.
     static let repoCacheLifetime: TimeInterval = 15
-    /// REST page size for the recent-PRs fetch.
+    /// REST page size for per-branch `head=` pull-request lookups.
     static let repoPageSize = 100
-    /// Maximum REST pages fetched per repository.
-    static let repoPageLimit = 2
     /// Per-request timeout for GitHub API calls and the `gh auth token` probe.
     static let probeTimeout: TimeInterval = 5.0
     /// Merged PRs older than this no longer earn a badge.

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestProbeServiceFetchTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestProbeServiceFetchTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Testing
+@testable import CmuxGit
+import CmuxFoundation
+
+/// Network fetch-layer behavior for ``PullRequestProbeService``. These drive the
+/// service's ``fetchRepoResults(...)`` through a stub `URLSession`, proving the
+/// per-branch `head=` resolution keeps GitHub's conditional (ETag/304) cache
+/// effective — the fix for the poller that re-fetched `state=all&sort=updated`
+/// pages and defeated its own cache (manaflow-ai/cmux#8367).
+@Suite(.serialized)
+struct PullRequestProbeServiceFetchTests {
+    private let repoSlug = "manaflow-ai/cmux"
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [GitHubPullRequestStubURLProtocol.self]
+        configuration.timeoutIntervalForRequest = 2
+        configuration.timeoutIntervalForResource = 2
+        return URLSession(configuration: configuration)
+    }
+
+    private func makeService() -> PullRequestProbeService {
+        PullRequestProbeService(
+            commandRunner: FixedTokenCommandRunner(),
+            requestCoordinator: GitHubPullRequestRequestCoordinator(session: makeSession())
+        )
+    }
+
+    private func pullRequestJSON(
+        number: Int,
+        branch: String,
+        state: String = "open",
+        mergedAt: String? = nil
+    ) -> String {
+        let mergedField = mergedAt.map { "\"\($0)\"" } ?? "null"
+        return """
+        {
+          "number": \(number),
+          "state": "\(state)",
+          "html_url": "https://github.com/\(repoSlug)/pull/\(number)",
+          "updated_at": "2026-07-01T12:00:00Z",
+          "merged_at": \(mergedField),
+          "head": {"ref": "\(branch)"},
+          "base": {"ref": "main"}
+        }
+        """
+    }
+
+    private func listBody(_ items: String...) -> Data {
+        Data("[\(items.joined(separator: ","))]".utf8)
+    }
+
+    private func fetch(
+        service: PullRequestProbeService,
+        branches: Set<String>,
+        cache: [String: WorkspacePullRequestRepoCacheEntry] = [:],
+        now: Date = Date(),
+        allowCachedResults: Bool = false
+    ) async -> WorkspacePullRequestRepoFetchResult {
+        let (repoResults, _) = await service.fetchRepoResults(
+            repoDirectoriesBySlug: [repoSlug: "/tmp/\(repoSlug)"],
+            candidateBranchesByRepo: [repoSlug: branches],
+            cacheBySlug: cache,
+            now: now,
+            allowCachedResults: allowCachedResults
+        )
+        return repoResults[repoSlug] ?? .transientFailure
+    }
+
+    private func entry(
+        from result: WorkspacePullRequestRepoFetchResult
+    ) -> WorkspacePullRequestRepoCacheEntry? {
+        guard case .success(let entry, _, _) = result else { return nil }
+        return entry
+    }
+
+    private func requestURLStrings() -> [String] {
+        GitHubPullRequestStubURLProtocol.capturedRequests().map { $0.url?.absoluteString ?? "" }
+    }
+
+    @Test func coldFetchIssuesPerBranchHeadRequestsAndNoListPagination() async throws {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: listBody(pullRequestJSON(number: 8175, branch: "feat/badge"))),
+        ])
+        let service = makeService()
+
+        let result = await fetch(service: service, branches: ["feat/badge"])
+
+        let resolved = try #require(entry(from: result))
+        #expect(resolved.pullRequestsByBranch["feat/badge"]?.number == 8175)
+        let urls = requestURLStrings()
+        #expect(urls.count == 1)
+        #expect(urls.allSatisfy { $0.contains("head=") })
+        // The defeated-cache pagination path (?state=all&sort=updated&…&page=N)
+        // must be gone — no listing request should be issued.
+        #expect(urls.allSatisfy { !$0.contains("page=") })
+    }
+
+    @Test func secondRefreshRevalidatesUnchangedBranchTo304() async throws {
+        let body = listBody(pullRequestJSON(number: 8175, branch: "feat/badge"))
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, headers: ["ETag": "\"badge-8175\""], data: body),
+            .init(statusCode: 304),
+        ])
+        let service = makeService()
+
+        let first = await fetch(service: service, branches: ["feat/badge"])
+        let second = await fetch(service: service, branches: ["feat/badge"])
+
+        #expect(entry(from: first)?.pullRequestsByBranch["feat/badge"]?.number == 8175)
+        // The 304 short-circuits to the cached body: the badge still resolves.
+        #expect(entry(from: second)?.pullRequestsByBranch["feat/badge"]?.number == 8175)
+        let requests = GitHubPullRequestStubURLProtocol.capturedRequests()
+        #expect(requests.count == 2)
+        #expect(try #require(requests.last).value(forHTTPHeaderField: "If-None-Match") == "\"badge-8175\"")
+    }
+
+    @Test func notFoundBranchBecomesKnownAbsentAndIsNotRefetchedFromFreshCache() async throws {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 404, data: Data("{\"message\":\"Not Found\"}".utf8)),
+        ])
+        let service = makeService()
+
+        let coldResult = await fetch(service: service, branches: ["deleted/branch"])
+        let coldEntry = try #require(entry(from: coldResult))
+        #expect(coldEntry.knownAbsentBranches.contains("deleted/branch"))
+        #expect(coldEntry.pullRequestsByBranch["deleted/branch"] == nil)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+
+        // A fresh cache that already marks the branch absent must not re-poll it,
+        // so a renamed/deleted repo backs off the fast loop instead of 404ing forever.
+        let cachedResult = await fetch(
+            service: service,
+            branches: ["deleted/branch"],
+            cache: [repoSlug: coldEntry],
+            now: coldEntry.fetchedAt,
+            allowCachedResults: true
+        )
+        guard case .success(_, let usedCache, _) = cachedResult else {
+            Issue.record("expected cached success, got \(cachedResult)")
+            return
+        }
+        #expect(usedCache)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+    }
+
+    @Test func multipleCandidateBranchesEachGetOwnHeadRequest() async throws {
+        // Each response carries both PRs; the per-branch `head=` filter keeps
+        // only the matching one, so resolution is order-independent under the
+        // concurrent task group.
+        let combined = listBody(
+            pullRequestJSON(number: 8100, branch: "feat/alpha"),
+            pullRequestJSON(number: 8200, branch: "feat/beta")
+        )
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: combined),
+            .init(statusCode: 200, data: combined),
+        ])
+        let service = makeService()
+
+        let result = await fetch(service: service, branches: ["feat/alpha", "feat/beta"])
+
+        let resolved = try #require(entry(from: result))
+        #expect(resolved.pullRequestsByBranch["feat/alpha"]?.number == 8100)
+        #expect(resolved.pullRequestsByBranch["feat/beta"]?.number == 8200)
+        let urls = requestURLStrings()
+        #expect(urls.count == 2)
+        #expect(urls.contains { $0.contains("feat/alpha") || $0.contains("feat%2Falpha") })
+        #expect(urls.contains { $0.contains("feat/beta") || $0.contains("feat%2Fbeta") })
+        #expect(urls.allSatisfy { !$0.contains("page=") })
+    }
+}
+
+/// Resolves a stable non-empty auth header so the fetch layer proceeds without a
+/// live `gh auth token` (or environment token).
+private actor FixedTokenCommandRunner: CommandRunning {
+    func run(
+        directory: String,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval?
+    ) async -> CommandResult {
+        CommandResult(
+            stdout: "ghtok-fixture",
+            stderr: nil,
+            exitStatus: 0,
+            timedOut: false,
+            executionError: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the workspace PR badge poller so it stops defeating its own ETag cache. Refs #8367.

Today, on a cold refresh the poller pages
`GET /repos/{owner}/{repo}/pulls?state=all&sort=updated&direction=desc&per_page=100&page=N`.
Because `sort=updated` reorders the whole list whenever *any* PR in the repo is touched, the
response ETag churns constantly, so the request coordinator's conditional `If-None-Match` cache
almost never revalidates to `304`. The poller re-downloads the full recent-PR window on nearly
every pass, per workspace, per window.

## What changed

- **Per-branch `head=` is now the primary path (`PullRequestProbeService+Fetch.swift`).**
  The cold path resolves each candidate branch with
  `pulls?state=all&head={owner}:{branch}&…` (reusing the existing `branchLookupOutcome`) instead
  of paging the recent-PR window. Each branch gets a small response whose ETag only changes when
  *that branch's* PR changes, so unchanged branches revalidate to `304` (or are served from the
  in-process cache) rather than re-fetching. This flips the bulk of the poller's `200`s into
  `304`/no-request.
- **404 → back off.** A per-branch lookup that returns `404` now resolves to `.notFound` (folded
  into `knownAbsentBranches`) instead of `.transientFailure`, so a renamed/deleted/inaccessible
  repo stops being re-polled on the fast loop.
- Removed the now-unused `repoPageLimit` constant and the cold-path pagination block.
  `pullRequestMapByNormalizedBranch` is retained (still exercised by unit tests).

## Tests

New `Tests/CmuxGitTests/PullRequestProbeServiceFetchTests.swift` (stub `URLSession`) covers:

1. Cold refresh issues **per-branch `head=` requests only** — no `…&page=N` listing request.
2. An unchanged branch **revalidates to `304`** on the next refresh and still resolves its badge
   from the cached body (the whole point of the fix).
3. A branch that returns **`404` becomes known-absent** and is **not re-requested** from a fresh
   cache.
4. Multiple candidate branches on one repo each get their **own `head=` request**.

A small internal test-seam initializer on `PullRequestProbeService` injects the request
coordinator (backed by the stub session) so the fetch layer can be driven deterministically.

## Note for reviewers

Dropping the whole-list recent-window map means a long-lived, non-default **base** branch
(e.g. `develop`) could surface a merged badge that the old map special-cased away. Per-branch
stale-merged filtering is still applied via `preferredPullRequest` / `isBadgeCandidate`, so
`main`/`master` behavior is unchanged. Flagging in case you'd prefer to also skip additional
long-lived base branches.

**Narrower `head=` filter (cross-fork PRs).** `head={repoOwner}:{branch}` matches PRs whose head
lives in the repo itself, so a PR opened **from a fork** (head owner ≠ repo owner) with the same
branch name won't be surfaced, whereas the old list-and-match-by-`headRefName` path would. Note
this is the behavior the pre-existing per-branch **fallback** path already had — this change only
promotes it to the primary path. It's fine for the common same-repo branch workflow; flagging in
case fork-based PR badges matter to you (could be a follow-up that also filters on `headRefName`).

**404 is repo-level, by design.** The pulls list endpoint returns `200 []` for a branch with no
PR, so a `404` means the repo was renamed/deleted or is no longer visible to the credential (auth
failures surface as `401`/`403`, handled by the request coordinator, not here). Treating it as
`.notFound` backs the branch off the fast poll loop; a cache-bypassing refresh
(branchChange/shellPrompt/commandHint) or cache eviction clears `knownAbsentBranches`, so regained
access is picked up on the next non-cached pass. See the inline comment in `branchFetchResult`.

**On request volume.** The candidate set is one branch **per open workspace panel** (deduped per
repo), not the repo's branch count. Cold refreshes issue one `head=` request per such branch
(run concurrently through the coordinator's bounded, coalescing, rate-limit-aware transport). On
subsequent polls those requests revalidate to `304`, which — when authorized — [does not count
against the primary rate limit](https://docs.github.com/rest/using-the-rest-api/best-practices-for-using-the-rest-api#conditional-requests),
so steady-state load drops sharply versus the old `sort=updated` window that almost never hit 304.

A follow-up (deferred here) could cache the canonical repo slug after a `301` redirect to avoid
re-resolving renamed repos; it needs `URLSession` redirect-delegate interception.

I couldn't build/test locally (Windows dev box, no Swift toolchain) — relying on CI here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request detection by resolving candidates via targeted per-branch `head={owner}:{branch}` lookups when cached results can’t be used.
  * Treats `head` lookup `404` as a known-absent branch to prevent repeated re-queries.
  * Refresh preserves previously resolved pull request data when responses are unchanged (ETag/`304`).
* **Performance**
  * Reduced unnecessary repository fetch work by avoiding list pagination for candidate resolution.
* **Tests**
  * Added coverage for per-branch requests, refresh caching behavior, `404` handling, and correct PR selection across multiple candidates.
* **Developer API**
  * Exposed and allow-injecting the shared request coordinator for customization/testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->