### PR TITLE
Fix sidebar notification reorder geometry

### DIFF
--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -4,6 +4,13 @@ import CmuxAppKitSupportUI
 import CmuxFoundation
 import SwiftUI
 
+#if DEBUG
+enum SidebarWorkspaceTableStructuralUpdate: Equatable {
+    case moveRows
+    case reloadData
+}
+#endif
+
 /// Main-actor owner of the default sidebar table lifecycle and its AppKit interactions.
 @MainActor
 final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NSTableViewDelegate {
@@ -24,6 +31,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
 #if DEBUG
     var reconfigurationProbe: (() -> Void)?
+    var structuralUpdateProbe: ((SidebarWorkspaceTableStructuralUpdate) -> Void)?
     var dropTargetComputationProbe: (() -> Void)? {
         get { dropTargetGeometry.computationProbe }
         set { dropTargetGeometry.computationProbe = newValue }
@@ -214,6 +222,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             if previousIds.count == nextIds.count,
                mismatches <= Self.maxAnimatedReorderMoves,
                Self.multisetEqual(previousIds, nextIds) {
+#if DEBUG
+                structuralUpdateProbe?(.moveRows)
+#endif
                 // Pure reorder (drag-drop): move rows in place. reloadData
                 // tears down every visible cell and snaps the scroll
                 // position — the "click to reorder is jank" report — while
@@ -240,6 +251,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
                     noteHeightOfRowsWithoutAnimation(table, heightChanges)
                 }
             } else {
+#if DEBUG
+                structuralUpdateProbe?(.reloadData)
+#endif
                 containerView.tableView.reloadData()
             }
         } else {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -219,16 +219,19 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             let mismatches = zip(previousIds, nextIds).reduce(into: 0) { count, pair in
                 if pair.0 != pair.1 { count += 1 }
             }
-            if previousIds.count == nextIds.count,
+            if heightChanges.isEmpty,
+               previousIds.count == nextIds.count,
                mismatches <= Self.maxAnimatedReorderMoves,
                Self.multisetEqual(previousIds, nextIds) {
 #if DEBUG
                 structuralUpdateProbe?(.moveRows)
 #endif
-                // Pure reorder (drag-drop): move rows in place. reloadData
-                // tears down every visible cell and snaps the scroll
-                // position — the "click to reorder is jank" report — while
-                // moves keep cells alive and settle smoothly.
+                // Stable-geometry reorder (drag-drop): move rows in place.
+                // AppKit reuses the live cell views during this transaction,
+                // so combining it with row-height invalidation can leave the
+                // reused views at stale frames. Geometry-changing reorders
+                // take the atomic reload path below. Stable moves keep cells
+                // alive and preserve smooth drag-drop settlement.
                 let table = containerView.tableView
                 table.beginUpdates()
                 var current = previousIds
@@ -246,9 +249,6 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
                     reconfigureVisibleRows(
                         IndexSet(integersIn: visible.lowerBound..<(visible.lowerBound + visible.length))
                     )
-                }
-                if !heightChanges.isEmpty {
-                    noteHeightOfRowsWithoutAnimation(table, heightChanges)
                 }
             } else {
 #if DEBUG

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -241,6 +241,77 @@ struct SidebarWorkspaceTableTests {
         controller.viewportDidChange()
         #expect(computations == 2)
     }
+
+    @Test
+    @MainActor
+    func notificationReorderWithHeightChangeUsesAtomicReload() throws {
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 900),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+
+        let ids = (0..<9).map { _ in UUID() }
+        let heights: [CGFloat] = [42, 86, 54, 132, 62, 104, 48, 118, 76]
+        let initialRows = zip(ids, heights).enumerated().map { index, pair in
+            makeSizedRowConfiguration(
+                workspaceId: pair.0,
+                contentToken: index,
+                height: pair.1
+            )
+        }
+        controller.apply(
+            rows: initialRows,
+            actions: makeTableActions(),
+            workspaceIds: ids,
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+
+        var structuralUpdates: [SidebarWorkspaceTableStructuralUpdate] = []
+        controller.structuralUpdateProbe = { structuralUpdates.append($0) }
+
+        let notifiedId = ids[7]
+        let reorderedIds = [notifiedId] + ids.filter { $0 != notifiedId }
+        let heightsById = Dictionary(uniqueKeysWithValues: zip(ids, heights))
+        let nextRows = reorderedIds.enumerated().map { index, id in
+            makeSizedRowConfiguration(
+                workspaceId: id,
+                contentToken: id == notifiedId ? 100 : index,
+                height: id == notifiedId ? 168 : heightsById[id]!
+            )
+        }
+
+        controller.apply(
+            rows: nextRows,
+            actions: makeTableActions(),
+            workspaceIds: reorderedIds,
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+
+        #expect(structuralUpdates == [.reloadData])
+        let table = container.tableView
+        let rowRects = nextRows.indices.map(table.rect(ofRow:))
+        for index in rowRects.indices.dropLast() {
+            #expect(rowRects[index].maxY <= rowRects[index + 1].minY)
+        }
+        for index in nextRows.indices {
+            let cell = try #require(
+                table.view(atColumn: 0, row: index, makeIfNecessary: true)
+                    as? SidebarWorkspaceTableCellView
+            )
+            #expect(cell.representedRowId == nextRows[index].id)
+        }
+    }
 #endif
 
     @Test
@@ -299,6 +370,38 @@ struct SidebarWorkspaceTableTests {
         }
     }
 
+    @MainActor
+    private func makeSizedRowConfiguration(
+        workspaceId: UUID,
+        contentToken: Int,
+        height: CGFloat
+    ) -> SidebarWorkspaceTableRowConfiguration {
+#if DEBUG
+        let environment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: .dark,
+            globalFontMagnificationPercent: 100,
+            lazyContractProbe: SidebarLazyContractProbe()
+        )
+#else
+        let environment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: .dark,
+            globalFontMagnificationPercent: 100
+        )
+#endif
+        let content = SizedTestRowContent(token: contentToken, height: height)
+        return SidebarWorkspaceTableRowConfiguration(
+            id: .workspace(workspaceId),
+            workspaceId: workspaceId,
+            groupId: nil,
+            isGroupHeader: false,
+            isPinned: false,
+            environment: environment,
+            equivalenceValue: content
+        ) { _, _ in
+            AnyView(content)
+        }
+    }
+
 #if DEBUG
     @MainActor
     private func configure(
@@ -346,6 +449,15 @@ struct SidebarWorkspaceTableTests {
 
         var body: some View {
             EmptyView()
+        }
+    }
+
+    private struct SizedTestRowContent: View, Equatable {
+        let token: Int
+        let height: CGFloat
+
+        var body: some View {
+            Color.clear.frame(height: height)
         }
     }
 }

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -312,6 +312,48 @@ struct SidebarWorkspaceTableTests {
             #expect(cell.representedRowId == nextRows[index].id)
         }
     }
+
+    @Test
+    @MainActor
+    func stableHeightReorderKeepsAnimatedMovePath() {
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+
+        let ids = (0..<3).map { _ in UUID() }
+        let initialRows = ids.enumerated().map { index, id in
+            makeSizedRowConfiguration(workspaceId: id, contentToken: index, height: 64)
+        }
+        controller.apply(
+            rows: initialRows,
+            actions: makeTableActions(),
+            workspaceIds: ids,
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+
+        var structuralUpdates: [SidebarWorkspaceTableStructuralUpdate] = []
+        controller.structuralUpdateProbe = { structuralUpdates.append($0) }
+        let reorderedIds = [ids[2], ids[0], ids[1]]
+        let reorderedRows = reorderedIds.map { id in
+            initialRows[ids.firstIndex(of: id)!]
+        }
+        controller.apply(
+            rows: reorderedRows,
+            actions: makeTableActions(),
+            workspaceIds: reorderedIds,
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+
+        #expect(structuralUpdates == [.moveRows])
+    }
 #endif
 
     @Test


### PR DESCRIPTION
Fixes sidebar geometry corruption when notification reordering also changes row height.

- Use animated AppKit row moves only for stable-height pure reorders.
- Reload the table atomically when a structural change also changes cached row heights.
- Add a red/green regression test against the controller branch and guard the stable-height drag path.

Verification:
- The regression test fails on the test-only commit because the controller selects row moves.
- The focused notification-reorder and stable-height tests pass on the fix commit.
- The sbrovl tagged build moved a target through a 13-row variable-height list with unique sequential rows and no interior gaps or overlap.

Dogfood: open http://127.0.0.1:17320/sbrovl and inspect the seeded Beta reorder at the top of the list.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787163147&installation_model_id=21920&pr_number=8522&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8522&signature=14bc29f44e4e354e8e56951f1c755c699f62b04b844aa9e1952a49c22133a43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar row overlap and gaps when reordering notifications that also change row heights. Stable-height reorders keep smooth animated moves; height-changing reorders now reload the table atomically.

- **Bug Fixes**
  - Use animated row moves only when heights are unchanged; otherwise call `reloadData` to avoid stale frames and geometry corruption.
  - Added regression tests covering height-changing notification reorders (atomic reload) and stable-height reorders (animated moves).

<sup>Written for commit 783d47d57e01fae9867911f81393a6107d500955. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar workspace reordering when row heights change, ensuring layouts remain correctly positioned without overlapping.
  * Preserved smooth animated row movement when reordered items retain the same height.

* **Tests**
  * Added coverage for height-changing reorders, stable-height animated moves, and resulting row layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->