### PR TITLE
Fix sidebar status URL clicks

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11618,6 +11618,9 @@ struct VerticalTabsSidebar: View, Equatable {
         }
         let rowActions = SidebarAppKitRowActions(
             commands: commands,
+            onOpenStatusURL: { url in
+                NSWorkspace.shared.open(url)
+            },
             onOpenPullRequest: { [prefer = input.settings.openPullRequestLinksInCmuxBrowser] url in
                 openInBrowser(url, prefer)
             },

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -574,7 +574,14 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             } else {
                 entryColor = explicitColor ?? .secondaryLabelColor
             }
-            metadataRows[index].configureMetadataEntry(entry, model: model, color: entryColor)
+            metadataRows[index].configureMetadataEntry(
+                entry,
+                model: model,
+                color: entryColor
+            ) { [weak self] url in
+                self?.actions?.commands.updateSelection()
+                self?.actions?.onOpenStatusURL(url)
+            }
         }
         let toggleFont = NSFont.systemFont(ofSize: model.scaled(10), weight: .semibold)
         let toggleColor = model.isActive

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
@@ -55,6 +55,7 @@ struct SidebarWorkspaceRowModel: Equatable {
 @MainActor
 struct SidebarAppKitRowActions {
     let commands: SidebarWorkspaceRowCommands
+    let onOpenStatusURL: (URL) -> Void
     let onOpenPullRequest: (URL) -> Void
     let onOpenPort: (Int) -> Void
     let onToggleChecklistExpansion: () -> Void

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -52,6 +52,7 @@ final class SidebarRowIconTextLine: NSView {
     private let iconView = NSImageView()
     private let iconLabel = NSTextField(labelWithString: "")
     private let textView = SidebarRowTextView(lines: 1)
+    private let metadataButton = SidebarRowLinkButton()
     private let secondTextView = SidebarRowTextView(lines: 1)
     private var iconSize: CGFloat = 0
     private var stacked = false
@@ -64,6 +65,9 @@ final class SidebarRowIconTextLine: NSView {
         addSubview(iconView)
         addSubview(iconLabel)
         addSubview(textView)
+        metadataButton.alignment = .left
+        metadataButton.isHidden = true
+        addSubview(metadataButton)
         secondTextView.isHidden = true
         addSubview(secondTextView)
     }
@@ -75,7 +79,8 @@ final class SidebarRowIconTextLine: NSView {
     func configureMetadataEntry(
         _ entry: SidebarStatusEntry,
         model: SidebarWorkspaceRowModel,
-        color: NSColor
+        color: NSColor,
+        onOpenURL: @escaping (URL) -> Void
     ) {
         stacked = false
         secondTextView.isHidden = true
@@ -106,9 +111,25 @@ final class SidebarRowIconTextLine: NSView {
                 }
             }
         }
-        textView.stringValue = entry.sidebarDisplayText
-        textView.font = .systemFont(ofSize: model.scaled(10))
-        textView.textColor = color
+        let font = NSFont.systemFont(ofSize: model.scaled(10))
+        if let url = entry.url {
+            textView.isHidden = true
+            metadataButton.isHidden = false
+            metadataButton.configure(
+                title: entry.sidebarDisplayText,
+                font: font,
+                color: color,
+                underlined: true,
+                toolTip: url.absoluteString,
+                onClick: { onOpenURL(url) }
+            )
+        } else {
+            metadataButton.isHidden = true
+            textView.isHidden = false
+            textView.stringValue = entry.sidebarDisplayText
+            textView.font = font
+            textView.textColor = color
+        }
         needsLayout = true
     }
 
@@ -118,6 +139,8 @@ final class SidebarRowIconTextLine: NSView {
         palette: SidebarRowPalette
     ) {
         stacked = false
+        metadataButton.isHidden = true
+        textView.isHidden = false
         secondTextView.isHidden = true
         iconLabel.isHidden = true
         let iconName: String
@@ -163,6 +186,8 @@ final class SidebarRowIconTextLine: NSView {
         model: SidebarWorkspaceRowModel,
         palette: SidebarRowPalette
     ) {
+        metadataButton.isHidden = true
+        textView.isHidden = false
         iconView.isHidden = true
         iconLabel.isHidden = true
         iconSize = 0
@@ -207,7 +232,9 @@ final class SidebarRowIconTextLine: NSView {
 
     func measuredHeight(width: CGFloat) -> CGFloat {
         resolveCandidates(width: width)
-        let first = textView.measuredHeight(width: max(10, width - iconSize))
+        let first = metadataButton.isHidden
+            ? textView.measuredHeight(width: max(10, width - iconSize))
+            : ceil(metadataButton.intrinsicContentSize.height)
         let second = secondTextView.isHidden ? 0 : secondTextView.measuredHeight(width: max(10, width - iconSize)) + 1
         return first + second
     }
@@ -240,8 +267,12 @@ final class SidebarRowIconTextLine: NSView {
             icon.frame = NSRect(x: 0, y: 1, width: side, height: side)
             x = side + 4
         }
-        let firstHeight = textView.measuredHeight(width: max(10, bounds.width - x))
-        textView.frame = NSRect(x: x, y: 0, width: max(10, bounds.width - x), height: firstHeight)
+        let availableWidth = max(10, bounds.width - x)
+        let firstHeight = metadataButton.isHidden
+            ? textView.measuredHeight(width: availableWidth)
+            : ceil(metadataButton.intrinsicContentSize.height)
+        let primaryView: NSView = metadataButton.isHidden ? textView : metadataButton
+        primaryView.frame = NSRect(x: x, y: 0, width: availableWidth, height: firstHeight)
         if !secondTextView.isHidden {
             let secondHeight = secondTextView.measuredHeight(width: max(10, bounds.width - x))
             secondTextView.frame = NSRect(x: x, y: firstHeight + 1, width: max(10, bounds.width - x), height: secondHeight)

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -145,7 +145,10 @@ struct SidebarAppKitRowCellTests {
         UserDefaults(suiteName: "SidebarAppKitRowCellTests.\(UUID().uuidString)")!
     }
 
-    private static func makeActions(model: SidebarWorkspaceRowModel) -> SidebarAppKitRowActions {
+    private static func makeActions(
+        model: SidebarWorkspaceRowModel,
+        onOpenStatusURL: @escaping (URL) -> Void = { _ in }
+    ) -> SidebarAppKitRowActions {
         let commands = SidebarWorkspaceRowCommands(
             tab: Workspace(),
             tabManager: nil,
@@ -167,6 +170,7 @@ struct SidebarAppKitRowCellTests {
         )
         return SidebarAppKitRowActions(
             commands: commands,
+            onOpenStatusURL: onOpenStatusURL,
             onOpenPullRequest: { _ in },
             onOpenPort: { _ in },
             onToggleChecklistExpansion: {},
@@ -182,12 +186,13 @@ struct SidebarAppKitRowCellTests {
     }
 
     private static func configuredCell(
-        model: SidebarWorkspaceRowModel
+        model: SidebarWorkspaceRowModel,
+        onOpenStatusURL: @escaping (URL) -> Void = { _ in }
     ) -> SidebarWorkspaceRowTableCellView {
         let cell = SidebarWorkspaceRowTableCellView()
         cell.configure(
             model: model,
-            actions: makeActions(model: model),
+            actions: makeActions(model: model, onOpenStatusURL: onOpenStatusURL),
             isPointerHovering: false,
             contextMenuDidOpen: {},
             contextMenuDidClose: {}
@@ -207,7 +212,8 @@ struct SidebarAppKitRowCellTests {
         row.configureMetadataEntry(
             SidebarStatusEntry(key: key, value: status, icon: "bolt.fill"),
             model: model,
-            color: .labelColor
+            color: .labelColor,
+            onOpenURL: { _ in }
         )
 
         let textView = try #require(row.subviews.compactMap { $0 as? SidebarRowTextView }.first)
@@ -221,13 +227,16 @@ struct SidebarAppKitRowCellTests {
         let model = Self.makeModel(
             metadataEntries: [SidebarStatusEntry(key: "repro_link", value: "click me", url: url)]
         )
-        let cell = Self.configuredCell(model: model)
-        let controls = Self.descendants(of: cell).compactMap { $0 as? NSControl }
+        var openedURL: URL?
+        let cell = Self.configuredCell(model: model) { openedURL = $0 }
+        let buttons = Self.descendants(of: cell).compactMap { $0 as? NSButton }
 
-        let link = try #require(controls.first { $0.toolTip == url.absoluteString })
+        let link = try #require(buttons.first { $0.toolTip == url.absoluteString })
         #expect(link.action != nil)
         #expect(link.target != nil)
         #expect(link.isEnabled)
+        link.performClick(nil)
+        #expect(openedURL == url)
     }
 
     @Test

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -8,7 +8,10 @@ import Testing
 @Suite
 @MainActor
 struct SidebarAppKitRowCellTests {
-    private static func makeSnapshot(title: String = "Workspace") -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+    private static func makeSnapshot(
+        title: String = "Workspace",
+        metadataEntries: [SidebarStatusEntry] = []
+    ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
             presentationKey: SidebarWorkspaceSnapshotFactory.presentationKey(
                 settings: SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!),
@@ -24,7 +27,7 @@ struct SidebarAppKitRowCellTests {
             showsRemoteReconnectAffordance: false,
             copyableSidebarSSHError: nil,
             latestConversationMessage: nil,
-            metadataEntries: [],
+            metadataEntries: metadataEntries,
             metadataBlocks: [],
             latestLog: nil,
             progress: nil,
@@ -52,14 +55,15 @@ struct SidebarAppKitRowCellTests {
         workspaceId: UUID = UUID(),
         isActive: Bool = false,
         canClose: Bool = true,
-        settings: SidebarTabItemSettingsSnapshot? = nil
+        settings: SidebarTabItemSettingsSnapshot? = nil,
+        metadataEntries: [SidebarStatusEntry] = []
     ) -> SidebarWorkspaceRowModel {
         let resolvedSettings = settings
             ?? SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!)
         return SidebarWorkspaceRowModel(
             workspaceId: workspaceId,
             index: 0,
-            snapshot: makeSnapshot(),
+            snapshot: makeSnapshot(metadataEntries: metadataEntries),
             settings: resolvedSettings,
             isActive: isActive,
             isMultiSelected: false,
@@ -191,6 +195,10 @@ struct SidebarAppKitRowCellTests {
         return cell
     }
 
+    private static func descendants(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap { descendants(of: $0) }
+    }
+
     @Test(arguments: zip(["codex", "claude_code"], ["Running", "Needs input"]))
     func metadataStatusTextOmitsRawAgentKey(_ key: String, _ status: String) throws {
         let model = Self.makeModel()
@@ -205,6 +213,21 @@ struct SidebarAppKitRowCellTests {
         let textView = try #require(row.subviews.compactMap { $0 as? SidebarRowTextView }.first)
         #expect(textView.stringValue == status)
         #expect(!textView.stringValue.contains(key))
+    }
+
+    @Test
+    func metadataStatusURLRendersAnActionBoundToItsDestination() throws {
+        let url = try #require(URL(string: "https://example.com/issues/8520"))
+        let model = Self.makeModel(
+            metadataEntries: [SidebarStatusEntry(key: "repro_link", value: "click me", url: url)]
+        )
+        let cell = Self.configuredCell(model: model)
+        let controls = Self.descendants(of: cell).compactMap { $0 as? NSControl }
+
+        let link = try #require(controls.first { $0.toolTip == url.absoluteString })
+        #expect(link.action != nil)
+        #expect(link.target != nil)
+        #expect(link.isEnabled)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- restore URL-bearing sidebar status entries as standard AppKit link buttons
- route status clicks through the immutable row action bundle after selecting the workspace
- reset pooled metadata rows between actionable and inert entries so stale click behavior cannot leak across reuse

## Root cause

`b7bd90103c` (#8270) introduced the AppKit sidebar renderer. The shared snapshot continued carrying the complete `SidebarStatusEntry`, including `url`, but `SidebarRowIconTextLine.configureMetadataEntry` consumed only icon, text, and color, and `SidebarAppKitRowActions` had no status-URL route. The legacy SwiftUI renderer still created a button and opened the URL.

`e35b74407a` (#8433) made the AppKit renderer the default before v0.64.20, exposing that latent omission and explaining why v0.64.19 worked while v0.64.20 regressed.

The fix makes metadata rendering consume presentation and action metadata together: URL entries become accessible `NSButton` controls bound through a required `onOpenStatusURL` action, while entries without URLs remain inert labels.

## Verification

- commit `57307391b3` adds the failing behavior test before the fix
- the test renders the real AppKit workspace cell, locates the control bound to the exact stored URL, performs the button click, and observes the dispatched URL through an injected opener
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-package-resolved-policy.py`
- local Xcode build/tests intentionally not run per issue instructions; GitHub CI is the Swift compile/test gate
- current main removed `scripts/swift_file_length_budget.py` and `.github/swift-file-length-budget.tsv` in #8125, so that requested checker is unavailable; neither budget TSV was touched

## Localization

No user-facing strings were added or changed. The pill continues to display the status value and uses the stored URL as its tooltip, matching the legacy renderer.

Closes #8520

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787171874&installation_model_id=21920&pr_number=8528&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8528&signature=b4718fefdde95fb1be944a74366ae918c2b0d27e3bd81a3cdf6c3b26c27c9715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore clickable sidebar status pills: URL-bearing entries now render as link buttons and open in the default browser after selecting the workspace, fixing #8520.

- **Bug Fixes**
  - Render URL metadata as `NSButton` links bound via `onOpenStatusURL`; wired to `NSWorkspace.shared.open`.
  - Route clicks through row actions after updating selection; non-URL entries remain inert labels.
  - Reset reused metadata views between actionable and inert states; updated layout/measurement to support buttons.

<sup>Written for commit 92b0e93d884e24d2c260e0519849a3c8b943d58b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status metadata entries with URLs now appear as clickable, underlined links.
  * Selecting a link opens its destination in the system’s default application.

* **Bug Fixes**
  * Non-link metadata and workspace row content continue displaying correctly alongside interactive status links.

* **Tests**
  * Added coverage verifying status links are rendered interactively and open the expected URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->