### PR TITLE
Prevent idle AppKit sidebar layout livelock

### DIFF
--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableApplyInput.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableApplyInput.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// The latest immutable input delivered by the SwiftUI table bridge.
+@MainActor
+struct SidebarWorkspaceTableApplyInput {
+    let rows: [SidebarWorkspaceTableRowConfiguration]
+    let actions: SidebarWorkspaceTableActions
+    let workspaceIds: [UUID]
+    let selectedWorkspaceId: UUID?
+    let selectedScrollTargetWorkspaceId: UUID?
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -19,6 +19,10 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var appKitDropIndicatorIncludesRowTargets = false
     private var clipBoundsObserver: NSObjectProtocol?
     private var resizeDidEndObserver: NSObjectProtocol?
+    private lazy var mutationScheduler = SidebarWorkspaceTableMutationScheduler(
+        applyFlush: { [weak self] in self?.flushApply($0) },
+        viewportChangeFlush: { [weak self] in self?.flushViewportChange() }
+    )
     private let rowHeightCache = SidebarWorkspaceTableRowHeightCache()
     private let dropTargetGeometry = SidebarWorkspaceTableDropTargetGeometryGate()
 
@@ -131,7 +135,24 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         selectedWorkspaceId: UUID?,
         selectedScrollTargetWorkspaceId: UUID?
     ) {
+        mutationScheduler.stageApply(
+            SidebarWorkspaceTableApplyInput(
+                rows: nextRows,
+                actions: actions,
+                workspaceIds: nextWorkspaceIds,
+                selectedWorkspaceId: selectedWorkspaceId,
+                selectedScrollTargetWorkspaceId: selectedScrollTargetWorkspaceId
+            )
+        )
+    }
+
+    private func flushApply(_ input: SidebarWorkspaceTableApplyInput) {
         guard let containerView else { return }
+        let nextRows = input.rows
+        let actions = input.actions
+        let nextWorkspaceIds = input.workspaceIds
+        let selectedWorkspaceId = input.selectedWorkspaceId
+        let selectedScrollTargetWorkspaceId = input.selectedScrollTargetWorkspaceId
         // Authoritative render: reconciles any optimistic preview, so the
         // preview bailout stands down.
         applyGeneration &+= 1
@@ -625,6 +646,10 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     }
 
     func viewportDidChange() {
+        mutationScheduler.stageViewportChange()
+    }
+
+    private func flushViewportChange() {
         let width = currentColumnWidth()
 #if DEBUG
         if width != lastMeasuredWidth {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableMutationScheduler.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableMutationScheduler.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// The latest immutable input delivered by the SwiftUI table bridge.
+@MainActor
+struct SidebarWorkspaceTableApplyInput {
+    let rows: [SidebarWorkspaceTableRowConfiguration]
+    let actions: SidebarWorkspaceTableActions
+    let workspaceIds: [UUID]
+    let selectedWorkspaceId: UUID?
+    let selectedScrollTargetWorkspaceId: UUID?
+}
+
+/// Owns the boundary between SwiftUI/AppKit callbacks and table mutations.
+///
+/// `NSViewRepresentable.updateNSView` and scroll-view bounds notifications can
+/// be delivered while SwiftUI or AppKit is already resolving layout. Mutating
+/// `NSTableView` from those callbacks can synchronously re-enter the same
+/// layout transaction. This scheduler keeps only the latest table input and
+/// one viewport signal, then flushes them after the originating callback has
+/// returned.
+@MainActor
+final class SidebarWorkspaceTableMutationScheduler {
+    private var pendingApply: SidebarWorkspaceTableApplyInput?
+    private var shouldFlushViewportChange = false
+    private var isFlushScheduled = false
+    private let applyFlush: @MainActor (SidebarWorkspaceTableApplyInput) -> Void
+    private let viewportChangeFlush: @MainActor () -> Void
+
+    init(
+        applyFlush: @escaping @MainActor (SidebarWorkspaceTableApplyInput) -> Void,
+        viewportChangeFlush: @escaping @MainActor () -> Void
+    ) {
+        self.applyFlush = applyFlush
+        self.viewportChangeFlush = viewportChangeFlush
+    }
+
+    func stageApply(_ input: SidebarWorkspaceTableApplyInput) {
+        pendingApply = input
+        scheduleFlushIfNeeded()
+    }
+
+    func stageViewportChange() {
+        shouldFlushViewportChange = true
+        scheduleFlushIfNeeded()
+    }
+
+    private func scheduleFlushIfNeeded() {
+        guard !isFlushScheduled else { return }
+        isFlushScheduled = true
+        RunLoop.main.perform(inModes: [.common]) { [weak self] in
+            // RunLoop guarantees main-thread delivery, but Foundation does
+            // not annotate this callback with MainActor.
+            MainActor.assumeIsolated {
+                self?.flushPendingMutations()
+            }
+        }
+    }
+
+    private func flushPendingMutations() {
+        let apply = pendingApply
+        let flushViewportChange = shouldFlushViewportChange
+        pendingApply = nil
+        shouldFlushViewportChange = false
+        isFlushScheduled = false
+
+        if let apply {
+            applyFlush(apply)
+        }
+        if flushViewportChange {
+            viewportChangeFlush()
+        }
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableMutationScheduler.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableMutationScheduler.swift
@@ -1,15 +1,5 @@
 import Foundation
 
-/// The latest immutable input delivered by the SwiftUI table bridge.
-@MainActor
-struct SidebarWorkspaceTableApplyInput {
-    let rows: [SidebarWorkspaceTableRowConfiguration]
-    let actions: SidebarWorkspaceTableActions
-    let workspaceIds: [UUID]
-    let selectedWorkspaceId: UUID?
-    let selectedScrollTargetWorkspaceId: UUID?
-}
-
 /// Owns the boundary between SwiftUI/AppKit callbacks and table mutations.
 ///
 /// `NSViewRepresentable.updateNSView` and scroll-view bounds notifications can

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1596,6 +1596,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		4F80E2D0A6377A1D8A97D411 /* SidebarWorkspaceStatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3896D9D4AD4D31A54882813E /* SidebarWorkspaceStatusPopover.swift */; };
 		A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */; };
 		B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */; };
+		B804A0130000000000000013 /* SidebarWorkspaceTableApplyInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0130000000000000013 /* SidebarWorkspaceTableApplyInput.swift */; };
 		B804A00E000000000000000E /* SidebarWorkspaceTableCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00E000000000000000E /* SidebarWorkspaceTableCellModel.swift */; };
 		B804A00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift */; };
 		B804A0100000000000000010 /* SidebarWorkspaceTableCellState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0100000000000000010 /* SidebarWorkspaceTableCellState.swift */; };
@@ -3651,6 +3652,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		3896D9D4AD4D31A54882813E /* SidebarWorkspaceStatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SidebarWorkspaceStatusPopover.swift"; sourceTree = "<group>"; };
 		A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceStatusSlots.swift; sourceTree = "<group>"; };
 		B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableActions.swift; sourceTree = "<group>"; };
+		B804B0130000000000000013 /* SidebarWorkspaceTableApplyInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableApplyInput.swift; sourceTree = "<group>"; };
 		B804B00E000000000000000E /* SidebarWorkspaceTableCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellModel.swift; sourceTree = "<group>"; };
 		B804B00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellRootView.swift; sourceTree = "<group>"; };
 		B804B0100000000000000010 /* SidebarWorkspaceTableCellState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellState.swift; sourceTree = "<group>"; };
@@ -4634,6 +4636,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */,
 				B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */,
 				B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */,
+				B804B0130000000000000013 /* SidebarWorkspaceTableApplyInput.swift */,
 				B804B0160000000000000016 /* SidebarWorkspaceTableMutationScheduler.swift */,
 				B804B0110000000000000011 /* SidebarWorkspaceTableDropTargetGeometryGate.swift */,
 				B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */,
@@ -7715,6 +7718,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				4F80E2D0A6377A1D8A97D411 /* SidebarWorkspaceStatusPopover.swift in Sources */,
 		A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */,
 				B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */,
+				B804A0130000000000000013 /* SidebarWorkspaceTableApplyInput.swift in Sources */,
 				B804A00E000000000000000E /* SidebarWorkspaceTableCellModel.swift in Sources */,
 				B804A00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift in Sources */,
 				B804A0100000000000000010 /* SidebarWorkspaceTableCellState.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1607,6 +1607,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B804A00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */; };
 		B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */; };
 		B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */; };
+		B804A0160000000000000016 /* SidebarWorkspaceTableMutationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0160000000000000016 /* SidebarWorkspaceTableMutationScheduler.swift */; };
 		B804A0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */; };
 		B804A00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift */; };
 		B804A0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */; };
@@ -3661,6 +3662,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableEmptyDropIndicatorView.swift; sourceTree = "<group>"; };
 		B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableEnvironmentSnapshot.swift; sourceTree = "<group>"; };
 		B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableHoverResolver.swift; sourceTree = "<group>"; };
+		B804B0160000000000000016 /* SidebarWorkspaceTableMutationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableMutationScheduler.swift; sourceTree = "<group>"; };
 		B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift; sourceTree = "<group>"; };
 		B804B00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCache.swift; sourceTree = "<group>"; };
 		B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCalculator.swift; sourceTree = "<group>"; };
@@ -4632,6 +4634,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */,
 				B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */,
 				B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */,
+				B804B0160000000000000016 /* SidebarWorkspaceTableMutationScheduler.swift */,
 				B804B0110000000000000011 /* SidebarWorkspaceTableDropTargetGeometryGate.swift */,
 				B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */,
 				B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */,
@@ -7723,6 +7726,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804A00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift in Sources */,
 				B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */,
 				B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */,
+				B804A0160000000000000016 /* SidebarWorkspaceTableMutationScheduler.swift in Sources */,
 				B804A0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift in Sources */,
 				B804A00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift in Sources */,
 				B804A0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -255,6 +255,7 @@ struct SidebarWorkspaceTableTests {
             selectedWorkspaceId: nil,
             selectedScrollTargetWorkspaceId: nil
         )
+        _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.02))
         container.layoutSubtreeIfNeeded()
         container.tableView.layoutSubtreeIfNeeded()
         var computations = 0

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -150,7 +150,7 @@ struct SidebarWorkspaceTableTests {
 #if DEBUG
     @Test
     @MainActor
-    func tableApplyCoalescesAndMutatesOnlyAfterTheCurrentCallbackReturns() {
+    func tableApplyCoalescesAndMutatesOnlyAfterTheCurrentCallbackReturns() async {
         let controller = SidebarWorkspaceTableController()
         let container = controller.makeContainerView()
         let first = makeRowConfiguration()
@@ -176,7 +176,7 @@ struct SidebarWorkspaceTableTests {
             container.tableView.numberOfRows == 0,
             "Representable updates must not mutate NSTableView before the originating callback returns."
         )
-        flushStagedTableMutations()
+        await flushStagedTableMutations()
         #expect(
             container.tableView.numberOfRows == 2,
             "The deferred boundary must coalesce repeated inputs and apply the newest table snapshot."
@@ -237,7 +237,7 @@ struct SidebarWorkspaceTableTests {
 
     @Test
     @MainActor
-    func dropTargetGeometryIsIdleDuringScrollAndTracksDragLifecycle() {
+    func dropTargetGeometryIsIdleDuringScrollAndTracksDragLifecycle() async {
         let controller = SidebarWorkspaceTableController()
         let container = controller.makeContainerView()
         let workspaceId = UUID()
@@ -255,7 +255,7 @@ struct SidebarWorkspaceTableTests {
             selectedWorkspaceId: nil,
             selectedScrollTargetWorkspaceId: nil
         )
-        flushStagedTableMutations()
+        await flushStagedTableMutations()
         container.layoutSubtreeIfNeeded()
         container.tableView.layoutSubtreeIfNeeded()
         var computations = 0
@@ -263,7 +263,7 @@ struct SidebarWorkspaceTableTests {
 
         controller.viewportDidChange()
         controller.viewportDidChange()
-        flushStagedTableMutations()
+        await flushStagedTableMutations()
         #expect(computations == 0)
 
         controller.workspaceDragSessionDidBegin()
@@ -271,13 +271,13 @@ struct SidebarWorkspaceTableTests {
         #expect(container.reorderDropView.targets.map(\.workspaceId) == [workspaceId])
 
         controller.viewportDidChange()
-        flushStagedTableMutations()
+        await flushStagedTableMutations()
         #expect(computations == 2)
 
         controller.workspaceDragSessionDidEnd()
         #expect(container.reorderDropView.targets.isEmpty)
         controller.viewportDidChange()
-        flushStagedTableMutations()
+        await flushStagedTableMutations()
         #expect(computations == 2)
     }
 #endif
@@ -339,8 +339,12 @@ struct SidebarWorkspaceTableTests {
     }
 
     @MainActor
-    private func flushStagedTableMutations() {
-        _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.02))
+    private func flushStagedTableMutations() async {
+        await withCheckedContinuation { continuation in
+            RunLoop.main.perform(inModes: [.common]) {
+                continuation.resume()
+            }
+        }
     }
 
 #if DEBUG

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -150,6 +150,41 @@ struct SidebarWorkspaceTableTests {
 #if DEBUG
     @Test
     @MainActor
+    func tableApplyCoalescesAndMutatesOnlyAfterTheCurrentCallbackReturns() {
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let first = makeRowConfiguration()
+        let second = makeRowConfiguration()
+        let actions = makeTableActions()
+
+        controller.apply(
+            rows: [first],
+            actions: actions,
+            workspaceIds: [first.workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        controller.apply(
+            rows: [first, second],
+            actions: actions,
+            workspaceIds: [first.workspaceId, second.workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+
+        #expect(
+            container.tableView.numberOfRows == 0,
+            "Representable updates must not mutate NSTableView before the originating callback returns."
+        )
+        _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.02))
+        #expect(
+            container.tableView.numberOfRows == 2,
+            "The deferred boundary must coalesce repeated inputs and apply the newest table snapshot."
+        )
+    }
+
+    @Test
+    @MainActor
     func equivalentCellConfigurationDoesNotRenderAgain() {
         let cell = SidebarWorkspaceTableCellView()
         let workspaceId = UUID()

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -176,7 +176,7 @@ struct SidebarWorkspaceTableTests {
             container.tableView.numberOfRows == 0,
             "Representable updates must not mutate NSTableView before the originating callback returns."
         )
-        _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.02))
+        flushStagedTableMutations()
         #expect(
             container.tableView.numberOfRows == 2,
             "The deferred boundary must coalesce repeated inputs and apply the newest table snapshot."
@@ -255,7 +255,7 @@ struct SidebarWorkspaceTableTests {
             selectedWorkspaceId: nil,
             selectedScrollTargetWorkspaceId: nil
         )
-        _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.02))
+        flushStagedTableMutations()
         container.layoutSubtreeIfNeeded()
         container.tableView.layoutSubtreeIfNeeded()
         var computations = 0
@@ -263,6 +263,7 @@ struct SidebarWorkspaceTableTests {
 
         controller.viewportDidChange()
         controller.viewportDidChange()
+        flushStagedTableMutations()
         #expect(computations == 0)
 
         controller.workspaceDragSessionDidBegin()
@@ -270,11 +271,13 @@ struct SidebarWorkspaceTableTests {
         #expect(container.reorderDropView.targets.map(\.workspaceId) == [workspaceId])
 
         controller.viewportDidChange()
+        flushStagedTableMutations()
         #expect(computations == 2)
 
         controller.workspaceDragSessionDidEnd()
         #expect(container.reorderDropView.targets.isEmpty)
         controller.viewportDidChange()
+        flushStagedTableMutations()
         #expect(computations == 2)
     }
 #endif
@@ -333,6 +336,11 @@ struct SidebarWorkspaceTableTests {
         ) { _, _ in
             AnyView(TestRowContent(token: contentToken))
         }
+    }
+
+    @MainActor
+    private func flushStagedTableMutations() {
+        _ = RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 0.02))
     }
 
 #if DEBUG


### PR DESCRIPTION
Closes #8525

## Root cause

v0.64.20 shipped the native AppKit workspace table from #8270 (`b7bd90103c`) and made it the fallback/default in #8433 (`e35b74407a`). That exposed the new bridge to users who had remained on the SwiftUI sidebar in v0.64.19.

`SidebarWorkspaceTableView.updateNSView` synchronously called the controller's `apply`. That path can reload/move rows and reconcile row heights. Those table mutations emit bounds/layout callbacks while the originating SwiftUI representable update is still resolving; the callbacks can synchronously perform more viewport and row-height work, producing a SwiftUI/AppKit layout transaction that does not converge while the app is otherwise idle.

## Fix

- Add one controller-owned `SidebarWorkspaceTableMutationScheduler`.
- Stage immutable table snapshots and viewport signals instead of mutating `NSTableView` inside representable/layout callbacks.
- Coalesce table applies to the latest snapshot and repeated viewport notifications to one signal.
- Flush on the next common main-run-loop turn, after the originating callback returns.
- Keep existing row diffing, height-cache, scrolling, hover, and drag behavior behind the shared mutation boundary.

This removes the reentrant mutation edge for the whole table controller instead of throttling one symptom.

## Regression proof

The test and fix are separate commits:

1. Test-only `edd08429af` fails because the table already has two rows before the callback boundary: https://github.com/manaflow-ai/cmux/actions/runs/29779690222
2. Fix `6400ffaf51` introduces the deferred/coalesced mutation boundary.
3. Final HEAD `10c6df9b48` has both scoped tests passing in a 12-test execution: https://github.com/manaflow-ai/cmux/actions/runs/29781424661

The final suite's two other failures are stale assertions already contradicted by current implementation: `.fullWidth` versus `.plain`, and an old-width cache value expected to be removed. Neither covers the changed scheduling path.

The exact tagged app build succeeded: https://github.com/manaflow-ai/cmux/actions/runs/29782552764. Its reload-build commit has final PR HEAD as its sole parent and only adds a provisioning log; the app debug dylib SHA-256 is `c99674c11e6cbd7fe5b880adc68e167ccb50b233cdd77fccc140fa3c5f075fa4`.

## Runtime verification

Normal idle on macOS 26.5.1, 10 continuous minutes after settle:

- CPU median 0.6%, p95 7.4%, max 18.9%; no sample reached 50%.
- First/last two-minute CPU medians both 0.5%.
- RSS first/last 60-second medians 267.750/265.719 MiB; slope -0.086 MiB/min.
- Same PID/socket remained alive and the tagged CLI returned `PONG`.
- Main thread was waiting 99.958% at minute 5 and 98.878% at minute 10; scheduler flush was 0.0721% of profiled cycles, with no `reloadData` or row-height samples.

Normal idle on macOS 15.7.4, 10 continuous minutes after settle:

- CPU median 0.6%, p95 8.1%, max 28%; all >=5% spikes lasted one 2-second interval.
- First/last two-minute CPU medians both 0.6%.
- RSS median delta +14.078 MiB; slope +1.602 MiB/min.
- Native table DEBUG event, process/socket liveness, and tagged CLI response were confirmed.

Restored scale on macOS 26.5.1:

- Created 128 workspaces / 250 panes / 250 terminal surfaces, quit cleanly, and relaunched to a new PID; all 128/250/250 items restored within four seconds with one selected row and authoritative order preserved.
- After a fixed 120-second settle, the restored PID idled 15 continuous minutes.
- CPU median 1.0%, p95 10.4%; no sustained >=75% episode. First/second-half medians were 0.2%/0.3% using the independent process sampler.
- RSS grew 36.469 MiB, within the 128 MiB gate; the final five minutes were flat (+0.156 MiB, 0.0133 MiB/min).
- Minute-5 and minute-10 samples found the main thread in the normal AppKit wait 99.623%/99.381% of samples, with no `reloadData`, row-height, or layout-subtree frames.
- Same restored PID/socket survived, CLI returned `PONG`, topology remained 128/250/250, and no crash/hang/DiagnosticReport or reentrant/layout-loop warning appeared.

Artifacts and raw metrics are under `artifacts/issue-8525-idle-high-cpu-crash/` in the verification worktree.

## Verification limitations

- The macOS 15.7.4 restored-scale extension could not start on the separately leased slot: that account had no Aqua `launchd` domain (`OSLaunchdErrorDomain 125`), so the tagged app could not create a PID/socket, and its VNC endpoint only offered unsupported Apple-auth security modes. The successful macOS 15.7.4 normal 10-minute run remains valid; no scaled result is claimed for that OS.
- Full-display capture on the macOS 26 host was blocked by Screen Recording denial, unavailable Accessibility/Computer Use, and a refused raw-VNC endpoint. A fresh macOS 26 cloud runner also failed to expose its Tailscale/VNC host within the bounded 900-second provisioning window: https://github.com/manaflow-ai/cmux-loader/actions/runs/29787107347. No TCC state was altered and no synthetic capture is claimed.
- Runtime create/close/select/reorder behavior was exercised, and unit coverage checks deferred viewport/drag behavior. GUI scroll/resize/drop-indicator exercise was blocked with the same unavailable Accessibility/VNC paths and is not claimed.
- The restored macOS 26 PID has minute-5/minute-10 samples; the 120-second Time Profiler trace was captured in the same 128/250/250 state before the clean restart, on the prior tagged PID. No same-restored-PID 120-second trace is claimed.
- The reporter has not yet supplied their crash report or macOS version, so runtime verification covers macOS 15.7.4 and 26.5.1 but cannot yet match their exact environment.
- `sentry-cli` is present locally but has no authenticated session.

## Static and localization checks

- Tagged Debug build passed with no warnings in the changed files.
- pbxproj normalization, test wiring, workspace package grouping, `Package.resolved` policy, and `git diff --check` passed.
- The Swift file-length budget guard was removed from this repository by #8125; the new Swift files are 11 and 63 lines, no tracked budget TSV exists, and no budget file changed.
- No user-facing strings or localization keys changed; the localization audit found no new UI, Settings, menu, shortcut, schema, docs, alert, or tooltip copy.
