### PR TITLE
Isolate and self-heal tagged computer use

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -937,7 +937,7 @@ cmux_computer_use_config() {
     # Stable per-terminal session id so the branded agent cursor survives helper
     # restarts in the same surface.
     default_session="cmux-${CMUX_SURFACE_ID:-$$}"
-    printf '{"mcpServers":{"cmux-computer-use":{"command":"%s","args":["mcp","--socket","%s"],"env":{"CUA_DRIVER_RS_MCP_FORCE_PROXY":"1","CUA_DRIVER_RS_EXTERNAL_PERMISSION_FLOW":"1","CUA_DRIVER_DEFAULT_SESSION":"%s","CUA_DRIVER_RS_TELEMETRY_ENABLED":"false","CUA_DRIVER_RS_UPDATE_CHECK":"false","CUA_DRIVER_CURSOR_GRADIENT":"#12c7f5,#2d8cff,#6c5cff","CUA_DRIVER_CURSOR_BLOOM":"#2d8cff","CUA_DRIVER_CURSOR_LABEL":"cmux","CUA_DRIVER_STATE_DIR":"%s","NODE_OPTIONS":"","BUN_OPTIONS":""}}}}' \
+    printf '{"mcpServers":{"cmux-computer-use":{"command":"%s","args":["mcp","--socket","%s"],"env":{"CUA_DRIVER_RS_MCP_FORCE_PROXY":"1","CUA_DRIVER_RS_EXTERNAL_PERMISSION_FLOW":"1","CUA_DRIVER_DAEMON_APP":"","CUA_DRIVER_EMBEDDED":"0","CUA_DRIVER_RS_MCP_NO_RELAUNCH":"0","CUA_DRIVER_DEFAULT_SESSION":"%s","CUA_DRIVER_RS_TELEMETRY_ENABLED":"false","CUA_DRIVER_RS_UPDATE_CHECK":"false","CUA_DRIVER_CURSOR_GRADIENT":"#12c7f5,#2d8cff,#6c5cff","CUA_DRIVER_CURSOR_BLOOM":"#2d8cff","CUA_DRIVER_CURSOR_LABEL":"cmux","CUA_DRIVER_STATE_DIR":"%s","NODE_OPTIONS":"","BUN_OPTIONS":""}}}}' \
         "$(cmux_computer_use_json_escape "$driver")" \
         "$(cmux_computer_use_json_escape "$cua_socket")" \
         "$(cmux_computer_use_json_escape "$default_session")" \

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -932,8 +932,8 @@ cmux_computer_use_config() {
     runtime_scope="$(printf '%s' "$runtime_scope" | LC_ALL=C /usr/bin/tr -c 'A-Za-z0-9_.-' '-' | /usr/bin/sed -E 's/^[.-]+//; s/[.-]+$//' | /usr/bin/cut -c1-64)"
     [[ -n "$runtime_scope" ]] || runtime_scope="default"
     runtime_uid="$(/usr/bin/id -u)"
-    state_dir="${CMUX_CUA_STATE_DIR:-${HOME}/Library/Application Support/cmux/computer-use/runtime/${runtime_scope}/state}"
-    cua_socket="${CMUX_CUA_SOCKET_PATH:-/tmp/cmux-cua-${runtime_uid}/${runtime_scope}/cua.sock}"
+    state_dir="${HOME}/Library/Application Support/cmux/computer-use/runtime/${runtime_scope}/state"
+    cua_socket="/tmp/cmux-cua-${runtime_uid}/${runtime_scope}/cua.sock"
     # Stable per-terminal session id so the branded agent cursor survives helper
     # restarts in the same surface.
     default_session="cmux-${CMUX_SURFACE_ID:-$$}"

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -244,8 +244,8 @@ cmux_codex_emit_computer_use_args() {
     runtime_scope="$(printf '%s' "$runtime_scope" | LC_ALL=C /usr/bin/tr -c 'A-Za-z0-9_.-' '-' | /usr/bin/sed -E 's/^[.-]+//; s/[.-]+$//' | /usr/bin/cut -c1-64)"
     [[ -n "$runtime_scope" ]] || runtime_scope="default"
     runtime_uid="$(/usr/bin/id -u)"
-    cua_socket="${CMUX_CUA_SOCKET_PATH:-/tmp/cmux-cua-${runtime_uid}/${runtime_scope}/cua.sock}"
-    state_dir="${CMUX_CUA_STATE_DIR:-${HOME}/Library/Application Support/cmux/computer-use/runtime/${runtime_scope}/state}"
+    cua_socket="/tmp/cmux-cua-${runtime_uid}/${runtime_scope}/cua.sock"
+    state_dir="${HOME}/Library/Application Support/cmux/computer-use/runtime/${runtime_scope}/state"
     printf '%s\0' \
         "-c" \
         "mcp_servers.cmux-computer-use.command=\"$(cmux_computer_use_json_escape "$driver")\"" \

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -256,6 +256,12 @@ cmux_codex_emit_computer_use_args() {
         "-c" \
         'mcp_servers.cmux-computer-use.env.CUA_DRIVER_RS_EXTERNAL_PERMISSION_FLOW="1"' \
         "-c" \
+        'mcp_servers.cmux-computer-use.env.CUA_DRIVER_DAEMON_APP=""' \
+        "-c" \
+        'mcp_servers.cmux-computer-use.env.CUA_DRIVER_EMBEDDED="0"' \
+        "-c" \
+        'mcp_servers.cmux-computer-use.env.CUA_DRIVER_RS_MCP_NO_RELAUNCH="0"' \
+        "-c" \
         "mcp_servers.cmux-computer-use.env.CUA_DRIVER_DEFAULT_SESSION=\"$(cmux_computer_use_json_escape "$default_session")\"" \
         "-c" \
         "mcp_servers.cmux-computer-use.env.CUA_DRIVER_RS_TELEMETRY_ENABLED=\"false\"" \

--- a/Sources/App/ComputerUseHelperSupervisor.swift
+++ b/Sources/App/ComputerUseHelperSupervisor.swift
@@ -1,0 +1,19 @@
+/// Restarts the Computer Use helper after an unexpected termination while the feature is enabled.
+@MainActor
+final class ComputerUseHelperSupervisor {
+    private let restart: @MainActor () async -> Void
+    private var isEnabled = false
+
+    init(restart: @escaping @MainActor () async -> Void) {
+        self.restart = restart
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+    }
+
+    func helperDidTerminate() async {
+        guard isEnabled else { return }
+        await restart()
+    }
+}

--- a/Sources/App/ComputerUseHelperSupervisor.swift
+++ b/Sources/App/ComputerUseHelperSupervisor.swift
@@ -1,19 +1,63 @@
+import Foundation
+
 /// Restarts the Computer Use helper after an unexpected termination while the feature is enabled.
 @MainActor
 final class ComputerUseHelperSupervisor {
+    private let helperAppURL: URL
+    private let helperBundleIdentifier: String?
     private let restart: @MainActor () async -> Void
     private var isEnabled = false
+    private var launchedProcessIdentifiers: Set<pid_t> = []
 
-    init(restart: @escaping @MainActor () async -> Void) {
+    init(
+        helperAppURL: URL,
+        helperBundleIdentifier: String?,
+        restart: @escaping @MainActor () async -> Void
+    ) {
+        self.helperAppURL = helperAppURL.resolvingSymlinksInPath().standardizedFileURL
+        self.helperBundleIdentifier = helperBundleIdentifier
         self.restart = restart
     }
 
     func setEnabled(_ enabled: Bool) {
         isEnabled = enabled
+        if !enabled {
+            launchedProcessIdentifiers.removeAll()
+        }
     }
 
-    func helperDidTerminate() async {
+    func helperDidLaunch(
+        bundleURL: URL?,
+        bundleIdentifier: String?,
+        processIdentifier: pid_t
+    ) {
+        guard matchesHelper(bundleURL: bundleURL, bundleIdentifier: bundleIdentifier) else { return }
+        launchedProcessIdentifiers.insert(processIdentifier)
+    }
+
+    func helperDidTerminate(
+        bundleURL: URL?,
+        bundleIdentifier: String?,
+        processIdentifier: pid_t
+    ) async {
+        let wasLaunchedProcess = launchedProcessIdentifiers.remove(processIdentifier) != nil
         guard isEnabled else { return }
+        let matchesHelperIdentity = matchesHelper(
+            bundleURL: bundleURL,
+            bundleIdentifier: bundleIdentifier
+        )
+        let hasNoReportedIdentity = bundleURL == nil && bundleIdentifier == nil
+        guard matchesHelperIdentity || (hasNoReportedIdentity && wasLaunchedProcess) else {
+            return
+        }
         await restart()
+    }
+
+    private func matchesHelper(bundleURL: URL?, bundleIdentifier: String?) -> Bool {
+        if let bundleURL {
+            return bundleURL.resolvingSymlinksInPath().standardizedFileURL == helperAppURL
+        }
+        guard let helperBundleIdentifier else { return false }
+        return bundleIdentifier == helperBundleIdentifier
     }
 }

--- a/Sources/App/ComputerUseMenuBarController.swift
+++ b/Sources/App/ComputerUseMenuBarController.swift
@@ -9,23 +9,29 @@ final class ComputerUseMenuBarController: NSObject, NSMenuDelegate {
     private let statusItem: NSStatusItem
     private let menu = NSMenu(title: String(localized: "computerUse.menu.title", defaultValue: "Computer Use"))
     private let snapshotStore: ComputerUseMenuBarSnapshotStore
-    private let onFocusTerminal: (UUID, UUID) -> Void
-    private let canFocusTarget: (ComputerUseTargetIdentity) -> Bool
-    private let onFocusTarget: (ComputerUseTargetIdentity) -> Void
+    private let isRunningInBackground: () -> Bool
+    private let onContinueInBackground: (UUID, UUID) -> Void
+    private let canViewComputerUse: (ComputerUseTargetIdentity) -> Bool
+    private let onViewComputerUse: (ComputerUseTargetIdentity) -> Void
+    private let onNoLiveSessions: () -> Void
     private var snapshotCancellable: AnyCancellable?
-    private var terminalActions: [ObjectIdentifier: () -> Void] = [:]
-    private var targetActions: [ObjectIdentifier: () -> Void] = [:]
+    private var backgroundActions: [ObjectIdentifier: () -> Void] = [:]
+    private var viewActions: [ObjectIdentifier: () -> Void] = [:]
 
     init(
         snapshotStore: ComputerUseMenuBarSnapshotStore,
-        onFocusTerminal: @escaping (UUID, UUID) -> Void,
-        canFocusTarget: @escaping (ComputerUseTargetIdentity) -> Bool,
-        onFocusTarget: @escaping (ComputerUseTargetIdentity) -> Void
+        isRunningInBackground: @escaping () -> Bool,
+        onContinueInBackground: @escaping (UUID, UUID) -> Void,
+        canViewComputerUse: @escaping (ComputerUseTargetIdentity) -> Bool,
+        onViewComputerUse: @escaping (ComputerUseTargetIdentity) -> Void,
+        onNoLiveSessions: @escaping () -> Void
     ) {
         self.snapshotStore = snapshotStore
-        self.onFocusTerminal = onFocusTerminal
-        self.canFocusTarget = canFocusTarget
-        self.onFocusTarget = onFocusTarget
+        self.isRunningInBackground = isRunningInBackground
+        self.onContinueInBackground = onContinueInBackground
+        self.canViewComputerUse = canViewComputerUse
+        self.onViewComputerUse = onViewComputerUse
+        self.onNoLiveSessions = onNoLiveSessions
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         super.init()
 
@@ -33,15 +39,16 @@ final class ComputerUseMenuBarController: NSObject, NSMenuDelegate {
         menu.delegate = self
         statusItem.menu = menu
         if let button = statusItem.button {
-            let label = String(localized: "computerUse.menu.title", defaultValue: "Computer Use")
-            let image = NSImage(systemSymbolName: "cursorarrow.rays", accessibilityDescription: label)
+            let image = NSImage(
+                systemSymbolName: "cursorarrow.rays",
+                accessibilityDescription: String(localized: "computerUse.menu.title", defaultValue: "Computer Use")
+            )
             image?.isTemplate = true
             button.image = image
             button.imagePosition = .imageOnly
             button.imageScaling = .scaleProportionallyDown
-            button.toolTip = label
-            button.setAccessibilityLabel(label)
         }
+        updateStatusItemAccessibility()
 
         snapshotCancellable = snapshotStore.$snapshot
             .receive(on: DispatchQueue.main)
@@ -66,14 +73,18 @@ final class ComputerUseMenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func refreshUI(snapshot: ComputerUseMenuBarSnapshot) {
+        if snapshot.rows.isEmpty {
+            onNoLiveSessions()
+        }
         statusItem.isVisible = snapshot.shouldShowStatusItem
+        updateStatusItemAccessibility()
         rebuildMenu(rows: snapshot.rows)
     }
 
     private func rebuildMenu(rows: [ComputerUseMenuBarRow]) {
         menu.removeAllItems()
-        terminalActions.removeAll(keepingCapacity: true)
-        targetActions.removeAll(keepingCapacity: true)
+        backgroundActions.removeAll(keepingCapacity: true)
+        viewActions.removeAll(keepingCapacity: true)
 
         guard !rows.isEmpty else {
             let item = NSMenuItem(
@@ -86,49 +97,69 @@ final class ComputerUseMenuBarController: NSObject, NSMenuDelegate {
             return
         }
 
+        let runningInBackground = isRunningInBackground()
         for row in rows {
             let sessionItem = NSMenuItem(title: row.title, action: nil, keyEquivalent: "")
             let submenu = NSMenu(title: row.title)
 
-            let terminalItem = NSMenuItem(
-                title: String(localized: "computerUse.menu.focusTerminal", defaultValue: "Focus Terminal"),
-                action: #selector(focusTerminalAction(_:)),
+            let viewItem = NSMenuItem(
+                title: String(localized: "computerUse.menu.viewComputerUse", defaultValue: "View Computer Use"),
+                action: #selector(viewComputerUseAction(_:)),
                 keyEquivalent: ""
             )
-            terminalItem.target = self
-            terminalActions[ObjectIdentifier(terminalItem)] = { [onFocusTerminal] in
-                onFocusTerminal(row.workspaceID, row.surfaceID)
-            }
-            submenu.addItem(terminalItem)
-
-            let targetItem = NSMenuItem(
-                title: String(localized: "computerUse.menu.focusTarget", defaultValue: "Focus Computer-Use Target"),
-                action: #selector(focusTargetAction(_:)),
-                keyEquivalent: ""
-            )
-            targetItem.target = self
-            if let identity = row.targetIdentity, canFocusTarget(identity) {
-                targetActions[ObjectIdentifier(targetItem)] = { [onFocusTarget] in
-                    onFocusTarget(identity)
+            viewItem.target = self
+            if let identity = row.targetIdentity, canViewComputerUse(identity) {
+                viewActions[ObjectIdentifier(viewItem)] = { [onViewComputerUse] in
+                    onViewComputerUse(identity)
                 }
+                viewItem.state = runningInBackground ? .off : .on
             } else {
-                targetItem.isEnabled = false
-                targetItem.toolTip = String(
+                viewItem.isEnabled = false
+                viewItem.toolTip = String(
                     localized: "computerUse.menu.noActivityTooltip",
                     defaultValue: "No computer-use activity yet"
                 )
             }
-            submenu.addItem(targetItem)
+            submenu.addItem(viewItem)
+
+            let backgroundItem = NSMenuItem(
+                title: String(
+                    localized: "computerUse.menu.continueInBackground",
+                    defaultValue: "Continue in Background"
+                ),
+                action: #selector(continueInBackgroundAction(_:)),
+                keyEquivalent: ""
+            )
+            backgroundItem.target = self
+            backgroundItem.state = runningInBackground ? .on : .off
+            backgroundActions[ObjectIdentifier(backgroundItem)] = { [onContinueInBackground] in
+                onContinueInBackground(row.workspaceID, row.surfaceID)
+            }
+            submenu.addItem(backgroundItem)
+
             sessionItem.submenu = submenu
             menu.addItem(sessionItem)
         }
     }
 
-    @objc private func focusTerminalAction(_ sender: NSMenuItem) {
-        terminalActions[ObjectIdentifier(sender)]?()
+    private func updateStatusItemAccessibility() {
+        let label = isRunningInBackground()
+            ? String(
+                localized: "computerUse.menu.backgroundStatus",
+                defaultValue: "Computer Use — Running in Background"
+            )
+            : String(localized: "computerUse.menu.title", defaultValue: "Computer Use")
+        statusItem.button?.toolTip = label
+        statusItem.button?.setAccessibilityLabel(label)
     }
 
-    @objc private func focusTargetAction(_ sender: NSMenuItem) {
-        targetActions[ObjectIdentifier(sender)]?()
+    @objc private func continueInBackgroundAction(_ sender: NSMenuItem) {
+        backgroundActions[ObjectIdentifier(sender)]?()
+        updateStatusItemAccessibility()
+    }
+
+    @objc private func viewComputerUseAction(_ sender: NSMenuItem) {
+        viewActions[ObjectIdentifier(sender)]?()
+        updateStatusItemAccessibility()
     }
 }

--- a/Sources/App/ComputerUseRuntimeService.swift
+++ b/Sources/App/ComputerUseRuntimeService.swift
@@ -20,6 +20,13 @@ final class ComputerUseRuntimeService {
     private var installedHelperURL: URL?
     private var installationTask: Task<URL?, Never>?
     private var cachedStatus = ComputerUsePermissionStatus.missing
+    private var runningHelperApplication: NSRunningApplication?
+    private var helperTerminationTask: Task<Void, Never>?
+    private var monitoredHelperProcessIdentifier: pid_t?
+    private lazy var helperSupervisor = ComputerUseHelperSupervisor { [weak self] in
+        guard let self else { return }
+        await self.startIfNeeded()
+    }
 
     init(
         bundle: Bundle = .main,
@@ -53,6 +60,7 @@ final class ComputerUseRuntimeService {
 
     /// Reconciles the helper daemon with the live `computerUse.enabled` setting.
     func setEnabled(_ newValue: Bool) async {
+        helperSupervisor.setEnabled(newValue)
         if newValue {
             await startIfNeeded()
         } else {
@@ -144,12 +152,22 @@ final class ComputerUseRuntimeService {
 
     private func startIfNeeded() async {
         guard let helperURL = await ensureStandaloneHelperInstalled() else { return }
-        guard !(await Self.isDaemonListening(paths: paths, transport: transport)) else { return }
+        if await Self.isDaemonListening(paths: paths, transport: transport) {
+            if let application = Self.runningHelperApplication(at: helperURL) {
+                await monitorHelper(application)
+                return
+            }
+
+            // A listening daemon without the exact LaunchServices app instance
+            // is not lifecycle-owned by cmux. Replace it with a monitored helper.
+            await stopDaemon()
+        }
         await launchHelper(at: helperURL)
         _ = await Self.waitForDaemonStart(paths: paths, transport: transport)
     }
 
     private func stopDaemon() async {
+        cancelHelperMonitoring()
         guard await Self.isDaemonListening(paths: paths, transport: transport) else { return }
         _ = await Self.sendDaemonRequest(
             ["method": "shutdown"],
@@ -176,14 +194,58 @@ final class ComputerUseRuntimeService {
         configuration.createsNewApplicationInstance = true
         configuration.arguments = launch.arguments
         configuration.environment = launch.environment
-        await withCheckedContinuation { continuation in
+        let application = await withCheckedContinuation { continuation in
             NSWorkspace.shared.openApplication(
                 at: helperURL,
                 configuration: configuration
-            ) { _, _ in
-                continuation.resume()
+            ) { application, _ in
+                continuation.resume(returning: application)
             }
         }
+        guard let application else { return }
+        await monitorHelper(application)
+    }
+
+    private func monitorHelper(_ application: NSRunningApplication) async {
+        cancelHelperMonitoring()
+        let processIdentifier = application.processIdentifier
+        runningHelperApplication = application
+        monitoredHelperProcessIdentifier = processIdentifier
+
+        let notifications = NSWorkspace.shared.notificationCenter.notifications(
+            named: NSWorkspace.didTerminateApplicationNotification
+        )
+        helperTerminationTask = Task { @MainActor [weak self] in
+            for await notification in notifications {
+                guard !Task.isCancelled else { return }
+                guard
+                    let terminatedApplication = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
+                        as? NSRunningApplication,
+                    terminatedApplication.processIdentifier == processIdentifier
+                else {
+                    continue
+                }
+                await self?.monitoredHelperDidTerminate(processIdentifier: processIdentifier)
+                return
+            }
+        }
+
+        if application.isTerminated {
+            await monitoredHelperDidTerminate(processIdentifier: processIdentifier)
+        }
+    }
+
+    private func monitoredHelperDidTerminate(processIdentifier: pid_t) async {
+        guard monitoredHelperProcessIdentifier == processIdentifier else { return }
+        cancelHelperMonitoring()
+        await helperSupervisor.helperDidTerminate()
+    }
+
+    private func cancelHelperMonitoring() {
+        helperTerminationTask?.cancel()
+        helperTerminationTask = nil
+        monitoredHelperProcessIdentifier = nil
+        runningHelperApplication = nil
     }
 
     private func openSystemSettings(_ deepLink: String) {
@@ -240,6 +302,15 @@ final class ComputerUseRuntimeService {
         }
         let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? helperAppName : trimmed
+    }
+
+    private static func runningHelperApplication(at helperAppURL: URL) -> NSRunningApplication? {
+        guard let bundleIdentifier = Bundle(url: helperAppURL)?.bundleIdentifier else { return nil }
+        let expectedURL = helperAppURL.resolvingSymlinksInPath().standardizedFileURL
+        return NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first { application in
+            guard !application.isTerminated, let bundleURL = application.bundleURL else { return false }
+            return bundleURL.resolvingSymlinksInPath().standardizedFileURL == expectedURL
+        }
     }
 
     nonisolated private static func isDaemonListening(

--- a/Sources/App/ComputerUseRuntimeService.swift
+++ b/Sources/App/ComputerUseRuntimeService.swift
@@ -16,14 +16,16 @@ final class ComputerUseRuntimeService {
     let applicationName: String
 
     private let bundledHelperAppURL: URL?
+    private let helperBundleIdentifier: String?
     private let transport: SocketTransport
     private var installedHelperURL: URL?
     private var installationTask: Task<URL?, Never>?
     private var cachedStatus = ComputerUsePermissionStatus.missing
-    private var runningHelperApplication: NSRunningApplication?
     private var helperTerminationTask: Task<Void, Never>?
-    private var monitoredHelperProcessIdentifier: pid_t?
-    private lazy var helperSupervisor = ComputerUseHelperSupervisor { [weak self] in
+    private lazy var helperSupervisor = ComputerUseHelperSupervisor(
+        helperAppURL: paths.installedHelperAppURL,
+        helperBundleIdentifier: helperBundleIdentifier
+    ) { [weak self] in
         guard let self else { return }
         await self.startIfNeeded()
     }
@@ -39,9 +41,11 @@ final class ComputerUseRuntimeService {
             .appendingPathComponent("Contents/Library/\(Self.helperAppName).app", isDirectory: true)
         if FileManager.default.fileExists(atPath: nestedURL.path) {
             bundledHelperAppURL = nestedURL
+            helperBundleIdentifier = Bundle(url: nestedURL)?.bundleIdentifier
             applicationName = Self.displayName(for: nestedURL)
         } else {
             bundledHelperAppURL = nil
+            helperBundleIdentifier = nil
             applicationName = Self.helperAppName
         }
     }
@@ -152,9 +156,10 @@ final class ComputerUseRuntimeService {
 
     private func startIfNeeded() async {
         guard let helperURL = await ensureStandaloneHelperInstalled() else { return }
+        beginHelperMonitoring()
         if await Self.isDaemonListening(paths: paths, transport: transport) {
             if let application = Self.runningHelperApplication(at: helperURL) {
-                await monitorHelper(application)
+                recordHelperApplication(application)
                 return
             }
 
@@ -179,6 +184,7 @@ final class ComputerUseRuntimeService {
     }
 
     private func launchHelper(at helperURL: URL) async {
+        beginHelperMonitoring()
         let launch = ComputerUseHelperLaunchConfiguration(paths: paths)
         try? FileManager.default.createDirectory(
             at: paths.runtimeDirectoryURL,
@@ -203,15 +209,18 @@ final class ComputerUseRuntimeService {
             }
         }
         guard let application else { return }
-        await monitorHelper(application)
+        recordHelperApplication(application)
+        if application.isTerminated {
+            await helperSupervisor.helperDidTerminate(
+                bundleURL: application.bundleURL,
+                bundleIdentifier: application.bundleIdentifier,
+                processIdentifier: application.processIdentifier
+            )
+        }
     }
 
-    private func monitorHelper(_ application: NSRunningApplication) async {
-        cancelHelperMonitoring()
-        let processIdentifier = application.processIdentifier
-        runningHelperApplication = application
-        monitoredHelperProcessIdentifier = processIdentifier
-
+    private func beginHelperMonitoring() {
+        guard helperTerminationTask == nil else { return }
         let notifications = NSWorkspace.shared.notificationCenter.notifications(
             named: NSWorkspace.didTerminateApplicationNotification
         )
@@ -220,32 +229,31 @@ final class ComputerUseRuntimeService {
                 guard !Task.isCancelled else { return }
                 guard
                     let terminatedApplication = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
-                        as? NSRunningApplication,
-                    terminatedApplication.processIdentifier == processIdentifier
+                        as? NSRunningApplication
                 else {
                     continue
                 }
-                await self?.monitoredHelperDidTerminate(processIdentifier: processIdentifier)
-                return
+                guard let self else { return }
+                await helperSupervisor.helperDidTerminate(
+                    bundleURL: terminatedApplication.bundleURL,
+                    bundleIdentifier: terminatedApplication.bundleIdentifier,
+                    processIdentifier: terminatedApplication.processIdentifier
+                )
             }
-        }
-
-        if application.isTerminated {
-            await monitoredHelperDidTerminate(processIdentifier: processIdentifier)
         }
     }
 
-    private func monitoredHelperDidTerminate(processIdentifier: pid_t) async {
-        guard monitoredHelperProcessIdentifier == processIdentifier else { return }
-        cancelHelperMonitoring()
-        await helperSupervisor.helperDidTerminate()
+    private func recordHelperApplication(_ application: NSRunningApplication) {
+        helperSupervisor.helperDidLaunch(
+            bundleURL: application.bundleURL,
+            bundleIdentifier: application.bundleIdentifier,
+            processIdentifier: application.processIdentifier
+        )
     }
 
     private func cancelHelperMonitoring() {
         helperTerminationTask?.cancel()
         helperTerminationTask = nil
-        monitoredHelperProcessIdentifier = nil
-        runningHelperApplication = nil
     }
 
     private func openSystemSettings(_ deepLink: String) {

--- a/Sources/App/ComputerUseRuntimeService.swift
+++ b/Sources/App/ComputerUseRuntimeService.swift
@@ -22,6 +22,7 @@ final class ComputerUseRuntimeService {
     private var installationTask: Task<URL?, Never>?
     private var cachedStatus = ComputerUsePermissionStatus.missing
     private var helperTerminationTask: Task<Void, Never>?
+    private var monitoredHelperProcessIdentifier: pid_t?
     private lazy var helperSupervisor = ComputerUseHelperSupervisor(
         helperAppURL: paths.installedHelperAppURL,
         helperBundleIdentifier: helperBundleIdentifier
@@ -120,6 +121,9 @@ final class ComputerUseRuntimeService {
             paths: paths,
             transport: transport
         ) ?? .missing
+        if let application = Self.runningHelperApplication(at: helperURL) {
+            await monitorHelper(application)
+        }
         return status()
     }
 
@@ -156,10 +160,9 @@ final class ComputerUseRuntimeService {
 
     private func startIfNeeded() async {
         guard let helperURL = await ensureStandaloneHelperInstalled() else { return }
-        beginHelperMonitoring()
         if await Self.isDaemonListening(paths: paths, transport: transport) {
             if let application = Self.runningHelperApplication(at: helperURL) {
-                recordHelperApplication(application)
+                await monitorHelper(application)
                 return
             }
 
@@ -168,7 +171,10 @@ final class ComputerUseRuntimeService {
             await stopDaemon()
         }
         await launchHelper(at: helperURL)
-        _ = await Self.waitForDaemonStart(paths: paths, transport: transport)
+        guard await Self.waitForDaemonStart(paths: paths, transport: transport) else { return }
+        if let application = Self.runningHelperApplication(at: helperURL) {
+            await monitorHelper(application)
+        }
     }
 
     private func stopDaemon() async {
@@ -184,7 +190,6 @@ final class ComputerUseRuntimeService {
     }
 
     private func launchHelper(at helperURL: URL) async {
-        beginHelperMonitoring()
         let launch = ComputerUseHelperLaunchConfiguration(paths: paths)
         try? FileManager.default.createDirectory(
             at: paths.runtimeDirectoryURL,
@@ -209,51 +214,61 @@ final class ComputerUseRuntimeService {
             }
         }
         guard let application else { return }
-        recordHelperApplication(application)
+        await monitorHelper(application)
+    }
+
+    private func monitorHelper(_ application: NSRunningApplication) async {
+        cancelHelperMonitoring()
+        let processIdentifier = application.processIdentifier
+        let bundleURL = application.bundleURL
+        let bundleIdentifier = application.bundleIdentifier
+        monitoredHelperProcessIdentifier = processIdentifier
+        helperSupervisor.helperDidLaunch(
+            bundleURL: bundleURL,
+            bundleIdentifier: bundleIdentifier,
+            processIdentifier: processIdentifier
+        )
+
+        let exitEvents = Self.processExitEvents(processIdentifier: processIdentifier)
+        helperTerminationTask = Task { @MainActor [weak self] in
+            for await exitedProcessIdentifier in exitEvents {
+                guard !Task.isCancelled else { return }
+                guard let self else { return }
+                await monitoredHelperDidTerminate(
+                    bundleURL: bundleURL,
+                    bundleIdentifier: bundleIdentifier,
+                    processIdentifier: exitedProcessIdentifier
+                )
+                return
+            }
+        }
         if application.isTerminated {
-            await helperSupervisor.helperDidTerminate(
-                bundleURL: application.bundleURL,
-                bundleIdentifier: application.bundleIdentifier,
-                processIdentifier: application.processIdentifier
+            await monitoredHelperDidTerminate(
+                bundleURL: bundleURL,
+                bundleIdentifier: bundleIdentifier,
+                processIdentifier: processIdentifier
             )
         }
     }
 
-    private func beginHelperMonitoring() {
-        guard helperTerminationTask == nil else { return }
-        let notifications = NSWorkspace.shared.notificationCenter.notifications(
-            named: NSWorkspace.didTerminateApplicationNotification
-        )
-        helperTerminationTask = Task { @MainActor [weak self] in
-            for await notification in notifications {
-                guard !Task.isCancelled else { return }
-                guard
-                    let terminatedApplication = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
-                        as? NSRunningApplication
-                else {
-                    continue
-                }
-                guard let self else { return }
-                await helperSupervisor.helperDidTerminate(
-                    bundleURL: terminatedApplication.bundleURL,
-                    bundleIdentifier: terminatedApplication.bundleIdentifier,
-                    processIdentifier: terminatedApplication.processIdentifier
-                )
-            }
-        }
-    }
-
-    private func recordHelperApplication(_ application: NSRunningApplication) {
-        helperSupervisor.helperDidLaunch(
-            bundleURL: application.bundleURL,
-            bundleIdentifier: application.bundleIdentifier,
-            processIdentifier: application.processIdentifier
+    private func monitoredHelperDidTerminate(
+        bundleURL: URL?,
+        bundleIdentifier: String?,
+        processIdentifier: pid_t
+    ) async {
+        guard monitoredHelperProcessIdentifier == processIdentifier else { return }
+        cancelHelperMonitoring()
+        await helperSupervisor.helperDidTerminate(
+            bundleURL: bundleURL,
+            bundleIdentifier: bundleIdentifier,
+            processIdentifier: processIdentifier
         )
     }
 
     private func cancelHelperMonitoring() {
         helperTerminationTask?.cancel()
         helperTerminationTask = nil
+        monitoredHelperProcessIdentifier = nil
     }
 
     private func openSystemSettings(_ deepLink: String) {
@@ -492,6 +507,28 @@ final class ComputerUseRuntimeService {
             }
             source.setCancelHandler {
                 Darwin.close(descriptor)
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                source.cancel()
+            }
+            source.resume()
+        }
+    }
+
+    nonisolated static func processExitEvents(processIdentifier: pid_t) -> AsyncStream<pid_t> {
+        AsyncStream { continuation in
+            // DispatchSource is Darwin's event-driven process-exit primitive; callers see only an AsyncStream.
+            let source = DispatchSource.makeProcessSource(
+                identifier: processIdentifier,
+                eventMask: .exit,
+                queue: .global(qos: .userInitiated)
+            )
+            source.setEventHandler {
+                continuation.yield(processIdentifier)
+                continuation.finish()
+            }
+            source.setCancelHandler {
                 continuation.finish()
             }
             continuation.onTermination = { _ in

--- a/Sources/App/ComputerUseUXCoordinator.swift
+++ b/Sources/App/ComputerUseUXCoordinator.swift
@@ -92,6 +92,13 @@ final class ComputerUseUXCoordinator {
             }
         }
 
+        // One controller owns both automatic target following and the explicit
+        // background/view switch, so every focus entrypoint shares one mode.
+        let watchTarget = ComputerUseWatchTargetController(
+            stateDirectoryURL: stateDirectoryURL,
+            featureEnabled: featureEnabled
+        )
+
         let snapshotStore = ComputerUseMenuBarSnapshotStore(
             liveAgentIndex: liveAgentIndex,
             stateRepository: stateRepository,
@@ -103,29 +110,21 @@ final class ComputerUseUXCoordinator {
         )
         menuBarController = ComputerUseMenuBarController(
             snapshotStore: snapshotStore,
-            onFocusTerminal: onFocusTerminal,
-            canFocusTarget: { identity in
-                guard let pid = pid_t(exactly: identity.processIdentifier) else { return false }
-                return identity.matches(NSRunningApplication(processIdentifier: pid))
+            isRunningInBackground: {
+                watchTarget.isRunningInBackground
             },
-            onFocusTarget: { identity in
-                guard let pid = pid_t(exactly: identity.processIdentifier),
-                      let application = NSRunningApplication(processIdentifier: pid),
-                      identity.matches(application)
-                else {
-                    return
-                }
-                // NSRunningApplication.activate is unreliable at fronting another
-                // app on macOS 14+; NSWorkspace.openApplication genuinely brings
-                // the already-running target to the front.
-                if let bundleURL = application.bundleURL {
-                    let configuration = NSWorkspace.OpenConfiguration()
-                    configuration.activates = true
-                    configuration.createsNewApplicationInstance = false
-                    NSWorkspace.shared.openApplication(at: bundleURL, configuration: configuration) { _, _ in }
-                } else {
-                    _ = application.activate(options: [.activateAllWindows])
-                }
+            onContinueInBackground: { workspaceID, surfaceID in
+                watchTarget.continueInBackground()
+                onFocusTerminal(workspaceID, surfaceID)
+            },
+            canViewComputerUse: { identity in
+                watchTarget.canViewTarget(identity)
+            },
+            onViewComputerUse: { identity in
+                _ = watchTarget.viewTarget(identity)
+            },
+            onNoLiveSessions: {
+                watchTarget.resetPresentationMode()
             }
         )
 
@@ -136,10 +135,6 @@ final class ComputerUseUXCoordinator {
         // Bring the app the local driver is steering to the front (once per target)
         // so the user watches the automation instead of the cmux-hosted cursor
         // clicking on top of a hidden target. Gated the same way via `featureEnabled`.
-        let watchTarget = ComputerUseWatchTargetController(
-            stateDirectoryURL: stateDirectoryURL,
-            featureEnabled: featureEnabled
-        )
         watchTarget.start()
         watchTargetController = watchTarget
 

--- a/Sources/App/ComputerUseWatchTargetController.swift
+++ b/Sources/App/ComputerUseWatchTargetController.swift
@@ -25,7 +25,12 @@ enum ComputerUseWatchTargetDecision {
     ///   from yanking focus back on every click.
     /// - otherwise a *different* app is now being driven -> return `current` so the
     ///   caller activates it once and records it as `lastActivated`.
-    static func activation(current: Int?, lastActivated: Int?) -> Int? {
+    static func activation(
+        current: Int?,
+        lastActivated: Int?,
+        automaticActivationEnabled: Bool = true
+    ) -> Int? {
+        guard automaticActivationEnabled else { return nil }
         guard let current else { return nil }
         if current == lastActivated { return nil }
         return current
@@ -108,7 +113,9 @@ struct ComputerUseWatchTargetFeed: Sendable {
 /// Fronts each distinct target exactly once (`ComputerUseWatchTargetDecision`)
 /// so it never competes with the user's own focus while a session runs. Gated by
 /// `featureEnabled` and validated with `ComputerUseTargetIdentity`, mirroring the
-/// menu bar's "Focus Target" action and the cursor overlay's watcher/poll shape.
+/// menu bar's "View Computer Use" action and the cursor overlay's watcher/poll shape.
+/// Choosing "Continue in Background" pauses this automatic activation until the
+/// user explicitly chooses "View Computer Use" or all live sessions end.
 @MainActor
 final class ComputerUseWatchTargetController {
     private let stateDirectoryURL: URL
@@ -116,6 +123,10 @@ final class ComputerUseWatchTargetController {
     private let feed: ComputerUseWatchTargetFeed
     private let pollInterval: TimeInterval
     private let activate: @MainActor (NSRunningApplication) -> Void
+
+    /// When true, Computer Use keeps driving but cmux never automatically
+    /// brings a target over the originating terminal.
+    private(set) var isRunningInBackground = false
 
     /// The pid of the target we most recently fronted. Persists across idle gaps
     /// so a paused-then-resumed same target is not re-fronted; only reset when a
@@ -198,12 +209,47 @@ final class ComputerUseWatchTargetController {
         pollTimer?.invalidate()
         pollTimer = nil
         lastActivatedTargetPID = nil
+        isRunningInBackground = false
+    }
+
+    /// Keeps the current agent working while preserving the user's terminal focus.
+    func continueInBackground() {
+        isRunningInBackground = true
+    }
+
+    /// Returns to a validated computer-use target and resumes following new targets.
+    @discardableResult
+    func viewTarget(_ identity: ComputerUseTargetIdentity) -> Bool {
+        guard
+            let pid = pid_t(exactly: identity.processIdentifier),
+            let application = NSRunningApplication(processIdentifier: pid),
+            identity.matches(application)
+        else {
+            return false
+        }
+
+        isRunningInBackground = false
+        activate(application)
+        lastActivatedTargetPID = identity.processIdentifier
+        return true
+    }
+
+    /// Reports whether a captured target still resolves to the same live app instance.
+    func canViewTarget(_ identity: ComputerUseTargetIdentity) -> Bool {
+        guard let pid = pid_t(exactly: identity.processIdentifier) else { return false }
+        return identity.matches(NSRunningApplication(processIdentifier: pid))
+    }
+
+    /// New agent activity starts in visible follow mode after all live sessions end.
+    func resetPresentationMode() {
+        isRunningInBackground = false
+        lastActivatedTargetPID = nil
     }
 
     func refresh() {
         // Feature off: do nothing and, crucially, leave `lastActivatedTargetPID`
         // untouched so toggling off/on does not re-front the same live target.
-        guard featureEnabled() else { return }
+        guard featureEnabled(), !isRunningInBackground else { return }
 
         // Never scan the untrusted state directory on the main thread. The driver
         // rewrites its state files many times per second while driving, so doing
@@ -233,7 +279,8 @@ final class ComputerUseWatchTargetController {
         guard
             let pidToActivate = ComputerUseWatchTargetDecision.activation(
                 current: current,
-                lastActivated: lastActivatedTargetPID
+                lastActivated: lastActivatedTargetPID,
+                automaticActivationEnabled: !isRunningInBackground
             ),
             let pid = pid_t(exactly: pidToActivate),
             let application = NSRunningApplication(processIdentifier: pid)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -724,6 +724,7 @@
 		C0A710A00000000000000002 /* ComputerUseCursorOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A710A00000000000000001 /* ComputerUseCursorOverlayController.swift */; };
 		C0A710020000000000000002 /* ComputerUseDriverState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A710020000000000000001 /* ComputerUseDriverState.swift */; };
 		C0A710C20000000000000002 /* ComputerUseHelperLaunchConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A710C20000000000000001 /* ComputerUseHelperLaunchConfiguration.swift */; };
+		C0A710D10000000000000002 /* ComputerUseHelperSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A710D10000000000000001 /* ComputerUseHelperSupervisor.swift */; };
 		C0A710FF0000000000000002 /* ComputerUseLiveSettingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A710FF0000000000000001 /* ComputerUseLiveSettingRepository.swift */; };
 		C0A710090000000000000002 /* ComputerUseMenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A710090000000000000001 /* ComputerUseMenuBarController.swift */; };
 		C0A710180000000000000002 /* ComputerUseMenuBarRefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A710180000000000000001 /* ComputerUseMenuBarRefreshPolicy.swift */; };
@@ -2813,6 +2814,7 @@
 		C0A710A00000000000000001 /* ComputerUseCursorOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ComputerUseCursorOverlayController.swift; sourceTree = "<group>"; };
 		C0A710020000000000000001 /* ComputerUseDriverState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ComputerUseDriverState.swift; sourceTree = "<group>"; };
 		C0A710C20000000000000001 /* ComputerUseHelperLaunchConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ComputerUseHelperLaunchConfiguration.swift; sourceTree = "<group>"; };
+		C0A710D10000000000000001 /* ComputerUseHelperSupervisor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ComputerUseHelperSupervisor.swift; sourceTree = "<group>"; };
 		C0A710FF0000000000000001 /* ComputerUseLiveSettingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ComputerUseLiveSettingRepository.swift; sourceTree = "<group>"; };
 		C0A710090000000000000001 /* ComputerUseMenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ComputerUseMenuBarController.swift; sourceTree = "<group>"; };
 		C0A710180000000000000001 /* ComputerUseMenuBarRefreshPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ComputerUseMenuBarRefreshPolicy.swift; sourceTree = "<group>"; };
@@ -4758,6 +4760,7 @@
 					C0A710C20000000000000001 /* ComputerUseHelperLaunchConfiguration.swift */,
 					C0A710C30000000000000001 /* ComputerUsePermissionStatus.swift */,
 					C0A710C10000000000000001 /* ComputerUseRuntimePaths.swift */,
+					C0A710D10000000000000001 /* ComputerUseHelperSupervisor.swift */,
 					C0A710010000000000000001 /* ComputerUseRuntimeService.swift */,
 					C0A710030000000000000001 /* ComputerUseSessionProcessScope.swift */,
 					C0A710050000000000000001 /* ComputerUseStateRepository.swift */,
@@ -7208,6 +7211,7 @@
 					C0A710A00000000000000002 /* ComputerUseCursorOverlayController.swift in Sources */,
 					C0A710020000000000000002 /* ComputerUseDriverState.swift in Sources */,
 					C0A710C20000000000000002 /* ComputerUseHelperLaunchConfiguration.swift in Sources */,
+					C0A710D10000000000000002 /* ComputerUseHelperSupervisor.swift in Sources */,
 					C0A710FF0000000000000002 /* ComputerUseLiveSettingRepository.swift in Sources */,
 					C0A710090000000000000002 /* ComputerUseMenuBarController.swift in Sources */,
 					C0A710180000000000000002 /* ComputerUseMenuBarRefreshPolicy.swift in Sources */,

--- a/cmuxTests/ClaudeWrapperResumeEnvironmentTests.swift
+++ b/cmuxTests/ClaudeWrapperResumeEnvironmentTests.swift
@@ -4,6 +4,88 @@ import Foundation
 import Testing
 
 @Suite struct ClaudeWrapperResumeEnvironmentTests {
+    @Test(arguments: ["cmux-claude-wrapper", "cmux-codex-wrapper"])
+    func computerUseWrappersIgnoreAmbientSocketAndStateOverrides(wrapperName: String) throws {
+        let fileManager = FileManager.default
+        let repoRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+        let sandbox = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("cmux-cua-scope-\(String(UUID().uuidString.prefix(8)))", isDirectory: true)
+        let wrapperDir = sandbox.appendingPathComponent("wrappers", isDirectory: true)
+        let binDir = sandbox.appendingPathComponent("bin", isDirectory: true)
+        let homeDir = sandbox.appendingPathComponent("home", isDirectory: true)
+        try fileManager.createDirectory(at: wrapperDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: homeDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: sandbox) }
+
+        let sourceWrapper = repoRoot.appendingPathComponent("Resources/bin/\(wrapperName)")
+        let wrapperURL = wrapperDir.appendingPathComponent(wrapperName)
+        try fileManager.copyItem(at: sourceWrapper, to: wrapperURL)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapperURL.path)
+        try writeExecutable(
+            wrapperDir.appendingPathComponent("cmux-cua-driver"),
+            "#!/usr/bin/env bash\nexit 99\n"
+        )
+
+        let agentName = wrapperName.contains("claude") ? "claude" : "codex"
+        let recordURL = sandbox.appendingPathComponent("record.txt")
+        let agentURL = binDir.appendingPathComponent(agentName)
+        try writeExecutable(
+            agentURL,
+            """
+            #!/usr/bin/env bash
+            printf '%s\n' "$@" > \(shellQuotedForTest(recordURL.path))
+            """
+        )
+        let fakeCmuxURL = binDir.appendingPathComponent("cmux")
+        try writeExecutable(
+            fakeCmuxURL,
+            """
+            #!/usr/bin/env bash
+            if [[ "${1:-}" == "--socket" && "${3:-}" == "ping" ]]; then
+              exit 0
+            fi
+            exit 1
+            """
+        )
+
+        let socketURL = sandbox.appendingPathComponent("cmux.sock")
+        let socketFD = try bindUnixSocket(at: socketURL.path)
+        defer {
+            Darwin.close(socketFD)
+            unlink(socketURL.path)
+        }
+
+        let process = Process()
+        process.executableURL = wrapperURL
+        process.arguments = ["--resume", "agent-session-123"]
+        process.environment = [
+            "PATH": "\(binDir.path):/usr/bin:/bin",
+            "HOME": homeDir.path,
+            "TMPDIR": sandbox.path,
+            "CMUX_TAG": "cua healing!!",
+            "CMUX_SURFACE_ID": UUID().uuidString,
+            "CMUX_SOCKET_PATH": socketURL.path,
+            "CMUX_BUNDLED_CLI_PATH": fakeCmuxURL.path,
+            "CMUX_CLAUDE_SKIP_DEFAULTS": "1",
+            "CMUX_CUSTOM_CLAUDE_PATH": agentURL.path,
+            "CMUX_CUSTOM_CODEX_PATH": agentURL.path,
+            "CMUX_CUA_SOCKET_PATH": "/tmp/hostile-default/cua-driver.sock",
+            "CMUX_CUA_STATE_DIR": "/tmp/hostile-default/state",
+        ]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try runWithBoundedWait(process, shellDescription: wrapperName)
+
+        let recorded = try String(contentsOf: recordURL, encoding: .utf8)
+        let uid = getuid()
+        #expect(recorded.contains("/tmp/cmux-cua-\(uid)/cua-healing/cua.sock"), Comment(rawValue: recorded))
+        #expect(recorded.contains("/computer-use/runtime/cua-healing/state"), Comment(rawValue: recorded))
+        #expect(recorded.contains("CUA_DRIVER_RS_MCP_FORCE_PROXY"), Comment(rawValue: recorded))
+        #expect(!recorded.contains("hostile-default"), Comment(rawValue: recorded))
+    }
+
     @Test func bundledClaudeWrapperScrubsSessionIdentityAndPreservesTrustBypassOnResume() throws {
         let fileManager = FileManager.default
         let repoRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent()

--- a/cmuxTests/ClaudeWrapperResumeEnvironmentTests.swift
+++ b/cmuxTests/ClaudeWrapperResumeEnvironmentTests.swift
@@ -72,6 +72,9 @@ import Testing
             "CMUX_CUSTOM_CODEX_PATH": agentURL.path,
             "CMUX_CUA_SOCKET_PATH": "/tmp/hostile-default/cua-driver.sock",
             "CMUX_CUA_STATE_DIR": "/tmp/hostile-default/state",
+            "CUA_DRIVER_DAEMON_APP": "/Applications/CuaDriver.app",
+            "CUA_DRIVER_EMBEDDED": "1",
+            "CUA_DRIVER_RS_MCP_NO_RELAUNCH": "1",
         ]
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
@@ -83,7 +86,15 @@ import Testing
         #expect(recorded.contains("/tmp/cmux-cua-\(uid)/cua-healing/cua.sock"), Comment(rawValue: recorded))
         #expect(recorded.contains("/computer-use/runtime/cua-healing/state"), Comment(rawValue: recorded))
         #expect(recorded.contains("CUA_DRIVER_RS_MCP_FORCE_PROXY"), Comment(rawValue: recorded))
+        #expect(recorded.contains("CUA_DRIVER_DAEMON_APP"), Comment(rawValue: recorded))
+        #expect(recorded.contains("CUA_DRIVER_EMBEDDED"), Comment(rawValue: recorded))
+        #expect(recorded.contains("CUA_DRIVER_RS_MCP_NO_RELAUNCH"), Comment(rawValue: recorded))
+        let valueSeparator = wrapperName.contains("claude") ? "\":\"" : "=\""
+        #expect(recorded.contains("CUA_DRIVER_DAEMON_APP\(valueSeparator)\""), Comment(rawValue: recorded))
+        #expect(recorded.contains("CUA_DRIVER_EMBEDDED\(valueSeparator)0\""), Comment(rawValue: recorded))
+        #expect(recorded.contains("CUA_DRIVER_RS_MCP_NO_RELAUNCH\(valueSeparator)0\""), Comment(rawValue: recorded))
         #expect(!recorded.contains("hostile-default"), Comment(rawValue: recorded))
+        #expect(!recorded.contains("/Applications/CuaDriver.app"), Comment(rawValue: recorded))
     }
 
     @Test func bundledClaudeWrapperScrubsSessionIdentityAndPreservesTrustBypassOnResume() throws {

--- a/cmuxTests/ComputerUseUXTests.swift
+++ b/cmuxTests/ComputerUseUXTests.swift
@@ -277,17 +277,34 @@ struct ComputerUseUXTests {
     }
 
     @Test @MainActor func unexpectedHelperTerminationRestartsOnlyWhileEnabled() async {
+        let helperURL = URL(fileURLWithPath: "/Applications/cmux Computer Use.app")
         var restartCount = 0
-        let supervisor = ComputerUseHelperSupervisor {
+        let supervisor = ComputerUseHelperSupervisor(
+            helperAppURL: helperURL,
+            helperBundleIdentifier: "com.cmuxterm.app.debug.test.computer-use"
+        ) {
             restartCount += 1
         }
 
         supervisor.setEnabled(true)
-        await supervisor.helperDidTerminate()
+        supervisor.helperDidLaunch(
+            bundleURL: helperURL,
+            bundleIdentifier: "com.cmuxterm.app.debug.test.computer-use",
+            processIdentifier: 101
+        )
+        await supervisor.helperDidTerminate(
+            bundleURL: helperURL,
+            bundleIdentifier: "com.cmuxterm.app.debug.test.computer-use",
+            processIdentifier: 202
+        )
         #expect(restartCount == 1)
 
         supervisor.setEnabled(false)
-        await supervisor.helperDidTerminate()
+        await supervisor.helperDidTerminate(
+            bundleURL: helperURL,
+            bundleIdentifier: "com.cmuxterm.app.debug.test.computer-use",
+            processIdentifier: 303
+        )
         #expect(restartCount == 1, "an intentional disabled state must not self-relaunch")
     }
 

--- a/cmuxTests/ComputerUseUXTests.swift
+++ b/cmuxTests/ComputerUseUXTests.swift
@@ -315,6 +315,28 @@ struct ComputerUseUXTests {
         #expect(restartCount == 1, "an intentional disabled state must not self-relaunch")
     }
 
+    @Test func helperProcessExitSignalReportsTheExitedProcessWithoutPolling() async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["60"]
+        try process.run()
+        defer {
+            if process.isRunning {
+                process.terminate()
+            }
+            process.waitUntilExit()
+        }
+
+        let processIdentifier = process.processIdentifier
+        let exitEvents = ComputerUseRuntimeService.processExitEvents(
+            processIdentifier: processIdentifier
+        )
+        process.terminate()
+
+        var iterator = exitEvents.makeAsyncIterator()
+        #expect(await iterator.next() == processIdentifier)
+    }
+
     @Test func taggedRuntimeSocketFitsDarwinUnixPathLimit() {
         let paths = ComputerUseRuntimePaths(
             homeDirectoryURL: URL(fileURLWithPath: "/Users/\(String(repeating: "long-home-", count: 10))"),

--- a/cmuxTests/ComputerUseUXTests.swift
+++ b/cmuxTests/ComputerUseUXTests.swift
@@ -276,6 +276,21 @@ struct ComputerUseUXTests {
         ))
     }
 
+    @Test @MainActor func unexpectedHelperTerminationRestartsOnlyWhileEnabled() async {
+        var restartCount = 0
+        let supervisor = ComputerUseHelperSupervisor {
+            restartCount += 1
+        }
+
+        supervisor.setEnabled(true)
+        await supervisor.helperDidTerminate()
+        #expect(restartCount == 1)
+
+        supervisor.setEnabled(false)
+        await supervisor.helperDidTerminate()
+        #expect(restartCount == 1, "an intentional disabled state must not self-relaunch")
+    }
+
     @Test func taggedRuntimeSocketFitsDarwinUnixPathLimit() {
         let paths = ComputerUseRuntimePaths(
             homeDirectoryURL: URL(fileURLWithPath: "/Users/\(String(repeating: "long-home-", count: 10))"),

--- a/cmuxTests/ComputerUseUXTests.swift
+++ b/cmuxTests/ComputerUseUXTests.swift
@@ -460,6 +460,32 @@ struct ComputerUseUXTests {
         #expect(ComputerUseWatchTargetDecision.activation(current: 200, lastActivated: 100) == 200)
     }
 
+    @Test func backgroundModeSuppressesAutomaticTargetFrontingUntilResumed() {
+        #expect(ComputerUseWatchTargetDecision.activation(
+            current: 200,
+            lastActivated: 100,
+            automaticActivationEnabled: false
+        ) == nil)
+        #expect(ComputerUseWatchTargetDecision.activation(
+            current: 200,
+            lastActivated: 100,
+            automaticActivationEnabled: true
+        ) == 200)
+    }
+
+    @Test @MainActor func computerUsePresentationModeResetsAfterLiveSessionsEnd() {
+        let controller = ComputerUseWatchTargetController(
+            stateDirectoryURL: FileManager.default.temporaryDirectory,
+            featureEnabled: { true }
+        )
+
+        #expect(!controller.isRunningInBackground)
+        controller.continueInBackground()
+        #expect(controller.isRunningInBackground)
+        controller.resetPresentationMode()
+        #expect(!controller.isRunningInBackground)
+    }
+
     @Test func watchTargetDoesNotReFrontAfterUserFocusAwayOrIdleGap() {
         // The user manually clicks into cmux mid-session. The driver keeps driving
         // the same target pid, so `current` stays equal to `lastActivated` and we

--- a/cmuxTests/ComputerUseUXTests.swift
+++ b/cmuxTests/ComputerUseUXTests.swift
@@ -299,11 +299,18 @@ struct ComputerUseUXTests {
         )
         #expect(restartCount == 1)
 
+        await supervisor.helperDidTerminate(
+            bundleURL: URL(fileURLWithPath: "/Applications/CuaDriver.app"),
+            bundleIdentifier: "com.trycua.driver",
+            processIdentifier: 303
+        )
+        #expect(restartCount == 1, "another computer-use bundle must not enter the cmux restart path")
+
         supervisor.setEnabled(false)
         await supervisor.helperDidTerminate(
             bundleURL: helperURL,
             bundleIdentifier: "com.cmuxterm.app.debug.test.computer-use",
-            processIdentifier: 303
+            processIdentifier: 404
         )
         #expect(restartCount == 1, "an intentional disabled state must not self-relaunch")
     }

--- a/scripts/build-cua-driver.sh
+++ b/scripts/build-cua-driver.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CMUX_CUA_REPO_URL="${CMUX_CUA_REPO_URL:-https://github.com/manaflow-ai/cmux-cua.git}"
-CMUX_CUA_PINNED_SHA="e7baba3ef2083c0692b67d977766a278896aeee6"
+CMUX_CUA_PINNED_SHA="9a3ede09f680940ee29fb6d5eeb758542d9d1b2e"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUTPUT=""

--- a/scripts/build-cua-driver.sh
+++ b/scripts/build-cua-driver.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CMUX_CUA_REPO_URL="${CMUX_CUA_REPO_URL:-https://github.com/manaflow-ai/cmux-cua.git}"
-CMUX_CUA_PINNED_SHA="395d1524dc24d38d9ef766e9bb5fe51474a21f2f"
+CMUX_CUA_PINNED_SHA="f77fc813d779e141d87cd1fdb4f180043fb07c30"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUTPUT=""

--- a/scripts/build-cua-driver.sh
+++ b/scripts/build-cua-driver.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CMUX_CUA_REPO_URL="${CMUX_CUA_REPO_URL:-https://github.com/manaflow-ai/cmux-cua.git}"
-CMUX_CUA_PINNED_SHA="72c25137f85e3d73a87b0d4c47f95a1f41e01c74"
+CMUX_CUA_PINNED_SHA="d2da94dd48def99d7472a4520222f402c5df9ffa"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUTPUT=""

--- a/scripts/build-cua-driver.sh
+++ b/scripts/build-cua-driver.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CMUX_CUA_REPO_URL="${CMUX_CUA_REPO_URL:-https://github.com/manaflow-ai/cmux-cua.git}"
-CMUX_CUA_PINNED_SHA="d2da94dd48def99d7472a4520222f402c5df9ffa"
+CMUX_CUA_PINNED_SHA="cd85728092b27fb9118879217d550ebc7f776cde"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUTPUT=""

--- a/scripts/build-cua-driver.sh
+++ b/scripts/build-cua-driver.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CMUX_CUA_REPO_URL="${CMUX_CUA_REPO_URL:-https://github.com/manaflow-ai/cmux-cua.git}"
-CMUX_CUA_PINNED_SHA="f77fc813d779e141d87cd1fdb4f180043fb07c30"
+CMUX_CUA_PINNED_SHA="e7baba3ef2083c0692b67d977766a278896aeee6"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUTPUT=""

--- a/scripts/build-cua-driver.sh
+++ b/scripts/build-cua-driver.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 CMUX_CUA_REPO_URL="${CMUX_CUA_REPO_URL:-https://github.com/manaflow-ai/cmux-cua.git}"
-CMUX_CUA_PINNED_SHA="cd85728092b27fb9118879217d550ebc7f776cde"
+CMUX_CUA_PINNED_SHA="395d1524dc24d38d9ef766e9bb5fe51474a21f2f"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUTPUT=""

--- a/skills/cmux-computer-use/SKILL.md
+++ b/skills/cmux-computer-use/SKILL.md
@@ -98,14 +98,17 @@ driver build.
 While an agent is driving, the **Computer Use menu-bar item** lists live agent
 sessions:
 
-- **Focus terminal** — reveal the workspace + surface running that agent (shared
-  reveal path with notifications).
-- **Focus target** — bring forward the app the agent is driving, read from the
-  driver's per-session state files under
-  `~/Library/Application Support/cmux/computer-use/runtime/<scope>/state/`.
+- **View Computer Use** — bring forward the app the agent is driving and resume
+  following newly driven targets, read from the driver's per-session state files
+  under `~/Library/Application Support/cmux/computer-use/runtime/<scope>/state/`.
+- **Continue in Background** — reveal the exact workspace + surface running that
+  agent (through the shared terminal-focus path) and stop automatically fronting
+  later targets. The agent keeps working through the driver's background-first
+  delivery; an explicit foreground fallback briefly acts and restores the terminal.
 
-The item hides when there is no live or recent session. Toggle visibility in
-Settings → Computer Use.
+The menu shows a checkmark for the active view/background mode. Background mode
+resets after all live sessions end. The item hides when there is no live or recent
+session. Toggle visibility in Settings → Computer Use.
 
 ## Troubleshooting
 

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -1059,8 +1059,6 @@ def expect_computer_use_env_scrubbed(
     server: dict,
     failures: list[str],
     context: str,
-    *,
-    helper_owned: bool,
 ) -> None:
     env = server.get("env")
     expect(isinstance(env, dict), f"{context}: expected MCP env, got {server}", failures)
@@ -1070,6 +1068,9 @@ def expect_computer_use_env_scrubbed(
         "CUA_DRIVER_DEFAULT_SESSION": "cmux-surface:test",
         "CUA_DRIVER_RS_MCP_FORCE_PROXY": "1",
         "CUA_DRIVER_RS_EXTERNAL_PERMISSION_FLOW": "1",
+        "CUA_DRIVER_DAEMON_APP": "",
+        "CUA_DRIVER_EMBEDDED": "0",
+        "CUA_DRIVER_RS_MCP_NO_RELAUNCH": "0",
         "CUA_DRIVER_RS_TELEMETRY_ENABLED": "false",
         "CUA_DRIVER_RS_UPDATE_CHECK": "false",
         "CUA_DRIVER_CURSOR_GRADIENT": "#12c7f5,#2d8cff,#6c5cff",
@@ -1086,9 +1087,7 @@ def expect_computer_use_env_scrubbed(
         f"{context}: unexpected state directory {state_dir!r}",
         failures,
     )
-    expect("CUA_DRIVER_EMBEDDED" not in env, f"{context}: computer use must never be embedded: {env}", failures)
     expect("CUA_DRIVER_RS_PERMISSIONS_GATE" not in env, f"{context}: proxy must not own the daemon gate: {env}", failures)
-    expect("CUA_DRIVER_DAEMON_APP" not in env, f"{context}: proxy must not launch the helper: {env}", failures)
 
 
 def expect_cua_driver_config(
@@ -1096,8 +1095,6 @@ def expect_cua_driver_config(
     failures: list[str],
     context: str,
     expected_name: str,
-    *,
-    helper_owned: bool,
 ) -> None:
     expect(config is not None, f"{context}: expected --mcp-config=<json>", failures)
     if config is None:
@@ -1126,7 +1123,7 @@ def expect_cua_driver_config(
         f"{context}: proxy command must not execute from the helper app, got {command}",
         failures,
     )
-    expect_computer_use_env_scrubbed(server, failures, context, helper_owned=helper_owned)
+    expect_computer_use_env_scrubbed(server, failures, context)
 
 
 def test_live_socket_attaches_cua_driver_when_available(failures: list[str]) -> None:
@@ -1148,7 +1145,6 @@ def test_live_socket_attaches_cua_driver_when_available(failures: list[str]) -> 
         failures,
         "computer use inject",
         "cmux-cua-driver",
-        helper_owned=True,
     )
     inject_index = injected_mcp_config_index(real_argv)
     expect(
@@ -1162,25 +1158,6 @@ def test_live_socket_attaches_cua_driver_when_available(failures: list[str]) -> 
     expect(
         injected_mcp_config_index(captured) is None and "--mcp-config" not in captured,
         f"computer use inject: captured launch argv must not include the injected flag, got {captured}",
-        failures,
-    )
-
-
-def test_computer_use_wrapper_is_a_pure_proxy(failures: list[str]) -> None:
-    source = SOURCE_WRAPPER.read_text(encoding="utf-8")
-    expect(
-        "cmux_computer_use_standalone_helper" not in source,
-        "computer use wrapper must not install or replace the standalone helper",
-        failures,
-    )
-    expect(
-        "CUA_DRIVER_DAEMON_APP" not in source,
-        "computer use wrapper must not own helper daemon launch",
-        failures,
-    )
-    expect(
-        "CUA_DRIVER_RS_MCP_FORCE_PROXY" in source,
-        "computer use wrapper must force the shared daemon proxy path",
         failures,
     )
 
@@ -1234,7 +1211,6 @@ def test_computer_use_driver_does_not_require_external_runtime_auth(failures: li
         failures,
         "computer use no external auth",
         "cmux-cua-driver",
-        helper_owned=True,
     )
 
 
@@ -1251,7 +1227,6 @@ def test_computer_use_uses_trusted_cua_driver_override(failures: list[str]) -> N
         failures,
         "computer use override",
         "echo",
-        helper_owned=False,
     )
 
 
@@ -2406,7 +2381,6 @@ def main() -> int:
     test_command_like_invocations_bypass_hook_injection(failures)
     test_passthrough_flags_bypass_hook_injection(failures)
     test_live_socket_attaches_cua_driver_when_available(failures)
-    test_computer_use_wrapper_is_a_pure_proxy(failures)
     test_computer_use_probe_uses_absolute_system_helpers(failures)
     test_computer_use_driver_does_not_require_external_runtime_auth(failures)
     test_computer_use_uses_trusted_cua_driver_override(failures)

--- a/tests/test_codex_wrapper_computer_use_mcp.py
+++ b/tests/test_codex_wrapper_computer_use_mcp.py
@@ -58,11 +58,10 @@ def expect_scrubbed_mcp_env(
     args: list[str],
     failures: list[str],
     context: str,
-    *,
-    helper_owned: bool,
 ) -> None:
     embedded = arg_value(args, "mcp_servers.cmux-computer-use.env.CUA_DRIVER_EMBEDDED=")
     daemon_app = arg_value(args, "mcp_servers.cmux-computer-use.env.CUA_DRIVER_DAEMON_APP=")
+    no_relaunch = arg_value(args, "mcp_servers.cmux-computer-use.env.CUA_DRIVER_RS_MCP_NO_RELAUNCH=")
     force_proxy = arg_value(args, "mcp_servers.cmux-computer-use.env.CUA_DRIVER_RS_MCP_FORCE_PROXY=")
     external_flow = arg_value(args, "mcp_servers.cmux-computer-use.env.CUA_DRIVER_RS_EXTERNAL_PERMISSION_FLOW=")
     default_session = arg_value(args, "mcp_servers.cmux-computer-use.env.CUA_DRIVER_DEFAULT_SESSION=")
@@ -75,8 +74,9 @@ def expect_scrubbed_mcp_env(
     state_dir = arg_value(args, "mcp_servers.cmux-computer-use.env.CUA_DRIVER_STATE_DIR=")
     node_options = arg_value(args, "mcp_servers.cmux-computer-use.env.NODE_OPTIONS=")
     bun_options = arg_value(args, "mcp_servers.cmux-computer-use.env.BUN_OPTIONS=")
-    expect(embedded is None, f"{context}: computer use must never be embedded: {args}", failures)
-    expect(daemon_app is None, f"{context}: wrapper must not launch the helper daemon: {args}", failures)
+    expect(embedded is not None, f"{context}: missing embedded-mode clamp: {args}", failures)
+    expect(daemon_app is not None, f"{context}: missing daemon-app clamp: {args}", failures)
+    expect(no_relaunch is not None, f"{context}: missing relaunch clamp: {args}", failures)
     expect(permissions_gate is None, f"{context}: proxy must not own the daemon permission gate: {args}", failures)
     expect(force_proxy is not None, f"{context}: missing forced proxy config in {args}", failures)
     expect(external_flow is not None, f"{context}: missing external permission flow config in {args}", failures)
@@ -90,7 +90,11 @@ def expect_scrubbed_mcp_env(
     expect(node_options is not None, f"{context}: missing NODE_OPTIONS scrub config in {args}", failures)
     expect(bun_options is not None, f"{context}: missing BUN_OPTIONS scrub config in {args}", failures)
     if embedded is not None:
-        expect(json.loads(embedded) == "1", f"{context}: expected embedded env, got {embedded}", failures)
+        expect(json.loads(embedded) == "0", f"{context}: expected embedded mode disabled, got {embedded}", failures)
+    if daemon_app is not None:
+        expect(json.loads(daemon_app) == "", f"{context}: expected daemon app disabled, got {daemon_app}", failures)
+    if no_relaunch is not None:
+        expect(json.loads(no_relaunch) == "0", f"{context}: expected cmux-owned relaunch, got {no_relaunch}", failures)
     if default_session is not None:
         expect(json.loads(default_session).startswith("cmux-"), f"{context}: expected cmux- default session, got {default_session}", failures)
     if permissions_gate is not None:
@@ -327,32 +331,13 @@ def test_codex_gets_cmux_cua_driver(failures: list[str]) -> None:
                 f"expected short per-user daemon socket, got {mcp_args[2]!r}",
                 failures,
             )
-    expect_scrubbed_mcp_env(args, failures, "bundled cua-driver", helper_owned=True)
+    expect_scrubbed_mcp_env(args, failures, "bundled cua-driver")
 
     computer_use_command_index = args.index("-c") if "-c" in args else -1
     prompt_index = args.index("hello") if "hello" in args else -1
     expect(
         0 <= computer_use_command_index < prompt_index,
         f"expected computer-use config before user argv, got {args}",
-        failures,
-    )
-
-
-def test_codex_computer_use_wrapper_is_a_pure_proxy(failures: list[str]) -> None:
-    source = SOURCE_WRAPPER.read_text(encoding="utf-8")
-    expect(
-        "cmux_computer_use_standalone_helper" not in source,
-        "codex wrapper must not install or replace the standalone helper",
-        failures,
-    )
-    expect(
-        "CUA_DRIVER_DAEMON_APP" not in source,
-        "codex wrapper must not own helper daemon launch",
-        failures,
-    )
-    expect(
-        "CUA_DRIVER_RS_MCP_FORCE_PROXY" in source,
-        "codex wrapper must force the shared daemon proxy path",
         failures,
     )
 
@@ -383,7 +368,7 @@ def test_codex_uses_trusted_cua_driver_override(failures: list[str]) -> None:
     if cmd is not None:
         command = json.loads(cmd)
         expect(Path(command).name == "echo", f"expected override driver command, got {cmd}", failures)
-    expect_scrubbed_mcp_env(args, failures, "override cua-driver", helper_owned=False)
+    expect_scrubbed_mcp_env(args, failures, "override cua-driver")
 
 
 def test_codex_fork_gets_hooks_and_cua_driver(failures: list[str]) -> None:
@@ -513,7 +498,7 @@ def test_codex_gets_cua_driver_when_hook_injection_fails(failures: list[str]) ->
             f"expected bundled driver command after hook failure, got {cmd}",
             failures,
         )
-    expect_scrubbed_mcp_env(args, failures, "hook-injection failure", helper_owned=True)
+    expect_scrubbed_mcp_env(args, failures, "hook-injection failure")
 
 
 def test_codex_skips_for_strict_mcp_config(failures: list[str]) -> None:
@@ -526,7 +511,6 @@ def test_codex_skips_for_strict_mcp_config(failures: list[str]) -> None:
 def main() -> int:
     failures: list[str] = []
     test_codex_gets_cmux_cua_driver(failures)
-    test_codex_computer_use_wrapper_is_a_pure_proxy(failures)
     test_codex_uses_trusted_cua_driver_override(failures)
     test_codex_rejects_cua_driver_override_under_world_writable_ancestor(failures)
     test_codex_skips_when_driver_unavailable(failures)


### PR DESCRIPTION
## Summary
- make `ComputerUseRuntimeService` the sole owner of the tag-scoped helper lifecycle
- force both agent wrappers through the tag-scoped proxy and clamp hostile embedded/daemon overrides
- monitor the real LaunchServices helper PID with a process-exit source and relaunch after unexpected exits
- pin the driver updates from https://github.com/manaflow-ai/cmux-cua/pull/2 for helper-only permissions, full-desktop overlay geometry, and visible branded cursor moves

## Verification
- focused `ComputerUseUXTests` and `ClaudeWrapperResumeEnvironmentTests`
- `tests/test_codex_wrapper_computer_use_mcp.py`
- `tests/test_claude_wrapper_hooks.py`
- project normalization, 530 test files wired, and Package.resolved policy
- tagged Debug build: `./scripts/reload.sh --tag cua-self-heal --launch`
- live forced-proxy dogfood: helper PID replacement 46556 -> 19081, same MCP proxy resumed, permissions attributed to `com.cmuxterm.app.debug.cua.self.heal.computer-use`, overlay bounds `(-575,-1080) 2087x2062`, cursor moved on the upper display above the real frontmost window

## Safety
- `/Applications/CuaDriver.app` is absent
- standalone `~/.local/bin/cua-driver` remains an immutable refusal shim
- no embedded fallback is enabled

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787180424&installation_model_id=21920&pr_number=8534&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8534&signature=7f1dda5170a701ef2be077c84fbf3273d15f0ec3096997786b6268f1e30ed7ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the tagged Computer Use runtime, adds self-healing of the helper, and introduces a menu‑bar background/foreground switch to control session visibility.

- **New Features**
  - `ComputerUseRuntimeService` owns the helper lifecycle: detects the exact LaunchServices instance, replaces non‑owned listeners, monitors process‑exit signals, and restarts only while enabled.
  - Added `ComputerUseHelperSupervisor` to match bundle identity, track launched PIDs, and trigger restarts on unexpected exits.
  - Wrappers (`cmux-claude-wrapper`, `cmux-codex-wrapper`) force the tag‑scoped proxy and clamp hostile overrides: ignore `CMUX_CUA_SOCKET_PATH`/`CMUX_CUA_STATE_DIR`; set `CUA_DRIVER_DAEMON_APP=""`, `CUA_DRIVER_EMBEDDED="0"`, `CUA_DRIVER_RS_MCP_NO_RELAUNCH="0"`.
  - Menu bar adds "View Computer Use" and "Continue in Background": background mode keeps agents working without auto‑fronting, shows a background status label, and resets after all live sessions end.

- **Dependencies**
  - Pinned `cmux-cua` to `9a3ede09f680940ee29fb6d5eeb758542d9d1b2e` with helper‑only permissions, accurate overlay geometry, branded cmux cursor moves, and the Lawrence Sky cursor driver.

<sup>Written for commit 8c4835cb23b1372b859f5bff5886792b28dfaad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

