### PR TITLE
Make updater converge on the latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,12 @@ jobs:
       - name: Validate Python R2 appcast upload guard
         run: ./tests/test_ci_r2_upload_python.sh
 
+      - name: Validate stable update feed contract
+        run: ./tests/test_stable_update_feed_contract.sh
+
+      - name: Validate strict Sparkle release guard
+        run: ./tests/test_ci_sparkle_monotonic_strict.sh
+
       - name: Validate release-build timeout guard
         run: ./tests/test_ci_release_build_timeout.sh
 
@@ -1191,6 +1197,7 @@ jobs:
             CmuxTerminal
             CmuxTerminalCore
             CmuxUpdater
+            CmuxUpdaterUI
             CMUXAgentLaunch
           )
           # SwiftPM emits an error-severity diagnostic while planning the

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -730,6 +730,13 @@ jobs:
           # installs to migrate onto the unified nightly appcast.
           cp appcast.xml appcast-universal.xml
 
+      - name: Validate nightly appcast before publication
+        run: |
+          python3 scripts/ci/validate_release_appcast_assets.py \
+            --appcast appcast.xml \
+            --tag nightly \
+            --enclosure-file "$NIGHTLY_DMG_IMMUTABLE"
+
       - name: Attest remote daemon nightly assets
         id: attest-remote-daemon-nightly-assets
         continue-on-error: true
@@ -803,16 +810,27 @@ jobs:
             remote-daemon-assets/cmuxd-remote-*
             appcast-universal.xml
           overwrite_files: true
+          preserve_order: true
 
       - name: Upload nightly appcast to R2
         if: needs.decide.outputs.should_publish == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         run: |
           set -euo pipefail
+
+          NIGHTLY_ASSETS_JSON="$RUNNER_TEMP/nightly-assets-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          gh release view nightly --json assets > "$NIGHTLY_ASSETS_JSON"
+          python3 scripts/ci/validate_release_appcast_assets.py \
+            --appcast appcast.xml \
+            --tag nightly \
+            --assets-json "$NIGHTLY_ASSETS_JSON" \
+            --current-feed-url "https://files.cmux.com/nightly/appcast.xml" \
+            --verify-enclosure
 
           # Upload after GitHub Release publish so the appcast never references
           # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
@@ -822,7 +840,8 @@ jobs:
             --endpoint-url "$R2_ENDPOINT" \
             --bucket cmux-binaries \
             --key nightly/appcast.xml \
-            --cache-control "no-cache, no-store, must-revalidate"
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --verify-url "https://files.cmux.com/nightly/appcast.xml"
 
           echo "R2 appcast upload complete: https://files.cmux.com/nightly/appcast.xml"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,29 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      operation:
+        description: Build a dry run, or publish an already-complete immutable release
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - publish
+          - publish-existing
+      release_tag:
+        description: Exact stable tag to publish from the default-branch workflow
+        required: false
+        type: string
+
+# A single stable publication owns both update pointers. Without serialization, an older release
+# that finishes last can overwrite the canonical appcast and GitHub's legacy /latest redirect.
+concurrency:
+  group: cmux-stable-release-publication
+  cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
   attestations: write
   id-token: write
@@ -15,7 +36,188 @@ env:
   CREATE_DMG_VERSION: 8.0.0
 
 jobs:
+  release-preflight:
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    outputs:
+      skip_all: ${{ steps.guard_release_assets.outputs.skip_all }}
+      skip_upload: ${{ steps.guard_release_assets.outputs.skip_upload }}
+      should_publish: ${{ steps.release_mode.outputs.should_publish }}
+      release_tag: ${{ steps.effective_release_tag.outputs.release_tag }}
+      checkout_ref: ${{ steps.release_mode.outputs.checkout_ref }}
+      release_tool_root: ${{ steps.release_mode.outputs.release_tool_root }}
+    steps:
+      - name: Resolve release operation
+        id: release_mode
+        shell: bash
+        env:
+          OPERATION: ${{ inputs.operation || '' }}
+          REQUESTED_RELEASE_TAG: ${{ inputs.release_tag || '' }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          SHOULD_PUBLISH=false
+          RELEASE_TAG=""
+          CHECKOUT_REF="$GITHUB_SHA"
+          RELEASE_TOOL_ROOT="."
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == refs/tags/* ]]; then
+            SHOULD_PUBLISH=true
+            RELEASE_TAG="${GITHUB_REF#refs/tags/}"
+            CHECKOUT_REF="$RELEASE_TAG"
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            case "$OPERATION" in
+              dry-run)
+                if [[ -n "$REQUESTED_RELEASE_TAG" ]]; then
+                  echo "dry-run must use the selected branch without release_tag" >&2
+                  exit 1
+                fi
+                if [[ "$GITHUB_REF" != refs/heads/* ]]; then
+                  echo "dry-run must be dispatched from a branch" >&2
+                  exit 1
+                fi
+                ;;
+              publish|publish-existing)
+                if [[ "$GITHUB_REF" != "refs/heads/$DEFAULT_BRANCH" ]]; then
+                  echo "$OPERATION must run from the default branch workflow" >&2
+                  exit 1
+                fi
+                if [[ ! "$REQUESTED_RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  echo "$OPERATION requires release_tag=v<major>.<minor>.<patch>" >&2
+                  exit 1
+                fi
+                SHOULD_PUBLISH=true
+                RELEASE_TAG="$REQUESTED_RELEASE_TAG"
+                CHECKOUT_REF="$RELEASE_TAG"
+                RELEASE_TOOL_ROOT="./.release-tools"
+                ;;
+              *)
+                echo "Unsupported release operation: $OPERATION" >&2
+                exit 1
+                ;;
+            esac
+          else
+            echo "Unsupported release event: $GITHUB_EVENT_NAME" >&2
+            exit 1
+          fi
+          {
+            echo "should_publish=$SHOULD_PUBLISH"
+            echo "release_tag=$RELEASE_TAG"
+            echo "checkout_ref=$CHECKOUT_REF"
+            echo "release_tool_root=$RELEASE_TOOL_ROOT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.release_mode.outputs.checkout_ref }}
+
+      - name: Checkout current release tooling
+        if: github.event_name == 'workflow_dispatch' && steps.release_mode.outputs.should_publish == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          path: .release-tools
+
+      - name: Resolve and validate artifact release tag
+        id: effective_release_tag
+        env:
+          RELEASE_TOOL_ROOT: ${{ steps.release_mode.outputs.release_tool_root }}
+          CMUX_PROJECT_FILE: ${{ github.workspace }}/cmux.xcodeproj/project.pbxproj
+          REQUESTED_RELEASE_TAG: ${{ steps.release_mode.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="$REQUESTED_RELEASE_TAG"
+          if [[ -z "$RELEASE_TAG" ]]; then
+            PROJECT_VERSIONS="$(
+              sed -n 's/.*MARKETING_VERSION = \([^;]*\);.*/\1/p' "$CMUX_PROJECT_FILE" \
+                | sort -u
+            )"
+            if [[ "$(printf '%s\n' "$PROJECT_VERSIONS" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]]; then
+              echo "Could not derive one MARKETING_VERSION for release dry-run" >&2
+              exit 1
+            fi
+            RELEASE_TAG="v$(printf '%s\n' "$PROJECT_VERSIONS" | head -n1)"
+          fi
+          "$RELEASE_TOOL_ROOT/scripts/validate-release-version.sh" "$RELEASE_TAG"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Guard immutable release assets
+        id: guard_release_assets
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_TAG: ${{ steps.release_mode.outputs.release_tag }}
+          RELEASE_TOOL_ROOT: ${{ steps.release_mode.outputs.release_tool_root }}
+        with:
+          script: |
+            const { evaluateReleaseAssetGuard } = require(
+              `${process.env.RELEASE_TOOL_ROOT}/scripts/release_asset_guard`
+            );
+            const tag = process.env.RELEASE_TAG || null;
+            core.setOutput('skip_all', 'false');
+            core.setOutput('skip_upload', 'false');
+            core.setOutput('finalize_draft', 'false');
+            if (!tag) {
+              core.notice('release guard is in dry-run mode.');
+              return;
+            }
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              const existingAssetNames = (release.data.assets || []).map((asset) => asset.name);
+              const {
+                conflicts,
+                missingImmutableAssets,
+                hasPartialConflict,
+                shouldSkipBuildAndUpload,
+                requiresDraftFinalization,
+              } = evaluateReleaseAssetGuard({
+                existingAssetNames,
+                releaseIsDraft: release.data.draft,
+              });
+
+              if (hasPartialConflict) {
+                core.setFailed(
+                  `Release ${tag} has a partial immutable asset state. Existing immutable assets: ` +
+                  `${conflicts.join(', ')}. Missing immutable assets: ${missingImmutableAssets.join(', ')}. ` +
+                  'Resolve release assets manually before rerunning.'
+                );
+                return;
+              }
+
+              if (shouldSkipBuildAndUpload) {
+                core.notice(
+                  `Release ${tag} already contains immutable assets (${conflicts.join(', ')}). ` +
+                  'Skipping build jobs; the publication job will verify and repair the canonical feed.'
+                );
+                core.setOutput('skip_all', 'true');
+                core.setOutput('skip_upload', 'true');
+                core.setOutput('finalize_draft', String(requiresDraftFinalization));
+                return;
+              }
+
+              core.notice(`Release ${tag} has no immutable release assets yet; continuing.`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice(`Release ${tag} does not exist yet; safe to build and publish assets.`);
+                return;
+              }
+              throw error;
+            }
+
+      - name: Require complete assets for publication-only dispatch
+        if: github.event_name == 'workflow_dispatch' && inputs.operation == 'publish-existing'
+        run: |
+          if [[ "${{ steps.guard_release_assets.outputs.skip_all }}" != "true" ]]; then
+            echo "publish-existing requires a release with every immutable asset already uploaded" >&2
+            exit 1
+          fi
+
   build-ghostty-cli-helper:
+    needs: release-preflight
+    if: needs.release-preflight.outputs.skip_all != 'true'
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
     timeout-minutes: 20
     steps:
@@ -34,6 +236,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ needs.release-preflight.outputs.checkout_ref }}
           submodules: recursive
 
       - name: Install zig
@@ -61,7 +264,12 @@ jobs:
           if-no-files-found: error
 
   build-sign-notarize:
-    needs: build-ghostty-cli-helper
+    needs: [release-preflight, build-ghostty-cli-helper]
+    if: >-
+      always() &&
+      needs.release-preflight.result == 'success' &&
+      (needs.build-ghostty-cli-helper.result == 'success' ||
+       needs.release-preflight.outputs.skip_all == 'true')
     # Build the app on macOS 26 so SDK-gated SwiftUI Liquid Glass code compiles
     # into stable releases. The real universal Ghostty CLI helper is built on
     # macOS 15 above because Zig 0.15.2 cannot link it on macOS 26.
@@ -87,25 +295,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          submodules: recursive
+          ref: ${{ needs.release-preflight.outputs.checkout_ref }}
+          # Exact-asset retries only verify and republish appcast.xml. Avoid coupling that repair
+          # path to mutable build submodules or the Ghostty toolchain.
+          submodules: ${{ needs.release-preflight.outputs.skip_all != 'true' && 'recursive' || 'false' }}
 
-      - name: Validate Sparkle build number is monotonic
-        run: ./tests/test_ci_sparkle_build_monotonic.sh
+      - name: Checkout current release tooling
+        if: github.event_name == 'workflow_dispatch' && needs.release-preflight.outputs.should_publish == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          path: .release-tools
 
       - name: Guard immutable release assets
         id: guard_release_assets
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_TAG: ${{ needs.release-preflight.outputs.should_publish == 'true' && needs.release-preflight.outputs.release_tag || '' }}
+          RELEASE_TOOL_ROOT: ${{ needs.release-preflight.outputs.release_tool_root }}
         with:
           script: |
-            const { evaluateReleaseAssetGuard } = require('./scripts/release_asset_guard');
-            const tag = context.ref.startsWith('refs/tags/')
-              ? context.ref.replace('refs/tags/', '')
-              : null;
+            const { evaluateReleaseAssetGuard } = require(
+              `${process.env.RELEASE_TOOL_ROOT}/scripts/release_asset_guard`
+            );
+            const tag = process.env.RELEASE_TAG || null;
             core.setOutput('skip_all', 'false');
             core.setOutput('skip_upload', 'false');
             core.setOutput('release_state', 'clear');
+            core.setOutput('finalize_draft', 'false');
             if (!tag) {
-              core.notice('workflow_dispatch is not running from a tag; release guard is in dry-run mode.');
+              core.notice('release guard is in dry-run mode.');
               return;
             }
             try {
@@ -121,7 +340,11 @@ jobs:
                 guardState,
                 hasPartialConflict,
                 shouldSkipBuildAndUpload,
-              } = evaluateReleaseAssetGuard({ existingAssetNames });
+                requiresDraftFinalization,
+              } = evaluateReleaseAssetGuard({
+                existingAssetNames,
+                releaseIsDraft: release.data.draft,
+              });
 
               core.setOutput('release_state', guardState);
 
@@ -141,6 +364,7 @@ jobs:
                 );
                 core.setOutput('skip_all', 'true');
                 core.setOutput('skip_upload', 'true');
+                core.setOutput('finalize_draft', String(requiresDraftFinalization));
                 return;
               }
 
@@ -152,6 +376,12 @@ jobs:
               }
               throw error;
             }
+
+      - name: Validate Sparkle build number is monotonic
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          CMUX_SPARKLE_MONOTONIC_STRICT: "1"
+        run: ./tests/test_ci_sparkle_build_monotonic.sh
 
       - name: Select Xcode
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -296,7 +526,7 @@ jobs:
           APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PLIST")
           ./scripts/build_remote_daemon_release_assets.sh \
             --version "$APP_VERSION" \
-            --release-tag "$GITHUB_REF_NAME" \
+            --release-tag "${{ needs.release-preflight.outputs.release_tag }}" \
             --repo "manaflow-ai/cmux" \
             --output-dir "remote-daemon-assets"
           MANIFEST_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8")), separators=(",",":")))' remote-daemon-assets/cmuxd-remote-manifest.json)"
@@ -327,7 +557,7 @@ jobs:
           echo "Adding SUPublicEDKey to Info.plist..."
           /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string ${SPARKLE_PUBLIC_KEY}" "$APP_PLIST"
           echo "Adding SUFeedURL to Info.plist..."
-          /usr/libexec/PlistBuddy -c "Add :SUFeedURL string https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml" "$APP_PLIST"
+          /usr/libexec/PlistBuddy -c "Add :SUFeedURL string https://files.cmux.com/stable/appcast.xml" "$APP_PLIST"
           echo "Verifying:"
           /usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "$APP_PLIST"
           /usr/libexec/PlistBuddy -c "Print :SUFeedURL" "$APP_PLIST"
@@ -480,12 +710,27 @@ jobs:
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          RELEASE_TOOL_ROOT: ${{ needs.release-preflight.outputs.release_tool_root }}
         run: |
           if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
             echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
             exit 1
           fi
-          ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$GITHUB_REF_NAME" appcast.xml
+          "$RELEASE_TOOL_ROOT/scripts/sparkle_generate_appcast.sh" \
+            cmux-macos.dmg \
+            "${{ needs.release-preflight.outputs.release_tag }}" \
+            appcast.xml
+
+      - name: Validate Sparkle appcast before immutable publication
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          RELEASE_TOOL_ROOT: ${{ needs.release-preflight.outputs.release_tool_root }}
+        run: |
+          python3 "$RELEASE_TOOL_ROOT/scripts/ci/validate_release_appcast_assets.py" \
+            --appcast appcast.xml \
+            --tag "${{ needs.release-preflight.outputs.release_tag }}" \
+            --enclosure-file cmux-macos.dmg \
+            --expected-enclosure cmux-macos.dmg
 
       - name: Attest remote daemon release assets
         id: attest-remote-daemon-release-assets
@@ -514,7 +759,7 @@ jobs:
             remote-daemon-assets/cmuxd-remote-manifest.json
 
       - name: Upload build artifacts (dry-run)
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'workflow_dispatch'
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'workflow_dispatch' && inputs.operation == 'dry-run'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cmux-release-dry-run
@@ -525,9 +770,10 @@ jobs:
           if-no-files-found: error
 
       - name: Upload release asset
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && needs.release-preflight.outputs.should_publish == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
+          tag_name: ${{ needs.release-preflight.outputs.release_tag }}
           files: |
             cmux-macos.dmg
             appcast.xml
@@ -538,40 +784,116 @@ jobs:
             remote-daemon-assets/cmuxd-remote-checksums.txt
             remote-daemon-assets/cmuxd-remote-manifest.json
           generate_release_notes: true
+          # Stage the immutable release first. The legacy pointer moves only after the canonical
+          # R2 appcast and its public URL have both verified.
+          make_latest: false
           overwrite_files: false
 
+      - name: Finalize complete draft release
+        if: >-
+          needs.release-preflight.outputs.should_publish == 'true' &&
+          steps.guard_release_assets.outputs.finalize_draft == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-preflight.outputs.release_tag }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest=false
+
+      - name: Classify stable release order at publication time
+        id: publish_release_order
+        if: needs.release-preflight.outputs.should_publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TOOL_ROOT: ${{ needs.release-preflight.outputs.release_tool_root }}
+        run: |
+          set -euo pipefail
+          RELEASES_JSON="$RUNNER_TEMP/stable-releases-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          gh release list --limit 1000 --exclude-drafts --exclude-pre-releases \
+            --json tagName > "$RELEASES_JSON"
+          python3 "$RELEASE_TOOL_ROOT/scripts/ci/classify_stable_release.py" \
+            --candidate "${{ needs.release-preflight.outputs.release_tag }}" \
+            --releases-json "$RELEASES_JSON" \
+            --github-output "$GITHUB_OUTPUT"
+
       - name: Upload release appcast to R2
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: needs.release-preflight.outputs.should_publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+          RELEASE_TOOL_ROOT: ${{ needs.release-preflight.outputs.release_tool_root }}
         run: |
           set -euo pipefail
 
-          # Guard: only upload if this tag is the highest semver release.
-          # Prevents a backport tag (e.g. v0.62.1 after v0.63.1) from
-          # overwriting the stable appcast with an older version.
-          LATEST=$(gh release list --exclude-drafts --exclude-pre-releases \
-            --json tagName -q '.[].tagName' | sort -V | tail -1)
-          if [ -n "$LATEST" ] && [ "$LATEST" != "$GITHUB_REF_NAME" ]; then
-            echo "Skipping R2 stable upload: $GITHUB_REF_NAME is not the latest release ($LATEST)"
+          # The same pre-publication order decision controls GitHub's legacy /latest redirect and
+          # the canonical R2 feed, so old and fixed clients resolve the same full release.
+          if [ "${{ steps.publish_release_order.outputs.is_latest }}" != "true" ]; then
+            echo "Skipping R2 stable upload: ${{ needs.release-preflight.outputs.release_tag }} is not the latest release (${{ steps.publish_release_order.outputs.latest_tag }})"
             exit 0
           fi
+
+          # A retry may find every immutable GitHub asset already present and skip the expensive
+          # build. Download that exact signed appcast so a previously-failed R2 publication can
+          # still repair the canonical feed without rebuilding or mutating the release.
+          APPCAST_PATH=appcast.xml
+          if [ "${{ steps.guard_release_assets.outputs.skip_all }}" = "true" ] || [ ! -f "$APPCAST_PATH" ]; then
+            APPCAST_PATH="$RUNNER_TEMP/cmux-appcast-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.xml"
+            gh release download \
+              "${{ needs.release-preflight.outputs.release_tag }}" \
+              --pattern appcast.xml \
+              --output "$APPCAST_PATH"
+          fi
+
+          ASSETS_JSON="$RUNNER_TEMP/cmux-assets-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          gh release view \
+            "${{ needs.release-preflight.outputs.release_tag }}" \
+            --json assets > "$ASSETS_JSON"
+          VALIDATION_ARGS=(
+            --appcast "$APPCAST_PATH"
+            --tag "${{ needs.release-preflight.outputs.release_tag }}"
+            --assets-json "$ASSETS_JSON"
+            --expected-enclosure cmux-macos.dmg
+            --current-feed-url "https://files.cmux.com/stable/appcast.xml"
+            --verify-enclosure
+          )
+          if [ "${{ steps.guard_release_assets.outputs.skip_all }}" = "true" ]; then
+            # An exact immutable-asset retry is the explicit disaster-repair path. Normal
+            # publication fails closed if the currently served feed cannot be read.
+            VALIDATION_ARGS+=(--allow-missing-current-feed)
+          fi
+          python3 "$RELEASE_TOOL_ROOT/scripts/ci/validate_release_appcast_assets.py" \
+            "${VALIDATION_ARGS[@]}"
 
           # Upload after GitHub Release publish so the appcast never references
           # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
           # is either the old version or the new one, never missing.
-          python3 scripts/ci/upload-r2-object.py \
-            --file appcast.xml \
+          python3 "$RELEASE_TOOL_ROOT/scripts/ci/upload-r2-object.py" \
+            --file "$APPCAST_PATH" \
             --endpoint-url "$R2_ENDPOINT" \
             --bucket cmux-binaries \
             --key stable/appcast.xml \
-            --cache-control "no-cache, no-store, must-revalidate"
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --verify-url "https://files.cmux.com/stable/appcast.xml"
 
           echo "R2 appcast upload complete: https://files.cmux.com/stable/appcast.xml"
+
+      - name: Reconcile GitHub latest release for legacy clients
+        if: needs.release-preflight.outputs.should_publish == 'true' && steps.publish_release_order.outputs.is_latest == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${{ steps.publish_release_order.outputs.latest_tag }}" --latest
+
+      - name: Queue Homebrew update for the verified latest release
+        if: needs.release-preflight.outputs.should_publish == 'true' && steps.publish_release_order.outputs.is_latest == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.release-preflight.outputs.release_tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          gh workflow run update-homebrew.yml \
+            --ref "$DEFAULT_BRANCH" \
+            --field version="$RELEASE_TAG"
 
       - name: Cleanup keychain
         if: always()

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,16 +1,19 @@
 name: Update Homebrew Cask
 
 on:
-  # Trigger after the release workflow completes (not on release:published,
-  # which fires before assets finish uploading — causing SHA mismatch).
-  workflow_run:
-    workflows: ["Release macOS app"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       version:
         description: 'Version (e.g., 0.58.0 or v0.58.0)'
         required: true
+
+# Release publication queues this workflow only after both update pointers verify. The latest
+# guard below is repeated at execution time so a delayed older job cannot roll the cask back.
+concurrency:
+  # Share the stable publication lock so GitHub latest cannot change between the final guard and
+  # the cask push. A delayed older request then skips after the newer release owns the pointer.
+  group: cmux-stable-release-publication
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -18,36 +21,46 @@ permissions:
 jobs:
   update-cask:
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    # Only run if the release workflow succeeded (or manual trigger)
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Get version
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            # workflow_run: extract tag from the triggering workflow's head branch
-            VERSION="${{ github.event.workflow_run.head_branch }}"
-          fi
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
           VERSION="${VERSION#v}"
           if [ -z "$VERSION" ]; then
             echo "Could not determine version" >&2
             exit 1
           fi
           if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              echo "Invalid version: ${VERSION}" >&2
-              exit 1
-            fi
-            echo "Skipping homebrew cask update for non-release ref: ${VERSION}"
-            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Invalid version: ${VERSION}" >&2
+            exit 1
+          fi
+
+          TAG="v$VERSION"
+          LATEST_TAG="$(
+            gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 1000 \
+              --exclude-drafts \
+              --exclude-pre-releases \
+              --json tagName,isLatest \
+              --jq '.[] | select(.isLatest == true) | .tagName' \
+              | head -n 1
+          )"
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "Could not resolve GitHub's explicit latest stable release" >&2
+            exit 1
+          fi
+          if [[ "$TAG" != "$LATEST_TAG" ]]; then
+            echo "Skipping Homebrew rollback: requested $TAG, explicit latest is $LATEST_TAG"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "skip=false" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Updating homebrew cask to version $VERSION"
 
       - name: Download DMG and get SHA256
@@ -133,8 +146,25 @@ jobs:
       - name: Commit and push
         if: steps.version.outputs.skip != 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
+          LATEST_TAG="$(
+            gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 1000 \
+              --exclude-drafts \
+              --exclude-pre-releases \
+              --json tagName,isLatest \
+              --jq '.[] | select(.isLatest == true) | .tagName' \
+              | head -n 1
+          )"
+          if [[ "v$VERSION" != "$LATEST_TAG" ]]; then
+            echo "Skipping stale Homebrew push: requested v$VERSION, explicit latest is $LATEST_TAG"
+            exit 0
+          fi
+
           cd homebrew-cmux
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
@@ -40,6 +40,13 @@ extension ControlCommandCoordinator {
             return debugShowProWelcomeChecklist()
         case "debug.command_palette.toggle":
             return debugCommandPaletteEvent(.toggle, request.params)
+        case "debug.command_palette.query.set":
+            guard let query = rawString(request.params, "query") else {
+                return .err(code: "invalid_params", message: "Missing query", data: nil)
+            }
+            return debugCommandPaletteEvent(.setQuery(query), request.params)
+        case "debug.command_palette.submit":
+            return debugCommandPaletteEvent(.submit, request.params)
         case "debug.command_palette.rename_tab.open":
             return debugCommandPaletteEvent(.renameTabOpen, request.params)
         case "debug.command_palette.visible":
@@ -316,10 +323,9 @@ extension ControlCommandCoordinator {
 
     // MARK: - debug.command_palette.* (event posts)
 
-    /// The shared body of the four palette-notification commands (`toggle`,
-    /// `rename_tab.open`, `rename_input.interact`,
-    /// `rename_input.delete_backward`): identical param shape, identical
-    /// `not_found` payload, differing only in the posted notification.
+    /// The shared body of the palette-notification commands. They have the
+    /// same window target and `not_found` behavior; the event carries the
+    /// requested action and any action-specific payload.
     func debugCommandPaletteEvent(
         _ event: ControlDebugCommandPaletteEvent,
         _ params: [String: JSONValue]

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugCommandPaletteEvent.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugCommandPaletteEvent.swift
@@ -4,6 +4,11 @@
 public enum ControlDebugCommandPaletteEvent: Sendable, Equatable {
     /// `debug.command_palette.toggle` (`commandPaletteToggleRequested`).
     case toggle
+    /// `debug.command_palette.query.set`
+    /// (`commandPaletteQuerySetRequested`).
+    case setQuery(String)
+    /// `debug.command_palette.submit` (`commandPaletteSubmitRequested`).
+    case submit
     /// `debug.command_palette.rename_tab.open`
     /// (`commandPaletteRenameTabRequested`).
     case renameTabOpen

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorDebugCommandPaletteTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorDebugCommandPaletteTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+#if DEBUG
+@MainActor
+private final class FakeDebugCommandPaletteControlCommandContext: ControlCommandContext {
+    var postedEvents: [(ControlDebugCommandPaletteEvent, UUID?)] = []
+    var shouldPost = true
+
+    func controlDebugPostCommandPaletteEvent(
+        _ event: ControlDebugCommandPaletteEvent,
+        windowID: UUID?
+    ) -> Bool {
+        postedEvents.append((event, windowID))
+        return shouldPost
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator debug command palette dispatch")
+struct ControlCommandCoordinatorDebugCommandPaletteTests {
+    private func makeCoordinator() -> (ControlCommandCoordinator, FakeDebugCommandPaletteControlCommandContext) {
+        let context = FakeDebugCommandPaletteControlCommandContext()
+        return (ControlCommandCoordinator(context: context), context)
+    }
+
+    private func request(
+        _ method: String,
+        _ params: [String: JSONValue] = [:]
+    ) -> ControlRequest {
+        ControlRequest(id: .int(1), method: method, params: params)
+    }
+
+    @Test func querySetPreservesTextAndTargetsExactWindow() {
+        let (coordinator, context) = makeCoordinator()
+        let windowID = UUID()
+
+        let result = coordinator.handle(request(
+            "debug.command_palette.query.set",
+            [
+                "query": .string("update"),
+                "window_id": .string(windowID.uuidString),
+            ]
+        ))
+
+        #expect(result == .ok(.object([:])))
+        #expect(context.postedEvents.count == 1)
+        #expect(context.postedEvents[0].0 == .setQuery("update"))
+        #expect(context.postedEvents[0].1 == windowID)
+    }
+
+    @Test func querySetRequiresQuery() {
+        let (coordinator, context) = makeCoordinator()
+
+        #expect(
+            coordinator.handle(request("debug.command_palette.query.set"))
+                == .err(code: "invalid_params", message: "Missing query", data: nil)
+        )
+        #expect(context.postedEvents.isEmpty)
+    }
+
+    @Test func submitTargetsExactWindow() {
+        let (coordinator, context) = makeCoordinator()
+        let windowID = UUID()
+
+        let result = coordinator.handle(request(
+            "debug.command_palette.submit",
+            ["window_id": .string(windowID.uuidString)]
+        ))
+
+        #expect(result == .ok(.object([:])))
+        #expect(context.postedEvents.count == 1)
+        #expect(context.postedEvents[0].0 == .submit)
+        #expect(context.postedEvents[0].1 == windowID)
+    }
+}
+#endif

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
@@ -100,7 +100,13 @@ struct AttemptUpdateCoordinator {
             case .updateAvailable:
                 phase = .startingDownload
                 return .confirmInstall
-            case .idle, .notFound:
+            case .notFound:
+                // The installed app can become current between the original prompt and this
+                // authoritative fresh check. Preserve Sparkle's "up to date" terminal instead of
+                // misreporting the successful check as a failed install.
+                phase = .inactive
+                return .none
+            case .idle:
                 phase = .inactive
                 return .installFailed
             case .error:

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/DebugUpdateErrorScenario.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/DebugUpdateErrorScenario.swift
@@ -105,15 +105,15 @@ public enum DebugUpdateErrorScenario: String, CaseIterable, Hashable, Sendable {
         case .installDidNotStart:
             return NSError(domain: UpdateStateModel.updateErrorDomain, code: UpdateStateModel.installDidNotStartCode, userInfo: [
                 NSLocalizedDescriptionKey: String(
-                    localized: "update.error.didNotStart.message",
-                    defaultValue: "cmux couldn’t start the update. Check your internet connection and try again."
+                    localized: "update.error.didNotStart.recovery.message",
+                    defaultValue: "cmux couldn’t start the update. Try again, or download the latest version below."
                 ),
             ])
         case .updaterNotReady:
             return NSError(domain: UpdateStateModel.updateErrorDomain, code: UpdateStateModel.updaterNotReadyCode, userInfo: [
                 NSLocalizedDescriptionKey: String(
                     localized: "update.error.notReady",
-                    defaultValue: "Updater is still starting. Try again in a moment."
+                    defaultValue: "The updater isn’t ready to check yet. Try again in a moment."
                 ),
             ])
         }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/InstallWatchdog.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/InstallWatchdog.swift
@@ -56,8 +56,10 @@ final class InstallWatchdog {
     }
 
     /// Whether `state`, observed when the watchdog fires, means the install never got going: the
-    /// user asked to install but the flow is still merely checking, showing "Update Available",
-    /// or sitting at `.idle` with no download underway. `.idle` counts as stalled because every
+    /// user asked to install but the flow is still waiting to start a check, waiting for Sparkle
+    /// to begin the accepted download, or sitting at `.idle` with no download underway. An active
+    /// authoritative `.checking` state is deliberately unbounded; the controller rearms when it
+    /// hands the freshly selected item to Sparkle. `.idle` counts as stalled because every
     /// legitimate way to be idle at the deadline disarms first (causal user-cancel callbacks end
     /// the attempt; terminal outcomes disarm via ``installAttemptResolved(_:)``) — so an armed
     /// deadline firing at idle is an unattributed accepted-install failure.
@@ -65,9 +67,10 @@ final class InstallWatchdog {
     /// would be wrong if Sparkle ever did).
     func installAttemptStalled(_ state: UpdateState) -> Bool {
         switch state {
-        case .preparingCheck, .checking, .updateAvailable, .startingDownload, .idle:
+        case .preparingCheck, .startingDownload, .idle:
             return true
-        case .permissionRequest, .downloading, .extracting, .installing, .notFound, .error:
+        case .permissionRequest, .checking, .updateAvailable, .downloading, .extracting,
+                .installing, .notFound, .error:
             return false
         }
     }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateActionDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateActionDelegate.swift
@@ -2,14 +2,10 @@
 ///
 /// This is the dependency-inversion seam between the `CmuxUpdater` package and the app: the
 /// package calls up through this protocol instead of reaching `AppDelegate`/`TerminalController`
-/// directly. The app's delegate conforms and is injected into ``UpdateController`` (which holds
-/// it `weak`).
+/// directly. Check and install retries remain inside ``UpdateController`` so their intent cannot
+/// be downgraded by a host callback.
 @MainActor
 public protocol UpdateActionDelegate: AnyObject {
-    /// The user asked to retry after an update error. The host should re-initiate a check
-    /// through its normal entry point.
-    func updaterRequestsRetryCheckForUpdates()
-
     /// Sparkle is about to relaunch the app to finish installing. The host should persist
     /// session state, stop its terminal/runtime, and invalidate restorable state so the
     /// relaunched instance starts cleanly.

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -16,6 +16,7 @@ extension UpdateController {
     }
 
     func requestUpdateCheck(_ intent: UpdateCheckIntent) {
+        noUpdateRetryIntent = nil
         // A coincident menu check must not downgrade ownership after the user already accepted an
         // install. It may replace the transport session, but its result still serves that install.
         let intent = attemptCoordinator.isMonitoring ? UpdateCheckIntent.installLatest : intent
@@ -39,7 +40,7 @@ extension UpdateController {
             activeCheckIntent = nil
             attemptCoordinator.cancel()
             installWatchdog.disarm()
-            model.setState(.notFound(.init(acknowledgement: {})))
+            model.setState(.notFound(.init(reason: .developmentBuild, acknowledgement: {})))
             return
         }
 
@@ -119,6 +120,7 @@ extension UpdateController {
             self?.cancelQueuedCheckByUser()
         }))
         model.replaceActiveState(with: state)
+        driver.finishPendingCheckTransitionAsSuperseded()
     }
 
     private func waitForReadinessThenCheck() {
@@ -174,7 +176,7 @@ extension UpdateController {
             code: UpdateStateModel.updaterNotReadyCode,
             userInfo: [NSLocalizedDescriptionKey: String(
                 localized: "update.error.notReady",
-                defaultValue: "Updater is still starting. Try again in a moment."
+                defaultValue: "The updater isn’t ready to check yet. Try again in a moment."
             )]
         )
         model.setState(.error(.init(
@@ -207,6 +209,59 @@ extension UpdateController {
 }
 
 extension UpdateController: UpdateDriverEventDelegate {
+    func updateDriverWillPresentNoUpdate() {
+        let intent = strongestCurrentIntent()
+        noUpdateRetryIntent = intent
+        log.append("controller captured no-update retry intent (intent=\(intent.rawValue))")
+    }
+
+    func updateDriverDidPresentError() {
+        var intent = strongestCurrentIntent()
+        switch model.state {
+        case .startingDownload, .downloading, .extracting, .installing:
+            intent = .installLatest
+        default:
+            break
+        }
+        // The queued replacement now belongs to the visible Retry action. Leaving it pending
+        // would start it from the old cycle's finish callback after install ownership is canceled.
+        pendingCheckIntent = nil
+        cancelReadinessRetry()
+        errorRetryIntent = intent
+        attemptCoordinator.cancel()
+        installWatchdog.disarm()
+        log.append("controller captured updater error retry intent (intent=\(intent.rawValue))")
+    }
+
+    private func strongestCurrentIntent() -> UpdateCheckIntent {
+        var intent = activeCheckIntent
+            ?? pendingCheckIntent
+            ?? (attemptCoordinator.isMonitoring ? .installLatest : .manual)
+        if let pendingCheckIntent {
+            intent = intent.merged(with: pendingCheckIntent)
+        }
+        if attemptCoordinator.isMonitoring {
+            intent = intent.merged(with: .installLatest)
+        }
+        return intent
+    }
+
+    func updateDriverRequestsRetryAfterError() {
+        let intent = errorRetryIntent ?? .manual
+        errorRetryIntent = nil
+        log.append("controller retrying updater error (intent=\(intent.rawValue))")
+        switch intent {
+        case .manual:
+            checkForUpdates()
+        case .installLatest:
+            attemptUpdate()
+        }
+    }
+
+    func updateDriverDidDismissError() {
+        errorRetryIntent = nil
+    }
+
     func updateDriverDidFinishCycle(_ updateCheck: SPUUpdateCheck, error: NSError?) {
         let finishedIntent = activeCheckIntent
         activeCheckIntent = nil

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -221,6 +221,13 @@ extension UpdateController: UpdateDriverEventDelegate {
         }
 
         if finishedIntent == .installLatest, attemptCoordinator.isMonitoring {
+            if case .notFound = model.state {
+                // Sparkle can finish the cycle before the async model observer consumes the
+                // no-update terminal. Reconcile it through the same coordinator path now.
+                reconcileInstallAttempt(with: model.state)
+                installWatchdog.disarm()
+                return
+            }
             switch model.state {
             case .downloading, .extracting, .installing, .error:
                 return

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
@@ -52,8 +52,8 @@ extension UpdateController {
             domain: UpdateStateModel.updateErrorDomain,
             code: UpdateStateModel.installDidNotStartCode,
             userInfo: [NSLocalizedDescriptionKey: String(
-                localized: "update.error.didNotStart.message",
-                defaultValue: "cmux couldn’t start the update. Check your internet connection and try again."
+                localized: "update.error.didNotStart.recovery.message",
+                defaultValue: "cmux couldn’t start the update. Try again, or download the latest version below."
             )]
         )
         let errorState = UpdateState.error(.init(
@@ -94,6 +94,7 @@ extension UpdateController {
                 )
                 // Publish ownership before invoking Sparkle because its callbacks may be
                 // synchronous. The pill stays visible until download or a retryable error.
+                installWatchdog.arm { [weak self] in self?.fireInstallWatchdogIfStalled() }
                 model.setState(.startingDownload)
                 available.reply.consume(.install, source: .installAttempt)
             } else if case .updateAvailable(let available) = model.state,

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
@@ -6,6 +6,14 @@ import Foundation
 extension UpdateController {
     // MARK: - Attempt update
 
+#if DEBUG
+    /// Surfaces the real retryable install-attempt error for debug-menu and UI automation. Unlike
+    /// a synthetic model override, its Retry action exercises the production attempt pipeline.
+    public func debugShowInstallDidNotStartError() {
+        setInstallDidNotStartError(diagnostic: "debug scenario: installDidNotStart")
+    }
+#endif
+
     /// Re-check for updates and auto-confirm the install of whatever the fresh check resolves.
     ///
     /// This is the single user-facing "install the update" entry point. It deliberately runs a

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -186,7 +186,19 @@ public final class UpdateController {
     /// (the merge of the old `$state.sink`, the attempt sink, and the `CombineLatest` dismiss
     /// observer).
     private func handleStateChange(_ state: UpdateState, overrideState: UpdateState?) {
+        reconcileInstallAttempt(with: state)
+        // Disarm the install watchdog the moment the flow progresses the install or shows a clear
+        // outcome, so a healthy install (or a real error / "no updates") never trips it.
+        if installWatchdog.isArmed, installWatchdog.installAttemptResolved(state) {
+            installWatchdog.disarm()
+        }
+        scheduleNoUpdateDismiss(for: state, overrideState: overrideState)
+    }
 
+    /// Reconciles an observed update state with the accepted-install coordinator. The Sparkle
+    /// cycle-finished callback also uses this path when it can arrive before the async state
+    /// observer, keeping both callback orders behaviorally identical.
+    func reconcileInstallAttempt(with state: UpdateState) {
         if attemptCoordinator.isMonitoring {
             let action = attemptCoordinator.handleStateChange(state)
             // The watchdog guards one specific install attempt. If that attempt just ended
@@ -203,12 +215,6 @@ public final class UpdateController {
             }
             performAttemptAction(action)
         }
-        // Disarm the install watchdog the moment the flow progresses the install or shows a clear
-        // outcome, so a healthy install (or a real error / "no updates") never trips it.
-        if installWatchdog.isArmed, installWatchdog.installAttemptResolved(state) {
-            installWatchdog.disarm()
-        }
-        scheduleNoUpdateDismiss(for: state, overrideState: overrideState)
     }
 
     // The attempt-update entry point, its coordinator actions, and the install-watchdog trip

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -30,7 +30,7 @@ public final class UpdateController {
     /// the public release appcast. See ``isDevLikeBundleIdentifier(_:)``.
     let isDevLikeBundle: Bool
 
-    /// Host actions the updater delegates upward (retry, relaunch prep). Forwarded to the driver.
+    /// Host relaunch preparation delegated upward. Forwarded to the driver.
     public weak var actionDelegate: (any UpdateActionDelegate)? {
         didSet { driver.actionDelegate = actionDelegate }
     }
@@ -44,6 +44,10 @@ public final class UpdateController {
     private var noUpdateDismissTask: Task<Void, Never>?
     var pendingCheckIntent: UpdateCheckIntent?
     var activeCheckIntent: UpdateCheckIntent?
+    /// Intent captured when Sparkle presents an error, retained until its Retry/Dismiss action.
+    var errorRetryIntent: UpdateCheckIntent?
+    /// Intent captured before a no-update result is presented, retained for its Retry action.
+    var noUpdateRetryIntent: UpdateCheckIntent?
     /// Armed when the user asks to install; fires a visible "Update Didn't Start" error if the
     /// flow never reaches downloading/installing (or another visible outcome). See
     /// ``attemptUpdate`` in `UpdateController+InstallAttempt.swift` (internal for that file).
@@ -187,10 +191,16 @@ public final class UpdateController {
     /// observer).
     private func handleStateChange(_ state: UpdateState, overrideState: UpdateState?) {
         reconcileInstallAttempt(with: state)
-        // Disarm the install watchdog the moment the flow progresses the install or shows a clear
-        // outcome, so a healthy install (or a real error / "no updates") never trips it.
-        if installWatchdog.isArmed, installWatchdog.installAttemptResolved(state) {
-            installWatchdog.disarm()
+        if installWatchdog.isArmed {
+            // A fresh authoritative feed check may legitimately take arbitrarily long. The first
+            // deadline only guards reaching this callback; a new deadline starts when the chosen
+            // latest item is handed to Sparkle for download.
+            if case .checking = state {
+                installWatchdog.disarm()
+            } else if installWatchdog.installAttemptResolved(state) {
+                // Healthy install progress and visible terminal outcomes end the deadline.
+                installWatchdog.disarm()
+            }
         }
         scheduleNoUpdateDismiss(for: state, overrideState: overrideState)
     }
@@ -222,12 +232,37 @@ public final class UpdateController {
 
     // MARK: - "No updates" auto-dismiss
 
+    /// Clears and acknowledges the currently visible no-update result exactly once.
+    public func acknowledgeNoUpdate() {
+        noUpdateDismissTask?.cancel()
+        noUpdateDismissTask = nil
+        guard case .notFound(let notFound) = model.state else { return }
+        noUpdateRetryIntent = nil
+        model.setState(.idle)
+        notFound.acknowledgement()
+    }
+
+    /// Acknowledges an indeterminate no-update result and retries the operation that produced it.
+    public func retryNoUpdate() {
+        guard case .notFound = model.state else { return }
+        let intent = noUpdateRetryIntent ?? .manual
+        acknowledgeNoUpdate()
+        log.append("retrying indeterminate no-update result (intent=\(intent.rawValue))")
+        switch intent {
+        case .manual:
+            checkForUpdates()
+        case .installLatest:
+            attemptUpdate()
+        }
+    }
+
     private func scheduleNoUpdateDismiss(for state: UpdateState, overrideState: UpdateState?) {
         noUpdateDismissTask?.cancel()
         noUpdateDismissTask = nil
 
         guard overrideState == nil else { return }
         guard case .notFound(let notFound) = state else { return }
+        guard notFound.automaticallyDismisses else { return }
 
         recordUITestTimestamp(key: "noUpdateShownAt")
         noUpdateDismissTask = Task { @MainActor [weak self] in
@@ -235,11 +270,19 @@ public final class UpdateController {
             // Bounded, cancellable auto-dismiss delay via the injected clock.
             try? await self.clock.sleep(for: .seconds(UpdateTiming.noUpdateDisplayDuration))
             guard !Task.isCancelled else { return }
-            guard self.model.overrideState == nil, case .notFound = self.model.state else { return }
+            guard self.model.overrideState == nil else { return }
+            guard self.acknowledgeNoUpdate(ifMatching: notFound.id) else { return }
             self.recordUITestTimestamp(key: "noUpdateHiddenAt")
-            self.model.setState(.idle)
-            notFound.acknowledgement()
         }
+    }
+
+    /// Clears only the result that armed an auto-dismiss task. A newer actionable result must
+    /// remain visible even if an older timer becomes runnable before its cancellation is observed.
+    @discardableResult
+    func acknowledgeNoUpdate(ifMatching resultID: UUID) -> Bool {
+        guard case .notFound(let current) = model.state, current.id == resultID else { return false }
+        acknowledgeNoUpdate()
+        return true
     }
 
     // MARK: - Updater lifecycle
@@ -276,6 +319,9 @@ public final class UpdateController {
             // whether to schedule its own background checks against the public appcast (#6292).
             defaults.set(false, forKey: UpdateSettings.automaticChecksKey)
         }
+        // Re-assert the user-driven install policy immediately before Sparkle selects its driver.
+        // This also repairs any value changed after controller construction.
+        defaults.set(false, forKey: UpdateSettings.automaticallyUpdateKey)
         do {
             try updater.start()
             didStartUpdater = true

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -6,8 +6,8 @@ import Foundation
 ///
 /// Sparkle's `SPUUserDriver`/`SPUUpdaterDelegate` are `@MainActor`, so every callback runs on
 /// the main actor and writes the model directly with no thread hopping. The minimum-display
-/// and check-timeout delays are bounded, cancellable ``UpdateClock`` tasks. Host actions the
-/// driver cannot perform itself (retry, relaunch prep) go through ``UpdateActionDelegate``.
+/// delay is a bounded, cancellable ``UpdateClock`` task. Host relaunch preparation goes through
+/// ``UpdateActionDelegate``; check/install intent stays owned by ``UpdateController``.
 @MainActor
 final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     /// The state model this driver drives.
@@ -25,10 +25,9 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     weak var eventDelegate: (any UpdateDriverEventDelegate)?
 
     private let minimumCheckDuration: TimeInterval = UpdateTiming.minimumCheckDisplayDuration
-    private let checkTimeoutDuration: TimeInterval = UpdateTiming.checkTimeoutDuration
     private var lastCheckStart: Date?
     private var pendingCheckTransitionTask: Task<Void, Never>?
-    private var checkTimeoutTask: Task<Void, Never>?
+    private var pendingCheckTransition: (id: UUID, state: UpdateState)?
     private(set) var lastFeedURLString: String?
 
     init(
@@ -50,7 +49,6 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
 
     deinit {
         pendingCheckTransitionTask?.cancel()
-        checkTimeoutTask?.cancel()
     }
 
     func show(_ request: SPUUpdatePermissionRequest,
@@ -96,21 +94,27 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     func showUpdateNotFoundWithError(_ error: any Error,
                                      acknowledgement: @escaping () -> Void) {
         log.append("show update not found: \(formatErrorForLog(error))")
-        setStateAfterMinimumCheckDelay(.notFound(.init(acknowledgement: acknowledgement)))
+        eventDelegate?.updateDriverWillPresentNoUpdate()
+        setStateAfterMinimumCheckDelay(.notFound(.init(
+            reason: notFoundReason(for: error),
+            acknowledgement: acknowledgement
+        )))
     }
 
     func showUpdaterError(_ error: any Error,
                           acknowledgement: @escaping () -> Void) {
         let details = formatErrorForLog(error)
         log.append("show updater error: \(details)")
+        eventDelegate?.updateDriverDidPresentError()
         setState(.error(.init(
             error: error,
             retry: { [weak self] in
                 self?.model.setState(.idle)
-                self?.actionDelegate?.updaterRequestsRetryCheckForUpdates()
+                self?.eventDelegate?.updateDriverRequestsRetryAfterError()
             },
             dismiss: { [weak self] in
                 self?.model.setState(.idle)
+                self?.eventDelegate?.updateDriverDidDismissError()
             },
             technicalDetails: details,
             feedURLString: lastFeedURLString
@@ -218,10 +222,7 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
 
     private func beginChecking(cancel: @escaping () -> Void) {
         model.setOverrideState(nil)
-        pendingCheckTransitionTask?.cancel()
-        pendingCheckTransitionTask = nil
-        checkTimeoutTask?.cancel()
-        checkTimeoutTask = nil
+        finishPendingCheckTransitionAsSuperseded()
         lastCheckStart = Date()
         applyState(.checking(.init(cancellationHandler: { [weak self] source in
             guard let self else {
@@ -237,14 +238,10 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
                 self.setState(.idle)
             }
         })))
-        scheduleCheckTimeout()
     }
 
     private func setStateAfterMinimumCheckDelay(_ newState: UpdateState) {
-        pendingCheckTransitionTask?.cancel()
-        pendingCheckTransitionTask = nil
-        checkTimeoutTask?.cancel()
-        checkTimeoutTask = nil
+        finishPendingCheckTransitionAsSuperseded()
 
         guard let start = lastCheckStart else {
             lastCheckStart = nil
@@ -260,34 +257,71 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
         }
 
         let delay = minimumCheckDuration - elapsed
+        let transitionID = UUID()
+        pendingCheckTransition = (transitionID, newState)
         pendingCheckTransitionTask = Task { @MainActor [weak self] in
             // Bounded, cancellable minimum-display delay via the injected clock.
             try? await self?.clock.sleep(for: .seconds(delay))
             guard !Task.isCancelled, let self else { return }
-            guard case .checking = self.model.state else { return }
+            guard let pending = self.pendingCheckTransition,
+                  pending.id == transitionID else { return }
+            self.pendingCheckTransition = nil
+            self.pendingCheckTransitionTask = nil
             self.lastCheckStart = nil
-            self.applyState(newState)
+            guard case .checking = self.model.state else {
+                pending.state.finishAsSuperseded()
+                return
+            }
+            self.applyState(pending.state)
         }
     }
 
     private func setState(_ newState: UpdateState) {
-        pendingCheckTransitionTask?.cancel()
-        pendingCheckTransitionTask = nil
-        checkTimeoutTask?.cancel()
-        checkTimeoutTask = nil
+        finishPendingCheckTransitionAsSuperseded()
         lastCheckStart = nil
         applyState(newState)
     }
 
-    private func scheduleCheckTimeout() {
-        checkTimeoutTask?.cancel()
-        checkTimeoutTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            // Bounded, cancellable check-timeout deadline via the injected clock.
-            try? await self.clock.sleep(for: .seconds(self.checkTimeoutDuration))
-            guard !Task.isCancelled else { return }
-            guard case .checking = self.model.state else { return }
-            self.setState(.notFound(.init(acknowledgement: {})))
+    /// Finishes a Sparkle result that arrived but is still waiting behind the minimum checking
+    /// display. A replacement request cannot discard the result's lifecycle callback.
+    func finishPendingCheckTransitionAsSuperseded() {
+        pendingCheckTransitionTask?.cancel()
+        pendingCheckTransitionTask = nil
+        guard let pending = pendingCheckTransition else { return }
+        pendingCheckTransition = nil
+        pending.state.finishAsSuperseded()
+    }
+
+    /// Converts Sparkle's no-update metadata into the exact terminal cmux should present.
+    /// A missing or future reason stays unknown; it must never be promoted to "latest".
+    private func notFoundReason(for error: any Error) -> UpdateState.NotFound.Reason {
+        let nsError = error as NSError
+        let rawReason = (nsError.userInfo[SPUNoUpdateFoundReasonKey] as? NSNumber)?.intValue
+        let reason = rawReason.flatMap { SPUNoUpdateFoundReason(rawValue: OSStatus($0)) }
+        let latestItem = nsError.userInfo[SPULatestAppcastItemFoundKey] as? SUAppcastItem
+        let latestVersion = latestItem?.displayVersionString.nilIfEmpty
+
+        switch reason {
+        case .onLatestVersion:
+            return .upToDate
+        case .onNewerThanLatestVersion:
+            return .newerThanLatest(latestVersion: latestVersion)
+        case .systemIsTooOld:
+            return .systemTooOld(
+                latestVersion: latestVersion,
+                minimumSystemVersion: latestItem?.minimumSystemVersion?.nilIfEmpty
+            )
+        case .systemIsTooNew:
+            return .systemTooNew(
+                latestVersion: latestVersion,
+                maximumSystemVersion: latestItem?.maximumSystemVersion?.nilIfEmpty
+            )
+        case .hardwareDoesNotSupportARM64:
+            return .unsupportedHardware(latestVersion: latestVersion)
+        case .unknown, .none:
+            return .unknown
+        @unknown default:
+            return .unknown
         }
     }
 
@@ -366,5 +400,11 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
         case .installing(let installing):
             return "installing(auto=\(installing.isAutoUpdate))"
         }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriverEventDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriverEventDelegate.swift
@@ -10,6 +10,20 @@ protocol UpdateDriverEventDelegate: AnyObject {
     /// Sparkle ended an update session, so a queued replacement check may safely start.
     func updateDriverDidFinishCycle(_ updateCheck: SPUUpdateCheck, error: NSError?)
 
+    /// Sparkle is about to present a no-update result. Snapshot the originating operation so an
+    /// indeterminate result can retry without downgrading an accepted install.
+    func updateDriverWillPresentNoUpdate()
+
+    /// Sparkle is about to present an error. Snapshot the operation intent before the model's
+    /// error state ends any active coordinator lifecycle.
+    func updateDriverDidPresentError()
+
+    /// The user asked to retry the Sparkle operation that produced the current error.
+    func updateDriverRequestsRetryAfterError()
+
+    /// The user dismissed the current Sparkle error.
+    func updateDriverDidDismissError()
+
     /// The user explicitly cancelled the foreground check.
     func updateDriverUserDidCancelCheck()
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateFeedResolver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateFeedResolver.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 /// Stable releases ship with the stable appcast URL and `cmux NIGHTLY` has the nightly
 /// appcast URL injected by CI. When the `Info.plist` value is missing or empty the resolver
-/// falls back to the latest-release appcast so the updater still has a feed to query.
+/// falls back to the atomic stable appcast so the updater still has a feed to query.
 ///
 /// ```swift
 /// let resolver = UpdateFeedResolver()
@@ -37,8 +37,8 @@ public struct UpdateFeedResolver: Sendable {
     /// Creates a resolver.
     ///
     /// - Parameter fallbackFeedURL: The appcast URL to fall back to when the build-time
-    ///   feed URL is absent. Defaults to the project's latest-release appcast.
-    public init(fallbackFeedURL: String = "https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml") {
+    ///   feed URL is absent. Defaults to the project's atomic stable appcast.
+    public init(fallbackFeedURL: String = "https://files.cmux.com/stable/appcast.xml") {
         self.fallbackFeedURL = fallbackFeedURL
     }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReply.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReply.swift
@@ -9,28 +9,28 @@ import Foundation
 /// prompt" from "the model state was clobbered by an unrelated emission" (for example a stale
 /// prompt's Sparkle dismiss callback landing after a fresh check already resolved).
 @MainActor
-public final class UpdatePromptReply {
+final class UpdatePromptReply {
     let id = UUID()
     private var handler: (@Sendable (SPUUserUpdateChoice) -> Void)?
     var onConsumed: ((UpdatePromptReply, SPUUserUpdateChoice, UpdatePromptReplySource) -> Void)?
 
     /// The first choice sent to Sparkle, or `nil` until this prompt is answered.
-    public private(set) var consumedChoice: SPUUserUpdateChoice?
+    private(set) var consumedChoice: SPUUserUpdateChoice?
     /// The cause of the first choice, or `nil` until this prompt is answered.
     private(set) var consumedSource: UpdatePromptReplySource?
 
     /// Wraps `handler` so it runs on the first call only.
-    public init(_ handler: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
+    init(_ handler: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
         self.handler = handler
     }
 
     /// Whether a choice has already been sent.
-    public var isConsumed: Bool {
+    var isConsumed: Bool {
         consumedChoice != nil
     }
 
     /// Sends `choice` to Sparkle; subsequent calls are no-ops.
-    public func callAsFunction(_ choice: SPUUserUpdateChoice) {
+    func callAsFunction(_ choice: SPUUserUpdateChoice) {
         consume(choice, source: .user)
     }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateSettings.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateSettings.swift
@@ -40,7 +40,8 @@ public struct UpdateSettings: Sendable {
     ///
     /// Registration is idempotent. The migration (guarded by ``migrationKey``) re-enables
     /// automatic checks and upgrades the legacy 24h interval to ``scheduledCheckInterval`` for
-    /// installs that predate the embedded defaults.
+    /// installs that predate the embedded defaults. Automatic downloads are always disabled:
+    /// every user-driven install must pass through the authoritative fresh-check pipeline.
     public func apply(to defaults: UserDefaults) {
         defaults.register(defaults: [
             Self.automaticChecksKey: true,
@@ -48,6 +49,11 @@ public struct UpdateSettings: Sendable {
             Self.scheduledCheckIntervalKey: scheduledCheckInterval,
             Self.sendProfileInfoKey: false,
         ])
+
+        // A persisted `true` makes Sparkle's background driver install the appcast item captured
+        // by an earlier check. That bypasses cmux's fresh resolution and can produce an immediate
+        // second update after relaunch, so this is a product policy rather than a default.
+        defaults.set(false, forKey: Self.automaticallyUpdateKey)
 
         guard !defaults.bool(forKey: Self.migrationKey) else { return }
 
@@ -65,9 +71,6 @@ public struct UpdateSettings: Sendable {
             defaults.set(scheduledCheckInterval, forKey: Self.scheduledCheckIntervalKey)
         }
 
-        if defaults.object(forKey: Self.automaticallyUpdateKey) == nil {
-            defaults.set(false, forKey: Self.automaticallyUpdateKey)
-        }
         if defaults.object(forKey: Self.sendProfileInfoKey) == nil {
             defaults.set(false, forKey: Self.sendProfileInfoKey)
         }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
@@ -39,21 +39,13 @@ public enum UpdateState: Equatable {
         return false
     }
 
-    /// Whether the flow is in a phase that the "force install" path can drive to completion
-    /// by repeatedly confirming (checking through installing).
+    /// Whether an update prompt is currently available to install.
+    ///
+    /// Progress states are deliberately excluded. Advertising another install action while a
+    /// check or install is already running makes the menu claim an action that will be ignored.
     public var isInstallable: Bool {
-        switch self {
-        case .preparingCheck,
-                .checking,
-                .updateAvailable,
-                .startingDownload,
-                .downloading,
-                .extracting,
-                .installing:
-            return true
-        default:
-            return false
-        }
+        if case .updateAvailable = self { return true }
+        return false
     }
 
     /// Invokes the phase-appropriate cancellation/acknowledgement callback.
@@ -62,7 +54,7 @@ public enum UpdateState: Equatable {
         case .preparingCheck(let checking), .checking(let checking):
             checking.cancel()
         case .updateAvailable(let available):
-            available.reply(.dismiss)
+            available.dismiss()
         case .downloading(let downloading):
             downloading.cancel()
         case .notFound(let notFound):
@@ -88,16 +80,6 @@ public enum UpdateState: Equatable {
         }
     }
 
-    /// Confirms the current phase, installing the update when one is available.
-    @MainActor public func confirm() {
-        switch self {
-        case .updateAvailable(let available):
-            available.reply(.install)
-        default:
-            break
-        }
-    }
-
     public static func == (lhs: UpdateState, rhs: UpdateState) -> Bool {
         switch (lhs, rhs) {
         case (.idle, .idle):
@@ -110,8 +92,8 @@ public enum UpdateState: Equatable {
             return true
         case (.updateAvailable(let lUpdate), .updateAvailable(let rUpdate)):
             return lUpdate.appcastItem.displayVersionString == rUpdate.appcastItem.displayVersionString
-        case (.notFound, .notFound):
-            return true
+        case (.notFound(let lResult), .notFound(let rResult)):
+            return lResult.reason == rResult.reason
         case (.error(let lErr), .error(let rErr)):
             return lErr.error.localizedDescription == rErr.error.localizedDescription
         case (.startingDownload, .startingDownload):
@@ -129,14 +111,132 @@ public enum UpdateState: Equatable {
 
     /// Payload for ``UpdateState/notFound(_:)``.
     public struct NotFound {
+        /// Identity for matching delayed presentation and dismissal work to this exact result.
+        let id = UUID()
+        /// Sparkle's authoritative reason that no installable update was returned.
+        public enum Reason: Equatable {
+            /// The installed build matches the latest build in the appcast.
+            case upToDate
+            /// The installed build is newer than the latest build in the appcast.
+            case newerThanLatest(latestVersion: String?)
+            /// The newest update requires a newer macOS version.
+            case systemTooOld(latestVersion: String?, minimumSystemVersion: String?)
+            /// The newest update does not support this macOS version.
+            case systemTooNew(latestVersion: String?, maximumSystemVersion: String?)
+            /// The newest update requires Apple silicon.
+            case unsupportedHardware(latestVersion: String?)
+            /// Development and staging builds do not participate in the public update channel.
+            case developmentBuild
+            /// Sparkle did not provide a reason that cmux understands.
+            case unknown
+        }
+
+        /// Why no update can be offered.
+        public let reason: Reason
         /// Tells Sparkle the "no update" result was acknowledged/dismissed.
         public let acknowledgement: () -> Void
 
         /// Creates the payload.
         ///
+        /// - Parameter reason: The authoritative reason no update can be offered.
         /// - Parameter acknowledgement: Tells Sparkle the result was acknowledged.
-        public init(acknowledgement: @escaping () -> Void) {
+        public init(reason: Reason = .upToDate, acknowledgement: @escaping () -> Void) {
+            self.reason = reason
             self.acknowledgement = acknowledgement
+        }
+
+        /// Whether this low-information success may disappear after the standard short delay.
+        /// Compatibility, development-build, and unknown results stay visible until acknowledged.
+        public var automaticallyDismisses: Bool {
+            switch reason {
+            case .upToDate, .newerThanLatest:
+                return true
+            case .systemTooOld, .systemTooNew, .unsupportedHardware, .developmentBuild, .unknown:
+                return false
+            }
+        }
+
+        /// A truthful localized title for this result.
+        public var title: String {
+            switch reason {
+            case .upToDate:
+                return String(localized: "update.notFound.upToDate.title", defaultValue: "No Updates Available")
+            case .newerThanLatest:
+                return String(localized: "update.notFound.newerThanLatest.title", defaultValue: "No Update Needed")
+            case .systemTooOld, .systemTooNew, .unsupportedHardware:
+                return String(localized: "update.notFound.incompatible.title", defaultValue: "Update Not Compatible")
+            case .developmentBuild:
+                return String(localized: "update.notFound.development.title", defaultValue: "Updates Unavailable for This Build")
+            case .unknown:
+                return String(localized: "update.notFound.unknown.title", defaultValue: "Update Status Unknown")
+            }
+        }
+
+        /// A truthful localized explanation for this result.
+        public var message: String {
+            switch reason {
+            case .upToDate:
+                return String(
+                    localized: "update.notFound.upToDate.message",
+                    defaultValue: "You are running the latest version currently available."
+                )
+            case .newerThanLatest(let latestVersion):
+                if let latestVersion, !latestVersion.isEmpty {
+                    return String(
+                        localized: "update.notFound.newerThanLatest.withVersion.message",
+                        defaultValue: "This cmux build is newer than the latest published version (\(latestVersion))."
+                    )
+                }
+                return String(
+                    localized: "update.notFound.newerThanLatest.message",
+                    defaultValue: "This cmux build is newer than the latest published version."
+                )
+            case .systemTooOld(let latestVersion, let minimumSystemVersion):
+                if let latestVersion, !latestVersion.isEmpty,
+                   let minimumSystemVersion, !minimumSystemVersion.isEmpty {
+                    return String(
+                        localized: "update.notFound.systemTooOld.withVersions.message",
+                        defaultValue: "cmux \(latestVersion) requires macOS \(minimumSystemVersion) or later. Upgrade macOS, then try again."
+                    )
+                }
+                return String(
+                    localized: "update.notFound.systemTooOld.message",
+                    defaultValue: "The latest cmux update requires a newer version of macOS. Upgrade macOS, then try again."
+                )
+            case .systemTooNew(let latestVersion, let maximumSystemVersion):
+                if let latestVersion, !latestVersion.isEmpty,
+                   let maximumSystemVersion, !maximumSystemVersion.isEmpty {
+                    return String(
+                        localized: "update.notFound.systemTooNew.withVersions.message",
+                        defaultValue: "cmux \(latestVersion) supports macOS through \(maximumSystemVersion). Try again when a compatible version is published."
+                    )
+                }
+                return String(
+                    localized: "update.notFound.systemTooNew.message",
+                    defaultValue: "The latest cmux update does not support this macOS version. Try again when a compatible version is published."
+                )
+            case .unsupportedHardware(let latestVersion):
+                if let latestVersion, !latestVersion.isEmpty {
+                    return String(
+                        localized: "update.notFound.unsupportedHardware.withVersion.message",
+                        defaultValue: "cmux \(latestVersion) requires a Mac with Apple silicon."
+                    )
+                }
+                return String(
+                    localized: "update.notFound.unsupportedHardware.message",
+                    defaultValue: "The latest cmux update requires a Mac with Apple silicon."
+                )
+            case .developmentBuild:
+                return String(
+                    localized: "update.notFound.development.message",
+                    defaultValue: "Development and staging builds do not receive updates from the public release channel."
+                )
+            case .unknown:
+                return String(
+                    localized: "update.notFound.unknown.message",
+                    defaultValue: "cmux could not determine whether a compatible update is available. Try again."
+                )
+            }
         }
     }
 
@@ -184,8 +284,9 @@ public enum UpdateState: Equatable {
     public struct UpdateAvailable {
         /// The appcast item describing the available update.
         public let appcastItem: SUAppcastItem
-        /// Replies to Sparkle with the user's install/dismiss choice (at most once).
-        public let reply: UpdatePromptReply
+        /// The one-shot Sparkle reply. Kept internal so external UI cannot bypass the
+        /// controller-owned install-latest flow with a captured appcast item.
+        let reply: UpdatePromptReply
 
         /// Creates the payload.
         @MainActor public init(appcastItem: SUAppcastItem, reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
@@ -198,9 +299,20 @@ public enum UpdateState: Equatable {
             self.reply = reply
         }
 
-        /// A link to the release notes for this update, derived from its version string.
+        /// Skips this version in Sparkle.
+        @MainActor public func skip() {
+            reply(.skip)
+        }
+
+        /// Dismisses this prompt without installing its captured appcast item.
+        @MainActor public func dismiss() {
+            reply(.dismiss)
+        }
+
+        /// A link to the release notes for this update. Appcast metadata is authoritative; the
+        /// version-derived GitHub URL is a fallback for older feeds without a notes link.
         public var releaseNotes: ReleaseNotes? {
-            ReleaseNotes(displayVersionString: appcastItem.displayVersionString)
+            ReleaseNotes(appcastItem: appcastItem)
         }
     }
 
@@ -210,6 +322,16 @@ public enum UpdateState: Equatable {
         case commit(URL)
         /// The version maps to a semantic-version tag; links to the release page.
         case tagged(URL)
+
+        /// Resolves release notes from an appcast item. The feed's explicit URL is authoritative;
+        /// deriving a GitHub URL from the display version only supports older feeds.
+        public init?(appcastItem: SUAppcastItem) {
+            if let appcastURL = appcastItem.fullReleaseNotesURL ?? appcastItem.releaseNotesURL {
+                self = .tagged(appcastURL)
+                return
+            }
+            self.init(displayVersionString: appcastItem.displayVersionString)
+        }
 
         /// Derives a release-notes link from a display version string, returning `nil` when
         /// the string contains neither a semantic version nor a git hash.

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel+ErrorFormatting.swift
@@ -52,7 +52,10 @@ extension UpdateStateModel {
         if nsError.domain == SUSparkleErrorDomain {
             switch nsError.code {
             case 4005:
-                return String(localized: "update.error.permissionError.title", defaultValue: "Updater Permission Error")
+                return String(
+                    localized: "update.error.installationFailed.title",
+                    defaultValue: "Update Installation Failed"
+                )
             case 2001:
                 return String(localized: "update.error.downloadFailed.title", defaultValue: "Couldn't Download Update")
             case 1000, 1002:
@@ -76,6 +79,20 @@ extension UpdateStateModel {
     public static func userFacingErrorMessage(for error: any Swift.Error) -> String {
         let nsError = error as NSError
         if nsError.domain == updateErrorDomain {
+            if nsError.code == installDidNotStartCode {
+                // Use the canonical recovery copy for this typed error instead of trusting an
+                // older embedded description that may have guessed the failure was networking.
+                return String(
+                    localized: "update.error.didNotStart.recovery.message",
+                    defaultValue: "cmux couldn’t start the update. Try again, or download the latest version below."
+                )
+            }
+            if nsError.code == updaterNotReadyCode {
+                return String(
+                    localized: "update.error.notReady",
+                    defaultValue: "The updater isn’t ready to check yet. Try again in a moment."
+                )
+            }
             // cmux-originated errors already carry user-ready, localized copy.
             let description = nsError.localizedDescription
             if !description.isEmpty {
@@ -85,15 +102,24 @@ extension UpdateStateModel {
         if let networkError = networkError(from: nsError) {
             switch networkError.code {
             case NSURLErrorNotConnectedToInternet:
-                return String(localized: "update.error.noInternet.message", defaultValue: "cmux can’t reach the update server. Check your internet connection and try again.")
+                return String(
+                    localized: "update.error.noInternetService.message",
+                    defaultValue: "cmux can’t reach the update service. Check your internet connection and try again."
+                )
             case NSURLErrorTimedOut:
-                return String(localized: "update.error.timedOut.message", defaultValue: "The update server took too long to respond. Try again in a moment.")
+                return String(
+                    localized: "update.error.operationTimedOut.message",
+                    defaultValue: "The update operation timed out. Try again in a moment."
+                )
             case NSURLErrorCannotFindHost:
                 return String(localized: "update.error.serverNotFound.message", defaultValue: "The update server can’t be found. Check your connection or try again later.")
             case NSURLErrorCannotConnectToHost:
                 return String(localized: "update.error.serverUnreachable.message", defaultValue: "cmux couldn’t connect to the update server. Check your connection or try again later.")
             case NSURLErrorNetworkConnectionLost:
-                return String(localized: "update.error.connectionLost.message", defaultValue: "The network connection was lost while checking for updates. Try again.")
+                return String(
+                    localized: "update.error.connectionLostDuringUpdate.message",
+                    defaultValue: "The network connection was lost while updating cmux. Try again."
+                )
             case NSURLErrorSecureConnectionFailed,
                  NSURLErrorServerCertificateUntrusted,
                  NSURLErrorServerCertificateHasBadDate,
@@ -104,10 +130,19 @@ extension UpdateStateModel {
                 break
             }
         }
+        if isUpdaterAgentConnectionFailure(nsError) {
+            return String(
+                localized: "update.error.installRecovery.message",
+                defaultValue: "Move cmux into Applications and relaunch to enable updates. If it’s already in Applications, restart your Mac and try again, or download the latest version below."
+            )
+        }
         if nsError.domain == SUSparkleErrorDomain {
             switch nsError.code {
             case 2001:
-                return String(localized: "update.error.feedDownload.message", defaultValue: "cmux couldn't download the update feed. Check your connection and try again.")
+                return String(
+                    localized: "update.error.download.message",
+                    defaultValue: "cmux couldn’t download the update. Check your connection and try again."
+                )
             case 1000, 1002:
                 return String(localized: "update.error.feedRead.message", defaultValue: "The update feed could not be read. Please try again later.")
             case 4:
@@ -118,7 +153,14 @@ extension UpdateStateModel {
                 return String(localized: "update.error.signatureError.message", defaultValue: "The update's signature could not be verified. Please try again later.")
             case 1003, 1005:
                 return String(localized: "update.error.permissionError.message", defaultValue: "Move cmux into Applications and relaunch to enable updates.")
-            case 4005, 4010:
+            case 4005:
+                return String(
+                    localized: "update.error.installationFailed.message",
+                    defaultValue: "cmux couldn’t install the update automatically. Try again, or download the latest version below."
+                )
+            case 4010:
+                // `isUpdaterAgentConnectionFailure` handles this above. Keep the fallback precise
+                // if Sparkle changes how this code is wrapped in a future release.
                 return String(localized: "update.error.installRecovery.message", defaultValue: "Move cmux into Applications and relaunch to enable updates. If it’s already in Applications, restart your Mac and try again, or download the latest version below.")
             default:
                 break
@@ -126,7 +168,10 @@ extension UpdateStateModel {
         }
         // Catch-all: keep user-facing copy in cmux terms; raw vendor descriptions, domains, and
         // codes stay in `errorDetails` (the copyable Details block + the update log), not here.
-        return String(localized: "update.error.failed.message", defaultValue: "Something went wrong while checking for updates. Try again, or check the update log for details.")
+        return String(
+            localized: "update.error.operationFailed.message",
+            defaultValue: "Something went wrong while updating cmux. Try again, or check the update log for details."
+        )
     }
 
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel.swift
@@ -187,7 +187,7 @@ public final class UpdateStateModel {
             retry: { [weak self] in self?.setOverrideState(nil) },
             dismiss: { [weak self] in self?.setOverrideState(nil) },
             technicalDetails: "debug scenario: \(scenario.rawValue)",
-            feedURLString: "https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml"
+            feedURLString: "https://files.cmux.com/stable/appcast.xml"
         )))
     }
     #endif
@@ -199,14 +199,14 @@ public final class UpdateStateModel {
 
         var didDismissUpdate = false
         if case .updateAvailable(let update) = state {
-            update.reply(.dismiss)
+            update.dismiss()
             didDismissUpdate = true
             setState(.idle)
         }
 
         if let overrideState, case .updateAvailable(let update) = overrideState {
             if !didDismissUpdate {
-                update.reply(.dismiss)
+                update.dismiss()
             }
             setOverrideState(nil)
         }
@@ -270,8 +270,8 @@ public final class UpdateStateModel {
             return String(localized: "update.extracting.progress", defaultValue: "Preparing: \(percent)")
         case .installing(let install):
             return install.isAutoUpdate ? String(localized: "update.restartToComplete", defaultValue: "Restart to Complete Update") : String(localized: "update.installing.status", defaultValue: "Installing…")
-        case .notFound:
-            return String(localized: "update.noUpdates.title", defaultValue: "No Updates Available")
+        case .notFound(let result):
+            return result.title
         case .error(let err):
             return Self.userFacingErrorTitle(for: err.error)
         case .startingDownload:
@@ -332,7 +332,10 @@ public final class UpdateStateModel {
         case .permissionRequest:
             return String(localized: "update.configureAutoUpdates", defaultValue: "Configure automatic update preferences")
         case .preparingCheck:
-            return String(localized: "update.preparingCheck.message", defaultValue: "Waiting for the current update session to finish")
+            return String(
+                localized: "update.preparingCheck.readiness.message",
+                defaultValue: "Waiting for the updater to become ready"
+            )
         case .checking:
             return String(localized: "update.pleaseWait", defaultValue: "Please wait while we check for available updates")
         case .updateAvailable(let update):
@@ -343,8 +346,8 @@ public final class UpdateStateModel {
             return String(localized: "update.preparingUpdate", defaultValue: "Extracting and preparing the update")
         case let .installing(install):
             return install.isAutoUpdate ? String(localized: "update.restartToComplete", defaultValue: "Restart to Complete Update") : String(localized: "update.installingAndRestarting", defaultValue: "Installing update and preparing to restart")
-        case .notFound:
-            return String(localized: "update.noUpdates.message", defaultValue: "You are running the latest version")
+        case .notFound(let result):
+            return result.message
         case .error(let err):
             return Self.userFacingErrorMessage(for: err.error)
         case .startingDownload:

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateTiming.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateTiming.swift
@@ -4,8 +4,8 @@ public import Foundation
 ///
 /// These are intentionally declarations (constant values), not behavior, so a no-case
 /// `enum` namespace is appropriate here. They are consumed by ``UpdateDriver`` (to keep a
-/// check visible for a minimum duration and to time out a stalled check) and by
-/// ``UpdateController`` (to auto-dismiss the "no updates" result).
+/// check visible for a minimum duration) and by ``UpdateController`` (to auto-dismiss the
+/// authoritative "no updates" result).
 public enum UpdateTiming {
     /// Minimum time the "Checking for Updates…" state stays visible before transitioning,
     /// so a near-instant check still reads as a deliberate action rather than a flicker.
@@ -14,14 +14,9 @@ public enum UpdateTiming {
     /// How long the "No Updates Available" result stays visible before auto-dismissing.
     public static let noUpdateDisplayDuration: TimeInterval = 5.0
 
-    /// How long a check may stay in the "checking" state before it is treated as a
-    /// silent "no updates" result (covers a Sparkle check that never calls back).
-    public static let checkTimeoutDuration: TimeInterval = 10.0
-
 }
 
-/// How long after the user asks to install an update the flow may stay in a non-progressing
-/// state (still checking or still merely "update available") before the updater surfaces a
-/// visible "Update Didn't Start" error instead of silently doing nothing. Kept internal because
-/// this is controller policy, not public timing API.
+/// How long the install flow may wait for Sparkle to start a fresh check or begin downloading an
+/// accepted item before surfacing "Update Didn't Start." The authoritative feed check itself is
+/// intentionally unbounded. Kept internal because this is controller policy, not public API.
 let installWatchdogTimeout: TimeInterval = 25.0

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
@@ -106,12 +106,12 @@ import Testing
         }
     }
 
-    @Test func stopsMonitoringWhenFreshCheckFindsNothing() {
+    @Test func freshCheckFindingNothingPreservesUpToDateResult() {
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
         coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
-        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .installFailed)
+        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .none)
         #expect(!coordinator.isMonitoring)
     }
 

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
@@ -84,6 +84,42 @@ import Testing
         #expect(!controller.model.description.localizedCaseInsensitiveContains("running the latest"))
     }
 
+    /// Retry from the production "Update Didn't Start" error must retain install-latest intent,
+    /// then terminate truthfully when the tagged DEV build is ineligible for public updates.
+    @Test func installDidNotStartRetryOnDevBuildShowsDevelopmentOutcome() throws {
+        let suiteName = "com.cmuxterm.updatertests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let controller = UpdateController(
+            log: NoopUpdateLog(),
+            clock: SystemUpdateClock(),
+            hostBundle: .main,
+            defaults: defaults,
+            isDevLikeBundle: true
+        )
+        controller.setInstallDidNotStartError(diagnostic: "test setup")
+        guard case .error(let failure) = controller.model.state else {
+            Issue.record("failed to create retryable install error")
+            return
+        }
+
+        failure.retry()
+
+        guard case .notFound(let result) = controller.model.state else {
+            Issue.record("Retry did not reach a no-update terminal: \(controller.model.state)")
+            return
+        }
+        #expect(result.reason == .developmentBuild)
+        #expect(result.title.localizedCaseInsensitiveContains("unavailable"))
+        #expect(result.message.localizedCaseInsensitiveContains("development"))
+        #expect(!result.message.localizedCaseInsensitiveContains("internet"))
+        #expect(!result.message.localizedCaseInsensitiveContains("latest version"))
+        #expect(!controller.updater.sessionInProgress)
+        #expect(!controller.attemptCoordinator.isMonitoring)
+        #expect(!controller.installWatchdog.isArmed)
+    }
+
     /// A DEV/staging build disables Sparkle's automatic checks so its scheduler never queries the
     /// public appcast. (The override is also re-asserted before `start()`, so the DEBUG
     /// permission-reset path cannot undo it.)

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/DevStagingUpdateGatingTests.swift
@@ -59,8 +59,8 @@ import Testing
     }
 
     /// A manual "Check for Updates" on a DEV/staging build must not query the public appcast or
-    /// offer the public release for install — it short-circuits to "No Updates Available" before
-    /// starting Sparkle. (Manual checks are the path that survived the passive-pill gating.)
+    /// offer the public release for install. Its terminal must explain that this build does not
+    /// participate in public updates instead of falsely claiming it is the latest release.
     @Test func devLikeBundleManualCheckIsSuppressed() throws {
         let suiteName = "com.cmuxterm.updatertests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
@@ -80,6 +80,8 @@ import Testing
             Issue.record("dev/staging manual check should surface .notFound, got \(controller.model.state)")
             return
         }
+        #expect(controller.model.description.localizedCaseInsensitiveContains("development"))
+        #expect(!controller.model.description.localizedCaseInsensitiveContains("running the latest"))
     }
 
     /// A DEV/staging build disables Sparkle's automatic checks so its scheduler never queries the
@@ -114,6 +116,27 @@ import Testing
             isDevLikeBundle: false
         )
         #expect(defaults.bool(forKey: UpdateSettings.automaticChecksKey) == true)
+    }
+
+    /// Persisted automatic downloads bypass the fresh-check install path by installing an older
+    /// captured appcast item on quit. Every startup must migrate that preference back to false,
+    /// even when the older settings migration already ran.
+    @Test func publicBundleForcesPersistedAutomaticDownloadsOff() throws {
+        let suiteName = "com.cmuxterm.updatertests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: UpdateSettings.automaticallyUpdateKey)
+        defaults.set(true, forKey: UpdateSettings.migrationKey)
+
+        _ = UpdateController(
+            log: NoopUpdateLog(),
+            clock: SystemUpdateClock(),
+            hostBundle: .main,
+            defaults: defaults,
+            isDevLikeBundle: false
+        )
+
+        #expect(defaults.bool(forKey: UpdateSettings.automaticallyUpdateKey) == false)
     }
 
     /// Builds a minimal valid `SUAppcastItem` for a version string (nested helper, not API).

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/InstallWatchdogTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/InstallWatchdogTests.swift
@@ -44,13 +44,14 @@ import Testing
         ]
     }
 
-    /// The watchdog reports a stall for every accepted-install phase that has not reached download
-    /// progress, plus unattributed idle (every causal user cancellation disarms first).
+    /// Only phases waiting for a check callback or accepted-download callback are bounded. A live
+    /// authoritative check may take arbitrarily long and an available prompt is handled by the
+    /// controller's coordinator rather than this transport deadline.
     @Test func stalledForNonProgressingStates() {
         for state in everyState {
             let stalled = watchdog.installAttemptStalled(state)
             switch state {
-            case .preparingCheck, .checking, .updateAvailable, .startingDownload, .idle:
+            case .preparingCheck, .startingDownload, .idle:
                 #expect(stalled, "\(state) should count as stalled")
             default:
                 #expect(!stalled, "\(state) should NOT count as stalled")
@@ -77,6 +78,18 @@ import Testing
     @Test func stalledAndResolvedAreMutuallyExclusive() {
         for state in everyState {
             #expect(!(watchdog.installAttemptStalled(state) && watchdog.installAttemptResolved(state)))
+        }
+    }
+
+    /// Menu/UI install affordances are truthful only while an update prompt is actually
+    /// available. Checking and active progress phases must not advertise another install action.
+    @Test func onlyAnAvailablePromptIsInstallable() {
+        for state in everyState {
+            if case .updateAvailable = state {
+                #expect(state.isInstallable)
+            } else {
+                #expect(!state.isInstallable, "\(state) must not advertise Install Update")
+            }
         }
     }
 
@@ -204,6 +217,7 @@ import Testing
         let message = UpdateStateModel.userFacingErrorMessage(for: error)
         #expect(title == "Update Didn’t Start")
         #expect(message.contains("couldn’t start the update"))
+        #expect(!message.localizedCaseInsensitiveContains("internet"))
         #expect(title != "Update Failed")
     }
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyEventSpy.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyEventSpy.swift
@@ -8,6 +8,10 @@ final class PromptReplyEventSpy: UpdateDriverEventDelegate {
     private(set) var promptDismissalCount = 0
 
     func updateDriverDidFinishCycle(_ updateCheck: SPUUpdateCheck, error: NSError?) {}
+    func updateDriverWillPresentNoUpdate() {}
+    func updateDriverDidPresentError() {}
+    func updateDriverRequestsRetryAfterError() {}
+    func updateDriverDidDismissError() {}
     func updateDriverUserDidCancelCheck() {}
     func updateDriverUserDidDismissPrompt() { promptDismissalCount += 1 }
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
@@ -32,6 +32,12 @@ actor TestDeadlineClock: UpdateClock {
         // A test may request a deadline and immediately release it before the task running
         // `sleep(for:)` reaches the actor. Poll that real registration signal without timing
         // sleeps, but bound the poll so a missing deadline fails instead of hanging the suite.
+        await waitForDeadlineToArm()
+        guard !parked.isEmpty else { return }
+        fireDeadlines()
+    }
+
+    func waitForDeadlineToArm() async {
         let clock = ContinuousClock()
         let timeout = clock.now.advanced(by: .seconds(2))
         while parked.isEmpty, clock.now < timeout {
@@ -41,7 +47,6 @@ actor TestDeadlineClock: UpdateClock {
             Issue.record("timed out waiting for a test deadline to be armed")
             return
         }
-        fireDeadlines()
     }
 
     private func cancelParked(_ id: UUID) {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -371,10 +371,10 @@ import Testing
         #expect(freshPrompt.choice == nil)
     }
 
-    /// A retryable accepted-install failure must also resolve the Sparkle terminal it replaces.
-    /// Otherwise Sparkle still owns an unanswered session and the Retry action can no-op behind
-    /// the visible error.
-    @Test func acceptedInstallFailureAcknowledgesReplacedSparkleTerminal() async {
+    /// A fresh install check can legitimately find nothing when this app already matches the
+    /// latest release. Preserve Sparkle's visible "up to date" terminal instead of replacing it
+    /// with an install failure.
+    @Test func acceptedInstallFindingNothingShowsUpToDate() async {
         let harness = Harness()
         let stalePrompt = ChoiceBox()
         var didAcknowledgeNotFound = false
@@ -389,10 +389,46 @@ import Testing
             didAcknowledgeNotFound = true
         })))
 
-        await waitUntil("accepted-install error") {
-            errorCode(for: harness.model.state) == UpdateStateModel.installDidNotStartCode
+        await waitUntil("accepted install to finish") {
+            !harness.controller.attemptCoordinator.isMonitoring
         }
-        #expect(didAcknowledgeNotFound)
+        guard case .notFound = harness.model.state else {
+            Issue.record("fresh check result was replaced by \(harness.model.state)")
+            return
+        }
+        #expect(!didAcknowledgeNotFound)
+        #expect(!harness.controller.installWatchdog.isArmed)
+    }
+
+    /// Regression: Retry from "Update Didn't Start" must not recreate the same error when the
+    /// installed app already matches the latest version in the feed.
+    @Test func retryWhenAlreadyCurrentShowsUpToDateInsteadOfRepeatingInstallError() async {
+        let harness = Harness()
+        var didAcknowledgeNotFound = false
+
+        harness.controller.setInstallDidNotStartError(diagnostic: "test setup")
+        guard case .error(let failure) = harness.model.state else {
+            Issue.record("failed to create retryable install error")
+            return
+        }
+
+        failure.retry()
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(.notFound(.init(acknowledgement: {
+            didAcknowledgeNotFound = true
+        })))
+        harness.finishSparkleCycle()
+
+        await waitUntil("retry to finish") {
+            !harness.controller.attemptCoordinator.isMonitoring
+        }
+        guard case .notFound = harness.model.state else {
+            Issue.record("retry recreated install error: \(harness.model.state)")
+            return
+        }
+        #expect(!didAcknowledgeNotFound)
+        #expect(!harness.controller.installWatchdog.isArmed)
     }
 
     /// If the live prompt is still visible but already answered before the queued confirm

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -149,6 +149,218 @@ import Testing
         }
     }
 
+    /// Acceptance contract: the gap size is irrelevant. A client several releases behind must
+    /// dismiss its captured prompt and install the one full artifact returned by the fresh check,
+    /// without first installing an intermediate version.
+    @Test func severalVersionsBehindInstallsFreshLatestWithoutIntermediateUpdate() async {
+        let harness = Harness()
+        let capturedPrompt = ChoiceBox()
+        let latestPrompt = ChoiceBox()
+
+        harness.model.setState(updateAvailable("0.60.0", replyingInto: capturedPrompt))
+        harness.controller.attemptUpdate()
+        #expect(capturedPrompt.choice == .dismiss)
+
+        harness.finishSparkleCycle()
+        await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(updateAvailable("0.64.20", replyingInto: latestPrompt))
+
+        await waitUntil("latest prompt to be installed") { latestPrompt.choice == .install }
+        #expect(capturedPrompt.choice != .install)
+        #expect(harness.model.state == .startingDownload)
+    }
+
+    /// Retry belongs to the operation that failed. An accepted install that hits a Sparkle error
+    /// must retry as install-latest and auto-confirm the new prompt, not fall back to a manual
+    /// check that requires a second Install click.
+    @Test func sparkleErrorRetryPreservesInstallLatestIntent() async {
+        let harness = Harness()
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 2001,
+            userInfo: [NSLocalizedDescriptionKey: "download failed"]
+        )
+
+        harness.controller.attemptUpdate()
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        harness.controller.driver.showUpdaterError(error, acknowledgement: {})
+        harness.finishSparkleCycle(error: error)
+
+        guard case .error(let failure) = harness.model.state else {
+            Issue.record("Sparkle error was not visible")
+            return
+        }
+        failure.retry()
+
+        await waitUntil("retry to start another check") {
+            harness.updater.checkForUpdatesCallCount == 2
+        }
+        let latestPrompt = ChoiceBox()
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(updateAvailable("0.64.20", replyingInto: latestPrompt))
+
+        await waitUntil("retry to preserve install intent") { latestPrompt.choice == .install }
+    }
+
+    /// A queued install-latest request outranks the manual check it is waiting to replace. If the
+    /// old check errors, Retry must consume that queued request and resume it as one install flow.
+    @Test func queuedInstallIntentSurvivesActiveManualCheckError() async {
+        let harness = Harness()
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 2001,
+            userInfo: [NSLocalizedDescriptionKey: "download failed"]
+        )
+
+        harness.controller.checkForUpdates()
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        harness.controller.attemptUpdate()
+        #expect(harness.controller.pendingCheckIntent == .installLatest)
+
+        harness.controller.driver.showUpdaterError(error, acknowledgement: {})
+        #expect(harness.controller.pendingCheckIntent == nil)
+        harness.finishSparkleCycle(error: error)
+
+        guard case .error(let failure) = harness.model.state else {
+            Issue.record("Sparkle error was not visible")
+            return
+        }
+        failure.retry()
+
+        await waitUntil("install retry to start a fresh check") {
+            harness.updater.checkForUpdatesCallCount == 2
+        }
+        let latestPrompt = ChoiceBox()
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(updateAvailable("0.64.20", replyingInto: latestPrompt))
+
+        await waitUntil("queued install retry to confirm latest") { latestPrompt.choice == .install }
+    }
+
+    /// Retry on an indeterminate no-update result belongs to Update cmux, even though the result
+    /// itself ends the active attempt coordinator before the user presses Retry.
+    @Test func unknownNoUpdateRetryPreservesInstallLatestIntent() async {
+        let harness = Harness()
+        var acknowledgementCount = 0
+
+        harness.controller.attemptUpdate()
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        harness.controller.driver.showUpdateNotFoundWithError(
+            NSError(domain: SUSparkleErrorDomain, code: 1001),
+            acknowledgement: { acknowledgementCount += 1 }
+        )
+        await harness.clock.fireDeadlineWhenReady()
+        await waitUntil("unknown no-update result") {
+            if case .notFound(let result) = harness.model.state, case .unknown = result.reason {
+                return true
+            }
+            return false
+        }
+
+        harness.controller.retryNoUpdate()
+        #expect(acknowledgementCount == 1)
+        harness.finishSparkleCycle()
+        await waitUntil("install-latest retry to start") {
+            harness.updater.checkForUpdatesCallCount == 2
+        }
+
+        let latestPrompt = ChoiceBox()
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(updateAvailable("0.64.20", replyingInto: latestPrompt))
+        await waitUntil("install-latest retry to confirm") { latestPrompt.choice == .install }
+    }
+
+    /// A manual check remains manual when its indeterminate result is retried; finding an update
+    /// presents the prompt instead of silently converting Check for Updates into an install.
+    @Test func unknownNoUpdateRetryPreservesManualIntent() async {
+        let harness = Harness()
+
+        harness.controller.checkForUpdates()
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        harness.controller.driver.showUpdateNotFoundWithError(
+            NSError(domain: SUSparkleErrorDomain, code: 1001),
+            acknowledgement: {}
+        )
+        await harness.clock.fireDeadlineWhenReady()
+        await waitUntil("unknown no-update result") {
+            if case .notFound(let result) = harness.model.state, case .unknown = result.reason {
+                return true
+            }
+            return false
+        }
+
+        harness.controller.retryNoUpdate()
+        harness.finishSparkleCycle()
+        await waitUntil("manual retry to start") {
+            harness.updater.checkForUpdatesCallCount == 2
+        }
+
+        let latestPrompt = ChoiceBox()
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(updateAvailable("0.64.20", replyingInto: latestPrompt))
+        await Task.yield()
+        #expect(latestPrompt.choice == nil)
+    }
+
+    /// Sparkle can finish resolving while the minimum checking display is still visible. If a
+    /// second update request supersedes that check, its hidden terminal must be acknowledged so
+    /// Sparkle can finish the old cycle and start the queued latest-version check.
+    @Test func deferredNoUpdateIsAcknowledgedWhenReplacementRequestSupersedesIt() async {
+        let harness = Harness()
+        var acknowledgementCount = 0
+
+        harness.controller.checkForUpdates()
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        harness.controller.driver.showUpdateNotFoundWithError(
+            NSError(domain: SUSparkleErrorDomain, code: 1001),
+            acknowledgement: { acknowledgementCount += 1 }
+        )
+        await harness.clock.waitForDeadlineToArm()
+
+        harness.controller.attemptUpdate()
+
+        #expect(acknowledgementCount == 1)
+        guard case .preparingCheck = harness.model.state else {
+            Issue.record("replacement request should remain visible while the old cycle finishes")
+            return
+        }
+
+        harness.finishSparkleCycle()
+        await waitUntil("replacement latest-version check to start") {
+            harness.updater.checkForUpdatesCallCount == 2
+        }
+        for _ in 0..<20 { await Task.yield() }
+        #expect(acknowledgementCount == 1)
+    }
+
+    /// An old up-to-date timer must not acknowledge a newer unknown result, whose Retry action is
+    /// the only truthful next step when Sparkle did not report a reason.
+    @Test func staleAutoDismissCannotHideActionableNoUpdateReplacement() {
+        let harness = Harness()
+        var oldAcknowledgementCount = 0
+        var newAcknowledgementCount = 0
+        let oldResult = UpdateState.NotFound(reason: .upToDate) {
+            oldAcknowledgementCount += 1
+        }
+        let newResult = UpdateState.NotFound(reason: .unknown) {
+            newAcknowledgementCount += 1
+        }
+
+        harness.model.setState(.notFound(oldResult))
+        harness.model.setState(.notFound(newResult))
+        harness.controller.acknowledgeNoUpdate(ifMatching: oldResult.id)
+
+        guard case .notFound(let visible) = harness.model.state else {
+            Issue.record("stale auto-dismiss hid the actionable replacement")
+            return
+        }
+        #expect(visible.id == newResult.id)
+        #expect(oldAcknowledgementCount == 0)
+        #expect(newAcknowledgementCount == 0)
+    }
+
     /// Regression for #8368: dismissing the old prompt does not synchronously end Sparkle's
     /// update cycle. Starting the replacement check before Sparkle reports that the old cycle
     /// finished is documented to refocus/no-op, which silently strands the accepted install.
@@ -324,6 +536,32 @@ import Testing
         #expect(!harness.controller.attemptCoordinator.isMonitoring)
     }
 
+    /// A slow authoritative feed response must never be turned into "Update Didn't Start."
+    /// Once Sparkle reports `.checking`, the transport deadline ends; the freshly resolved latest
+    /// item remains installable even after that old deadline would have elapsed.
+    @Test func slowFreshCheckStillInstallsItsLatestResultAfterWatchdogDeadline() async {
+        let harness = Harness()
+        let stalePrompt = ChoiceBox()
+
+        harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
+        harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
+        await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
+
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        await waitUntil("check deadline to end") { !harness.controller.installWatchdog.isArmed }
+        await harness.clock.fireDeadlines()
+        guard case .checking = harness.model.state else {
+            Issue.record("slow check was replaced by \(harness.model.state)")
+            return
+        }
+
+        let latestPrompt = ChoiceBox()
+        harness.model.setState(updateAvailable("0.64.20", replyingInto: latestPrompt))
+        await waitUntil("latest prompt to be installed") { latestPrompt.choice == .install }
+        #expect(harness.controller.installWatchdog.isArmed)
+    }
+
     /// If the old Sparkle cycle never finishes, the preparation phase stays visible until the
     /// watchdog surfaces an error rather than leaving the user at a silently empty pill.
     @Test func watchdogSurfacesErrorWhenRecheckIsDropped() async {
@@ -398,6 +636,21 @@ import Testing
         }
         #expect(!didAcknowledgeNotFound)
         #expect(!harness.controller.installWatchdog.isArmed)
+    }
+
+    @Test func actionableNoUpdateAcknowledgementClearsStateExactlyOnce() {
+        let harness = Harness()
+        var acknowledgementCount = 0
+        harness.model.setState(.notFound(.init(reason: .unknown, acknowledgement: {
+            acknowledgementCount += 1
+        })))
+
+        harness.controller.acknowledgeNoUpdate()
+        #expect(harness.model.state.isIdle)
+        #expect(acknowledgementCount == 1)
+
+        harness.controller.acknowledgeNoUpdate()
+        #expect(acknowledgementCount == 1)
     }
 
     /// Regression: Retry from "Update Didn't Start" must not recreate the same error when the

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateFeedResolverTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateFeedResolverTests.swift
@@ -2,6 +2,13 @@ import Testing
 @testable import CmuxUpdater
 
 @Suite struct UpdateFeedResolverTests {
+    @Test func defaultFallbackUsesAtomicStableFeed() {
+        let resolution = UpdateFeedResolver().resolve(infoFeedURL: nil)
+        #expect(resolution.url == "https://files.cmux.com/stable/appcast.xml")
+        #expect(resolution.usedFallback)
+        #expect(!resolution.isNightly)
+    }
+
     @Test func missingInfoFeedURLUsesFallback() {
         let resolver = UpdateFeedResolver(fallbackFeedURL: "https://example.com/appcast.xml")
         let resolution = resolver.resolve(infoFeedURL: nil)

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateOutcomeContractTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateOutcomeContractTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+@preconcurrency import Sparkle
+@testable import CmuxUpdater
+
+private struct ImmediateUpdateClock: UpdateClock {
+    func sleep(for _: Duration) async throws {}
+}
+
+@MainActor
+@Suite struct UpdateOutcomeContractTests {
+    private func makeItem(
+        _ version: String = "0.64.20",
+        minimumSystemVersion: String? = nil,
+        maximumSystemVersion: String? = nil
+    ) -> SUAppcastItem {
+        var dictionary: [String: Any] = [
+            "title": "cmux \(version)",
+            "pubDate": "Wed, 25 Mar 2026 12:00:00 +0000",
+            "enclosure": [
+                "url": "https://example.com/cmux.zip",
+                "length": "1024",
+                "sparkle:version": "100",
+                "sparkle:shortVersionString": version,
+            ],
+        ]
+        dictionary["sparkle:minimumSystemVersion"] = minimumSystemVersion
+        dictionary["sparkle:maximumSystemVersion"] = maximumSystemVersion
+        return SUAppcastItem(dictionary: dictionary) ?? SUAppcastItem.empty()
+    }
+
+    private func noUpdateError(
+        reason: SPUNoUpdateFoundReason,
+        latestItem: SUAppcastItem? = nil
+    ) -> NSError {
+        var userInfo: [String: Any] = [
+            SPUNoUpdateFoundReasonKey: NSNumber(value: reason.rawValue),
+            SPUNoUpdateFoundUserInitiatedKey: true,
+        ]
+        userInfo[SPULatestAppcastItemFoundKey] = latestItem
+        return NSError(domain: SUSparkleErrorDomain, code: 1001, userInfo: userInfo)
+    }
+
+    private func presentation(
+        for reason: SPUNoUpdateFoundReason,
+        latestItem: SUAppcastItem? = nil
+    ) -> (title: String, message: String) {
+        let model = UpdateStateModel()
+        let driver = UpdateDriver(
+            model: model,
+            log: NoopUpdateLog(),
+            clock: ImmediateUpdateClock()
+        )
+        driver.showUpdateNotFoundWithError(
+            noUpdateError(reason: reason, latestItem: latestItem),
+            acknowledgement: {}
+        )
+        return (model.text, model.description)
+    }
+
+    /// A local UI deadline is not evidence that the feed contains no newer version. A slow
+    /// Sparkle request must remain in progress until Sparkle returns an authoritative result.
+    @Test func slowCheckNeverClaimsTheInstalledBuildIsLatest() async {
+        let model = UpdateStateModel()
+        let driver = UpdateDriver(
+            model: model,
+            log: NoopUpdateLog(),
+            clock: ImmediateUpdateClock()
+        )
+
+        driver.showUserInitiatedUpdateCheck(cancellation: {})
+        for _ in 0..<100 { await Task.yield() }
+
+        guard case .checking = model.state else {
+            Issue.record("slow check produced a false terminal: \(model.state)")
+            return
+        }
+        #expect(!model.description.localizedCaseInsensitiveContains("latest"))
+    }
+
+    @Test func authoritativeLatestResultUsesUpToDateCopy() {
+        let result = presentation(for: .onLatestVersion, latestItem: makeItem())
+        #expect(result.title.localizedCaseInsensitiveContains("no updates"))
+        #expect(result.message.localizedCaseInsensitiveContains("latest"))
+    }
+
+    @Test func newerThanFeedResultSaysTheInstalledBuildIsNewer() {
+        let result = presentation(for: .onNewerThanLatestVersion, latestItem: makeItem())
+        #expect(result.message.localizedCaseInsensitiveContains("newer"))
+    }
+
+    @Test func oldSystemResultNamesTheAvailableVersionAndRequirement() {
+        let result = presentation(
+            for: .systemIsTooOld,
+            latestItem: makeItem(minimumSystemVersion: "15.0")
+        )
+        #expect(result.message.contains("0.64.20"))
+        #expect(result.message.contains("15.0"))
+        #expect(result.message.localizedCaseInsensitiveContains("macOS"))
+        #expect(!result.message.localizedCaseInsensitiveContains("running the latest"))
+    }
+
+    @Test func newSystemResultNamesTheAvailableVersionAndMaximum() {
+        let result = presentation(
+            for: .systemIsTooNew,
+            latestItem: makeItem(maximumSystemVersion: "26.0")
+        )
+        #expect(result.message.contains("0.64.20"))
+        #expect(result.message.contains("26.0"))
+        #expect(!result.message.localizedCaseInsensitiveContains("running the latest"))
+    }
+
+    @Test func unsupportedHardwareResultNamesAppleSiliconRequirement() {
+        let result = presentation(for: .hardwareDoesNotSupportARM64, latestItem: makeItem())
+        #expect(result.message.contains("0.64.20"))
+        #expect(result.message.localizedCaseInsensitiveContains("Apple silicon"))
+        #expect(!result.message.localizedCaseInsensitiveContains("running the latest"))
+    }
+
+    @Test func unknownNoUpdateReasonDoesNotClaimTheInstalledBuildIsLatest() {
+        let result = presentation(for: .unknown, latestItem: makeItem())
+        #expect(!result.message.localizedCaseInsensitiveContains("running the latest"))
+    }
+
+    @Test func actionableNoUpdateReasonsStayVisibleUntilAcknowledged() {
+        let reasons: [UpdateState.NotFound.Reason] = [
+            .systemTooOld(latestVersion: "0.64.20", minimumSystemVersion: "15.0"),
+            .systemTooNew(latestVersion: "0.64.20", maximumSystemVersion: "26.0"),
+            .unsupportedHardware(latestVersion: "0.64.20"),
+            .developmentBuild,
+            .unknown,
+        ]
+
+        #expect(reasons.allSatisfy {
+            !UpdateState.NotFound(reason: $0, acknowledgement: {}).automaticallyDismisses
+        })
+        #expect(UpdateState.NotFound(reason: .upToDate, acknowledgement: {}).automaticallyDismisses)
+    }
+}

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
@@ -123,10 +123,45 @@ import Testing
         #expect(!model.text.isEmpty)
     }
 
+    @Test func preparingCheckCopyDoesNotAssumeAnExistingSession() {
+        let model = UpdateStateModel()
+        model.setState(.preparingCheck(.init(cancel: {})))
+        #expect(model.description == "Waiting for the updater to become ready")
+    }
+
     @Test func networkErrorTitleIsUserFacing() {
         let offline = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
         let title = UpdateStateModel.userFacingErrorTitle(for: offline)
         #expect(title == "No Internet Connection")
+    }
+
+    @Test func phaseNeutralNetworkMessagesSurviveSparkleWrapping() {
+        let cases: [(code: Int, expected: String)] = [
+            (
+                NSURLErrorNotConnectedToInternet,
+                "cmux can’t reach the update service. Check your internet connection and try again."
+            ),
+            (
+                NSURLErrorTimedOut,
+                "The update operation timed out. Try again in a moment."
+            ),
+            (
+                NSURLErrorNetworkConnectionLost,
+                "The network connection was lost while updating cmux. Try again."
+            ),
+        ]
+
+        for testCase in cases {
+            let networkError = NSError(domain: NSURLErrorDomain, code: testCase.code)
+            let wrappedError = NSError(
+                domain: SUSparkleErrorDomain,
+                code: 2001,
+                userInfo: [NSUnderlyingErrorKey: networkError]
+            )
+
+            #expect(UpdateStateModel.userFacingErrorMessage(for: networkError) == testCase.expected)
+            #expect(UpdateStateModel.userFacingErrorMessage(for: wrappedError) == testCase.expected)
+        }
     }
 
     @Test func errorDetailsIncludesLogPath() {
@@ -187,14 +222,60 @@ import Testing
         #expect(UpdateManualDownloadRecovery().url(for: err) != nil)
     }
 
-    @Test func genericInstallFailureKeepsPermissionTitleAndOffersDownload() {
+    @Test func genericInstallFailureUsesInstallationTitleAndOffersDownload() {
         let err = NSError(domain: "SUSparkleErrorDomain", code: 4005)
         let title = UpdateStateModel.userFacingErrorTitle(for: err)
         #expect(!title.contains("Start Updater"))
-        #expect(title.contains("Permission"))
+        #expect(title.contains("Installation"))
         let message = UpdateStateModel.userFacingErrorMessage(for: err)
-        #expect(message.localizedCaseInsensitiveContains("Applications"))
+        #expect(message.localizedCaseInsensitiveContains("install"))
+        #expect(!message.localizedCaseInsensitiveContains("Applications"))
+        #expect(!message.localizedCaseInsensitiveContains("restart"))
         #expect(UpdateManualDownloadRecovery().url(for: err) != nil)
+    }
+
+    @Test func downloadFailureCopyDoesNotMisdiagnoseTheUpdateFeed() {
+        let err = NSError(domain: SUSparkleErrorDomain, code: 2001)
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(message.localizedCaseInsensitiveContains("download"))
+        #expect(!message.localizedCaseInsensitiveContains("update feed"))
+    }
+
+    @Test func unknownFailureUsesOperationNeutralCopy() {
+        let err = NSError(domain: SUSparkleErrorDomain, code: 9999)
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(message.localizedCaseInsensitiveContains("updating cmux"))
+        #expect(!message.localizedCaseInsensitiveContains("checking for updates"))
+    }
+
+    @Test func updaterReadinessTimeoutDoesNotInventAStartupCause() {
+        let err = NSError(
+            domain: UpdateStateModel.updateErrorDomain,
+            code: UpdateStateModel.updaterNotReadyCode,
+            userInfo: [NSLocalizedDescriptionKey: "Updater is still starting."]
+        )
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(message.localizedCaseInsensitiveContains("isn’t ready"))
+        #expect(!message.localizedCaseInsensitiveContains("starting"))
+    }
+
+    @Test func appcastReleaseNotesURLWinsOverVersionDerivedStableTag() throws {
+        let nightlyURL = try #require(URL(string: "https://github.com/manaflow-ai/cmux/releases/tag/nightly"))
+        let item = SUAppcastItem(dictionary: [
+            "title": "cmux nightly",
+            "pubDate": "Wed, 25 Mar 2026 12:00:00 +0000",
+            "sparkle:fullReleaseNotesLink": nightlyURL.absoluteString,
+            "enclosure": [
+                "url": "https://example.com/cmux.zip",
+                "length": "1024",
+                "sparkle:version": "101",
+                "sparkle:shortVersionString": "0.64.20-nightly.101",
+            ],
+        ]) ?? SUAppcastItem.empty()
+        let update = UpdateState.UpdateAvailable(appcastItem: item, reply: { _ in })
+
+        #expect(update.releaseNotes?.url == nightlyURL)
+        #expect(UpdateState.ReleaseNotes(appcastItem: item)?.url == nightlyURL)
     }
 
     /// A 4005 wrapping a non-agent installer cause (auth failure, relaunch failure) must NOT be
@@ -211,7 +292,10 @@ import Testing
         ])
         let title = UpdateStateModel.userFacingErrorTitle(for: err)
         #expect(!title.contains("Start Updater"))
-        #expect(title.contains("Permission"))
+        #expect(title.contains("Installation"))
+        let message = UpdateStateModel.userFacingErrorMessage(for: err)
+        #expect(!message.localizedCaseInsensitiveContains("Applications"))
+        #expect(!message.localizedCaseInsensitiveContains("restart"))
         #expect(UpdateManualDownloadRecovery().url(for: err) != nil)
     }
 

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateActionsHost.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateActionsHost.swift
@@ -14,6 +14,12 @@ public protocol UpdateActionsHost: AnyObject {
     /// "Install and Relaunch" action on the detected-update popover).
     func attemptUpdate()
 
+    /// Acknowledges the visible no-update result and atomically clears it from the UI.
+    func acknowledgeNoUpdate()
+
+    /// Retries an indeterminate no-update result with the operation intent that produced it.
+    func retryNoUpdate()
+
     /// The filesystem path of the update log, shown in the error popover's details block.
     var updateLogPath: String { get }
 }

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
@@ -5,6 +5,11 @@ import AppKit
 
 /// A pill-shaped button that displays update status and provides access to update actions.
 public struct UpdatePill: View {
+    enum NotFoundTapBehavior: Equatable {
+        case acknowledge
+        case showDetails
+    }
+
     private let model: UpdateStateModel
     private let appearance: UpdateAppearance
     private let actions: any UpdateActionsHost
@@ -87,11 +92,32 @@ public struct UpdatePill: View {
         }
 
         if case .notFound(let notFound) = model.state {
-            model.setState(.idle)
-            notFound.acknowledgement()
+            switch Self.notFoundTapBehavior(for: notFound) {
+            case .acknowledge:
+                actions.acknowledgeNoUpdate()
+            case .showDetails:
+                showPopover.toggle()
+            }
         } else {
             showPopover.toggle()
         }
+    }
+
+    static func notFoundTapBehavior(for result: UpdateState.NotFound) -> NotFoundTapBehavior {
+        result.automaticallyDismisses ? .acknowledge : .showDetails
+    }
+
+    static func offersRetry(for result: UpdateState.NotFound) -> Bool {
+        if case .unknown = result.reason { return true }
+        return false
+    }
+
+    static func performNoUpdateRetry(using actions: any UpdateActionsHost) {
+        actions.retryNoUpdate()
+    }
+
+    static func performInstall(using actions: any UpdateActionsHost) {
+        actions.attemptUpdate()
     }
 
     private var textWidth: CGFloat? {
@@ -269,7 +295,7 @@ public struct InstallUpdateMenuItem: View {
             Button(String(localized: "update.installAndRelaunch", defaultValue: "Install Update and Relaunch")) {
                 // Re-resolve to the latest available version before installing rather than
                 // installing the version that was current when this menu item appeared (#6366).
-                actions.attemptUpdate()
+                UpdatePill.performInstall(using: actions)
             }
         }
     }

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePopoverView.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePopoverView.swift
@@ -61,7 +61,7 @@ public struct UpdatePopoverView: View {
                 InstallingView(installing: installing, dismiss: dismiss)
 
             case .notFound(let notFound):
-                NotFoundView(notFound: notFound, dismiss: dismiss)
+                NotFoundView(notFound: notFound, actions: actions, dismiss: dismiss)
 
             case .error(let error):
                 UpdateErrorView(error: error, logPath: actions.updateLogPath, dismiss: dismiss)
@@ -160,7 +160,7 @@ private struct DetectedBackgroundUpdateView: View {
                     Spacer()
 
                     Button(String(localized: "common.installAndRelaunch", defaultValue: "Install and Relaunch")) {
-                        actions.attemptUpdate()
+                        UpdatePill.performInstall(using: actions)
                         dismiss()
                     }
                     .keyboardShortcut(.defaultAction)
@@ -170,7 +170,7 @@ private struct DetectedBackgroundUpdateView: View {
             }
             .padding(16)
 
-            if let notes = UpdateState.ReleaseNotes(displayVersionString: item.displayVersionString) {
+            if let notes = UpdateState.ReleaseNotes(appcastItem: item) {
                 Divider()
                 UpdateReleaseNotesLink(notes: notes)
             }
@@ -296,13 +296,13 @@ private struct UpdateAvailableView: View {
 
                 HStack(spacing: 8) {
                     Button(String(localized: "common.skip", defaultValue: "Skip")) {
-                        update.reply(.skip)
+                        update.skip()
                         dismiss()
                     }
                     .controlSize(.small)
 
                     Button(String(localized: "common.later", defaultValue: "Later")) {
-                        update.reply(.dismiss)
+                        update.dismiss()
                         dismiss()
                     }
                     .controlSize(.small)
@@ -314,7 +314,7 @@ private struct UpdateAvailableView: View {
                         // Re-resolve to the latest available version at install time instead of
                         // installing the version captured when this prompt was generated, so a
                         // newer release published in the meantime is installed directly (#6366).
-                        actions.attemptUpdate()
+                        UpdatePill.performInstall(using: actions)
                         dismiss()
                     }
                     .keyboardShortcut(.defaultAction)
@@ -430,15 +430,16 @@ private struct InstallingView: View {
 
 private struct NotFoundView: View {
     let notFound: UpdateState.NotFound
+    let actions: any UpdateActionsHost
     let dismiss: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
-                Text(String(localized: "update.popover.noUpdatesFound", defaultValue: "No Updates Found"))
+                Text(notFound.title)
                     .cmuxFont(size: 13, weight: .semibold)
 
-                Text(String(localized: "update.popover.noUpdatesFound.message", defaultValue: "You're already running the latest version."))
+                Text(notFound.message)
                     .cmuxFont(size: 11)
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -446,12 +447,29 @@ private struct NotFoundView: View {
 
             HStack {
                 Spacer()
-                Button(String(localized: "common.ok", defaultValue: "OK")) {
-                    notFound.acknowledgement()
-                    dismiss()
+                if UpdatePill.offersRetry(for: notFound) {
+                    Button(String(localized: "common.ok", defaultValue: "OK")) {
+                        actions.acknowledgeNoUpdate()
+                        dismiss()
+                    }
+                    .keyboardShortcut(.cancelAction)
+                    .controlSize(.small)
+
+                    Button(String(localized: "common.retry", defaultValue: "Retry")) {
+                        dismiss()
+                        UpdatePill.performNoUpdateRetry(using: actions)
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                } else {
+                    Button(String(localized: "common.ok", defaultValue: "OK")) {
+                        actions.acknowledgeNoUpdate()
+                        dismiss()
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .controlSize(.small)
                 }
-                .keyboardShortcut(.defaultAction)
-                .controlSize(.small)
             }
         }
         .padding(16)

--- a/Packages/macOS/CmuxUpdaterUI/Tests/CmuxUpdaterUITests/UpdatePillNotFoundInteractionTests.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Tests/CmuxUpdaterUITests/UpdatePillNotFoundInteractionTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import CmuxUpdater
+@testable import CmuxUpdaterUI
+
+@MainActor
+@Suite("Update pill no-update interaction")
+struct UpdatePillNotFoundInteractionTests {
+    @Test func actionableResultsOpenDetailsInsteadOfBeingAcknowledged() {
+        let actionableReasons: [UpdateState.NotFound.Reason] = [
+            .systemTooOld(latestVersion: "0.64.20", minimumSystemVersion: "15.0"),
+            .systemTooNew(latestVersion: "0.64.20", maximumSystemVersion: "26.0"),
+            .unsupportedHardware(latestVersion: "0.64.20"),
+            .developmentBuild,
+            .unknown,
+        ]
+
+        for reason in actionableReasons {
+            let result = UpdateState.NotFound(reason: reason, acknowledgement: {})
+            #expect(UpdatePill.notFoundTapBehavior(for: result) == .showDetails)
+        }
+    }
+
+    @Test func lowInformationSuccessAcknowledgesDirectly() {
+        let reasons: [UpdateState.NotFound.Reason] = [
+            .upToDate,
+            .newerThanLatest(latestVersion: "0.64.20"),
+        ]
+
+        for reason in reasons {
+            let result = UpdateState.NotFound(reason: reason, acknowledgement: {})
+            #expect(UpdatePill.notFoundTapBehavior(for: result) == .acknowledge)
+        }
+    }
+
+    @Test func unknownResultOffersRetry() {
+        #expect(UpdatePill.offersRetry(for: .init(reason: .unknown, acknowledgement: {})))
+        #expect(!UpdatePill.offersRetry(for: .init(reason: .developmentBuild, acknowledgement: {})))
+    }
+
+    @Test func unknownRetryUsesIntentPreservingHostAction() {
+        let actions = UpdateActionsSpy()
+        UpdatePill.performNoUpdateRetry(using: actions)
+
+        #expect(actions.retryNoUpdateCount == 1)
+        #expect(actions.manualCheckCount == 0)
+        #expect(actions.attemptUpdateCount == 0)
+    }
+
+    @Test func primaryInstallUsesFreshLatestVersionHostAction() {
+        let actions = UpdateActionsSpy()
+        UpdatePill.performInstall(using: actions)
+
+        #expect(actions.attemptUpdateCount == 1)
+        #expect(actions.manualCheckCount == 0)
+        #expect(actions.retryNoUpdateCount == 0)
+    }
+}
+
+@MainActor
+private final class UpdateActionsSpy: UpdateActionsHost {
+    var manualCheckCount = 0
+    var attemptUpdateCount = 0
+    var retryNoUpdateCount = 0
+
+    func checkForUpdatesInCustomUI() { manualCheckCount += 1 }
+    func attemptUpdate() { attemptUpdateCount += 1 }
+    func acknowledgeNoUpdate() {}
+    func retryNoUpdate() { retryNoUpdateCount += 1 }
+    var updateLogPath: String { "/tmp/cmux-update-test.log" }
+}

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -238,12 +238,14 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>SUAllowsAutomaticUpdates</key>
+	<false/>
 	<key>SUAutomaticallyUpdate</key>
 	<false/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml</string>
+	<string>https://files.cmux.com/stable/appcast.xml</string>
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
 	<key>SUSendProfileInfo</key>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -17636,13 +17636,9 @@ private extension NSWindow {
 
 // MARK: - CmuxUpdater seams
 
-/// Conforms the composition root to updater host actions, retry, and relaunch seams.
+/// Conforms the composition root to updater host relaunch actions.
 /// `checkForUpdatesInCustomUI()` is satisfied by the main `AppDelegate` declaration.
 extension AppDelegate: UpdateActionDelegate, UpdateActionsHost {
-    func updaterRequestsRetryCheckForUpdates() {
-        checkForUpdates(nil)
-    }
-
     func updaterWillRelaunchApplication() {
         persistSessionForUpdateRelaunch()
         TerminalController.shared.stop()
@@ -17654,6 +17650,14 @@ extension AppDelegate: UpdateActionDelegate, UpdateActionsHost {
 
     func attemptUpdate() {
         attemptUpdate(nil)
+    }
+
+    func acknowledgeNoUpdate() {
+        updateController.acknowledgeNoUpdate()
+    }
+
+    func retryNoUpdate() {
+        updateController.retryNoUpdate()
     }
 
     var updateLogPath: String {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8849,6 +8849,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         updateController.checkForUpdatesInCustomUI()
     }
 
+#if DEBUG
+    func debugShowUpdateError(_ scenario: DebugUpdateErrorScenario) {
+        if scenario == .installDidNotStart {
+            updateController.debugShowInstallDidNotStartError()
+        } else {
+            updateViewModel.debugShowUpdateError(scenario)
+        }
+    }
+#endif
+
     func openWelcomeWorkspace() {
         guard let context = preferredMainWindowContextForWorkspaceCreation(event: nil, debugSource: "welcome") else {
             return

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2893,6 +2893,20 @@ struct ContentView: View {
             toggleCommandPalette()
         })
 
+#if DEBUG
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteQuerySetRequested)) { notification in
+            guard isCommandPalettePresented, case .commands = commandPaletteMode else { return }
+            let requestedWindow = notification.object as? NSWindow
+            guard Self.shouldHandleCommandPaletteRequest(
+                observedWindow: observedWindow,
+                requestedWindow: requestedWindow,
+                keyWindow: NSApp.keyWindow,
+                mainWindow: NSApp.mainWindow
+            ), let query = notification.userInfo?["query"] as? String else { return }
+            commandPaletteQuery = query
+        })
+#endif
+
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteRequested)) { notification in
             let requestedWindow = notification.object as? NSWindow
             guard Self.shouldHandleCommandPaletteRequest(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6825,6 +6825,39 @@ struct ContentView: View {
         "ios", "ipados", "iphone", "ipad", "phone", "tablet", "qr",
     ]
 
+    static func commandPaletteUpdateCommandContributions() -> [CommandPaletteCommandContribution] {
+        let constant: (String) -> (CommandPaletteContextSnapshot) -> String = { value in
+            { _ in value }
+        }
+        return [
+            CommandPaletteCommandContribution(
+                commandId: "palette.attemptUpdate",
+                title: constant(String(localized: "command.updateCmux.title", defaultValue: "Update cmux")),
+                subtitle: constant(String(localized: "command.attemptUpdate.subtitle", defaultValue: "Global")),
+                keywords: ["update", "upgrade", "install", "latest", "release", "check"]
+            ),
+            CommandPaletteCommandContribution(
+                commandId: "palette.checkForUpdates",
+                title: constant(String(localized: "command.checkForUpdates.title", defaultValue: "Check for Updates")),
+                subtitle: constant(String(localized: "command.checkForUpdates.subtitle", defaultValue: "Global")),
+                keywords: ["check", "inspect", "update", "upgrade", "release"]
+            ),
+        ]
+    }
+
+    static func registerUpdateCommandHandlers(
+        _ registry: inout CommandPaletteHandlerRegistry,
+        checkForUpdates: @escaping () -> Void,
+        applyLegacyUpdate: @escaping () -> Void,
+        attemptUpdate: @escaping () -> Void
+    ) {
+        registry.register(commandId: "palette.checkForUpdates", handler: checkForUpdates)
+        // Keep the old identifier runnable for saved/custom integrations, but do not contribute it
+        // to search results. All visible install actions use the fresh latest-version entrypoint.
+        registry.register(commandId: "palette.applyUpdateIfAvailable", handler: applyLegacyUpdate)
+        registry.register(commandId: "palette.attemptUpdate", handler: attemptUpdate)
+    }
+
     private func commandPaletteCommandContributions() -> [CommandPaletteCommandContribution] {
         func constant(_ value: String) -> (CommandPaletteContextSnapshot) -> String {
             { _ in value }
@@ -7185,31 +7218,7 @@ struct ContentView: View {
                 when: { !$0.bool(CommandPaletteContextKeys.defaultTerminalIsDefault) }
             )
         )
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.checkForUpdates",
-                title: constant(String(localized: "command.checkForUpdates.title", defaultValue: "Check for Updates")),
-                subtitle: constant(String(localized: "command.checkForUpdates.subtitle", defaultValue: "Global")),
-                keywords: ["update", "upgrade", "release"]
-            )
-        )
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.applyUpdateIfAvailable",
-                title: constant(String(localized: "command.applyUpdateIfAvailable.title", defaultValue: "Apply Update (If Available)")),
-                subtitle: constant(String(localized: "command.applyUpdateIfAvailable.subtitle", defaultValue: "Global")),
-                keywords: ["apply", "install", "update", "available"],
-                when: { $0.bool(CommandPaletteContextKeys.updateHasAvailable) }
-            )
-        )
-        contributions.append(
-            CommandPaletteCommandContribution(
-                commandId: "palette.attemptUpdate",
-                title: constant(String(localized: "command.attemptUpdate.title", defaultValue: "Attempt Update")),
-                subtitle: constant(String(localized: "command.attemptUpdate.subtitle", defaultValue: "Global")),
-                keywords: ["attempt", "check", "update", "upgrade", "release"]
-            )
-        )
+        contributions.append(contentsOf: Self.commandPaletteUpdateCommandContributions())
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.restartSocketListener",
@@ -8307,15 +8316,12 @@ struct ContentView: View {
         registry.register(commandId: "palette.makeDefaultTerminal") {
             DefaultTerminalUserAction.setAsDefault(debugSource: "palette.makeDefaultTerminal")
         }
-        registry.register(commandId: "palette.checkForUpdates") {
-            AppDelegate.shared?.checkForUpdates(nil)
-        }
-        registry.register(commandId: "palette.applyUpdateIfAvailable") {
-            AppDelegate.shared?.applyUpdateIfAvailable(nil)
-        }
-        registry.register(commandId: "palette.attemptUpdate") {
-            AppDelegate.shared?.attemptUpdate(nil)
-        }
+        Self.registerUpdateCommandHandlers(
+            &registry,
+            checkForUpdates: { AppDelegate.shared?.checkForUpdates(nil) },
+            applyLegacyUpdate: { AppDelegate.shared?.applyUpdateIfAvailable(nil) },
+            attemptUpdate: { AppDelegate.shared?.attemptUpdate(nil) }
+        )
         registry.register(commandId: "palette.restartSocketListener") {
             AppDelegate.shared?.restartSocketListener(nil)
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -6180,6 +6180,9 @@ extension Notification.Name {
     // The sidebar multi-selection sync events moved to CmuxSidebar as typed
     // SidebarMultiSelectionShouldCollapseEvent / DidHideEvent (same names).
     static let commandPaletteToggleRequested = Notification.Name("cmux.commandPaletteToggleRequested")
+#if DEBUG
+    static let commandPaletteQuerySetRequested = Notification.Name("cmux.commandPaletteQuerySetRequested")
+#endif
     static let commandPaletteRequested = Notification.Name("cmux.commandPaletteRequested")
     static let commandPaletteSwitcherRequested = Notification.Name("cmux.commandPaletteSwitcherRequested")
     static let commandPaletteSubmitRequested = Notification.Name("cmux.commandPaletteSubmitRequested")

--- a/Sources/TerminalController+ControlDebugContext.swift
+++ b/Sources/TerminalController+ControlDebugContext.swift
@@ -250,17 +250,28 @@ extension TerminalController: ControlDebugContext {
             targetWindow = NSApp.keyWindow ?? NSApp.mainWindow
         }
         let name: Notification.Name
+        let userInfo: [AnyHashable: Any]?
         switch event {
         case .toggle:
             name = .commandPaletteToggleRequested
+            userInfo = nil
+        case .setQuery(let query):
+            name = .commandPaletteQuerySetRequested
+            userInfo = ["query": query]
+        case .submit:
+            name = .commandPaletteSubmitRequested
+            userInfo = nil
         case .renameTabOpen:
             name = .commandPaletteRenameTabRequested
+            userInfo = nil
         case .renameInputInteraction:
             name = .commandPaletteRenameInputInteractionRequested
+            userInfo = nil
         case .renameInputDeleteBackward:
             name = .commandPaletteRenameInputDeleteBackwardRequested
+            userInfo = nil
         }
-        NotificationCenter.default.post(name: name, object: targetWindow)
+        NotificationCenter.default.post(name: name, object: targetWindow, userInfo: userInfo)
         return true
     }
 

--- a/Sources/TerminalController+DebugMethodNames.swift
+++ b/Sources/TerminalController+DebugMethodNames.swift
@@ -14,6 +14,8 @@ extension TerminalController {
         "debug.workspace_todo.checklist_add_field",
         "debug.pro_welcome_checklist.show",
         "debug.command_palette.toggle",
+        "debug.command_palette.query.set",
+        "debug.command_palette.submit",
         "debug.command_palette.rename_tab.open",
         "debug.command_palette.visible",
         "debug.command_palette.selection",

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -455,7 +455,7 @@ struct cmuxApp: App {
                 Menu("Show Update Error…") {
                     ForEach(DebugUpdateErrorScenario.allCases, id: \.self) { scenario in
                         Button(scenario.menuTitle) {
-                            appDelegate.updateViewModel.debugShowUpdateError(scenario)
+                            appDelegate.debugShowUpdateError(scenario)
                         }
                     }
                 }

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -1982,6 +1982,42 @@ final class UpdateChannelSettingsTests: XCTestCase {
 }
 
 
+@MainActor
+final class UpdateCommandPaletteEntrypointTests: XCTestCase {
+    func testUpdateCmuxIsPrimaryVisibleContribution() {
+        let contributions = ContentView.commandPaletteUpdateCommandContributions()
+        XCTAssertEqual(
+            contributions.map(\.commandId),
+            ["palette.attemptUpdate", "palette.checkForUpdates"]
+        )
+        XCTAssertEqual(
+            contributions[0].title(CommandPaletteContextSnapshot()),
+            String(localized: "command.updateCmux.title", defaultValue: "Update cmux")
+        )
+        XCTAssertTrue(contributions[0].keywords.contains("latest"))
+    }
+
+    func testUpdateCmuxHandlerDispatchesFreshLatestVersionAction() {
+        var registry = CommandPaletteHandlerRegistry()
+        var checkCount = 0
+        var legacyApplyCount = 0
+        var attemptCount = 0
+        ContentView.registerUpdateCommandHandlers(
+            &registry,
+            checkForUpdates: { checkCount += 1 },
+            applyLegacyUpdate: { legacyApplyCount += 1 },
+            attemptUpdate: { attemptCount += 1 }
+        )
+
+        registry.handler(for: "palette.attemptUpdate")?()
+
+        XCTAssertEqual(attemptCount, 1)
+        XCTAssertEqual(checkCount, 0)
+        XCTAssertEqual(legacyApplyCount, 0)
+    }
+}
+
+
 final class UpdateSettingsTests: XCTestCase {
     func testApplyEnablesAutomaticChecksAndDailySchedule() {
         let defaults = makeDefaults()
@@ -1994,7 +2030,7 @@ final class UpdateSettingsTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: UpdateSettings.migrationKey))
     }
 
-    func testApplyRepairsLegacyDisabledAutomaticChecksOnce() {
+    func testApplyRepairsLegacyChecksAndDisablesCapturedAutomaticInstalls() {
         let defaults = makeDefaults()
         defaults.set(false, forKey: UpdateSettings.automaticChecksKey)
         defaults.set(0, forKey: UpdateSettings.scheduledCheckIntervalKey)
@@ -2004,7 +2040,7 @@ final class UpdateSettingsTests: XCTestCase {
 
         XCTAssertTrue(defaults.bool(forKey: UpdateSettings.automaticChecksKey))
         XCTAssertEqual(defaults.double(forKey: UpdateSettings.scheduledCheckIntervalKey), UpdateSettings().scheduledCheckInterval)
-        XCTAssertTrue(defaults.bool(forKey: UpdateSettings.automaticallyUpdateKey))
+        XCTAssertFalse(defaults.bool(forKey: UpdateSettings.automaticallyUpdateKey))
 
         defaults.set(false, forKey: UpdateSettings.automaticChecksKey)
         UpdateSettings().apply(to: defaults)

--- a/cmuxUITests/SidebarHelpMenuUITests.swift
+++ b/cmuxUITests/SidebarHelpMenuUITests.swift
@@ -437,6 +437,33 @@ final class CommandPaletteAllSurfacesUITests: XCTestCase {
         XCTAssertEqual(row1.value as? String, "palette.attemptUpdate")
     }
 
+    func testCmdShiftPUpdateQueryPrefersInstallLatestAction() throws {
+        let app = XCUIApplication()
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        launchAndActivate(app)
+
+        XCTAssertTrue(
+            sidebarHelpPollUntil(timeout: 8.0) {
+                app.windows.count >= 1
+            },
+            "Expected the main window to be visible"
+        )
+
+        openCommandPaletteCommands(app: app)
+        let searchField = app.textFields["CommandPaletteSearchField"]
+        searchField.typeText("update")
+
+        let row0 = app.descendants(matching: .any).matching(identifier: "CommandPaletteResultRow.0").firstMatch
+        XCTAssertTrue(
+            sidebarHelpPollUntil(timeout: 5.0) {
+                row0.exists && (row0.value as? String) == "palette.attemptUpdate"
+            },
+            "Expected Update cmux to be the primary update command. row0=\(String(describing: row0.value))"
+        )
+        XCTAssertEqual(row0.value as? String, "palette.attemptUpdate")
+    }
+
     func testCmdPSearchCanIncludeSurfacesFromOtherWorkspacesWhenEnabled() throws {
         let app = XCUIApplication()
         configureSocketControlledLaunch(app, showSettingsWindow: true)

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -1,33 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build, sign, notarize, create DMG, generate appcast, and upload to GitHub release.
-# Usage: ./scripts/build-sign-upload.sh <tag> [--allow-overwrite]
-# Requires: source ~/.secrets/cmuxterm.env && export SPARKLE_PRIVATE_KEY
+# Queue stable publication through release.yml, the single serialized owner of the canonical R2
+# appcast and GitHub's legacy /latest pointer. Nightly requests route through nightly.yml.
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/build-sign-upload.sh <tag> [--allow-overwrite]
+Usage: ./scripts/build-sign-upload.sh <tag> [--repair-appcast]
 
 Options:
-  --allow-overwrite   Permit replacing existing release assets for the same tag.
-                      Use only for emergency rerolls.
+  --repair-appcast  Verify and republish an existing release's immutable appcast.
+
+Normal stable publication creates/pushes the local tag when needed. An existing remote tag is
+retried through the current default-branch release workflow. Nightly appcast-only repair is not
+supported because nightly assets are rolling and mutable. Direct asset overwrite is unsupported.
 EOF
 }
 
-ALLOW_OVERWRITE="false"
+REPAIR_APPCAST="false"
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --allow-overwrite)
-      ALLOW_OVERWRITE="true"
+    --repair-appcast)
+      REPAIR_APPCAST="true"
       shift
+      ;;
+    --allow-overwrite)
+      echo "ERROR: Signed release assets are immutable. Publish a new tag instead of overwriting." >&2
+      exit 1
       ;;
     -h|--help)
       usage
       exit 0
       ;;
-    -*)
+    --*)
       echo "Unknown option: $1" >&2
       usage >&2
       exit 1
@@ -38,177 +44,83 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-set -- "${POSITIONAL[@]}"
 
+set -- "${POSITIONAL[@]}"
 if [[ $# -ne 1 ]]; then
   usage >&2
   exit 1
 fi
 
 TAG="$1"
-SIGN_HASH="A050CC7E193C8221BDBA204E731B046CDCCC1B30"
-ENTITLEMENTS="cmux.entitlements"
-APP_PATH="build/Build/Products/Release/cmux.app"
-GHOSTTYKIT_CRASH_REPORT_SUBDIR="cmux/crash"
-
-# --- Pre-flight ---
-source ~/.secrets/cmuxterm.env
-export SPARKLE_PRIVATE_KEY
-for tool in zig xcodebuild create-dmg xcrun codesign ditto gh; do
+WORKFLOW_REF="${CMUX_RELEASE_WORKFLOW_REF:-main}"
+for tool in gh git; do
   command -v "$tool" >/dev/null || { echo "MISSING: $tool" >&2; exit 1; }
 done
-echo "Pre-flight checks passed"
 
-# --- Build GhosttyKit ---
-echo "Building GhosttyKit..."
-rm -rf GhosttyKit.xcframework ghostty/macos/GhosttyKit.xcframework
-(
-  cd ghostty
-  zig build -Dcrash-report-subdir="$GHOSTTYKIT_CRASH_REPORT_SUBDIR" -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
-)
-cp -R ghostty/macos/GhosttyKit.xcframework GhosttyKit.xcframework
+if [[ "$TAG" == "nightly" || "$TAG" == *"-nightly"* ]]; then
+  if [[ "$TAG" != "nightly" ]]; then
+    echo "ERROR: Nightly publication uses the rolling 'nightly' release." >&2
+    exit 1
+  fi
+  if [[ "$REPAIR_APPCAST" == "true" ]]; then
+    echo "ERROR: Nightly appcast-only repair is unsupported; rerun nightly publication without --repair-appcast." >&2
+    exit 1
+  fi
+  gh workflow run nightly.yml --ref "$WORKFLOW_REF" --field force=true
+  echo "Queued serialized nightly publication through .github/workflows/nightly.yml."
+  exit 0
+fi
 
-# --- Build app (Release, unsigned) ---
-echo "Building app..."
-rm -rf build/
-xcodebuild -scheme cmux -configuration Release -derivedDataPath build CODE_SIGNING_ALLOWED=NO build 2>&1 | tail -5
-echo "Build succeeded"
-
-HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-if [ ! -x "$HELPER_PATH" ]; then
-  echo "Ghostty theme picker helper not found at $HELPER_PATH" >&2
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: Stable release tag must match v<major>.<minor>.<patch> exactly (got '$TAG')." >&2
   exit 1
 fi
 
-# --- Inject Sparkle keys ---
-echo "Injecting Sparkle keys..."
-SPARKLE_PUBLIC_KEY_DERIVED=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
-APP_PLIST="$APP_PATH/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$APP_PLIST" 2>/dev/null || true
-/usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$APP_PLIST" 2>/dev/null || true
-/usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string $SPARKLE_PUBLIC_KEY_DERIVED" "$APP_PLIST"
-/usr/libexec/PlistBuddy -c "Add :SUFeedURL string https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml" "$APP_PLIST"
-echo "Sparkle keys injected"
-
-# cmux is a non-sandboxed app. Sparkle's sandbox-only XPC services make the
-# installer handoff wait for an agent connection that never arrives.
-./scripts/remove-sparkle-sandbox-xpc-services.sh "$APP_PATH"
-
-# --- Codesign ---
-echo "Codesigning..."
-./scripts/sign-cmux-bundle.sh "$APP_PATH" "$ENTITLEMENTS" "$SIGN_HASH"
-echo "Codesign verified"
-
-# --- Notarize app ---
-echo "Notarizing app..."
-ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" cmux-notary.zip
-xcrun notarytool submit cmux-notary.zip \
-  --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait
-xcrun stapler staple "$APP_PATH"
-xcrun stapler validate "$APP_PATH"
-rm -f cmux-notary.zip
-echo "App notarized"
-
-# --- Create and notarize DMG ---
-echo "Creating DMG..."
-./scripts/verify-app-bundle-licenses.sh "$APP_PATH"
-rm -f cmux-macos.dmg
-create-dmg --codesign "$SIGN_HASH" cmux-macos.dmg "$APP_PATH"
-echo "Notarizing DMG..."
-xcrun notarytool submit cmux-macos.dmg \
-  --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait
-xcrun stapler staple cmux-macos.dmg
-xcrun stapler validate cmux-macos.dmg
-echo "DMG notarized"
-
-# --- Generate Sparkle appcast ---
-echo "Generating appcast..."
-./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$TAG" appcast.xml
-
-# --- Create GitHub release (if needed) and upload ---
-if gh release view "$TAG" >/dev/null 2>&1; then
-  echo "Release $TAG already exists"
-  EXISTING_ASSETS="$(gh release view "$TAG" --json assets --jq '.assets[].name' || true)"
-  HAS_CONFLICTING_ASSET="false"
-  for asset in cmux-macos.dmg appcast.xml; do
-    if printf '%s\n' "$EXISTING_ASSETS" | grep -Fxq "$asset"; then
-      HAS_CONFLICTING_ASSET="true"
-      break
-    fi
-  done
-
-  if [[ "$HAS_CONFLICTING_ASSET" == "true" && "$ALLOW_OVERWRITE" != "true" ]]; then
-    echo "ERROR: Refusing to overwrite signed release assets for existing tag $TAG." >&2
-    echo "Use a new tag, or rerun with --allow-overwrite for an emergency reroll." >&2
+if [[ "$REPAIR_APPCAST" == "true" ]]; then
+  if ! git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+    echo "ERROR: Cannot repair $TAG because the remote tag does not exist." >&2
     exit 1
   fi
+  gh workflow run release.yml \
+    --ref "$WORKFLOW_REF" \
+    --field operation=publish-existing \
+    --field release_tag="$TAG"
+  echo "Queued serialized appcast repair for $TAG through .github/workflows/release.yml."
+  exit 0
+fi
 
-  if [[ "$ALLOW_OVERWRITE" == "true" ]]; then
-    echo "Uploading with overwrite enabled for existing release $TAG..."
-    gh release upload "$TAG" cmux-macos.dmg appcast.xml --clobber
-  else
-    echo "Uploading to existing release $TAG..."
-    gh release upload "$TAG" cmux-macos.dmg appcast.xml
-  fi
+if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+  gh workflow run release.yml \
+    --ref "$WORKFLOW_REF" \
+    --field operation=publish \
+    --field release_tag="$TAG"
+  echo "Queued serialized release retry for existing remote tag $TAG."
 else
-  echo "Creating release $TAG and uploading..."
-  gh release create "$TAG" cmux-macos.dmg appcast.xml --title "$TAG" --notes "See CHANGELOG.md for details"
-fi
-
-# --- Verify ---
-gh release view "$TAG"
-
-# --- Update Homebrew cask (skip for nightlies) ---
-if [[ "$TAG" != *"-nightly"* ]]; then
-  VERSION="${TAG#v}"
-  DMG_SHA256=$(shasum -a 256 cmux-macos.dmg | cut -d' ' -f1)
-  echo "Updating homebrew cask to $VERSION (SHA: $DMG_SHA256)..."
-  CASK_FILE="homebrew-cmux/Casks/cmux.rb"
-  if [ -f "$CASK_FILE" ]; then
-    cat > "$CASK_FILE" << CASKEOF
-cask "cmux" do
-  version "${VERSION}"
-  sha256 "${DMG_SHA256}"
-
-  url "https://github.com/manaflow-ai/cmux/releases/download/v#{version}/cmux-macos.dmg"
-  name "cmux"
-  desc "Lightweight native macOS terminal with vertical tabs for AI coding agents"
-  homepage "https://github.com/manaflow-ai/cmux"
-
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  depends_on macos: ">= :ventura"
-
-  app "cmux.app"
-  binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"
-
-  zap trash: [
-    "~/Library/Application Support/cmux",
-    "~/Library/Caches/cmux",
-    "~/Library/Preferences/ai.manaflow.cmuxterm.plist",
-  ]
-end
-CASKEOF
-    cd homebrew-cmux
-    git add Casks/cmux.rb
-    if git diff --staged --quiet; then
-      echo "Homebrew cask already up to date"
-    else
-      git commit -m "Update cmux to ${VERSION}"
-      git push
-      echo "Homebrew cask updated"
-    fi
-    cd ..
-  else
-    echo "WARNING: homebrew-cmux submodule not found, skipping cask update"
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "ERROR: Refusing to tag HEAD while tracked changes are uncommitted." >&2
+    exit 1
   fi
+  PROJECT_SNAPSHOT="$(mktemp)"
+  if ! git show "HEAD:cmux.xcodeproj/project.pbxproj" > "$PROJECT_SNAPSHOT"; then
+    rm -f "$PROJECT_SNAPSHOT"
+    echo "ERROR: Could not read the committed Xcode project from HEAD." >&2
+    exit 1
+  fi
+  if ! CMUX_PROJECT_FILE="$PROJECT_SNAPSHOT" ./scripts/validate-release-version.sh "$TAG"; then
+    rm -f "$PROJECT_SNAPSHOT"
+    echo "ERROR: Refusing to tag HEAD because its committed version does not match $TAG." >&2
+    exit 1
+  fi
+  rm -f "$PROJECT_SNAPSHOT"
+  if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+    if [[ "$(git rev-list -n 1 "$TAG")" != "$(git rev-parse HEAD)" ]]; then
+      echo "ERROR: Local tag $TAG does not point at the current release commit." >&2
+      exit 1
+    fi
+  else
+    git tag "$TAG"
+  fi
+  # The tag push is the authoritative release trigger. Do not dispatch a duplicate run.
+  git push origin "refs/tags/$TAG"
+  echo "Pushed $TAG; the serialized release workflow will build and publish it."
 fi
-
-# --- Cleanup ---
-rm -rf build/ cmux-macos.dmg appcast.xml
-echo ""
-echo "=== Release $TAG complete ==="
-say "cmux release complete"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -25,9 +25,9 @@ echo "Current: MARKETING_VERSION=$CURRENT_MARKETING, CURRENT_PROJECT_VERSION=$CU
 # Keep Sparkle build numbers monotonic with the latest published stable appcast.
 # If local build numbers have fallen behind due merges/rebases, auto-correct upward.
 LATEST_RELEASE_BUILD="$(
-  curl -fsSL --max-time 8 https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml 2>/dev/null \
+  curl -fsSL --max-time 8 https://files.cmux.com/stable/appcast.xml 2>/dev/null \
     | sed -n 's#.*<sparkle:version>\([0-9][0-9]*\)</sparkle:version>.*#\1#p' \
-    | head -n1
+    | head -n1 || true
 )"
 if [[ "$LATEST_RELEASE_BUILD" =~ ^[0-9]+$ ]]; then
   if (( LATEST_RELEASE_BUILD > MIN_BUILD )); then

--- a/scripts/ci/classify_stable_release.py
+++ b/scripts/ci/classify_stable_release.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Classify whether a stable tag is the highest semantic version."""
+
+import argparse
+import json
+import pathlib
+import re
+
+
+STABLE_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def parse_version(tag: str) -> tuple[int, int, int] | None:
+    match = STABLE_TAG.fullmatch(tag)
+    return tuple(map(int, match.groups())) if match else None
+
+
+def classify(candidate: str, releases: list[dict[str, object]]) -> dict[str, str]:
+    candidate_version = parse_version(candidate)
+    if candidate_version is None:
+        raise ValueError(f"candidate is not an exact stable tag: {candidate}")
+
+    tags = {candidate: candidate_version}
+    for release in releases:
+        tag = release.get("tagName")
+        if isinstance(tag, str) and (version := parse_version(tag)) is not None:
+            tags[tag] = version
+
+    latest_tag = max(tags, key=tags.__getitem__)
+    is_latest = latest_tag == candidate
+    return {
+        "latest_tag": latest_tag,
+        "is_latest": str(is_latest).lower(),
+        "make_latest": str(is_latest).lower(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--releases-json", required=True)
+    parser.add_argument("--github-output")
+    args = parser.parse_args()
+
+    releases = json.loads(pathlib.Path(args.releases_json).read_text(encoding="utf-8"))
+    result = classify(args.candidate, releases)
+    if args.github_output:
+        with pathlib.Path(args.github_output).open("a", encoding="utf-8") as output:
+            for key, value in result.items():
+                output.write(f"{key}={value}\n")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/upload-r2-object.py
+++ b/scripts/ci/upload-r2-object.py
@@ -6,6 +6,7 @@ import hmac
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -91,6 +92,37 @@ def _build_signed_request(args: argparse.Namespace, body: bytes, amz_date: str) 
     return urllib.request.Request(url, data=body, headers=request_headers, method="PUT")
 
 
+def _cache_busted(url: str, token: str) -> str:
+    parsed = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.append(("cmux_verify", token))
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urllib.parse.urlencode(query), parsed.fragment)
+    )
+
+
+def verify_publication(url: str, expected_body: bytes, *, attempts: int, delay: float) -> tuple[bool, str]:
+    expected_hash = hashlib.sha256(expected_body).hexdigest()
+    last_error = "no response"
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(
+            _cache_busted(url, f"{expected_hash}-{time.time_ns()}-{attempt}"),
+            headers={"Cache-Control": "no-cache", "User-Agent": "cmux-r2-publication-verifier"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                actual_body = response.read()
+            actual_hash = hashlib.sha256(actual_body).hexdigest()
+            if actual_body == expected_body:
+                return True, actual_hash
+            last_error = f"served SHA-256 {actual_hash}, expected {expected_hash}"
+        except (OSError, urllib.error.URLError) as error:
+            last_error = str(error)
+        if attempt < attempts:
+            time.sleep(delay)
+    return False, last_error
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Upload one object to Cloudflare R2 using AWS SigV4.")
     parser.add_argument("--file", required=True, help="Local file to upload")
@@ -98,6 +130,9 @@ def main() -> int:
     parser.add_argument("--bucket", required=True, help="R2 bucket name")
     parser.add_argument("--key", required=True, help="Object key inside the bucket")
     parser.add_argument("--cache-control", required=True, help="Cache-Control metadata")
+    parser.add_argument("--verify-url", help="Public URL that must serve the uploaded bytes")
+    parser.add_argument("--verify-attempts", type=int, default=10)
+    parser.add_argument("--verify-delay", type=float, default=2.0)
     parser.add_argument("--dry-run-json", action="store_true", help="Print the signed request instead of uploading")
     args = parser.parse_args()
 
@@ -127,7 +162,20 @@ def main() -> int:
         with urllib.request.urlopen(request, timeout=30) as response:
             response.read()
             print(f"Uploaded {args.file} to s3://{args.bucket}/{args.key} ({response.status})")
-            return 0
+        if args.verify_url:
+            verified, detail = verify_publication(
+                args.verify_url,
+                body,
+                attempts=args.verify_attempts,
+                delay=args.verify_delay,
+            )
+            if not verified:
+                sys.stderr.write(
+                    f"R2 upload succeeded but public verification failed for {args.verify_url}: {detail}\n"
+                )
+                return 1
+            print(f"Verified public appcast bytes at {args.verify_url} (SHA-256 {detail})")
+        return 0
     except urllib.error.HTTPError as error:
         sys.stderr.write(f"R2 upload failed: HTTP {error.code} {error.reason}\n")
         sys.stderr.write(error.read().decode("utf-8", errors="replace"))

--- a/scripts/ci/validate_release_appcast_assets.py
+++ b/scripts/ci/validate_release_appcast_assets.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Validate that one appcast points at one complete GitHub release artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+
+class ValidationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Candidate:
+    build: int
+    display_version: str
+    enclosure_url: str
+    enclosure_name: str
+    enclosure_length: int
+
+
+@dataclass(frozen=True)
+class PublishedRelease:
+    build: int
+    display_version: str
+
+
+def _local_name(name: str) -> str:
+    return name.rsplit("}", 1)[-1].rsplit(":", 1)[-1]
+
+
+def _attribute(element: ET.Element, local_name: str) -> str | None:
+    for name, value in element.attrib.items():
+        if _local_name(name) == local_name:
+            return value
+    return None
+
+
+def _child_text(element: ET.Element, local_name: str) -> str | None:
+    for child in element:
+        if _local_name(child.tag) == local_name and child.text:
+            return child.text.strip()
+    return None
+
+
+def parse_candidate(data: bytes, *, tag: str) -> Candidate:
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError as error:
+        raise ValidationError(f"appcast is not valid XML: {error}") from error
+
+    items = [element for element in root.iter() if _local_name(element.tag) == "item"]
+    if len(items) != 1:
+        raise ValidationError(f"appcast must contain exactly one full update item (found {len(items)})")
+
+    enclosures = [
+        element for element in items[0].iter() if _local_name(element.tag) == "enclosure"
+    ]
+    if len(enclosures) != 1:
+        raise ValidationError(f"appcast item must contain exactly one enclosure (found {len(enclosures)})")
+
+    enclosure = enclosures[0]
+    build_text = _attribute(enclosure, "version") or _child_text(items[0], "version") or ""
+    display_version = (
+        _attribute(enclosure, "shortVersionString")
+        or _child_text(items[0], "shortVersionString")
+        or ""
+    )
+    url = enclosure.attrib.get("url", "")
+    length_text = enclosure.attrib.get("length", "")
+    signature = _attribute(enclosure, "edSignature") or ""
+
+    if not build_text.isdigit() or int(build_text) <= 0:
+        raise ValidationError(f"appcast enclosure has invalid Sparkle build '{build_text}'")
+    if not display_version:
+        raise ValidationError("appcast enclosure is missing sparkle:shortVersionString")
+    if re.fullmatch(r"v\d+\.\d+\.\d+", tag) and display_version != tag.removeprefix("v"):
+        raise ValidationError(
+            f"appcast version {display_version} does not match stable release tag {tag}"
+        )
+    if not length_text.isdigit() or int(length_text) <= 0:
+        raise ValidationError(f"appcast enclosure has invalid length '{length_text}'")
+    if not signature:
+        raise ValidationError("appcast enclosure is missing sparkle:edSignature")
+
+    parsed = urllib.parse.urlsplit(url)
+    decoded_path = urllib.parse.unquote(parsed.path)
+    expected_prefix = f"/manaflow-ai/cmux/releases/download/{tag}/"
+    if parsed.scheme != "https" or parsed.netloc != "github.com" or not decoded_path.startswith(expected_prefix):
+        raise ValidationError(f"appcast enclosure does not target the {tag} GitHub release: {url}")
+    enclosure_name = decoded_path.removeprefix(expected_prefix)
+    if not enclosure_name or "/" in enclosure_name:
+        raise ValidationError(f"appcast enclosure has an invalid release asset name: {url}")
+
+    return Candidate(
+        build=int(build_text),
+        display_version=display_version,
+        enclosure_url=url,
+        enclosure_name=enclosure_name,
+        enclosure_length=int(length_text),
+    )
+
+
+def validate_release_assets(
+    candidate: Candidate,
+    *,
+    appcast_data: bytes,
+    assets_document: dict[str, object],
+    expected_enclosure: str | None,
+) -> None:
+    raw_assets = assets_document.get("assets")
+    if not isinstance(raw_assets, list):
+        raise ValidationError("GitHub release asset document has no assets list")
+
+    assets: dict[str, dict[str, object]] = {}
+    for raw_asset in raw_assets:
+        if isinstance(raw_asset, dict) and isinstance(raw_asset.get("name"), str):
+            assets[raw_asset["name"]] = raw_asset
+
+    if "appcast.xml" not in assets:
+        raise ValidationError("GitHub release is missing appcast.xml")
+    if candidate.enclosure_name not in assets:
+        raise ValidationError(
+            f"GitHub release is missing appcast enclosure asset {candidate.enclosure_name}"
+        )
+    if expected_enclosure is not None and candidate.enclosure_name != expected_enclosure:
+        raise ValidationError(
+            f"appcast enclosure is {candidate.enclosure_name}, expected {expected_enclosure}"
+        )
+
+    asset_size = assets[candidate.enclosure_name].get("size")
+    if not isinstance(asset_size, int) or asset_size <= 0:
+        raise ValidationError(f"GitHub asset {candidate.enclosure_name} has invalid size {asset_size!r}")
+    if asset_size != candidate.enclosure_length:
+        raise ValidationError(
+            f"appcast length {candidate.enclosure_length} does not match GitHub asset size {asset_size}"
+        )
+
+    appcast_asset = assets["appcast.xml"]
+    appcast_size = appcast_asset.get("size")
+    if appcast_size != len(appcast_data):
+        raise ValidationError(
+            f"local appcast size {len(appcast_data)} does not match GitHub asset size {appcast_size!r}"
+        )
+    digest = appcast_asset.get("digest")
+    expected_digest = f"sha256:{hashlib.sha256(appcast_data).hexdigest()}"
+    if digest != expected_digest:
+        raise ValidationError(
+            f"GitHub appcast digest {digest!r} does not match local appcast digest {expected_digest}"
+        )
+
+
+def validate_local_enclosure(
+    candidate: Candidate, *, enclosure_file: pathlib.Path, expected_enclosure: str | None
+) -> None:
+    if expected_enclosure is not None and candidate.enclosure_name != expected_enclosure:
+        raise ValidationError(
+            f"appcast enclosure is {candidate.enclosure_name}, expected {expected_enclosure}"
+        )
+    if enclosure_file.name != candidate.enclosure_name:
+        raise ValidationError(
+            f"appcast enclosure is {candidate.enclosure_name}, local file is {enclosure_file.name}"
+        )
+    size = enclosure_file.stat().st_size
+    if size != candidate.enclosure_length:
+        raise ValidationError(
+            f"appcast length {candidate.enclosure_length} does not match local artifact size {size}"
+        )
+
+
+def _cache_busted(url: str, token: str) -> str:
+    parsed = urllib.parse.urlsplit(url)
+    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query.append(("cmux_verify", token))
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urllib.parse.urlencode(query), parsed.fragment)
+    )
+
+
+def parse_current_release(data: bytes) -> PublishedRelease:
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError as error:
+        raise ValidationError(f"current appcast is not valid XML: {error}") from error
+    items = [element for element in root.iter() if _local_name(element.tag) == "item"]
+    if len(items) != 1:
+        raise ValidationError(f"current appcast must have one item (found {len(items)})")
+    enclosures = [element for element in items[0].iter() if _local_name(element.tag) == "enclosure"]
+    if len(enclosures) != 1:
+        raise ValidationError(f"current appcast must have one enclosure (found {len(enclosures)})")
+    build_text = _attribute(enclosures[0], "version") or _child_text(items[0], "version") or ""
+    display_version = (
+        _attribute(enclosures[0], "shortVersionString")
+        or _child_text(items[0], "shortVersionString")
+        or ""
+    )
+    if not build_text.isdigit() or int(build_text) <= 0:
+        raise ValidationError(f"current appcast has invalid Sparkle build '{build_text}'")
+    if not display_version:
+        raise ValidationError("current appcast is missing sparkle:shortVersionString")
+    return PublishedRelease(build=int(build_text), display_version=display_version)
+
+
+def parse_current_build(data: bytes) -> int:
+    return parse_current_release(data).build
+
+
+def fetch_current_release(url: str, *, attempts: int, delay: float) -> PublishedRelease | None:
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(
+            _cache_busted(url, f"current-{time.time_ns()}-{attempt}"),
+            headers={"Cache-Control": "no-cache", "User-Agent": "cmux-release-validator"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                return parse_current_release(response.read())
+        except (OSError, urllib.error.URLError, ValidationError):
+            if attempt < attempts:
+                time.sleep(delay)
+    return None
+
+
+def validate_publication_order(
+    candidate: Candidate,
+    current_release: PublishedRelease | None,
+    *,
+    allow_missing_current_feed: bool,
+) -> None:
+    if current_release is None:
+        if not allow_missing_current_feed:
+            raise ValidationError(
+                "current feed is missing or invalid; normal publication fails closed "
+                "(use explicit appcast repair)"
+            )
+        return
+    if candidate.build < current_release.build:
+        raise ValidationError(
+            f"candidate Sparkle build {candidate.build} would roll back current build "
+            f"{current_release.build}"
+        )
+    if (
+        candidate.build == current_release.build
+        and candidate.display_version != current_release.display_version
+    ):
+        raise ValidationError(
+            f"candidate {candidate.display_version} reuses Sparkle build {candidate.build} "
+            f"from current release {current_release.display_version}"
+        )
+
+
+def verify_enclosure(candidate: Candidate, *, attempts: int, delay: float) -> None:
+    last_error = "unknown error"
+    for attempt in range(1, attempts + 1):
+        request = urllib.request.Request(
+            _cache_busted(candidate.enclosure_url, f"asset-{time.time_ns()}-{attempt}"),
+            headers={"Cache-Control": "no-cache", "User-Agent": "cmux-release-validator"},
+            method="HEAD",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                length_text = response.headers.get("Content-Length")
+                if length_text is not None and int(length_text) != candidate.enclosure_length:
+                    raise ValidationError(
+                        f"public enclosure length {length_text} does not match appcast length "
+                        f"{candidate.enclosure_length}"
+                    )
+                return
+        except (OSError, ValueError, urllib.error.URLError, ValidationError) as error:
+            last_error = str(error)
+            if attempt < attempts:
+                time.sleep(delay)
+    raise ValidationError(f"public enclosure never became readable: {last_error}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--appcast", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--assets-json")
+    parser.add_argument("--enclosure-file")
+    parser.add_argument("--expected-enclosure")
+    parser.add_argument("--current-feed-url")
+    parser.add_argument(
+        "--allow-missing-current-feed",
+        action="store_true",
+        help="Allow an unreadable current feed only for an explicit repair operation",
+    )
+    parser.add_argument("--verify-enclosure", action="store_true")
+    parser.add_argument("--attempts", type=int, default=10)
+    parser.add_argument("--delay", type=float, default=2.0)
+    args = parser.parse_args()
+
+    try:
+        appcast_data = pathlib.Path(args.appcast).read_bytes()
+        candidate = parse_candidate(appcast_data, tag=args.tag)
+        if not args.assets_json and not args.enclosure_file:
+            raise ValidationError("provide --assets-json or --enclosure-file")
+        if args.assets_json:
+            assets_document = json.loads(pathlib.Path(args.assets_json).read_text(encoding="utf-8"))
+            validate_release_assets(
+                candidate,
+                appcast_data=appcast_data,
+                assets_document=assets_document,
+                expected_enclosure=args.expected_enclosure,
+            )
+        if args.enclosure_file:
+            validate_local_enclosure(
+                candidate,
+                enclosure_file=pathlib.Path(args.enclosure_file),
+                expected_enclosure=args.expected_enclosure,
+            )
+        if args.current_feed_url:
+            current_release = fetch_current_release(
+                args.current_feed_url, attempts=args.attempts, delay=args.delay
+            )
+            validate_publication_order(
+                candidate,
+                current_release,
+                allow_missing_current_feed=args.allow_missing_current_feed,
+            )
+            if current_release is None:
+                print(
+                    f"WARNING: current feed is missing or invalid; allowing explicit build {candidate.build} repair",
+                    file=sys.stderr,
+                )
+        if args.verify_enclosure:
+            verify_enclosure(candidate, attempts=args.attempts, delay=args.delay)
+    except (OSError, json.JSONDecodeError, ValidationError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"PASS: {args.tag} appcast build {candidate.build} points to complete asset "
+        f"{candidate.enclosure_name}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release-pretag-guard.sh
+++ b/scripts/release-pretag-guard.sh
@@ -4,5 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 echo "Running release pre-tag checks..."
-"$ROOT_DIR/tests/test_ci_sparkle_build_monotonic.sh"
+PROJECT_VERSION="$(sed -n 's/.*MARKETING_VERSION = \([^;]*\);.*/\1/p' "$ROOT_DIR/cmux.xcodeproj/project.pbxproj" | head -n1)"
+"$ROOT_DIR/scripts/validate-release-version.sh" "${1:-v$PROJECT_VERSION}"
+CMUX_SPARKLE_MONOTONIC_STRICT=1 "$ROOT_DIR/tests/test_ci_sparkle_build_monotonic.sh"
 echo "Release pre-tag checks passed."

--- a/scripts/release_asset_guard.js
+++ b/scripts/release_asset_guard.js
@@ -16,7 +16,11 @@ const RELEASE_ASSET_GUARD_STATE = Object.freeze({
   COMPLETE: "complete",
 });
 
-function evaluateReleaseAssetGuard({ existingAssetNames, immutableAssetNames = IMMUTABLE_RELEASE_ASSETS }) {
+function evaluateReleaseAssetGuard({
+  existingAssetNames,
+  immutableAssetNames = IMMUTABLE_RELEASE_ASSETS,
+  releaseIsDraft = false,
+}) {
   const immutableAssets = immutableAssetNames || IMMUTABLE_RELEASE_ASSETS;
   const existing = new Set(existingAssetNames || []);
   const conflicts = immutableAssets.filter((assetName) => existing.has(assetName));
@@ -36,6 +40,8 @@ function evaluateReleaseAssetGuard({ existingAssetNames, immutableAssetNames = I
     hasPartialConflict: guardState === RELEASE_ASSET_GUARD_STATE.PARTIAL,
     shouldSkipBuildAndUpload: guardState === RELEASE_ASSET_GUARD_STATE.COMPLETE,
     shouldSkipUpload: guardState === RELEASE_ASSET_GUARD_STATE.COMPLETE,
+    requiresDraftFinalization:
+      guardState === RELEASE_ASSET_GUARD_STATE.COMPLETE && Boolean(releaseIsDraft),
   };
 }
 

--- a/scripts/release_asset_guard.test.js
+++ b/scripts/release_asset_guard.test.js
@@ -20,6 +20,18 @@ test("marks guard as complete and skips build/upload when all immutable assets a
   assert.equal(result.hasPartialConflict, false);
   assert.equal(result.shouldSkipBuildAndUpload, true);
   assert.equal(result.shouldSkipUpload, true);
+  assert.equal(result.requiresDraftFinalization, false);
+});
+
+test("finalizes a complete draft before repairing downstream publication", () => {
+  const result = evaluateReleaseAssetGuard({
+    existingAssetNames: IMMUTABLE_RELEASE_ASSETS,
+    releaseIsDraft: true,
+  });
+
+  assert.equal(result.guardState, RELEASE_ASSET_GUARD_STATE.COMPLETE);
+  assert.equal(result.shouldSkipBuildAndUpload, true);
+  assert.equal(result.requiresDraftFinalization, true);
 });
 
 test("marks guard as clear when immutable assets are not present", () => {
@@ -33,6 +45,7 @@ test("marks guard as clear when immutable assets are not present", () => {
   assert.equal(result.hasPartialConflict, false);
   assert.equal(result.shouldSkipBuildAndUpload, false);
   assert.equal(result.shouldSkipUpload, false);
+  assert.equal(result.requiresDraftFinalization, false);
 });
 
 test("marks guard as partial when only some immutable assets exist", () => {
@@ -50,4 +63,5 @@ test("marks guard as partial when only some immutable assets exist", () => {
   assert.equal(result.hasPartialConflict, true);
   assert.equal(result.shouldSkipBuildAndUpload, false);
   assert.equal(result.shouldSkipUpload, false);
+  assert.equal(result.requiresDraftFinalization, false);
 });

--- a/scripts/sparkle_generate_appcast.sh
+++ b/scripts/sparkle_generate_appcast.sh
@@ -37,27 +37,12 @@ xcodebuild \
   CODE_SIGNING_ALLOWED=NO \
   build >/dev/null
 
-echo "Building Sparkle sign_update tool..."
-xcodebuild \
-  -project "$work_dir/Sparkle/Sparkle.xcodeproj" \
-  -scheme sign_update \
-  -configuration Release \
-  -derivedDataPath "$work_dir/build" \
-  CODE_SIGNING_ALLOWED=NO \
-  build >/dev/null
-
 generate_appcast="$work_dir/build/Build/Products/Release/generate_appcast"
-sign_update="$work_dir/build/Build/Products/Release/sign_update"
 
 if [[ ! -x "$generate_appcast" ]]; then
   echo "generate_appcast binary not found at $generate_appcast" >&2
   exit 1
 fi
-if [[ ! -x "$sign_update" ]]; then
-  echo "sign_update binary not found at $sign_update" >&2
-  exit 1
-fi
-
 archives_dir="$work_dir/archives"
 mkdir -p "$archives_dir"
 cp "$DMG_PATH" "$archives_dir/$(basename "$DMG_PATH")"
@@ -90,31 +75,11 @@ if [[ ! -f "$generated_appcast_path" ]]; then
   exit 1
 fi
 
-# Check if generate_appcast added the edSignature. If not, use sign_update
-# to sign the DMG and inject the signature. generate_appcast silently skips
-# signing when the public key derived from the private key doesn't match the
-# SUPublicEDKey in the app's Info.plist.
+# `generate_appcast` must sign structurally. Text-injecting a fallback signature can duplicate
+# enclosure attributes and publish malformed XML; a key mismatch is a release-blocking error.
 if ! grep -q 'sparkle:edSignature' "$generated_appcast_path"; then
-  echo "Warning: generate_appcast did not add edSignature. Using sign_update fallback..."
-  SIGNATURE=$("$sign_update" -p --ed-key-file "$key_file" "$DMG_PATH")
-  DMG_LENGTH=$(stat -f%z "$DMG_PATH")
-  echo "  EdDSA signature: ${SIGNATURE:0:20}..."
-  echo "  DMG length: $DMG_LENGTH"
-
-  # Inject sparkle:edSignature and correct length into the enclosure element
-  python3 -c "
-import sys
-xml = open('$generated_appcast_path').read()
-sig = '$SIGNATURE'
-length = '$DMG_LENGTH'
-# Add edSignature to enclosure
-xml = xml.replace(
-    'type=\"application/octet-stream\"',
-    'sparkle:edSignature=\"' + sig + '\" length=\"' + length + '\" type=\"application/octet-stream\"'
-)
-open('$generated_appcast_path', 'w').write(xml)
-print('  Injected edSignature into appcast.xml')
-"
+  echo "ERROR: generate_appcast did not sign the enclosure; verify SPARKLE_PRIVATE_KEY matches the app's SUPublicEDKey." >&2
+  exit 1
 fi
 
 cp "$generated_appcast_path" "$OUT_PATH"

--- a/scripts/validate-release-version.sh
+++ b/scripts/validate-release-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PROJECT_FILE="${CMUX_PROJECT_FILE:-$ROOT_DIR/cmux.xcodeproj/project.pbxproj}"
+TAG="${1:-}"
+
+if [[ ! "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "FAIL: stable release tag must match v<major>.<minor>.<patch> exactly (got '$TAG')" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PROJECT_FILE" ]]; then
+  echo "FAIL: Xcode project not found at $PROJECT_FILE" >&2
+  exit 1
+fi
+
+PROJECT_VERSIONS="$(
+  sed -n 's/.*MARKETING_VERSION = \([^;]*\);.*/\1/p' "$PROJECT_FILE" \
+    | sort -u
+)"
+VERSION_COUNT="$(printf '%s\n' "$PROJECT_VERSIONS" | sed '/^$/d' | wc -l | tr -d ' ')"
+if [[ "$VERSION_COUNT" != "1" ]]; then
+  echo "FAIL: MARKETING_VERSION values are missing or inconsistent:" >&2
+  printf '%s\n' "$PROJECT_VERSIONS" >&2
+  exit 1
+fi
+
+PROJECT_VERSION="$(printf '%s\n' "$PROJECT_VERSIONS" | head -n1)"
+TAG_VERSION="${TAG#v}"
+if [[ "$TAG_VERSION" != "$PROJECT_VERSION" ]]; then
+  echo "FAIL: release tag $TAG does not match MARKETING_VERSION $PROJECT_VERSION" >&2
+  exit 1
+fi
+
+echo "PASS: release tag $TAG matches MARKETING_VERSION $PROJECT_VERSION"

--- a/tests/test_build_sign_upload_contract.sh
+++ b/tests/test_build_sign_upload_contract.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+REMOTE_DIR="$FIXTURE_DIR/origin.git"
+REPO_DIR="$FIXTURE_DIR/repo"
+BIN_DIR="$FIXTURE_DIR/bin"
+GH_LOG="$FIXTURE_DIR/gh.log"
+mkdir -p "$REPO_DIR/scripts" "$REPO_DIR/cmux.xcodeproj" "$BIN_DIR"
+
+git init --bare -q "$REMOTE_DIR"
+git init -q "$REPO_DIR"
+git -C "$REPO_DIR" config user.name "Release Contract Test"
+git -C "$REPO_DIR" config user.email "release-contract@example.com"
+git -C "$REPO_DIR" config commit.gpgsign false
+git -C "$REPO_DIR" remote add origin "$REMOTE_DIR"
+
+cp "$ROOT_DIR/scripts/build-sign-upload.sh" "$REPO_DIR/scripts/build-sign-upload.sh"
+cp "$ROOT_DIR/scripts/validate-release-version.sh" "$REPO_DIR/scripts/validate-release-version.sh"
+printf '%s\n' \
+  'MARKETING_VERSION = 1.2.3;' \
+  'MARKETING_VERSION = 1.2.3;' \
+  > "$REPO_DIR/cmux.xcodeproj/project.pbxproj"
+git -C "$REPO_DIR" add scripts cmux.xcodeproj/project.pbxproj
+git -C "$REPO_DIR" commit -qm "release fixture"
+git -C "$REPO_DIR" branch -M main
+git -C "$REPO_DIR" push -q -u origin main
+
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'printf "%s\n" "$*" >> "$CMUX_TEST_GH_LOG"'
+} > "$BIN_DIR/gh"
+chmod +x "$BIN_DIR/gh"
+
+run_wrapper() {
+  (
+    cd "$REPO_DIR"
+    PATH="$BIN_DIR:$PATH" CMUX_TEST_GH_LOG="$GH_LOG" \
+      ./scripts/build-sign-upload.sh "$@"
+  )
+}
+
+# A new tag validates the committed project, pushes exactly once, and lets the tag push trigger CI.
+run_wrapper v1.2.3 >/dev/null
+git ls-remote --exit-code "$REMOTE_DIR" refs/tags/v1.2.3 >/dev/null
+if [[ -s "$GH_LOG" ]]; then
+  echo "FAIL: new tag push also dispatched a duplicate workflow" >&2
+  exit 1
+fi
+
+# Existing-tag publication and repair execute current default-branch workflow code at the target tag.
+run_wrapper v1.2.3 >/dev/null
+run_wrapper v1.2.3 --repair-appcast >/dev/null
+if ! grep -Fxq \
+  'workflow run release.yml --ref main --field operation=publish --field release_tag=v1.2.3' \
+  "$GH_LOG"; then
+  echo "FAIL: existing release retry did not dispatch default-branch publish with release_tag" >&2
+  exit 1
+fi
+if ! grep -Fxq \
+  'workflow run release.yml --ref main --field operation=publish-existing --field release_tag=v1.2.3' \
+  "$GH_LOG"; then
+  echo "FAIL: appcast repair did not dispatch default-branch publish-existing with release_tag" >&2
+  exit 1
+fi
+
+# An uncommitted version bump must never create an immutable tag for the old HEAD commit.
+printf '%s\n' 'MARKETING_VERSION = 1.2.4;' > "$REPO_DIR/cmux.xcodeproj/project.pbxproj"
+if run_wrapper v1.2.4 >/dev/null 2>&1; then
+  echo "FAIL: uncommitted marketing version created a release tag" >&2
+  exit 1
+fi
+if git ls-remote --exit-code "$REMOTE_DIR" refs/tags/v1.2.4 >/dev/null 2>&1; then
+  echo "FAIL: mismatched committed release tag reached origin" >&2
+  exit 1
+fi
+
+# Rolling nightly publication can rebuild, but cannot claim exact immutable appcast repair.
+run_wrapper nightly >/dev/null
+LINES_BEFORE_REPAIR="$(wc -l < "$GH_LOG" | tr -d ' ')"
+if run_wrapper nightly --repair-appcast >/dev/null 2>&1; then
+  echo "FAIL: nightly accepted unsupported appcast-only repair" >&2
+  exit 1
+fi
+LINES_AFTER_REPAIR="$(wc -l < "$GH_LOG" | tr -d ' ')"
+if [[ "$LINES_BEFORE_REPAIR" != "$LINES_AFTER_REPAIR" ]]; then
+  echo "FAIL: rejected nightly repair still dispatched a workflow" >&2
+  exit 1
+fi
+if ! grep -Fxq 'workflow run nightly.yml --ref main --field force=true' "$GH_LOG"; then
+  echo "FAIL: normal nightly publication did not dispatch the serialized workflow" >&2
+  exit 1
+fi
+
+echo "PASS: release wrapper dispatches current workflows and tags committed versions only"

--- a/tests/test_ci_r2_publication_verification.py
+++ b/tests/test_ci_r2_publication_verification.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import importlib.util
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts/ci/upload-r2-object.py"
+SPEC = importlib.util.spec_from_file_location("upload_r2_object", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class Response:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return self.body
+
+
+class PublicationVerificationTests(unittest.TestCase):
+    @mock.patch.object(MODULE.time, "sleep")
+    @mock.patch.object(MODULE.urllib.request, "urlopen")
+    def test_retries_stale_bytes_until_exact_match(self, urlopen, _sleep) -> None:
+        urlopen.side_effect = [Response(b"old"), Response(b"new")]
+        verified, _detail = MODULE.verify_publication(
+            "https://files.cmux.com/stable/appcast.xml", b"new", attempts=2, delay=0
+        )
+        self.assertTrue(verified)
+        self.assertEqual(urlopen.call_count, 2)
+
+    @mock.patch.object(MODULE.time, "sleep")
+    @mock.patch.object(MODULE.urllib.request, "urlopen")
+    def test_fails_when_public_url_never_matches(self, urlopen, _sleep) -> None:
+        urlopen.side_effect = [Response(b"old"), Response(b"still-old")]
+        verified, detail = MODULE.verify_publication(
+            "https://files.cmux.com/stable/appcast.xml", b"new", attempts=2, delay=0
+        )
+        self.assertFalse(verified)
+        self.assertIn("expected", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_r2_upload_python.sh
+++ b/tests/test_ci_r2_upload_python.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 printf '<rss>ok</rss>' >"$TMP_DIR/appcast.xml"
 
 python3 -m py_compile "$ROOT_DIR/scripts/ci/upload-r2-object.py"
+python3 "$ROOT_DIR/tests/test_ci_r2_publication_verification.py"
 
 AWS_ACCESS_KEY_ID=AKIDEXAMPLE \
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY \
@@ -51,6 +52,11 @@ if ! grep -Fq "scripts/ci/upload-r2-object.py" "$ROOT_DIR/.github/workflows/nigh
 fi
 if ! grep -Fq "scripts/ci/upload-r2-object.py" "$ROOT_DIR/.github/workflows/release.yml"; then
   echo "FAIL: release workflow must use the Python R2 uploader"
+  exit 1
+fi
+if ! grep -Fq -- '--verify-url "https://files.cmux.com/nightly/appcast.xml"' "$ROOT_DIR/.github/workflows/nightly.yml" \
+  || ! grep -Fq -- '--verify-url "https://files.cmux.com/stable/appcast.xml"' "$ROOT_DIR/.github/workflows/release.yml"; then
+  echo "FAIL: release appcast uploads must verify the authoritative public URL"
   exit 1
 fi
 

--- a/tests/test_ci_sparkle_build_monotonic.sh
+++ b/tests/test_ci_sparkle_build_monotonic.sh
@@ -8,8 +8,9 @@
 # compares CFBundleVersion (CURRENT_PROJECT_VERSION) against <sparkle:version>
 # — the marketing string is informational only.
 #
-# If the published appcast cannot be fetched (e.g. offline CI runner), the
-# test soft-passes with a warning so it never blocks unrelated work.
+# Release callers set CMUX_SPARKLE_MONOTONIC_STRICT=1 so an unavailable
+# authoritative appcast fails closed. Non-release callers retain a soft pass
+# so an offline network does not block unrelated development checks.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -36,11 +37,15 @@ if [[ "$MISMATCHED" != "1" ]]; then
 fi
 
 PUBLISHED_BUILD=$(curl -fsSL --max-time 15 \
-  https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml 2>/dev/null \
+  https://files.cmux.com/stable/appcast.xml 2>/dev/null \
   | sed -n 's#.*<sparkle:version>\([0-9][0-9]*\)</sparkle:version>.*#\1#p' \
   | head -n1 || true)
 
 if ! [[ "$PUBLISHED_BUILD" =~ ^[0-9]+$ ]]; then
+  if [[ "${CMUX_SPARKLE_MONOTONIC_STRICT:-0}" == "1" ]]; then
+    echo "FAIL: could not fetch the authoritative stable Sparkle build from https://files.cmux.com/stable/appcast.xml" >&2
+    exit 1
+  fi
   echo "WARN: could not fetch latest published Sparkle build; skipping monotonic check"
   echo "PASS (soft): local CURRENT_PROJECT_VERSION=$LOCAL_BUILD"
   exit 0

--- a/tests/test_ci_sparkle_monotonic_strict.sh
+++ b/tests/test_ci_sparkle_monotonic_strict.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+cat >"$STUB_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 22
+EOF
+chmod +x "$STUB_DIR/curl"
+
+if PATH="$STUB_DIR:$PATH" CMUX_SPARKLE_MONOTONIC_STRICT=1 \
+  "$ROOT_DIR/tests/test_ci_sparkle_build_monotonic.sh" >"$STUB_DIR/output.log" 2>&1; then
+  echo "FAIL: release-mode Sparkle validation passed without an authoritative feed" >&2
+  cat "$STUB_DIR/output.log" >&2
+  exit 1
+fi
+
+echo "PASS: release-mode Sparkle validation fails closed when the feed is unavailable"

--- a/tests/test_ci_universal_release_settings.sh
+++ b/tests/test_ci_universal_release_settings.sh
@@ -6,8 +6,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 for file in \
   "$ROOT_DIR/.github/workflows/build-ghosttykit.yml" \
-  "$ROOT_DIR/scripts/setup.sh" \
-  "$ROOT_DIR/scripts/build-sign-upload.sh"
+  "$ROOT_DIR/scripts/ensure-ghosttykit.sh"
 do
   if ! grep -Fq -- '-Dxcframework-target=universal' "$file"; then
     echo "FAIL: $file must build GhosttyKit with -Dxcframework-target=universal"

--- a/tests/test_classify_stable_release.py
+++ b/tests/test_classify_stable_release.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts/ci/classify_stable_release.py"
+SPEC = importlib.util.spec_from_file_location("classify_stable_release", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class StableReleaseOrderTests(unittest.TestCase):
+    def test_candidate_is_included_before_github_lists_it(self) -> None:
+        result = MODULE.classify("v0.64.21", [{"tagName": "v0.64.20"}])
+        self.assertEqual(result["is_latest"], "true")
+        self.assertEqual(result["latest_tag"], "v0.64.21")
+
+    def test_backport_is_never_latest(self) -> None:
+        result = MODULE.classify("v0.63.9", [{"tagName": "v0.64.20"}])
+        self.assertEqual(result["make_latest"], "false")
+        self.assertEqual(result["latest_tag"], "v0.64.20")
+
+    def test_nonstable_existing_tags_do_not_contaminate_order(self) -> None:
+        result = MODULE.classify(
+            "v0.64.21",
+            [{"tagName": "nightly"}, {"tagName": "v99.0.0-rc.1"}],
+        )
+        self.assertEqual(result["is_latest"], "true")
+
+    def test_nonstable_candidate_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            MODULE.classify("v0.65.0-rc.1", [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_appcast_asset_validation.py
+++ b/tests/test_release_appcast_asset_validation.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+import importlib.util
+import hashlib
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts/ci/validate_release_appcast_assets.py"
+SPEC = importlib.util.spec_from_file_location("validate_release_appcast_assets", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def appcast(*, tag: str = "v0.64.20", build: int = 100, asset: str = "cmux-macos.dmg", length: int = 123) -> bytes:
+    return f'''<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel><item>
+  <sparkle:version>{build}</sparkle:version>
+  <sparkle:shortVersionString>0.64.20</sparkle:shortVersionString>
+  <enclosure
+    url="https://github.com/manaflow-ai/cmux/releases/download/{tag}/{asset}"
+    length="{length}"
+    type="application/octet-stream"
+    sparkle:edSignature="signed" />
+  </item></channel>
+</rss>'''.encode()
+
+
+class ReleaseAppcastValidationTests(unittest.TestCase):
+    def assets(
+        self,
+        *,
+        appcast_data: bytes | None = None,
+        include_dmg: bool = True,
+        size: int = 123,
+    ) -> dict[str, object]:
+        appcast_data = appcast() if appcast_data is None else appcast_data
+        values = [{
+            "name": "appcast.xml",
+            "size": len(appcast_data),
+            "digest": f"sha256:{hashlib.sha256(appcast_data).hexdigest()}",
+        }]
+        if include_dmg:
+            values.append({"name": "cmux-macos.dmg", "size": size})
+        return {"assets": values}
+
+    def test_valid_single_full_release(self) -> None:
+        appcast_data = appcast()
+        candidate = MODULE.parse_candidate(appcast_data, tag="v0.64.20")
+        MODULE.validate_release_assets(
+            candidate,
+            appcast_data=appcast_data,
+            assets_document=self.assets(appcast_data=appcast_data),
+            expected_enclosure="cmux-macos.dmg",
+        )
+        self.assertEqual(candidate.build, 100)
+
+    def test_local_artifact_must_match_enclosure_length(self) -> None:
+        candidate = MODULE.parse_candidate(appcast(length=3), tag="v0.64.20")
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = pathlib.Path(directory) / "cmux-macos.dmg"
+            artifact.write_bytes(b"dmg")
+            MODULE.validate_local_enclosure(
+                candidate,
+                enclosure_file=artifact,
+                expected_enclosure="cmux-macos.dmg",
+            )
+            artifact.write_bytes(b"wrong")
+            with self.assertRaises(MODULE.ValidationError):
+                MODULE.validate_local_enclosure(
+                    candidate,
+                    enclosure_file=artifact,
+                    expected_enclosure="cmux-macos.dmg",
+                )
+
+    def test_missing_dmg_is_rejected(self) -> None:
+        candidate = MODULE.parse_candidate(appcast(), tag="v0.64.20")
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.validate_release_assets(
+                candidate,
+                appcast_data=appcast(),
+                assets_document=self.assets(include_dmg=False),
+                expected_enclosure="cmux-macos.dmg",
+            )
+
+    def test_wrong_tag_and_length_are_rejected(self) -> None:
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.parse_candidate(appcast(tag="v0.64.19"), tag="v0.64.20")
+
+        candidate = MODULE.parse_candidate(appcast(length=124), tag="v0.64.20")
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.validate_release_assets(
+                candidate,
+                appcast_data=appcast(length=124),
+                assets_document=self.assets(appcast_data=appcast(length=124), size=123),
+                expected_enclosure="cmux-macos.dmg",
+            )
+
+    def test_github_appcast_digest_must_match_local_bytes(self) -> None:
+        appcast_data = appcast()
+        candidate = MODULE.parse_candidate(appcast_data, tag="v0.64.20")
+        assets = self.assets(appcast_data=appcast_data)
+        assets["assets"][0]["digest"] = "sha256:" + ("0" * 64)
+
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.validate_release_assets(
+                candidate,
+                appcast_data=appcast_data,
+                assets_document=assets,
+                expected_enclosure="cmux-macos.dmg",
+            )
+
+    def test_malformed_duplicate_length_is_rejected(self) -> None:
+        malformed = appcast().replace(b'length="123"', b'length="123" length="123"')
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.parse_candidate(malformed, tag="v0.64.20")
+
+    def test_lower_candidate_build_is_rejected_and_higher_build_is_allowed(self) -> None:
+        candidate = MODULE.parse_candidate(appcast(build=99), tag="v0.64.20")
+        current = MODULE.parse_current_release(appcast(build=100))
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.validate_publication_order(
+                candidate,
+                current,
+                allow_missing_current_feed=False,
+            )
+
+        higher = MODULE.parse_candidate(appcast(build=101), tag="v0.64.20")
+        MODULE.validate_publication_order(
+            higher,
+            current,
+            allow_missing_current_feed=False,
+        )
+
+    def test_equal_build_with_different_version_is_not_the_same_release(self) -> None:
+        current = MODULE.parse_current_release(appcast(build=100))
+        candidate_data = appcast(tag="v0.64.21", build=100).replace(b"0.64.20", b"0.64.21")
+        candidate = MODULE.parse_candidate(candidate_data, tag="v0.64.21")
+
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.validate_publication_order(
+                candidate,
+                current,
+                allow_missing_current_feed=False,
+            )
+
+    def test_equal_build_and_version_is_allowed_for_exact_repair(self) -> None:
+        candidate = MODULE.parse_candidate(appcast(), tag="v0.64.20")
+        current = MODULE.parse_current_release(appcast())
+        MODULE.validate_publication_order(
+            candidate,
+            current,
+            allow_missing_current_feed=False,
+        )
+
+    def test_missing_current_feed_requires_explicit_repair(self) -> None:
+        candidate = MODULE.parse_candidate(appcast(), tag="v0.64.20")
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.validate_publication_order(
+                candidate,
+                None,
+                allow_missing_current_feed=False,
+            )
+        MODULE.validate_publication_order(
+            candidate,
+            None,
+            allow_missing_current_feed=True,
+        )
+
+    def test_multiple_items_are_rejected(self) -> None:
+        data = appcast()
+        item_start = data.index(b"<item>")
+        item_end = data.index(b"</item>") + len(b"</item>")
+        duplicated = data.replace(b"</channel>", data[item_start:item_end] + b"</channel>")
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.parse_candidate(duplicated, tag="v0.64.20")
+
+    def test_multiple_enclosures_are_rejected(self) -> None:
+        data = appcast()
+        enclosure_start = data.index(b"<enclosure")
+        enclosure_end = data.index(b"/>", enclosure_start) + len(b"/>")
+        enclosure = data[enclosure_start:enclosure_end]
+        duplicated = data.replace(enclosure, enclosure + enclosure)
+        with self.assertRaises(MODULE.ValidationError):
+            MODULE.parse_candidate(duplicated, tag="v0.64.20")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_version_contract.sh
+++ b/tests/test_release_version_contract.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+PROJECT_FILE="$FIXTURE_DIR/project.pbxproj"
+
+write_versions() {
+  printf 'MARKETING_VERSION = %s;\nMARKETING_VERSION = %s;\n' "$1" "$2" > "$PROJECT_FILE"
+}
+
+write_versions 0.64.20 0.64.20
+CMUX_PROJECT_FILE="$PROJECT_FILE" "$ROOT_DIR/scripts/validate-release-version.sh" v0.64.20 >/dev/null
+
+for invalid_tag in v0.64.19 v0.64.20-rc.1 nightly release-0.64.20; do
+  if CMUX_PROJECT_FILE="$PROJECT_FILE" "$ROOT_DIR/scripts/validate-release-version.sh" "$invalid_tag" >/dev/null 2>&1; then
+    echo "FAIL: accepted invalid or mismatched stable tag $invalid_tag" >&2
+    exit 1
+  fi
+done
+
+write_versions 0.64.20 0.64.21
+if CMUX_PROJECT_FILE="$PROJECT_FILE" "$ROOT_DIR/scripts/validate-release-version.sh" v0.64.20 >/dev/null 2>&1; then
+  echo "FAIL: accepted inconsistent MARKETING_VERSION values" >&2
+  exit 1
+fi
+
+echo "PASS: stable release tags must exactly match one project marketing version"

--- a/tests/test_stable_update_feed_contract.sh
+++ b/tests/test_stable_update_feed_contract.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+EXPECTED_FEED="https://files.cmux.com/stable/appcast.xml"
+LEGACY_FEED="https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml"
+
+"$ROOT_DIR/tests/test_release_version_contract.sh"
+bash "$ROOT_DIR/tests/test_build_sign_upload_contract.sh"
+node --test "$ROOT_DIR/scripts/release_asset_guard.test.js"
+python3 "$ROOT_DIR/tests/test_classify_stable_release.py"
+python3 "$ROOT_DIR/tests/test_release_appcast_asset_validation.py"
+
+python3 - "$ROOT_DIR/Resources/Info.plist" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    plist = plistlib.load(handle)
+if plist.get("SUAllowsAutomaticUpdates") is not False:
+    raise SystemExit("FAIL: Sparkle automatic installs bypass the fresh latest-resolution path")
+PY
+
+FILES=(
+  "$ROOT_DIR/Resources/Info.plist"
+  "$ROOT_DIR/.github/workflows/release.yml"
+  "$ROOT_DIR/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateFeedResolver.swift"
+)
+
+for file in "${FILES[@]}"; do
+  if ! rg -Fq "$EXPECTED_FEED" "$file"; then
+    echo "FAIL: $file does not use the atomic stable appcast" >&2
+    exit 1
+  fi
+  if rg -Fq "$LEGACY_FEED" "$file"; then
+    echo "FAIL: $file still uses the redirect-based stable appcast" >&2
+    exit 1
+  fi
+done
+
+MANUAL_RELEASE="$ROOT_DIR/scripts/build-sign-upload.sh"
+if ! rg -Fq 'gh workflow run release.yml' "$MANUAL_RELEASE" \
+  || ! rg -Fq 'operation=publish-existing' "$MANUAL_RELEASE" \
+  || rg -Fq 'upload-r2-object.py' "$MANUAL_RELEASE" \
+  || rg -Fq 'gh release edit' "$MANUAL_RELEASE"; then
+  echo "FAIL: the manual release path bypasses serialized workflow publication" >&2
+  exit 1
+fi
+
+if ! rg -Fq -- '--repair-appcast' "$MANUAL_RELEASE" \
+  || ! rg -Fq -- '--field operation=publish-existing' "$MANUAL_RELEASE" \
+  || ! rg -Fq -- '--field release_tag="$TAG"' "$MANUAL_RELEASE" \
+  || ! rg -Fq -- '--ref "$WORKFLOW_REF"' "$MANUAL_RELEASE" \
+  || rg -Fq -- '--ref "$TAG"' "$MANUAL_RELEASE"; then
+  echo "FAIL: manual appcast repair does not use serialized workflow publication" >&2
+  exit 1
+fi
+
+RELEASE_WORKFLOW="$ROOT_DIR/.github/workflows/release.yml"
+if ! rg -Fq 'gh release download \' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq -- '--output "$APPCAST_PATH"' "$RELEASE_WORKFLOW"; then
+  echo "FAIL: release retries cannot repair a missing canonical appcast from immutable assets" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'release_tag:' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'CHECKOUT_REF="$RELEASE_TAG"' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'name: Resolve and validate artifact release tag' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'RELEASE_TAG="v$(printf' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'ref: ${{ needs.release-preflight.outputs.checkout_ref }}' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'path: .release-tools' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'RELEASE_TOOL_ROOT="./.release-tools"' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq '$OPERATION requires release_tag=v<major>.<minor>.<patch>' "$RELEASE_WORKFLOW"; then
+  echo "FAIL: default-branch publication does not validate and checkout an explicit release tag" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'name: Finalize complete draft release' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'steps.guard_release_assets.outputs.finalize_draft' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'gh release edit "$RELEASE_TAG" --draft=false --latest=false' "$RELEASE_WORKFLOW"; then
+  echo "FAIL: complete draft release retries cannot reach public asset validation" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'group: cmux-stable-release-publication' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'make_latest: false' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'name: Classify stable release order at publication time' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'steps.publish_release_order.outputs.is_latest' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq "if: needs.release-preflight.outputs.should_publish == 'true' && steps.publish_release_order.outputs.is_latest == 'true'" "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'gh release edit "${{ steps.publish_release_order.outputs.latest_tag }}" --latest' "$RELEASE_WORKFLOW"; then
+  echo "FAIL: GitHub latest and the canonical feed do not share one release-order decision" >&2
+  exit 1
+fi
+
+UPLOAD_LINE="$(rg -n -m1 'name: Upload release asset' "$RELEASE_WORKFLOW" | cut -d: -f1)"
+CLASSIFY_LINE="$(rg -n -m1 'name: Classify stable release order at publication time' "$RELEASE_WORKFLOW" | cut -d: -f1)"
+if [[ -z "$UPLOAD_LINE" || -z "$CLASSIFY_LINE" || "$CLASSIFY_LINE" -le "$UPLOAD_LINE" ]]; then
+  echo "FAIL: stable release order is classified before the long build instead of at publication" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'scripts/ci/validate_release_appcast_assets.py' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq '"$RELEASE_TOOL_ROOT/scripts/validate-release-version.sh"' "$RELEASE_WORKFLOW"; then
+  echo "FAIL: release publication does not validate the tag and complete appcast artifact" >&2
+  exit 1
+fi
+
+
+GUARD_LINE="$(rg -n -m1 'name: Guard immutable release assets' "$RELEASE_WORKFLOW" | cut -d: -f1)"
+STRICT_LINE="$(rg -n -m1 'name: Validate Sparkle build number is monotonic' "$RELEASE_WORKFLOW" | cut -d: -f1)"
+if [[ -z "$GUARD_LINE" || -z "$STRICT_LINE" || "$STRICT_LINE" -le "$GUARD_LINE" ]] \
+  || ! rg -A2 -F 'name: Validate Sparkle build number is monotonic' "$RELEASE_WORKFLOW" \
+    | rg -Fq "if: steps.guard_release_assets.outputs.skip_all != 'true'"; then
+  echo "FAIL: canonical-feed repair must run for existing immutable releases even when R2 is unavailable" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'release-preflight:' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq "if: needs.release-preflight.outputs.skip_all != 'true'" "$RELEASE_WORKFLOW" \
+  || ! rg -Fq "needs.release-preflight.outputs.skip_all == 'true'" "$RELEASE_WORKFLOW"; then
+  echo "FAIL: immutable-asset retries still depend on the Ghostty helper build" >&2
+  exit 1
+fi
+
+if ! rg -Fq -- '--allow-missing-current-feed' "$RELEASE_WORKFLOW" \
+  || ! rg -Fq 'steps.guard_release_assets.outputs.skip_all' "$RELEASE_WORKFLOW"; then
+  echo "FAIL: only an explicit immutable-asset retry may repair a missing canonical feed" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'operation=publish-existing' "$MANUAL_RELEASE" \
+  || ! rg -Fq 'git ls-remote --exit-code origin "refs/tags/$TAG"' "$MANUAL_RELEASE" \
+  || ! rg -Fq 'git show "HEAD:cmux.xcodeproj/project.pbxproj"' "$MANUAL_RELEASE" \
+  || ! rg -Fq 'git diff --cached --quiet' "$MANUAL_RELEASE"; then
+  echo "FAIL: manual appcast repair is coupled to the current checkout or an unverified local tag" >&2
+  exit 1
+fi
+
+if ! rg -Fq 'Nightly appcast-only repair is unsupported' "$MANUAL_RELEASE"; then
+  echo "FAIL: release wrapper silently treats nightly repair as a full rebuild" >&2
+  exit 1
+fi
+
+HOMEBREW_WORKFLOW="$ROOT_DIR/.github/workflows/update-homebrew.yml"
+if rg -Fq 'workflow_run:' "$HOMEBREW_WORKFLOW" \
+  || ! rg -Fq 'group: cmux-stable-release-publication' "$HOMEBREW_WORKFLOW" \
+  || ! rg -Fq -- '--json tagName,isLatest' "$HOMEBREW_WORKFLOW" \
+  || ! rg -Fq 'if [[ "$TAG" != "$LATEST_TAG" ]]' "$HOMEBREW_WORKFLOW" \
+  || ! rg -Fq 'name: Queue Homebrew update for the verified latest release' "$RELEASE_WORKFLOW"; then
+  echo "FAIL: delayed Homebrew jobs can roll the cask back from GitHub latest" >&2
+  exit 1
+fi
+
+if [[ "$(rg -c 'timeout-minutes: 40' "$RELEASE_WORKFLOW")" != "1" ]] \
+  || [[ "$(rg -c 'Add :SUPublicEDKey string \$\{SPARKLE_PUBLIC_KEY\}' "$RELEASE_WORKFLOW")" != "1" ]]; then
+  echo "FAIL: release workflow contains duplicated build keys or timeout settings" >&2
+  exit 1
+fi
+
+NIGHTLY_WORKFLOW="$ROOT_DIR/.github/workflows/nightly.yml"
+if ! rg -Fq 'name: Validate nightly appcast before publication' "$NIGHTLY_WORKFLOW" \
+  || ! rg -Fq 'preserve_order: true' "$NIGHTLY_WORKFLOW"; then
+  echo "FAIL: nightly appcast can publish before its full immutable artifact is validated" >&2
+  exit 1
+fi
+
+GENERATOR="$ROOT_DIR/scripts/sparkle_generate_appcast.sh"
+if ! rg -Fq 'archives_dir="$work_dir/archives"' "$GENERATOR" \
+  || ! rg -Fq 'cp "$DMG_PATH" "$archives_dir/$(basename "$DMG_PATH")"' "$GENERATOR"; then
+  echo "FAIL: appcast generation must isolate the current full DMG from prior releases" >&2
+  exit 1
+fi
+if rg -Fq "xml.replace(" "$GENERATOR"; then
+  echo "FAIL: appcast signatures must never be injected with text replacement" >&2
+  exit 1
+fi
+
+echo "PASS: every shipped stable feed entrypoint uses $EXPECTED_FEED"


### PR DESCRIPTION
## Root cause

Sparkle successfully loaded the appcast and reported `onLatestVersion`, but the controller converted that result into “Update Didn’t Start” with an incorrect network message.

## Why earlier fixes missed it

- [PR 3833](https://github.com/manaflow-ai/cmux/pull/3833), author `austinywang`, refreshed the passive pill while the active prompt still captured an older release.
- [PR 6853](https://github.com/manaflow-ai/cmux/pull/6853), author `austinywang`, added an install-time check, but its synthetic test covered one available version rather than a real several-version feed and relaunch.
- [PR 7174](https://github.com/manaflow-ai/cmux/pull/7174), author `lawrencecchen`, and [PR 7237](https://github.com/manaflow-ai/cmux/pull/7237), author `austinywang`, repaired idle and callback ordering without defining terminal-result ownership.
- [PR 8375](https://github.com/manaflow-ai/cmux/pull/8375), author `austinywang`, made install failures visible but treated an authoritative no-update result as failure code 2.
- [PR 2363](https://github.com/manaflow-ai/cmux/pull/2363), author `lawrencecchen`, [PR 2625](https://github.com/manaflow-ai/cmux/pull/2625), author `austinywang`, [PR 2651](https://github.com/manaflow-ai/cmux/pull/2651), author `austinywang`, and [PR 4918](https://github.com/manaflow-ai/cmux/pull/4918), author `lawrencecchen`, hardened separate feed and build-number steps without one serialized publication authority.
- [PR 4491](https://github.com/manaflow-ai/cmux/pull/4491), author `lawrencecchen`, added progress timeouts, and [PR 4655](https://github.com/manaflow-ai/cmux/pull/4655), author `lawrencecchen`, reverted them. A separate check timeout still invented a no-update outcome.

Their tests covered individual callbacks and publication steps. None enforced one invariant across every visible entrypoint, a fresh authoritative feed, one full artifact, and release publication.

## Invariant

Starting with the first release containing this fix, the update pill and Cmd-Shift-P `Update cmux` command perform a fresh authoritative check and can install only the newest eligible full release available at that moment. Users several versions behind do not install an intermediate release and update again.

Existing pre-fix binaries cannot be changed retroactively. “Latest” means the newest eligible full artifact returned by the successful fresh check.

## Changes

- Preserve install-latest intent through Sparkle’s complete callback lifecycle, including Retry and delayed terminal results.
- Disable automatic captured-prompt installs and route visible update entrypoints through one shared action.
- Represent up-to-date, incompatible-system, unsupported-hardware, development-build, and unknown results explicitly.
- Remove the synthetic check timeout and make every update message match the observed outcome.
- Publish one verified full artifact through a serialized canonical stable appcast, with strict build monotonicity and matching GitHub, R2, and Homebrew release decisions.
- Add headless command-palette controls for exact entrypoint preflight.

## Verification

- `swift test --package-path Packages/macOS/CmuxUpdater`: 113 passed
- `swift test --package-path Packages/macOS/CmuxUpdaterUI`: 9 passed
- focused CmuxControlSocket command-palette tests: 3 passed
- release/feed shell, Python, and Node contract tests passed
- workflow lint, localization catalog compile, and full tagged cloud build passed
- live stable artifact validation confirmed GitHub and R2 SHA-256 equality for v0.64.20 build 100

The normal live monotonic check correctly rejects project build 100 because released build 100 already exists. The strict-unavailable regression passed.

## Regression proof

- `dfcd4240c6` fails on the already-current Retry bug; `658566ad51` fixes it.
- `4208a0ea0d` defines the one-hop update contract; `894d15631d` implements it.
- `325c3d9ddb` defines command-palette preflight; `1ea0ce277b` implements it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved update prompts with clearer “up to date,” development-build, compatibility, and hardware messaging.
  * Added explicit Retry and dismissal actions for actionable no-update results.
  * Release notes now use links supplied by the update feed when available.
  * Updated the command palette with clearer update actions.

* **Bug Fixes**
  * Prevented completed installs that find no newer version from appearing as failures.
  * Improved retry intent preservation and install monitoring for slow or interrupted checks.
  * Refined network, download, installation, and updater-readiness error guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->