### PR TITLE
fix(homebrew): use symbol form for depends_on macos to fix deprecation warning

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -104,7 +104,7 @@ jobs:
               strategy :github_latest
             end
 
-            depends_on macos: ">= :sonoma"
+            depends_on macos: :sonoma
 
             app "cmux.app"
             binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -180,7 +180,7 @@ cask "cmux" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "cmux.app"
   binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"


### PR DESCRIPTION
## Summary

The generated Homebrew cask uses the deprecated string comparison format for `depends_on macos:`, which makes Homebrew print a deprecation warning on every cask install / `brew bundle`:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
  /opt/homebrew/Library/Taps/manaflow-ai/homebrew-cmux/Casks/cmux.rb:15
```

This switches both cask generators to the symbol form. A bare symbol is interpreted as a `>=` comparison, so the meaning (that macOS version or newer) is unchanged.

## Why fix it here (not in the tap)

The tap's `Casks/cmux.rb` is regenerated by the release bot from `.github/workflows/update-homebrew.yml`. Manual fixes applied directly to the tap were reverted twice by subsequent releases (`0c51f8b`, `7501cea` in `manaflow-ai/homebrew-cmux`), because the generator template still contains the deprecated string. Fixing the template makes the corrected form stick.

## Changes

- `.github/workflows/update-homebrew.yml` — `depends_on macos: ">= :sonoma"` → `depends_on macos: :sonoma`
- `scripts/build-sign-upload.sh` — `depends_on macos: ">= :ventura"` → `depends_on macos: :ventura`

## Impact

No behavior change. The next release will regenerate `homebrew-cmux/Casks/cmux.rb` without the deprecation warning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787187056&installation_model_id=21920&pr_number=8538&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8538&signature=8733192733a85779646f4da4322a33b35b15f0a6574fe9b5a1f095621d40da02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Homebrew cask generators to use the symbol form for `depends_on macos:` (e.g., `:sonoma`, `:ventura`) to remove the deprecation warning. No behavior change; future releases will regenerate the tap cask without warnings.

<sup>Written for commit 84ef556cb3cc2e719cfa4ef6619669a0214faacc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Homebrew installation requirements to use explicit macOS version compatibility declarations.
  * Improved consistency between generated cask metadata and automated Homebrew updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->