### PR TITLE
Attach workspace rename and color alerts to their window

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12772,14 +12772,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
         let alertWindow = alert.window
         alertWindow.initialFirstResponder = input
-        DispatchQueue.main.async {
+        let response = alert.runCmuxModal(
+            presentingWindow: mainWindowContainingWorkspace(tab.id)
+        ) { _ in
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-
-        let response = alert.runCmuxModal(
-            presentingWindow: mainWindowContainingWorkspace(tab.id)
-        )
         guard response == .alertFirstButtonReturn else { return true }
         tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
         return true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12777,7 +12777,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             input.selectText(nil)
         }
 
-        let response = alert.runModal()
+        let response = alert.runCmuxModal(
+            presentingWindow: mainWindowContainingWorkspace(tab.id)
+        )
         guard response == .alertFirstButtonReturn else { return true }
         tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
         return true

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15670,7 +15670,9 @@ struct TabItemView: View, Equatable {
             input.selectText(nil)
         }
 
-        let response = alert.runModal()
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(workspaceId)
+        )
         guard response == .alertFirstButtonReturn else { return }
         guard let normalized = WorkspaceTabColorSettings.addCustomColor(input.stringValue) else {
             showInvalidColorAlert(input.stringValue)
@@ -15690,7 +15692,9 @@ struct TabItemView: View, Equatable {
             alert.informativeText = String(localized: "alert.invalidColor.invalidMessage", defaultValue: "\"\(trimmed)\" is not a valid hex color. Use #RRGGBB.")
         }
         alert.addButton(withTitle: String(localized: "alert.invalidColor.ok", defaultValue: "OK"))
-        _ = alert.runModal()
+        _ = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(workspaceId)
+        )
     }
 
     func promptRename() {
@@ -15709,7 +15713,9 @@ struct TabItemView: View, Equatable {
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-        let response = alert.runModal()
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(workspaceId)
+        )
         guard response == .alertFirstButtonReturn else { return }
         actions.setCustomTitle(input.stringValue)
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15665,14 +15665,12 @@ struct TabItemView: View, Equatable {
 
         let alertWindow = alert.window
         alertWindow.initialFirstResponder = input
-        DispatchQueue.main.async {
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(workspaceId)
+        ) { _ in
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-
-        let response = alert.runCmuxModal(
-            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(workspaceId)
-        )
         guard response == .alertFirstButtonReturn else { return }
         guard let normalized = WorkspaceTabColorSettings.addCustomColor(input.stringValue) else {
             showInvalidColorAlert(input.stringValue)
@@ -15709,13 +15707,12 @@ struct TabItemView: View, Equatable {
         alert.addButton(withTitle: String(localized: "alert.renameWorkspace.cancel", defaultValue: "Cancel"))
         let alertWindow = alert.window
         alertWindow.initialFirstResponder = input
-        DispatchQueue.main.async {
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(workspaceId)
+        ) { _ in
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-        let response = alert.runCmuxModal(
-            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(workspaceId)
-        )
         guard response == .alertFirstButtonReturn else { return }
         actions.setCustomTitle(input.stringValue)
     }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -161,7 +161,9 @@ struct SidebarWorkspaceRowCommands {
         alert.addButton(withTitle: String(localized: "alert.renameWorkspace.rename", defaultValue: "Rename"))
         alert.addButton(withTitle: String(localized: "alert.renameWorkspace.cancel", defaultValue: "Cancel"))
         alert.window.initialFirstResponder = input
-        let response = alert.runModal()
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
+        )
         guard response == .alertFirstButtonReturn else { return }
         tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
     }
@@ -194,7 +196,9 @@ struct SidebarWorkspaceRowCommands {
         alert.addButton(withTitle: String(localized: "alert.customColor.apply", defaultValue: "Apply"))
         alert.addButton(withTitle: String(localized: "alert.customColor.cancel", defaultValue: "Cancel"))
         alert.window.initialFirstResponder = input
-        let response = alert.runModal()
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
+        )
         guard response == .alertFirstButtonReturn else { return }
         guard let normalized = WorkspaceTabColorSettings.addCustomColor(input.stringValue) else {
             showInvalidColorAlert(input.stringValue)
@@ -214,7 +218,9 @@ struct SidebarWorkspaceRowCommands {
             alert.informativeText = String(localized: "alert.invalidColor.invalidMessage", defaultValue: "\"\(trimmed)\" is not a valid hex color. Use #RRGGBB.")
         }
         alert.addButton(withTitle: String(localized: "alert.invalidColor.ok", defaultValue: "OK"))
-        _ = alert.runModal()
+        _ = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
+        )
     }
 
     /// Parity with TabItemView.moveWorkspaces(_:toWindow:).

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -162,13 +162,12 @@ struct SidebarWorkspaceRowCommands {
         alert.addButton(withTitle: String(localized: "alert.renameWorkspace.cancel", defaultValue: "Cancel"))
         let alertWindow = alert.window
         alertWindow.initialFirstResponder = input
-        DispatchQueue.main.async {
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
+        ) { _ in
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-        let response = alert.runCmuxModal(
-            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
-        )
         guard response == .alertFirstButtonReturn else { return }
         tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
     }
@@ -202,13 +201,12 @@ struct SidebarWorkspaceRowCommands {
         alert.addButton(withTitle: String(localized: "alert.customColor.cancel", defaultValue: "Cancel"))
         let alertWindow = alert.window
         alertWindow.initialFirstResponder = input
-        DispatchQueue.main.async {
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
+        ) { _ in
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-        let response = alert.runCmuxModal(
-            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
-        )
         guard response == .alertFirstButtonReturn else { return }
         guard let normalized = WorkspaceTabColorSettings.addCustomColor(input.stringValue) else {
             showInvalidColorAlert(input.stringValue)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -160,7 +160,12 @@ struct SidebarWorkspaceRowCommands {
         alert.accessoryView = input
         alert.addButton(withTitle: String(localized: "alert.renameWorkspace.rename", defaultValue: "Rename"))
         alert.addButton(withTitle: String(localized: "alert.renameWorkspace.cancel", defaultValue: "Cancel"))
-        alert.window.initialFirstResponder = input
+        let alertWindow = alert.window
+        alertWindow.initialFirstResponder = input
+        DispatchQueue.main.async {
+            alertWindow.makeFirstResponder(input)
+            input.selectText(nil)
+        }
         let response = alert.runCmuxModal(
             presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
         )
@@ -195,7 +200,12 @@ struct SidebarWorkspaceRowCommands {
         alert.accessoryView = input
         alert.addButton(withTitle: String(localized: "alert.customColor.apply", defaultValue: "Apply"))
         alert.addButton(withTitle: String(localized: "alert.customColor.cancel", defaultValue: "Cancel"))
-        alert.window.initialFirstResponder = input
+        let alertWindow = alert.window
+        alertWindow.initialFirstResponder = input
+        DispatchQueue.main.async {
+            alertWindow.makeFirstResponder(input)
+            input.selectText(nil)
+        }
         let response = alert.runCmuxModal(
             presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(tab.id)
         )

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10673,13 +10673,12 @@ final class Workspace: Identifiable, ObservableObject {
         alert.addButton(withTitle: String(localized: "alert.cancel", defaultValue: "Cancel"))
         let alertWindow = alert.window
         alertWindow.initialFirstResponder = input
-        DispatchQueue.main.async {
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(id)
+        ) { _ in
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-        let response = alert.runCmuxModal(
-            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(id)
-        )
         guard response == .alertFirstButtonReturn else { return }
         setPanelCustomTitle(panelId: panelId, title: input.stringValue)
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10677,7 +10677,9 @@ final class Workspace: Identifiable, ObservableObject {
             alertWindow.makeFirstResponder(input)
             input.selectText(nil)
         }
-        let response = alert.runModal()
+        let response = alert.runCmuxModal(
+            presentingWindow: AppDelegate.shared?.mainWindowContainingWorkspace(id)
+        )
         guard response == .alertFirstButtonReturn else { return }
         setPanelCustomTitle(panelId: panelId, title: input.stringValue)
     }


### PR DESCRIPTION
The Rename Workspace alert always appeared on a different monitor than the cmux window on multi-monitor setups. It was presented with bare `NSAlert.runModal()`, which creates a detached alert window that macOS centers on whichever screen it considers main rather than the screen showing cmux.

All affected alerts now go through the existing `runCmuxModal(presentingWindow:)` presenter, resolving the host window with `mainWindowContainingWorkspace`, so each alert attaches as a sheet to the window that owns the workspace (also correct with multiple cmux windows open). Migrated call sites:

- `SidebarWorkspaceRowCommands.promptRename` (AppKit sidebar context menu, the reported path)
- `TabItemView.promptRename` (SwiftUI sidebar parity path)
- `AppDelegate.promptRenameSelectedWorkspace` (rename keyboard shortcut)
- Custom workspace color prompt + invalid-color alert in both sidebar paths
- `Workspace.promptRenamePanel` (Rename Tab alert)

No new user-facing strings; all localization keys unchanged. No automated regression test: sheet-vs-detached presentation of a blocking modal has no practical unit-level assertion, verification is via tagged-build dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787192312&installation_model_id=21920&pr_number=8544&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8544&signature=2080554d54bdec6f48deae8b5efef27dd24bb832a467f34074ca88154bffa9fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach workspace rename and color alerts to their owning window as sheets so they appear on the correct monitor. Also focus and select the input on open using the modal’s willPresent hook.

- **Bug Fixes**
  - Applies to: workspace rename (sidebar, SwiftUI tab row, keyboard shortcut), custom color prompt, invalid-color alert, and Rename Tab alert.
  - Uses runCmuxModal(presentingWindow:) to attach to the workspace’s window across multiple cmux windows/monitors, and sets input focus in willPresent (replacing the async main hop); no string or behavior changes beyond presentation.

<sup>Written for commit 495b05f8940ad3ad3d3770ce01c2d8df1a3e2a37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alert and confirmation dialog presentation by attaching modals to the relevant workspace’s main window across the app.
  - Preserved existing response handling for rename and custom color prompts, including the first-button outcome logic.
  - Improved consistency of user interaction behavior by reliably focusing the input field and selecting its text when the modal opens in Content, the sidebar, and workspace rename flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->