### PR TITLE
Restore socket discovery for legacy external clients

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/CmuxStateDirectory.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/CmuxStateDirectory.swift
@@ -54,11 +54,12 @@ public enum CmuxStateDirectory {
     /// The legacy Application Support control directory
     /// (`~/Library/Application Support/cmux`).
     ///
-    /// Retained only so the app can migrate persistent files (the socket
-    /// password) out of TCC-protected storage on launch. New reads and writes go
-    /// through ``url(homeDirectory:)``; nothing on the CLI hook path should touch
-    /// this location. The `FileManager` is injected (no ambient default) to keep
-    /// the seam explicit for tests and alternate callers.
+    /// Retained so the app can migrate the socket password out of TCC-protected
+    /// storage and mirror `last-socket-path` discovery markers for external
+    /// clients that use the pre-0.64.20 contract. The listener, password store,
+    /// and CLI use ``url(homeDirectory:)``; nothing on the CLI hook path should
+    /// touch this location. The `FileManager` is injected (no ambient default)
+    /// to keep the seam explicit for tests and alternate callers.
     ///
     /// - Parameter fileManager: Used to resolve Application Support.
     /// - Returns: The legacy directory, or `nil` when Application Support cannot

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings+SocketPathMarkers.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings+SocketPathMarkers.swift
@@ -34,15 +34,23 @@ public extension SocketControlSettings {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> [String] {
-        socketPathMarkerPaths(
-            bundleIdentifier: bundleIdentifier,
-            environment: environment,
-            directories: [
-                stableSocketDirectoryURL(fileManager: fileManager),
-                CmuxStateDirectory.legacyApplicationSupportURL(fileManager: fileManager),
-            ].compactMap { $0 },
-            baseDebugBundleIdentifier: baseDebugBundleIdentifier
-        )
+        (
+            SocketPathMarkerFiles.paths(
+                bundleIdentifier: bundleIdentifier,
+                environment: environment,
+                directory: stableSocketDirectoryURL(fileManager: fileManager),
+                baseDebugBundleIdentifier: baseDebugBundleIdentifier
+            ) + SocketPathMarkerFiles.paths(
+                bundleIdentifier: bundleIdentifier,
+                environment: environment,
+                directory: CmuxStateDirectory.legacyApplicationSupportURL(fileManager: fileManager),
+                baseDebugBundleIdentifier: baseDebugBundleIdentifier
+            )
+        ).reduce(into: (seen: Set<String>(), paths: [String]())) { result, path in
+            if result.seen.insert(path).inserted {
+                result.paths.append(path)
+            }
+        }.paths
     }
 
     private static func writeSocketPathMarker(_ payload: Data, to filePath: String) {

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings+SocketPathMarkers.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings+SocketPathMarkers.swift
@@ -34,14 +34,13 @@ public extension SocketControlSettings {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> [String] {
-        let directories = [
-            stableSocketDirectoryURL(fileManager: fileManager),
-            CmuxStateDirectory.legacyApplicationSupportURL(fileManager: fileManager),
-        ].compactMap { $0 }
-        return SocketPathMarkerFiles.paths(
+        socketPathMarkerPaths(
             bundleIdentifier: bundleIdentifier,
             environment: environment,
-            directories: directories,
+            directories: [
+                stableSocketDirectoryURL(fileManager: fileManager),
+                CmuxStateDirectory.legacyApplicationSupportURL(fileManager: fileManager),
+            ].compactMap { $0 },
             baseDebugBundleIdentifier: baseDebugBundleIdentifier
         )
     }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings+SocketPathMarkers.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketControlSettings+SocketPathMarkers.swift
@@ -1,7 +1,12 @@
 public import Foundation
 
 public extension SocketControlSettings {
-    /// Records the active socket path to every marker file for the current build variant.
+    /// Records the active socket path to every discovery marker for the current build variant.
+    ///
+    /// The control socket remains authoritative in ``CmuxStateDirectory``. The
+    /// app also mirrors its absolute path into the legacy Application Support
+    /// marker so external clients using the pre-0.64.20 discovery contract keep
+    /// following the live listener without creating a second socket.
     /// - Parameters:
     ///   - path: The socket path to record.
     ///   - bundleIdentifier: The running app's bundle identifier.
@@ -17,21 +22,26 @@ public extension SocketControlSettings {
         }
     }
 
-    /// The marker file paths that record the last socket path for the current build variant.
+    /// The marker file paths that advertise the live socket for the current build variant.
     /// - Parameters:
     ///   - bundleIdentifier: The running app's bundle identifier.
     ///   - environment: The process environment.
-    ///   - fileManager: The file manager used to resolve the cmux state directory; defaults to `.default`.
+    ///   - fileManager: The file manager used to resolve current and legacy marker
+    ///     directories; defaults to `.default`.
     /// - Returns: The marker file paths to write.
     static func lastSocketPathFiles(
         bundleIdentifier: String? = Bundle.main.bundleIdentifier,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> [String] {
-        SocketPathMarkerFiles.paths(
+        let directories = [
+            stableSocketDirectoryURL(fileManager: fileManager),
+            CmuxStateDirectory.legacyApplicationSupportURL(fileManager: fileManager),
+        ].compactMap { $0 }
+        return SocketPathMarkerFiles.paths(
             bundleIdentifier: bundleIdentifier,
             environment: environment,
-            directory: stableSocketDirectoryURL(fileManager: fileManager),
+            directories: directories,
             baseDebugBundleIdentifier: baseDebugBundleIdentifier
         )
     }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketPathMarkerFiles.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketPathMarkerFiles.swift
@@ -17,10 +17,32 @@ public enum SocketPathMarkerFiles {
         directory?.appendingPathComponent(fileName, isDirectory: false)
     }
 
+    /// Resolves build-variant marker paths for one state directory and `/tmp`.
+    /// - Parameters:
+    ///   - bundleIdentifier: The running app's bundle identifier.
+    ///   - environment: The process environment.
+    ///   - directory: The directory that owns the persistent marker.
+    ///   - baseDebugBundleIdentifier: The base bundle identifier for debug builds.
+    /// - Returns: Ordered, deduplicated marker paths for the build variant.
     public static func paths(
         bundleIdentifier: String?,
         environment: [String: String],
         directory: URL?,
+        baseDebugBundleIdentifier: String = defaultBaseDebugBundleIdentifier
+    ) -> [String] {
+        paths(
+            bundleIdentifier: bundleIdentifier,
+            environment: environment,
+            directories: directory.map { [$0] } ?? [],
+            baseDebugBundleIdentifier: baseDebugBundleIdentifier
+        )
+    }
+
+    /// Resolves build-variant marker paths across app-owned discovery directories.
+    static func paths(
+        bundleIdentifier: String?,
+        environment: [String: String],
+        directories: [URL],
         baseDebugBundleIdentifier: String = defaultBaseDebugBundleIdentifier
     ) -> [String] {
         let variant = variant(
@@ -28,12 +50,11 @@ public enum SocketPathMarkerFiles {
             environment: environment,
             baseDebugBundleIdentifier: baseDebugBundleIdentifier
         )
-        var candidates: [String] = []
-        if let directoryPath = markerFileURL(
-            fileName: variant.markerFileName,
-            directory: directory
-        )?.path {
-            candidates.append(directoryPath)
+        var candidates = directories.compactMap { directory in
+            markerFileURL(
+                fileName: variant.markerFileName,
+                directory: directory
+            )?.path
         }
         candidates.append(variant.tmpPath)
         return dedupe(candidates)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketPathMarkerFiles.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketPathMarkerFiles.swift
@@ -30,34 +30,12 @@ public enum SocketPathMarkerFiles {
         directory: URL?,
         baseDebugBundleIdentifier: String = defaultBaseDebugBundleIdentifier
     ) -> [String] {
-        paths(
+        socketPathMarkerPaths(
             bundleIdentifier: bundleIdentifier,
             environment: environment,
             directories: directory.map { [$0] } ?? [],
             baseDebugBundleIdentifier: baseDebugBundleIdentifier
         )
-    }
-
-    /// Resolves build-variant marker paths across app-owned discovery directories.
-    static func paths(
-        bundleIdentifier: String?,
-        environment: [String: String],
-        directories: [URL],
-        baseDebugBundleIdentifier: String = defaultBaseDebugBundleIdentifier
-    ) -> [String] {
-        let variant = variant(
-            bundleIdentifier: bundleIdentifier,
-            environment: environment,
-            baseDebugBundleIdentifier: baseDebugBundleIdentifier
-        )
-        var candidates = directories.compactMap { directory in
-            markerFileURL(
-                fileName: variant.markerFileName,
-                directory: directory
-            )?.path
-        }
-        candidates.append(variant.tmpPath)
-        return dedupe(candidates)
     }
 
     public static func variant(
@@ -146,13 +124,28 @@ public enum SocketPathMarkerFiles {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
+}
 
-    private static func dedupe(_ values: [String]) -> [String] {
-        var seen = Set<String>()
-        var ordered: [String] = []
-        for value in values where seen.insert(value).inserted {
-            ordered.append(value)
-        }
-        return ordered
+/// Resolves build-variant marker paths across app-owned discovery directories.
+func socketPathMarkerPaths(
+    bundleIdentifier: String?,
+    environment: [String: String],
+    directories: [URL],
+    baseDebugBundleIdentifier: String = SocketPathMarkerFiles.defaultBaseDebugBundleIdentifier
+) -> [String] {
+    let variant = SocketPathMarkerFiles.variant(
+        bundleIdentifier: bundleIdentifier,
+        environment: environment,
+        baseDebugBundleIdentifier: baseDebugBundleIdentifier
+    )
+    var candidates = directories.compactMap { directory in
+        SocketPathMarkerFiles.markerFileURL(
+            fileName: variant.markerFileName,
+            directory: directory
+        )?.path
     }
+    candidates.append(variant.tmpPath)
+
+    var seen = Set<String>()
+    return candidates.filter { seen.insert($0).inserted }
 }

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketPathMarkerFiles.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/SocketPathMarkerFiles.swift
@@ -17,25 +17,26 @@ public enum SocketPathMarkerFiles {
         directory?.appendingPathComponent(fileName, isDirectory: false)
     }
 
-    /// Resolves build-variant marker paths for one state directory and `/tmp`.
-    /// - Parameters:
-    ///   - bundleIdentifier: The running app's bundle identifier.
-    ///   - environment: The process environment.
-    ///   - directory: The directory that owns the persistent marker.
-    ///   - baseDebugBundleIdentifier: The base bundle identifier for debug builds.
-    /// - Returns: Ordered, deduplicated marker paths for the build variant.
     public static func paths(
         bundleIdentifier: String?,
         environment: [String: String],
         directory: URL?,
         baseDebugBundleIdentifier: String = defaultBaseDebugBundleIdentifier
     ) -> [String] {
-        socketPathMarkerPaths(
+        let variant = variant(
             bundleIdentifier: bundleIdentifier,
             environment: environment,
-            directories: directory.map { [$0] } ?? [],
             baseDebugBundleIdentifier: baseDebugBundleIdentifier
         )
+        var candidates: [String] = []
+        if let directoryPath = markerFileURL(
+            fileName: variant.markerFileName,
+            directory: directory
+        )?.path {
+            candidates.append(directoryPath)
+        }
+        candidates.append(variant.tmpPath)
+        return dedupe(candidates)
     }
 
     public static func variant(
@@ -124,28 +125,13 @@ public enum SocketPathMarkerFiles {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
-}
 
-/// Resolves build-variant marker paths across app-owned discovery directories.
-func socketPathMarkerPaths(
-    bundleIdentifier: String?,
-    environment: [String: String],
-    directories: [URL],
-    baseDebugBundleIdentifier: String = SocketPathMarkerFiles.defaultBaseDebugBundleIdentifier
-) -> [String] {
-    let variant = SocketPathMarkerFiles.variant(
-        bundleIdentifier: bundleIdentifier,
-        environment: environment,
-        baseDebugBundleIdentifier: baseDebugBundleIdentifier
-    )
-    var candidates = directories.compactMap { directory in
-        SocketPathMarkerFiles.markerFileURL(
-            fileName: variant.markerFileName,
-            directory: directory
-        )?.path
+    private static func dedupe(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for value in values where seen.insert(value).inserted {
+            ordered.append(value)
+        }
+        return ordered
     }
-    candidates.append(variant.tmpPath)
-
-    var seen = Set<String>()
-    return candidates.filter { seen.insert($0).inserted }
 }

--- a/cmuxTests/SocketConfigurationLifecycleTests.swift
+++ b/cmuxTests/SocketConfigurationLifecycleTests.swift
@@ -357,6 +357,29 @@ extension SocketACLReloadRegressionTests {
         #expect(controller.socketServer.transport.pathIdentity(at: socketPath) == listenerIdentity)
     }
 
+    @Test func socketPathMarkersKeepLegacyExternalClientDiscoveryLive() throws {
+        let fileManager = FileManager.default
+        let currentDirectory = CmuxStateDirectory.url(
+            homeDirectory: fileManager.homeDirectoryForCurrentUser
+        )
+        let legacyDirectory = try #require(
+            CmuxStateDirectory.legacyApplicationSupportURL(fileManager: fileManager)
+        )
+        let markerPaths = SocketControlSettings.lastSocketPathFiles(
+            bundleIdentifier: "com.cmuxterm.app",
+            environment: [:],
+            fileManager: fileManager
+        )
+
+        #expect(markerPaths.contains(
+            currentDirectory.appendingPathComponent("last-socket-path").path
+        ))
+        #expect(markerPaths.contains(
+            legacyDirectory.appendingPathComponent("last-socket-path").path
+        ))
+        #expect(markerPaths.contains(SocketPathMarkerFiles.stableTmpPath))
+    }
+
     private func capturedSocketDefaults(_ defaults: UserDefaults) -> [(String, Any?)] {
         socketDefaultsKeys.map { ($0, defaults.object(forKey: $0)) }
     }


### PR DESCRIPTION
## Summary

- keep one authoritative control socket under `~/.local/state/cmux`
- mirror the live absolute socket path into the variant-matched legacy Application Support marker after a successful bind
- keep the official CLI on the state-directory-only discovery path, preserving the TCC fix from #5146

## Root cause

cmux 0.64.20 moved the socket, marker, lock, and password from `~/Library/Application Support/cmux` to `~/.local/state/cmux` so the separately signed CLI would not trigger macOS App Data prompts. The app and official CLI moved together, but external clients using the pre-0.64.20 `last-socket-path` contract were left reading an abandoned marker beside a stale lock file. Password mode was binding successfully in the new state directory; discovery compatibility was what broke.

This change preserves a single listener and single socket owner. On successful listener startup, the app writes the same absolute live path to the authoritative state marker, the app-owned legacy discovery marker, and the existing variant-specific `/tmp` marker. It does not add a proxy, second listener, retry, or timing path. The CLI still never reads Application Support.

## Regression proof

- failing test commit: `50df15b0f`
- red class run: https://github.com/manaflow-ai/cmux/actions/runs/29795211208 (22 tests executed; only the new legacy marker expectation failed)
- fix commit: `1d1e7cc42`
- focused green run: https://github.com/manaflow-ai/cmux/actions/runs/29795695707

## Validation

- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `git diff --check origin/main...HEAD`

No user-facing strings changed, so no localization catalogs needed updates.

Closes #8512

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787192679&installation_model_id=21920&pr_number=8545&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8545&signature=0f73c5fc4a1419b1cb7ca7b4f27892c95ccf1b90c1c4b111813318074a733353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores legacy external client discovery by mirroring the live control socket path into the legacy Application Support `last-socket-path` marker. The socket stays authoritative in `~/.local/state/cmux`, and the CLI remains on the state-only discovery path (addresses #8512).

- **Bug Fixes**
  - Advertise the active socket via current state, legacy Application Support, and the variant-specific `/tmp` marker.
  - Resolve and de-duplicate marker paths across both directories.
  - Add a test to confirm current, legacy, and `/tmp` markers are all present.

- **Refactors**
  - `lastSocketPathFiles(...)` now reuses `SocketPathMarkerFiles.paths` for both current and legacy directories and dedupes results.
  - Clarify legacy directory purpose in comments; keep `FileManager` injection explicit.

<sup>Written for commit 544c3066148a6ca1b57aa36f7fb1a5d53268b2e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved external client discovery of the active control socket through legacy marker locations.
  * Continued supporting clients using the pre-0.64.20 socket discovery contract.
  * Avoided duplicate socket path markers when current and legacy locations overlap.

* **Tests**
  * Added coverage verifying socket discovery markers are available in all supported locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->