### PR TITLE
Fix browser automation recovery after load failures

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13353,7 +13353,10 @@ struct CMUXCLI {
                 guard !url.isEmpty else {
                     throw CLIError(message: "browser <surface> open requires a URL")
                 }
-                let payload = try client.sendV2(method: "browser.navigate", params: ["surface_id": sid, "url": url])
+                let payload = try sendBrowserAutomationRequest(
+                    method: "browser.navigate",
+                    params: ["surface_id": sid, "url": url]
+                )
                 output(payload, fallback: "OK")
                 return
             }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12928,11 +12928,12 @@ struct CMUXCLI {
         let subArgs = Array(args.dropFirst())
         let browserValueTextFormatter = BrowserValueTextFormatter()
 
-        // A post-action snapshot can spend 3s in document readiness, 10s in the
-        // requested action, 10s in snapshot JavaScript, and 2.5s in recovery.
-        // Keep transport headroom beyond that 25.5s app-side maximum.
+        // A committed navigation can spend up to 17.5s on its initial attempt and one
+        // WebView-replacement retry. A post-action snapshot can then spend another 10s
+        // in JavaScript and 2.5s in recovery. Keep transport headroom beyond that 30s
+        // app-side maximum when --snapshot-after is requested.
         func sendBrowserAutomationRequest(method: String, params: [String: Any]) throws -> [String: Any] {
-            let responseTimeout: TimeInterval = (params["snapshot_after"] as? Bool) == true ? 30 : 20
+            let responseTimeout: TimeInterval = (params["snapshot_after"] as? Bool) == true ? 35 : 20
             return try client.sendV2(method: method, params: params, responseTimeout: responseTimeout)
         }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12928,10 +12928,10 @@ struct CMUXCLI {
         let subArgs = Array(args.dropFirst())
         let browserValueTextFormatter = BrowserValueTextFormatter()
 
-        // A committed navigation can spend up to 17.5s on its initial attempt and one
-        // WebView-replacement retry. A post-action snapshot can then spend another 10s
-        // in JavaScript and 2.5s in recovery. Keep transport headroom beyond that 30s
-        // app-side maximum when --snapshot-after is requested.
+        // A committed navigation can spend up to 15s waiting for its delegate callback.
+        // A post-action snapshot can then spend another 10s in JavaScript and 2.5s in
+        // recovery. Keep transport headroom beyond that 27.5s app-side maximum when
+        // --snapshot-after is requested.
         func sendBrowserAutomationRequest(method: String, params: [String: Any]) throws -> [String: Any] {
             let responseTimeout: TimeInterval = (params["snapshot_after"] as? Bool) == true ? 35 : 20
             return try client.sendV2(method: method, params: params, responseTimeout: responseTimeout)

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -168,9 +168,16 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(activeTicket, with: .committed)
     }
 
-    /// Completes the transaction when its exact provisional navigation becomes a download.
-    public func didBecomeDownload(instanceID: UUID, navigationID: ObjectIdentifier?) {
-        finishMatching(instanceID: instanceID, navigationID: navigationID, with: .downloaded)
+    /// Completes the transaction when its target becomes a main-frame download.
+    public func didBecomeDownload(instanceID: UUID, url: URL?) {
+        guard let activeTicket,
+              activeTicket.instanceID == instanceID,
+              activeNavigationID != nil,
+              let activeTargetURL,
+              url == activeTargetURL else {
+            return
+        }
+        finish(activeTicket, with: .downloaded)
     }
 
     /// Records a commit only when it belongs to the exact active navigation.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -91,13 +91,21 @@ public final class BrowserAutomationNavigationCoordinator {
     }
 
     /// Records a provisional delegate start, binding a deferred or replacement load when needed.
-    public func didStart(instanceID: UUID, navigationID: ObjectIdentifier?) {
+    public func didStart(
+        instanceID: UUID,
+        navigationID: ObjectIdentifier?,
+        targetURL: URL? = nil
+    ) {
         guard let navigationID,
               let activeTicket,
               activeTicket.instanceID == instanceID else {
             return
         }
         if activeNavigationID == nil {
+            if let activeTargetURL, targetURL != activeTargetURL {
+                finish(activeTicket, with: .superseded)
+                return
+            }
             activeNavigationID = navigationID
         }
         if activeNavigationID == navigationID {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -25,7 +25,7 @@ public final class BrowserAutomationNavigationCoordinator {
     )?
 
     /// Creates a coordinator with a bounded continuous-clock navigation deadline.
-    public init(navigationTimeout: Duration = .seconds(8)) {
+    public init(navigationTimeout: Duration = .seconds(15)) {
         self.navigationTimeout = navigationTimeout
         let clock = ContinuousClock()
         self.sleep = { duration in
@@ -35,7 +35,7 @@ public final class BrowserAutomationNavigationCoordinator {
 
     /// Creates a coordinator with an injected timing source for deterministic tests.
     public init(
-        navigationTimeout: Duration = .seconds(8),
+        navigationTimeout: Duration = .seconds(15),
         sleep: @escaping Sleep
     ) {
         self.navigationTimeout = navigationTimeout

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -15,6 +15,8 @@ public final class BrowserAutomationNavigationCoordinator {
     private var observedInstanceID: UUID?
     private var activeTicket: BrowserAutomationNavigationTicket?
     private var activeNavigationID: ObjectIdentifier?
+    private var activeNavigationBeganProvisionally = false
+    private var activeTargetURL: URL?
     private var terminalOutcome: (
         ticket: BrowserAutomationNavigationTicket,
         outcome: BrowserAutomationNavigationOutcome
@@ -52,7 +54,10 @@ public final class BrowserAutomationNavigationCoordinator {
     }
 
     /// Begins a transaction for the currently bound WebView instance.
-    public func begin(instanceID: UUID) -> BrowserAutomationNavigationTicket {
+    public func begin(
+        instanceID: UUID,
+        targetURL: URL? = nil
+    ) -> BrowserAutomationNavigationTicket {
         if let activeTicket {
             finish(activeTicket, with: .superseded)
         }
@@ -67,6 +72,8 @@ public final class BrowserAutomationNavigationCoordinator {
         }
         activeTicket = ticket
         activeNavigationID = nil
+        activeNavigationBeganProvisionally = false
+        activeTargetURL = targetURL
         return ticket
     }
 
@@ -83,22 +90,33 @@ public final class BrowserAutomationNavigationCoordinator {
         activeNavigationID = navigationID
     }
 
-    /// Associates a deferred or policy-replacement load with the active transaction.
+    /// Records a provisional delegate start, binding a deferred or replacement load when needed.
     public func didStart(instanceID: UUID, navigationID: ObjectIdentifier?) {
         guard let navigationID,
               let activeTicket,
-              activeTicket.instanceID == instanceID,
-              activeNavigationID == nil else {
+              activeTicket.instanceID == instanceID else {
             return
         }
-        activeNavigationID = navigationID
+        if activeNavigationID == nil {
+            activeNavigationID = navigationID
+        }
+        if activeNavigationID == navigationID {
+            activeNavigationBeganProvisionally = true
+        }
     }
 
     /// Releases the current navigation identity while a policy flow waits to start its replacement.
     @discardableResult
-    public func prepareForNavigationReplacement(instanceID: UUID) -> Bool {
+    public func prepareForNavigationReplacement(
+        instanceID: UUID,
+        targetURL: URL? = nil
+    ) -> Bool {
         guard let activeTicket, activeTicket.instanceID == instanceID else { return false }
         activeNavigationID = nil
+        activeNavigationBeganProvisionally = false
+        if let targetURL {
+            activeTargetURL = targetURL
+        }
         return true
     }
 
@@ -116,6 +134,22 @@ public final class BrowserAutomationNavigationCoordinator {
             return
         }
         finish(activeTicket, with: .notStarted)
+    }
+
+    /// Completes the active transaction when WebKit changes to its target URL without a document commit.
+    ///
+    /// The owning WebView must call this only for an authoritative URL change outside a provisional
+    /// main-frame load, which is WebKit's observable signal for a same-document navigation.
+    public func didReachSameDocumentURL(instanceID: UUID, url: URL?) {
+        guard let url,
+              let activeTicket,
+              activeTicket.instanceID == instanceID,
+              activeNavigationID != nil,
+              !activeNavigationBeganProvisionally,
+              activeTargetURL == url else {
+            return
+        }
+        finish(activeTicket, with: .committed)
     }
 
     /// Records a commit only when it belongs to the exact active navigation.
@@ -224,6 +258,8 @@ public final class BrowserAutomationNavigationCoordinator {
         guard activeTicket == ticket else { return }
         activeTicket = nil
         activeNavigationID = nil
+        activeNavigationBeganProvisionally = false
+        activeTargetURL = nil
         terminalOutcome = (ticket, outcome)
         if let waiter, waiter.transactionID == ticket.transactionID {
             self.waiter = nil

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -17,10 +17,9 @@ public final class BrowserAutomationNavigationCoordinator {
     private var activeNavigationID: ObjectIdentifier?
     private var activeNavigationBeganProvisionally = false
     private var activeTargetURL: URL?
-    private var terminalOutcome: (
-        ticket: BrowserAutomationNavigationTicket,
-        outcome: BrowserAutomationNavigationOutcome
-    )?
+    private var terminalOutcomes: [
+        BrowserAutomationNavigationTicket: BrowserAutomationNavigationOutcome
+    ] = [:]
     private var waiter: (
         transactionID: UUID,
         continuation: AsyncStream<BrowserAutomationNavigationOutcome>.Continuation
@@ -63,11 +62,8 @@ public final class BrowserAutomationNavigationCoordinator {
         }
 
         let ticket = BrowserAutomationNavigationTicket(instanceID: instanceID)
-        // One panel has one authoritative automation navigation. Once a newer
-        // transaction begins, an abandoned older outcome is only superseded.
-        terminalOutcome = nil
         guard observedInstanceID == instanceID else {
-            terminalOutcome = (ticket, .superseded)
+            terminalOutcomes[ticket] = .superseded
             return ticket
         }
         activeTicket = ticket
@@ -128,10 +124,22 @@ public final class BrowserAutomationNavigationCoordinator {
         return true
     }
 
-    /// Completes a reload that has no document and therefore requires no WebKit navigation.
-    public func didCompleteWithoutNavigation(_ ticket: BrowserAutomationNavigationTicket) {
+    /// Resolves a reload after WebKit returns no navigation identity.
+    ///
+    /// A document-less new tab is already in its requested state. Active recovery/deferred
+    /// signals keep the transaction open for the delegate callback that binds its real load;
+    /// every other nil return means WebKit did not start the requested reload.
+    public func didReturnNoNavigation(
+        _ ticket: BrowserAutomationNavigationTicket,
+        hasCurrentHistoryItem: Bool,
+        isShowingNewTabPage: Bool,
+        waitsForDeferredNavigation: Bool
+    ) {
         guard activeTicket == ticket, activeNavigationID == nil else { return }
-        finish(ticket, with: .committed)
+        guard !waitsForDeferredNavigation else { return }
+        let outcome: BrowserAutomationNavigationOutcome =
+            !hasCurrentHistoryItem && isShowingNewTabPage ? .committed : .notStarted
+        finish(ticket, with: outcome)
     }
 
     /// Terminates a deferred replacement when policy resolution starts no navigation.
@@ -205,11 +213,11 @@ public final class BrowserAutomationNavigationCoordinator {
     ) async -> BrowserAutomationNavigationOutcome {
         guard !Task.isCancelled else {
             cancel(ticket)
+            terminalOutcomes.removeValue(forKey: ticket)
             return .cancelled
         }
-        if let completed = terminalOutcome, completed.ticket == ticket {
-            terminalOutcome = nil
-            return completed.outcome
+        if let completed = terminalOutcomes.removeValue(forKey: ticket) {
+            return completed
         }
         guard activeTicket == ticket else { return .superseded }
 
@@ -245,12 +253,10 @@ public final class BrowserAutomationNavigationCoordinator {
         if waiter?.transactionID == ticket.transactionID {
             waiter = nil
         }
-        if terminalOutcome?.ticket == ticket {
-            terminalOutcome = nil
-        }
+        terminalOutcomes.removeValue(forKey: ticket)
         if activeTicket == ticket {
             finish(ticket, with: Task.isCancelled ? .cancelled : outcome)
-            terminalOutcome = nil
+            terminalOutcomes.removeValue(forKey: ticket)
         }
         return Task.isCancelled ? .cancelled : outcome
     }
@@ -278,7 +284,7 @@ public final class BrowserAutomationNavigationCoordinator {
         activeNavigationID = nil
         activeNavigationBeganProvisionally = false
         activeTargetURL = nil
-        terminalOutcome = (ticket, outcome)
+        terminalOutcomes[ticket] = outcome
         if let waiter, waiter.transactionID == ticket.transactionID {
             self.waiter = nil
             waiter.continuation.yield(outcome)

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -3,8 +3,8 @@ public import Foundation
 /// Owns the lifecycle of browser-automation navigations for one browser panel.
 ///
 /// A transaction is associated with the exact navigation identity returned by the load call.
-/// Only a delegate callback for that identity can complete it, preventing an error-page commit
-/// or an older in-flight navigation from being acknowledged as the requested document.
+/// Document loads complete only for a delegate callback carrying that identity. Same-document
+/// loads complete only for a trusted main-frame event that reaches the exact target URL.
 @MainActor
 public final class BrowserAutomationNavigationCoordinator {
     /// Cancellable timing source used for the terminal-navigation deadline.
@@ -15,8 +15,8 @@ public final class BrowserAutomationNavigationCoordinator {
     private var observedInstanceID: UUID?
     private var activeTicket: BrowserAutomationNavigationTicket?
     private var activeNavigationID: ObjectIdentifier?
-    private var activeNavigationBeganProvisionally = false
     private var activeTargetURL: URL?
+    private var allowsSameDocumentCompletion = false
 
     /// Creates a coordinator with a bounded continuous-clock navigation deadline.
     public init(navigationTimeout: Duration = .seconds(15)) {
@@ -46,9 +46,17 @@ public final class BrowserAutomationNavigationCoordinator {
     }
 
     /// Begins a transaction for the currently bound WebView instance.
+    ///
+    /// - Parameters:
+    ///   - instanceID: Identity of the WebView instance that will perform the navigation.
+    ///   - targetURL: Display URL the navigation must reach.
+    ///   - allowsSameDocumentCompletion: Whether a trusted same-document event may finish
+    ///     the transaction. Pass `false` for reloads and app-owned error documents.
+    /// - Returns: A ticket that observes the transaction's one terminal outcome.
     public func begin(
         instanceID: UUID,
-        targetURL: URL? = nil
+        targetURL: URL? = nil,
+        allowsSameDocumentCompletion: Bool = false
     ) -> BrowserAutomationNavigationTicket {
         if let activeTicket {
             finish(activeTicket, with: .superseded)
@@ -61,8 +69,8 @@ public final class BrowserAutomationNavigationCoordinator {
         }
         activeTicket = ticket
         activeNavigationID = nil
-        activeNavigationBeganProvisionally = false
         activeTargetURL = targetURL
+        self.allowsSameDocumentCompletion = allowsSameDocumentCompletion
         return ticket
     }
 
@@ -106,8 +114,6 @@ public final class BrowserAutomationNavigationCoordinator {
         targetURL: URL? = nil
     ) {
         didAssociate(instanceID: instanceID, navigationID: navigationID, targetURL: targetURL)
-        guard let navigationID, activeNavigationID == navigationID else { return }
-        activeNavigationBeganProvisionally = true
     }
 
     /// Releases the current navigation identity while a policy flow waits to start its replacement.
@@ -120,7 +126,6 @@ public final class BrowserAutomationNavigationCoordinator {
     ) -> BrowserAutomationNavigationTicket? {
         guard let activeTicket, activeTicket.instanceID == instanceID else { return nil }
         activeNavigationID = nil
-        activeNavigationBeganProvisionally = false
         if let targetURL {
             activeTargetURL = targetURL
         }
@@ -154,16 +159,16 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(ticket, with: .notStarted)
     }
 
-    /// Completes the active transaction when WebKit changes to its target URL without a document commit.
+    /// Completes the active transaction after WebKit reports a same-document navigation.
     ///
-    /// The owning WebView must call this only for an authoritative URL change outside a provisional
-    /// main-frame load, which is WebKit's observable signal for a same-document navigation.
-    public func didReachSameDocumentURL(instanceID: UUID, url: URL?) {
+    /// The owning WebView must call this only from a trusted main-frame same-document event.
+    /// Presentation URL observation is not a navigation lifecycle signal and must not call this API.
+    public func didFinishSameDocumentNavigation(instanceID: UUID, url: URL?) {
         guard let url,
               let activeTicket,
               activeTicket.instanceID == instanceID,
               activeNavigationID != nil,
-              !activeNavigationBeganProvisionally,
+              allowsSameDocumentCompletion,
               activeTargetURL == url else {
             return
         }
@@ -272,8 +277,8 @@ public final class BrowserAutomationNavigationCoordinator {
         guard activeTicket == ticket else { return }
         activeTicket = nil
         activeNavigationID = nil
-        activeNavigationBeganProvisionally = false
         activeTargetURL = nil
+        allowsSameDocumentCompletion = false
         ticket.transaction.finish(with: outcome)
     }
 }

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -86,8 +86,8 @@ public final class BrowserAutomationNavigationCoordinator {
         activeNavigationID = navigationID
     }
 
-    /// Records a provisional delegate start, binding a deferred or replacement load when needed.
-    public func didStart(
+    /// Associates a deferred or replacement load's returned navigation identity.
+    public func didAssociate(
         instanceID: UUID,
         navigationID: ObjectIdentifier?,
         targetURL: URL? = nil
@@ -104,9 +104,17 @@ public final class BrowserAutomationNavigationCoordinator {
             }
             activeNavigationID = navigationID
         }
-        if activeNavigationID == navigationID {
-            activeNavigationBeganProvisionally = true
-        }
+    }
+
+    /// Records the provisional delegate start for an associated navigation.
+    public func didStart(
+        instanceID: UUID,
+        navigationID: ObjectIdentifier?,
+        targetURL: URL? = nil
+    ) {
+        didAssociate(instanceID: instanceID, navigationID: navigationID, targetURL: targetURL)
+        guard let navigationID, activeNavigationID == navigationID else { return }
+        activeNavigationBeganProvisionally = true
     }
 
     /// Releases the current navigation identity while a policy flow waits to start its replacement.
@@ -168,16 +176,9 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(activeTicket, with: .committed)
     }
 
-    /// Completes the transaction when its target becomes a main-frame download.
-    public func didBecomeDownload(instanceID: UUID, url: URL?) {
-        guard let activeTicket,
-              activeTicket.instanceID == instanceID,
-              activeNavigationID != nil,
-              let activeTargetURL,
-              url == activeTargetURL else {
-            return
-        }
-        finish(activeTicket, with: .downloaded)
+    /// Completes the transaction when its exact provisional navigation becomes a download.
+    public func didBecomeDownload(instanceID: UUID, navigationID: ObjectIdentifier?) {
+        finishMatching(instanceID: instanceID, navigationID: navigationID, with: .downloaded)
     }
 
     /// Records a commit only when it belongs to the exact active navigation.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -160,6 +160,16 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(activeTicket, with: .committed)
     }
 
+    /// Completes the transaction when its main-frame navigation becomes a download.
+    public func didBecomeDownload(instanceID: UUID, url: URL?) {
+        guard let activeTicket, activeTicket.instanceID == instanceID else { return }
+        if activeNavigationID == nil, let activeTargetURL, url != activeTargetURL {
+            finish(activeTicket, with: .superseded)
+            return
+        }
+        finish(activeTicket, with: .downloaded)
+    }
+
     /// Records a commit only when it belongs to the exact active navigation.
     public func didCommit(instanceID: UUID, navigationID: ObjectIdentifier?) {
         finishMatching(instanceID: instanceID, navigationID: navigationID, with: .committed)

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -17,6 +17,7 @@ public final class BrowserAutomationNavigationCoordinator {
     private var activeNavigationID: ObjectIdentifier?
     private var activeTargetURL: URL?
     private var allowsSameDocumentCompletion = false
+    private var downloadPolicyNavigationID: ObjectIdentifier?
 
     /// Creates a coordinator with a bounded continuous-clock navigation deadline.
     public init(navigationTimeout: Duration = .seconds(15)) {
@@ -71,6 +72,7 @@ public final class BrowserAutomationNavigationCoordinator {
         activeNavigationID = nil
         activeTargetURL = targetURL
         self.allowsSameDocumentCompletion = allowsSameDocumentCompletion
+        downloadPolicyNavigationID = nil
         return ticket
     }
 
@@ -116,22 +118,6 @@ public final class BrowserAutomationNavigationCoordinator {
         didAssociate(instanceID: instanceID, navigationID: navigationID, targetURL: targetURL)
     }
 
-    /// Releases the current navigation identity while a policy flow waits to start its replacement.
-    ///
-    /// - Returns: The exact ticket handed to the replacement flow, or `nil` when no transaction is active.
-    @discardableResult
-    public func prepareForNavigationReplacement(
-        instanceID: UUID,
-        targetURL: URL? = nil
-    ) -> BrowserAutomationNavigationTicket? {
-        guard let activeTicket, activeTicket.instanceID == instanceID else { return nil }
-        activeNavigationID = nil
-        if let targetURL {
-            activeTargetURL = targetURL
-        }
-        return activeTicket
-    }
-
     /// Resolves a reload after WebKit returns no navigation identity.
     ///
     /// A document-less new tab is already in its requested state. Active recovery/deferred
@@ -150,15 +136,6 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(ticket, with: outcome)
     }
 
-    /// Terminates the exact deferred replacement when policy resolution starts no navigation.
-    public func didNotStart(_ ticket: BrowserAutomationNavigationTicket) {
-        guard activeTicket == ticket,
-              activeNavigationID == nil else {
-            return
-        }
-        finish(ticket, with: .notStarted)
-    }
-
     /// Completes the active transaction after WebKit reports a same-document navigation.
     ///
     /// The owning WebView must call this only from a trusted main-frame same-document event.
@@ -175,9 +152,45 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(activeTicket, with: .committed)
     }
 
-    /// Completes the transaction when its exact provisional navigation becomes a download.
-    public func didBecomeDownload(instanceID: UUID, navigationID: ObjectIdentifier?) {
-        finishMatching(instanceID: instanceID, navigationID: navigationID, with: .downloaded)
+    /// Authorizes a download outcome for the exact provisional navigation whose response policy changed.
+    ///
+    /// - Parameters:
+    ///   - instanceID: Identity of the WebView instance receiving the response.
+    ///   - navigationID: Identity of the provisional navigation whose response became a download.
+    public func didChooseDownloadPolicy(instanceID: UUID, navigationID: ObjectIdentifier?) {
+        guard let navigationID,
+              let activeTicket,
+              activeTicket.instanceID == instanceID,
+              activeNavigationID == navigationID else {
+            return
+        }
+        downloadPolicyNavigationID = navigationID
+    }
+
+    /// Completes an exact policy-interrupted navigation and reports whether it was an authorized download.
+    ///
+    /// WebKit error 102 covers every policy interruption, so only a preceding response-download decision
+    /// for the same navigation identity is a successful download. All other matching interruptions
+    /// are cancellations.
+    ///
+    /// - Parameters:
+    ///   - instanceID: Identity of the WebView instance reporting the interruption.
+    ///   - navigationID: Identity of the provisional navigation interrupted by policy.
+    /// - Returns: `true` only when the exact navigation had an authorized response-download decision.
+    @discardableResult
+    public func didInterruptByPolicyChange(
+        instanceID: UUID,
+        navigationID: ObjectIdentifier?
+    ) -> Bool {
+        guard let navigationID,
+              let activeTicket,
+              activeTicket.instanceID == instanceID,
+              activeNavigationID == navigationID else {
+            return false
+        }
+        let isDownload = downloadPolicyNavigationID == navigationID
+        finish(activeTicket, with: isDownload ? .downloaded : .cancelled)
+        return isDownload
     }
 
     /// Records a commit only when it belongs to the exact active navigation.
@@ -279,6 +292,7 @@ public final class BrowserAutomationNavigationCoordinator {
         activeNavigationID = nil
         activeTargetURL = nil
         allowsSameDocumentCompletion = false
+        downloadPolicyNavigationID = nil
         ticket.transaction.finish(with: outcome)
     }
 }

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -146,7 +146,10 @@ public final class BrowserAutomationNavigationCoordinator {
               activeTicket.instanceID == instanceID,
               activeNavigationID != nil,
               allowsSameDocumentCompletion,
-              activeTargetURL == url else {
+              let activeTargetURL,
+              let observedNavigationURL = BrowserAutomationNavigationURL(url),
+              let targetNavigationURL = BrowserAutomationNavigationURL(activeTargetURL),
+              observedNavigationURL == targetNavigationURL else {
             return
         }
         finish(activeTicket, with: .committed)

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -15,10 +15,14 @@ public final class BrowserAutomationNavigationCoordinator {
     private var observedInstanceID: UUID?
     private var activeTicket: BrowserAutomationNavigationTicket?
     private var activeNavigationID: ObjectIdentifier?
-    private var terminalOutcomes: [UUID: BrowserAutomationNavigationOutcome] = [:]
-    private var waiters: [
-        UUID: AsyncStream<BrowserAutomationNavigationOutcome>.Continuation
-    ] = [:]
+    private var terminalOutcome: (
+        ticket: BrowserAutomationNavigationTicket,
+        outcome: BrowserAutomationNavigationOutcome
+    )?
+    private var waiter: (
+        transactionID: UUID,
+        continuation: AsyncStream<BrowserAutomationNavigationOutcome>.Continuation
+    )?
 
     /// Creates a coordinator with a bounded continuous-clock navigation deadline.
     public init(navigationTimeout: Duration = .seconds(8)) {
@@ -54,8 +58,11 @@ public final class BrowserAutomationNavigationCoordinator {
         }
 
         let ticket = BrowserAutomationNavigationTicket(instanceID: instanceID)
+        // One panel has one authoritative automation navigation. Once a newer
+        // transaction begins, an abandoned older outcome is only superseded.
+        terminalOutcome = nil
         guard observedInstanceID == instanceID else {
-            terminalOutcomes[ticket.transactionID] = .superseded
+            terminalOutcome = (ticket, .superseded)
             return ticket
         }
         activeTicket = ticket
@@ -113,8 +120,9 @@ public final class BrowserAutomationNavigationCoordinator {
             cancel(ticket)
             return .cancelled
         }
-        if let outcome = terminalOutcomes.removeValue(forKey: ticket.transactionID) {
-            return outcome
+        if let completed = terminalOutcome, completed.ticket == ticket {
+            terminalOutcome = nil
+            return completed.outcome
         }
         guard activeTicket == ticket else { return .superseded }
 
@@ -122,7 +130,7 @@ public final class BrowserAutomationNavigationCoordinator {
             of: BrowserAutomationNavigationOutcome.self,
             bufferingPolicy: .bufferingNewest(1)
         )
-        waiters[ticket.transactionID] = continuation
+        waiter = (ticket.transactionID, continuation)
         let outcome = await withTaskGroup(
             of: BrowserAutomationNavigationOutcome.self,
             returning: BrowserAutomationNavigationOutcome.self
@@ -147,11 +155,15 @@ public final class BrowserAutomationNavigationCoordinator {
             return first
         }
 
-        waiters.removeValue(forKey: ticket.transactionID)
-        terminalOutcomes.removeValue(forKey: ticket.transactionID)
+        if waiter?.transactionID == ticket.transactionID {
+            waiter = nil
+        }
+        if terminalOutcome?.ticket == ticket {
+            terminalOutcome = nil
+        }
         if activeTicket == ticket {
             finish(ticket, with: Task.isCancelled ? .cancelled : outcome)
-            terminalOutcomes.removeValue(forKey: ticket.transactionID)
+            terminalOutcome = nil
         }
         return Task.isCancelled ? .cancelled : outcome
     }
@@ -177,10 +189,11 @@ public final class BrowserAutomationNavigationCoordinator {
         guard activeTicket == ticket else { return }
         activeTicket = nil
         activeNavigationID = nil
-        terminalOutcomes[ticket.transactionID] = outcome
-        if let waiter = waiters.removeValue(forKey: ticket.transactionID) {
-            waiter.yield(outcome)
-            waiter.finish()
+        terminalOutcome = (ticket, outcome)
+        if let waiter, waiter.transactionID == ticket.transactionID {
+            self.waiter = nil
+            waiter.continuation.yield(outcome)
+            waiter.continuation.finish()
         }
     }
 }

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -17,13 +17,6 @@ public final class BrowserAutomationNavigationCoordinator {
     private var activeNavigationID: ObjectIdentifier?
     private var activeNavigationBeganProvisionally = false
     private var activeTargetURL: URL?
-    private var terminalOutcomes: [
-        BrowserAutomationNavigationTicket: BrowserAutomationNavigationOutcome
-    ] = [:]
-    private var waiter: (
-        transactionID: UUID,
-        continuation: AsyncStream<BrowserAutomationNavigationOutcome>.Continuation
-    )?
 
     /// Creates a coordinator with a bounded continuous-clock navigation deadline.
     public init(navigationTimeout: Duration = .seconds(15)) {
@@ -63,7 +56,7 @@ public final class BrowserAutomationNavigationCoordinator {
 
         let ticket = BrowserAutomationNavigationTicket(instanceID: instanceID)
         guard observedInstanceID == instanceID else {
-            terminalOutcomes[ticket] = .superseded
+            ticket.transaction.finish(with: .superseded)
             return ticket
         }
         activeTicket = ticket
@@ -217,19 +210,15 @@ public final class BrowserAutomationNavigationCoordinator {
     ) async -> BrowserAutomationNavigationOutcome {
         guard !Task.isCancelled else {
             cancel(ticket)
-            terminalOutcomes.removeValue(forKey: ticket)
+            ticket.transaction.discardTerminalOutcome()
             return .cancelled
         }
-        if let completed = terminalOutcomes.removeValue(forKey: ticket) {
+        if let completed = ticket.transaction.takeTerminalOutcome() {
             return completed
         }
         guard activeTicket == ticket else { return .superseded }
 
-        let (events, continuation) = AsyncStream.makeStream(
-            of: BrowserAutomationNavigationOutcome.self,
-            bufferingPolicy: .bufferingNewest(1)
-        )
-        waiter = (ticket.transactionID, continuation)
+        let events = ticket.transaction.makeEventStream()
         let outcome = await withTaskGroup(
             of: BrowserAutomationNavigationOutcome.self,
             returning: BrowserAutomationNavigationOutcome.self
@@ -249,18 +238,15 @@ public final class BrowserAutomationNavigationCoordinator {
 
             let first = await group.next() ?? .cancelled
             group.cancelAll()
-            continuation.finish()
+            ticket.transaction.cancelWaiter()
             await group.waitForAll()
             return first
         }
 
-        if waiter?.transactionID == ticket.transactionID {
-            waiter = nil
-        }
-        terminalOutcomes.removeValue(forKey: ticket)
+        ticket.transaction.discardTerminalOutcome()
         if activeTicket == ticket {
             finish(ticket, with: Task.isCancelled ? .cancelled : outcome)
-            terminalOutcomes.removeValue(forKey: ticket)
+            ticket.transaction.discardTerminalOutcome()
         }
         return Task.isCancelled ? .cancelled : outcome
     }
@@ -288,11 +274,6 @@ public final class BrowserAutomationNavigationCoordinator {
         activeNavigationID = nil
         activeNavigationBeganProvisionally = false
         activeTargetURL = nil
-        terminalOutcomes[ticket] = outcome
-        if let waiter, waiter.transactionID == ticket.transactionID {
-            self.waiter = nil
-            waiter.continuation.yield(outcome)
-            waiter.continuation.finish()
-        }
+        ticket.transaction.finish(with: outcome)
     }
 }

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -118,18 +118,20 @@ public final class BrowserAutomationNavigationCoordinator {
     }
 
     /// Releases the current navigation identity while a policy flow waits to start its replacement.
+    ///
+    /// - Returns: The exact ticket handed to the replacement flow, or `nil` when no transaction is active.
     @discardableResult
     public func prepareForNavigationReplacement(
         instanceID: UUID,
         targetURL: URL? = nil
-    ) -> Bool {
-        guard let activeTicket, activeTicket.instanceID == instanceID else { return false }
+    ) -> BrowserAutomationNavigationTicket? {
+        guard let activeTicket, activeTicket.instanceID == instanceID else { return nil }
         activeNavigationID = nil
         activeNavigationBeganProvisionally = false
         if let targetURL {
             activeTargetURL = targetURL
         }
-        return true
+        return activeTicket
     }
 
     /// Resolves a reload after WebKit returns no navigation identity.
@@ -150,14 +152,13 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(ticket, with: outcome)
     }
 
-    /// Terminates a deferred replacement when policy resolution starts no navigation.
-    public func didNotStart(instanceID: UUID) {
-        guard let activeTicket,
-              activeTicket.instanceID == instanceID,
+    /// Terminates the exact deferred replacement when policy resolution starts no navigation.
+    public func didNotStart(_ ticket: BrowserAutomationNavigationTicket) {
+        guard activeTicket == ticket,
               activeNavigationID == nil else {
             return
         }
-        finish(activeTicket, with: .notStarted)
+        finish(ticket, with: .notStarted)
     }
 
     /// Completes the active transaction when WebKit changes to its target URL without a document commit.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -83,6 +83,41 @@ public final class BrowserAutomationNavigationCoordinator {
         activeNavigationID = navigationID
     }
 
+    /// Associates a deferred or policy-replacement load with the active transaction.
+    public func didStart(instanceID: UUID, navigationID: ObjectIdentifier?) {
+        guard let navigationID,
+              let activeTicket,
+              activeTicket.instanceID == instanceID,
+              activeNavigationID == nil else {
+            return
+        }
+        activeNavigationID = navigationID
+    }
+
+    /// Releases the current navigation identity while a policy flow waits to start its replacement.
+    @discardableResult
+    public func prepareForNavigationReplacement(instanceID: UUID) -> Bool {
+        guard let activeTicket, activeTicket.instanceID == instanceID else { return false }
+        activeNavigationID = nil
+        return true
+    }
+
+    /// Completes a reload that has no document and therefore requires no WebKit navigation.
+    public func didCompleteWithoutNavigation(_ ticket: BrowserAutomationNavigationTicket) {
+        guard activeTicket == ticket, activeNavigationID == nil else { return }
+        finish(ticket, with: .committed)
+    }
+
+    /// Terminates a deferred replacement when policy resolution starts no navigation.
+    public func didNotStart(instanceID: UUID) {
+        guard let activeTicket,
+              activeTicket.instanceID == instanceID,
+              activeNavigationID == nil else {
+            return
+        }
+        finish(activeTicket, with: .notStarted)
+    }
+
     /// Records a commit only when it belongs to the exact active navigation.
     public func didCommit(instanceID: UUID, navigationID: ObjectIdentifier?) {
         finishMatching(instanceID: instanceID, navigationID: navigationID, with: .committed)

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -168,14 +168,9 @@ public final class BrowserAutomationNavigationCoordinator {
         finish(activeTicket, with: .committed)
     }
 
-    /// Completes the transaction when its main-frame navigation becomes a download.
-    public func didBecomeDownload(instanceID: UUID, url: URL?) {
-        guard let activeTicket, activeTicket.instanceID == instanceID else { return }
-        if activeNavigationID == nil, let activeTargetURL, url != activeTargetURL {
-            finish(activeTicket, with: .superseded)
-            return
-        }
-        finish(activeTicket, with: .downloaded)
+    /// Completes the transaction when its exact provisional navigation becomes a download.
+    public func didBecomeDownload(instanceID: UUID, navigationID: ObjectIdentifier?) {
+        finishMatching(instanceID: instanceID, navigationID: navigationID, with: .downloaded)
     }
 
     /// Records a commit only when it belongs to the exact active navigation.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationCoordinator.swift
@@ -1,0 +1,186 @@
+public import Foundation
+
+/// Owns the lifecycle of browser-automation navigations for one browser panel.
+///
+/// A transaction is associated with the exact navigation identity returned by the load call.
+/// Only a delegate callback for that identity can complete it, preventing an error-page commit
+/// or an older in-flight navigation from being acknowledged as the requested document.
+@MainActor
+public final class BrowserAutomationNavigationCoordinator {
+    /// Cancellable timing source used for the terminal-navigation deadline.
+    public typealias Sleep = @Sendable (_ duration: Duration) async throws -> Void
+
+    private let navigationTimeout: Duration
+    private let sleep: Sleep
+    private var observedInstanceID: UUID?
+    private var activeTicket: BrowserAutomationNavigationTicket?
+    private var activeNavigationID: ObjectIdentifier?
+    private var terminalOutcomes: [UUID: BrowserAutomationNavigationOutcome] = [:]
+    private var waiters: [
+        UUID: AsyncStream<BrowserAutomationNavigationOutcome>.Continuation
+    ] = [:]
+
+    /// Creates a coordinator with a bounded continuous-clock navigation deadline.
+    public init(navigationTimeout: Duration = .seconds(8)) {
+        self.navigationTimeout = navigationTimeout
+        let clock = ContinuousClock()
+        self.sleep = { duration in
+            try await clock.sleep(for: duration)
+        }
+    }
+
+    /// Creates a coordinator with an injected timing source for deterministic tests.
+    public init(
+        navigationTimeout: Duration = .seconds(8),
+        sleep: @escaping Sleep
+    ) {
+        self.navigationTimeout = navigationTimeout
+        self.sleep = sleep
+    }
+
+    /// Starts observing a WebView instance and supersedes a transaction from an older instance.
+    public func bind(to instanceID: UUID) {
+        guard observedInstanceID != instanceID else { return }
+        if let activeTicket {
+            finish(activeTicket, with: .superseded)
+        }
+        observedInstanceID = instanceID
+    }
+
+    /// Begins a transaction for the currently bound WebView instance.
+    public func begin(instanceID: UUID) -> BrowserAutomationNavigationTicket {
+        if let activeTicket {
+            finish(activeTicket, with: .superseded)
+        }
+
+        let ticket = BrowserAutomationNavigationTicket(instanceID: instanceID)
+        guard observedInstanceID == instanceID else {
+            terminalOutcomes[ticket.transactionID] = .superseded
+            return ticket
+        }
+        activeTicket = ticket
+        activeNavigationID = nil
+        return ticket
+    }
+
+    /// Associates the load call's returned navigation identity with its transaction.
+    public func didStart(
+        _ ticket: BrowserAutomationNavigationTicket,
+        navigationID: ObjectIdentifier?
+    ) {
+        guard activeTicket == ticket else { return }
+        guard let navigationID else {
+            finish(ticket, with: .notStarted)
+            return
+        }
+        activeNavigationID = navigationID
+    }
+
+    /// Records a commit only when it belongs to the exact active navigation.
+    public func didCommit(instanceID: UUID, navigationID: ObjectIdentifier?) {
+        finishMatching(instanceID: instanceID, navigationID: navigationID, with: .committed)
+    }
+
+    /// Records a failure only when it belongs to the exact active navigation.
+    public func didFail(instanceID: UUID, navigationID: ObjectIdentifier?, message: String) {
+        finishMatching(instanceID: instanceID, navigationID: navigationID, with: .failed(message))
+    }
+
+    /// Records a cancellation only when it belongs to the exact active navigation.
+    public func didCancel(instanceID: UUID, navigationID: ObjectIdentifier?) {
+        finishMatching(instanceID: instanceID, navigationID: navigationID, with: .cancelled)
+    }
+
+    /// Cancels a transaction that no longer has a caller waiting for it.
+    public func cancel(_ ticket: BrowserAutomationNavigationTicket) {
+        guard activeTicket == ticket else { return }
+        finish(ticket, with: .cancelled)
+    }
+
+    /// Cancels the active transaction and stops observing the current WebView instance.
+    public func invalidate() {
+        if let activeTicket {
+            finish(activeTicket, with: .cancelled)
+        }
+        observedInstanceID = nil
+    }
+
+    /// Waits for the exact navigation to commit or reach another terminal delegate outcome.
+    public func wait(
+        for ticket: BrowserAutomationNavigationTicket
+    ) async -> BrowserAutomationNavigationOutcome {
+        guard !Task.isCancelled else {
+            cancel(ticket)
+            return .cancelled
+        }
+        if let outcome = terminalOutcomes.removeValue(forKey: ticket.transactionID) {
+            return outcome
+        }
+        guard activeTicket == ticket else { return .superseded }
+
+        let (events, continuation) = AsyncStream.makeStream(
+            of: BrowserAutomationNavigationOutcome.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        waiters[ticket.transactionID] = continuation
+        let outcome = await withTaskGroup(
+            of: BrowserAutomationNavigationOutcome.self,
+            returning: BrowserAutomationNavigationOutcome.self
+        ) { group in
+            group.addTask {
+                var iterator = events.makeAsyncIterator()
+                return await iterator.next() ?? .cancelled
+            }
+            group.addTask { [navigationTimeout, sleep] in
+                do {
+                    try await sleep(navigationTimeout)
+                } catch {
+                    return .cancelled
+                }
+                return Task.isCancelled ? .cancelled : .timedOut
+            }
+
+            let first = await group.next() ?? .cancelled
+            group.cancelAll()
+            continuation.finish()
+            await group.waitForAll()
+            return first
+        }
+
+        waiters.removeValue(forKey: ticket.transactionID)
+        terminalOutcomes.removeValue(forKey: ticket.transactionID)
+        if activeTicket == ticket {
+            finish(ticket, with: Task.isCancelled ? .cancelled : outcome)
+            terminalOutcomes.removeValue(forKey: ticket.transactionID)
+        }
+        return Task.isCancelled ? .cancelled : outcome
+    }
+
+    private func finishMatching(
+        instanceID: UUID,
+        navigationID: ObjectIdentifier?,
+        with outcome: BrowserAutomationNavigationOutcome
+    ) {
+        guard let navigationID,
+              let activeTicket,
+              activeTicket.instanceID == instanceID,
+              activeNavigationID == navigationID else {
+            return
+        }
+        finish(activeTicket, with: outcome)
+    }
+
+    private func finish(
+        _ ticket: BrowserAutomationNavigationTicket,
+        with outcome: BrowserAutomationNavigationOutcome
+    ) {
+        guard activeTicket == ticket else { return }
+        activeTicket = nil
+        activeNavigationID = nil
+        terminalOutcomes[ticket.transactionID] = outcome
+        if let waiter = waiters.removeValue(forKey: ticket.transactionID) {
+            waiter.yield(outcome)
+            waiter.finish()
+        }
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationOutcome.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationOutcome.swift
@@ -1,0 +1,20 @@
+/// The terminal result of one browser-automation navigation transaction.
+public enum BrowserAutomationNavigationOutcome: Sendable, Equatable {
+    /// The exact navigation started for the transaction committed a document.
+    case committed
+
+    /// WebKit reported a terminal navigation failure.
+    case failed(String)
+
+    /// WebKit cancelled the provisional navigation before it committed.
+    case cancelled
+
+    /// A newer automation navigation or WebView instance replaced this transaction.
+    case superseded
+
+    /// WebKit declined to create a navigation for the requested load.
+    case notStarted
+
+    /// No terminal delegate callback arrived before the bounded navigation deadline.
+    case timedOut
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationOutcome.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationOutcome.swift
@@ -3,6 +3,9 @@ public enum BrowserAutomationNavigationOutcome: Sendable, Equatable {
     /// The exact navigation started for the transaction committed a document.
     case committed
 
+    /// The exact main-frame navigation became a download instead of a document.
+    case downloaded
+
     /// WebKit reported a terminal navigation failure.
     case failed(String)
 

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationTicket.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationTicket.swift
@@ -6,9 +6,25 @@ public struct BrowserAutomationNavigationTicket: Sendable, Hashable {
     public let instanceID: UUID
 
     let transactionID: UUID
+    let transaction: BrowserAutomationNavigationTransaction
 
+    @MainActor
     init(instanceID: UUID, transactionID: UUID = UUID()) {
         self.instanceID = instanceID
         self.transactionID = transactionID
+        self.transaction = BrowserAutomationNavigationTransaction()
+    }
+
+    /// Returns whether two tickets identify the same navigation transaction.
+    public static func == (
+        lhs: BrowserAutomationNavigationTicket,
+        rhs: BrowserAutomationNavigationTicket
+    ) -> Bool {
+        lhs.transactionID == rhs.transactionID
+    }
+
+    /// Hashes the stable identity of this navigation transaction.
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(transactionID)
     }
 }

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationTicket.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationTicket.swift
@@ -1,0 +1,14 @@
+public import Foundation
+
+/// Stable identity for one browser-automation navigation transaction.
+public struct BrowserAutomationNavigationTicket: Sendable, Hashable {
+    /// Identity of the WebView instance that owns the transaction.
+    public let instanceID: UUID
+
+    let transactionID: UUID
+
+    init(instanceID: UUID, transactionID: UUID = UUID()) {
+        self.instanceID = instanceID
+        self.transactionID = transactionID
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationTransaction.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationTransaction.swift
@@ -1,0 +1,37 @@
+/// One-shot result storage owned by the navigation ticket returned to a caller.
+@MainActor
+final class BrowserAutomationNavigationTransaction {
+    private var terminalOutcome: BrowserAutomationNavigationOutcome?
+    private var waiter: AsyncStream<BrowserAutomationNavigationOutcome>.Continuation?
+
+    func takeTerminalOutcome() -> BrowserAutomationNavigationOutcome? {
+        defer { terminalOutcome = nil }
+        return terminalOutcome
+    }
+
+    func makeEventStream() -> AsyncStream<BrowserAutomationNavigationOutcome> {
+        let (events, continuation) = AsyncStream.makeStream(
+            of: BrowserAutomationNavigationOutcome.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        waiter?.finish()
+        waiter = continuation
+        return events
+    }
+
+    func finish(with outcome: BrowserAutomationNavigationOutcome) {
+        terminalOutcome = outcome
+        waiter?.yield(outcome)
+        waiter?.finish()
+        waiter = nil
+    }
+
+    func cancelWaiter() {
+        waiter?.finish()
+        waiter = nil
+    }
+
+    func discardTerminalOutcome() {
+        terminalOutcome = nil
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationURL.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Control/BrowserAutomationNavigationURL.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// A deterministic URL value for matching WebKit same-document navigation reports.
+struct BrowserAutomationNavigationURL: Equatable {
+    private static let uppercaseHexadecimal = Array("0123456789ABCDEF".utf8)
+
+    private let scheme: String?
+    private let user: String?
+    private let password: String?
+    private let host: String?
+    private let port: Int?
+    private let path: String
+    private let query: String?
+    private let fragment: String?
+
+    init?(_ url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        let normalizedScheme = components.scheme?.lowercased()
+        scheme = normalizedScheme
+        user = components.percentEncodedUser.map(Self.normalizePercentEncoding)
+        password = components.percentEncodedPassword.map(Self.normalizePercentEncoding)
+        host = components.host?.lowercased()
+        switch (normalizedScheme, components.port) {
+        case ("http", 80), ("https", 443):
+            port = nil
+        default:
+            port = components.port
+        }
+
+        let normalizedPath = Self.normalizePercentEncoding(components.percentEncodedPath)
+        if (normalizedScheme == "http" || normalizedScheme == "https"),
+           components.host != nil,
+           normalizedPath.isEmpty {
+            path = "/"
+        } else {
+            path = normalizedPath
+        }
+        query = components.percentEncodedQuery.map(Self.normalizePercentEncoding)
+        fragment = components.percentEncodedFragment.map(Self.normalizePercentEncoding)
+    }
+
+    private static func normalizePercentEncoding(_ value: String) -> String {
+        let bytes = Array(value.utf8)
+        var normalized: [UInt8] = []
+        normalized.reserveCapacity(bytes.count)
+        var index = 0
+
+        while index < bytes.count {
+            if bytes[index] == 0x25,
+               index + 2 < bytes.count,
+               let high = hexadecimalValue(bytes[index + 1]),
+               let low = hexadecimalValue(bytes[index + 2]) {
+                let decoded = high << 4 | low
+                if isUnreserved(decoded) {
+                    normalized.append(decoded)
+                } else {
+                    normalized.append(0x25)
+                    normalized.append(uppercaseHexadecimal[Int(decoded >> 4)])
+                    normalized.append(uppercaseHexadecimal[Int(decoded & 0x0F)])
+                }
+                index += 3
+                continue
+            }
+
+            normalized.append(bytes[index])
+            index += 1
+        }
+
+        return String(decoding: normalized, as: UTF8.self)
+    }
+
+    private static func hexadecimalValue(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 0x30...0x39: byte - 0x30
+        case 0x41...0x46: byte - 0x41 + 10
+        case 0x61...0x66: byte - 0x61 + 10
+        default: nil
+        }
+    }
+
+    private static func isUnreserved(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 0x30...0x39, 0x41...0x5A, 0x61...0x7A, 0x2D, 0x2E, 0x5F, 0x7E: true
+        default: false
+        }
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -90,6 +90,45 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .committed)
     }
 
+    @Test("A policy replacement hands the transaction to the new navigation")
+    func policyReplacementHandsOffNavigationIdentity() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let originalNavigation = NSObject()
+        let replacementNavigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(originalNavigation))
+
+        #expect(coordinator.prepareForNavigationReplacement(instanceID: instanceID))
+        coordinator.didCancel(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(originalNavigation)
+        )
+        coordinator.didStart(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(replacementNavigation)
+        )
+        coordinator.didCommit(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(replacementNavigation)
+        )
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
+    @Test("A URL-less reload can complete without starting WebKit navigation")
+    func reloadWithoutNavigationCompletes() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+
+        coordinator.didCompleteWithoutNavigation(ticket)
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
     @Test("A load that returns no navigation terminates as not started")
     func missingNavigationIsNotStarted() async {
         let coordinator = BrowserAutomationNavigationCoordinator()

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -164,6 +164,32 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .committed)
     }
 
+    @Test("A same-document policy replacement keeps its navigation identity")
+    func sameDocumentPolicyReplacementCompletes() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let originalNavigation = NSObject()
+        let replacementNavigation = NSObject()
+        let originalURL = URL(string: "https://example.com/page")!
+        let fallbackURL = URL(string: "https://example.com/page#fallback")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: originalURL)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(originalNavigation))
+
+        #expect(coordinator.prepareForNavigationReplacement(
+            instanceID: instanceID,
+            targetURL: fallbackURL
+        ))
+        coordinator.didStart(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(replacementNavigation),
+            targetURL: fallbackURL
+        )
+        coordinator.didReachSameDocumentURL(instanceID: instanceID, url: fallbackURL)
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
     @Test("An unrelated deferred navigation supersedes the transaction")
     func unrelatedDeferredNavigationSupersedes() async {
         let coordinator = BrowserAutomationNavigationCoordinator()
@@ -206,10 +232,7 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
 
-        coordinator.didBecomeDownload(
-            instanceID: instanceID,
-            navigationID: ObjectIdentifier(navigation)
-        )
+        coordinator.didBecomeDownload(instanceID: instanceID, url: targetURL)
 
         #expect(await coordinator.wait(for: ticket) == .downloaded)
     }
@@ -219,13 +242,14 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let coordinator = BrowserAutomationNavigationCoordinator(sleep: { _ in })
         let instanceID = UUID()
         let navigation = NSObject()
+        let targetURL = URL(string: "https://example.com/page")!
         coordinator.bind(to: instanceID)
-        let ticket = coordinator.begin(instanceID: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
 
         coordinator.didBecomeDownload(
             instanceID: instanceID,
-            navigationID: ObjectIdentifier(NSObject())
+            url: URL(string: "https://example.com/unrelated.zip")!
         )
 
         #expect(await coordinator.wait(for: ticket) == .timedOut)

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -96,11 +96,16 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let instanceID = UUID()
         let originalNavigation = NSObject()
         let replacementNavigation = NSObject()
+        let originalURL = URL(string: "https://example.com/launch")!
+        let fallbackURL = URL(string: "https://example.com/fallback")!
         coordinator.bind(to: instanceID)
-        let ticket = coordinator.begin(instanceID: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: originalURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(originalNavigation))
 
-        #expect(coordinator.prepareForNavigationReplacement(instanceID: instanceID))
+        #expect(coordinator.prepareForNavigationReplacement(
+            instanceID: instanceID,
+            targetURL: fallbackURL
+        ))
         coordinator.didCancel(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(originalNavigation)
@@ -113,6 +118,21 @@ struct BrowserAutomationNavigationCoordinatorTests {
             instanceID: instanceID,
             navigationID: ObjectIdentifier(replacementNavigation)
         )
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
+    @Test("An authoritative same-document URL change completes the transaction")
+    func sameDocumentURLChangeCompletes() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        let targetURL = URL(string: "https://example.com/page#section")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        coordinator.didReachSameDocumentURL(instanceID: instanceID, url: targetURL)
 
         #expect(await coordinator.wait(for: ticket) == .committed)
     }

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -112,7 +112,8 @@ struct BrowserAutomationNavigationCoordinatorTests {
         )
         coordinator.didStart(
             instanceID: instanceID,
-            navigationID: ObjectIdentifier(replacementNavigation)
+            navigationID: ObjectIdentifier(replacementNavigation),
+            targetURL: fallbackURL
         )
         coordinator.didCommit(
             instanceID: instanceID,
@@ -120,6 +121,23 @@ struct BrowserAutomationNavigationCoordinatorTests {
         )
 
         #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
+    @Test("An unrelated deferred navigation supersedes the transaction")
+    func unrelatedDeferredNavigationSupersedes() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let expectedURL = URL(string: "https://example.com/expected")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: expectedURL)
+
+        coordinator.didStart(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(NSObject()),
+            targetURL: URL(string: "https://example.com/unrelated")!
+        )
+
+        #expect(await coordinator.wait(for: ticket) == .superseded)
     }
 
     @Test("An authoritative same-document URL change completes the transaction")

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -76,6 +76,24 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .failed("connection refused"))
     }
 
+    @Test("A completed outcome survives a newer transaction beginning")
+    func completedOutcomeSurvivesNewerTransaction() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let firstNavigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let firstTicket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(firstTicket, navigationID: ObjectIdentifier(firstNavigation))
+        coordinator.didCommit(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(firstNavigation)
+        )
+
+        _ = coordinator.begin(instanceID: instanceID)
+
+        #expect(await coordinator.wait(for: firstTicket) == .committed)
+    }
+
     @Test("A deferred load can bind when its real navigation starts")
     func deferredLoadBindsOnStart() async {
         let coordinator = BrowserAutomationNavigationCoordinator()
@@ -170,14 +188,62 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .downloaded)
     }
 
-    @Test("A URL-less reload can complete without starting WebKit navigation")
-    func reloadWithoutNavigationCompletes() async {
+    @Test("A document-less new-tab reload can complete without WebKit navigation")
+    func documentlessNewTabReloadCompletes() async {
         let coordinator = BrowserAutomationNavigationCoordinator()
         let instanceID = UUID()
         coordinator.bind(to: instanceID)
         let ticket = coordinator.begin(instanceID: instanceID)
 
-        coordinator.didCompleteWithoutNavigation(ticket)
+        coordinator.didReturnNoNavigation(
+            ticket,
+            hasCurrentHistoryItem: false,
+            isShowingNewTabPage: true,
+            waitsForDeferredNavigation: false
+        )
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
+    @Test("A nil reload for an existing document is not reported as committed")
+    func existingDocumentNilReloadIsNotStarted() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+
+        coordinator.didReturnNoNavigation(
+            ticket,
+            hasCurrentHistoryItem: true,
+            isShowingNewTabPage: false,
+            waitsForDeferredNavigation: false
+        )
+
+        #expect(await coordinator.wait(for: ticket) == .notStarted)
+    }
+
+    @Test("A deferred nil reload remains pending for its real navigation")
+    func deferredNilReloadBindsRealNavigation() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didReturnNoNavigation(
+            ticket,
+            hasCurrentHistoryItem: true,
+            isShowingNewTabPage: false,
+            waitsForDeferredNavigation: true
+        )
+
+        coordinator.didStart(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation)
+        )
+        coordinator.didCommit(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation)
+        )
 
         #expect(await coordinator.wait(for: ticket) == .committed)
     }

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -43,6 +43,29 @@ struct BrowserAutomationNavigationCoordinatorTests {
         registrationContinuation.finish()
     }
 
+    @Test("Cancelling a wait cancels its active transaction")
+    func cancellingWaitCancelsTransaction() async {
+        let (registrations, registrationContinuation) = AsyncStream.makeStream(of: Void.self)
+        var registrationIterator = registrations.makeAsyncIterator()
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+        let wait = Task { @MainActor in
+            registrationContinuation.yield()
+            return await coordinator.wait(for: ticket)
+        }
+        let registered: Void? = await registrationIterator.next()
+        #expect(registered != nil)
+
+        wait.cancel()
+
+        #expect(await wait.value == .cancelled)
+        registrationContinuation.finish()
+    }
+
     @Test("A different navigation cannot satisfy the active transaction")
     func unrelatedCommitIsIgnored() async {
         let coordinator = BrowserAutomationNavigationCoordinator(
@@ -183,9 +206,29 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
 
-        coordinator.didBecomeDownload(instanceID: instanceID, url: targetURL)
+        coordinator.didBecomeDownload(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation)
+        )
 
         #expect(await coordinator.wait(for: ticket) == .downloaded)
+    }
+
+    @Test("An unrelated download cannot satisfy the active transaction")
+    func unrelatedDownloadIsIgnored() async {
+        let coordinator = BrowserAutomationNavigationCoordinator(sleep: { _ in })
+        let instanceID = UUID()
+        let navigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        coordinator.didBecomeDownload(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(NSObject())
+        )
+
+        #expect(await coordinator.wait(for: ticket) == .timedOut)
     }
 
     @Test("A document-less new-tab reload can complete without WebKit navigation")

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -146,7 +146,7 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(coordinator.prepareForNavigationReplacement(
             instanceID: instanceID,
             targetURL: fallbackURL
-        ))
+        ) == ticket)
         coordinator.didCancel(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(originalNavigation)
@@ -179,7 +179,7 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(coordinator.prepareForNavigationReplacement(
             instanceID: instanceID,
             targetURL: fallbackURL
-        ))
+        ) == ticket)
         coordinator.didAssociate(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(replacementNavigation),
@@ -205,6 +205,35 @@ struct BrowserAutomationNavigationCoordinatorTests {
         )
 
         #expect(await coordinator.wait(for: ticket) == .superseded)
+    }
+
+    @Test("A stale deferred cancellation cannot terminate a newer transaction")
+    func staleDeferredCancellationIsIgnored() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let firstURL = URL(string: "https://example.com/first")!
+        let secondURL = URL(string: "https://example.com/second")!
+        let secondNavigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let firstTicket = coordinator.begin(instanceID: instanceID, targetURL: firstURL)
+        let deferredTicket = coordinator.prepareForNavigationReplacement(
+            instanceID: instanceID,
+            targetURL: firstURL
+        )
+        let secondTicket = coordinator.begin(instanceID: instanceID, targetURL: secondURL)
+
+        if let deferredTicket {
+            coordinator.didNotStart(deferredTicket)
+        }
+        coordinator.didStart(secondTicket, navigationID: ObjectIdentifier(secondNavigation))
+        coordinator.didCommit(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(secondNavigation)
+        )
+
+        #expect(deferredTicket == firstTicket)
+        #expect(await coordinator.wait(for: firstTicket) == .superseded)
+        #expect(await coordinator.wait(for: secondTicket) == .committed)
     }
 
     @Test("An authoritative same-document URL change completes the transaction")

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import CmuxBrowser
+
+@MainActor
+@Suite("Browser automation navigation coordinator")
+struct BrowserAutomationNavigationCoordinatorTests {
+    @Test("The exact started navigation commit completes the transaction")
+    func exactNavigationCommitCompletesTransaction() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        coordinator.didCommit(instanceID: instanceID, navigationID: ObjectIdentifier(navigation))
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
+    @Test("A delegate commit releases an already waiting transaction")
+    func commitReleasesWaitingTransaction() async {
+        let (registrations, registrationContinuation) = AsyncStream.makeStream(of: Void.self)
+        var registrationIterator = registrations.makeAsyncIterator()
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+        let wait = Task { @MainActor in
+            registrationContinuation.yield()
+            return await coordinator.wait(for: ticket)
+        }
+        let registered: Void? = await registrationIterator.next()
+        #expect(registered != nil)
+
+        coordinator.didCommit(instanceID: instanceID, navigationID: ObjectIdentifier(navigation))
+
+        #expect(await wait.value == .committed)
+        registrationContinuation.finish()
+    }
+
+    @Test("A different navigation cannot satisfy the active transaction")
+    func unrelatedCommitIsIgnored() async {
+        let coordinator = BrowserAutomationNavigationCoordinator(
+            sleep: { _ in }
+        )
+        let instanceID = UUID()
+        let requestedNavigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(requestedNavigation))
+
+        coordinator.didCommit(instanceID: instanceID, navigationID: ObjectIdentifier(NSObject()))
+
+        #expect(await coordinator.wait(for: ticket) == .timedOut)
+    }
+
+    @Test("A failure delivered before waiting remains observable")
+    func earlyFailureRemainsObservable() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+        coordinator.didFail(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation),
+            message: "connection refused"
+        )
+
+        #expect(await coordinator.wait(for: ticket) == .failed("connection refused"))
+    }
+
+    @Test("A load that returns no navigation terminates as not started")
+    func missingNavigationIsNotStarted() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+
+        coordinator.didStart(ticket, navigationID: nil)
+
+        #expect(await coordinator.wait(for: ticket) == .notStarted)
+    }
+
+    @Test("A newer transaction supersedes the previous transaction")
+    func newerTransactionSupersedesPreviousTransaction() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        coordinator.bind(to: instanceID)
+        let firstTicket = coordinator.begin(instanceID: instanceID)
+
+        _ = coordinator.begin(instanceID: instanceID)
+
+        #expect(await coordinator.wait(for: firstTicket) == .superseded)
+    }
+
+    @Test("Binding a replacement instance supersedes the old transaction")
+    func replacementSupersedesOldTransaction() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let firstInstanceID = UUID()
+        coordinator.bind(to: firstInstanceID)
+        let ticket = coordinator.begin(instanceID: firstInstanceID)
+
+        coordinator.bind(to: UUID())
+
+        #expect(await coordinator.wait(for: ticket) == .superseded)
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -76,6 +76,20 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .failed("connection refused"))
     }
 
+    @Test("A deferred load can bind when its real navigation starts")
+    func deferredLoadBindsOnStart() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID)
+
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+        coordinator.didCommit(instanceID: instanceID, navigationID: ObjectIdentifier(navigation))
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
     @Test("A load that returns no navigation terminates as not started")
     func missingNavigationIsNotStarted() async {
         let coordinator = BrowserAutomationNavigationCoordinator()

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -218,6 +218,61 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .committed)
     }
 
+    @Test("WebKit-canonical same-document URLs complete the transaction")
+    func canonicalSameDocumentURLsComplete() async {
+        let equivalents = [
+            ("https://example.com#verified", "https://example.com/#verified"),
+            (
+                "HTTPS://EXAMPLE.COM:443/%7euser?q=%7e#part%2fvalue",
+                "https://example.com/~user?q=~#part%2Fvalue"
+            ),
+            ("http://EXAMPLE.COM:80#verified", "http://example.com/#verified"),
+        ]
+
+        for (target, observed) in equivalents {
+            let coordinator = BrowserAutomationNavigationCoordinator()
+            let instanceID = UUID()
+            let navigation = NSObject()
+            let targetURL = URL(string: target)!
+            coordinator.bind(to: instanceID)
+            let ticket = coordinator.begin(
+                instanceID: instanceID,
+                targetURL: targetURL,
+                allowsSameDocumentCompletion: true
+            )
+            coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+            coordinator.didFinishSameDocumentNavigation(
+                instanceID: instanceID,
+                url: URL(string: observed)
+            )
+
+            #expect(await coordinator.wait(for: ticket) == .committed)
+        }
+    }
+
+    @Test("Reserved escapes are not collapsed when matching same-document URLs")
+    func reservedEscapeRemainsDistinct() async {
+        let coordinator = BrowserAutomationNavigationCoordinator(sleep: { _ in })
+        let instanceID = UUID()
+        let navigation = NSObject()
+        let targetURL = URL(string: "https://example.com/a%2Fb#verified")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(
+            instanceID: instanceID,
+            targetURL: targetURL,
+            allowsSameDocumentCompletion: true
+        )
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        coordinator.didFinishSameDocumentNavigation(
+            instanceID: instanceID,
+            url: URL(string: "https://example.com/a/b#verified")
+        )
+
+        #expect(await coordinator.wait(for: ticket) == .timedOut)
+    }
+
     @Test("An error document cannot satisfy a navigation with a fragment event")
     func errorDocumentSameDocumentEventIsIgnored() async {
         let coordinator = BrowserAutomationNavigationCoordinator(sleep: { _ in })

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -195,7 +195,11 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let originalURL = URL(string: "https://example.com/page")!
         let fallbackURL = URL(string: "https://example.com/page#fallback")!
         coordinator.bind(to: instanceID)
-        let ticket = coordinator.begin(instanceID: instanceID, targetURL: originalURL)
+        let ticket = coordinator.begin(
+            instanceID: instanceID,
+            targetURL: originalURL,
+            allowsSameDocumentCompletion: true
+        )
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(originalNavigation))
 
         #expect(coordinator.prepareForNavigationReplacement(
@@ -207,7 +211,7 @@ struct BrowserAutomationNavigationCoordinatorTests {
             navigationID: ObjectIdentifier(replacementNavigation),
             targetURL: fallbackURL
         )
-        coordinator.didReachSameDocumentURL(instanceID: instanceID, url: fallbackURL)
+        coordinator.didFinishSameDocumentNavigation(instanceID: instanceID, url: fallbackURL)
 
         #expect(await coordinator.wait(for: ticket) == .committed)
     }
@@ -258,9 +262,28 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: secondTicket) == .committed)
     }
 
-    @Test("An authoritative same-document URL change completes the transaction")
-    func sameDocumentURLChangeCompletes() async {
+    @Test("An authoritative same-document navigation event completes the transaction")
+    func sameDocumentNavigationEventCompletes() async {
         let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        let targetURL = URL(string: "https://example.com/page#section")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(
+            instanceID: instanceID,
+            targetURL: targetURL,
+            allowsSameDocumentCompletion: true
+        )
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        coordinator.didFinishSameDocumentNavigation(instanceID: instanceID, url: targetURL)
+
+        #expect(await coordinator.wait(for: ticket) == .committed)
+    }
+
+    @Test("An error document cannot satisfy a navigation with a fragment event")
+    func errorDocumentSameDocumentEventIsIgnored() async {
+        let coordinator = BrowserAutomationNavigationCoordinator(sleep: { _ in })
         let instanceID = UUID()
         let navigation = NSObject()
         let targetURL = URL(string: "https://example.com/page#section")!
@@ -268,9 +291,23 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
 
-        coordinator.didReachSameDocumentURL(instanceID: instanceID, url: targetURL)
+        coordinator.didFinishSameDocumentNavigation(instanceID: instanceID, url: targetURL)
 
-        #expect(await coordinator.wait(for: ticket) == .committed)
+        #expect(await coordinator.wait(for: ticket) == .timedOut)
+    }
+
+    @Test("Associating a matching load is not itself a navigation completion")
+    func navigationAssociationDoesNotCompleteTransaction() async {
+        let coordinator = BrowserAutomationNavigationCoordinator(sleep: { _ in })
+        let instanceID = UUID()
+        let navigation = NSObject()
+        let targetURL = URL(string: "https://example.com/page")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
+
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        #expect(await coordinator.wait(for: ticket) == .timedOut)
     }
 
     @Test("A main-frame download completes the transaction without a document commit")

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -151,7 +151,7 @@ struct BrowserAutomationNavigationCoordinatorTests {
             instanceID: instanceID,
             navigationID: ObjectIdentifier(originalNavigation)
         )
-        coordinator.didStart(
+        coordinator.didAssociate(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(replacementNavigation),
             targetURL: fallbackURL
@@ -180,7 +180,7 @@ struct BrowserAutomationNavigationCoordinatorTests {
             instanceID: instanceID,
             targetURL: fallbackURL
         ))
-        coordinator.didStart(
+        coordinator.didAssociate(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(replacementNavigation),
             targetURL: fallbackURL
@@ -232,7 +232,10 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
 
-        coordinator.didBecomeDownload(instanceID: instanceID, url: targetURL)
+        coordinator.didBecomeDownload(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation)
+        )
 
         #expect(await coordinator.wait(for: ticket) == .downloaded)
     }
@@ -249,7 +252,7 @@ struct BrowserAutomationNavigationCoordinatorTests {
 
         coordinator.didBecomeDownload(
             instanceID: instanceID,
-            url: URL(string: "https://example.com/unrelated.zip")!
+            navigationID: ObjectIdentifier(NSObject())
         )
 
         #expect(await coordinator.wait(for: ticket) == .timedOut)

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -155,6 +155,21 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .committed)
     }
 
+    @Test("A main-frame download completes the transaction without a document commit")
+    func mainFrameDownloadCompletes() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        let targetURL = URL(string: "https://example.com/archive.zip")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        coordinator.didBecomeDownload(instanceID: instanceID, url: targetURL)
+
+        #expect(await coordinator.wait(for: ticket) == .downloaded)
+    }
+
     @Test("A URL-less reload can complete without starting WebKit navigation")
     func reloadWithoutNavigationCompletes() async {
         let coordinator = BrowserAutomationNavigationCoordinator()

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -153,69 +153,6 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .committed)
     }
 
-    @Test("A policy replacement hands the transaction to the new navigation")
-    func policyReplacementHandsOffNavigationIdentity() async {
-        let coordinator = BrowserAutomationNavigationCoordinator()
-        let instanceID = UUID()
-        let originalNavigation = NSObject()
-        let replacementNavigation = NSObject()
-        let originalURL = URL(string: "https://example.com/launch")!
-        let fallbackURL = URL(string: "https://example.com/fallback")!
-        coordinator.bind(to: instanceID)
-        let ticket = coordinator.begin(instanceID: instanceID, targetURL: originalURL)
-        coordinator.didStart(ticket, navigationID: ObjectIdentifier(originalNavigation))
-
-        #expect(coordinator.prepareForNavigationReplacement(
-            instanceID: instanceID,
-            targetURL: fallbackURL
-        ) == ticket)
-        coordinator.didCancel(
-            instanceID: instanceID,
-            navigationID: ObjectIdentifier(originalNavigation)
-        )
-        coordinator.didAssociate(
-            instanceID: instanceID,
-            navigationID: ObjectIdentifier(replacementNavigation),
-            targetURL: fallbackURL
-        )
-        coordinator.didCommit(
-            instanceID: instanceID,
-            navigationID: ObjectIdentifier(replacementNavigation)
-        )
-
-        #expect(await coordinator.wait(for: ticket) == .committed)
-    }
-
-    @Test("A same-document policy replacement keeps its navigation identity")
-    func sameDocumentPolicyReplacementCompletes() async {
-        let coordinator = BrowserAutomationNavigationCoordinator()
-        let instanceID = UUID()
-        let originalNavigation = NSObject()
-        let replacementNavigation = NSObject()
-        let originalURL = URL(string: "https://example.com/page")!
-        let fallbackURL = URL(string: "https://example.com/page#fallback")!
-        coordinator.bind(to: instanceID)
-        let ticket = coordinator.begin(
-            instanceID: instanceID,
-            targetURL: originalURL,
-            allowsSameDocumentCompletion: true
-        )
-        coordinator.didStart(ticket, navigationID: ObjectIdentifier(originalNavigation))
-
-        #expect(coordinator.prepareForNavigationReplacement(
-            instanceID: instanceID,
-            targetURL: fallbackURL
-        ) == ticket)
-        coordinator.didAssociate(
-            instanceID: instanceID,
-            navigationID: ObjectIdentifier(replacementNavigation),
-            targetURL: fallbackURL
-        )
-        coordinator.didFinishSameDocumentNavigation(instanceID: instanceID, url: fallbackURL)
-
-        #expect(await coordinator.wait(for: ticket) == .committed)
-    }
-
     @Test("An unrelated deferred navigation supersedes the transaction")
     func unrelatedDeferredNavigationSupersedes() async {
         let coordinator = BrowserAutomationNavigationCoordinator()
@@ -233,33 +170,33 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: ticket) == .superseded)
     }
 
-    @Test("A stale deferred cancellation cannot terminate a newer transaction")
-    func staleDeferredCancellationIsIgnored() async {
+    @Test("An uncorrelated policy replacement cannot seize the active transaction")
+    func policyReplacementCannotSeizeTransaction() async {
         let coordinator = BrowserAutomationNavigationCoordinator()
         let instanceID = UUID()
-        let firstURL = URL(string: "https://example.com/first")!
-        let secondURL = URL(string: "https://example.com/second")!
-        let secondNavigation = NSObject()
+        let originalNavigation = NSObject()
+        let replacementNavigation = NSObject()
+        let originalURL = URL(string: "https://example.com/launch")!
+        let fallbackURL = URL(string: "https://example.com/fallback")!
         coordinator.bind(to: instanceID)
-        let firstTicket = coordinator.begin(instanceID: instanceID, targetURL: firstURL)
-        let deferredTicket = coordinator.prepareForNavigationReplacement(
-            instanceID: instanceID,
-            targetURL: firstURL
-        )
-        let secondTicket = coordinator.begin(instanceID: instanceID, targetURL: secondURL)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: originalURL)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(originalNavigation))
 
-        if let deferredTicket {
-            coordinator.didNotStart(deferredTicket)
-        }
-        coordinator.didStart(secondTicket, navigationID: ObjectIdentifier(secondNavigation))
+        coordinator.didStart(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(replacementNavigation),
+            targetURL: fallbackURL
+        )
         coordinator.didCommit(
             instanceID: instanceID,
-            navigationID: ObjectIdentifier(secondNavigation)
+            navigationID: ObjectIdentifier(replacementNavigation)
+        )
+        coordinator.didCancel(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(originalNavigation)
         )
 
-        #expect(deferredTicket == firstTicket)
-        #expect(await coordinator.wait(for: firstTicket) == .superseded)
-        #expect(await coordinator.wait(for: secondTicket) == .committed)
+        #expect(await coordinator.wait(for: ticket) == .cancelled)
     }
 
     @Test("An authoritative same-document navigation event completes the transaction")
@@ -320,17 +257,21 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
 
-        coordinator.didBecomeDownload(
+        coordinator.didChooseDownloadPolicy(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(navigation)
         )
+        #expect(coordinator.didInterruptByPolicyChange(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation)
+        ))
 
         #expect(await coordinator.wait(for: ticket) == .downloaded)
     }
 
-    @Test("An unrelated download cannot satisfy the active transaction")
-    func unrelatedDownloadIsIgnored() async {
-        let coordinator = BrowserAutomationNavigationCoordinator(sleep: { _ in })
+    @Test("An unrelated download policy cannot authorize the active transaction")
+    func unrelatedDownloadPolicyIsIgnored() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
         let instanceID = UUID()
         let navigation = NSObject()
         let targetURL = URL(string: "https://example.com/page")!
@@ -338,12 +279,34 @@ struct BrowserAutomationNavigationCoordinatorTests {
         let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
         coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
 
-        coordinator.didBecomeDownload(
+        coordinator.didChooseDownloadPolicy(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(NSObject())
         )
+        #expect(!coordinator.didInterruptByPolicyChange(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation)
+        ))
 
-        #expect(await coordinator.wait(for: ticket) == .timedOut)
+        #expect(await coordinator.wait(for: ticket) == .cancelled)
+    }
+
+    @Test("A matching URL without exact download policy identity is a cancellation")
+    func urlMatchCannotAuthorizeDownload() async {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        let navigation = NSObject()
+        let targetURL = URL(string: "https://example.com/archive.zip")!
+        coordinator.bind(to: instanceID)
+        let ticket = coordinator.begin(instanceID: instanceID, targetURL: targetURL)
+        coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+
+        #expect(!coordinator.didInterruptByPolicyChange(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation)
+        ))
+
+        #expect(await coordinator.wait(for: ticket) == .cancelled)
     }
 
     @Test("A document-less new-tab reload can complete without WebKit navigation")

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Control/BrowserAutomationNavigationCoordinatorTests.swift
@@ -117,6 +117,28 @@ struct BrowserAutomationNavigationCoordinatorTests {
         #expect(await coordinator.wait(for: firstTicket) == .committed)
     }
 
+    @Test("An abandoned terminal outcome is released with its ticket")
+    func abandonedTerminalOutcomeIsReleased() {
+        let coordinator = BrowserAutomationNavigationCoordinator()
+        let instanceID = UUID()
+        coordinator.bind(to: instanceID)
+        weak var transaction: BrowserAutomationNavigationTransaction?
+
+        do {
+            let navigation = NSObject()
+            let ticket = coordinator.begin(instanceID: instanceID)
+            transaction = ticket.transaction
+            coordinator.didStart(ticket, navigationID: ObjectIdentifier(navigation))
+            coordinator.didFail(
+                instanceID: instanceID,
+                navigationID: ObjectIdentifier(navigation),
+                message: "connection refused"
+            )
+        }
+
+        #expect(transaction == nil)
+    }
+
     @Test("A deferred load can bind when its real navigation starts")
     func deferredLoadBindsOnStart() async {
         let coordinator = BrowserAutomationNavigationCoordinator()

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -11,8 +11,9 @@ import WebKit
     var didFinish: ((WKWebView) -> Void)?
     var didFailNavigation: ((WKWebView, String, String, WKNavigation?) -> Void)?
     var didCancelProvisionalNavigation: ((WKWebView, WKNavigation?) -> Void)?
+    var didConvertProvisionalNavigationToDownload: ((WKWebView, WKNavigation?) -> Void)?
     var didCancelNavigationPolicy: ((WKWebView, PolicyCancellationKind) -> Void)?
-    var didBecomeDownload: ((WKWebView, Bool, URL?, UUID?) -> Void)?
+    var didBecomeDownload: ((WKWebView, Bool, UUID?) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
     var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
@@ -134,7 +135,7 @@ import WebKit
         // navigation response is converted into a download via .download policy.
         // This is expected and should not show an error page.
         if nsError.domain == "WebKitErrorDomain", nsError.code == 102 {
-            didCancelProvisionalNavigation?(webView, navigation)
+            didConvertProvisionalNavigationToDownload?(webView, navigation)
             return
         }
 
@@ -626,7 +627,7 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationAction")
         #endif
         NSLog("BrowserPanel download didBecome from navigationAction")
-        didBecomeDownload?(webView, isMainFrame, navigationAction.request.url, restoreAttemptID)
+        didBecomeDownload?(webView, isMainFrame, restoreAttemptID)
         if isMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }
@@ -637,12 +638,7 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationResponse")
         #endif
         NSLog("BrowserPanel download didBecome from navigationResponse")
-        didBecomeDownload?(
-            webView,
-            navigationResponse.isForMainFrame,
-            navigationResponse.response.url,
-            restoreAttemptID
-        )
+        didBecomeDownload?(webView, navigationResponse.isForMainFrame, restoreAttemptID)
         if navigationResponse.isForMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -12,7 +12,7 @@ import WebKit
     var didFailNavigation: ((WKWebView, String, String, WKNavigation?) -> Void)?
     var didCancelProvisionalNavigation: ((WKWebView, WKNavigation?) -> Void)?
     var didCancelNavigationPolicy: ((WKWebView, PolicyCancellationKind) -> Void)?
-    var didBecomeDownload: ((WKWebView, Bool, UUID?) -> Void)?
+    var didBecomeDownload: ((WKWebView, Bool, URL?, UUID?) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
     var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
@@ -626,7 +626,7 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationAction")
         #endif
         NSLog("BrowserPanel download didBecome from navigationAction")
-        didBecomeDownload?(webView, isMainFrame, restoreAttemptID)
+        didBecomeDownload?(webView, isMainFrame, navigationAction.request.url, restoreAttemptID)
         if isMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }
@@ -637,7 +637,12 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationResponse")
         #endif
         NSLog("BrowserPanel download didBecome from navigationResponse")
-        didBecomeDownload?(webView, navigationResponse.isForMainFrame, restoreAttemptID)
+        didBecomeDownload?(
+            webView,
+            navigationResponse.isForMainFrame,
+            navigationResponse.response.url,
+            restoreAttemptID
+        )
         if navigationResponse.isForMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -213,6 +213,11 @@ import WebKit
         return .urlOnly
     }
 
+    func activeErrorPageRetryForAutomation() -> BrowserErrorPageRetry? {
+        guard let failedURL = activeErrorPageDisplayURL?.absoluteString else { return nil }
+        return retryForFailedNavigation(failedURL: failedURL)
+    }
+
     private func loadErrorPage(in webView: WKWebView, failedURL: String, retry: BrowserErrorPageRetry, error: NSError) {
         activeSSLTrustBypassReplayRequest = nil
         activeSSLTrustBypassErrorPageRetryRequest = nil

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -21,6 +21,7 @@ import WebKit
     var shouldBlockInsecureHTTPSubframeDownload: ((URL) -> Bool)?
     var handleBlockedInsecureHTTPNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
     var handleDroppedFileNavigation: (([URL]) -> Bool)?
+    var prepareForPolicyNavigationReplacement: ((WKWebView, URL) -> Void)?
     var currentRestoreAttemptID: (() -> UUID?)?
     var terminalPolicyCancellationReporter: ((WKNavigationAction, WKWebView) -> () -> Void)?
     var didRenderPDFDocument: ((URL, Bool) -> Void)?
@@ -338,6 +339,9 @@ import WebKit
            browserShouldRouteExternalNavigation(url) {
             clearAttemptedRequest(discardPendingBypasses: true)
             let reportTerminalCancellation = terminalPolicyCancellationReporter?(navigationAction, webView) ?? {}
+            if case .browserFallback(let fallbackURL) = browserExternalNavigationAction(for: url) {
+                prepareForPolicyNavigationReplacement?(webView, fallbackURL)
+            }
             browserHandleExternalNavigation(
                 url,
                 source: "navDelegate",

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -11,7 +11,8 @@ import WebKit
     var didFinish: ((WKWebView) -> Void)?
     var didFailNavigation: ((WKWebView, String, String, WKNavigation?) -> Void)?
     var didCancelProvisionalNavigation: ((WKWebView, WKNavigation?) -> Void)?
-    var didConvertProvisionalNavigationToDownload: ((WKWebView, WKNavigation?) -> Void)?
+    var didChooseMainFrameDownloadPolicy: ((WKWebView, WKNavigation?) -> Void)?
+    var didInterruptProvisionalNavigationByPolicy: ((WKWebView, WKNavigation?) -> Bool)?
     var didCancelNavigationPolicy: ((WKWebView, PolicyCancellationKind) -> Void)?
     var didBecomeDownload: ((WKWebView, Bool, UUID?) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
@@ -22,7 +23,6 @@ import WebKit
     var shouldBlockInsecureHTTPSubframeDownload: ((URL) -> Bool)?
     var handleBlockedInsecureHTTPNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
     var handleDroppedFileNavigation: (([URL]) -> Bool)?
-    var prepareForPolicyNavigationReplacement: ((WKWebView, URL) -> ((WKNavigation?) -> Void)?)?
     var currentRestoreAttemptID: (() -> UUID?)?
     var terminalPolicyCancellationReporter: ((WKNavigationAction, WKWebView) -> () -> Void)?
     var didRenderPDFDocument: ((URL, Bool) -> Void)?
@@ -42,7 +42,8 @@ import WebKit
     private var activeSSLTrustBypassReplayRequest: URLRequest?
     private var activeSSLTrustBypassErrorPageRetryRequest: URLRequest?
     private var pendingMainFrameDownloadRestoreAttemptID: UUID?
-    private var pendingMainFrameDownloadPolicyURLString: String?
+    // WKNavigation is WebKit's only public identity linking a load to its lifecycle callbacks.
+    private var activeMainFrameNavigation: WKNavigation?
 
     func cancelPendingAuthenticationPrompts(allowFuturePrompts: Bool = false) {
         basicAuthPromptCoordinator.cancelAll(allowFuturePrompts: allowFuturePrompts)
@@ -93,6 +94,7 @@ import WebKit
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        activeMainFrameNavigation = navigation
         lastAttemptedURL = lastAttemptedURL ?? webView.url ?? lastAttemptedRequest?.url
         shouldPrintAfterCurrentNavigationFinishes = false
         didClearPDFDocument?()
@@ -104,10 +106,12 @@ import WebKit
             clearAttemptedRequest(discardPendingBypasses: true)
         }
         didCommit?(webView, navigation)
+        clearActiveMainFrameNavigation(ifMatching: navigation)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         didFinish?(webView)
+        clearActiveMainFrameNavigation(ifMatching: navigation)
         if shouldPrintAfterCurrentNavigationFinishes {
             shouldPrintAfterCurrentNavigationFinishes = false
             webView.cmuxRunPrintOperation()
@@ -120,6 +124,7 @@ import WebKit
         // stale favicon/title state from the prior page gets cleared.
         let failedURL = webView.url?.absoluteString ?? ""
         didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
+        clearActiveMainFrameNavigation(ifMatching: navigation)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
@@ -129,23 +134,18 @@ import WebKit
         // Cancelled navigations (e.g. rapid typing) are not real errors.
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
             didCancelProvisionalNavigation?(webView, navigation)
+            clearActiveMainFrameNavigation(ifMatching: navigation)
             return
         }
 
         // "Frame load interrupted" (WebKitErrorDomain code 102) can result from
         // several policy transfers. Only an explicit .download decision is success.
         if nsError.domain == "WebKitErrorDomain", nsError.code == 102 {
-            let interruptedURLString = nsError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String
-                ?? lastAttemptedURL?.absoluteString
-                ?? webView.url?.absoluteString
-            let isPendingDownload = pendingMainFrameDownloadPolicyURLString != nil &&
-                pendingMainFrameDownloadPolicyURLString == interruptedURLString
-            pendingMainFrameDownloadPolicyURLString = nil
-            if isPendingDownload {
-                didConvertProvisionalNavigationToDownload?(webView, navigation)
-            } else {
+            let isDownload = didInterruptProvisionalNavigationByPolicy?(webView, navigation) == true
+            if !isDownload {
                 didCancelProvisionalNavigation?(webView, navigation)
             }
+            clearActiveMainFrameNavigation(ifMatching: navigation)
             return
         }
 
@@ -153,6 +153,7 @@ import WebKit
             ?? lastAttemptedURL?.absoluteString
             ?? ""
         didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
+        clearActiveMainFrameNavigation(ifMatching: navigation)
         loadErrorPage(
             in: webView,
             failedURL: failedURL,
@@ -290,10 +291,6 @@ import WebKit
         )
         let hasUserActivation = browserNavigationHasSimpleUserActivation()
         subframeDownloadIntents.updateIfNeeded(navigationAction, hasUserActivation: hasUserActivation)
-        let canOwnMainFrameDownloadPolicy = navigationAction.targetFrame?.isMainFrame != false
-        if canOwnMainFrameDownloadPolicy {
-            pendingMainFrameDownloadPolicyURLString = nil
-        }
         if navigationAction.targetFrame?.isMainFrame == true {
             pendingMainFrameDownloadRestoreAttemptID = currentRestoreAttemptID?()
         }
@@ -354,18 +351,14 @@ import WebKit
            browserShouldRouteExternalNavigation(url) {
             clearAttemptedRequest(discardPendingBypasses: true)
             let reportTerminalCancellation = terminalPolicyCancellationReporter?(navigationAction, webView) ?? {}
-            let replacementNavigationStarted: ((WKNavigation?) -> Void)?
-            if case .browserFallback(let fallbackURL) = browserExternalNavigationAction(for: url) {
-                replacementNavigationStarted = prepareForPolicyNavigationReplacement?(webView, fallbackURL)
-            } else {
-                replacementNavigationStarted = nil
-            }
+            // WKNavigationAction has no public WKNavigation identity. Keep the replacement
+            // unbound so the exact original policy cancellation terminates automation.
             browserHandleExternalNavigation(
                 url,
                 source: "navDelegate",
                 webView: webView,
                 loadFallbackRequest: { [requestNavigation] request in
-                    requestNavigation?(request, .currentTab, replacementNavigationStarted)
+                    requestNavigation?(request, .currentTab, nil)
                 },
                 presentAlert: presentAlert,
                 onTerminalExternalNavigation: reportTerminalCancellation
@@ -375,6 +368,8 @@ import WebKit
         }
 
         if navigationAction.shouldPerformDownload {
+            // Action-policy downloads expose no WKNavigation identity. Only a response-policy
+            // conversion can authorize automation success for an exact provisional navigation.
             if navigationAction.targetFrame?.isMainFrame == false {
                 guard let url = navigationAction.request.url else {
                     decisionHandler(.cancel)
@@ -389,9 +384,6 @@ import WebKit
                     decisionHandler(.cancel)
                     return
                 }
-            }
-            if canOwnMainFrameDownloadPolicy {
-                pendingMainFrameDownloadPolicyURLString = navigationAction.request.url?.absoluteString
             }
             clearAttemptedRequest(discardPendingBypasses: true)
             decisionHandler(.download)
@@ -601,7 +593,9 @@ import WebKit
             cmuxDebugLog("download.policy=download reason=\(reason) mime=\(mime) mainFrame=\(navigationResponse.isForMainFrame ? 1 : 0)")
             #endif
             if navigationResponse.isForMainFrame {
-                pendingMainFrameDownloadPolicyURLString = navigationResponse.response.url?.absoluteString
+                // A main-frame response follows didStartProvisionalNavigation, so this is the
+                // exact WKNavigation whose response WebKit is converting into a download.
+                didChooseMainFrameDownloadPolicy?(webView, activeMainFrameNavigation)
             }
             decisionHandler(.download)
             return
@@ -641,6 +635,11 @@ import WebKit
         mimeType?.split(separator: ";", maxSplits: 1).first?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .caseInsensitiveCompare("application/pdf") == .orderedSame
+    }
+
+    private func clearActiveMainFrameNavigation(ifMatching navigation: WKNavigation?) {
+        guard activeMainFrameNavigation === navigation else { return }
+        activeMainFrameNavigation = nil
     }
 
     func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -9,7 +9,7 @@ import WebKit
     var didStartProvisionalNavigation: ((WKWebView, WKNavigation?) -> Void)?
     var didCommit: ((WKWebView, WKNavigation?) -> Void)?
     var didFinish: ((WKWebView) -> Void)?
-    var didFailNavigation: ((WKWebView, String, WKNavigation?) -> Void)?
+    var didFailNavigation: ((WKWebView, String, String, WKNavigation?) -> Void)?
     var didCancelProvisionalNavigation: ((WKWebView, WKNavigation?) -> Void)?
     var didCancelNavigationPolicy: ((WKWebView, PolicyCancellationKind) -> Void)?
     var didBecomeDownload: ((WKWebView, Bool, UUID?) -> Void)?
@@ -116,7 +116,7 @@ import WebKit
         // Treat committed-navigation failures the same as provisional ones so
         // stale favicon/title state from the prior page gets cleared.
         let failedURL = webView.url?.absoluteString ?? ""
-        didFailNavigation?(webView, failedURL, navigation)
+        didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
@@ -140,7 +140,7 @@ import WebKit
         let failedURL = nsError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String
             ?? lastAttemptedURL?.absoluteString
             ?? ""
-        didFailNavigation?(webView, failedURL, navigation)
+        didFailNavigation?(webView, failedURL, error.localizedDescription, navigation)
         loadErrorPage(
             in: webView,
             failedURL: failedURL,

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -16,13 +16,13 @@ import WebKit
     var didBecomeDownload: ((WKWebView, Bool, UUID?) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
-    var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
+    var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent, ((WKNavigation?) -> Void)?) -> Void)?
     var presentAlert: BrowserAlertPresenter = browserPresentAlert
     var shouldBlockInsecureHTTPNavigation: ((URL) -> Bool)?
     var shouldBlockInsecureHTTPSubframeDownload: ((URL) -> Bool)?
     var handleBlockedInsecureHTTPNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
     var handleDroppedFileNavigation: (([URL]) -> Bool)?
-    var prepareForPolicyNavigationReplacement: ((WKWebView, URL) -> Void)?
+    var prepareForPolicyNavigationReplacement: ((WKWebView, URL) -> ((WKNavigation?) -> Void)?)?
     var currentRestoreAttemptID: (() -> UUID?)?
     var terminalPolicyCancellationReporter: ((WKNavigationAction, WKWebView) -> () -> Void)?
     var didRenderPDFDocument: ((URL, Bool) -> Void)?
@@ -274,7 +274,7 @@ import WebKit
 
         let openRequestInNewTab: (URLRequest) -> Void = { [requestNavigation, openInNewTab] request in
             if let requestNavigation {
-                requestNavigation(request, .newTab)
+                requestNavigation(request, .newTab, nil)
                 return
             }
             if let url = request.url {
@@ -354,15 +354,18 @@ import WebKit
            browserShouldRouteExternalNavigation(url) {
             clearAttemptedRequest(discardPendingBypasses: true)
             let reportTerminalCancellation = terminalPolicyCancellationReporter?(navigationAction, webView) ?? {}
+            let replacementNavigationStarted: ((WKNavigation?) -> Void)?
             if case .browserFallback(let fallbackURL) = browserExternalNavigationAction(for: url) {
-                prepareForPolicyNavigationReplacement?(webView, fallbackURL)
+                replacementNavigationStarted = prepareForPolicyNavigationReplacement?(webView, fallbackURL)
+            } else {
+                replacementNavigationStarted = nil
             }
             browserHandleExternalNavigation(
                 url,
                 source: "navDelegate",
                 webView: webView,
                 loadFallbackRequest: { [requestNavigation] request in
-                    requestNavigation?(request, .currentTab)
+                    requestNavigation?(request, .currentTab, replacementNavigationStarted)
                 },
                 presentAlert: presentAlert,
                 onTerminalExternalNavigation: reportTerminalCancellation

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -11,8 +11,9 @@ import WebKit
     var didFinish: ((WKWebView) -> Void)?
     var didFailNavigation: ((WKWebView, String, String, WKNavigation?) -> Void)?
     var didCancelProvisionalNavigation: ((WKWebView, WKNavigation?) -> Void)?
+    var didConvertProvisionalNavigationToDownload: ((WKWebView, WKNavigation?) -> Void)?
     var didCancelNavigationPolicy: ((WKWebView, PolicyCancellationKind) -> Void)?
-    var didBecomeDownload: ((WKWebView, Bool, URL?, UUID?) -> Void)?
+    var didBecomeDownload: ((WKWebView, Bool, UUID?) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
     var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
@@ -41,6 +42,7 @@ import WebKit
     private var activeSSLTrustBypassReplayRequest: URLRequest?
     private var activeSSLTrustBypassErrorPageRetryRequest: URLRequest?
     private var pendingMainFrameDownloadRestoreAttemptID: UUID?
+    private var pendingMainFrameDownloadPolicyURLString: String?
 
     func cancelPendingAuthenticationPrompts(allowFuturePrompts: Bool = false) {
         basicAuthPromptCoordinator.cancelAll(allowFuturePrompts: allowFuturePrompts)
@@ -130,11 +132,20 @@ import WebKit
             return
         }
 
-        // "Frame load interrupted" (WebKitErrorDomain code 102) means navigation
-        // policy transferred ownership, including downloads and external-app routes.
-        // The actual download callback reports downloads separately.
+        // "Frame load interrupted" (WebKitErrorDomain code 102) can result from
+        // several policy transfers. Only an explicit .download decision is success.
         if nsError.domain == "WebKitErrorDomain", nsError.code == 102 {
-            didCancelProvisionalNavigation?(webView, navigation)
+            let interruptedURLString = nsError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String
+                ?? lastAttemptedURL?.absoluteString
+                ?? webView.url?.absoluteString
+            let isPendingDownload = pendingMainFrameDownloadPolicyURLString != nil &&
+                pendingMainFrameDownloadPolicyURLString == interruptedURLString
+            pendingMainFrameDownloadPolicyURLString = nil
+            if isPendingDownload {
+                didConvertProvisionalNavigationToDownload?(webView, navigation)
+            } else {
+                didCancelProvisionalNavigation?(webView, navigation)
+            }
             return
         }
 
@@ -279,6 +290,10 @@ import WebKit
         )
         let hasUserActivation = browserNavigationHasSimpleUserActivation()
         subframeDownloadIntents.updateIfNeeded(navigationAction, hasUserActivation: hasUserActivation)
+        let canOwnMainFrameDownloadPolicy = navigationAction.targetFrame?.isMainFrame != false
+        if canOwnMainFrameDownloadPolicy {
+            pendingMainFrameDownloadPolicyURLString = nil
+        }
         if navigationAction.targetFrame?.isMainFrame == true {
             pendingMainFrameDownloadRestoreAttemptID = currentRestoreAttemptID?()
         }
@@ -371,6 +386,9 @@ import WebKit
                     decisionHandler(.cancel)
                     return
                 }
+            }
+            if canOwnMainFrameDownloadPolicy {
+                pendingMainFrameDownloadPolicyURLString = navigationAction.request.url?.absoluteString
             }
             clearAttemptedRequest(discardPendingBypasses: true)
             decisionHandler(.download)
@@ -579,6 +597,9 @@ import WebKit
             #if DEBUG
             cmuxDebugLog("download.policy=download reason=\(reason) mime=\(mime) mainFrame=\(navigationResponse.isForMainFrame ? 1 : 0)")
             #endif
+            if navigationResponse.isForMainFrame {
+                pendingMainFrameDownloadPolicyURLString = navigationResponse.response.url?.absoluteString
+            }
             decisionHandler(.download)
             return
         }
@@ -626,7 +647,7 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationAction")
         #endif
         NSLog("BrowserPanel download didBecome from navigationAction")
-        didBecomeDownload?(webView, isMainFrame, navigationAction.request.url, restoreAttemptID)
+        didBecomeDownload?(webView, isMainFrame, restoreAttemptID)
         if isMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }
@@ -637,12 +658,7 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationResponse")
         #endif
         NSLog("BrowserPanel download didBecome from navigationResponse")
-        didBecomeDownload?(
-            webView,
-            navigationResponse.isForMainFrame,
-            navigationResponse.response.url,
-            restoreAttemptID
-        )
+        didBecomeDownload?(webView, navigationResponse.isForMainFrame, restoreAttemptID)
         if navigationResponse.isForMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }

--- a/Sources/Panels/BrowserNavigationDelegate.swift
+++ b/Sources/Panels/BrowserNavigationDelegate.swift
@@ -11,9 +11,8 @@ import WebKit
     var didFinish: ((WKWebView) -> Void)?
     var didFailNavigation: ((WKWebView, String, String, WKNavigation?) -> Void)?
     var didCancelProvisionalNavigation: ((WKWebView, WKNavigation?) -> Void)?
-    var didConvertProvisionalNavigationToDownload: ((WKWebView, WKNavigation?) -> Void)?
     var didCancelNavigationPolicy: ((WKWebView, PolicyCancellationKind) -> Void)?
-    var didBecomeDownload: ((WKWebView, Bool, UUID?) -> Void)?
+    var didBecomeDownload: ((WKWebView, Bool, URL?, UUID?) -> Void)?
     var didTerminateWebContentProcess: ((WKWebView) -> Void)?
     var openInNewTab: ((URL) -> Void)?
     var requestNavigation: ((URLRequest, BrowserInsecureHTTPNavigationIntent) -> Void)?
@@ -131,11 +130,11 @@ import WebKit
             return
         }
 
-        // "Frame load interrupted" (WebKitErrorDomain code 102) fires when a
-        // navigation response is converted into a download via .download policy.
-        // This is expected and should not show an error page.
+        // "Frame load interrupted" (WebKitErrorDomain code 102) means navigation
+        // policy transferred ownership, including downloads and external-app routes.
+        // The actual download callback reports downloads separately.
         if nsError.domain == "WebKitErrorDomain", nsError.code == 102 {
-            didConvertProvisionalNavigationToDownload?(webView, navigation)
+            didCancelProvisionalNavigation?(webView, navigation)
             return
         }
 
@@ -627,7 +626,7 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationAction")
         #endif
         NSLog("BrowserPanel download didBecome from navigationAction")
-        didBecomeDownload?(webView, isMainFrame, restoreAttemptID)
+        didBecomeDownload?(webView, isMainFrame, navigationAction.request.url, restoreAttemptID)
         if isMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }
@@ -638,7 +637,12 @@ import WebKit
         cmuxDebugLog("download.didBecome source=navigationResponse")
         #endif
         NSLog("BrowserPanel download didBecome from navigationResponse")
-        didBecomeDownload?(webView, navigationResponse.isForMainFrame, restoreAttemptID)
+        didBecomeDownload?(
+            webView,
+            navigationResponse.isForMainFrame,
+            navigationResponse.response.url,
+            restoreAttemptID
+        )
         if navigationResponse.isForMainFrame { pendingMainFrameDownloadRestoreAttemptID = nil }
         download.delegate = downloadDelegate
     }

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -58,10 +58,15 @@ extension BrowserPanel {
         case nil:
             if let navigation = reload() {
                 navigationStarted(navigation)
-            } else if !webView.isLoading,
-                      !isMainFrameProvisionalNavigationActive,
-                      !hasPendingRemoteNavigation {
-                automationNavigationCoordinator.didCompleteWithoutNavigation(ticket)
+            } else {
+                automationNavigationCoordinator.didReturnNoNavigation(
+                    ticket,
+                    hasCurrentHistoryItem: webView.backForwardList.currentItem != nil,
+                    isShowingNewTabPage: isShowingNewTabPage,
+                    waitsForDeferredNavigation: webView.isLoading ||
+                        isMainFrameProvisionalNavigationActive ||
+                        hasPendingRemoteNavigation
+                )
             }
         }
         return (ticket, targetURL)

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -3,6 +3,57 @@ import CmuxBrowser
 import WebKit
 
 extension BrowserPanel {
+    func beginAutomationNavigation(
+        to targetURL: URL,
+        recordTypedNavigation: Bool
+    ) -> BrowserAutomationNavigationTicket {
+        let ticket = automationNavigationCoordinator.begin(instanceID: webViewInstanceID)
+        let navigation = navigate(to: targetURL, recordTypedNavigation: recordTypedNavigation)
+        automationNavigationCoordinator.didStart(
+            ticket,
+            navigationID: navigation.map { ObjectIdentifier($0) }
+        )
+        return ticket
+    }
+
+    func beginAutomationReloadFromCLI() -> (
+        ticket: BrowserAutomationNavigationTicket,
+        targetURL: URL
+    )? {
+        guard let targetURL = automationReloadTargetURL() else { return nil }
+        return (beginAutomationNavigation(to: targetURL, recordTypedNavigation: false), targetURL)
+    }
+
+    func finishAutomationNavigation(
+        _ ticket: BrowserAutomationNavigationTicket,
+        retrying targetURL: URL
+    ) async -> BrowserAutomationNavigationOutcome {
+        let firstOutcome = await automationNavigationCoordinator.wait(for: ticket)
+        guard firstOutcome == .timedOut else { return firstOutcome }
+        guard replaceWebViewAfterAutomationNavigationTimeout(
+            expectedInstanceID: ticket.instanceID
+        ) else {
+            return .superseded
+        }
+
+        let retryTicket = beginAutomationNavigation(to: targetURL, recordTypedNavigation: false)
+        return await automationNavigationCoordinator.wait(for: retryTicket)
+    }
+
+    @discardableResult
+    private func replaceWebViewAfterAutomationNavigationTimeout(
+        expectedInstanceID: UUID
+    ) -> Bool {
+        guard webViewInstanceID == expectedInstanceID, canRecoverFromAutomationTimeout else { return false }
+        replaceWebViewPreservingState(
+            from: webView,
+            websiteDataStore: websiteDataStore,
+            reason: "automation_navigation_unresponsive",
+            waitForManualRecovery: true
+        )
+        return true
+    }
+
     func registerBrowserAutomationInitScript(_ userScript: WKUserScript) -> Int {
         browserAutomationUserScripts.append(userScript)
         browserAutomationInitScriptCount += 1

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -50,7 +50,13 @@ extension BrowserPanel {
         case .disabled:
             navigationStarted(nil)
         case nil:
-            navigationStarted(reload())
+            if let navigation = reload() {
+                navigationStarted(navigation)
+            } else if !webView.isLoading,
+                      !isMainFrameProvisionalNavigationActive,
+                      !hasPendingRemoteNavigation {
+                automationNavigationCoordinator.didCompleteWithoutNavigation(ticket)
+            }
         }
         return (ticket, targetURL)
     }

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -3,6 +3,22 @@ import CmuxBrowser
 import WebKit
 
 extension BrowserPanel {
+    func recordAutomationReplacementNavigationStart(
+        _ navigation: WKNavigation?,
+        instanceID: UUID,
+        targetURL: URL?
+    ) {
+        guard let navigation else {
+            automationNavigationCoordinator.didNotStart(instanceID: instanceID)
+            return
+        }
+        automationNavigationCoordinator.didStart(
+            instanceID: instanceID,
+            navigationID: ObjectIdentifier(navigation),
+            targetURL: targetURL
+        )
+    }
+
     func beginAutomationNavigation(
         to targetURL: URL,
         recordTypedNavigation: Bool

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -33,16 +33,6 @@ extension BrowserPanel {
         )
     }
 
-    func recordAutomationReplacementNavigationStart(
-        _ navigation: WKNavigation?,
-        ticket: BrowserAutomationNavigationTicket
-    ) {
-        automationNavigationCoordinator.didStart(
-            ticket,
-            navigationID: navigation.map { ObjectIdentifier($0) }
-        )
-    }
-
     func beginAutomationNavigation(
         to targetURL: URL,
         recordTypedNavigation: Bool

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -7,7 +7,10 @@ extension BrowserPanel {
         to targetURL: URL,
         recordTypedNavigation: Bool
     ) -> BrowserAutomationNavigationTicket {
-        let ticket = automationNavigationCoordinator.begin(instanceID: webViewInstanceID)
+        let ticket = automationNavigationCoordinator.begin(
+            instanceID: webViewInstanceID,
+            targetURL: targetURL
+        )
         navigate(
             to: targetURL,
             recordTypedNavigation: recordTypedNavigation,
@@ -26,7 +29,10 @@ extension BrowserPanel {
         targetURL: URL
     )? {
         guard let targetURL = automationReloadTargetURL() else { return nil }
-        let ticket = automationNavigationCoordinator.begin(instanceID: webViewInstanceID)
+        let ticket = automationNavigationCoordinator.begin(
+            instanceID: webViewInstanceID,
+            targetURL: targetURL
+        )
         let navigationStarted: (WKNavigation?) -> Void = { [weak self] navigation in
             self?.automationNavigationCoordinator.didStart(
                 ticket,

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -12,7 +12,7 @@ extension BrowserPanel {
             automationNavigationCoordinator.didNotStart(instanceID: instanceID)
             return
         }
-        automationNavigationCoordinator.didStart(
+        automationNavigationCoordinator.didAssociate(
             instanceID: instanceID,
             navigationID: ObjectIdentifier(navigation),
             targetURL: targetURL

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -8,10 +8,15 @@ extension BrowserPanel {
         recordTypedNavigation: Bool
     ) -> BrowserAutomationNavigationTicket {
         let ticket = automationNavigationCoordinator.begin(instanceID: webViewInstanceID)
-        let navigation = navigate(to: targetURL, recordTypedNavigation: recordTypedNavigation)
-        automationNavigationCoordinator.didStart(
-            ticket,
-            navigationID: navigation.map { ObjectIdentifier($0) }
+        navigate(
+            to: targetURL,
+            recordTypedNavigation: recordTypedNavigation,
+            onNavigationStarted: { [weak self] navigation in
+                self?.automationNavigationCoordinator.didStart(
+                    ticket,
+                    navigationID: navigation.map { ObjectIdentifier($0) }
+                )
+            }
         )
         return ticket
     }
@@ -21,37 +26,39 @@ extension BrowserPanel {
         targetURL: URL
     )? {
         guard let targetURL = automationReloadTargetURL() else { return nil }
-        return (beginAutomationNavigation(to: targetURL, recordTypedNavigation: false), targetURL)
+        let ticket = automationNavigationCoordinator.begin(instanceID: webViewInstanceID)
+        let navigationStarted: (WKNavigation?) -> Void = { [weak self] navigation in
+            self?.automationNavigationCoordinator.didStart(
+                ticket,
+                navigationID: navigation.map { ObjectIdentifier($0) }
+            )
+        }
+
+        switch navigationDelegate?.activeErrorPageRetryForAutomation() {
+        case .request(let request):
+            navigateWithoutInsecureHTTPPrompt(
+                request: request,
+                recordTypedNavigation: false,
+                onNavigationStarted: navigationStarted
+            )
+        case .urlOnly:
+            navigate(
+                to: targetURL,
+                recordTypedNavigation: false,
+                onNavigationStarted: navigationStarted
+            )
+        case .disabled:
+            navigationStarted(nil)
+        case nil:
+            navigationStarted(reload())
+        }
+        return (ticket, targetURL)
     }
 
     func finishAutomationNavigation(
-        _ ticket: BrowserAutomationNavigationTicket,
-        retrying targetURL: URL
+        _ ticket: BrowserAutomationNavigationTicket
     ) async -> BrowserAutomationNavigationOutcome {
-        let firstOutcome = await automationNavigationCoordinator.wait(for: ticket)
-        guard firstOutcome == .timedOut else { return firstOutcome }
-        guard replaceWebViewAfterAutomationNavigationTimeout(
-            expectedInstanceID: ticket.instanceID
-        ) else {
-            return .superseded
-        }
-
-        let retryTicket = beginAutomationNavigation(to: targetURL, recordTypedNavigation: false)
-        return await automationNavigationCoordinator.wait(for: retryTicket)
-    }
-
-    @discardableResult
-    private func replaceWebViewAfterAutomationNavigationTimeout(
-        expectedInstanceID: UUID
-    ) -> Bool {
-        guard webViewInstanceID == expectedInstanceID, canRecoverFromAutomationTimeout else { return false }
-        replaceWebViewPreservingState(
-            from: webView,
-            websiteDataStore: websiteDataStore,
-            reason: "automation_navigation_unresponsive",
-            waitForManualRecovery: true
-        )
-        return true
+        await automationNavigationCoordinator.wait(for: ticket)
     }
 
     func registerBrowserAutomationInitScript(_ userScript: WKUserScript) -> Int {

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -3,6 +3,36 @@ import CmuxBrowser
 import WebKit
 
 extension BrowserPanel {
+    func setupSameDocumentNavigationMessageHandler(for webView: WKWebView) {
+        let observedWebViewInstanceID = webViewInstanceID
+        let handler = BrowserSameDocumentNavigationMessageHandler(
+            webView: webView,
+            onNavigation: { [weak self, weak webView] url in
+                guard let self, let webView,
+                      self.webView === webView,
+                      self.webViewInstanceID == observedWebViewInstanceID else {
+                    return
+                }
+                let displayURL = Self.remoteProxyDisplayURL(for: url) ?? url
+                self.automationNavigationCoordinator.didFinishSameDocumentNavigation(
+                    instanceID: observedWebViewInstanceID,
+                    url: displayURL
+                )
+            }
+        )
+        sameDocumentNavigationMessageHandler = handler
+        let userContentController = webView.configuration.userContentController
+        userContentController.removeScriptMessageHandler(
+            forName: BrowserSameDocumentNavigationMessageHandler.name,
+            contentWorld: BrowserSameDocumentNavigationMessageHandler.contentWorld
+        )
+        userContentController.add(
+            handler,
+            contentWorld: BrowserSameDocumentNavigationMessageHandler.contentWorld,
+            name: BrowserSameDocumentNavigationMessageHandler.name
+        )
+    }
+
     func recordAutomationReplacementNavigationStart(
         _ navigation: WKNavigation?,
         ticket: BrowserAutomationNavigationTicket
@@ -19,7 +49,8 @@ extension BrowserPanel {
     ) -> BrowserAutomationNavigationTicket {
         let ticket = automationNavigationCoordinator.begin(
             instanceID: webViewInstanceID,
-            targetURL: targetURL
+            targetURL: targetURL,
+            allowsSameDocumentCompletion: navigationDelegate?.activeErrorPageDisplayURL == nil
         )
         navigate(
             to: targetURL,

--- a/Sources/Panels/BrowserPanel+AutomationRecovery.swift
+++ b/Sources/Panels/BrowserPanel+AutomationRecovery.swift
@@ -5,17 +5,11 @@ import WebKit
 extension BrowserPanel {
     func recordAutomationReplacementNavigationStart(
         _ navigation: WKNavigation?,
-        instanceID: UUID,
-        targetURL: URL?
+        ticket: BrowserAutomationNavigationTicket
     ) {
-        guard let navigation else {
-            automationNavigationCoordinator.didNotStart(instanceID: instanceID)
-            return
-        }
-        automationNavigationCoordinator.didAssociate(
-            instanceID: instanceID,
-            navigationID: ObjectIdentifier(navigation),
-            targetURL: targetURL
+        automationNavigationCoordinator.didStart(
+            ticket,
+            navigationID: navigation.map { ObjectIdentifier($0) }
         )
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3771,6 +3771,10 @@ final class BrowserPanel: Panel, ObservableObject {
             MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
                 (webView as? CmuxWebView)?.diffViewerNavigationDidStart(navigation)
+                self.automationNavigationCoordinator.didStart(
+                    instanceID: boundWebViewInstanceID,
+                    navigationID: navigation.map { ObjectIdentifier($0) }
+                )
                 self.isMainFrameProvisionalNavigationActive = true
                 self.refreshBackgroundAppearance()
                 self.applyMuteState(to: webView, reason: "navigationStart")
@@ -4062,6 +4066,9 @@ final class BrowserPanel: Panel, ObservableObject {
         navDelegate.handleBlockedInsecureHTTPNavigation = { [weak self] request, intent in
             guard let self else { return }
             let restoreAttemptID = self.currentDiscardRestoreAttemptID
+            let automationInstanceID = self.webViewInstanceID
+            let replacesAutomationNavigation = self.automationNavigationCoordinator
+                .prepareForNavigationReplacement(instanceID: automationInstanceID)
             self.presentInsecureHTTPAlert(
                 for: request,
                 intent: intent,
@@ -4069,7 +4076,18 @@ final class BrowserPanel: Panel, ObservableObject {
                 onResolution: { [weak self] resolution in
                     guard resolution.isTerminalPolicyCancellation else { return }
                     self?.noteDiscardedWebViewRestoreNavigationTerminallyCancelled(restoreAttemptID: restoreAttemptID)
-                }
+                },
+                onNavigationStarted: replacesAutomationNavigation ? { [weak self] navigation in
+                    guard let self else { return }
+                    if let navigation {
+                        self.automationNavigationCoordinator.didStart(
+                            instanceID: automationInstanceID,
+                            navigationID: ObjectIdentifier(navigation)
+                        )
+                    } else {
+                        self.automationNavigationCoordinator.didNotStart(instanceID: automationInstanceID)
+                    }
+                } : nil
             )
         }
         navDelegate.currentRestoreAttemptID = { [weak self] in self?.currentDiscardRestoreAttemptID }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4071,8 +4071,12 @@ final class BrowserPanel: Panel, ObservableObject {
         navDelegate.openInNewTab = { [weak self] url in
             self?.openLinkInNewTab(url: url)
         }
-        navDelegate.requestNavigation = { [weak self] request, intent in
-            self?.requestNavigation(request, intent: intent)
+        navDelegate.requestNavigation = { [weak self] request, intent, onNavigationStarted in
+            self?.requestNavigation(
+                request,
+                intent: intent,
+                onNavigationStarted: onNavigationStarted
+            )
         }
         navDelegate.presentAlert = { [weak self] alert, webView, completion, cancel in
             guard let self else {
@@ -4087,11 +4091,19 @@ final class BrowserPanel: Panel, ObservableObject {
             guard let self else { return }
             let restoreAttemptID = self.currentDiscardRestoreAttemptID
             let automationInstanceID = self.webViewInstanceID
-            let replacesAutomationNavigation = self.automationNavigationCoordinator
+            let replacementTicket = self.automationNavigationCoordinator
                 .prepareForNavigationReplacement(
                     instanceID: automationInstanceID,
                     targetURL: request.url
                 )
+            let onNavigationStarted: ((WKNavigation?) -> Void)? = replacementTicket.map { ticket in
+                { [weak self] navigation in
+                    self?.recordAutomationReplacementNavigationStart(
+                        navigation,
+                        ticket: ticket
+                    )
+                }
+            }
             self.presentInsecureHTTPAlert(
                 for: request,
                 intent: intent,
@@ -4100,21 +4112,21 @@ final class BrowserPanel: Panel, ObservableObject {
                     guard resolution.isTerminalPolicyCancellation else { return }
                     self?.noteDiscardedWebViewRestoreNavigationTerminallyCancelled(restoreAttemptID: restoreAttemptID)
                 },
-                onNavigationStarted: replacesAutomationNavigation ? { [weak self] navigation in
-                    self?.recordAutomationReplacementNavigationStart(
-                        navigation,
-                        instanceID: automationInstanceID,
-                        targetURL: request.url
-                    )
-                } : nil
+                onNavigationStarted: onNavigationStarted
             )
         }
         navDelegate.prepareForPolicyNavigationReplacement = { [weak self] webView, targetURL in
-            guard let self, self.isCurrentWebView(webView) else { return }
-            self.automationNavigationCoordinator.prepareForNavigationReplacement(
+            guard let self, self.isCurrentWebView(webView) else { return nil }
+            guard let ticket = self.automationNavigationCoordinator.prepareForNavigationReplacement(
                 instanceID: self.webViewInstanceID,
                 targetURL: targetURL
-            )
+            ) else { return nil }
+            return { [weak self] navigation in
+                self?.recordAutomationReplacementNavigationStart(
+                    navigation,
+                    ticket: ticket
+                )
+            }
         }
         navDelegate.currentRestoreAttemptID = { [weak self] in self?.currentDiscardRestoreAttemptID }
         navDelegate.terminalPolicyCancellationReporter = { [weak self] navigationAction, webView in
@@ -6034,17 +6046,13 @@ final class BrowserPanel: Panel, ObservableObject {
         browserShouldConsumeOneTimeInsecureHTTPBypass(url, bypassHostOnce: &insecureHTTPBypassHostOnce)
     }
 
-    private func requestNavigation(_ request: URLRequest, intent: BrowserInsecureHTTPNavigationIntent) {
-        let automationInstanceID = webViewInstanceID
-        let navigationStarted: (WKNavigation?) -> Void = { [weak self] navigation in
-            self?.recordAutomationReplacementNavigationStart(
-                navigation,
-                instanceID: automationInstanceID,
-                targetURL: request.url
-            )
-        }
+    private func requestNavigation(
+        _ request: URLRequest,
+        intent: BrowserInsecureHTTPNavigationIntent,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
+    ) {
         guard let url = request.url else {
-            navigationStarted(nil)
+            onNavigationStarted?(nil)
             return
         }
         if shouldBlockInsecureHTTPNavigation(to: url) {
@@ -6052,7 +6060,7 @@ final class BrowserPanel: Panel, ObservableObject {
                 for: request,
                 intent: intent,
                 recordTypedNavigation: false,
-                onNavigationStarted: navigationStarted
+                onNavigationStarted: onNavigationStarted
             )
             return
         }
@@ -6061,10 +6069,10 @@ final class BrowserPanel: Panel, ObservableObject {
             navigateWithoutInsecureHTTPPrompt(
                 request: request,
                 recordTypedNavigation: false,
-                onNavigationStarted: navigationStarted
+                onNavigationStarted: onNavigationStarted
             )
         case .newTab:
-            navigationStarted(nil)
+            onNavigationStarted?(nil)
             openLinkInNewTab(request: request)
         }
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -4068,7 +4068,10 @@ final class BrowserPanel: Panel, ObservableObject {
             let restoreAttemptID = self.currentDiscardRestoreAttemptID
             let automationInstanceID = self.webViewInstanceID
             let replacesAutomationNavigation = self.automationNavigationCoordinator
-                .prepareForNavigationReplacement(instanceID: automationInstanceID)
+                .prepareForNavigationReplacement(
+                    instanceID: automationInstanceID,
+                    targetURL: request.url
+                )
             self.presentInsecureHTTPAlert(
                 for: request,
                 intent: intent,
@@ -4078,16 +4081,16 @@ final class BrowserPanel: Panel, ObservableObject {
                     self?.noteDiscardedWebViewRestoreNavigationTerminallyCancelled(restoreAttemptID: restoreAttemptID)
                 },
                 onNavigationStarted: replacesAutomationNavigation ? { [weak self] navigation in
-                    guard let self else { return }
-                    if let navigation {
-                        self.automationNavigationCoordinator.didStart(
-                            instanceID: automationInstanceID,
-                            navigationID: ObjectIdentifier(navigation)
-                        )
-                    } else {
-                        self.automationNavigationCoordinator.didNotStart(instanceID: automationInstanceID)
-                    }
+                    guard navigation == nil else { return }
+                    self?.automationNavigationCoordinator.didNotStart(instanceID: automationInstanceID)
                 } : nil
+            )
+        }
+        navDelegate.prepareForPolicyNavigationReplacement = { [weak self] webView, targetURL in
+            guard let self, self.isCurrentWebView(webView) else { return }
+            self.automationNavigationCoordinator.prepareForNavigationReplacement(
+                instanceID: self.webViewInstanceID,
+                targetURL: targetURL
             )
         }
         navDelegate.currentRestoreAttemptID = { [weak self] in self?.currentDiscardRestoreAttemptID }
@@ -4941,8 +4944,13 @@ final class BrowserPanel: Panel, ObservableObject {
             MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
                 guard !self.isMainFrameProvisionalNavigationActive else { return }
+                let displayURL = Self.remoteProxyDisplayURL(for: observedURL) ?? observedURL
+                self.automationNavigationCoordinator.didReachSameDocumentURL(
+                    instanceID: observedWebViewInstanceID,
+                    url: displayURL
+                )
                 self.designModeController.webViewURLDidChange(to: observedURL)
-                self.currentURL = Self.remoteProxyDisplayURL(for: observedURL)
+                self.currentURL = displayURL
                 self.refreshBackgroundAppearance()
                 GlobalSearchCoordinator.shared.captureBrowserPanel(self)
             }
@@ -6004,15 +6012,33 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func requestNavigation(_ request: URLRequest, intent: BrowserInsecureHTTPNavigationIntent) {
-        guard let url = request.url else { return }
+        let automationInstanceID = webViewInstanceID
+        let navigationStarted: (WKNavigation?) -> Void = { [weak self] navigation in
+            guard navigation == nil else { return }
+            self?.automationNavigationCoordinator.didNotStart(instanceID: automationInstanceID)
+        }
+        guard let url = request.url else {
+            navigationStarted(nil)
+            return
+        }
         if shouldBlockInsecureHTTPNavigation(to: url) {
-            presentInsecureHTTPAlert(for: request, intent: intent, recordTypedNavigation: false)
+            presentInsecureHTTPAlert(
+                for: request,
+                intent: intent,
+                recordTypedNavigation: false,
+                onNavigationStarted: navigationStarted
+            )
             return
         }
         switch intent {
         case .currentTab:
-            navigateWithoutInsecureHTTPPrompt(request: request, recordTypedNavigation: false)
+            navigateWithoutInsecureHTTPPrompt(
+                request: request,
+                recordTypedNavigation: false,
+                onNavigationStarted: navigationStarted
+            )
         case .newTab:
+            navigationStarted(nil)
             openLinkInNewTab(request: request)
         }
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3116,6 +3116,7 @@ final class BrowserPanel: Panel, ObservableObject {
         let request: URLRequest
         let recordTypedNavigation: Bool
         let preserveRestoredSessionHistory: Bool
+        let onNavigationStarted: ((WKNavigation?) -> Void)?
     }
     private var pendingRemoteNavigation: PendingRemoteNavigation?
     private let bypassesRemoteWorkspaceProxy: Bool
@@ -5756,13 +5757,26 @@ final class BrowserPanel: Panel, ObservableObject {
 
     /// Navigate to a URL
     @discardableResult
-    func navigate(to url: URL, recordTypedNavigation: Bool = false) -> WKNavigation? {
+    func navigate(
+        to url: URL,
+        recordTypedNavigation: Bool = false,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
+    ) -> WKNavigation? {
         let request = URLRequest(url: url)
         if shouldBlockInsecureHTTPNavigation(to: url) {
-            presentInsecureHTTPAlert(for: request, intent: .currentTab, recordTypedNavigation: recordTypedNavigation)
+            presentInsecureHTTPAlert(
+                for: request,
+                intent: .currentTab,
+                recordTypedNavigation: recordTypedNavigation,
+                onNavigationStarted: onNavigationStarted
+            )
             return nil
         }
-        return navigateWithoutInsecureHTTPPrompt(request: request, recordTypedNavigation: recordTypedNavigation)
+        return navigateWithoutInsecureHTTPPrompt(
+            request: request,
+            recordTypedNavigation: recordTypedNavigation,
+            onNavigationStarted: onNavigationStarted
+        )
     }
 
     @discardableResult
@@ -5770,29 +5784,37 @@ final class BrowserPanel: Panel, ObservableObject {
         to url: URL,
         recordTypedNavigation: Bool,
         preserveRestoredSessionHistory: Bool = false,
-        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
+        cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
         let request = URLRequest(url: url, cachePolicy: cachePolicy)
         return navigateWithoutInsecureHTTPPrompt(
             request: request,
             recordTypedNavigation: recordTypedNavigation,
-            preserveRestoredSessionHistory: preserveRestoredSessionHistory
+            preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+            onNavigationStarted: onNavigationStarted
         )
     }
 
     @discardableResult
-    private func navigateWithoutInsecureHTTPPrompt(
+    func navigateWithoutInsecureHTTPPrompt(
         request: URLRequest,
         recordTypedNavigation: Bool,
-        preserveRestoredSessionHistory: Bool = false
+        preserveRestoredSessionHistory: Bool = false,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
-        guard let url = request.url else { return nil }
+        guard let url = request.url else {
+            onNavigationStarted?(nil)
+            return nil
+        }
         cancelHiddenWebViewDiscard()
         if usesRemoteWorkspaceProxy, remoteProxyEndpoint == nil {
+            pendingRemoteNavigation?.onNavigationStarted?(nil)
             pendingRemoteNavigation = PendingRemoteNavigation(
                 request: request,
                 recordTypedNavigation: recordTypedNavigation,
-                preserveRestoredSessionHistory: preserveRestoredSessionHistory
+                preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+                onNavigationStarted: onNavigationStarted
             )
             hiddenWebViewDiscardManager.updateRestoredSessionRenderIntent(nil)
             currentURL = Self.remoteProxyDisplayURL(for: url) ?? url
@@ -5805,7 +5827,8 @@ final class BrowserPanel: Panel, ObservableObject {
             request: request,
             originalURL: url,
             recordTypedNavigation: recordTypedNavigation,
-            preserveRestoredSessionHistory: preserveRestoredSessionHistory
+            preserveRestoredSessionHistory: preserveRestoredSessionHistory,
+            onNavigationStarted: onNavigationStarted
         )
     }
 
@@ -5817,6 +5840,7 @@ final class BrowserPanel: Panel, ObservableObject {
             return
         }
         guard let originalURL = navigation.request.url else {
+            navigation.onNavigationStarted?(nil)
             pendingRemoteNavigation = nil
             reevaluateHiddenWebViewDiscardScheduling(reason: "pending_remote_navigation_cleared")
             return
@@ -5825,7 +5849,8 @@ final class BrowserPanel: Panel, ObservableObject {
             request: navigation.request,
             originalURL: originalURL,
             recordTypedNavigation: navigation.recordTypedNavigation,
-            preserveRestoredSessionHistory: navigation.preserveRestoredSessionHistory
+            preserveRestoredSessionHistory: navigation.preserveRestoredSessionHistory,
+            onNavigationStarted: navigation.onNavigationStarted
         )
         pendingRemoteNavigation = nil
     }
@@ -5835,7 +5860,8 @@ final class BrowserPanel: Panel, ObservableObject {
         request: URLRequest,
         originalURL: URL,
         recordTypedNavigation: Bool,
-        preserveRestoredSessionHistory: Bool
+        preserveRestoredSessionHistory: Bool,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) -> WKNavigation? {
         cancelHiddenWebViewDiscard()
         clearWebContentTerminationRecovery()
@@ -5864,6 +5890,7 @@ final class BrowserPanel: Panel, ObservableObject {
         } else if hiddenWebViewDiscardManager.isDiscardedForMemory {
             pendingDiscardRestoreNavigation = startedNavigation
         }
+        onNavigationStarted?(startedNavigation)
         return startedNavigation
     }
 
@@ -5976,10 +6003,17 @@ final class BrowserPanel: Panel, ObservableObject {
         for request: URLRequest,
         intent: BrowserInsecureHTTPNavigationIntent,
         recordTypedNavigation: Bool,
-        onResolution: @escaping (BrowserInsecureHTTPNavigationResolution) -> Void = { _ in }
+        onResolution: @escaping (BrowserInsecureHTTPNavigationResolution) -> Void = { _ in },
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) {
-        guard let url = request.url else { return }
-        guard let host = BrowserInsecureHTTPSettings.normalizeHost(url.host ?? "") else { return }
+        guard let url = request.url else {
+            onNavigationStarted?(nil)
+            return
+        }
+        guard let host = BrowserInsecureHTTPSettings.normalizeHost(url.host ?? "") else {
+            onNavigationStarted?(nil)
+            return
+        }
         let alert = insecureHTTPAlertFactory()
         alert.alertStyle = .warning
         alert.messageText = String(localized: "browser.error.insecure.title", defaultValue: "Connection isn\u{2019}t secure")
@@ -5999,11 +6033,21 @@ final class BrowserPanel: Panel, ObservableObject {
                 url: url,
                 intent: intent,
                 recordTypedNavigation: recordTypedNavigation,
-                onResolution: onResolution
+                onResolution: onResolution,
+                onNavigationStarted: onNavigationStarted
             )
         }
 
-        presentBrowserAlert(alert, in: webView, windowProvider: insecureHTTPAlertWindowProvider, completion: handleResponse, cancel: { onResolution(.cancelled) })
+        presentBrowserAlert(
+            alert,
+            in: webView,
+            windowProvider: insecureHTTPAlertWindowProvider,
+            completion: handleResponse,
+            cancel: {
+                onNavigationStarted?(nil)
+                onResolution(.cancelled)
+            }
+        )
     }
 
     func handleInsecureHTTPAlertResponse(
@@ -6014,7 +6058,8 @@ final class BrowserPanel: Panel, ObservableObject {
         url: URL,
         intent: BrowserInsecureHTTPNavigationIntent,
         recordTypedNavigation: Bool, openExternalURL: (URL) -> Bool = { NSWorkspace.shared.open($0) },
-        onResolution: (BrowserInsecureHTTPNavigationResolution) -> Void
+        onResolution: (BrowserInsecureHTTPNavigationResolution) -> Void,
+        onNavigationStarted: ((WKNavigation?) -> Void)? = nil
     ) {
         if browserShouldPersistInsecureHTTPAllowlistSelection(
             response: response,
@@ -6024,19 +6069,29 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         switch response {
         case .alertFirstButtonReturn:
-            if !openExternalURL(url) { return }
+            if !openExternalURL(url) {
+                onNavigationStarted?(nil)
+                return
+            }
+            onNavigationStarted?(nil)
             onResolution(.openedExternally)
         case .alertSecondButtonReturn:
             switch intent {
             case .currentTab:
                 onResolution(.proceededInCurrentTab)
                 insecureHTTPBypassHostOnce = host
-                navigateWithoutInsecureHTTPPrompt(request: request, recordTypedNavigation: recordTypedNavigation)
+                navigateWithoutInsecureHTTPPrompt(
+                    request: request,
+                    recordTypedNavigation: recordTypedNavigation,
+                    onNavigationStarted: onNavigationStarted
+                )
             case .newTab:
+                onNavigationStarted?(nil)
                 onResolution(.proceededInNewTab)
                 openLinkInNewTab(request: request, bypassInsecureHTTPHostOnce: host)
             }
         default:
+            onNavigationStarted?(nil)
             onResolution(.cancelled)
             return
         }
@@ -6508,11 +6563,12 @@ extension BrowserPanel {
     }
 
     /// Reload the current page
-    func reload() {
+    @discardableResult
+    func reload() -> WKNavigation? {
         if prepareForReload(reason: "reload", mode: .soft) {
-            return
+            return nil
         }
-        webView.reload()
+        return webView.reload()
     }
 
     /// Reload the current page, bypassing WebKit's cache.

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3773,7 +3773,9 @@ final class BrowserPanel: Panel, ObservableObject {
                 (webView as? CmuxWebView)?.diffViewerNavigationDidStart(navigation)
                 self.automationNavigationCoordinator.didStart(
                     instanceID: boundWebViewInstanceID,
-                    navigationID: navigation.map { ObjectIdentifier($0) }
+                    navigationID: navigation.map { ObjectIdentifier($0) },
+                    targetURL: Self.remoteProxyDisplayURL(for: self.navigationDelegate?.lastAttemptedURL)
+                        ?? self.navigationDelegate?.lastAttemptedURL
                 )
                 self.isMainFrameProvisionalNavigationActive = true
                 self.refreshBackgroundAppearance()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3878,10 +3878,21 @@ final class BrowserPanel: Panel, ObservableObject {
                 }
             }
         }
-        navigationDelegate.didBecomeDownload = { [weak self] webView, isMainFrame, restoreAttemptID in
+        navigationDelegate.didBecomeDownload = { [weak self] webView, isMainFrame, url, restoreAttemptID in
             MainActor.assumeIsolated {
-                guard isMainFrame, let restoreAttemptID else { return }
-                guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID), restoreAttemptID == self.currentDiscardRestoreAttemptID else { return }
+                guard isMainFrame,
+                      let self,
+                      self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else {
+                    return
+                }
+                self.automationNavigationCoordinator.didBecomeDownload(
+                    instanceID: boundWebViewInstanceID,
+                    url: Self.remoteProxyDisplayURL(for: url) ?? url
+                )
+                guard let restoreAttemptID,
+                      restoreAttemptID == self.currentDiscardRestoreAttemptID else {
+                    return
+                }
                 // A main-frame download is a terminal outcome with no document commit; never restart it on the next reveal.
                 self.hasCommittedDocumentSinceWebViewReplacement = true
                 self.noteDiscardedWebViewRestoreNavigationCommitted(reason: "navigation_download")

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3878,17 +3878,24 @@ final class BrowserPanel: Panel, ObservableObject {
                 }
             }
         }
-        navigationDelegate.didBecomeDownload = { [weak self] webView, isMainFrame, url, restoreAttemptID in
+        navigationDelegate.didConvertProvisionalNavigationToDownload = { [weak self] webView, navigation in
+            MainActor.assumeIsolated {
+                guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
+                self.automationNavigationCoordinator.didBecomeDownload(
+                    instanceID: boundWebViewInstanceID,
+                    navigationID: navigation.map { ObjectIdentifier($0) }
+                )
+                self.isMainFrameProvisionalNavigationActive = false
+                self.refreshBackgroundAppearance()
+            }
+        }
+        navigationDelegate.didBecomeDownload = { [weak self] webView, isMainFrame, restoreAttemptID in
             MainActor.assumeIsolated {
                 guard isMainFrame,
                       let self,
                       self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else {
                     return
                 }
-                self.automationNavigationCoordinator.didBecomeDownload(
-                    instanceID: boundWebViewInstanceID,
-                    url: Self.remoteProxyDisplayURL(for: url) ?? url
-                )
                 guard let restoreAttemptID,
                       restoreAttemptID == self.currentDiscardRestoreAttemptID else {
                     return

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3884,15 +3884,28 @@ final class BrowserPanel: Panel, ObservableObject {
                 }
             }
         }
-        navigationDelegate.didConvertProvisionalNavigationToDownload = { [weak self] webView, navigation in
+        navigationDelegate.didChooseMainFrameDownloadPolicy = { [weak self] webView, navigation in
             MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
-                self.automationNavigationCoordinator.didBecomeDownload(
+                self.automationNavigationCoordinator.didChooseDownloadPolicy(
                     instanceID: boundWebViewInstanceID,
                     navigationID: navigation.map { ObjectIdentifier($0) }
                 )
+            }
+        }
+        navigationDelegate.didInterruptProvisionalNavigationByPolicy = { [weak self] webView, navigation in
+            MainActor.assumeIsolated {
+                guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else {
+                    return false
+                }
+                let isDownload = self.automationNavigationCoordinator.didInterruptByPolicyChange(
+                    instanceID: boundWebViewInstanceID,
+                    navigationID: navigation.map { ObjectIdentifier($0) }
+                )
+                guard isDownload else { return false }
                 self.isMainFrameProvisionalNavigationActive = false
                 self.refreshBackgroundAppearance()
+                return true
             }
         }
         navigationDelegate.didBecomeDownload = { [weak self] webView, isMainFrame, restoreAttemptID in
@@ -4096,20 +4109,8 @@ final class BrowserPanel: Panel, ObservableObject {
         navDelegate.handleBlockedInsecureHTTPNavigation = { [weak self] request, intent in
             guard let self else { return }
             let restoreAttemptID = self.currentDiscardRestoreAttemptID
-            let automationInstanceID = self.webViewInstanceID
-            let replacementTicket = self.automationNavigationCoordinator
-                .prepareForNavigationReplacement(
-                    instanceID: automationInstanceID,
-                    targetURL: request.url
-                )
-            let onNavigationStarted: ((WKNavigation?) -> Void)? = replacementTicket.map { ticket in
-                { [weak self] navigation in
-                    self?.recordAutomationReplacementNavigationStart(
-                        navigation,
-                        ticket: ticket
-                    )
-                }
-            }
+            // This is an action-policy replacement, which exposes no WKNavigation identity.
+            // Do not transfer an automation ticket based on WebView or URL coincidence.
             self.presentInsecureHTTPAlert(
                 for: request,
                 intent: intent,
@@ -4117,22 +4118,8 @@ final class BrowserPanel: Panel, ObservableObject {
                 onResolution: { [weak self] resolution in
                     guard resolution.isTerminalPolicyCancellation else { return }
                     self?.noteDiscardedWebViewRestoreNavigationTerminallyCancelled(restoreAttemptID: restoreAttemptID)
-                },
-                onNavigationStarted: onNavigationStarted
+                }
             )
-        }
-        navDelegate.prepareForPolicyNavigationReplacement = { [weak self] webView, targetURL in
-            guard let self, self.isCurrentWebView(webView) else { return nil }
-            guard let ticket = self.automationNavigationCoordinator.prepareForNavigationReplacement(
-                instanceID: self.webViewInstanceID,
-                targetURL: targetURL
-            ) else { return nil }
-            return { [weak self] navigation in
-                self?.recordAutomationReplacementNavigationStart(
-                    navigation,
-                    ticket: ticket
-                )
-            }
         }
         navDelegate.currentRestoreAttemptID = { [weak self] in self?.currentDiscardRestoreAttemptID }
         navDelegate.terminalPolicyCancellationReporter = { [weak self] navigationAction, webView in

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2804,6 +2804,7 @@ final class BrowserPanel: Panel, ObservableObject {
     private let visualAutomationCaptureGate = BrowserScreenshotCaptureGate()
     let automationWatchdog = BrowserAutomationWatchdog()
     let automationDocumentReadiness = BrowserAutomationDocumentReadiness()
+    let automationNavigationCoordinator = BrowserAutomationNavigationCoordinator()
     var activeVisualAutomationCaptureCount: Int = 0
     private struct PendingInteractiveBrowserPrompt {
         let present: (NSWindow, @escaping () -> Void) -> Void
@@ -3725,6 +3726,7 @@ final class BrowserPanel: Panel, ObservableObject {
         }
         configureMoveTabToNewWorkspaceContextMenu(for: webView); configureNavigationDelegateCallbacks()
         automationDocumentReadiness.bind(to: webViewInstanceID, hasCommittedDocument: webView.backForwardList.currentItem != nil)
+        automationNavigationCoordinator.bind(to: webViewInstanceID)
         webView.cmuxDownloadDelegate = downloadDelegate
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate
@@ -3780,6 +3782,10 @@ final class BrowserPanel: Panel, ObservableObject {
                 (webView as? CmuxWebView)?.diffViewerNavigationDidCommit(navigation)
                 self.isMainFrameProvisionalNavigationActive = false
                 self.automationDocumentReadiness.didCommit(instanceID: boundWebViewInstanceID)
+                self.automationNavigationCoordinator.didCommit(
+                    instanceID: boundWebViewInstanceID,
+                    navigationID: navigation.map { ObjectIdentifier($0) }
+                )
                 // An about:blank placeholder leaves the restore-stall detector armed.
                 if !Self.isAboutBlankURL(webView.url) {
                     self.hasCommittedDocumentSinceWebViewReplacement = true
@@ -3813,9 +3819,14 @@ final class BrowserPanel: Panel, ObservableObject {
                 self.restoreFindStateAfterNavigation(replaySearch: true)
             }
         }
-        navigationDelegate.didFailNavigation = { [weak self] failedWebView, failedURL, failedNavigation in
+        navigationDelegate.didFailNavigation = { [weak self] failedWebView, failedURL, failureMessage, failedNavigation in
             MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(failedWebView, instanceID: boundWebViewInstanceID) else { return }
+                self.automationNavigationCoordinator.didFail(
+                    instanceID: boundWebViewInstanceID,
+                    navigationID: failedNavigation.map { ObjectIdentifier($0) },
+                    message: failureMessage
+                )
                 self.isMainFrameProvisionalNavigationActive = false
                 if let url = URL(string: failedURL) {
                     self.currentURL = Self.remoteProxyDisplayURL(for: url) ?? url
@@ -3845,6 +3856,10 @@ final class BrowserPanel: Panel, ObservableObject {
             MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
                 (webView as? CmuxWebView)?.diffViewerNavigationDidCancel(cancelledNavigation)
+                self.automationNavigationCoordinator.didCancel(
+                    instanceID: boundWebViewInstanceID,
+                    navigationID: cancelledNavigation.map { ObjectIdentifier($0) }
+                )
                 let isRestoreBookkeepingNavigation = self.isDiscardRestoreBookkeepingNavigation(cancelledNavigation)
                 self.isMainFrameProvisionalNavigationActive = false
                 if isRestoreBookkeepingNavigation {
@@ -5352,6 +5367,7 @@ final class BrowserPanel: Panel, ObservableObject {
     func close() {
         cancelHiddenWebViewDiscard()
         isClosingWebViewLifecycle = true
+        automationNavigationCoordinator.invalidate()
         automationDocumentReadiness.invalidate()
         automationWatchdog.invalidate()
         refreshWebViewLifecycleState()
@@ -5739,35 +5755,38 @@ final class BrowserPanel: Panel, ObservableObject {
     // MARK: - Navigation
 
     /// Navigate to a URL
-    func navigate(to url: URL, recordTypedNavigation: Bool = false) {
+    @discardableResult
+    func navigate(to url: URL, recordTypedNavigation: Bool = false) -> WKNavigation? {
         let request = URLRequest(url: url)
         if shouldBlockInsecureHTTPNavigation(to: url) {
             presentInsecureHTTPAlert(for: request, intent: .currentTab, recordTypedNavigation: recordTypedNavigation)
-            return
+            return nil
         }
-        navigateWithoutInsecureHTTPPrompt(request: request, recordTypedNavigation: recordTypedNavigation)
+        return navigateWithoutInsecureHTTPPrompt(request: request, recordTypedNavigation: recordTypedNavigation)
     }
 
+    @discardableResult
     func navigateWithoutInsecureHTTPPrompt(
         to url: URL,
         recordTypedNavigation: Bool,
         preserveRestoredSessionHistory: Bool = false,
         cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy
-    ) {
+    ) -> WKNavigation? {
         let request = URLRequest(url: url, cachePolicy: cachePolicy)
-        navigateWithoutInsecureHTTPPrompt(
+        return navigateWithoutInsecureHTTPPrompt(
             request: request,
             recordTypedNavigation: recordTypedNavigation,
             preserveRestoredSessionHistory: preserveRestoredSessionHistory
         )
     }
 
+    @discardableResult
     private func navigateWithoutInsecureHTTPPrompt(
         request: URLRequest,
         recordTypedNavigation: Bool,
         preserveRestoredSessionHistory: Bool = false
-    ) {
-        guard let url = request.url else { return }
+    ) -> WKNavigation? {
+        guard let url = request.url else { return nil }
         cancelHiddenWebViewDiscard()
         if usesRemoteWorkspaceProxy, remoteProxyEndpoint == nil {
             pendingRemoteNavigation = PendingRemoteNavigation(
@@ -5780,9 +5799,9 @@ final class BrowserPanel: Panel, ObservableObject {
             navigationDelegate?.recordAttemptedRequest(request)
             refreshBackgroundAppearance()
             shouldRenderWebView = true
-            return
+            return nil
         }
-        performNavigation(
+        return performNavigation(
             request: request,
             originalURL: url,
             recordTypedNavigation: recordTypedNavigation,
@@ -5811,12 +5830,13 @@ final class BrowserPanel: Panel, ObservableObject {
         pendingRemoteNavigation = nil
     }
 
+    @discardableResult
     private func performNavigation(
         request: URLRequest,
         originalURL: URL,
         recordTypedNavigation: Bool,
         preserveRestoredSessionHistory: Bool
-    ) {
+    ) -> WKNavigation? {
         cancelHiddenWebViewDiscard()
         clearWebContentTerminationRecovery()
         if !preserveRestoredSessionHistory {
@@ -5844,6 +5864,7 @@ final class BrowserPanel: Panel, ObservableObject {
         } else if hiddenWebViewDiscardManager.isDiscardedForMemory {
             pendingDiscardRestoreNavigation = startedNavigation
         }
+        return startedNavigation
     }
 
     private func remoteProxyPreparedRequest(from request: URLRequest, logScope: String) -> URLRequest {
@@ -5897,18 +5918,28 @@ final class BrowserPanel: Panel, ObservableObject {
     /// Navigate with smart URL/search detection
     /// - If input looks like a URL, navigate to it
     /// - Otherwise, perform a web search
-    func navigateSmart(_ input: String) {
+    @discardableResult
+    func navigateSmart(_ input: String) -> WKNavigation? {
+        guard let navigation = resolveSmartNavigation(from: input) else { return nil }
+        return navigate(
+            to: navigation.url,
+            recordTypedNavigation: navigation.recordTypedNavigation
+        )
+    }
+
+    func resolveSmartNavigation(
+        from input: String
+    ) -> (url: URL, recordTypedNavigation: Bool)? {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else { return nil }
 
         if let url = resolveNavigableURL(from: trimmed) {
-            navigate(to: url, recordTypedNavigation: true)
-            return
+            return (url, true)
         }
 
         let searchConfiguration = BrowserSearchSettingsStore().currentConfiguration
-        guard let searchURL = searchConfiguration.searchURL(query: trimmed) else { return }
-        navigate(to: searchURL)
+        guard let searchURL = searchConfiguration.searchURL(query: trimmed) else { return nil }
+        return (searchURL, false)
     }
 
     func resolveNavigableURL(from input: String) -> URL? {
@@ -6439,6 +6470,15 @@ extension BrowserPanel {
 
     var bypassesRemoteWorkspaceProxyForTabDuplication: Bool {
         bypassesRemoteWorkspaceProxy
+    }
+
+    func automationReloadTargetURL() -> URL? {
+        restorableDisplayURLForCurrentErrorPage(liveURL: webView.url)
+            ?? Self.remoteProxyDisplayURL(for: navigationDelegate?.lastAttemptedURL)
+            ?? navigationDelegate?.lastAttemptedURL
+            ?? resolvedCurrentSessionHistoryURL()
+            ?? currentURL
+            ?? URL(string: "about:blank")
     }
 
     private func prepareForReload(reason: String, mode: BrowserPanelReloadMode) -> Bool {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3878,24 +3878,17 @@ final class BrowserPanel: Panel, ObservableObject {
                 }
             }
         }
-        navigationDelegate.didConvertProvisionalNavigationToDownload = { [weak self] webView, navigation in
-            MainActor.assumeIsolated {
-                guard let self, self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else { return }
-                self.automationNavigationCoordinator.didBecomeDownload(
-                    instanceID: boundWebViewInstanceID,
-                    navigationID: navigation.map { ObjectIdentifier($0) }
-                )
-                self.isMainFrameProvisionalNavigationActive = false
-                self.refreshBackgroundAppearance()
-            }
-        }
-        navigationDelegate.didBecomeDownload = { [weak self] webView, isMainFrame, restoreAttemptID in
+        navigationDelegate.didBecomeDownload = { [weak self] webView, isMainFrame, url, restoreAttemptID in
             MainActor.assumeIsolated {
                 guard isMainFrame,
                       let self,
                       self.isCurrentWebView(webView, instanceID: boundWebViewInstanceID) else {
                     return
                 }
+                self.automationNavigationCoordinator.didBecomeDownload(
+                    instanceID: boundWebViewInstanceID,
+                    url: Self.remoteProxyDisplayURL(for: url) ?? url
+                )
                 guard let restoreAttemptID,
                       restoreAttemptID == self.currentDiscardRestoreAttemptID else {
                     return
@@ -4101,8 +4094,11 @@ final class BrowserPanel: Panel, ObservableObject {
                     self?.noteDiscardedWebViewRestoreNavigationTerminallyCancelled(restoreAttemptID: restoreAttemptID)
                 },
                 onNavigationStarted: replacesAutomationNavigation ? { [weak self] navigation in
-                    guard navigation == nil else { return }
-                    self?.automationNavigationCoordinator.didNotStart(instanceID: automationInstanceID)
+                    self?.recordAutomationReplacementNavigationStart(
+                        navigation,
+                        instanceID: automationInstanceID,
+                        targetURL: request.url
+                    )
                 } : nil
             )
         }
@@ -6034,8 +6030,11 @@ final class BrowserPanel: Panel, ObservableObject {
     private func requestNavigation(_ request: URLRequest, intent: BrowserInsecureHTTPNavigationIntent) {
         let automationInstanceID = webViewInstanceID
         let navigationStarted: (WKNavigation?) -> Void = { [weak self] navigation in
-            guard navigation == nil else { return }
-            self?.automationNavigationCoordinator.didNotStart(instanceID: automationInstanceID)
+            self?.recordAutomationReplacementNavigationStart(
+                navigation,
+                instanceID: automationInstanceID,
+                targetURL: request.url
+            )
         }
         guard let url = request.url else {
             navigationStarted(nil)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3046,6 +3046,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
     var reactGrabMessageHandler: ReactGrabMessageHandler?
     var sslTrustBypassMessageHandler: BrowserSSLTrustBypassMessageHandler?
+    var sameDocumentNavigationMessageHandler: BrowserSameDocumentNavigationMessageHandler?
     /// Whether the live page currently has any actively-playing `<video>` or
     /// `<audio>` element, in the main frame or any iframe, reported by the
     /// injected media-playback hook. Keeps an actively-playing pane alive in the
@@ -3613,6 +3614,9 @@ final class BrowserPanel: Panel, ObservableObject {
                 forMainFrameOnly: true
             )
         )
+        configuration.userContentController.addUserScript(
+            BrowserSameDocumentNavigationMessageHandler.userScript
+        )
         // Keep browser console/error/dialog telemetry active from document start on every navigation.
         // Main frame only — injecting into cross-origin iframes causes CAPTCHA providers
         // (reCAPTCHA, hCaptcha, Cloudflare Turnstile) to detect the overridden console.*
@@ -3732,6 +3736,7 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate
         setupObservers(for: webView)
+        setupSameDocumentNavigationMessageHandler(for: webView)
         setupReactGrabMessageHandler(for: webView)
         designModeController.install(on: webView)
         setupSSLTrustBypassMessageHandler(for: webView)
@@ -3754,6 +3759,7 @@ final class BrowserPanel: Panel, ObservableObject {
         userContentController.removeScriptMessageHandler(forName: BrowserSSLTrustBypassMessageHandler.name)
         userContentController.add(handler, name: BrowserSSLTrustBypassMessageHandler.name)
     }
+
     private func configureNavigationDelegateCallbacks() {
         guard let navigationDelegate else { return }
         let boundWebViewInstanceID = webViewInstanceID
@@ -4965,6 +4971,11 @@ final class BrowserPanel: Panel, ObservableObject {
     /// from the fresh web view.
     private func detachWebViewObservers() {
         webViewObservers.removeAll()
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: BrowserSameDocumentNavigationMessageHandler.name,
+            contentWorld: BrowserSameDocumentNavigationMessageHandler.contentWorld
+        )
+        sameDocumentNavigationMessageHandler = nil
         resetMediaPlaybackTracking()
         setMediaActivity(isUsingMicrophone: false, isUsingCamera: false, reason: "media_capture_changed")
         webViewCancellables.removeAll()
@@ -4979,13 +4990,8 @@ final class BrowserPanel: Panel, ObservableObject {
             MainActor.assumeIsolated {
                 guard let self, self.isCurrentWebView(webView, instanceID: observedWebViewInstanceID) else { return }
                 guard !self.isMainFrameProvisionalNavigationActive else { return }
-                let displayURL = Self.remoteProxyDisplayURL(for: observedURL) ?? observedURL
-                self.automationNavigationCoordinator.didReachSameDocumentURL(
-                    instanceID: observedWebViewInstanceID,
-                    url: displayURL
-                )
                 self.designModeController.webViewURLDidChange(to: observedURL)
-                self.currentURL = displayURL
+                self.currentURL = Self.remoteProxyDisplayURL(for: observedURL) ?? observedURL
                 self.refreshBackgroundAppearance()
                 GlobalSearchCoordinator.shared.captureBrowserPanel(self)
             }

--- a/Sources/Panels/BrowserSameDocumentNavigationMessageHandler.swift
+++ b/Sources/Panels/BrowserSameDocumentNavigationMessageHandler.swift
@@ -1,0 +1,52 @@
+import Foundation
+import WebKit
+
+/// Bridges authoritative same-document events from the active main-frame document.
+@MainActor
+final class BrowserSameDocumentNavigationMessageHandler: NSObject, WKScriptMessageHandler {
+    static let name = "cmuxSameDocumentNavigation"
+    static let contentWorld = WKContentWorld.world(name: "cmux.browser.same-document-navigation")
+
+    static let userScript = WKUserScript(
+        source: """
+        (() => {
+          const reportNavigation = (event) => {
+            // The isolated content world hides the handler from page script;
+            // isTrusted also rejects synthetic events dispatched by the page.
+            if (!event.isTrusted) return;
+            window.webkit.messageHandlers['\(name)'].postMessage(window.location.href);
+          };
+          window.addEventListener('hashchange', reportNavigation, true);
+          window.addEventListener('popstate', reportNavigation, true);
+        })();
+        """,
+        injectionTime: .atDocumentStart,
+        forMainFrameOnly: true,
+        in: contentWorld
+    )
+
+    private weak var webView: WKWebView?
+    private let onNavigation: @MainActor (URL) -> Void
+
+    init(
+        webView: WKWebView,
+        onNavigation: @escaping @MainActor (URL) -> Void
+    ) {
+        self.webView = webView
+        self.onNavigation = onNavigation
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        guard message.name == Self.name,
+              message.frameInfo.isMainFrame,
+              message.webView === webView,
+              let value = message.body as? String,
+              let url = URL(string: value) else {
+            return
+        }
+        onNavigation(url)
+    }
+}

--- a/Sources/Panels/DiffCommentsBridge.swift
+++ b/Sources/Panels/DiffCommentsBridge.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxBrowser
 import Foundation
 import WebKit
 
@@ -275,17 +276,28 @@ extension BrowserPanel {
         (webView.url ?? currentURL)?.absoluteString == expectedURL
     }
 
-    @discardableResult
-    func navigateFromCLI(_ url: String, expectedURL: String? = nil) -> Bool {
-        guard expectedURL.map(hasCurrentURL) != false else { return false }
+    func beginAutomationNavigationFromCLI(
+        _ url: String,
+        expectedURL: String? = nil
+    ) -> (ticket: BrowserAutomationNavigationTicket, targetURL: URL)? {
+        guard expectedURL.map(hasCurrentURL) != false else { return nil }
+        let targetURL: URL
         if let internalURL = URL(string: url),
            internalURL.scheme == CmuxDiffViewerURLSchemeHandler.scheme {
-            guard CmuxDiffViewerURLSchemeHandler.shared.allowsNavigation(to: internalURL) else { return false }
-            navigate(to: internalURL)
+            guard CmuxDiffViewerURLSchemeHandler.shared.allowsNavigation(to: internalURL) else { return nil }
+            targetURL = internalURL
         } else {
-            navigateSmart(url)
+            guard let resolvedNavigation = resolveSmartNavigation(from: url) else { return nil }
+            targetURL = resolvedNavigation.url
+            return (
+                beginAutomationNavigation(
+                    to: targetURL,
+                    recordTypedNavigation: resolvedNavigation.recordTypedNavigation
+                ),
+                targetURL
+            )
         }
-        return true
+        return (beginAutomationNavigation(to: targetURL, recordTypedNavigation: false), targetURL)
     }
 }
 

--- a/Sources/TerminalController+BrowserAutomationRecovery.swift
+++ b/Sources/TerminalController+BrowserAutomationRecovery.swift
@@ -15,9 +15,6 @@ extension TerminalController {
         }
         if outcome == nil {
             navigationTask?.cancel()
-            v2MainSync {
-                browserPanel.automationNavigationCoordinator.cancel(ticket)
-            }
         }
         return outcome
     }

--- a/Sources/TerminalController+BrowserAutomationRecovery.swift
+++ b/Sources/TerminalController+BrowserAutomationRecovery.swift
@@ -27,8 +27,15 @@ extension TerminalController {
         switch outcome {
         case .committed, .downloaded:
             return nil
-        case .failed(let message):
-            return .err(code: "navigation_failed", message: message, data: data)
+        case .failed:
+            return .err(
+                code: "navigation_failed",
+                message: String(
+                    localized: "cli.browser.error.operationFailed",
+                    defaultValue: "Browser operation failed"
+                ),
+                data: data
+            )
         case .cancelled:
             return .err(
                 code: "navigation_cancelled",

--- a/Sources/TerminalController+BrowserAutomationRecovery.swift
+++ b/Sources/TerminalController+BrowserAutomationRecovery.swift
@@ -3,6 +3,75 @@ import Foundation
 import WebKit
 
 extension TerminalController {
+    nonisolated func v2AwaitBrowserAutomationNavigation(
+        _ ticket: BrowserAutomationNavigationTicket,
+        targetURL: URL,
+        browserPanel: BrowserPanel
+    ) -> BrowserAutomationNavigationOutcome? {
+        var navigationTask: Task<Void, Never>?
+        let outcome: BrowserAutomationNavigationOutcome? = socketAwaitCallback(timeout: 17.5) { finish in
+            navigationTask = Task { @MainActor in
+                finish(await browserPanel.finishAutomationNavigation(ticket, retrying: targetURL))
+            }
+        }
+        if outcome == nil {
+            navigationTask?.cancel()
+            v2MainSync {
+                browserPanel.automationNavigationCoordinator.cancel(ticket)
+            }
+        }
+        return outcome
+    }
+
+    nonisolated func v2BrowserNavigationFailureResult(
+        _ outcome: BrowserAutomationNavigationOutcome?,
+        targetURL: URL
+    ) -> V2CallResult? {
+        let data: [String: Any] = ["url": targetURL.absoluteString]
+        switch outcome {
+        case .committed:
+            return nil
+        case .failed(let message):
+            return .err(code: "navigation_failed", message: message, data: data)
+        case .cancelled:
+            return .err(
+                code: "navigation_cancelled",
+                message: String(
+                    localized: "cli.browser.error.operationFailed",
+                    defaultValue: "Browser operation failed"
+                ),
+                data: data
+            )
+        case .superseded:
+            return .err(
+                code: "stale_state",
+                message: String(
+                    localized: "browser.automation.error.superseded",
+                    defaultValue: "The browser surface was already recovered. Retry the command."
+                ),
+                data: data
+            )
+        case .notStarted:
+            return .err(
+                code: "navigation_failed",
+                message: String(
+                    localized: "cli.browser.error.operationFailed",
+                    defaultValue: "Browser operation failed"
+                ),
+                data: data
+            )
+        case .timedOut, nil:
+            return .err(
+                code: "navigation_timeout",
+                message: String(
+                    localized: "browser.automation.error.documentReadinessTimedOut",
+                    defaultValue: "Timed out waiting for the browser document to become ready"
+                ),
+                data: data
+            )
+        }
+    }
+
     nonisolated func v2CaptureBrowserAutomationSnapshot(
         _ browserPanel: BrowserPanel,
         timeout: TimeInterval

--- a/Sources/TerminalController+BrowserAutomationRecovery.swift
+++ b/Sources/TerminalController+BrowserAutomationRecovery.swift
@@ -5,13 +5,12 @@ import WebKit
 extension TerminalController {
     nonisolated func v2AwaitBrowserAutomationNavigation(
         _ ticket: BrowserAutomationNavigationTicket,
-        targetURL: URL,
         browserPanel: BrowserPanel
     ) -> BrowserAutomationNavigationOutcome? {
         var navigationTask: Task<Void, Never>?
         let outcome: BrowserAutomationNavigationOutcome? = socketAwaitCallback(timeout: 17.5) { finish in
             navigationTask = Task { @MainActor in
-                finish(await browserPanel.finishAutomationNavigation(ticket, retrying: targetURL))
+                finish(await browserPanel.finishAutomationNavigation(ticket))
             }
         }
         if outcome == nil {

--- a/Sources/TerminalController+BrowserAutomationRecovery.swift
+++ b/Sources/TerminalController+BrowserAutomationRecovery.swift
@@ -28,7 +28,7 @@ extension TerminalController {
     ) -> V2CallResult? {
         let data: [String: Any] = ["url": targetURL.absoluteString]
         switch outcome {
-        case .committed:
+        case .committed, .downloaded:
             return nil
         case .failed(let message):
             return .err(code: "navigation_failed", message: message, data: data)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6720,7 +6720,6 @@ class TerminalController {
         }
         let navigationOutcome = v2AwaitBrowserAutomationNavigation(
             navigationTicket,
-            targetURL: navigationTargetURL,
             browserPanel: navigationPanel
         )
         if let failure = v2BrowserNavigationFailureResult(
@@ -6822,7 +6821,6 @@ class TerminalController {
         }
         let navigationOutcome = v2AwaitBrowserAutomationNavigation(
             navigationTicket,
-            targetURL: navigationTargetURL,
             browserPanel: navigationPanel
         )
         if let failure = v2BrowserNavigationFailureResult(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6641,16 +6641,33 @@ class TerminalController {
 
     private nonisolated func v2BrowserNavigate(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
-            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+            return .err(
+                code: "unavailable",
+                message: String(
+                    localized: "cli.browser.error.tabManagerUnavailable",
+                    defaultValue: "Browser controls are unavailable"
+                ),
+                data: nil
+            )
         }
         guard let surfaceId = v2UUID(params, "surface_id") else {
-            return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
+            return .err(
+                code: "invalid_params",
+                message: String(
+                    localized: "cli.browser.error.operationFailed",
+                    defaultValue: "Browser operation failed"
+                ),
+                data: nil
+            )
         }
         guard let url = v2String(params, "url") else {
             return .err(code: "invalid_params", message: "Missing url", data: nil)
         }
         var basePayload: [String: Any]?
         var resolutionError: V2CallResult?
+        var navigationPanel: BrowserPanel?
+        var navigationTicket: BrowserAutomationNavigationTicket?
+        var navigationTargetURL: URL?
         v2MainSync {
             let resolvedContext = v2ResolveBrowserPanelContext(params: params, tabManager: tabManager)
             if let error = resolvedContext.error {
@@ -6659,7 +6676,20 @@ class TerminalController {
             }
             guard let context = resolvedContext.context,
                   context.surfaceId == surfaceId else { return }
-            if !context.browserPanel.navigateFromCLI(url, expectedURL: v2String(params, "expected_url")) { resolutionError = .err(code: "stale_state", message: "Browser URL changed before navigation", data: nil); return }
+            guard let navigation = context.browserPanel.beginAutomationNavigationFromCLI(
+                url,
+                expectedURL: v2String(params, "expected_url")
+            ) else {
+                resolutionError = .err(
+                    code: "stale_state",
+                    message: "Browser URL changed before navigation",
+                    data: nil
+                )
+                return
+            }
+            navigationPanel = context.browserPanel
+            navigationTicket = navigation.ticket
+            navigationTargetURL = navigation.targetURL
             if AppDelegate.shared?.tabManagerForWindowDockOwner(context.workspaceId) != nil {
                 basePayload = v2WindowDockBrowserActionPayload(context)
             } else {
@@ -6678,6 +6708,27 @@ class TerminalController {
         guard var payload = basePayload else {
             return .err(code: "not_found", message: "Surface not found or not a browser", data: ["surface_id": surfaceId.uuidString])
         }
+        guard let navigationPanel, let navigationTicket, let navigationTargetURL else {
+            return .err(
+                code: "internal_error",
+                message: String(
+                    localized: "cli.browser.error.operationFailed",
+                    defaultValue: "Browser operation failed"
+                ),
+                data: nil
+            )
+        }
+        let navigationOutcome = v2AwaitBrowserAutomationNavigation(
+            navigationTicket,
+            targetURL: navigationTargetURL,
+            browserPanel: navigationPanel
+        )
+        if let failure = v2BrowserNavigationFailureResult(
+            navigationOutcome,
+            targetURL: navigationTargetURL
+        ) {
+            return failure
+        }
         // Run the optional --snapshot-after walk on the worker thread (not inside
         // v2MainSync) so a slow accessibility-tree snapshot on a fresh surface
         // can't block SwiftUI and recreate mount deadlocks. Standalone
@@ -6695,7 +6746,93 @@ class TerminalController {
     }
 
     private nonisolated func v2BrowserReload(params: [String: Any]) -> V2CallResult {
-        return v2BrowserNavSimple(params: params, action: "reload")
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(
+                code: "unavailable",
+                message: String(
+                    localized: "cli.browser.error.tabManagerUnavailable",
+                    defaultValue: "Browser controls are unavailable"
+                ),
+                data: nil
+            )
+        }
+        guard let surfaceId = v2UUID(params, "surface_id") else {
+            return .err(
+                code: "invalid_params",
+                message: String(
+                    localized: "cli.browser.error.operationFailed",
+                    defaultValue: "Browser operation failed"
+                ),
+                data: nil
+            )
+        }
+
+        var setupError: V2CallResult?
+        var basePayload: [String: Any]?
+        var navigationPanel: BrowserPanel?
+        var navigationTicket: BrowserAutomationNavigationTicket?
+        var navigationTargetURL: URL?
+        v2MainSync {
+            let resolvedContext = v2ResolveBrowserPanelContext(params: params, tabManager: tabManager)
+            if let error = resolvedContext.error {
+                setupError = error
+                return
+            }
+            guard let context = resolvedContext.context,
+                  context.surfaceId == surfaceId else { return }
+            guard let navigation = context.browserPanel.beginAutomationReloadFromCLI() else {
+                setupError = .err(
+                    code: "internal_error",
+                    message: String(
+                        localized: "cli.browser.error.operationFailed",
+                        defaultValue: "Browser operation failed"
+                    ),
+                    data: nil
+                )
+                return
+            }
+            navigationPanel = context.browserPanel
+            navigationTicket = navigation.ticket
+            navigationTargetURL = navigation.targetURL
+            if AppDelegate.shared?.tabManagerForWindowDockOwner(context.workspaceId) != nil {
+                basePayload = v2WindowDockBrowserActionPayload(context)
+            } else {
+                basePayload = v2BrowserActionPayload(
+                    workspaceId: context.workspaceId,
+                    surfaceId: context.surfaceId,
+                    tabManager: tabManager
+                )
+            }
+        }
+        if let setupError {
+            return setupError
+        }
+        guard var payload = basePayload,
+              let navigationPanel,
+              let navigationTicket,
+              let navigationTargetURL else {
+            return .err(
+                code: "not_found",
+                message: String(
+                    localized: "cli.browser.error.operationFailed",
+                    defaultValue: "Browser operation failed"
+                ),
+                data: ["surface_id": surfaceId.uuidString]
+            )
+        }
+        let navigationOutcome = v2AwaitBrowserAutomationNavigation(
+            navigationTicket,
+            targetURL: navigationTargetURL,
+            browserPanel: navigationPanel
+        )
+        if let failure = v2BrowserNavigationFailureResult(
+            navigationOutcome,
+            targetURL: navigationTargetURL
+        ) {
+            return failure
+        }
+        v2BrowserAppendPostSnapshot(params: params, surfaceId: surfaceId, payload: &payload)
+        return .ok(payload)
     }
 
     private nonisolated func v2BrowserNotFoundDiagnostics(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B424PWRS000000000000PW01 /* BrowserPortalWebViewRenderingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424PWRS000000000000PW02 /* BrowserPortalWebViewRenderingState.swift */; };
 		B4245003000000000000PW01 /* BrowserPrewarmedWebViewPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4245004000000000000PW01 /* BrowserPrewarmedWebViewPool.swift */; };
 		B6585001B6585001B658PW01 /* BrowserPrewarmedWebViewPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6585002B6585002B658PW02 /* BrowserPrewarmedWebViewPoolTests.swift */; };
+		8478A0000000000000000002 /* BrowserRecoveryHTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */; };
 		7B5F1A2E9C0D4B6A8E217304 /* BrowserReliabilityRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */; };
 		BFBAC1A77CEE7A2DF91DA02C /* BrowserRemoteWorkspaceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */; };
 		4472A0014472A0014472A001 /* BrowserScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4472B0014472B0014472B001 /* BrowserScreenshot.swift */; };
@@ -2508,6 +2509,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B424PWRS000000000000PW02 /* BrowserPortalWebViewRenderingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPortalWebViewRenderingState.swift; sourceTree = "<group>"; };
 		B4245004000000000000PW01 /* BrowserPrewarmedWebViewPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPrewarmedWebViewPool.swift; sourceTree = "<group>"; };
 		B6585002B6585002B658PW02 /* BrowserPrewarmedWebViewPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrewarmedWebViewPoolTests.swift; sourceTree = "<group>"; };
+		8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserRecoveryHTTPServer.swift; sourceTree = "<group>"; };
 		7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserReliabilityRegressionUITests.swift; sourceTree = "<group>"; };
 		109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserRemoteWorkspaceStatus.swift; sourceTree = "<group>"; };
 		4472B0014472B0014472B001 /* BrowserScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserScreenshot.swift; sourceTree = "<group>"; };
@@ -4374,6 +4376,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
 				7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */,
 				7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */,
+				8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */,
 				C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */,
 				D10000000000000000A00011 /* SettingsUITestSupport.swift */,
 				D10000000000000000B00001 /* ControlSocketReadinessUITestSupport.swift */,
@@ -8332,6 +8335,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */,
 				D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */,
 				D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */,
+				8478A0000000000000000002 /* BrowserRecoveryHTTPServer.swift in Sources */,
 				7B5F1A2E9C0D4B6A8E217304 /* BrowserReliabilityRegressionUITests.swift in Sources */,
 				B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */,
 				B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		A5008373 /* BrowserFindWebViewEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008372 /* BrowserFindWebViewEvaluator.swift */; };
 		7B5F1A2E9C0D4B6A8E217302 /* BrowserFixtureInteractionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */; };
+		8478B0000000000000000002 /* BrowserFixtureSocketTestCase+PendingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8478B0000000000000000001 /* BrowserFixtureSocketTestCase+PendingRequest.swift */; };
 		A28B087F0000000000000013 /* BrowserFocusModeKeyDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F0000000000000012 /* BrowserFocusModeKeyDecision.swift */; };
 		B42450030000000000000001 /* BrowserHiddenWebViewDiscardManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */; };
 		B6585001B6585001B6585001 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */; };
@@ -2431,6 +2432,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 		A5008372 /* BrowserFindWebViewEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserFindWebViewEvaluator.swift; sourceTree = "<group>"; };
 		7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFixtureInteractionUITests.swift; sourceTree = "<group>"; };
+		8478B0000000000000000001 /* BrowserFixtureSocketTestCase+PendingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserFixtureSocketTestCase+PendingRequest.swift"; sourceTree = "<group>"; };
 		A28B087F0000000000000012 /* BrowserFocusModeKeyDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserFocusModeKeyDecision.swift; sourceTree = "<group>"; };
 		B42450040000000000000001 /* BrowserHiddenWebViewDiscardManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserHiddenWebViewDiscardManager.swift; sourceTree = "<group>"; };
 		B6585002B6585002B6585002 /* BrowserHiddenWebViewDiscardMemoryPressureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserHiddenWebViewDiscardMemoryPressureTests.swift; sourceTree = "<group>"; };
@@ -4375,6 +4377,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */,
 				FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
 				7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */,
+				8478B0000000000000000001 /* BrowserFixtureSocketTestCase+PendingRequest.swift */,
 				7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */,
 				8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */,
 				C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */,
@@ -8332,6 +8335,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */,
 				AA1B2C3D4E5F60718 /* BonsplitTabDragUITests.swift in Sources */,
 				7B5F1A2E9C0D4B6A8E217302 /* BrowserFixtureInteractionUITests.swift in Sources */,
+				8478B0000000000000000002 /* BrowserFixtureSocketTestCase+PendingRequest.swift in Sources */,
 				FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */,
 				D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */,
 				D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		8478A0000000000000000002 /* BrowserRecoveryHTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */; };
 		7B5F1A2E9C0D4B6A8E217304 /* BrowserReliabilityRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */; };
 		BFBAC1A77CEE7A2DF91DA02C /* BrowserRemoteWorkspaceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */; };
+		8478A0010000000000000001 /* BrowserSameDocumentNavigationMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8478A0010000000000000002 /* BrowserSameDocumentNavigationMessageHandler.swift */; };
 		4472A0014472A0014472A001 /* BrowserScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4472B0014472B0014472B001 /* BrowserScreenshot.swift */; };
 		4472A0024472A0024472A002 /* BrowserScreenshotPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4472B0024472B0024472B002 /* BrowserScreenshotPipeline.swift */; };
 		4472A0034472A0034472A003 /* BrowserScreenshotSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4472B0034472B0034472B003 /* BrowserScreenshotSnapshotter.swift */; };
@@ -2514,6 +2515,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserRecoveryHTTPServer.swift; sourceTree = "<group>"; };
 		7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserReliabilityRegressionUITests.swift; sourceTree = "<group>"; };
 		109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserRemoteWorkspaceStatus.swift; sourceTree = "<group>"; };
+		8478A0010000000000000002 /* BrowserSameDocumentNavigationMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserSameDocumentNavigationMessageHandler.swift; sourceTree = "<group>"; };
 		4472B0014472B0014472B001 /* BrowserScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserScreenshot.swift; sourceTree = "<group>"; };
 		4472B0024472B0024472B002 /* BrowserScreenshotPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserScreenshotPipeline.swift; sourceTree = "<group>"; };
 		4472B0034472B0034472B003 /* BrowserScreenshotSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserScreenshotSnapshotter.swift; sourceTree = "<group>"; };
@@ -5357,6 +5359,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C2035A0C000000000000002 /* BrowserErrorPageRetry.swift */,
 				C2035A030000000000000002 /* BrowserSSLTrustBypassState.swift */,
 				C2035A0B000000000000002 /* BrowserSSLTrustBypassMessageHandler.swift */,
+				8478A0010000000000000002 /* BrowserSameDocumentNavigationMessageHandler.swift */,
 				C2035A080000000000000002 /* BrowserSSLTrustGrant.swift */,
 				C2035A040000000000000002 /* BrowserSSLTrustScope.swift */,
 				C2035A050000000000000002 /* BrowserServerTrustFingerprint.swift */,
@@ -7138,6 +7141,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B424PWRS000000000000PW01 /* BrowserPortalWebViewRenderingState.swift in Sources */,
 				B4245003000000000000PW01 /* BrowserPrewarmedWebViewPool.swift in Sources */,
 				BFBAC1A77CEE7A2DF91DA02C /* BrowserRemoteWorkspaceStatus.swift in Sources */,
+				8478A0010000000000000001 /* BrowserSameDocumentNavigationMessageHandler.swift in Sources */,
 				4472A0014472A0014472A001 /* BrowserScreenshot.swift in Sources */,
 				4472A0024472A0024472A002 /* BrowserScreenshotPipeline.swift in Sources */,
 				4472A0034472A0034472A003 /* BrowserScreenshotSnapshotter.swift in Sources */,

--- a/cmuxTests/BrowserDiscardedWebViewRestoreRetryTests.swift
+++ b/cmuxTests/BrowserDiscardedWebViewRestoreRetryTests.swift
@@ -457,12 +457,7 @@ struct BrowserDiscardedWebViewRestoreRetryGreenTests {
 
         // Simulate WebKit converting the pending restore navigation into a
         // main-frame download before any document commits.
-        panel.navigationDelegate?.didBecomeDownload?(
-            panel.webView,
-            true,
-            url,
-            panel.currentDiscardRestoreAttemptID
-        )
+        panel.navigationDelegate?.didBecomeDownload?(panel.webView, true, panel.currentDiscardRestoreAttemptID)
 
         let payload = panel.webViewLifecycleTopPayload()
         #expect(payload["restore_pending"] as? Bool == false)

--- a/cmuxTests/BrowserDiscardedWebViewRestoreRetryTests.swift
+++ b/cmuxTests/BrowserDiscardedWebViewRestoreRetryTests.swift
@@ -457,7 +457,12 @@ struct BrowserDiscardedWebViewRestoreRetryGreenTests {
 
         // Simulate WebKit converting the pending restore navigation into a
         // main-frame download before any document commits.
-        panel.navigationDelegate?.didBecomeDownload?(panel.webView, true, panel.currentDiscardRestoreAttemptID)
+        panel.navigationDelegate?.didBecomeDownload?(
+            panel.webView,
+            true,
+            url,
+            panel.currentDiscardRestoreAttemptID
+        )
 
         let payload = panel.webViewLifecycleTopPayload()
         #expect(payload["restore_pending"] as? Bool == false)

--- a/cmuxUITests/BrowserFixtureSocketTestCase+PendingRequest.swift
+++ b/cmuxUITests/BrowserFixtureSocketTestCase+PendingRequest.swift
@@ -1,0 +1,120 @@
+import Darwin
+import Foundation
+
+extension BrowserFixtureSocketTestCase {
+    func beginPendingSocketRequest(
+        method: String,
+        params: [String: Any],
+        responseTimeout: TimeInterval = 15
+    ) throws -> Int32 {
+        let request: [String: Any] = [
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params,
+        ]
+        guard JSONSerialization.isValidJSONObject(request) else {
+            throw POSIXError(.EINVAL)
+        }
+        let requestData = try JSONSerialization.data(withJSONObject: request) + Data([0x0A])
+        let descriptor = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw POSIXError(.EIO) }
+
+        do {
+            try configurePendingSocket(descriptor, responseTimeout: responseTimeout)
+            try connectPendingSocket(descriptor)
+            try writePendingSocketRequest(requestData, to: descriptor)
+            return descriptor
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    func pendingSocketResponseIsReady(_ descriptor: Int32) -> Bool {
+        var readiness = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+        return Darwin.poll(&readiness, 1, 0) > 0
+    }
+
+    func finishPendingSocketRequest(_ descriptor: Int32) -> [String: Any]? {
+        var bytes = [UInt8](repeating: 0, count: 4096)
+        var response = Data()
+        while true {
+            let count = Darwin.read(descriptor, &bytes, bytes.count)
+            guard count > 0 else { return nil }
+            response.append(contentsOf: bytes[..<count])
+            guard let newline = response.firstIndex(of: 0x0A) else { continue }
+            let line = response[..<newline]
+            return (try? JSONSerialization.jsonObject(with: line)) as? [String: Any]
+        }
+    }
+
+    func closePendingSocketRequest(_ descriptor: Int32) {
+        Darwin.close(descriptor)
+    }
+
+    private func configurePendingSocket(
+        _ descriptor: Int32,
+        responseTimeout: TimeInterval
+    ) throws {
+        var timeout = timeval(
+            tv_sec: Int(responseTimeout),
+            tv_usec: Int32((responseTimeout - floor(responseTimeout)) * 1_000_000)
+        )
+        let result = withUnsafePointer(to: &timeout) { pointer in
+            setsockopt(
+                descriptor,
+                SOL_SOCKET,
+                SO_RCVTIMEO,
+                pointer,
+                socklen_t(MemoryLayout<timeval>.size)
+            )
+        }
+        guard result == 0 else { throw posixError() }
+    }
+
+    private func connectPendingSocket(_ descriptor: Int32) throws {
+        var address = sockaddr_un()
+        memset(&address, 0, MemoryLayout<sockaddr_un>.size)
+        address.sun_family = sa_family_t(AF_UNIX)
+
+        let pathBytes = Array(socketPath.utf8CString)
+        guard pathBytes.count <= MemoryLayout.size(ofValue: address.sun_path) else {
+            throw POSIXError(.ENAMETOOLONG)
+        }
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            let raw = UnsafeMutableRawPointer(pointer).assumingMemoryBound(to: CChar.self)
+            for index in pathBytes.indices {
+                raw[index] = pathBytes[index]
+            }
+        }
+
+        let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+        let addressLength = socklen_t(pathOffset + pathBytes.count)
+        let result = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.connect(descriptor, socketAddress, addressLength)
+            }
+        }
+        guard result == 0 else { throw posixError() }
+    }
+
+    private func writePendingSocketRequest(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var written = 0
+            while written < rawBuffer.count {
+                let count = Darwin.write(
+                    descriptor,
+                    baseAddress.advanced(by: written),
+                    rawBuffer.count - written
+                )
+                guard count > 0 else { throw posixError() }
+                written += count
+            }
+        }
+    }
+
+    private func posixError() -> POSIXError {
+        POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+}

--- a/cmuxUITests/BrowserRecoveryHTTPServer.swift
+++ b/cmuxUITests/BrowserRecoveryHTTPServer.swift
@@ -4,12 +4,14 @@ import Foundation
 final class BrowserRecoveryHTTPServer {
     let port: UInt16
 
-    private let responseDelay: TimeInterval
+    private let inputPipe = Pipe()
+    private let outputPipe = Pipe()
+    private var outputBuffer = Data()
     private var process: Process?
+    private var hasHeldRequest = false
 
-    init(responseDelay: TimeInterval) throws {
+    init() throws {
         self.port = try Self.availablePort()
-        self.responseDelay = responseDelay
     }
 
     deinit {
@@ -26,31 +28,63 @@ final class BrowserRecoveryHTTPServer {
             "-c",
             Self.serverScript,
             String(port),
-            String(responseDelay),
         ]
-        process.standardOutput = Pipe()
+        process.standardInput = inputPipe
+        process.standardOutput = outputPipe
         process.standardError = Pipe()
         try process.run()
         self.process = process
 
-        let deadline = Date().addingTimeInterval(5)
-        while Date() < deadline {
-            if Self.canConnect(to: port) {
-                return
-            }
-            if !process.isRunning {
-                throw ServerError.exitedBeforeListening
-            }
-            usleep(20_000)
+        guard try nextSignal(timeoutMilliseconds: 5_000) == "READY" else {
+            throw ServerError.unexpectedSignal
         }
-        throw ServerError.didNotStartListening
+    }
+
+    func waitForRequest() throws {
+        guard try nextSignal(timeoutMilliseconds: 15_000) == "REQUEST" else {
+            throw ServerError.unexpectedSignal
+        }
+        hasHeldRequest = true
+    }
+
+    func releaseResponse() throws {
+        guard hasHeldRequest else { return }
+        hasHeldRequest = false
+        try inputPipe.fileHandleForWriting.write(contentsOf: Data("RELEASE\n".utf8))
     }
 
     func stop() {
         guard let process else { return }
         self.process = nil
+        try? releaseResponse()
         if process.isRunning {
             process.terminate()
+        }
+    }
+
+    private func nextSignal(timeoutMilliseconds: Int32) throws -> String {
+        while true {
+            if let newline = outputBuffer.firstIndex(of: 0x0A) {
+                let line = outputBuffer[..<newline]
+                outputBuffer.removeSubrange(...newline)
+                return String(decoding: line, as: UTF8.self)
+            }
+
+            var readiness = pollfd(
+                fd: outputPipe.fileHandleForReading.fileDescriptor,
+                events: Int16(POLLIN),
+                revents: 0
+            )
+            guard Darwin.poll(&readiness, 1, timeoutMilliseconds) > 0 else {
+                throw ServerError.signalTimedOut
+            }
+
+            var bytes = [UInt8](repeating: 0, count: 128)
+            let count = Darwin.read(readiness.fd, &bytes, bytes.count)
+            guard count > 0 else {
+                throw ServerError.signalStreamClosed
+            }
+            outputBuffer.append(contentsOf: bytes[..<count])
         }
     }
 
@@ -83,40 +117,25 @@ final class BrowserRecoveryHTTPServer {
         return UInt16(bigEndian: resolvedAddress.sin_port)
     }
 
-    private static func canConnect(to port: UInt16) -> Bool {
-        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
-        guard descriptor >= 0 else { return false }
-        defer { close(descriptor) }
-
-        var address = sockaddr_in()
-        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
-        address.sin_family = sa_family_t(AF_INET)
-        address.sin_port = port.bigEndian
-        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
-        return withUnsafePointer(to: &address) { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
-                Darwin.connect(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
-            }
-        }
-    }
-
     private enum ServerError: Error {
         case couldNotReservePort
-        case didNotStartListening
-        case exitedBeforeListening
+        case signalStreamClosed
+        case signalTimedOut
+        case unexpectedSignal
     }
 
     private static let serverScript = #"""
 import sys
-import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 port = int(sys.argv[1])
-delay = float(sys.argv[2])
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
-        time.sleep(delay)
+        print('REQUEST', flush=True)
+        if sys.stdin.readline().strip() != 'RELEASE':
+            self.send_error(500)
+            return
         body = b'<!doctype html><body data-cmux-recovered="true">recovered</body>'
         self.send_response(200)
         self.send_header('Content-Type', 'text/html; charset=utf-8')
@@ -127,6 +146,8 @@ class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         pass
 
-HTTPServer(('127.0.0.1', port), Handler).serve_forever()
+server = HTTPServer(('127.0.0.1', port), Handler)
+print('READY', flush=True)
+server.serve_forever()
 """#
 }

--- a/cmuxUITests/BrowserRecoveryHTTPServer.swift
+++ b/cmuxUITests/BrowserRecoveryHTTPServer.swift
@@ -1,0 +1,132 @@
+import Darwin
+import Foundation
+
+final class BrowserRecoveryHTTPServer {
+    let port: UInt16
+
+    private let responseDelay: TimeInterval
+    private var process: Process?
+
+    init(responseDelay: TimeInterval) throws {
+        self.port = try Self.availablePort()
+        self.responseDelay = responseDelay
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start() throws {
+        guard process == nil else { return }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        process.arguments = [
+            "-u",
+            "-c",
+            Self.serverScript,
+            String(port),
+            String(responseDelay),
+        ]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        self.process = process
+
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if Self.canConnect(to: port) {
+                return
+            }
+            if !process.isRunning {
+                throw ServerError.exitedBeforeListening
+            }
+            usleep(20_000)
+        }
+        throw ServerError.didNotStartListening
+    }
+
+    func stop() {
+        guard let process else { return }
+        self.process = nil
+        if process.isRunning {
+            process.terminate()
+        }
+    }
+
+    private static func availablePort() throws -> UInt16 {
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { throw ServerError.couldNotReservePort }
+        defer { close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let didBind = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.bind(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard didBind == 0 else { throw ServerError.couldNotReservePort }
+
+        var resolvedAddress = sockaddr_in()
+        var resolvedLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let didResolve = withUnsafeMutablePointer(to: &resolvedAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                getsockname(descriptor, socketAddress, &resolvedLength)
+            }
+        }
+        guard didResolve == 0 else { throw ServerError.couldNotReservePort }
+        return UInt16(bigEndian: resolvedAddress.sin_port)
+    }
+
+    private static func canConnect(to port: UInt16) -> Bool {
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return false }
+        defer { close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = port.bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        return withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.connect(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size)) == 0
+            }
+        }
+    }
+
+    private enum ServerError: Error {
+        case couldNotReservePort
+        case didNotStartListening
+        case exitedBeforeListening
+    }
+
+    private static let serverScript = #"""
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+delay = float(sys.argv[2])
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        time.sleep(delay)
+        body = b'<!doctype html><body data-cmux-recovered="true">recovered</body>'
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+HTTPServer(('127.0.0.1', port), Handler).serve_forever()
+"""#
+}

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -14,7 +14,8 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
     func testGotoWaitsForRecoveredDocumentCommitAfterConnectionRefusal() throws {
         try launchApp()
         let sid = try openBrowserSurface()
-        let server = try BrowserRecoveryHTTPServer(responseDelay: 2)
+        let responseDelay = 6.0
+        let server = try BrowserRecoveryHTTPServer(responseDelay: responseDelay)
         let failedURL = "http://127.0.0.1:\(server.port)/unavailable"
         let recoveredURL = "http://127.0.0.1:\(server.port)/recovered"
 
@@ -39,10 +40,16 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
         try server.start()
         defer { server.stop() }
 
+        let navigationStartedAt = Date()
         try socketResult(
             method: "browser.navigate",
             params: ["surface_id": sid, "url": recoveredURL],
             responseTimeout: 15
+        )
+        XCTAssertGreaterThanOrEqual(
+            Date().timeIntervalSince(navigationStartedAt),
+            responseDelay * 0.9,
+            "browser.navigate returned before the delayed recovered response could commit"
         )
         XCTAssertEqual(
             try evalString(

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -70,6 +70,31 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
             "true",
             "browser.navigate returned success before the recovered document committed"
         )
+
+        let sameDocumentURL = recoveredURL + "#verified"
+        let sameDocumentEnvelope = try XCTUnwrap(
+            socketEnvelope(
+                method: "browser.navigate",
+                params: ["surface_id": sid, "url": sameDocumentURL],
+                responseTimeout: 15
+            ),
+            "Expected a terminal response for the same-document navigation"
+        )
+        XCTAssertEqual(
+            sameDocumentEnvelope["ok"] as? Bool,
+            true,
+            "same-document browser.navigate failed: \(sameDocumentEnvelope)"
+        )
+        XCTAssertEqual(
+            try evalString("window.location.hash", surfaceID: sid),
+            "#verified",
+            "same-document browser.navigate returned before the trusted document event"
+        )
+        XCTAssertEqual(
+            try evalString("document.body.dataset.cmuxRecovered || ''", surfaceID: sid),
+            "true",
+            "the fragment navigation unexpectedly replaced the recovered document"
+        )
     }
 
     /// Regression: a WKWebView that has never committed a navigation has no

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -14,7 +14,7 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
     func testGotoWaitsForRecoveredDocumentCommitAfterConnectionRefusal() throws {
         try launchApp()
         let sid = try openBrowserSurface()
-        let server = try BrowserRecoveryHTTPServer(responseDelay: 6.0)
+        let server = try BrowserRecoveryHTTPServer()
         let failedURL = "http://127.0.0.1:\(server.port)/unavailable"
         let recoveredURL = "http://127.0.0.1:\(server.port)/recovered"
 
@@ -39,10 +39,28 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
         try server.start()
         defer { server.stop() }
 
-        try socketResult(
+        let pendingNavigation = try beginPendingSocketRequest(
             method: "browser.navigate",
             params: ["surface_id": sid, "url": recoveredURL],
             responseTimeout: 15
+        )
+        defer { closePendingSocketRequest(pendingNavigation) }
+        try server.waitForRequest()
+        let returnedBeforeResponseRelease = pendingSocketResponseIsReady(pendingNavigation)
+        try server.releaseResponse()
+
+        let navigationEnvelope = try XCTUnwrap(
+            finishPendingSocketRequest(pendingNavigation),
+            "Expected browser.navigate to return after the recovered response was released"
+        )
+        XCTAssertEqual(
+            navigationEnvelope["ok"] as? Bool,
+            true,
+            "browser.navigate failed after the recovered response was released: \(navigationEnvelope)"
+        )
+        XCTAssertFalse(
+            returnedBeforeResponseRelease,
+            "browser.navigate returned before the recovered response could commit"
         )
         XCTAssertEqual(
             try evalString(

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -14,8 +14,7 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
     func testGotoWaitsForRecoveredDocumentCommitAfterConnectionRefusal() throws {
         try launchApp()
         let sid = try openBrowserSurface()
-        let responseDelay = 6.0
-        let server = try BrowserRecoveryHTTPServer(responseDelay: responseDelay)
+        let server = try BrowserRecoveryHTTPServer(responseDelay: 6.0)
         let failedURL = "http://127.0.0.1:\(server.port)/unavailable"
         let recoveredURL = "http://127.0.0.1:\(server.port)/recovered"
 
@@ -40,16 +39,10 @@ final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
         try server.start()
         defer { server.stop() }
 
-        let navigationStartedAt = Date()
         try socketResult(
             method: "browser.navigate",
             params: ["surface_id": sid, "url": recoveredURL],
             responseTimeout: 15
-        )
-        XCTAssertGreaterThanOrEqual(
-            Date().timeIntervalSince(navigationStartedAt),
-            responseDelay * 0.9,
-            "browser.navigate returned before the delayed recovered response could commit"
         )
         XCTAssertEqual(
             try evalString(

--- a/cmuxUITests/BrowserReliabilityRegressionUITests.swift
+++ b/cmuxUITests/BrowserReliabilityRegressionUITests.swift
@@ -7,6 +7,53 @@ import Foundation
 /// (defined in BrowserFixtureInteractionUITests.swift).
 final class BrowserReliabilityRegressionUITests: BrowserFixtureSocketTestCase {
 
+    /// Regression: browser.navigate used to acknowledge only that WKWebView.load
+    /// was called. After a connection-refused error page, a slow recovered origin
+    /// therefore returned `ok` while the old error-page DOM was still active.
+    /// Success must mean that the requested document actually committed.
+    func testGotoWaitsForRecoveredDocumentCommitAfterConnectionRefusal() throws {
+        try launchApp()
+        let sid = try openBrowserSurface()
+        let server = try BrowserRecoveryHTTPServer(responseDelay: 2)
+        let failedURL = "http://127.0.0.1:\(server.port)/unavailable"
+        let recoveredURL = "http://127.0.0.1:\(server.port)/recovered"
+
+        XCTAssertNotNil(
+            socketEnvelope(
+                method: "browser.navigate",
+                params: ["surface_id": sid, "url": failedURL],
+                responseTimeout: 15
+            ),
+            "Expected the refused navigation to reach a terminal response"
+        )
+        try socketResult(
+            method: "browser.wait",
+            params: [
+                "surface_id": sid,
+                "text": "refused to connect",
+                "timeout_ms": 10_000,
+            ],
+            responseTimeout: 15
+        )
+
+        try server.start()
+        defer { server.stop() }
+
+        try socketResult(
+            method: "browser.navigate",
+            params: ["surface_id": sid, "url": recoveredURL],
+            responseTimeout: 15
+        )
+        XCTAssertEqual(
+            try evalString(
+                "document.body.dataset.cmuxRecovered || ''",
+                surfaceID: sid
+            ),
+            "true",
+            "browser.navigate returned success before the recovered document committed"
+        )
+    }
+
     /// Regression: a WKWebView that has never committed a navigation has no
     /// JavaScript context, so browser.wait used to hang for its full timeout
     /// (or fail) on a URL-less browser.open_split surface. The surface must


### PR DESCRIPTION
## Summary

- make `browser goto` and automation `reload` wait for the exact `WKNavigation` to emit a real main-frame commit before returning success
- report WebKit failure/cancellation/not-started/timeout outcomes instead of silently returning `OK`
- replace the still-current `WKWebView` after a bounded missing-callback deadline and retry the exact requested URL once
- keep transaction state structurally bounded to one active navigation, one waiter, and one terminal outcome per browser panel

## Root cause

`browser.navigate` previously returned as soon as `WKWebView.load(_:)` returned a `WKNavigation`. That only acknowledged submission; it did not prove that WebKit committed the requested document. After a provisional failure, the app-owned error page could therefore remain authoritative while `goto`/`reload` reported success. A genuinely dropped navigation had the same silent-success result because no code owned or awaited its terminal delegate callback.

The new `BrowserAutomationNavigationCoordinator` binds each automation request to both its WebView instance and the exact navigation object returned by the load. Only the matching `didCommit` succeeds it; matching failure and cancellation callbacks produce errors. An unrelated error-page commit cannot satisfy the request. If no terminal callback arrives, the panel replaces that exact WebView and retries the captured target once, using delegate signals rather than polling or delay-based app logic.

Automation `reload` now enters the same transaction path and issues a fresh request for the panel's display URL, including the failed URL preserved behind cmux's error page.

## Reproduction and evidence

On an isolated macOS 15.7.4 AWS Mac using cmux v0.64.20, connection refusal rendered cmux's `Can't reach this page`. Once the origin recovered, an explicit wait recovered 20/20 times. With the recovered origin delaying its response by two seconds, `browser goto` returned `OK` while the old error-page DOM was still observable; the recovered document appeared later. This isolated the deterministic defect to the missing commit barrier rather than proving a permanent WebKit latch.

The behavior UI test was committed before the fix. Two test-only CI runs executed it on unmodified code, but the CI WKWebView/socket scheduling masked the early acknowledgement and both passed ([initial](https://github.com/manaflow-ai/cmux/actions/runs/29795247703), [strengthened](https://github.com/manaflow-ai/cmux/actions/runs/29795915216)). I am preserving that evidence rather than claiming a synthetic red result. Exact-navigation lifecycle races are covered deterministically in package unit tests, and the recovered-origin flow is covered end-to-end.

A requested clean cloud-Mac visual reproduction could not be recorded: [cmux-loader run 29794176541](https://github.com/manaflow-ai/cmux-loader/actions/runs/29794176541) timed out because the provisioned loader never appeared through tailnet DNS/status and no macfleet Admin API token was available on this machine.

## Verification

- `xcrun swiftc -frontend -parse` for every changed Swift file
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh` (546 test files)
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- `git diff --check`
- fixed-HEAD targeted E2E: https://github.com/manaflow-ai/cmux/actions/runs/29796925706

Localization audit: the changed CLI error surfaces reuse existing localized keys. `cli.browser.error.operationFailed`, `cli.browser.error.tabManagerUnavailable`, `browser.automation.error.documentReadinessTimedOut`, and `browser.automation.error.superseded` were parsed and verified present in both English and Japanese; no localization catalogs changed.

Closes #8478

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787195097&installation_model_id=21920&pr_number=8548&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8548&signature=41f040d62c41e9f7c01abdd98385a806a6cd9c040f86a91a7d8009bf847f44e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser automation recovery by waiting for the exact `WKNavigation` to commit and binding identity/outcome to a ticket across replacements, downloads, deferred handoffs, and trusted same-document signals. Adds normalized target/display URL matching to prevent false “ok” on error pages; closes #8478.

- **Bug Fixes**
  - `browser.navigate`/`browser.reload` succeed only after the matching `didCommit`; unrelated commits (including error pages) never satisfy the request.
  - Same-document completion only from trusted main-frame `hashchange`/`popstate` in an isolated content world, and only when the normalized URL reaches the exact target.
  - Correlate policy outcomes to the ticket: explicit main-frame downloads are reported as downloaded; other interrupted-load cases are cancellations; handle replacements, deferred starts/hand-offs, insecure-HTTP prompts, and external-app fallbacks.
  - Terminal outcomes are precise: committed, downloaded, failed(message), cancelled, not-started, superseded, timed-out; CLI surfaces localized errors.
  - Reloads share the same path: retry error-page targets, accept authoritative same-document changes, treat document-less new-tab reloads as committed, report nil reloads as not-started, and await deferred reloads.
  - One active navigation and one waiter per panel; bind the exact `WKNavigation`; preserve results across newer transactions. Timeouts: 15s navigation deadline, 17.5s controller await; CLI adds headroom when `--snapshot-after` is used. Tests cover commit/failure/cancel/handoff/deferred/same-document/download/result preservation and a UI regression with a delayed local HTTP server.

<sup>Written for commit 95f22dba4ae2c5a7ff305da0e33d16a37cfa6747. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser navigation and reload CLI commands now complete only after the full browser-automation result is known (commit, download, failure, cancellation, supersession, not-started, or timeout).
  * Improved reliability for same-document navigation, deferred/replacement flows, and main-frame interrupted download recovery.
  * `--snapshot-after` operations now use extra timeout headroom to reduce premature failures.
  * CLI navigation error reporting includes additional localized failure detail.
* **Tests**
  * Added coordinator unit tests plus UI regression coverage using a local recovery server to confirm recovered documents truly commit before success is reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->