### PR TITLE
tests: update the remote-tmux resolver assertion to the shared builder's argv

### DIFF
--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -171,7 +171,9 @@ import Testing
         // executable name and not-found sentinel before the forwarded arguments. Pin both
         // halves: the command goes through the resolver, and what it forwards is the tmux
         // attach for this session.
-        #expect(remoteCommand.contains("'cmux-remote-executable' 'tmux'"))
+        #expect(
+            remoteCommand.contains(
+                "'cmux-remote-executable' 'tmux' '\(RemoteTmuxHost.tmuxNotFoundSentinel)'"))
         #expect(remoteCommand.hasSuffix("'-CC' 'attach-session' '-t' 'work session'"))
     }
 

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -167,7 +167,12 @@ import Testing
         let remoteCommand = args[dashDash + 2]
         #expect(!remoteCommand.contains("\n"))
         #expect(remoteCommand.contains("/opt/homebrew/bin"))
-        #expect(remoteCommand.hasSuffix("'cmux-remote-tmux' '-CC' 'attach-session' '-t' 'work session'"))
+        // The resolver is shared across remote executables, so its argv carries the
+        // executable name and not-found sentinel before the forwarded arguments. Pin both
+        // halves: the command goes through the resolver, and what it forwards is the tmux
+        // attach for this session.
+        #expect(remoteCommand.contains("'cmux-remote-executable' 'tmux'"))
+        #expect(remoteCommand.hasSuffix("'-CC' 'attach-session' '-t' 'work session'"))
     }
 
     @Test func controlArgsAppendPortAndIdentity() {


### PR DESCRIPTION
`RemoteTmuxAuthTests/controlModeArgumentsUseRemoteTmuxResolverAfterDestinationGuard` fails on `main` today. It asserts the remote command ends with

```
'cmux-remote-tmux' '-CC' 'attach-session' '-t' 'work session'
```

but #8442 generalized the tmux-specific resolver into `RemoteExecutableCommandBuilder`, which passes the executable name and the not-found sentinel as arguments ahead of what it forwards:

```
'cmux-remote-executable' 'tmux' 'cmux-remote-tmux: tmux not found' '-CC' 'attach-session' '-t' 'work session'
```

The test's intent still holds — a destination that looks like an SSH flag (`-oProxyCommand=evil`) is still passed after `--`, and the remote command still routes through the resolver — so only the asserted literal went stale. This pins both halves instead of the old single literal: the command goes through the resolver, and what it forwards is the tmux attach for this session.

## Test plan

Before, on `6f7e3dccdc` with no other changes:

```
$ xcodebuild test-without-building -scheme cmux-unit \
    '-only-testing:cmuxTests/RemoteTmuxAuthTests/controlModeArgumentsUseRemoteTmuxResolverAfterDestinationGuard()'
✘ Expectation failed: (remoteCommand → "'/bin/sh' '-c' '…' 'cmux-remote-executable' 'tmux'
  'cmux-remote-tmux: tmux not found' '-CC' 'attach-session' '-t' 'work session'")
  .hasSuffix("'cmux-remote-tmux' '-CC' 'attach-session' '-t' 'work session'")
✘ Test run with 1 test in 1 suite failed after 0.001 seconds with 1 issue.
```

After, the whole suite:

```
$ xcodebuild test-without-building -scheme cmux-unit -only-testing:cmuxTests/RemoteTmuxAuthTests
✔ Test run with 34 tests in 1 suite passed after 0.316 seconds.
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787196457&installation_model_id=21920&pr_number=8550&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8550&signature=1508d869754b4c11947977de49ee6d2c0abf1b9f44d7b405ff873a5cedf8a8dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RemoteTmuxAuthTests by updating the assertion to match the shared `RemoteExecutableCommandBuilder` argv. It now requires the resolver prefix `'cmux-remote-executable' 'tmux'` plus the not-found sentinel derived from `RemoteTmuxHost.tmuxNotFoundSentinel`, and separately checks the attach suffix `'-CC' 'attach-session' '-t' 'work session'`.

<sup>Written for commit 0c8e4b68087ffd1a4c55849c31b9054abb694136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated remote tmux authentication coverage to verify commands use the shared remote resolver.
  * Added validation for forwarded tmux attach-session arguments, including session names containing spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->