### PR TITLE
Use project notification gold for surface focus flashes

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -958,9 +958,12 @@ struct BrowserPanelView: View {
     }
 
     private var focusFlashOverlayView: some View {
-        RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
-            .stroke(cmuxAccentColor().opacity(focusFlashOpacity), lineWidth: 3)
-            .shadow(color: cmuxAccentColor().opacity(focusFlashOpacity * 0.35), radius: 10)
+        let presentation = WorkspaceAttentionCoordinator.flashStyle(for: .navigation)
+        let color = Color(nsColor: presentation.accent.strokeColor)
+
+        return RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
+            .stroke(color.opacity(focusFlashOpacity), lineWidth: 3)
+            .shadow(color: color.opacity(focusFlashOpacity * 0.35), radius: 10)
             .padding(FocusFlashPattern.ringInset)
             .allowsHitTesting(false)
     }

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -103,12 +103,12 @@ public enum WorkspaceAttentionFlashReason: String, Equatable, Sendable {
 }
 
 enum WorkspaceAttentionFlashAccent: Equatable, Sendable {
-    case notificationBlue
+    case projectNotificationGold
 
     var strokeColor: NSColor {
         switch self {
-        case .notificationBlue:
-            return .systemBlue
+        case .projectNotificationGold:
+            return .systemYellow
         }
     }
 }
@@ -145,13 +145,13 @@ struct WorkspaceAttentionFlashDecision: Equatable, Sendable {
 
 enum WorkspaceAttentionCoordinator {
     static let notificationRingStyle = WorkspaceAttentionFlashPresentation(
-        accent: .notificationBlue,
+        accent: .projectNotificationGold,
         glowOpacity: 0.35,
         glowRadius: 3
     )
 
     static let flashRingStyle = WorkspaceAttentionFlashPresentation(
-        accent: .notificationBlue,
+        accent: .projectNotificationGold,
         glowOpacity: 0.6,
         glowRadius: 6
     )

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -3920,10 +3920,10 @@ final class TmuxWorkspacePaneOverlayTests: XCTestCase {
         }
     }
 
-    func testFocusFlashUsesNotificationRingColor() {
+    func testFocusFlashUsesProjectNotificationGold() {
         XCTAssertEqual(
             WorkspaceAttentionCoordinator.flashStyle(for: .navigation).accent.strokeColor.hexString(),
-            WorkspaceAttentionCoordinator.notificationRingStyle.accent.strokeColor.hexString()
+            NSColor.systemYellow.hexString()
         )
     }
 


### PR DESCRIPTION
## Summary
- replace the default blue attention accent with macOS system yellow, matching project notifications
- route the browser surface's separate flash renderer through the shared attention color token
- preserve the existing flash timing, geometry, and glow behavior

## Verification
- added a focused runtime assertion for the navigation flash color in the first commit
- kept the regression test and implementation in separate commits so the test is red before the fix and green after it
- `git diff --check`

## Local build limitation
- local `cmux-unit` and tagged reload could not run because this machine has Command Line Tools only and no Xcode installation; CI must perform compilation and test verification

## Localization
- no user-facing strings were added or changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787201894&installation_model_id=21920&pr_number=8553&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8553&signature=a19edc32dbebf6ee47580789bfa2aca783375a0ac2902576b3be001f42fbddce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches focus flash accents from blue to project notification gold to match macOS system yellow and unify attention cues. The browser surface now pulls its flash color from the shared attention token; timing and glow are unchanged.

- **Refactors**
  - Replace `.systemBlue` with `.systemYellow` via `projectNotificationGold` accent.
  - Route `BrowserPanelView` overlay through `WorkspaceAttentionCoordinator.flashStyle(for: .navigation)`.
  - Add a test verifying the navigation flash uses `NSColor.systemYellow`.

<sup>Written for commit 740314946bdd35e55cf898b23c71342b87202d5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigation focus flashes to use the workspace’s configured attention styling.
  * Changed project notification and focus flash accents to a clear system-yellow color for improved visual consistency.

* **Tests**
  * Updated coverage to verify the new system-yellow navigation focus flash color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->