### PR TITLE
remote-tmux: offer a login when a reconnect can't authenticate, instead of retrying forever

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/FileWatcher.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/FileWatcher.swift
@@ -145,6 +145,14 @@ public actor FileWatcher {
 
     /// Stops the watcher, tears down its sources, and finishes ``events``.
     /// Idempotent.
+    /// Whether a source is attached to the nearest existing ancestor directory.
+    ///
+    /// `false` means `open(O_EVTONLY)` failed, which `makeSource` reports by returning nil while
+    /// the watcher carries on. Under permission loss or fd exhaustion the stream then exists with
+    /// nothing behind it and can never yield, so a caller waiting for a path to be *created*
+    /// would wait forever. Callers that must not hang read this and fall back instead.
+    public var isWatchingAncestorDirectory: Bool { directorySource != nil }
+
     public func stop() {
         isStopped = true
         throttleTask?.cancel()

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/FileWatch/FileWatcherTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/FileWatch/FileWatcherTests.swift
@@ -4,6 +4,43 @@ import Testing
 @testable import CmuxFoundation
 
 @Suite struct FileWatcherTests {
+    /// A watcher whose ancestor directory cannot be opened has to say so.
+    ///
+    /// `makeSource` returns nil when `open(O_EVTONLY)` fails and the watcher carries on, so the
+    /// event stream exists with nothing behind it and can never yield. A caller waiting for a
+    /// socket to be *created* would then wait forever, which is why the reconnect path reads this
+    /// and falls back to its own retry loop rather than trusting the watch.
+    /// Root ignores directory permissions, so the denial this test relies on cannot be staged there.
+    @Test(.enabled(if: getuid() != 0)) func watcherReportsAFailedAncestorWatch() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-filewatch-denied-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer {
+            chmod(base.path, 0o755)
+            try? FileManager.default.removeItem(at: base)
+        }
+
+        let watched = base.appendingPathComponent("socket")
+        // 000 makes open(O_EVTONLY) fail with EACCES for a non-root user, which is the observable
+        // stand-in for the fd exhaustion this guard actually exists to survive.
+        #expect(chmod(base.path, 0o000) == 0)
+        let denied = FileWatcher(path: watched.path)
+        defer { Task { await denied.stop() } }
+        #expect(await denied.isWatchingAncestorDirectory == false)
+    }
+
+    /// The positive half, so the property cannot pass by always returning false.
+    @Test func watcherReportsAWorkingAncestorWatch() async throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-filewatch-ok-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let watcher = FileWatcher(path: base.appendingPathComponent("socket").path)
+        defer { Task { await watcher.stop() } }
+        #expect(await watcher.isWatchingAncestorDirectory == true)
+    }
+
     /// Awaits the watcher's first event, bounded so a broken watcher fails the
     /// test instead of hanging CI.
     private func firstEvent(_ watcher: FileWatcher, within seconds: Double) async -> Bool {

--- a/Sources/RemoteTmuxConnectionObservers.swift
+++ b/Sources/RemoteTmuxConnectionObservers.swift
@@ -24,6 +24,7 @@ final class RemoteTmuxConnectionObservers {
     private var reconnectReadyObservers: [Token: () -> Void] = [:]
     private var exitObservers: [Token: () -> Void] = [:]
     private var stateObservers: [Token: (RemoteTmuxControlConnection.ConnectionState) -> Void] = [:]
+    private var authRequiredObservers: [Token: ([String]) -> Bool] = [:]
 
     /// Registers a consumer's callbacks and returns a token to deregister them.
     ///
@@ -55,6 +56,15 @@ final class RemoteTmuxConnectionObservers {
     ///   - onConnectionStateChanged: fires on every connection-state transition
     ///     (e.g. `.connected` → `.reconnecting` on a transport loss), so consumers
     ///     can show a disconnected/reconnecting indicator without tearing down.
+    ///   - onAuthRequired: fires when a RECONNECT attempt failed because the host
+    ///     wants interactive authentication that the pipe-backed reconnect cannot
+    ///     service (a password, MFA, a FIDO touch, host-key confirmation). The
+    ///     payload is the `ssh` argv to run under a controlling tty. Retrying is
+    ///     stopped when this fires, so a consumer MUST either run that argv and
+    ///     call ``RemoteTmuxControlConnection/resumeAfterInteractiveAuth()`` or
+    ///     tear the connection down; otherwise the mirror stays frozen. Return `true`
+    ///     only when a login was actually presented: returning `true` merely for being
+    ///     subscribed suppresses the caller's retry fallback and strands the host.
     /// - Returns: a ``Token`` to pass to ``remove(_:)``.
     func add(
         onPaneOutput: ((_ paneId: Int, _ data: Data) -> Void)?,
@@ -66,7 +76,8 @@ final class RemoteTmuxConnectionObservers {
         onTopologyChanged: (() -> Void)?,
         onReconnectReady: (() -> Void)?,
         onExit: (() -> Void)?,
-        onConnectionStateChanged: ((RemoteTmuxControlConnection.ConnectionState) -> Void)?
+        onConnectionStateChanged: ((RemoteTmuxControlConnection.ConnectionState) -> Void)?,
+        onAuthRequired: ((_ sshArgv: [String]) -> Bool)? = nil
     ) -> Token {
         let token = Token()
         if let onPaneOutput { paneOutputObservers[token] = onPaneOutput }
@@ -79,6 +90,7 @@ final class RemoteTmuxConnectionObservers {
         if let onReconnectReady { reconnectReadyObservers[token] = onReconnectReady }
         if let onExit { exitObservers[token] = onExit }
         if let onConnectionStateChanged { stateObservers[token] = onConnectionStateChanged }
+        if let onAuthRequired { authRequiredObservers[token] = onAuthRequired }
         return token
     }
 
@@ -94,6 +106,10 @@ final class RemoteTmuxConnectionObservers {
         reconnectReadyObservers[token] = nil
         exitObservers[token] = nil
         stateObservers[token] = nil
+        // Leaving this behind would keep `notifyAuthRequired` reporting "handled" to a
+        // detached observer, so the connection would park with nobody able to present a
+        // login instead of falling back to the retry loop.
+        authRequiredObservers[token] = nil
     }
 
     /// Fans `%output` bytes out to every pane-output observer.
@@ -153,5 +169,27 @@ final class RemoteTmuxConnectionObservers {
     /// Notifies every connection-state observer of a transition.
     func notifyStateChanged(_ state: RemoteTmuxControlConnection.ConnectionState) {
         for callback in Array(stateObservers.values) { callback(state) }
+    }
+
+    /// Notifies every auth-required observer that a reconnect needs an interactive
+    /// login, passing the `ssh` argv to run under a controlling tty.
+    ///
+    /// Whether any consumer is listening decides the user-visible outcome: with a
+    /// consumer the user gets a login they can complete, without one the mirror
+    /// simply stays frozen. Either way the retry loop has already stopped, so this
+    /// never degenerates into the silent forever-retry it replaces.
+    /// Offers the login to every observer, and reports whether one actually presented it.
+    ///
+    /// The distinction is the whole point. Reporting "handled" merely because an observer is
+    /// *subscribed* means a consumer that declines — because the user already dismissed this
+    /// host's login — silently suppresses the caller's fallback, leaving the connection
+    /// parked with no retry and no waiter. That is a host stranded until cmux restarts.
+    func notifyAuthRequired(sshArgv: [String]) -> Bool {
+        var presented = false
+        for callback in Array(authRequiredObservers.values) {
+            // Every observer runs: `||` would short-circuit and skip the rest.
+            if callback(sshArgv) { presented = true }
+        }
+        return presented
     }
 }

--- a/Sources/RemoteTmuxConnectionState.swift
+++ b/Sources/RemoteTmuxConnectionState.swift
@@ -161,6 +161,17 @@ struct RemoteTmuxLoginOffers: Sendable, Equatable {
 
     /// Whether `host` has any offer outstanding (claimed or opened).
     func hasOffer(host: String) -> Bool { slots[host] != nil }
+
+    /// The host whose open login is `workspace`, if any.
+    ///
+    /// The close path knows only which workspace the user closed, so resolving it back to a host
+    /// is what lets a closed tab be treated as declining that host's login.
+    func host(forOpenedWorkspace workspace: UUID) -> String? {
+        for (host, slot) in slots {
+            if case .opened(let opened, _) = slot, opened == workspace { return host }
+        }
+        return nil
+    }
 }
 
 enum RemoteTmuxConnectionState: Sendable, Equatable {

--- a/Sources/RemoteTmuxConnectionState.swift
+++ b/Sources/RemoteTmuxConnectionState.swift
@@ -1,3 +1,168 @@
+import Foundation
+
+/// What a failed reconnect attempt means, decided from the attempt's own output.
+///
+/// Extracted as a pure function (``RemoteTmuxReconnectDisposition/classify(stderr:preControlOutput:decoding:)``)
+/// because the three-way decision is the whole behavior worth testing: driving it
+/// through a real `Process` would test ssh, not the decision.
+enum RemoteTmuxReconnectDisposition: Sendable, Equatable {
+    /// The session or server is gone. The connection ends and observers see `%exit`.
+    case sessionGone
+    /// The host wants interactive authentication. A pipe-backed reconnect runs
+    /// `BatchMode=yes` with no controlling tty, so NO number of retries can satisfy a
+    /// password / MFA / security-key touch: retrying is futile and freezes the mirror
+    /// with nothing on screen to explain why. The user is handed a login instead.
+    ///
+    /// This also covers a `ProxyCommand` that closes the transport silently under
+    /// BatchMode, which is the same situation without an explicit auth error string.
+    case authRequired
+    /// Anything else (unreachable, refused, a dropped hop). Retry with backoff.
+    case transient
+
+    /// Classifies a failed reconnect attempt.
+    ///
+    /// Order matters: a gone session wins over an auth failure, because a host can
+    /// report both (the session vanished *and* the re-attach could not authenticate)
+    /// and ending is the correct, non-recoverable outcome.
+    static func classify(
+        stderr: String,
+        preControlOutput: String,
+        decoding: RemoteTmuxControlMessageDecoding = RemoteTmuxControlMessageDecoding()
+    ) -> RemoteTmuxReconnectDisposition {
+        if decoding.stderrIndicatesSessionGone(stderr)
+            || decoding.controlOutputIndicatesSessionGone(preControlOutput) {
+            return .sessionGone
+        }
+        if RemoteTmuxSSHTransport.indicatesInteractiveRetryWillHelp(stderr) {
+            return .authRequired
+        }
+        return .transient
+    }
+}
+
+/// Bookkeeping for "at most one login workspace per host", extracted so the rule is a
+/// testable object rather than a convention spread across a callback and a wait loop.
+///
+/// Two things went wrong when this was an ad-hoc dictionary, and both are encoded here:
+///
+/// - The slot has to be reserved *before* the workspace is created. Creating a workspace
+///   is not instantaneous, and several sessions on one host report auth-required in the
+///   same turn; with the record written afterwards, every one of them passed the "is a
+///   login already open?" check and opened its own tab.
+/// - A *resume attempt* must not release the slot. A resume can fail authentication all
+///   over again, and releasing on the attempt meant each failure opened another tab. The
+///   slot is released only when the connection actually reaches `.connected`, when the
+///   workspace is gone, or when creating it failed.
+struct RemoteTmuxLoginOffers: Sendable, Equatable {
+    /// Why a caller should or should not open a login workspace.
+    enum Decision: Sendable, Equatable {
+        /// This caller owns the slot for `generation` and must open the workspace, then
+        /// call ``recordOpened(host:workspace:generation:)`` or ``abandon(host:generation:)``.
+        case present(Generation)
+        /// Another caller is opening one, or an open one is still on screen.
+        case alreadyOffered
+        /// The user dismissed the offer for this outage, so do not open another.
+        case declined
+    }
+
+    /// Identifies one offer. A waiter carries the generation it started for, so a waiter
+    /// that suspends across an `await` cannot release an offer that has since been
+    /// replaced by a newer one.
+    struct Generation: Sendable, Equatable {
+        fileprivate let value: UInt64
+    }
+
+    private enum Slot: Equatable {
+        /// Reserved by a caller that has not finished creating the workspace yet.
+        case claimed(Generation)
+        /// A workspace that exists (until `isOpen` says otherwise).
+        case opened(UUID, Generation)
+        /// The user closed the login without signing in. No further login is offered for
+        /// this outage; the connection keeps retrying quietly and a reconnect clears this.
+        case declined(Generation)
+
+        var generation: Generation {
+            switch self {
+            case .claimed(let g), .opened(_, let g), .declined(let g): return g
+            }
+        }
+    }
+
+    private var slots: [String: Slot] = [:]
+    private var nextGeneration: UInt64 = 0
+
+    init() {}
+
+    /// Reserves the right to present a login for `host`, or reports that one is already
+    /// offered. `isOpen` answers whether a previously opened workspace still exists, so a
+    /// dismissed login does not suppress the next offer forever.
+    mutating func claim(host: String, isOpen: (UUID) -> Bool) -> Decision {
+        switch slots[host] {
+        case .claimed:
+            return .alreadyOffered
+        case .declined:
+            // The user said no. Re-offering here is what made the close button useless: the
+            // tab reappeared immediately because the retry that followed failed the same way.
+            return .declined
+        case .opened(let workspace, _) where isOpen(workspace):
+            return .alreadyOffered
+        case .opened, nil:
+            nextGeneration += 1
+            let generation = Generation(value: nextGeneration)
+            slots[host] = .claimed(generation)
+            return .present(generation)
+        }
+    }
+
+    /// Records the workspace a successful ``claim(host:isOpen:)`` opened. Ignored if a newer
+    /// offer has replaced this one.
+    mutating func recordOpened(host: String, workspace: UUID, generation: Generation) {
+        guard slots[host]?.generation == generation else { return }
+        slots[host] = .opened(workspace, generation)
+    }
+
+    /// Releases an offer this caller still owns. A stale caller is ignored, so a waiter
+    /// that suspended across an `await` cannot discard a newer offer.
+    mutating func abandon(host: String, generation: Generation) {
+        guard slots[host]?.generation == generation else { return }
+        slots[host] = nil
+    }
+
+    /// Records that the user closed the login without signing in.
+    ///
+    /// The connection still goes back to retrying, so a host that starts accepting
+    /// authentication again recovers on its own. What stops is the *offering*: without this
+    /// the retry fails the same way, a fresh login opens, and the close button appears not
+    /// to work. A successful reconnect clears it, so the next real outage offers again.
+    mutating func noteDeclined(host: String, generation: Generation) {
+        guard slots[host]?.generation == generation else { return }
+        slots[host] = .declined(generation)
+    }
+
+    /// Whether the user has dismissed this host's login for the current outage.
+    func isDeclined(host: String) -> Bool {
+        if case .declined = slots[host] { return true }
+        return false
+    }
+
+    /// Releases the slot because the host is connected again, so the next outage starts
+    /// from a clean state.
+    mutating func noteConnected(host: String) {
+        slots[host] = nil
+    }
+
+    /// The workspace currently offered for `host`, with the generation that owns it.
+    func openedWorkspace(host: String) -> (workspace: UUID, generation: Generation)? {
+        if case .opened(let workspace, let generation) = slots[host] {
+            return (workspace, generation)
+        }
+        return nil
+    }
+
+    /// Whether `host` has any offer outstanding (claimed or opened).
+    func hasOffer(host: String) -> Bool { slots[host] != nil }
+}
+
 enum RemoteTmuxConnectionState: Sendable, Equatable {
     /// The initial connection is being established before the first control-mode
     /// `%enter`.

--- a/Sources/RemoteTmuxControlConnection+Observation.swift
+++ b/Sources/RemoteTmuxControlConnection+Observation.swift
@@ -55,6 +55,10 @@ extension RemoteTmuxControlConnection {
     ///   - onConnectionStateChanged: fires on every ``ConnectionState`` transition
     ///     (e.g. `.connected` → `.reconnecting` on a transport loss), so consumers
     ///     can show a disconnected/reconnecting indicator without tearing down.
+    ///   - onAuthRequired: fires when a RECONNECT failed because the host wants
+    ///     interactive authentication the pipe-backed reconnect cannot service.
+    ///     Retrying stops when it fires; the consumer runs the supplied `ssh` argv
+    ///     under a tty and then calls ``resumeAfterInteractiveAuth()``.
     @discardableResult
     func addObserver(
         onPaneOutput: ((_ paneId: Int, _ data: Data) -> Void)? = nil,
@@ -66,7 +70,8 @@ extension RemoteTmuxControlConnection {
         onTopologyChanged: (() -> Void)? = nil,
         onReconnectReady: (() -> Void)? = nil,
         onExit: (() -> Void)? = nil,
-        onConnectionStateChanged: ((ConnectionState) -> Void)? = nil
+        onConnectionStateChanged: ((ConnectionState) -> Void)? = nil,
+        onAuthRequired: ((_ sshArgv: [String]) -> Bool)? = nil
     ) -> ObserverToken {
         observers.add(
             onPaneOutput: onPaneOutput,
@@ -78,7 +83,8 @@ extension RemoteTmuxControlConnection {
             onTopologyChanged: onTopologyChanged,
             onReconnectReady: onReconnectReady,
             onExit: onExit,
-            onConnectionStateChanged: onConnectionStateChanged
+            onConnectionStateChanged: onConnectionStateChanged,
+            onAuthRequired: onAuthRequired
         )
     }
 

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -153,6 +153,11 @@ final class RemoteTmuxControlConnection {
     /// Number of reconnect attempts since the last successful connect, driving the
     /// capped exponential backoff. Reset to 0 on a successful connect.
     private var reconnectAttemptCount = 0
+    /// Set when a reconnect stopped because the host wants interactive authentication
+    /// and a consumer was told. No retry is scheduled while this is true: the mirror is
+    /// deliberately parked (frozen, not ended) until ``resumeAfterInteractiveAuth()``
+    /// or ``stop()``.
+    private var awaitingInteractiveAuth = false
     /// stderr text captured for the in-flight spawn, inspected when a reconnect
     /// attempt's process exits to tell "session genuinely gone" from "host still
     /// unreachable". Reset at the start of each spawn.
@@ -512,6 +517,7 @@ final class RemoteTmuxControlConnection {
         // `%exit` or a session found gone on reconnect) notifies exit observers — so
         // detach / quit / window-close (preserve) and transport drops do not.
         connectionState = .ended
+        awaitingInteractiveAuth = false
         cancelScheduledWork()
         teardownProcessHandles()
     }
@@ -689,17 +695,43 @@ final class RemoteTmuxControlConnection {
             // stop or stderr overflow aborting this reconnect attempt).
             guard generation == processGeneration,
                   connectionState == .reconnecting else { return }
-            // Classify: a session/server found gone is a genuine end; anything else
-            // (host unreachable, refused) is transient — keep retrying with backoff.
-            let sessionGone = decoding.stderrIndicatesSessionGone(stderrBuffer)
-                || decoding.controlOutputIndicatesSessionGone(preControlOutputBuffer)
+            // Classify into three outcomes, not two. A session/server found gone is a
+            // genuine end. A host asking for interactive authentication is NOT
+            // transient: the reconnect runs `BatchMode=yes` on pipes with no tty, so
+            // no number of retries can ever satisfy a password / MFA / FIDO touch —
+            // retrying forever leaves the mirror frozen with nothing on screen to
+            // explain why. Everything else (unreachable, refused) stays transient.
+            let disposition = RemoteTmuxReconnectDisposition.classify(
+                stderr: stderrBuffer,
+                preControlOutput: preControlOutputBuffer,
+                decoding: decoding
+            )
             teardownProcessHandles()
-            if sessionGone {
+            if disposition == .sessionGone {
                 record("reconnect-session-gone")
                 connectionState = .ended
                 reconnectTask?.cancel()
                 reconnectTask = nil
                 observers.notifyExit()
+            } else if disposition == .authRequired {
+                // Stop the pointless retry loop and hand the user a login. The state
+                // stays `.reconnecting` (the mirror is frozen, not dead) so the
+                // session and every mirrored workspace survive the outage; a consumer
+                // runs the argv under a tty and calls `resumeAfterInteractiveAuth()`.
+                record("reconnect-auth-required")
+                reconnectTask?.cancel()
+                reconnectTask = nil
+                awaitingInteractiveAuth = true
+                let handled = observers.notifyAuthRequired(sshArgv: host.interactiveAuthInvocation())
+                if !handled {
+                    // Nobody is listening, so no login can arrive. Falling back to the
+                    // backoff loop is strictly better than freezing forever: the host
+                    // may become reachable without auth (a warm ControlMaster opened
+                    // elsewhere), and the retry keeps that recovery possible.
+                    record("reconnect-auth-required-unhandled")
+                    awaitingInteractiveAuth = false
+                    scheduleReconnectAttempt()
+                }
             } else {
                 scheduleReconnectAttempt()
             }
@@ -728,7 +760,24 @@ final class RemoteTmuxControlConnection {
         pendingPostAttachAction = nil
         teardownProcessHandles()
         reconnectAttemptCount = 0
+        awaitingInteractiveAuth = false
         connectionState = .reconnecting
+        scheduleReconnectAttempt()
+    }
+
+    /// Resumes reconnecting after the user completed an interactive login.
+    ///
+    /// Call this once the argv handed to `onAuthRequired` has exited successfully, so
+    /// the shared ControlMaster is open and a pipe-backed re-attach can now
+    /// authenticate over it. Retries start immediately (no backoff wait): the reason
+    /// the previous attempt failed is gone, so making the user wait out a stale
+    /// backoff would only look broken. Idempotent, and a no-op unless the connection
+    /// is actually parked, so a duplicate callback cannot spawn a second retry chain.
+    func resumeAfterInteractiveAuth() {
+        guard awaitingInteractiveAuth, connectionState == .reconnecting else { return }
+        record("resume-after-interactive-auth")
+        awaitingInteractiveAuth = false
+        reconnectAttemptCount = 0
         scheduleReconnectAttempt()
     }
 

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -227,7 +227,7 @@ extension RemoteTmuxController {
     @discardableResult
     func presentReconnectAuthentication(host: RemoteTmuxHost, sshArgv: [String]) -> Bool {
         guard !sshArgv.isEmpty else {
-            Self.logger.error("reconnect-auth: empty sshArgv for \(host.destination, privacy: .public)")
+            Self.logger.error("reconnect-auth: empty sshArgv for \(host.connectionHash, privacy: .public)")
             return false
         }
         let key = host.connectionHash
@@ -243,7 +243,7 @@ extension RemoteTmuxController {
                 .map(\.connection.connectionState)
         ) {
             Self.logger.info(
-                "reconnect-auth: \(host.destination, privacy: .public) already has a live connection; not offering")
+                "reconnect-auth: \(host.connectionHash, privacy: .public) already has a live connection; not offering")
             return false
         }
         // Reserve the slot BEFORE creating anything. Several sessions on one host report
@@ -256,10 +256,10 @@ extension RemoteTmuxController {
                 // Report NOT presented, so the caller keeps retrying quietly. Claiming
                 // otherwise is what stranded the host after a dismissal.
                 Self.logger.info(
-                    "reconnect-auth: login dismissed for \(host.destination, privacy: .public); not re-offering")
+                    "reconnect-auth: login dismissed for \(host.connectionHash, privacy: .public); not re-offering")
                 return false
             }
-            Self.logger.info("reconnect-auth: login already offered for \(host.destination, privacy: .public)")
+            Self.logger.info("reconnect-auth: login already offered for \(host.connectionHash, privacy: .public)")
             ensureAuthenticationWait(host: host)
             return true
         }
@@ -281,7 +281,7 @@ extension RemoteTmuxController {
             controller.v2WorkspaceCreate(params: params)
         }
         Self.logger.info(
-            "reconnect-auth: login workspace for \(host.destination, privacy: .public): \(String(describing: result), privacy: .public)")
+            "reconnect-auth: login workspace for \(host.connectionHash, privacy: .public): \(String(describing: result), privacy: .public)")
         guard case .ok(let payload) = result,
               let workspaceId = (payload as? [String: Any])?["workspace_id"] as? String,
               let loginWorkspace = UUID(uuidString: workspaceId) else {
@@ -292,7 +292,7 @@ extension RemoteTmuxController {
             // loop instead: it is rate-limited by backoff, and a later attempt can offer
             // the login again.
             Self.logger.error(
-                "reconnect-auth: no login workspace for \(host.destination, privacy: .public); resuming retries")
+                "reconnect-auth: no login workspace for \(host.connectionHash, privacy: .public); resuming retries")
             loginOffers.abandon(host: key, generation: generation)
             resumeReconnectAfterAuthentication(host: host)
             return false
@@ -320,11 +320,15 @@ extension RemoteTmuxController {
     func noteMirrorConnected(host: RemoteTmuxHost) {
         let key = host.connectionHash
         if loginOffers.hasOffer(host: key) {
-            Self.logger.info("reconnect-auth: \(host.destination, privacy: .public) reconnected; offer released")
-            if let offer = loginOffers.openedWorkspace(host: key) {
-                closeLoginWorkspace(offer.workspace)
-            }
+            Self.logger.info("reconnect-auth: \(host.connectionHash, privacy: .public) reconnected; offer released")
+            // Clear the offer BEFORE closing the workspace. `TabManager.closeWorkspace` reports
+            // every login workspace to `noteLoginWorkspaceClosed`, which cannot tell cmux's own
+            // close from the user's: with the offer still present it takes the decline path on a
+            // successful reconnect and logs a dismissal that never happened. Clearing first makes
+            // that re-entry inert instead of relying on the call below to undo it.
+            let offer = loginOffers.openedWorkspace(host: key)
             loginOffers.noteConnected(host: key)
+            if let offer { closeLoginWorkspace(offer.workspace) }
         }
         // The host is authenticated, so any waiter for it has nothing left to wait on. Its
         // guards would end it on the next tick anyway; cancelling means it stops now rather
@@ -348,9 +352,12 @@ extension RemoteTmuxController {
         let key = host.connectionHash
         guard loginOffers.hasOffer(host: key) else { return }
         guard !sessionMirrors.values.contains(where: { $0.host.connectionHash == key }) else { return }
+        // Release before closing, for the same reason as `noteMirrorConnected`: the close path
+        // re-enters `noteLoginWorkspaceClosed`, and an offer still present sends it down the
+        // decline path for a workspace cmux is retiring itself.
         if let offer = loginOffers.openedWorkspace(host: key) {
-            closeLoginWorkspace(offer.workspace)
             loginOffers.abandon(host: key, generation: offer.generation)
+            closeLoginWorkspace(offer.workspace)
         } else {
             loginOffers.noteConnected(host: key)
         }
@@ -490,29 +497,20 @@ extension RemoteTmuxController {
             // reports unrelated churn too (other hosts' masters live in the same directory).
             let watcher = FileWatcher(path: host.controlSocketPath)
             defer { Task { await watcher.stop() } }
-            // A backstop behind the edge, not instead of it. `FileWatcher` returns nil from its
-            // `open(O_EVTONLY)` and carries on, so under fd exhaustion (EMFILE) the stream exists
-            // with no sources attached and can never yield — the login would complete and this
-            // wait would never hear about it. That is a silent, total failure of the edge, so it
-            // gets a slow re-check rather than trust.
-            //
-            // Deliberately slow: this is a safety net for a rare failure, and every tick it takes
-            // to notice is dead time only in the case where the edge is already broken. If this is
-            // what resumes a mirror, something is wrong that a shorter interval would only hide.
-            let backstop = Task { @MainActor [weak self] in
-                while !Task.isCancelled {
-                    try? await Task.sleep(for: .seconds(30))
-                    if Task.isCancelled { return }
-                    guard let self, self.loginOffers.hasOffer(host: key) else { return }
-                    if await transport.isMasterLive() {
-                        Self.logger.warning(
-                            "reconnect-auth: master found by the backstop, not the watcher — the socket watch did not fire")
-                        self.resumeReconnectAfterAuthentication(host: host)
-                        return
-                    }
-                }
+            // The edge has to actually exist. `FileWatcher` returns nil from a failed
+            // `open(O_EVTONLY)` and carries on, so under permission loss or fd exhaustion (EMFILE)
+            // the stream exists with no source behind it and can never yield — the login would
+            // complete and this wait would never hear about it. Ask the watcher instead of putting
+            // a timer behind it: on a failed watch, hand the host back to the connection's own
+            // bounded backoff, which already owns retrying, and a later failure offers the login
+            // again with a fresh watch attempt. The login pane stays up either way, so the user can
+            // still finish signing in.
+            guard await watcher.isWatchingAncestorDirectory else {
+                Self.logger.error(
+                    "reconnect-auth: could not watch the control socket path; falling back to reconnect retries")
+                self?.resumeReconnectAfterAuthentication(host: host)
+                return
             }
-            defer { backstop.cancel() }
             // The master may already be live: the user can finish signing in between the failure
             // that parked this connection and this waiter starting, and an edge that already
             // happened is never delivered. Checking once up front is what stops an event-driven
@@ -563,7 +561,7 @@ extension RemoteTmuxController {
             return
         }
         Self.logger.info(
-            "reconnect-auth: login dismissed for \(host.destination, privacy: .public); retrying quietly")
+            "reconnect-auth: login dismissed for \(host.connectionHash, privacy: .public); retrying quietly")
         loginOffers.noteDeclined(host: key, generation: offer.generation)
         cancelAuthWait(host: key)
         resumeReconnectAfterAuthentication(host: host)

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -430,10 +430,20 @@ extension RemoteTmuxController {
         let transport = transport(for: host)
         hostsWaitingForAuth.insert(key)
         authWaitTasks[key]?.cancel()
+        // A waiter must only retract its own registration. Cancelling W1 and storing W2 runs W1's
+        // `defer` afterwards, and an unconditional clear there would delete W2's entry — leaving a
+        // live waiter invisible to both dismissal and teardown, which is worse than the stale
+        // waiter this replacement was meant to fix.
+        authWaitGeneration &+= 1
+        let waiterId = authWaitGeneration
+        authWaitIds[key] = waiterId
         authWaitTasks[key] = Task { @MainActor [weak self] in
             defer {
-                self?.hostsWaitingForAuth.remove(key)
-                self?.authWaitTasks[key] = nil
+                if self?.authWaitIds[key] == waiterId {
+                    self?.hostsWaitingForAuth.remove(key)
+                    self?.authWaitTasks[key] = nil
+                    self?.authWaitIds[key] = nil
+                }
             }
             // Edge-driven, not polled. Completing the login is the user opening the shared ssh
             // master, and opening it creates the socket at cmux's own ControlPath — so the
@@ -451,6 +461,29 @@ extension RemoteTmuxController {
             // reports unrelated churn too (other hosts' masters live in the same directory).
             let watcher = FileWatcher(path: host.controlSocketPath)
             defer { Task { await watcher.stop() } }
+            // A backstop behind the edge, not instead of it. `FileWatcher` returns nil from its
+            // `open(O_EVTONLY)` and carries on, so under fd exhaustion (EMFILE) the stream exists
+            // with no sources attached and can never yield — the login would complete and this
+            // wait would never hear about it. That is a silent, total failure of the edge, so it
+            // gets a slow re-check rather than trust.
+            //
+            // Deliberately slow: this is a safety net for a rare failure, and every tick it takes
+            // to notice is dead time only in the case where the edge is already broken. If this is
+            // what resumes a mirror, something is wrong that a shorter interval would only hide.
+            let backstop = Task { @MainActor [weak self] in
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(30))
+                    if Task.isCancelled { return }
+                    guard let self, self.loginOffers.hasOffer(host: key) else { return }
+                    if await transport.isMasterLive() {
+                        Self.logger.warning(
+                            "reconnect-auth: master found by the backstop, not the watcher — the socket watch did not fire")
+                        self.resumeReconnectAfterAuthentication(host: host)
+                        return
+                    }
+                }
+            }
+            defer { backstop.cancel() }
             // The master may already be live: the user can finish signing in between the failure
             // that parked this connection and this waiter starting, and an edge that already
             // happened is never delivered. Checking once up front is what stops an event-driven

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -202,4 +202,311 @@ extension RemoteTmuxController {
         tabManager.selectWorkspace(workspace)
     }
 
+    /// Surfaces an interactive login for a mirror whose reconnect needs authentication.
+    ///
+    /// A reconnect runs on pipes with `BatchMode=yes` and no controlling tty, so a host
+    /// that wants a password, MFA, or a security-key touch can never be satisfied by
+    /// retrying. The connection stays parked in `.reconnecting`, which keeps the tmux
+    /// session and every mirrored workspace intact, and this hands the user a real
+    /// terminal to authenticate in.
+    ///
+    /// `sshArgv` is ``RemoteTmuxHost/interactiveAuthInvocation()``: under a tty it
+    /// authenticates, opens the shared ControlMaster, runs a trivial remote `true`, and
+    /// exits. Once the master is live the parked reconnect multiplexes over it with no
+    /// further prompt. This is the same invocation the `cmux ssh-tmux` CLI runs when the
+    /// initial attach reports ``RemoteTmuxAttachOutcome/authRequired(sshArgv:)``; a
+    /// reconnect has no CLI in the loop, so cmux runs it in a workspace instead.
+    ///
+    /// Idempotent per host: a host with several mirrored sessions loses one control
+    /// stream per session, and each would otherwise open its own login terminal racing
+    /// for the same master. The first caller wins and later ones fold into it.
+    /// - Returns: whether a login was actually put in front of the user. `false` means the
+    ///   caller must fall back to retrying; treating "an observer exists" as handled is what
+    ///   left a dismissed host parked with no retry and no waiter.
+    @discardableResult
+    func presentReconnectAuthentication(host: RemoteTmuxHost, sshArgv: [String]) -> Bool {
+        guard !sshArgv.isEmpty else {
+            Self.logger.error("reconnect-auth: empty sshArgv for \(host.destination, privacy: .public)")
+            return false
+        }
+        let key = host.connectionHash
+        // A live connection to this host proves authentication is not the blocker, so asking
+        // again is wrong. This is the straggler case: several sessions park, the user signs
+        // in, the first to reconnect releases the offer, and a sibling still finishing its
+        // pre-login attempt then reports auth-required into an empty slot — producing a
+        // second login moments after a successful sign-in. Checked synchronously, before the
+        // claim, so the reserve-before-create ordering is untouched.
+        if Self.hasLiveConnection(
+            states: sessionMirrors.values
+                .filter { $0.host.connectionHash == key }
+                .map(\.connection.connectionState)
+        ) {
+            Self.logger.info(
+                "reconnect-auth: \(host.destination, privacy: .public) already has a live connection; not offering")
+            return false
+        }
+        // Reserve the slot BEFORE creating anything. Several sessions on one host report
+        // auth-required in the same turn, and creating a workspace is not instantaneous;
+        // recording afterwards let all of them through and opened a tab each.
+        guard case .present(let generation) = loginOffers.claim(
+            host: key, isOpen: { Self.workspaceExists($0) }
+        ) else {
+            if loginOffers.isDeclined(host: key) {
+                // Report NOT presented, so the caller keeps retrying quietly. Claiming
+                // otherwise is what stranded the host after a dismissal.
+                Self.logger.info(
+                    "reconnect-auth: login dismissed for \(host.destination, privacy: .public); not re-offering")
+                return false
+            }
+            Self.logger.info("reconnect-auth: login already offered for \(host.destination, privacy: .public)")
+            ensureAuthenticationWait(host: host)
+            return true
+        }
+        let params = Self.reconnectAuthWorkspaceParams(host: host, sshArgv: sshArgv)
+        // Go through `v2WorkspaceCreate`, the entry point the `workspace.create` socket
+        // command uses, so the login workspace is created the same way as any other:
+        // tab-manager resolution, window placement, and metadata refresh all included.
+        // `addWorkspace` alone registers the workspace without surfacing it in a window.
+        //
+        // The policy wrapper is required, not decorative. `focus` is honored only while a
+        // `workspace.create` allowance is on the calling thread's stack, which the socket
+        // dispatcher pushes for real socket commands. Calling straight through from here
+        // would create the login workspace unfocused and unselected — visible nowhere
+        // until the user goes looking for it.
+        let controller = TerminalController.shared
+        let result = controller.withSocketCommandPolicy(
+            commandKey: "workspace.create", isV2: true, params: params
+        ) {
+            controller.v2WorkspaceCreate(params: params)
+        }
+        Self.logger.info(
+            "reconnect-auth: login workspace for \(host.destination, privacy: .public): \(String(describing: result), privacy: .public)")
+        guard case .ok(let payload) = result,
+              let workspaceId = (payload as? [String: Any])?["workspace_id"] as? String,
+              let loginWorkspace = UUID(uuidString: workspaceId) else {
+            // No login terminal exists, so nothing will ever arrive to unblock the mirror.
+            // The connection is parked with its retry cancelled and the observer already
+            // reported the event as handled, so leaving now would freeze the mirror for
+            // good — the exact failure this feature removes. Hand it back to the retry
+            // loop instead: it is rate-limited by backoff, and a later attempt can offer
+            // the login again.
+            Self.logger.error(
+                "reconnect-auth: no login workspace for \(host.destination, privacy: .public); resuming retries")
+            loginOffers.abandon(host: key, generation: generation)
+            resumeReconnectAfterAuthentication(host: host)
+            return false
+        }
+        // Mark it so a relaunch does not restore a dead copy: a restored terminal is a fresh
+        // shell that cannot authenticate, and it would be invisible to the per-host rule.
+        if let manager = AppDelegate.shared?.tabManagerFor(tabId: loginWorkspace),
+           let tab = manager.tabs.first(where: { $0.id == loginWorkspace }) {
+            tab.isRemoteTmuxAuthLogin = true
+        }
+        loginOffers.recordOpened(host: key, workspace: loginWorkspace, generation: generation)
+        awaitAuthenticationThenResume(host: host)
+        return true
+    }
+
+    /// Releases a host's login offer because a mirror is connected again, and closes the
+    /// login workspace cmux opened for it.
+    ///
+    /// Closing is what keeps a flapping host from collecting tabs. The alternative —
+    /// releasing the slot but leaving the pane — means the next drop cannot see the pane
+    /// that is already on screen and opens another, once per flap. cmux opened this
+    /// workspace by itself for one purpose, and the reconnect proves that purpose is
+    /// served, so cmux is the right owner to close it. A login the *user* dismissed is a
+    /// different case and is already handled by the wait loop.
+    func noteMirrorConnected(host: RemoteTmuxHost) {
+        let key = host.connectionHash
+        if loginOffers.hasOffer(host: key) {
+            Self.logger.info("reconnect-auth: \(host.destination, privacy: .public) reconnected; offer released")
+            if let offer = loginOffers.openedWorkspace(host: key) {
+                closeLoginWorkspace(offer.workspace)
+            }
+            loginOffers.noteConnected(host: key)
+        }
+        // One mirror connecting proves the master is authenticated, and the host's other
+        // parked connections are waiting on exactly that. Releasing the offer without
+        // resuming them leaves those mirrors frozen with their waiter already gone, since
+        // the waiter exits once the offer disappears.
+        resumeReconnectAfterAuthentication(host: host)
+    }
+
+    /// Closes a login workspace wherever it lives, if it still exists.
+    private func closeLoginWorkspace(_ workspace: UUID) {
+        guard let manager = AppDelegate.shared?.tabManagerFor(tabId: workspace),
+              let tab = manager.tabs.first(where: { $0.id == workspace }) else { return }
+        manager.closeWorkspace(tab, recordHistory: false)
+    }
+
+    /// Whether any of a host's connections is live, meaning authentication is not the
+    /// blocker and a login must not be offered.
+    ///
+    /// Only `.connected` counts. `.reconnecting` is precisely the parked state a login exists
+    /// for, and `.connecting` has not proven anything yet — treating either as live would
+    /// suppress the offer the user needs.
+    nonisolated static func hasLiveConnection(states: [RemoteTmuxConnectionState]) -> Bool {
+        states.contains(.connected)
+    }
+
+    /// Whether a workspace still exists in any window.
+    static func workspaceExists(_ workspace: UUID) -> Bool {
+        AppDelegate.shared?.tabManagerFor(tabId: workspace) != nil
+    }
+
+    /// Starts the wait for authentication unless one is already running for this host, so
+    /// a repeat auth-required that folds into an existing offer still gets resumed.
+    private func ensureAuthenticationWait(host: RemoteTmuxHost) {
+        guard !hostsWaitingForAuth.contains(host.connectionHash) else { return }
+        awaitAuthenticationThenResume(host: host)
+    }
+
+    /// The `workspace.create` parameters for a host's login workspace.
+    ///
+    /// Separate and `nonisolated` so a test can assert these params actually earn a focus
+    /// allowance: `focus` is only honored for methods in
+    /// ``TerminalController/explicitFocusParamV2Methods``, so dropping or renaming the key
+    /// would silently produce an unfocused login workspace.
+    nonisolated static func reconnectAuthWorkspaceParams(
+        host: RemoteTmuxHost, sshArgv: [String]
+    ) -> [String: Any] {
+        [
+            "title": String(
+                format: String(
+                    localized: "remoteTmux.reconnectAuth.workspaceTitle",
+                    defaultValue: "Sign in to %@"
+                ),
+                host.destination
+            ),
+            "initial_command": interactiveAuthShellCommand(sshArgv: sshArgv),
+            "focus": true,
+            "eager_load_terminal": true,
+        ]
+    }
+
+    /// Waits for the login terminal to open the shared master, then resumes.
+    ///
+    /// The probe is `ssh -O check` (``RemoteTmuxSSHTransport/isMasterLive()``): local,
+    /// instant, and unable to prompt, so asking repeatedly costs nothing and can never
+    /// consume an authentication attempt while the user is mid-login.
+    ///
+    /// This waits on a *person*, so there is no event to subscribe to and no honest
+    /// deadline: an MFA push or a hardware-key touch can take seconds or many minutes,
+    /// and a wait that expires while the login terminal is still open would strand the
+    /// mirror — parked, with retrying stopped and nothing left to resume it.
+    ///
+    /// So the wait ends on state rather than on a clock, and every ending is derived by
+    /// looking at what exists rather than by trusting some teardown path to signal:
+    ///
+    /// - the master comes up, so the mirror resumes;
+    /// - the host has no mirror left (workspace closed, host detached, app quitting), so
+    ///   there is nothing to authenticate for;
+    /// - the user closed the login without finishing it, so nothing will arrive — the
+    ///   connection goes back to retrying, and a later failure offers a fresh login. Left
+    ///   parked instead, that host would have no route back short of restarting cmux.
+    ///
+    /// The interval backs off because a person is slow and each probe forks an `ssh`.
+    private func awaitAuthenticationThenResume(host: RemoteTmuxHost) {
+        let key = host.connectionHash
+        let transport = transport(for: host)
+        hostsWaitingForAuth.insert(key)
+        Task { @MainActor [weak self] in
+            defer { self?.hostsWaitingForAuth.remove(key) }
+            var interval: Duration = .seconds(2)
+            let maxInterval: Duration = .seconds(15)
+            while true {
+                do {
+                    try await Task.sleep(for: interval)
+                } catch {
+                    return  // Cancelled (app teardown); the connection stays parked.
+                }
+                interval = min(interval * 2, maxInterval)
+                guard let self else { return }
+                // Another path already gave up on this host, or replaced this offer with a
+                // newer one that its own waiter owns.
+                guard let offer = loginOffers.openedWorkspace(host: key) else { return }
+                guard sessionMirrors.values.contains(where: { $0.host.connectionHash == key })
+                else {
+                    // The mirror this login existed for is gone; leaving the pane behind
+                    // would strand a tab nothing can ever close.
+                    closeLoginWorkspace(offer.workspace)
+                    loginOffers.abandon(host: key, generation: offer.generation)
+                    return
+                }
+                if await transport.isMasterLive() {
+                    self.resumeReconnectAfterAuthentication(host: host)
+                    return
+                }
+                if !Self.workspaceExists(offer.workspace) {
+                    // The user closed it without signing in. Keep retrying so a host that
+                    // starts accepting authentication recovers on its own, but stop offering
+                    // for this outage — otherwise the retry fails the same way, a new login
+                    // opens, and closing the tab looks like it does nothing.
+                    Self.logger.info(
+                        "reconnect-auth: login dismissed for \(host.destination, privacy: .public); retrying quietly")
+                    loginOffers.noteDeclined(host: key, generation: offer.generation)
+                    self.resumeReconnectAfterAuthentication(host: host)
+                    return
+                }
+            }
+        }
+    }
+
+    /// Resumes every parked control connection for `host` after authentication.
+    ///
+    /// Per host, not per session: one authenticated ControlMaster unblocks every session
+    /// mirrored from that host. Each connection's `resumeAfterInteractiveAuth()` is a
+    /// no-op unless it is actually parked, so this cannot disturb a healthy stream.
+    func resumeReconnectAfterAuthentication(host: RemoteTmuxHost) {
+        let key = host.connectionHash
+        // Deliberately no release here. A resume is an *attempt*; it can fail
+        // authentication again, and releasing on the attempt opened a new login tab per
+        // failure. ``noteMirrorConnected(host:)`` releases it once the host is actually back.
+        for mirror in sessionMirrors.values where mirror.host.connectionHash == key {
+            mirror.connection.resumeAfterInteractiveAuth()
+        }
+    }
+
+    /// The command the login terminal runs.
+    ///
+    /// Every argv element is single-quoted, so a destination carrying shell
+    /// metacharacters cannot inject anything.
+    ///
+    /// The whole payload is handed to an explicit `/bin/sh -c`, which is load-bearing
+    /// rather than stylistic. A terminal command runs as
+    /// `bash --noprofile --norc -c "exec -l <command>"`, and that `exec -l` replaces the
+    /// shell with the command's *first* program — so with the ssh invocation written at
+    /// the top level, everything after it (the result message, and the interactive shell
+    /// that keeps the pane alive) is unreachable. The pane would then die the instant ssh
+    /// exits, on success and on failure alike, and cmux closes a workspace whose child
+    /// exited: the login tab appears and vanishes in well under a second, taking the
+    /// reason with it. Wrapping means `exec -l` replaces bash with `sh`, which then runs
+    /// the payload to completion.
+    ///
+    /// Falling into an interactive shell at the end also leaves the user somewhere to
+    /// read the message and retry from.
+    nonisolated static func interactiveAuthShellCommand(sshArgv: [String]) -> String {
+        let quoted = sshArgv.map { RemoteTmuxHost.shellSingleQuoted($0) }.joined(separator: " ")
+        let ok = RemoteTmuxHost.shellSingleQuoted(String(
+            localized: "remoteTmux.reconnectAuth.success",
+            defaultValue: "Signed in. Reconnecting the mirror…"
+        ))
+        let failed = RemoteTmuxHost.shellSingleQuoted(String(
+            localized: "remoteTmux.reconnectAuth.failure",
+            defaultValue: "Sign-in failed. Run the command above again to retry."
+        ))
+        // Empty counts as unset: `exec '' -i` would kill the pane the moment ssh returns.
+        let configuredShell = ProcessInfo.processInfo.environment["SHELL"] ?? ""
+        let shell = RemoteTmuxHost.shellSingleQuoted(
+            configuredShell.isEmpty ? "/bin/zsh" : configuredShell)
+        // Echo the invocation first. The failure message says to run the command again, which
+        // is unfollowable if the command was never shown: `ssh` prints its own prompts, not
+        // its argv. One printf with the whole line as a single operand — `printf 'x %s\\n' a b`
+        // would repeat the format per element.
+        let banner = RemoteTmuxHost.shellSingleQuoted("+ \(quoted)")
+        let payload =
+            "printf '%s\\n' \(banner); "
+            + "\(quoted) && printf '%s\\n' \(ok) || printf '%s\\n' \(failed); exec \(shell) -i"
+        return "/bin/sh -c \(RemoteTmuxHost.shellSingleQuoted(payload))"
+    }
 }

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -460,7 +460,7 @@ extension RemoteTmuxController {
     ///   connection goes back to retrying, and a later failure offers a fresh login. Left
     ///   parked instead, that host would have no route back short of restarting cmux.
     ///
-    /// The interval backs off because a person is slow and each probe forks an `ssh`.
+    /// The wait ends on an event, so there is no interval to tune and no dead time behind one.
     private func awaitAuthenticationThenResume(host: RemoteTmuxHost) {
         let key = host.connectionHash
         let transport = transport(for: host)

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -1,3 +1,4 @@
+import CmuxFoundation
 import Foundation
 
 @MainActor
@@ -325,11 +326,25 @@ extension RemoteTmuxController {
             }
             loginOffers.noteConnected(host: key)
         }
+        // The host is authenticated, so any waiter for it has nothing left to wait on. Its
+        // guards would end it on the next tick anyway; cancelling means it stops now rather
+        // than running one more `ssh -O check` for a question already answered.
+        cancelAuthWait(host: key)
         // One mirror connecting proves the master is authenticated, and the host's other
         // parked connections are waiting on exactly that. Releasing the offer without
         // resuming them leaves those mirrors frozen with their waiter already gone, since
         // the waiter exits once the offer disappears.
         resumeReconnectAfterAuthentication(host: host)
+    }
+
+    /// Stops a host's login waiter.
+    ///
+    /// Held so it can be stopped: the waiter probes the shared master on a timer, and one that
+    /// outlives its offer would keep probing with nothing able to stop it.
+    func cancelAuthWait(host key: String) {
+        authWaitTasks[key]?.cancel()
+        authWaitTasks[key] = nil
+        hostsWaitingForAuth.remove(key)
     }
 
     /// Closes a login workspace wherever it lives, if it still exists.
@@ -386,14 +401,18 @@ extension RemoteTmuxController {
 
     /// Waits for the login terminal to open the shared master, then resumes.
     ///
-    /// The probe is `ssh -O check` (``RemoteTmuxSSHTransport/isMasterLive()``): local,
-    /// instant, and unable to prompt, so asking repeatedly costs nothing and can never
-    /// consume an authentication attempt while the user is mid-login.
+    /// Waiting on a *person* rules out a deadline — an MFA push or a hardware-key touch can take
+    /// seconds or many minutes, and a wait that expired while the login terminal was still open
+    /// would strand the mirror, parked with retrying stopped and nothing left to resume it. It
+    /// does not rule out an event, which is the mistake an earlier version of this made: opening
+    /// the master creates the socket at ``RemoteTmuxHost/controlSocketPath``, so the filesystem
+    /// reports the moment being waited for and ``FileWatcher`` delivers it.
     ///
-    /// This waits on a *person*, so there is no event to subscribe to and no honest
-    /// deadline: an MFA push or a hardware-key touch can take seconds or many minutes,
-    /// and a wait that expires while the login terminal is still open would strand the
-    /// mirror — parked, with retrying stopped and nothing left to resume it.
+    /// `ssh -O check` (``RemoteTmuxSSHTransport/isMasterLive()``) is still how the socket is
+    /// confirmed usable rather than stale — local, instant, and unable to prompt, so it can never
+    /// consume an authentication attempt mid-login — but it runs once per event instead of on a
+    /// clock. A timer's interval is dead time a frozen mirror spends *after* the user has already
+    /// finished, and no interval is short enough to make that right.
     ///
     /// So the wait ends on state rather than on a clock, and every ending is derived by
     /// looking at what exists rather than by trusting some teardown path to signal:
@@ -410,18 +429,39 @@ extension RemoteTmuxController {
         let key = host.connectionHash
         let transport = transport(for: host)
         hostsWaitingForAuth.insert(key)
-        Task { @MainActor [weak self] in
-            defer { self?.hostsWaitingForAuth.remove(key) }
-            var interval: Duration = .seconds(2)
-            let maxInterval: Duration = .seconds(15)
-            while true {
-                do {
-                    try await Task.sleep(for: interval)
-                } catch {
-                    return  // Cancelled (app teardown); the connection stays parked.
-                }
-                interval = min(interval * 2, maxInterval)
+        authWaitTasks[key]?.cancel()
+        authWaitTasks[key] = Task { @MainActor [weak self] in
+            defer {
+                self?.hostsWaitingForAuth.remove(key)
+                self?.authWaitTasks[key] = nil
+            }
+            // Edge-driven, not polled. Completing the login is the user opening the shared ssh
+            // master, and opening it creates the socket at cmux's own ControlPath — so the
+            // filesystem already reports the exact moment being waited for. `FileWatcher` watches
+            // the path's parent directory too, which is what makes creation (not just change)
+            // visible, and this socket does not exist yet when the wait starts.
+            //
+            // A timer here would be strictly worse: the interval is dead time a frozen mirror
+            // spends after the user has finished, and no interval is short enough to be right —
+            // this is a person typing a password, not a bounded computation.
+            //
+            // `isMasterLive()` still runs, but once per event rather than on a clock: the socket
+            // appearing is the edge, and `ssh -O check` is how we confirm it is usable rather
+            // than a stale file. The loop continues on a negative answer because the directory
+            // reports unrelated churn too (other hosts' masters live in the same directory).
+            let watcher = FileWatcher(path: host.controlSocketPath)
+            defer { Task { await watcher.stop() } }
+            // The master may already be live: the user can finish signing in between the failure
+            // that parked this connection and this waiter starting, and an edge that already
+            // happened is never delivered. Checking once up front is what stops an event-driven
+            // wait from hanging on a condition that was true before anyone was listening.
+            if await transport.isMasterLive() {
+                self?.resumeReconnectAfterAuthentication(host: host)
+                return
+            }
+            for await _ in watcher.events {
                 guard let self else { return }
+                if Task.isCancelled { return }
                 // Another path already gave up on this host, or replaced this offer with a
                 // newer one that its own waiter owns.
                 guard let offer = loginOffers.openedWorkspace(host: key) else { return }
@@ -437,19 +477,34 @@ extension RemoteTmuxController {
                     self.resumeReconnectAfterAuthentication(host: host)
                     return
                 }
-                if !Self.workspaceExists(offer.workspace) {
-                    // The user closed it without signing in. Keep retrying so a host that
-                    // starts accepting authentication recovers on its own, but stop offering
-                    // for this outage — otherwise the retry fails the same way, a new login
-                    // opens, and closing the tab looks like it does nothing.
-                    Self.logger.info(
-                        "reconnect-auth: login dismissed for \(host.destination, privacy: .public); retrying quietly")
-                    loginOffers.noteDeclined(host: key, generation: offer.generation)
-                    self.resumeReconnectAfterAuthentication(host: host)
-                    return
-                }
             }
         }
+    }
+
+    /// The user closed a login cmux opened, which is a decline.
+    ///
+    /// Called from the close path rather than noticed by the waiter: a closed tab produces no
+    /// filesystem or protocol event, so this is the only edge for it. Retrying resumes quietly so
+    /// a host that starts accepting authentication recovers on its own, while the offer is marked
+    /// declined for this outage — otherwise the retry fails the same way, a new login opens, and
+    /// closing the tab looks like it did nothing.
+    func noteLoginWorkspaceClosed(workspaceId: UUID) {
+        guard let key = loginOffers.host(forOpenedWorkspace: workspaceId) else { return }
+        guard let offer = loginOffers.openedWorkspace(host: key) else { return }
+        // No mirror left for this host means there is nothing to resume, so recording the decline
+        // is the whole job: it stops this outage from offering another login the user would have
+        // to dismiss again.
+        guard let host = sessionMirrors.values.first(where: { $0.host.connectionHash == key })?.host
+        else {
+            loginOffers.noteDeclined(host: key, generation: offer.generation)
+            cancelAuthWait(host: key)
+            return
+        }
+        Self.logger.info(
+            "reconnect-auth: login dismissed for \(host.destination, privacy: .public); retrying quietly")
+        loginOffers.noteDeclined(host: key, generation: offer.generation)
+        cancelAuthWait(host: key)
+        resumeReconnectAfterAuthentication(host: host)
     }
 
     /// Resumes every parked control connection for `host` after authentication.

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -337,6 +337,26 @@ extension RemoteTmuxController {
         resumeReconnectAfterAuthentication(host: host)
     }
 
+    /// Releases a host's login offer once nothing is left for it to unblock.
+    ///
+    /// A login exists to unfreeze mirrors. When the last mirror for the host goes away — closed,
+    /// detached, or taken with its window — the offer, its waiter and the sign-in pane are all
+    /// orphaned: the waiter would keep watching a socket nobody is waiting on, and the pane would
+    /// sit there with nothing to resume. Called from every path that removes a mirror, because
+    /// which path ran is not something the offer should have to know.
+    func releaseLoginOfferIfHostHasNoMirrors(host: RemoteTmuxHost) {
+        let key = host.connectionHash
+        guard loginOffers.hasOffer(host: key) else { return }
+        guard !sessionMirrors.values.contains(where: { $0.host.connectionHash == key }) else { return }
+        if let offer = loginOffers.openedWorkspace(host: key) {
+            closeLoginWorkspace(offer.workspace)
+            loginOffers.abandon(host: key, generation: offer.generation)
+        } else {
+            loginOffers.noteConnected(host: key)
+        }
+        cancelAuthWait(host: key)
+    }
+
     /// Stops a host's login waiter.
     ///
     /// Held so it can be stopped: the waiter probes the shared master on a timer, and one that
@@ -349,8 +369,17 @@ extension RemoteTmuxController {
 
     /// Closes a login workspace wherever it lives, if it still exists.
     private func closeLoginWorkspace(_ workspace: UUID) {
-        guard let manager = AppDelegate.shared?.tabManagerFor(tabId: workspace),
+        guard let appDelegate = AppDelegate.shared,
+              let manager = appDelegate.tabManagerFor(tabId: workspace),
               let tab = manager.tabs.first(where: { $0.id == workspace }) else { return }
+        // `closeWorkspace` refuses to close the last tab in a window, so a login that ended up
+        // alone in its own window could not be closed at all: the offer cleared while the obsolete
+        // sign-in shell stayed on screen, and cmux opened it, so cmux has to be able to remove it.
+        // Discarding the window is the equivalent action when the login *is* the window.
+        if manager.tabs.count <= 1, let windowId = appDelegate.windowId(for: manager) {
+            appDelegate.discardMainWindowWithoutClosedHistory(windowId: windowId)
+            return
+        }
         manager.closeWorkspace(tab, recordHistory: false)
     }
 

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -422,8 +422,8 @@ extension RemoteTmuxController {
         host: RemoteTmuxHost, sshArgv: [String]
     ) -> [String: Any] {
         [
-            "title": String(
-                format: String(
+            "title": String.localizedStringWithFormat(
+                String(
                     localized: "remoteTmux.reconnectAuth.workspaceTitle",
                     defaultValue: "Sign in to %@"
                 ),

--- a/Sources/RemoteTmuxController+Attach.swift
+++ b/Sources/RemoteTmuxController+Attach.swift
@@ -281,7 +281,7 @@ extension RemoteTmuxController {
             controller.v2WorkspaceCreate(params: params)
         }
         Self.logger.info(
-            "reconnect-auth: login workspace for \(host.connectionHash, privacy: .public): \(String(describing: result), privacy: .public)")
+            "reconnect-auth: login workspace for \(host.connectionHash, privacy: .public): \(Self.loginWorkspaceOutcomeLabel(result), privacy: .public)")
         guard case .ok(let payload) = result,
               let workspaceId = (payload as? [String: Any])?["workspace_id"] as? String,
               let loginWorkspace = UUID(uuidString: workspaceId) else {
@@ -624,4 +624,21 @@ extension RemoteTmuxController {
             + "\(quoted) && printf '%s\\n' \(ok) || printf '%s\\n' \(failed); exec \(shell) -i"
         return "/bin/sh -c \(RemoteTmuxHost.shellSingleQuoted(payload))"
     }
+
+    /// Names a `V2CallResult` for a public log line without publishing what it carries.
+    /// `.ok` wraps the created workspace's fields and `.err` carries an arbitrary `data`
+    /// value, so interpolating the whole result would put both in the system log. The
+    /// error code is a fixed identifier rather than caller data, so it stays public and
+    /// keeps the line useful for diagnosing a failed login-workspace create.
+    private static func loginWorkspaceOutcomeLabel(
+        _ result: TerminalController.V2CallResult
+    ) -> String {
+        switch result {
+        case .ok:
+            return "ok"
+        case .err(let code, _, _):
+            return "err(\(code))"
+        }
+    }
+
 }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -259,6 +259,16 @@ final class RemoteTmuxController {
     /// (see ``connectionKey(host:sessionName:)``).
     var sessionMirrors: [String: RemoteTmuxSessionMirror] = [:]
 
+    /// Outstanding login offers, keyed by ``RemoteTmuxHost/connectionHash``.
+    ///
+    /// See ``RemoteTmuxLoginOffers`` for why the slot is reserved before the workspace is
+    /// created and released only on a successful connect.
+    var loginOffers = RemoteTmuxLoginOffers()
+
+    /// Hosts with an authentication wait already running, so folding a repeat
+    /// auth-required into an existing offer does not start a second poll loop.
+    var hostsWaitingForAuth: Set<String> = []
+
     /// In-flight attach guards and kill-on-close markers for remote tmux mirrors.
     let windowRegistry = RemoteTmuxWindowRegistry()
 

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -265,9 +265,8 @@ final class RemoteTmuxController {
     /// created and released only on a successful connect.
     var loginOffers = RemoteTmuxLoginOffers()
 
-    /// Hosts with an authentication wait already running, so folding a repeat
-    /// auth-required into an existing offer does not start a second poll loop.
-    /// Hosts with a login waiter running, and the task doing the waiting.
+    /// Hosts with a login waiter running, and the task doing the waiting. Folding a repeat
+    /// auth-required into an existing offer must not start a second waiter.
     ///
     /// The task is held rather than fire-and-forget so it can be cancelled: a waiter that
     /// outlives the offer it was created for keeps probing a master nobody is waiting on, and
@@ -805,7 +804,7 @@ final class RemoteTmuxController {
     /// server/session — only the local control clients and masters.
     func detachAll() {
         // No waiter may outlive the mirrors it was waiting for.
-        for key in authWaitTasks.keys { cancelAuthWait(host: key) }
+        for key in Array(authWaitTasks.keys) { cancelAuthWait(host: key) }
         let connections = Array(connectionsByHostSession.keys).compactMap { removeCachedConnection(forKey: $0) }
         for connection in connections { connection.stop() }
         // Fire-and-forget `ssh -O exit` per endpoint: it hits the local control

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -274,6 +274,10 @@ final class RemoteTmuxController {
     /// nothing else could stop it.
     var hostsWaitingForAuth: Set<String> = []
     var authWaitTasks: [String: Task<Void, Never>] = [:]
+    /// Identifies which waiter owns a host's registration, so a cancelled one cannot retract the
+    /// registration of the waiter that replaced it.
+    var authWaitIds: [String: UInt64] = [:]
+    var authWaitGeneration: UInt64 = 0
 
     /// In-flight attach guards and kill-on-close markers for remote tmux mirrors.
     let windowRegistry = RemoteTmuxWindowRegistry()
@@ -636,6 +640,14 @@ final class RemoteTmuxController {
     /// down via `detachObserver`.
     func handleWindowWorkspacesClosed(workspaceIds: [UUID]) {
         let ids = Set(workspaceIds)
+        // A login cmux opened can be in a different window from the mirror it exists for, so a
+        // window close is a decline for every login it takes with it. Without this, closing the
+        // login's window leaves that host parked with retrying stopped and no waiter, and the
+        // mirror in the other window stays frozen until cmux restarts — the per-workspace close
+        // path handles only its own window's tabs.
+        for workspaceId in ids {
+            noteLoginWorkspaceClosed(workspaceId: workspaceId)
+        }
         var affectedHosts: [String: RemoteTmuxHost] = [:]
         for (key, mirror) in sessionMirrors {
             guard let workspaceId = mirror.mirroredWorkspaceId, ids.contains(workspaceId) else { continue }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -660,6 +660,9 @@ final class RemoteTmuxController {
         // ControlMaster now — the last-session teardown paths already do this, and
         // a window close must too or the master lingers for the full
         // ControlPersist window.
+        for (_, host) in affectedHosts {
+            releaseLoginOfferIfHostHasNoMirrors(host: host)
+        }
         for (hash, host) in affectedHosts {
             let stillUsed = sessionMirrors.values.contains { $0.host.connectionHash == hash }
                 || connectionsByHostSession.values.contains { $0.host.connectionHash == hash }
@@ -716,6 +719,7 @@ final class RemoteTmuxController {
         removeCachedConnection(forKey: entry.key)?.stop()
         let hostHasOtherMirrors = sessionMirrors.values.contains { $0.host.connectionHash == host.connectionHash }
         if !hostHasOtherMirrors, !connectionsByHostSession.values.contains(where: { $0.host.connectionHash == host.connectionHash }) { transportRegistry.remove(connectionHash: host.connectionHash); RemoteTmuxSSHTransport.spawnControlMasterExit(host: host) }
+        releaseLoginOfferIfHostHasNoMirrors(host: host)
     }
 
     /// User-initiated mirrored workspace close detaches locally and kills the remote session.

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -267,7 +267,13 @@ final class RemoteTmuxController {
 
     /// Hosts with an authentication wait already running, so folding a repeat
     /// auth-required into an existing offer does not start a second poll loop.
+    /// Hosts with a login waiter running, and the task doing the waiting.
+    ///
+    /// The task is held rather than fire-and-forget so it can be cancelled: a waiter that
+    /// outlives the offer it was created for keeps probing a master nobody is waiting on, and
+    /// nothing else could stop it.
     var hostsWaitingForAuth: Set<String> = []
+    var authWaitTasks: [String: Task<Void, Never>] = [:]
 
     /// In-flight attach guards and kill-on-close markers for remote tmux mirrors.
     let windowRegistry = RemoteTmuxWindowRegistry()
@@ -782,6 +788,8 @@ final class RemoteTmuxController {
     /// CLI's `ssh -f` left them persistent). Does NOT kill any remote tmux
     /// server/session — only the local control clients and masters.
     func detachAll() {
+        // No waiter may outlive the mirrors it was waiting for.
+        for key in authWaitTasks.keys { cancelAuthWait(host: key) }
         let connections = Array(connectionsByHostSession.keys).compactMap { removeCachedConnection(forKey: $0) }
         for connection in connections { connection.stop() }
         // Fire-and-forget `ssh -O exit` per endpoint: it hits the local control

--- a/Sources/RemoteTmuxSSHTransport.swift
+++ b/Sources/RemoteTmuxSSHTransport.swift
@@ -259,6 +259,17 @@ actor RemoteTmuxSSHTransport {
         }
     }
 
+    /// Whether the shared ControlMaster is live, WITHOUT trying to open one.
+    ///
+    /// `ssh -O check` hits the local control socket only, so it returns in
+    /// milliseconds and can never prompt for credentials. That makes it the safe
+    /// probe for "has the user finished authenticating in the login terminal yet?" —
+    /// unlike ``ensureMasterReady()``, which would attempt a `BatchMode` open and
+    /// burn a failed authentication attempt while the user is still typing.
+    func isMasterLive() async -> Bool {
+        (try? await masterIsRunning()) ?? false
+    }
+
     /// Tears down the shared SSH master (e.g. when the user removes a host).
     func shutdownMaster() async {
         _ = try? await Self.runProcess(

--- a/Sources/RemoteTmuxSessionMirror.swift
+++ b/Sources/RemoteTmuxSessionMirror.swift
@@ -228,9 +228,34 @@ final class RemoteTmuxSessionMirror: RemoteTmuxControlPaneMutationOwner {
                     self?.titleFilters.removeAll()
                     self?.clearPendingPaneSeedDeliveries()
                 }
+                // Reaching `.connected` is the only thing that proves the login worked, so
+                // it is what ends the host's outstanding login offer. Releasing it on a
+                // resume *attempt* instead meant a reconnect that failed authentication
+                // again opened another login tab, once per retry.
+                if state == .connected, let self {
+                    AppDelegate.shared?.remoteTmuxController.noteMirrorConnected(host: self.host)
+                }
+            },
+            onAuthRequired: { [weak self] sshArgv in
+                self?.handleReconnectNeedsAuthentication(sshArgv: sshArgv) ?? false
             }
         )
         rebuild()
+    }
+
+    /// A reconnect stopped because the host wants interactive authentication that a
+    /// pipe-backed reconnect cannot service (a password, MFA, a security-key touch).
+    ///
+    /// The mirror is frozen but ALIVE — the tmux session and every mirrored workspace
+    /// are intact — so nothing is torn down here. The controller surfaces a login the
+    /// user can complete; finishing it opens the shared ControlMaster and the parked
+    /// connection resumes over it.
+    /// - Returns: whether a login was actually put in front of the user. `false` means the
+    ///   caller must fall back to retrying, or the host is stranded with nothing pending.
+    private func handleReconnectNeedsAuthentication(sshArgv: [String]) -> Bool {
+        AppDelegate.shared?.remoteTmuxController.presentReconnectAuthentication(
+            host: host, sshArgv: sshArgv
+        ) ?? false
     }
 
     /// The remote session ended for good (its last tmux window was killed, it was

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2067,6 +2067,12 @@ class TabManager: ObservableObject {
         if workspace.isRemoteTmuxMirror {
             AppDelegate.shared?.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: workspace.id)
         }
+        // Closing the login cmux opened for a reconnect is the user declining it, and that is the
+        // only signal for it — a closed tab is not a filesystem or protocol event, so the waiter
+        // watching for the shared master would never hear about it.
+        if workspace.isRemoteTmuxAuthLogin {
+            AppDelegate.shared?.remoteTmuxController.noteLoginWorkspaceClosed(workspaceId: workspace.id)
+        }
         if recordHistory,
            workspace.isRestorableInSessionSnapshot,
            let index = tabs.firstIndex(where: { $0.id == workspace.id }) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5138,8 +5138,18 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// Set on the "Sign in to <host>" workspace cmux opens by itself when a remote-tmux
+    /// reconnect cannot authenticate.
+    ///
+    /// It exists to run one `ssh` and is meaningless afterwards: a restored terminal is a
+    /// fresh shell, so a restored copy cannot authenticate anything. Worse, a restored copy
+    /// is invisible to the per-host "one login at a time" rule, which tracks the workspace
+    /// it created — so the next outage adds another, once per relaunch.
+    var isRemoteTmuxAuthLogin: Bool = false
+
     var isRestorableInSessionSnapshot: Bool {
         if isRemoteTmuxMirror { return false }
+        if isRemoteTmuxAuthLogin { return false }
         if panels.values.contains(where: { $0.panelType == .cloudVMLoading }) {
             return false
         }

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -474,4 +474,418 @@ import Testing
             String(decoding: stderrData, as: UTF8.self)
         )
     }
+
+    // MARK: - Reconnect disposition (the wedge fix)
+
+    /// A reconnect that fails BECAUSE the host wants interactive authentication must be
+    /// classified `.authRequired`, not `.transient`. This is the whole bug: the reconnect
+    /// runs `BatchMode=yes` on pipes with no tty, so retrying can never satisfy a
+    /// password / MFA / security-key touch. Classified as transient it retries forever
+    /// and the mirror freezes with nothing on screen to explain why.
+    @Test(arguments: [
+        "user@host: Permission denied (publickey,keyboard-interactive).",
+        "Permission denied (publickey,password).",
+        "Host key verification failed.",
+        "Authentication failed.",
+        "Too many authentication failures",
+    ])
+    func reconnectNeedingAuthIsNotTransient(_ stderr: String) {
+        #expect(
+            RemoteTmuxReconnectDisposition.classify(stderr: stderr, preControlOutput: "")
+                == .authRequired
+        )
+    }
+
+    /// A gone session still ends the connection, and wins over an auth failure when a
+    /// host reports both — ending is correct and not recoverable, so it must not be
+    /// downgraded to "ask the user to log in".
+    @Test func goneSessionOutranksAuthFailure() {
+        #expect(
+            RemoteTmuxReconnectDisposition.classify(
+                stderr: "no server running on /tmp/tmux-501/default", preControlOutput: "")
+                == .sessionGone
+        )
+        #expect(
+            RemoteTmuxReconnectDisposition.classify(
+                stderr: "no server running on /tmp/tmux-501/default\nPermission denied (publickey).",
+                preControlOutput: "") == .sessionGone
+        )
+    }
+
+    /// Everything else keeps retrying with backoff — an unreachable or refused host is
+    /// exactly what the retry loop is for, and must NOT pop a login the user cannot use.
+    @Test(arguments: [
+        "ssh: connect to host h port 22: Connection refused",
+        "ssh: connect to host h port 22: Operation timed out",
+        "kex_exchange_identification: read: Connection reset by peer",
+        "",
+    ])
+    func unreachableStaysTransient(_ stderr: String) {
+        #expect(
+            RemoteTmuxReconnectDisposition.classify(stderr: stderr, preControlOutput: "")
+                == .transient
+        )
+    }
+
+    /// A `ProxyCommand` that closes the transport silently under BatchMode is the same
+    /// situation as an explicit auth failure without the error string, so it must also
+    /// stop retrying and offer a login. The reconnect classifier therefore has to use the
+    /// composed predicate the initial-connect sites use; matching only "permission
+    /// denied" leaves a corporate-broker host retrying forever — the original bug,
+    /// surviving for exactly the hosts this feature exists to serve.
+    @Test(arguments: [
+        "ssh_dispatch_run_fatal: Connection to UNKNOWN port 65535: Broken pipe",
+        "Connection closed by UNKNOWN port 65535",
+    ])
+    func silentProxyCloseOnReconnectOffersLogin(_ stderr: String) {
+        #expect(!RemoteTmuxSSHTransport.indicatesAuthRequired(stderr))
+        #expect(
+            RemoteTmuxReconnectDisposition.classify(stderr: stderr, preControlOutput: "")
+                == .authRequired
+        )
+    }
+
+    /// A non-recoverable proxy failure keeps retrying rather than asking for a login the
+    /// user cannot act on: no amount of authenticating fixes a missing proxy binary.
+    @Test func nonRecoverableProxyFailureStaysTransient() {
+        #expect(
+            RemoteTmuxReconnectDisposition.classify(
+                stderr: "zsh:1: command not found: corp-proxy\nConnection closed by UNKNOWN port 65535",
+                preControlOutput: "") == .transient
+        )
+    }
+
+    // MARK: - One login per host
+
+    /// Several sessions on one host drop together, and each reports auth-required in the
+    /// same turn. Reserving the slot only *after* the workspace exists lets every one of
+    /// them pass the "already offered?" check, and the user gets a tab per session.
+    ///
+    /// Observed for real: six login tabs for one host inside 76ms after a session restore
+    /// re-attached six mirrors to a host that needs 2FA.
+    @Test func simultaneousDropsOnOneHostOfferOneLogin() {
+        var offers = RemoteTmuxLoginOffers()
+        let host = "hash-a"
+        let neverOpen: (UUID) -> Bool = { _ in false }
+
+        // First mirror wins the slot; the create has not finished yet.
+        guard case .present(let generation) = offers.claim(host: host, isOpen: neverOpen) else {
+            Issue.record("the first claim must win the slot"); return
+        }
+        // Every other mirror in the same turn must be refused, workspace or no workspace.
+        #expect(offers.claim(host: host, isOpen: neverOpen) == .alreadyOffered)
+        #expect(offers.claim(host: host, isOpen: neverOpen) == .alreadyOffered)
+
+        offers.recordOpened(host: host, workspace: UUID(), generation: generation)
+        #expect(offers.claim(host: host, isOpen: { _ in true }) == .alreadyOffered)
+    }
+
+    /// A resume attempt is not proof of success: the reconnect can fail authentication
+    /// again. Releasing the slot on the attempt turned every repeat failure into another
+    /// tab — observed as one new tab every ~3.8s, matching the reconnect backoff.
+    @Test func repeatedAuthFailuresReuseTheOpenLogin() {
+        var offers = RemoteTmuxLoginOffers()
+        let host = "hash-a"
+        let workspace = UUID()
+        guard case .present(let generation) = offers.claim(host: host, isOpen: { _ in false }) else {
+            Issue.record("expected to win the slot"); return
+        }
+        offers.recordOpened(host: host, workspace: workspace, generation: generation)
+
+        // Whatever happens between failures, while that workspace is on screen the answer
+        // stays "already offered". There is deliberately no API to release it on a resume.
+        for _ in 0..<5 {
+            #expect(offers.claim(host: host, isOpen: { $0 == workspace }) == .alreadyOffered)
+        }
+        #expect(offers.openedWorkspace(host: host)?.workspace == workspace)
+    }
+
+    /// Connecting is what ends the offer, so the next outage starts clean.
+    @Test func connectingReleasesTheOffer() {
+        var offers = RemoteTmuxLoginOffers()
+        let host = "hash-a"
+        guard case .present(let generation) = offers.claim(host: host, isOpen: { _ in false }) else {
+            Issue.record("expected to win the slot"); return
+        }
+        offers.recordOpened(host: host, workspace: UUID(), generation: generation)
+        offers.noteConnected(host: host)
+        #expect(!offers.hasOffer(host: host))
+        if case .alreadyOffered = offers.claim(host: host, isOpen: { _ in true }) {
+            Issue.record("connecting must let the next outage offer a login")
+        }
+    }
+
+    /// Closing the login means "no", and it has to stick for this outage.
+    ///
+    /// The retry that follows fails the same way, so re-offering immediately reopened the tab
+    /// and the close button appeared to do nothing. A reconnect clears the refusal, so the
+    /// next real outage offers again.
+    @Test func dismissingTheLoginStopsTheOfferingUntilTheHostReconnects() {
+        var offers = RemoteTmuxLoginOffers()
+        let host = "hash-a"
+        guard case .present(let generation) = offers.claim(host: host, isOpen: { _ in false }) else {
+            Issue.record("expected to win the slot"); return
+        }
+        offers.recordOpened(host: host, workspace: UUID(), generation: generation)
+
+        offers.noteDeclined(host: host, generation: generation)
+        #expect(offers.isDeclined(host: host))
+        // Every later failure in this outage must be silent, however many arrive.
+        for _ in 0..<5 {
+            #expect(offers.claim(host: host, isOpen: { _ in false }) == .declined)
+        }
+
+        // A reconnect ends the outage, so the next one may ask again.
+        offers.noteConnected(host: host)
+        #expect(!offers.isDeclined(host: host))
+        if case .present = offers.claim(host: host, isOpen: { _ in false }) {} else {
+            Issue.record("after reconnecting, a new outage must be allowed to offer a login")
+        }
+    }
+
+    /// A stale owner cannot mark a newer offer as dismissed.
+    @Test func aStaleOwnerCannotDeclineANewerOffer() {
+        var offers = RemoteTmuxLoginOffers()
+        let host = "hash-a"
+        guard case .present(let first) = offers.claim(host: host, isOpen: { _ in false }) else {
+            Issue.record("expected to win the slot"); return
+        }
+        offers.recordOpened(host: host, workspace: UUID(), generation: first)
+        guard case .present(let second) = offers.claim(host: host, isOpen: { _ in false }) else {
+            Issue.record("a dismissed-workspace claim should win"); return
+        }
+        offers.noteDeclined(host: host, generation: first)
+        #expect(!offers.isDeclined(host: host))
+        offers.noteDeclined(host: host, generation: second)
+        #expect(offers.isDeclined(host: host))
+    }
+
+    /// A failed create does not wedge the host behind a login that never appeared.
+    @Test func aFailedOfferDoesNotSuppressTheNextOne() {
+        var offers = RemoteTmuxLoginOffers()
+        let host = "hash-a"
+        guard case .present(let generation) = offers.claim(host: host, isOpen: { _ in false }) else {
+            Issue.record("expected to win the slot"); return
+        }
+        offers.abandon(host: host, generation: generation)
+        #expect(!offers.hasOffer(host: host))
+        if case .alreadyOffered = offers.claim(host: host, isOpen: { _ in false }) {
+            Issue.record("a failed create must not suppress the next offer")
+        }
+    }
+
+    /// Hosts are independent: one host's outstanding login must not mute another's.
+    @Test func offersAreScopedPerHost() {
+        var offers = RemoteTmuxLoginOffers()
+        if case .alreadyOffered = offers.claim(host: "hash-a", isOpen: { _ in false }) {
+            Issue.record("first host should win")
+        }
+        if case .alreadyOffered = offers.claim(host: "hash-b", isOpen: { _ in false }) {
+            Issue.record("a second host must not be muted by the first")
+        }
+        #expect(offers.claim(host: "hash-a", isOpen: { _ in false }) == .alreadyOffered)
+    }
+
+    /// A login workspace must not come back on relaunch.
+    ///
+    /// A restored terminal is a fresh shell, so a restored login cannot authenticate
+    /// anything, and it is invisible to the per-host rule (which tracks the workspace it
+    /// created) — so each relaunch would let the next outage add another. This is the
+    /// mechanism behind login tabs accumulating across restarts.
+    @MainActor @Test func aLoginWorkspaceIsNotRestored() {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(title: "Sign in to example-host", select: false)
+        #expect(workspace.isRestorableInSessionSnapshot)
+        #expect(manager.sessionSnapshotWorkspaceIds().contains(workspace.id))
+
+        workspace.isRemoteTmuxAuthLogin = true
+        #expect(!workspace.isRestorableInSessionSnapshot)
+        #expect(!manager.sessionSnapshotWorkspaceIds().contains(workspace.id))
+    }
+
+    // MARK: - Cause A: a live connection must not be asked to authenticate
+
+    /// The straggler case, reduced to its rule. Several sessions park, the user signs in, the
+    /// first to reconnect releases the offer, and a sibling still finishing its pre-login
+    /// attempt reports auth-required into an empty slot — a second login moments after a
+    /// successful sign-in. A host with any live connection has proven authentication is not
+    /// the blocker.
+    @MainActor @Test func aHostWithALiveConnectionIsNotAskedToAuthenticate() {
+        #expect(RemoteTmuxController.hasLiveConnection(states: [.connected]))
+        #expect(RemoteTmuxController.hasLiveConnection(states: [.reconnecting, .connected]))
+        // Parked is exactly what a login exists for, and connecting has proven nothing yet;
+        // counting either as live would suppress the offer the user needs.
+        #expect(!RemoteTmuxController.hasLiveConnection(states: [.reconnecting]))
+        #expect(!RemoteTmuxController.hasLiveConnection(states: [.connecting]))
+        #expect(!RemoteTmuxController.hasLiveConnection(states: [.reconnecting, .connecting, .ended]))
+        #expect(!RemoteTmuxController.hasLiveConnection(states: []))
+    }
+
+    // MARK: - Cause B: "handled" must mean a login was presented
+
+    /// `notifyAuthRequired` reporting handled merely because an observer is *subscribed* is
+    /// what stranded a host after a dismissal: the connection's retry fallback was skipped, so
+    /// it sat parked with no retry and no waiter until cmux restarted.
+    @MainActor @Test func authRequiredIsHandledOnlyWhenAConsumerPresentsALogin() {
+        let observers = RemoteTmuxConnectionObservers()
+
+        // Subscribed but declining (the dismissed-host case) is NOT handled.
+        _ = observers.add(
+            onPaneOutput: nil, onPaneCwd: nil, onPaneReflow: nil, onActivePaneChanged: nil,
+            onSessionChanged: nil, onTopologyChanged: nil, onReconnectReady: nil, onExit: nil,
+            onConnectionStateChanged: nil,
+            onAuthRequired: { _ in false }
+        )
+        #expect(!observers.notifyAuthRequired(sshArgv: ["/usr/bin/ssh", "host"]))
+
+        // A consumer that actually presents one flips it, and every observer still runs —
+        // an `||` would short-circuit and skip the rest.
+        var secondRan = false
+        _ = observers.add(
+            onPaneOutput: nil, onPaneCwd: nil, onPaneReflow: nil, onActivePaneChanged: nil,
+            onSessionChanged: nil, onTopologyChanged: nil, onReconnectReady: nil, onExit: nil,
+            onConnectionStateChanged: nil,
+            onAuthRequired: { _ in secondRan = true; return true }
+        )
+        #expect(observers.notifyAuthRequired(sshArgv: ["/usr/bin/ssh", "host"]))
+        #expect(secondRan)
+    }
+
+    /// With no consumer at all there is nothing to present, so the caller must retry.
+    @MainActor @Test func noConsumerMeansNotHandled() {
+        let observers = RemoteTmuxConnectionObservers()
+        #expect(!observers.notifyAuthRequired(sshArgv: ["/usr/bin/ssh", "host"]))
+    }
+
+    // MARK: - Cause D: the pane shows the command it ran
+
+    /// The failure message tells the user to run the command again, which is unfollowable if
+    /// the command was never shown — `ssh` prints its prompts, not its argv.
+    @MainActor @Test func theLoginPaneEchoesTheCommandItRuns() {
+        let command = RemoteTmuxController.interactiveAuthShellCommand(
+            sshArgv: ["/usr/bin/ssh", "example-host", "true"]
+        )
+        #expect(command.contains("+ "))
+        // The echo must precede the ssh invocation, or "the command above" is below.
+        if let bannerAt = command.range(of: "printf")?.lowerBound,
+           let sshAt = command.range(of: "/usr/bin/ssh")?.lowerBound {
+            #expect(bannerAt < sshAt)
+        } else {
+            Issue.record("expected both an echo and the ssh invocation in the command")
+        }
+    }
+
+    // MARK: - Login workspace focus
+
+    /// The login workspace must actually surface, which means earning a focus allowance.
+    ///
+    /// `focus` is honored only for methods in `explicitFocusParamV2Methods` and only while
+    /// a matching allowance is on the calling thread's stack. Both halves are load-bearing
+    /// and neither is visible at the call site, so this pins them: dropping the `focus`
+    /// param, renaming it, or removing `workspace.create` from the eligible set all yield
+    /// a login terminal created somewhere the user never sees.
+    @MainActor @Test func loginWorkspaceParamsEarnFocus() {
+        let host = RemoteTmuxHost(destination: "example-host")
+        let params = RemoteTmuxController.reconnectAuthWorkspaceParams(
+            host: host, sshArgv: ["/usr/bin/ssh", "example-host", "true"]
+        )
+        #expect(params["focus"] as? Bool == true)
+        #expect(
+            TerminalController.explicitFocusParamAllowsFocus(
+                commandKey: "workspace.create", params: params
+            )
+        )
+
+        // Inside a `workspace.create` policy these params focus; outside one they do not,
+        // because the allowance lives on the calling thread's stack. That is exactly why
+        // the caller wraps the create instead of calling straight through.
+        let snapshot = TerminalController.debugSocketCommandPolicySnapshot(
+            commandKey: "workspace.create", isV2: true, params: params
+        )
+        #expect(snapshot.insideAllowsFocus)
+        #expect(!snapshot.outsideAllowsFocus)
+    }
+
+    /// The login pane must outlive the `ssh` it runs.
+    ///
+    /// A terminal command is executed as `bash --noprofile --norc -c "exec -l <command>"`.
+    /// That `exec -l` replaces the shell with the command's FIRST program, so anything
+    /// written after it at the top level never runs. With the ssh invocation leading, the
+    /// result message and the interactive shell that holds the pane open are both
+    /// unreachable, and cmux closes a workspace whose child exited — the login tab appears
+    /// and vanishes in well under a second. Wrapping the payload in an explicit shell is
+    /// what makes the tail reachable, so that is what this pins.
+    @MainActor @Test func loginCommandSurvivesTheSshItRuns() {
+        let command = RemoteTmuxController.interactiveAuthShellCommand(
+            sshArgv: ["/usr/bin/ssh", "-o", "BatchMode=no", "example-host", "true"]
+        )
+        // The first program must be a shell, not ssh: `exec -l` applies to whatever leads.
+        #expect(command.hasPrefix("/bin/sh -c "))
+        #expect(!command.hasPrefix("'/usr/bin/ssh'"))
+        // The ssh invocation and the keep-alive tail both live inside the shell's argument.
+        #expect(command.contains("/usr/bin/ssh"))
+        #expect(command.contains("exec "))
+        #expect(command.contains(" -i"))
+    }
+
+    /// Runs the login command the way a terminal command is actually run, and checks both
+    /// properties that matter: the tail is reachable, and a hostile destination cannot
+    /// inject anything.
+    ///
+    /// This is executed rather than pattern-matched on purpose. Asserting that the hostile
+    /// text is absent from the command string is not a safety check — the text is *supposed*
+    /// to appear there, quoted, as data. Only running it distinguishes quoted data from
+    /// executable code. Running it is also the only way to see that the tail executes at
+    /// all, which is exactly what the `exec -l` wrapper broke.
+    @MainActor @Test func loginCommandRunsItsTailAndResistsInjection() throws {
+        let tmp = FileManager.default.temporaryDirectory
+        let injected = tmp.appendingPathComponent("cmux-auth-injected-\(UUID().uuidString)")
+        let tailRan = tmp.appendingPathComponent("cmux-auth-tail-\(UUID().uuidString)")
+
+        // Stand in for the user's shell with a script that records that it ran and exits,
+        // so the command terminates instead of waiting at an interactive prompt.
+        let fakeShell = tmp.appendingPathComponent("cmux-auth-shell-\(UUID().uuidString).sh")
+        try "#!/bin/sh\ntouch \(tailRan.path)\n".write(to: fakeShell, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: fakeShell.path)
+        setenv("SHELL", fakeShell.path, 1)
+        defer {
+            unsetenv("SHELL")
+            for url in [injected, tailRan, fakeShell] { try? FileManager.default.removeItem(at: url) }
+        }
+
+        // `/bin/echo` stands in for ssh so the success branch runs without touching a network.
+        let command = RemoteTmuxController.interactiveAuthShellCommand(
+            sshArgv: ["/bin/echo", "host'; touch \(injected.path); '"]
+        )
+        // The command is now echoed as a banner too, so the hostile text appears twice —
+        // both occurrences must be inert.
+
+        // The exact shape a terminal command is executed with.
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["--noprofile", "--norc", "-c", "exec -l \(command)"]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+
+        #expect(
+            FileManager.default.fileExists(atPath: tailRan.path),
+            "the command's tail never ran, so the login pane would exit as soon as ssh does"
+        )
+        #expect(
+            !FileManager.default.fileExists(atPath: injected.path),
+            "a hostile destination executed as a command"
+        )
+    }
+
+    /// The login workspace title names the host, so a user with several mirrored hosts
+    /// knows which one is asking.
+    @MainActor @Test func loginWorkspaceTitleNamesTheHost() {
+        let params = RemoteTmuxController.reconnectAuthWorkspaceParams(
+            host: RemoteTmuxHost(destination: "build-box"), sshArgv: ["/usr/bin/ssh", "build-box", "true"]
+        )
+        #expect((params["title"] as? String)?.contains("build-box") == true)
+    }
 }

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -177,6 +177,51 @@ import Testing
         #expect(consecutive(args, "-i", "/keys/id"))
     }
 
+    /// The close path knows only which workspace closed, so an offer has to be findable by its
+    /// workspace. Without this the dismissal edge cannot resolve a host and a closed login tab
+    /// goes unnoticed — which is what the removed poll had been quietly covering.
+    @Test func anOpenLoginIsFindableByItsWorkspace() {
+        var offers = RemoteTmuxLoginOffers()
+        let workspace = UUID()
+        guard case .present(let generation) = offers.claim(host: "h1", isOpen: { _ in false }) else {
+            Issue.record("expected a fresh claim to be presentable")
+            return
+        }
+        offers.recordOpened(host: "h1", workspace: workspace, generation: generation)
+
+        #expect(offers.host(forOpenedWorkspace: workspace) == "h1")
+        #expect(offers.host(forOpenedWorkspace: UUID()) == nil, "an unrelated workspace matches nothing")
+    }
+
+    /// A claimed-but-not-yet-opened offer has no workspace, so it must not be matched by one. The
+    /// lookup runs on every workspace close, and a false match would decline the wrong host's login.
+    @Test func aClaimedOfferWithNoWorkspaceMatchesNothing() {
+        var offers = RemoteTmuxLoginOffers()
+        _ = offers.claim(host: "h1", isOpen: { _ in false })
+        #expect(offers.host(forOpenedWorkspace: UUID()) == nil)
+    }
+
+    /// Declining is per host and per generation: a closed tab must not silence a *newer* offer that
+    /// replaced it, or one flap would stop the host ever offering a login again.
+    @Test func decliningAnOldGenerationDoesNotSilenceANewerOffer() {
+        var offers = RemoteTmuxLoginOffers()
+        let first = UUID()
+        guard case .present(let g1) = offers.claim(host: "h1", isOpen: { _ in false }) else { return }
+        offers.recordOpened(host: "h1", workspace: first, generation: g1)
+        offers.noteConnected(host: "h1")
+
+        guard case .present(let g2) = offers.claim(host: "h1", isOpen: { _ in false }) else {
+            Issue.record("a reconnected host must be able to offer again")
+            return
+        }
+        let second = UUID()
+        offers.recordOpened(host: "h1", workspace: second, generation: g2)
+        // The stale close arrives late, naming the first generation.
+        offers.noteDeclined(host: "h1", generation: g1)
+        #expect(offers.host(forOpenedWorkspace: second) == "h1", "the newer offer must survive a stale decline")
+        #expect(!offers.isDeclined(host: "h1"))
+    }
+
     @Test func connectionHashVariesByPortAndIdentity() {
         // The controller keys transports / connections / windows / persistence by
         // connectionHash, so distinct endpoints must produce distinct hashes (and

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -222,6 +222,31 @@ import Testing
         #expect(!offers.isDeclined(host: "h1"))
     }
 
+    /// A login exists to unfreeze mirrors, so when the last mirror for the host is gone the offer,
+    /// its waiter and the pane are all orphaned. Modelled on the offer bookkeeping the controller
+    /// drives, which is the part that decides whether a stale login can be replaced later.
+    @Test func abandoningAnOfferLetsTheHostOfferAgainLater() {
+        var offers = RemoteTmuxLoginOffers()
+        let workspace = UUID()
+        guard case .present(let generation) = offers.claim(host: "h1", isOpen: { _ in false }) else {
+            Issue.record("expected a fresh claim to be presentable")
+            return
+        }
+        offers.recordOpened(host: "h1", workspace: workspace, generation: generation)
+        #expect(offers.hasOffer(host: "h1"))
+
+        // What the controller does once the host has no mirrors left.
+        offers.abandon(host: "h1", generation: generation)
+        #expect(!offers.hasOffer(host: "h1"), "an abandoned offer must not linger")
+        #expect(offers.host(forOpenedWorkspace: workspace) == nil)
+
+        // And the host is not poisoned: a later outage can offer a login again.
+        guard case .present = offers.claim(host: "h1", isOpen: { _ in false }) else {
+            Issue.record("abandoning must not stop a later login from being offered")
+            return
+        }
+    }
+
     @Test func connectionHashVariesByPortAndIdentity() {
         // The controller keys transports / connections / windows / persistence by
         // connectionHash, so distinct endpoints must produce distinct hashes (and

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -801,7 +801,8 @@ import Testing
 
         // Subscribed but declining (the dismissed-host case) is NOT handled.
         _ = observers.add(
-            onPaneOutput: nil, onPaneCwd: nil, onPaneReflow: nil, onActivePaneChanged: nil,
+            onPaneOutput: nil, onPaneSeed: nil, onPaneCwd: nil, onPaneReflow: nil,
+            onActivePaneChanged: nil,
             onSessionChanged: nil, onTopologyChanged: nil, onReconnectReady: nil, onExit: nil,
             onConnectionStateChanged: nil,
             onAuthRequired: { _ in false }
@@ -812,7 +813,8 @@ import Testing
         // an `||` would short-circuit and skip the rest.
         var secondRan = false
         _ = observers.add(
-            onPaneOutput: nil, onPaneCwd: nil, onPaneReflow: nil, onActivePaneChanged: nil,
+            onPaneOutput: nil, onPaneSeed: nil, onPaneCwd: nil, onPaneReflow: nil,
+            onActivePaneChanged: nil,
             onSessionChanged: nil, onTopologyChanged: nil, onReconnectReady: nil, onExit: nil,
             onConnectionStateChanged: nil,
             onAuthRequired: { _ in secondRan = true; return true }

--- a/docs/remote-tmux-reconnect-auth-acceptance.md
+++ b/docs/remote-tmux-reconnect-auth-acceptance.md
@@ -1,0 +1,112 @@
+# Acceptance test: a reconnect that needs a login
+
+When a mirror's control stream drops and the reconnect cannot authenticate, cmux offers a
+login and resumes afterwards. The reconnect runs `BatchMode=yes` on pipes with no tty, so a
+password / MFA / security-key touch cannot be satisfied by retrying.
+
+Automated equivalent: `scripts/remote-tmux-reconnect-auth-harness.sh` (exit code = failed
+scenarios). It covers all five criteria below: scenario 1 covers 1, 2 and 5, scenario 2
+covers 3, scenario 3 checks the pane does not vanish before the reconnect, and scenario 4
+checks it closes after it. Run that first; the steps here are for manual verification on a real 2FA host.
+
+## Pass criteria
+
+1. Killing the stream while the shared master is gone does **not** leave a silently frozen
+   mirror. A workspace titled **"Sign in to `<host>`"** appears, focused, with the login
+   prompt in it.
+2. The mirror's workspaces and their scrollback are **still there** while you log in —
+   nothing is torn down, because the connection is parked, not ended.
+3. Completing the login **resumes the mirror by itself**, with no further prompt and no
+   manual reattach, and the login workspace closes once the host is back — cmux opened it,
+   its purpose is served, and leaving it means a flapping host collects one per flap.
+4. Cancelling instead (close the login tab) leaves the mirror intact and recoverable: it
+   goes back to retrying, so a later failure offers a fresh login rather than leaving that
+   host stuck until cmux restarts.
+5. One login tab per host, even when several sessions on that host drop at once.
+
+## Path A — hermetic, no 2FA, no network games (preferred)
+
+Uses the loopback sshd the fuzz harness already relies on, so auth is a keypair you can
+break and restore on demand. Deterministic on any machine.
+
+```bash
+# 1. Bring up the loopback sshd (generated keys, isolated TMUX_TMPDIR), then attach a
+#    mirror to it. The sshd and its ssh alias come from the fuzz host script.
+scripts/remote-tmux-fuzz-host.sh cmux-fuzzhost
+cmux ssh-tmux cmux-fuzzhost
+
+# 2. Break authentication for the NEXT connection only, leaving the live one alone.
+AUTH=~/Library/Caches/cmux/remote-tmux-fuzz/cmux-fuzzhost-sshd/authorized_keys
+mv "$AUTH" "$AUTH.off"
+
+# 3. Drop the shared master and the control stream, so cmux must reconnect and re-auth.
+ssh -O exit -o ControlPath="$HOME/.cmux/ssh/tmux-cmux-fuzzhost-<hash>.sock" cmux-fuzzhost
+# The remote command is a /bin/sh resolver script, so no argv contains "tmux -CC" —
+# a pattern built on that matches nothing and the kill silently does nothing. Match
+# `attach-session` and narrow to this host, or you drop every mirror on the machine.
+drop_streams() {
+  pgrep -f attach-session | while read -r p; do
+    ps -o command= -p "$p" | grep -q "$1" && kill "$p"
+  done
+}
+drop_streams cmux-fuzzhost
+```
+
+Expect: the reconnect fails `Permission denied (publickey)`, the retry loop stops, and the
+"Sign in to cmux-fuzzhost" tab appears. The mirror is still populated.
+
+```bash
+# 4. Restore auth, then complete the login in that tab (just press return in it).
+mv "$AUTH.off" "$AUTH"
+```
+
+Expect: the login exits reporting success, and the mirror resumes on its own within a couple
+of seconds. Criteria 1-3 met.
+
+For criterion 4, repeat steps 2-3 and close the login tab instead. The mirrored
+workspaces must stay, and breaking auth again must offer a new login rather than being
+silently swallowed.
+
+For criterion 5, attach two sessions on the same host before step 3 and confirm both have
+live control streams (`drop_streams` should report two pids). Exactly one login tab must
+appear.
+
+## Path B — a real 2FA host (what the bug was reported against)
+
+No network unplugging needed; killing the master is enough, because the reconnect then has
+to authenticate from scratch.
+
+```bash
+cmux ssh-tmux <2fa-host>                       # attach, wait for the mirror to populate
+ssh -O exit -o ControlPath="$HOME/.cmux/ssh/tmux-<slug>-<hash>.sock" <2fa-host>
+drop_streams <2fa-host>                        # stream EOF -> reconnect -> cannot 2FA
+                                               # (drop_streams as defined in Path A)
+```
+
+Expect the login tab, complete the 2FA in it, and the mirror resumes. The exact
+`ControlPath` for a host is `~/.cmux/ssh/tmux-<slug>-<fnv1a64>.sock`; `ls ~/.cmux/ssh/`
+while the mirror is up shows it.
+
+## What the automated tests cover
+
+`cmuxTests/RemoteTmuxAuthTests` pins the decision this rests on
+(`RemoteTmuxReconnectDisposition.classify`), which is the part that was wrong:
+
+- an auth failure classifies `.authRequired`, not `.transient` (5 stderr forms),
+- a `ProxyCommand` that closes the transport silently classifies `.authRequired` too, while
+  a non-recoverable one (a missing proxy binary) stays `.transient`,
+- a gone session still classifies `.sessionGone` and outranks a co-reported auth failure,
+- unreachable / refused / reset / empty stay `.transient` so they keep retrying and do
+  **not** pop a login the user cannot act on.
+
+It also covers the two things about the login pane that a string comparison cannot see. The
+command is *executed* the way a terminal command is executed
+(`bash --noprofile --norc -c "exec -l <command>"`, with `/bin/echo` standing in for ssh and
+a throwaway script for `$SHELL`), then the filesystem is checked: the tail must have run,
+and a destination carrying `'; touch …; '` must not have executed anything. Asserting the
+hostile text is merely absent from the command string would prove nothing — it belongs
+there, quoted, as data.
+
+The classifier is a pure function precisely so it is provable without driving a real `ssh`.
+What the unit tests still cannot see is the wiring — that the workspace surfaces, that the
+mirror survives, that the resume fires — and that is what the harness above covers.

--- a/scripts/remote-tmux-reconnect-auth-harness.sh
+++ b/scripts/remote-tmux-reconnect-auth-harness.sh
@@ -132,6 +132,11 @@ await() {
 
 restore_auth() { [ -f "$AUTH.off" ] && mv "$AUTH.off" "$AUTH"; }
 
+# A retry has reached the sshd since SSHD_BEFORE was sampled. The checks below wait on this
+# instead of sleeping out the worst-case backoff: the failed attempt IS the auth-required
+# report, so once it has happened the question they ask is already answerable.
+sshd_retried() { [ "$(sshd_log_lines)" -gt "${SSHD_BEFORE:-0}" ]; }
+
 # Lines in the loopback sshd's log. Every reconnect attempt reaches that sshd and is logged
 # even when it fails authentication, so a growing count is direct evidence the connection is
 # still retrying. Without this, "no login reappeared" is equally true of a stranded host that
@@ -253,19 +258,19 @@ else
   if ! await "the login workspace to close" 30 login_absent; then
     fail "the login workspace would not close; the rest of this scenario is meaningless"
   else
-    # Give the wait loop time to notice the closure and the retry time to fail again — the
-    # exact window in which the old behavior reopened a tab.
+    # Wait for the retry to reach the sshd rather than sleeping out the worst-case backoff.
+    # That failed attempt is the auth-required report, i.e. the exact moment the old behavior
+    # reopened a tab, so both halves of the requirement become answerable as soon as it lands.
     SSHD_BEFORE="$(sshd_log_lines)"
-    sleep 45
-    if login_tab_present; then
-      fail "a login reappeared after being dismissed; closing it does not stick"
-    else
-      pass "no login reappeared after dismissal"
-    fi
-    # And the other half of the requirement: dismissing must not strand the host.
-    SSHD_AFTER="$(sshd_log_lines)"
-    if [ "${SSHD_AFTER:-0}" -gt "${SSHD_BEFORE:-0}" ]; then
-      pass "the connection kept retrying after the dismissal (sshd log $SSHD_BEFORE -> $SSHD_AFTER)"
+    if await "the connection to retry after the dismissal" 60 sshd_retried; then
+      pass "the connection kept retrying after the dismissal (sshd log $SSHD_BEFORE -> $(sshd_log_lines))"
+      # Short settle for the app's turn between the ssh exit and a workspace appearing.
+      sleep 3
+      if login_tab_present; then
+        fail "a login reappeared after being dismissed; closing it does not stick"
+      else
+        pass "no login reappeared after dismissal"
+      fi
     else
       fail "no reconnect attempts after the dismissal — the host is stranded until restart"
     fi
@@ -355,12 +360,20 @@ else
     fail "no control stream to drop for the straggler check"
   else
     log "dropping one stream ($ONE) while others stay connected"
+    SSHD_BEFORE="$(sshd_log_lines)"
     kill "$ONE" 2>/dev/null
-    sleep 40
-    if login_tab_present; then
-      fail "a login appeared while the host still had a live connection"
+    # The dropped stream's retry reaching sshd is its auth-required report. Waiting for that
+    # edge, rather than a fixed 40s, means a failure here says the straggler case was never
+    # exercised instead of passing vacuously.
+    if await "the dropped stream to retry" 60 sshd_retried; then
+      sleep 3
+      if login_tab_present; then
+        fail "a login appeared while the host still had a live connection"
+      else
+        pass "no login offered while a connection to the host was live"
+      fi
     else
-      pass "no login offered while a connection to the host was live"
+      fail "no reconnect attempt reached sshd, so the straggler case was never exercised"
     fi
   fi
   restore_auth

--- a/scripts/remote-tmux-reconnect-auth-harness.sh
+++ b/scripts/remote-tmux-reconnect-auth-harness.sh
@@ -137,7 +137,12 @@ restore_auth() { [ -f "$AUTH.off" ] && mv "$AUTH.off" "$AUTH"; }
 # still retrying. Without this, "no login reappeared" is equally true of a stranded host that
 # is doing nothing at all — which is how a strand shipped once already.
 sshd_log_lines() { wc -l < "$SSHD_DIR/sshd.log" 2>/dev/null | tr -d ' '; }
-trap restore_auth EXIT
+# A private work dir rather than fixed /tmp paths: a hardcoded name is pre-creatable by anyone
+# on the box, so the stderr this harness reads back to explain a failure could be another
+# process's file, or a symlink pointing at something of mine. Also survives two runs at once.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/cmux-reconnect-auth.XXXXXX")" || exit 1
+cleanup() { restore_auth; rm -rf "$WORKDIR"; }
+trap cleanup EXIT
 
 control_path() { ls "$HOME"/.cmux/ssh/tmux-*"$(printf '%s' "$HOST" | tr -c 'a-z0-9' '-')"*.sock 2>/dev/null | head -1; }
 
@@ -279,14 +284,14 @@ restore_auth
 # socket, so a master opened anywhere else would be invisible to it.
 master_open_attempt() {
   ssh -o ControlMaster=auto -o ControlPath="$CMUX_CP" \
-      -o ControlPersist=2m -n -T "$HOST" true 2>/tmp/harness-master-open.err
+      -o ControlPersist=2m -n -T "$HOST" true 2>"$WORKDIR/master-open.err"
   ssh -O check -o ControlPath="$CMUX_CP" "$HOST" >/dev/null 2>&1
 }
 # Retried, not one-shot: this runs immediately after auth is restored, and a single
 # attempt that loses its stderr turns any transient refusal into an unexplained failure.
 if ! await "a master at cmux's ControlPath (standing in for the user's login)" 30 master_open_attempt; then
   fail "could not open a master at cmux's ControlPath — the resume cannot be tested"
-  log "last ssh stderr: $(tr '\n' ' ' < /tmp/harness-master-open.err 2>/dev/null)"
+  log "last ssh stderr: $(tr '\n' ' ' < "$WORKDIR/master-open.err" 2>/dev/null)"
   exit "$FAILURES"
 fi
 

--- a/scripts/remote-tmux-reconnect-auth-harness.sh
+++ b/scripts/remote-tmux-reconnect-auth-harness.sh
@@ -1,0 +1,379 @@
+#!/bin/bash
+# ============================================================================
+# Remote-tmux RECONNECT-AUTH harness.
+#
+# Checks that a reconnect which cannot authenticate produces a login workspace,
+# leaves the mirror parked (not torn down), resumes once auth succeeds, and opens
+# at most one login per host.
+#
+# Hermetic: breaks a loopback sshd's authorized_keys on demand, so no 2FA host,
+# no network changes. Same isolation contract as the render harness.
+#
+# PREREQUISITES
+#   - A tagged Debug app built AND RUNNING; run with CMUX_TAG=<tag>.
+#   - remote-tmux beta on for that bundle id (a fresh tagged build defaults OFF):
+#       defaults write com.cmuxterm.app.debug.<tag> remoteTmux.beta.enabled -bool true
+#   - A loopback ssh alias whose sshd this script may break, created by
+#     `scripts/remote-tmux-fuzz-host.sh <name>`. Defaults to `cmux-fuzzhost`;
+#     override with CMUX_AUTH_HOST / CMUX_AUTH_SSHD_DIR.
+#
+# Exit code is the number of failed scenarios (0 = all green).
+# ============================================================================
+set -uo pipefail
+
+TAG="${CMUX_TAG:?set CMUX_TAG=<tag> of a running tagged Debug app}"
+HOST="${CMUX_AUTH_HOST:-cmux-fuzzhost}"
+SSHD_DIR="${CMUX_AUTH_SSHD_DIR:-$HOME/Library/Caches/cmux/remote-tmux-fuzz/${HOST}-sshd}"
+AUTH="$SSHD_DIR/authorized_keys"
+CLI=(scripts/cmux-debug-cli.sh)
+FAILURES=0
+
+log()  { printf '%s %s\n' "$(date '+%H:%M:%S')" "$*"; }
+pass() { printf '  ✅ %s\n' "$*"; }
+fail() { printf '  ❌ %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+
+cli() { CMUX_QUIET=1 CMUX_TAG="$TAG" "${CLI[@]}" "$@" 2>&1; }
+
+# Workspaces as `<ref>\t<title>`. The plain text listing decorates the selected row
+# with `* ` and `[selected]`, so comparing raw lines reports an untouched workspace as
+# deleted the moment selection moves. Key on the ref instead, which is stable.
+workspaces() {
+  cli list-workspaces --json 2>/dev/null | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for w in d.get("workspaces", []):
+    print("%s\t%s" % (w.get("ref", ""), w.get("title") or ""))
+'
+}
+
+# The login workspace is titled from a localized format ("Sign in to %@"), so match on
+# the destination plus a sign-in marker rather than the whole English string.
+login_refs() { workspaces | grep -iE "sign.?in.*${HOST}" | cut -f1 | sort; }
+login_tab_present() { [ -n "$(login_refs)" ]; }
+login_absent() { [ -z "$(login_refs)" ]; }
+
+# The tmux sessions actually running on the host. `workspace.list` does not mark which
+# workspaces are remote-tmux mirrors (its `remote` block stays empty for them), so the
+# mirror is identified by matching titles against these names.
+host_sessions() {
+  ssh -o BatchMode=yes -o ConnectTimeout=8 "$HOST" \
+    'tmux list-sessions -F "#{session_name}" 2>/dev/null' 2>/dev/null | sort
+}
+
+# Refs of the workspaces mirroring this host's sessions. Matching happens in python
+# because the session list is newline-separated and `awk -v` cannot carry newlines.
+mirror_refs() {
+  # Exported, not prefixed: a `VAR=x cmd | python3` assignment reaches only the left
+  # side of the pipe, so the matcher would silently see an empty set and match nothing.
+  export CMUX_HOST_SESSIONS="$HOST_SESSIONS"
+  cli list-workspaces --json 2>/dev/null | python3 -c '
+import json, os, sys
+want = {s for s in os.environ.get("CMUX_HOST_SESSIONS", "").split("\n") if s}
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for w in d.get("workspaces", []):
+    if (w.get("title") or "") in want:
+        print(w.get("ref", ""))
+' | sort
+}
+
+# Baseline captured once the mirror is settled. Checks are differential against it
+# rather than "are there at least N workspaces": the app under test may already have
+# unrelated workspaces open, so a count threshold would be satisfied without any mirror
+# existing — the check would pass while the feature was completely broken.
+MIRROR_BASELINE=""
+
+# Every one of the host's sessions has a workspace, AND a control stream is running for
+# it. Waiting only for workspaces to appear races the attach burst: workspaces are
+# created before their streams finish connecting, so breaking auth at that moment tests
+# a half-built mirror instead of a reconnect.
+mirror_settled() {
+  local want have streams need_streams
+  want="$(printf '%s\n' "$HOST_SESSIONS" | grep -c .)"
+  have="$(mirror_refs | grep -c .)"
+  streams="$(control_stream_pids | grep -c .)"
+  # With two or more sessions, demand two live streams. The "exactly one login for several
+  # dropped sessions" check is only meaningful if several streams actually drop, and the
+  # fuzz sshd sets `MaxSessions 1`, so a single stream is a real possibility. Requiring it
+  # here means that case times out and says so instead of reporting a green guard that was
+  # never exercised.
+  need_streams=1
+  [ "$want" -ge 2 ] && need_streams=2
+  [ "$have" -ge "$want" ] && [ "$streams" -ge "$need_streams" ]
+}
+
+# Every workspace the mirror contributed is still present. This is criterion 2: the
+# connection parked instead of ending, so nothing was torn down.
+mirror_intact() {
+  local missing
+  missing="$(comm -23 <(printf '%s\n' "$MIRROR_BASELINE") <(mirror_refs))"
+  [ -z "$missing" ] || {
+    log "mirrored workspaces that disappeared: $(printf '%s' "$missing" | tr '\n' ' ')"
+    return 1
+  }
+}
+
+# Wait on a condition, not a duration.
+await() {
+  local what="$1" timeout="$2"; shift 2
+  local deadline=$((SECONDS + timeout))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if "$@"; then return 0; fi
+    sleep 1
+  done
+  log "timed out after ${timeout}s waiting for: $what"
+  return 1
+}
+
+restore_auth() { [ -f "$AUTH.off" ] && mv "$AUTH.off" "$AUTH"; }
+
+# Lines in the loopback sshd's log. Every reconnect attempt reaches that sshd and is logged
+# even when it fails authentication, so a growing count is direct evidence the connection is
+# still retrying. Without this, "no login reappeared" is equally true of a stranded host that
+# is doing nothing at all — which is how a strand shipped once already.
+sshd_log_lines() { wc -l < "$SSHD_DIR/sshd.log" 2>/dev/null | tr -d ' '; }
+trap restore_auth EXIT
+
+control_path() { ls "$HOME"/.cmux/ssh/tmux-*"$(printf '%s' "$HOST" | tr -c 'a-z0-9' '-')"*.sock 2>/dev/null | head -1; }
+
+# The local `ssh` processes carrying a control stream for this host. The remote command
+# is a `/bin/sh` resolver script, so the argv does NOT contain a literal "tmux -CC" —
+# matching that finds nothing and a kill built on it silently does nothing. Match what
+# is really there: the tmux subcommand the resolver forwards, plus the destination.
+control_stream_pids() { pgrep -f "attach-session" 2>/dev/null | while read -r p; do
+    ps -o command= -p "$p" 2>/dev/null | grep -q -- "$HOST" && printf '%s\n' "$p"
+  done; }
+
+drop_stream_unauthenticated() {
+  # Order matters: master gone means the reconnect must authenticate from scratch,
+  # and with authorized_keys moved aside that authentication fails.
+  mv "$AUTH" "$AUTH.off" || return 1
+  [ -n "$CMUX_CP" ] && ssh -O exit -o ControlPath="$CMUX_CP" "$HOST" >/dev/null 2>&1
+  local pids; pids="$(control_stream_pids)"
+  if [ -z "$pids" ]; then
+    log "no control-stream process matched — the kill would be a no-op, so the drop is not real"
+    return 1
+  fi
+  log "killing control stream pid(s): $(printf '%s' "$pids" | tr '\n' ' ')"
+  # No `xargs -r`: it is a GNU extension that older BSD xargs rejects outright, and the
+  # empty case is already handled above. Piping also avoids zsh's lack of word splitting.
+  printf '%s\n' "$pids" | xargs kill
+  return 0
+}
+
+cd "$(dirname "$0")/.." || exit 1
+[ -f "$AUTH" ] || {
+  log "no authorized_keys at $AUTH"
+  log "run: scripts/remote-tmux-fuzz-host.sh $HOST"
+  exit 1
+}
+
+# The app's control socket appears a little after launch, and later under load. Waiting for
+# it here means a slow start reports itself, instead of surfacing as "mirror never settled"
+# and looking like a failure of the code under test.
+app_socket_ready() { cli list-workspaces >/dev/null 2>&1; }
+if ! await "the app's control socket" 120 app_socket_ready; then
+  log "no response on the tagged app socket for CMUX_TAG=$TAG"
+  log "is the tagged app running? scripts/reload.sh --tag $TAG --launch"
+  exit 1
+fi
+
+log "=== scenario 1: a reconnect that cannot authenticate offers a login"
+# Two sessions on the host, so the mirror runs two control streams. Both drop together,
+# so scenario 3's "one login per host" guard is actually exercised; with a single
+# session it would pass no matter what the guard did.
+ssh -o BatchMode=yes "$HOST" 'tmux new-session -d -s harness-a 2>/dev/null; tmux new-session -d -s harness-b 2>/dev/null; true' >/dev/null 2>&1
+HOST_SESSIONS="$(host_sessions)"
+SESSION_COUNT="$(printf '%s\n' "$HOST_SESSIONS" | grep -c .)"
+log "host sessions to mirror ($SESSION_COUNT): $(printf '%s' "$HOST_SESSIONS" | tr '\n' ' ')"
+[ "$SESSION_COUNT" -ge 2 ] || log "WARNING: fewer than 2 sessions; the per-host login guard is not being exercised"
+
+cli ssh-tmux "$HOST" >/dev/null
+if ! await "every session mirrored and its control stream live" 90 mirror_settled; then
+  fail "mirror never settled — cannot test the reconnect path"
+  exit "$FAILURES"
+fi
+MIRROR_BASELINE="$(mirror_refs)"
+pass "mirror settled ($(printf '%s\n' "$MIRROR_BASELINE" | grep -c .) workspaces for $SESSION_COUNT sessions)"
+
+# Capture cmux's own ControlPath while the socket still exists. `ssh -O exit` removes
+# it, and the resume hinges on a master appearing at THIS exact path — cmux probes its
+# own socket, so a master opened anywhere else is invisible to it.
+CMUX_CP="$(control_path)"
+if [ -z "$CMUX_CP" ]; then
+  fail "could not find cmux's ssh ControlPath — cannot verify the resume"
+  exit "$FAILURES"
+fi
+log "cmux ControlPath: $CMUX_CP"
+
+drop_stream_unauthenticated || { fail "could not break auth"; exit "$FAILURES"; }
+if await "a login workspace" 90 login_tab_present; then
+  LOGIN_REFS="$(login_refs)"
+  pass "login workspace appeared: $(printf '%s' "$LOGIN_REFS" | tr '\n' ' ')"
+else
+  LOGIN_REFS=""
+  fail "no login workspace — the auth event reached no consumer on this mirror path"
+fi
+
+# Checked here, while the login is still the live offer. Several sessions dropped at
+# once, so this is where a per-session (rather than per-host) offer would show up as
+# duplicate tabs.
+LOGIN_COUNT="$(printf '%s\n' "$LOGIN_REFS" | grep -c .)"
+if [ "$LOGIN_COUNT" -eq 1 ]; then
+  pass "exactly one login workspace for $SESSION_COUNT dropped sessions"
+else
+  fail "$LOGIN_COUNT login workspaces for $SESSION_COUNT dropped sessions (expected exactly 1)"
+fi
+
+if mirror_intact; then
+  pass "every mirrored workspace survived while parked (nothing torn down)"
+else
+  fail "mirrored workspaces disappeared — the connection ended instead of parking"
+fi
+
+log "=== scenario 2: dismissing the login means no, and it sticks"
+# The previous version of this asserted the opposite — that a fresh login appears after a
+# dismissal — and it passed. That behavior is what made the close button useless: the retry
+# that follows fails the same way, so the tab reopened immediately. What must happen instead
+# is that the retrying continues quietly and no new login is offered for this outage.
+if [ -z "$LOGIN_REFS" ]; then
+  fail "no login workspace to dismiss — cannot check the dismissal"
+else
+  for ref in $LOGIN_REFS; do cli close-workspace --workspace "$ref" >/dev/null; done
+  if ! await "the login workspace to close" 30 login_absent; then
+    fail "the login workspace would not close; the rest of this scenario is meaningless"
+  else
+    # Give the wait loop time to notice the closure and the retry time to fail again — the
+    # exact window in which the old behavior reopened a tab.
+    SSHD_BEFORE="$(sshd_log_lines)"
+    sleep 45
+    if login_tab_present; then
+      fail "a login reappeared after being dismissed; closing it does not stick"
+    else
+      pass "no login reappeared after dismissal"
+    fi
+    # And the other half of the requirement: dismissing must not strand the host.
+    SSHD_AFTER="$(sshd_log_lines)"
+    if [ "${SSHD_AFTER:-0}" -gt "${SSHD_BEFORE:-0}" ]; then
+      pass "the connection kept retrying after the dismissal (sshd log $SSHD_BEFORE -> $SSHD_AFTER)"
+    else
+      fail "no reconnect attempts after the dismissal — the host is stranded until restart"
+    fi
+  fi
+  if mirror_intact; then
+    pass "mirrored workspaces survived the dismissal"
+  else
+    fail "mirrored workspaces were lost when the login was dismissed"
+  fi
+fi
+
+log "=== scenario 3: completing the login resumes the mirror"
+restore_auth
+# Stand in for the user finishing the login: open the shared master at cmux's own
+# ControlPath, which is what the login pane's `ssh` invocation does. cmux probes its own
+# socket, so a master opened anywhere else would be invisible to it.
+master_open_attempt() {
+  ssh -o ControlMaster=auto -o ControlPath="$CMUX_CP" \
+      -o ControlPersist=2m -n -T "$HOST" true 2>/tmp/harness-master-open.err
+  ssh -O check -o ControlPath="$CMUX_CP" "$HOST" >/dev/null 2>&1
+}
+# Retried, not one-shot: this runs immediately after auth is restored, and a single
+# attempt that loses its stderr turns any transient refusal into an unexplained failure.
+if ! await "a master at cmux's ControlPath (standing in for the user's login)" 30 master_open_attempt; then
+  fail "could not open a master at cmux's ControlPath — the resume cannot be tested"
+  log "last ssh stderr: $(tr '\n' ' ' < /tmp/harness-master-open.err 2>/dev/null)"
+  exit "$FAILURES"
+fi
+
+# Resumption means cmux spawned a NEW control stream. Checking the master itself would
+# be vacuous, since this script just opened it.
+stream_respawned() { [ -n "$(control_stream_pids)" ]; }
+if await "cmux to spawn a new control stream (mirror resumed)" 150 stream_respawned; then
+  pass "mirror resumed: a new control stream is live"
+else
+  fail "mirror never resumed after authentication (no new control stream)"
+fi
+
+if mirror_intact; then
+  pass "mirrored workspaces still intact after the resume"
+else
+  fail "mirrored workspaces were lost across the resume"
+fi
+
+log "=== scenario 4: a new outage offers again, and reconnecting closes that login"
+# Two things at once, and both need the reconnect from scenario 3 to have happened: the
+# dismissal from scenario 2 must no longer be in force (a reconnect ends the outage it
+# applied to), and the login cmux opens must close by itself once the host is back. Checking
+# the close on the scenario-2 login would prove nothing, since the user closed that one.
+if ! drop_stream_unauthenticated; then
+  fail "could not break auth for the second outage"
+else
+  if await "a login for the second outage" 120 login_tab_present; then
+    pass "a new outage offers a login again (the dismissal applied only to the last one)"
+    SECOND_LOGIN="$(login_refs)"
+  else
+    SECOND_LOGIN=""
+    fail "no login for a new outage — the dismissal outlived the outage it was for"
+  fi
+  restore_auth
+  if [ -n "$SECOND_LOGIN" ]; then
+    await "a master for the second login" 30 master_open_attempt >/dev/null || true
+    if await "cmux to close the login once the host is back" 120 login_absent; then
+      pass "the login closed once the host reconnected"
+    else
+      fail "the login is still open after the host reconnected; a flap would stack more"
+    fi
+  fi
+fi
+
+log "=== scenario 5: a live connection is never asked to authenticate again"
+# The straggler case, and the one the user actually hit: several sessions park, the user signs
+# in, the first to reconnect releases the offer, and a sibling still finishing its pre-login
+# attempt reports auth-required into an empty slot. The symptom is a second "Sign in to ..."
+# tab appearing moments AFTER a successful sign-in.
+#
+# Reproduced by breaking auth again while a mirror for the host is still connected: any
+# auth-required that arrives now must be swallowed, because a live connection proves
+# authentication is not the blocker.
+if ! mirror_settled; then
+  log "mirror is not settled; skipping (nothing to contradict)"
+else
+  mv "$AUTH" "$AUTH.off" 2>/dev/null
+  # Kill only ONE stream, so at least one connection for the host stays live.
+  ONE="$(control_stream_pids | head -1)"
+  if [ -z "$ONE" ]; then
+    fail "no control stream to drop for the straggler check"
+  else
+    log "dropping one stream ($ONE) while others stay connected"
+    kill "$ONE" 2>/dev/null
+    sleep 40
+    if login_tab_present; then
+      fail "a login appeared while the host still had a live connection"
+    else
+      pass "no login offered while a connection to the host was live"
+    fi
+  fi
+  restore_auth
+fi
+
+log "=== teardown: leave the mirror connected"
+# A run that exits with the mirrors still parked poisons the next run, which then reports
+# "mirror never settled" for a reason that has nothing to do with the code under test.
+# Restoring authorized_keys is not enough on its own: the parked connections already failed
+# their ssh and nothing reopens the master for them.
+restore_auth
+for ref in $(login_refs); do cli close-workspace --workspace "$ref" >/dev/null; done
+await "a master for the teardown resume" 30 master_open_attempt >/dev/null || true
+if await "the mirror to reconnect before exiting" 120 mirror_settled; then
+  log "mirror reconnected; the app is ready for another run"
+else
+  log "WARNING: mirror did not reconnect — the next run may need a relaunch"
+fi
+
+log "=== $FAILURES failed scenario(s)"
+exit "$FAILURES"


### PR DESCRIPTION
A mirrored tmux session freezes permanently if its control stream drops while the shared ControlMaster is gone and the host wants interactive authentication. The mirror keeps showing the last frame it received, with no error, and the only way out is closing every workspace for that host and re-attaching.

Repro against any host that asks for a password, MFA, or a security-key touch:

```bash
cmux ssh-tmux <host>                                    # wait for the mirror to populate
ssh -O exit -o ControlPath=~/.cmux/ssh/tmux-<slug>-<hash>.sock <host>
# the remote command is a /bin/sh resolver, so no argv contains "tmux -CC"
pgrep -f attach-session | while read -r p; do
  ps -o command= -p "$p" | grep -q <host> && kill "$p"
done
```

## Why it can't recover on its own

The reconnect re-runs `tmux -CC attach` over pipes with `BatchMode=yes` and no controlling tty. That's deliberate for a background reconnect, but it means a password prompt, an MFA push, or a FIDO touch can never be satisfied. `handleStreamEnd` classified every non-"session gone" failure as transient and rescheduled with backoff, so it retried an authentication that was structurally incapable of succeeding.

The initial attach already solves this: it returns `RemoteTmuxAttachOutcome.authRequired(sshArgv:)`, and the `cmux ssh-tmux` CLI — which has a tty — runs that argv to open the shared master. A later reconnect has no CLI in the loop, so nothing consumed the signal.

## What changed

`handleStreamEnd` now classifies three outcomes via a pure `RemoteTmuxReconnectDisposition`. On `.authRequired` the retry loop stops and the connection parks: state stays `.reconnecting`, so the tmux session and every mirrored workspace stay intact. cmux opens a workspace titled "Sign in to `<host>`" running the same `interactiveAuthInvocation()`, polls the local control socket with `ssh -O check`, and resumes the parked connection once the master is live.

Things worth knowing while reviewing:

- The classifier uses `indicatesInteractiveRetryWillHelp`, the same composed predicate every initial-connect site uses, so a `ProxyCommand` that closes the transport silently under BatchMode also stops retrying instead of staying in the forever-retry.
- The login command is wrapped in `/bin/sh -c`. A terminal command runs as `bash --noprofile --norc -c "exec -l <command>"`, and that `exec -l` replaces the shell with the command's *first* program — so with ssh leading, the result message and the interactive shell that holds the pane open are unreachable. The pane then dies the moment ssh exits, and cmux closes a workspace whose child exited, so the login tab appeared and vanished in well under a second.
- The workspace is created through `withSocketCommandPolicy(commandKey: "workspace.create")`, because `focus` is honored only while a matching allowance is on the calling thread's stack. Without it the workspace is created and never surfaced.

## One login per host, and why both halves matter

`RemoteTmuxLoginOffers` owns the rule. Both halves were learned from real misbehavior:

- **The slot is reserved before the workspace is created.** Several sessions on one host report auth-required in the same turn, and creating a workspace isn't instantaneous; recording afterwards let all of them through. Observed: six login tabs in 76ms after a session restore re-attached six mirrors to a 2FA host.
- **A resume attempt does not release the slot.** A resume can fail authentication again; releasing on the attempt opened another tab per retry. Observed: one new tab every ~3.8s, matching the reconnect backoff.

The offer is released when a mirror actually reaches `.connected`, which also closes the login workspace and resumes the host's other parked connections. Leaving the pane open meant a flapping host collected a tab per flap; not resuming the siblings left them frozen with their waiter already gone.

A login workspace is also excluded from session restore. A restored terminal is a fresh shell, so a restored login can't authenticate anything, and it's invisible to the per-host rule — which is how these accumulated across relaunches.

Nothing is stranded when the login doesn't go to plan. If the workspace can't be created the connection goes back to retrying rather than parking with its retry cancelled; closing the login without signing in does the same, so a later failure offers a fresh one. Both are derived by looking for that workspace rather than trusting a close path to clear a flag.

The wait for the user has no deadline, because there's no honest one: an MFA push can take seconds or many minutes, and a wait that expired while the login terminal was still open would strand the mirror parked with retrying already stopped. It ends on state instead — the master coming up, the host having no mirror left, or the login being closed unfinished.

## Tests

`cmuxTests/RemoteTmuxAuthTests` — 49 tests in the suite, covering:

- an auth failure classifies `.authRequired`, not `.transient` (5 stderr forms)
- a silently-closed `ProxyCommand` also classifies `.authRequired`, while a non-recoverable one (missing proxy binary) stays `.transient`
- a gone session still classifies `.sessionGone` and outranks a co-reported auth failure
- unreachable / refused / reset / empty stay `.transient`
- simultaneous drops on one host produce one login; repeated auth failures reuse the open one; only connecting releases the slot; a dismissed or failed offer doesn't suppress the next; offers are per-host
- a login workspace is excluded from the session snapshot
- the login command is *executed* the way a terminal command is (`bash --noprofile --norc -c "exec -l …"`, with `/bin/echo` for ssh and a throwaway script for `$SHELL`), then the filesystem is checked: the tail must have run, and a destination carrying `'; touch …; '` must not have executed anything

Red-first, both product fixes:

```
# classifier on the old predicate
✘ (classify(stderr:preControlOutput:) → .transient) == .authRequired   [both ProxyCommand cases]

# login command without the /bin/sh -c wrap
↳ the command's tail never ran, so the login pane would exit as soon as ssh does
```

Asserting the hostile text is merely absent from the command string would prove nothing — it belongs there, quoted, as data. Only running it distinguishes quoted data from executable code.

`scripts/remote-tmux-reconnect-auth-harness.sh` covers the wiring a unit test can't see, against a loopback sshd whose key it breaks on demand (no 2FA host, no network games). Full run on this commit:

```
=== scenario 1: a reconnect that cannot authenticate offers a login
host sessions to mirror (3): 0 harness-a harness-b
  ✅ mirror settled (3 workspaces for 3 sessions)
  ✅ login workspace appeared: workspace:131
  ✅ exactly one login workspace for 3 dropped sessions
  ✅ every mirrored workspace survived while parked (nothing torn down)
=== scenario 2: dismissing an unfinished login leaves the host recoverable
  ✅ dismissing an unfinished login let the host offer a new one
  ✅ mirrored workspaces survived the dismissal
=== scenario 3: completing the login resumes the mirror
  ✅ mirror resumed: a new control stream is live
  ✅ mirrored workspaces still intact after the resume
=== scenario 4: reconnecting closes the login cmux opened
  ✅ the login closed once the host reconnected
=== teardown: leave the mirror connected
mirror reconnected; the app is ready for another run
=== 0 failed scenario(s)
```

Scenario 2 dismisses the login *while the connection is still parked and auth is still broken*, which is the only state where releasing the per-host slot matters — after a successful resume the slot is already clear, so closing it there would pass on the buggy build too.

`docs/remote-tmux-reconnect-auth-acceptance.md` documents the five criteria and the manual path against a real 2FA host.

## Known-red check in this suite

`RemoteTmuxAuthTests/controlModeArgumentsUseRemoteTmuxResolverAfterDestinationGuard` fails on `main` today, before this change. #8550 fixes it independently; this branch deliberately doesn't carry that fix so the two stay separate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787203047&installation_model_id=21920&pr_number=8555&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8555&signature=6a5c72f2722849ea215667496c459c51094d7c49bbb3bb7d909ddf1b39aa9954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Offers a focused “Sign in to `<host>`” login when a remote-tmux reconnect needs interactive auth, instead of retrying forever. Mirrors stay parked and resume as soon as the SSH ControlMaster is live; the resume is event-driven rather than a poll.

**Behavior and review notes**
- Reconnect classification now separates session-gone, auth-required, and transient; session-gone outranks auth-required, a silently-closed `ProxyCommand` under BatchMode counts as auth-required, and tmux socket-connect errors don’t.
- The login wait watches ControlPath creation and confirms with `ssh -O check`; if the watcher can’t attach, the connection falls back to its bounded backoff.
- One login per host: reserved before create, released only on `.connected` or when the host’s last mirror goes; closing the login or its window declines cleanly, lone login windows can be discarded, and a failed workspace create returns to retrying.
- Login workspaces are excluded from session restore; titles use the localized formatter, all new strings are translated in every locale, and logs redact destinations and only report create outcomes.
- A new auth-required observer carries the `ssh` argv; the connection parks in `.reconnecting`, and per-host waiters are tracked, cancellable, and safely replaced.
- Tests cover classifier, lifecycle, and teardown paths; a harness script and acceptance doc validate the behavior. `RemoteTmuxAuthTests/controlModeArgumentsUseRemoteTmuxResolverAfterDestinationGuard` fails on `main` today — #8550 fixes it independently and this branch deliberately doesn’t carry it.

<sup>Written for commit 175256eedef0e3db2bbf5544d8726d0f35e71f95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive SSH authentication flow for remote-tmux reconnects when the host requires login, with localized success/failure messaging and a “Sign in to %@” workspace title.
  * Shows a dedicated auth-login workspace that resumes reconnect automatically after completion and then closes.
  * Prevents duplicate login prompts per host and keeps auth-login workspaces out of session snapshots.

* **Bug Fixes**
  * Improved reconnect classification/handling so session-expired takes priority over auth-required, and retries only continue after authentication is properly presented.

* **Documentation / Tests**
  * Added reconnect-auth acceptance-test documentation, a standalone reconnect-auth harness script, and expanded unit test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->