### PR TITLE
remote-tmux: name the transport seam so a persistent-session transport can be added

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8775,6 +8775,8 @@ struct CMUXCLI {
         var identityFile: String?
         var noFocus = false
         var newWindow = false
+        var transport: String?
+        var transportPort: Int?
 
         // Intentional subset of parseSSHCommandOptions: ssh-tmux has no relay,
         // passthrough, --ssh-option, --name, or --window support.
@@ -8796,6 +8798,25 @@ struct CMUXCLI {
                     throw CLIError(message: "ssh-tmux: --identity requires a path")
                 }
                 identityFile = commandArgs[index + 1]
+                index += 2
+            case "--transport":
+                guard index + 1 < commandArgs.count else {
+                    throw CLIError(message: "ssh-tmux: --transport requires a value (ssh or et)")
+                }
+                let raw = commandArgs[index + 1].lowercased()
+                guard raw == "ssh" || raw == "et" else {
+                    throw CLIError(message: "ssh-tmux: --transport must be ssh or et")
+                }
+                transport = raw
+                index += 2
+            case "--transport-port":
+                guard index + 1 < commandArgs.count else {
+                    throw CLIError(message: "ssh-tmux: --transport-port requires a value")
+                }
+                guard let parsed = Int(commandArgs[index + 1]), parsed > 0, parsed <= 65535 else {
+                    throw CLIError(message: "ssh-tmux: --transport-port must be 1-65535")
+                }
+                transportPort = parsed
                 index += 2
             case "--no-focus":
                 noFocus = true
@@ -8825,6 +8846,8 @@ struct CMUXCLI {
         var params: [String: Any] = ["host": destination]
         if let port { params["port"] = port }
         if let identityFile, !identityFile.isEmpty { params["identity_file"] = identityFile }
+        if let transport { params["transport"] = transport }
+        if let transportPort { params["transport_port"] = transportPort }
         params["activate"] = !noFocus
         if !newWindow {
             try applyWindowOrCallerContext(to: &params, client: client, windowRaw: nil)

--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -62,27 +62,40 @@ extension RemoteTmuxControlConnection {
     /// without this check a wedged et connection stays `.connected` forever and the mirror
     /// freezes with no error and no retry.
     ///
+    /// A silent stream alone does not say which of those two it is. A real network interruption
+    /// silences the stream too, and the transport cannot answer a probe while it is reconnecting
+    /// underneath — so treating silence as the verdict kills the process and throws away the
+    /// session it was in the middle of recovering. The unanswered probe is therefore a suspicion,
+    /// and the question that settles it is asked somewhere else: ``sessionReachability`` runs a
+    /// one-shot over ssh's shared master, a channel this stream's wedge cannot affect. A host that
+    /// answers there proves the network is fine and the stream is the broken part, which is the
+    /// case to recover. A host that does not answer is an outage, and an outage is what this
+    /// transport exists to ride out — so stay `.connected` and ask again next tick, bounded by
+    /// ``maxConsecutiveLivenessDeferrals`` so a host that is both unreachable and wedged still
+    /// gets its reconnect.
+    ///
     /// Only reachable for `reconnectsInternally` transports: ssh gets its EOF and must keep its
     /// existing behavior exactly, including staying quiet on an idle stream.
     ///
-    /// - Parameter completion: `true` if the stream answered (or the check did not apply), and
-    ///   `false` if it was found wedged and recovery was started.
+    /// - Parameter completion: `true` if the stream answered, the check did not apply, or the
+    ///   verdict was deferred; `false` if the stream was found wedged and recovery was started.
+    ///   A deferral reports `true` because `false` means "recovery has started" — callers act on
+    ///   that edge, and a deferral deliberately starts nothing.
     func checkLivenessAndRecoverIfStalled(completion: ((Bool) -> Void)? = nil) {
         guard transportProfile.reconnectsInternally, connectionState == .connected, !exited else {
             completion?(true)
             return
         }
         let generation = processGeneration
-        // An unanswered previous probe IS the stall. ET can accept stdin while producing no
-        // control output, so a probe can be written and simply never answered — without this the
-        // probes accumulate, every one of them still pending, and the connection sits
-        // `.connected` forever. The deadline is the next tick rather than a second timer: probe N
-        // must be answered before probe N+1 is due, which is a generous bound on a local
+        // A previous probe left unanswered is the suspected stall. ET can accept stdin while
+        // producing no control output, so a probe can be written and simply never answered —
+        // without this the probes accumulate, every one of them still pending, and the connection
+        // sits `.connected` forever. The deadline is the next tick rather than a second timer:
+        // probe N must be answered before probe N+1 is due, which is a generous bound on a local
         // round-trip and needs no clock of its own.
         if livenessProbeOutstanding {
             record("liveness-unanswered")
-            recoverFromStalledTransport()
-            completion?(false)
+            resolveSuspectedStall(generation: generation, completion: completion)
             return
         }
         livenessProbeOutstanding = true
@@ -96,6 +109,8 @@ extension RemoteTmuxControlConnection {
                 return
             }
             if answered {
+                // The stream is carrying the protocol, so any run of deferred ticks is over.
+                self.livenessDeferralCount = 0
                 completion?(true)
             } else {
                 self.recoverFromStalledTransport()
@@ -107,6 +122,70 @@ extension RemoteTmuxControlConnection {
             recoverFromStalledTransport()
             completion?(false)
         }
+    }
+
+    /// Asks out of band whether the far end is reachable, then either recovers the stream or
+    /// defers the verdict to the next tick. See ``checkLivenessAndRecoverIfStalled(completion:)``
+    /// for why the silent stream cannot answer this itself.
+    private func resolveSuspectedStall(generation: UInt64, completion: ((Bool) -> Void)?) {
+        // One query at a time. The one-shot bounds itself with ssh's `ConnectTimeout` and
+        // `ServerAlive*` rather than a deadline of its own, so on a dead network it can outlast a
+        // tick; a second query would ask about the same outage and could recover twice for one
+        // stall. Report `true` — this tick found nothing wedged, and the query already running is
+        // the one that decides.
+        guard !livenessReachabilityQueryInFlight else {
+            completion?(true)
+            return
+        }
+        livenessReachabilityQueryInFlight = true
+        // Read the session name now: a `rename-session` during the query would otherwise change
+        // which session the answer is about.
+        let reachability = sessionReachability
+        let host = self.host
+        let sessionName = self.sessionName
+        Task { @MainActor [weak self] in
+            let reachable = await reachability(host, sessionName)
+            guard let self else { return }
+            self.livenessReachabilityQueryInFlight = false
+            // A respawn overtook the query: the stream this answer describes is gone, so acting on
+            // it would recover a stream that was already replaced.
+            guard generation == self.processGeneration, self.connectionState == .connected else {
+                completion?(true)
+                return
+            }
+            // The probe came back while the query was out. The stream is answering after all, so
+            // there is nothing to recover regardless of what the host said.
+            guard self.livenessProbeOutstanding else {
+                completion?(true)
+                return
+            }
+            if reachable {
+                self.recoverFromStalledTransport()
+                completion?(false)
+                return
+            }
+            self.livenessDeferralCount += 1
+            if self.livenessDeferralCount > Self.maxConsecutiveLivenessDeferrals {
+                // Long enough. Either the outage is not what is keeping the stream quiet, or it
+                // has lasted past anything this transport is going to recover from on its own.
+                self.record("liveness-deferral-exhausted")
+                self.recoverFromStalledTransport()
+                completion?(false)
+                return
+            }
+            self.record("liveness-deferred-unreachable")
+            completion?(true)
+        }
+    }
+
+    /// Clears the probe bookkeeping so a fresh stream is judged on its own evidence.
+    ///
+    /// Leaves ``livenessReachabilityQueryInFlight`` alone deliberately: a query that is still
+    /// running clears that itself when it lands, and clearing it here would let a second query
+    /// start while the first is outstanding.
+    func resetLivenessProbeState() {
+        livenessProbeOutstanding = false
+        livenessDeferralCount = 0
     }
 
     /// Replaces a transport that is alive but no longer carrying the protocol.

--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -53,6 +53,59 @@ extension RemoteTmuxControlConnection {
         return sendTracked("display-message -p cmux-liveness", completion: completion)
     }
 
+    /// Checks a stalled-but-alive control stream and recovers it.
+    ///
+    /// A transport that reconnects internally never delivers the EOF that drives ssh recovery:
+    /// during a network change its process stays up and the stream simply pauses. That is the
+    /// behavior worth having, but it means a transport that is alive and *not* recovering looks
+    /// exactly like one that is idle. Nothing else in the lifecycle can tell those apart, so
+    /// without this check a wedged et connection stays `.connected` forever and the mirror
+    /// freezes with no error and no retry.
+    ///
+    /// Only reachable for `reconnectsInternally` transports: ssh gets its EOF and must keep its
+    /// existing behavior exactly, including staying quiet on an idle stream.
+    ///
+    /// - Parameter completion: `true` if the stream answered (or the check did not apply), and
+    ///   `false` if it was found wedged and recovery was started.
+    func checkLivenessAndRecoverIfStalled(completion: ((Bool) -> Void)? = nil) {
+        guard transportProfile.reconnectsInternally, connectionState == .connected, !exited else {
+            completion?(true)
+            return
+        }
+        let generation = processGeneration
+        // A probe that cannot even be enqueued means the stream is already unusable.
+        let enqueued = probeLiveness { [weak self] answered in
+            guard let self else { return }
+            guard generation == self.processGeneration else {
+                // A respawn overtook this probe; its answer says nothing about the live stream.
+                completion?(true)
+                return
+            }
+            if answered {
+                completion?(true)
+            } else {
+                self.recoverFromStalledTransport()
+                completion?(false)
+            }
+        }
+        if !enqueued {
+            recoverFromStalledTransport()
+            completion?(false)
+        }
+    }
+
+    /// Replaces a transport that is alive but no longer carrying the protocol.
+    ///
+    /// Recovery is a respawn rather than an end: the remote session is very likely still there —
+    /// it is the client that is wedged — so the mirror should be reconnected, not torn down. This
+    /// routes through the same `beginReconnecting()` path as an ssh transport loss so there is one
+    /// reconnect implementation rather than a second one for this case.
+    private func recoverFromStalledTransport() {
+        guard connectionState == .connected else { return }
+        record("liveness-stalled")
+        beginReconnecting()
+    }
+
     func failPendingTrackedSends() {
         let completions = Array(trackedSendCompletions.values)
         trackedSendCompletions.removeAll()

--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -28,6 +28,31 @@ extension RemoteTmuxControlConnection {
         return true
     }
 
+    /// Asks tmux to answer, so a stalled-but-alive transport can be told from a healthy one.
+    ///
+    /// This is the liveness check a transport that owns its own reconnection needs. cmux's
+    /// recovery is built on stdout EOF, but such a transport produces no EOF for a network
+    /// drop — the stream pauses and resumes — so EOF cannot be the trigger and a stall must
+    /// not be mistaken for death. What is left is asking the far end a question:
+    ///
+    /// - the process is still alive, and
+    /// - a control-mode round-trip completes.
+    ///
+    /// `display-message -p` is the cheapest question that proves both. It is a read, so it
+    /// moves no client size and mutates nothing, and it resolves through the same
+    /// `%begin`/`%end` correlation as any other command — which is why this reuses
+    /// ``sendTracked(_:completion:)`` rather than inventing a heartbeat with its own timer
+    /// and its own failure modes.
+    ///
+    /// - Parameter completion: `true` when tmux answered, `false` when the block resolved as
+    ///   an error or the stream reset before answering. Not called at all if the command
+    ///   could not be enqueued, which the `false` return reports.
+    @discardableResult
+    func probeLiveness(completion: @escaping (Bool) -> Void) -> Bool {
+        guard !exited else { return false }
+        return sendTracked("display-message -p cmux-liveness", completion: completion)
+    }
+
     func failPendingTrackedSends() {
         let completions = Array(trackedSendCompletions.values)
         trackedSendCompletions.removeAll()

--- a/Sources/RemoteTmuxControlConnection+Commands.swift
+++ b/Sources/RemoteTmuxControlConnection+Commands.swift
@@ -73,8 +73,22 @@ extension RemoteTmuxControlConnection {
             return
         }
         let generation = processGeneration
+        // An unanswered previous probe IS the stall. ET can accept stdin while producing no
+        // control output, so a probe can be written and simply never answered — without this the
+        // probes accumulate, every one of them still pending, and the connection sits
+        // `.connected` forever. The deadline is the next tick rather than a second timer: probe N
+        // must be answered before probe N+1 is due, which is a generous bound on a local
+        // round-trip and needs no clock of its own.
+        if livenessProbeOutstanding {
+            record("liveness-unanswered")
+            recoverFromStalledTransport()
+            completion?(false)
+            return
+        }
+        livenessProbeOutstanding = true
         // A probe that cannot even be enqueued means the stream is already unusable.
         let enqueued = probeLiveness { [weak self] answered in
+            self?.livenessProbeOutstanding = false
             guard let self else { return }
             guard generation == self.processGeneration else {
                 // A respawn overtook this probe; its answer says nothing about the live stream.
@@ -89,6 +103,7 @@ extension RemoteTmuxControlConnection {
             }
         }
         if !enqueued {
+            livenessProbeOutstanding = false
             recoverFromStalledTransport()
             completion?(false)
         }

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -305,12 +305,18 @@ final class RemoteTmuxControlConnection {
     static let altScreenEnterSequence = Data("\u{1b}[?1049h".utf8)
     static let altScreenExitSequence = Data("\u{1b}[?1049l".utf8)
 
+    /// How this connection is carried, derived from the host's transport unless a caller
+    /// overrides it (which tests do, to assert argv without spawning anything).
+    let transportProfile: RemoteTmuxTransportProfile
+
     init(
         host: RemoteTmuxHost,
         sessionName: String,
         createIfMissing: Bool = false,
-        pendingPaneSeedByteLimit: Int = RemoteTmuxControlConnection.maximumPendingPaneSeedBytes
+        pendingPaneSeedByteLimit: Int = RemoteTmuxControlConnection.maximumPendingPaneSeedBytes,
+        transportProfile: RemoteTmuxTransportProfile? = nil
     ) {
+        self.transportProfile = transportProfile ?? host.transport.profile(port: host.transportPort)
         self.host = host
         self.sessionName = sessionName
         self.createIfMissing = createIfMissing
@@ -399,11 +405,25 @@ final class RemoteTmuxControlConnection {
         enterReceived = false
 
         let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: RemoteTmuxHost.defaultSSHExecutablePath())
-        proc.arguments = host.controlModeArguments(
+        let transportExecutable = transportProfile.executablePath()
+        let transportArgv = transportProfile.controlStreamArgv(
+            host: host,
             sessionName: sessionName,
             createIfMissing: createIfMissing
         )
+        if transportProfile.requiresPseudoTerminal {
+            // A terminal client will not talk over pipes: measured against et 6.2.11, it
+            // emits nothing at all and aborts at session end, which reads as "the host
+            // produced no output" rather than "this was spawned without a tty". Give it one.
+            record("transport-pty")
+            proc.executableURL = URL(fileURLWithPath: RemoteTmuxPseudoTerminal.allocatorPath)
+            proc.arguments = RemoteTmuxPseudoTerminal.wrap(
+                executable: transportExecutable, arguments: transportArgv
+            )
+        } else {
+            proc.executableURL = URL(fileURLWithPath: transportExecutable)
+            proc.arguments = transportArgv
+        }
         let inPipe = Pipe(), outPipe = Pipe(), errPipe = Pipe()
         proc.standardInput = inPipe
         proc.standardOutput = outPipe
@@ -675,9 +695,23 @@ final class RemoteTmuxControlConnection {
         case .ended:
             return
         case .connecting, .connected:
-            // The control stream died without `%exit` — a transport loss. Keep the
-            // mirror frozen and reconnect.
-            beginReconnecting()
+            // The control stream died without `%exit`. What that means depends on who owns
+            // reconnection: for ssh it is a transport loss cmux recovers from, but a
+            // transport that reconnects internally does not end for a network drop, so its
+            // exit is the session genuinely ending.
+            switch RemoteTmuxStreamEndDisposition.forStreamEnd(
+                reconnectsInternally: transportProfile.reconnectsInternally
+            ) {
+            case .reconnect:
+                // Keep the mirror frozen and reconnect.
+                beginReconnecting()
+            case .sessionOver:
+                record("stream-end-session-over")
+                connectionState = .ended
+                cancelScheduledWork()
+                teardownProcessHandles()
+                observers.notifyExit()
+            }
         case .reconnecting:
             // A reconnect attempt's process exited before reaching control mode
             // (a successful attach would have moved us to `.connected` via `.enter`).

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -157,12 +157,30 @@ final class RemoteTmuxControlConnection {
     /// ``checkLivenessAndRecoverIfStalled(completion:)``). Nil for ssh, which gets an EOF instead.
     private var livenessTask: Task<Void, Never>?
     /// Whether a liveness probe is still waiting for its answer. The next probe's due time is the
-    /// previous one's deadline, so this is what turns "no answer" into a detected stall.
+    /// previous one's deadline, so this is what turns "no answer" into a suspected stall.
     var livenessProbeOutstanding = false
+    /// Whether an out-of-band reachability query is still running. One at a time: the query rides
+    /// ssh, which bounds itself with `ConnectTimeout`/`ServerAlive*` rather than a deadline of its
+    /// own, so on a dead network it can outlast a tick. A second query would answer about the same
+    /// outage and could recover twice for one stall, so a tick that lands on top of one in flight
+    /// does nothing and lets the query it is waiting on decide.
+    var livenessReachabilityQueryInFlight = false
+    /// Consecutive ticks that found the stream silent AND the host unreachable. Reset when a probe
+    /// is answered and when the connection reconnects, so only an unbroken run counts.
+    var livenessDeferralCount = 0
     /// How often to ask a self-reconnecting transport whether it is still carrying the protocol.
     /// Long enough that an ordinary reconnect finishes untouched, short enough that a wedged
     /// mirror is not left silently frozen.
     static var livenessProbeIntervalSeconds: UInt64 = 30
+    /// How many consecutive unreachable ticks may be deferred before the stream is recovered
+    /// anyway. At the 30-second interval that is about two minutes of outage.
+    ///
+    /// The cap is what keeps deferral honest. A transport that is mid-reconnect deserves to be
+    /// left alone, but "unreachable" cannot be trusted forever: if the host is both unreachable
+    /// and the stream is wedged, deferring without a limit leaves a frozen mirror that never
+    /// retries — the exact failure this monitor was added to prevent. Recovering after the cap
+    /// costs a reconnect that the backoff would have performed anyway.
+    static let maxConsecutiveLivenessDeferrals = 4
     /// Number of reconnect attempts since the last successful connect, driving the
     /// capped exponential backoff. Reset to 0 on a successful connect.
     private var reconnectAttemptCount = 0
@@ -322,15 +340,44 @@ final class RemoteTmuxControlConnection {
     /// overrides it (which tests do, to assert argv without spawning anything).
     let transportProfile: RemoteTmuxTransportProfile
 
+    /// Asks whether the session is still reachable, on a channel that does not run through this
+    /// connection's control stream — the one question that separates a wedged stream from a
+    /// transport that is busy reconnecting underneath. Supplied by the caller the same way
+    /// ``transportProfile`` is, defaulting to ``oneShotSessionReachability`` (which tests replace,
+    /// to decide the answer without a host).
+    let sessionReachability: @Sendable (RemoteTmuxHost, String) async -> Bool
+
+    /// The production reachability check: one `tmux has-session` over ssh's shared control master.
+    ///
+    /// Independent of the wedged stream by construction. Even for an et connection, one-shot
+    /// commands ride ssh (see ``RemoteTmuxETTransportProfile/oneShotArgv(host:remoteCommand:)``),
+    /// so this asks over a different transport entirely — and against et 6.2.11+7 that difference
+    /// is measurable: restarting `etserver` closes the control stream while `has-session` keeps
+    /// succeeding. The master is already open and single-flighted, so the question costs a
+    /// round-trip and no authentication.
+    ///
+    /// Anything other than a clean exit counts as unreachable, including a session tmux says is
+    /// gone. That is deliberately coarse: a gone session normally arrives as `%exit` on the
+    /// control stream, and if it somehow does not, the deferral cap recovers within about two
+    /// minutes and the reattach classifies the end the way it always does.
+    static let oneShotSessionReachability: @Sendable (RemoteTmuxHost, String) async -> Bool = {
+        host, sessionName in
+        let transport = RemoteTmuxSSHTransport(host: host)
+        let result = try? await transport.runTmux(["has-session", "-t", sessionName])
+        return result?.succeeded == true
+    }
+
     init(
         host: RemoteTmuxHost,
         sessionName: String,
         createIfMissing: Bool = false,
         pendingPaneSeedByteLimit: Int = RemoteTmuxControlConnection.maximumPendingPaneSeedBytes,
-        transportProfile: RemoteTmuxTransportProfile? = nil
+        transportProfile: RemoteTmuxTransportProfile? = nil,
+        sessionReachability: (@Sendable (RemoteTmuxHost, String) async -> Bool)? = nil
     ) {
         self.transportProfile = transportProfile
             ?? host.transport.profile(port: host.transportPort, terminalPath: host.transportTerminalPath)
+        self.sessionReachability = sessionReachability ?? Self.oneShotSessionReachability
         self.host = host
         self.sessionName = sessionName
         self.createIfMissing = createIfMissing
@@ -559,7 +606,7 @@ final class RemoteTmuxControlConnection {
         reconnectTask = nil
         livenessTask?.cancel()
         livenessTask = nil
-        livenessProbeOutstanding = false
+        resetLivenessProbeState()
         resetWindowListRequestCoalescing()
         cancelSizingFollowUps()
         pendingPostAttachAction = nil
@@ -776,6 +823,11 @@ final class RemoteTmuxControlConnection {
 
     /// Starts the stall monitor for a transport that owns its own reconnection.
     ///
+    /// Each tick asks the stream a question and reads the previous tick's answer; a probe still
+    /// unanswered when the next one is due makes the stream a suspect, not a casualty. What
+    /// separates a wedged stream from one whose transport is busy reconnecting is asked out of
+    /// band — see ``checkLivenessAndRecoverIfStalled(completion:)``.
+    ///
     /// ssh is deliberately excluded: its stream ends on transport loss, `handleStreamEnd` already
     /// recovers from that, and probing an idle ssh stream would add traffic and a failure mode
     /// where today there is none.
@@ -800,6 +852,9 @@ final class RemoteTmuxControlConnection {
         // The stream is dead: a close decision awaiting an activity query must
         // not hang for the whole backoff window — fail it onto the cache now.
         failPendingCommandTransactions()
+        // The reconnect this starts is the recovery the deferral was waiting for, so the run of
+        // deferred ticks ends here rather than carrying into the next stream's accounting.
+        resetLivenessProbeState()
         resetWindowListRequestCoalescing()
         cancelSizingFollowUps()
         // Subscriptions belong to the dying client, so forget them HERE, not in

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -156,6 +156,9 @@ final class RemoteTmuxControlConnection {
     /// Periodic liveness probe for transports that reconnect internally (see
     /// ``checkLivenessAndRecoverIfStalled(completion:)``). Nil for ssh, which gets an EOF instead.
     private var livenessTask: Task<Void, Never>?
+    /// Whether a liveness probe is still waiting for its answer. The next probe's due time is the
+    /// previous one's deadline, so this is what turns "no answer" into a detected stall.
+    var livenessProbeOutstanding = false
     /// How often to ask a self-reconnecting transport whether it is still carrying the protocol.
     /// Long enough that an ordinary reconnect finishes untouched, short enough that a wedged
     /// mirror is not left silently frozen.
@@ -555,6 +558,7 @@ final class RemoteTmuxControlConnection {
         reconnectTask = nil
         livenessTask?.cancel()
         livenessTask = nil
+        livenessProbeOutstanding = false
         resetWindowListRequestCoalescing()
         cancelSizingFollowUps()
         pendingPostAttachAction = nil

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -716,6 +716,17 @@ final class RemoteTmuxControlConnection {
             // reconnection: for ssh it is a transport loss cmux recovers from, but a
             // transport that reconnects internally does not end for a network drop, so its
             // exit is the session genuinely ending.
+            // A transport that could not start will not start on the next try either, and
+            // retrying hides the reason: end-of-stream no longer implies the session is over, so
+            // without this the mirror waits out the attach timeout with nothing to explain it.
+            if RemoteTmuxSSHTransport.indicatesUnrecoverableTransportFailure(stderrBuffer) {
+                record("stream-end-unrecoverable")
+                connectionState = .ended
+                cancelScheduledWork()
+                teardownProcessHandles()
+                observers.notifyExit()
+                return
+            }
             switch RemoteTmuxStreamEndDisposition.forStreamEnd() {
             case .reconnect:
                 // Keep the mirror frozen and reconnect.
@@ -742,8 +753,12 @@ final class RemoteTmuxControlConnection {
             // (host unreachable, refused) is transient — keep retrying with backoff.
             let sessionGone = decoding.stderrIndicatesSessionGone(stderrBuffer)
                 || decoding.controlOutputIndicatesSessionGone(preControlOutputBuffer)
+            // Same rule on the retry path: a reconnect that failed because the transport cannot run
+            // is not transient, and looping on it burns the backoff forever.
+            let unrecoverable = RemoteTmuxSSHTransport.indicatesUnrecoverableTransportFailure(stderrBuffer)
             teardownProcessHandles()
-            if sessionGone {
+            if sessionGone || unrecoverable {
+                if unrecoverable { record("reconnect-unrecoverable") }
                 record("reconnect-session-gone")
                 connectionState = .ended
                 reconnectTask?.cancel()

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -329,7 +329,8 @@ final class RemoteTmuxControlConnection {
         pendingPaneSeedByteLimit: Int = RemoteTmuxControlConnection.maximumPendingPaneSeedBytes,
         transportProfile: RemoteTmuxTransportProfile? = nil
     ) {
-        self.transportProfile = transportProfile ?? host.transport.profile(port: host.transportPort)
+        self.transportProfile = transportProfile
+            ?? host.transport.profile(port: host.transportPort, terminalPath: host.transportTerminalPath)
         self.host = host
         self.sessionName = sessionName
         self.createIfMissing = createIfMissing

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -715,9 +715,7 @@ final class RemoteTmuxControlConnection {
             // reconnection: for ssh it is a transport loss cmux recovers from, but a
             // transport that reconnects internally does not end for a network drop, so its
             // exit is the session genuinely ending.
-            switch RemoteTmuxStreamEndDisposition.forStreamEnd(
-                reconnectsInternally: transportProfile.reconnectsInternally
-            ) {
+            switch RemoteTmuxStreamEndDisposition.forStreamEnd() {
             case .reconnect:
                 // Keep the mirror frozen and reconnect.
                 beginReconnecting()

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -727,12 +727,14 @@ final class RemoteTmuxControlConnection {
                 observers.notifyExit()
                 return
             }
-            switch RemoteTmuxStreamEndDisposition.forStreamEnd() {
+            switch RemoteTmuxStreamEndDisposition.forStreamEnd(hasReachedControlMode: enterReceived) {
             case .reconnect:
                 // Keep the mirror frozen and reconnect.
                 beginReconnecting()
             case .sessionOver:
-                record("stream-end-session-over")
+                // Either the session ended, or the transport never started — both are terminal, and
+                // both must report rather than retry.
+                record(enterReceived ? "stream-end-session-over" : "stream-end-before-connect")
                 connectionState = .ended
                 cancelScheduledWork()
                 teardownProcessHandles()

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -118,7 +118,10 @@ final class RemoteTmuxControlConnection {
     private var stderrTask: Task<Void, Never>?
     private var parser = RemoteTmuxControlStreamParser()
     private var ingestTask: Task<Void, Never>?
-    private var processGeneration: UInt64 = 0
+    /// Bumped on every spawn. Readable across the type's extensions so a completion that
+    /// outlived its process — a liveness probe answered after a respawn, say — can tell that its
+    /// answer describes a stream that no longer exists. Writable only here.
+    private(set) var processGeneration: UInt64 = 0
     var pendingCommands: [CommandKind] = []
     var windowListRequestInFlight = false
     var windowListRequestDirty = false
@@ -150,6 +153,13 @@ final class RemoteTmuxControlConnection {
     /// attempts); cancelled on `stop()` / genuine end so a dead connection stops
     /// retrying.
     private var reconnectTask: Task<Void, Never>?
+    /// Periodic liveness probe for transports that reconnect internally (see
+    /// ``checkLivenessAndRecoverIfStalled(completion:)``). Nil for ssh, which gets an EOF instead.
+    private var livenessTask: Task<Void, Never>?
+    /// How often to ask a self-reconnecting transport whether it is still carrying the protocol.
+    /// Long enough that an ordinary reconnect finishes untouched, short enough that a wedged
+    /// mirror is not left silently frozen.
+    static var livenessProbeIntervalSeconds: UInt64 = 30
     /// Number of reconnect attempts since the last successful connect, driving the
     /// capped exponential backoff. Reset to 0 on a successful connect.
     private var reconnectAttemptCount = 0
@@ -543,6 +553,8 @@ final class RemoteTmuxControlConnection {
         failPendingCommandTransactions()
         reconnectTask?.cancel()
         reconnectTask = nil
+        livenessTask?.cancel()
+        livenessTask = nil
         resetWindowListRequestCoalescing()
         cancelSizingFollowUps()
         pendingPostAttachAction = nil
@@ -742,6 +754,25 @@ final class RemoteTmuxControlConnection {
 
     // MARK: - Reconnect
 
+    /// Starts the stall monitor for a transport that owns its own reconnection.
+    ///
+    /// ssh is deliberately excluded: its stream ends on transport loss, `handleStreamEnd` already
+    /// recovers from that, and probing an idle ssh stream would add traffic and a failure mode
+    /// where today there is none.
+    private func startLivenessMonitorIfNeeded() {
+        guard transportProfile.reconnectsInternally else { return }
+        livenessTask?.cancel()
+        let interval = Self.livenessProbeIntervalSeconds
+        livenessTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: interval * 1_000_000_000)
+                if Task.isCancelled { return }
+                guard let self else { return }
+                await MainActor.run { self.checkLivenessAndRecoverIfStalled() }
+            }
+        }
+    }
+
     /// Freezes the mirror and reconnects after an unusable control stream.
     func beginReconnecting() {
         guard connectionState == .connected || connectionState == .connecting else { return }
@@ -820,6 +851,7 @@ final class RemoteTmuxControlConnection {
             if connectionState != .connected {
                 let wasReconnecting = connectionState == .reconnecting
                 connectionState = .connected
+                startLivenessMonitorIfNeeded()
                 // Only a first attach needs the rows-minus-one redraw kick. A
                 // reconnect keeps the existing tmux grid and replaces the mirror
                 // with an authoritative full-history seed; kicking after that seed

--- a/Sources/RemoteTmuxControlStreamParser.swift
+++ b/Sources/RemoteTmuxControlStreamParser.swift
@@ -21,6 +21,10 @@ struct RemoteTmuxControlStreamParser {
     private let maxCommandBlockBytes: Int
     private var buffer: [UInt8] = []
     private var inBlock = false
+    /// Whether control mode has been entered. Entering happens once per stream, so the scan for
+    /// the enter DCS stops after it — searching later lines could match a DCS that is genuinely
+    /// part of a pane's own bytes.
+    private var sawEnter = false
     private var blockNumber = 0
     private var blockLines: [String] = []
     private var blockBufferedBytes = 0
@@ -35,6 +39,22 @@ struct RemoteTmuxControlStreamParser {
 
     /// The DCS sequence tmux emits to enter control mode: `ESC P 1000 p`.
     private static let enterSequence: [UInt8] = [0x1b, 0x50, 0x31, 0x30, 0x30, 0x30, 0x70]
+
+    /// Index range of the first occurrence of `needle` in `haystack`, or nil.
+    private static func firstRange(of needle: [UInt8], in haystack: [UInt8]) -> Range<Int>? {
+        guard !needle.isEmpty, haystack.count >= needle.count else { return nil }
+        let last = haystack.count - needle.count
+        var start = 0
+        while start <= last {
+            if haystack[start] == needle[0] {
+                var offset = 1
+                while offset < needle.count, haystack[start + offset] == needle[offset] { offset += 1 }
+                if offset == needle.count { return start..<(start + needle.count) }
+            }
+            start += 1
+        }
+        return nil
+    }
 
     /// ASCII bytes of the `%output ` notification prefix (used to detect and parse
     /// `%output` lines from raw bytes, before any String decode).
@@ -67,10 +87,23 @@ struct RemoteTmuxControlStreamParser {
         var bytes = rawBytes
         var prefixMessages: [RemoteTmuxControlMessage] = []
 
-        // Strip a leading enter DCS (it is prepended to the first %begin line).
-        if bytes.starts(with: Self.enterSequence) {
+        // Strip the enter DCS. It usually opens the line, but it does not have to: a transport
+        // that types the command into a login shell (et) leaves the shell's echo and its OSC
+        // title sequences on the same line, with the DCS arriving partway through and no
+        // newline before it. Requiring it at offset 0 means `.enter` is never emitted there,
+        // and since commands are withheld until `.enter`, the mirror waits forever while the
+        // notifications after it parse normally.
+        //
+        // Everything before the DCS is pre-control-mode shell noise by definition — tmux emits
+        // this sequence when it takes over the terminal — so dropping that prefix is right
+        // rather than merely convenient.
+        // Scoped to before control mode is entered and outside a command block: block content is
+        // raw pane bytes (`capture-pane -e`) that can legitimately contain this DCS, and matching
+        // it there would cut the painted pane apart — the same hazard the ST strip below avoids.
+        if !sawEnter, !inBlock, let dcs = Self.firstRange(of: Self.enterSequence, in: bytes) {
+            sawEnter = true
             prefixMessages.append(.enter)
-            bytes.removeFirst(Self.enterSequence.count)
+            bytes.removeFirst(dcs.upperBound)
         }
         // Drop ST (ESC \) DCS-teardown framing — but ONLY on notification lines.
         // Command-block content (e.g. `capture-pane -e` output) is raw terminal

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -117,8 +117,13 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
         // today: it names the shared master's socket path and persisted mirror state, and
         // changing it for existing hosts would orphan both.
         var fingerprint = "\(destination)\u{1f}\(port.map(String.init) ?? "")\u{1f}\(identityFile ?? "")"
-        if transport != .ssh || transportPort != nil {
-            fingerprint += "\u{1f}\(transport.rawValue)\u{1f}\(transportPort.map(String.init) ?? "")"
+        // Normalized, so two spellings of one endpoint are one key. An unset et port and an
+        // explicit 2022 both resolve to 2022 in `RemoteTmuxTransportKind.profile(port:)`, and ssh
+        // ignores a transport port entirely — hashing the spelling instead of the meaning gave the
+        // controller two keys for the same host, which bypasses mirror de-duplication and lets one
+        // host be mirrored twice.
+        if transport != .ssh {
+            fingerprint += "\u{1f}\(transport.rawValue)\u{1f}\(transport.resolvedTransportPort(transportPort))"
         }
         var hash: UInt64 = 0xcbf2_9ce4_8422_2325 // FNV offset basis
         for byte in fingerprint.utf8 {

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -106,7 +106,20 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     /// distinct endpoints must never collapse onto one socket and risk routing a
     /// command to the wrong server.
     var connectionHash: String {
-        let fingerprint = "\(destination)\u{1f}\(port.map(String.init) ?? "")\u{1f}\(identityFile ?? "")"
+        // The transport and its port belong in the fingerprint because they decide what the
+        // control stream actually is. Everything keyed by this hash — the attach single-flight,
+        // the transport registry, matching a mirror to a host — would otherwise treat an ssh
+        // host and an et host at the same destination as one endpoint, and hand an attach a
+        // cached connection whose profile or port is wrong. Two et hosts on different
+        // etserver ports collide the same way.
+        //
+        // Only appended for a non-default transport, so a plain ssh host keeps the hash it has
+        // today: it names the shared master's socket path and persisted mirror state, and
+        // changing it for existing hosts would orphan both.
+        var fingerprint = "\(destination)\u{1f}\(port.map(String.init) ?? "")\u{1f}\(identityFile ?? "")"
+        if transport != .ssh || transportPort != nil {
+            fingerprint += "\u{1f}\(transport.rawValue)\u{1f}\(transportPort.map(String.init) ?? "")"
+        }
         var hash: UInt64 = 0xcbf2_9ce4_8422_2325 // FNV offset basis
         for byte in fingerprint.utf8 {
             hash ^= UInt64(byte)

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -46,10 +46,34 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     /// ``RemoteTmuxController`` keys its per-endpoint state.
     var id: String { connectionHash }
 
-    init(destination: String, port: Int? = nil, identityFile: String? = nil) {
+    /// Which transport carries this host's control stream.
+    ///
+    /// Part of the host rather than a global setting, because it is a property of the
+    /// endpoint: one host may be reachable over a session-preserving transport while
+    /// another is plain ssh. Defaults to ssh, so an unspecified host behaves exactly as
+    /// before.
+    let transport: RemoteTmuxTransportKind
+
+    /// The port of a non-ssh transport, when it differs from ssh's.
+    ///
+    /// Separate from ``port`` because the two are genuinely different endpoints on the same
+    /// host: one-shot discovery and mutation commands keep riding ssh even when the control
+    /// stream does not, so folding both into one field points ssh at the other transport's
+    /// port and every one-shot fails with `kex_exchange_identification`.
+    let transportPort: Int?
+
+    init(
+        destination: String,
+        port: Int? = nil,
+        identityFile: String? = nil,
+        transport: RemoteTmuxTransportKind = .ssh,
+        transportPort: Int? = nil
+    ) {
         self.destination = destination
         self.port = port
         self.identityFile = identityFile
+        self.transport = transport
+        self.transportPort = transportPort
     }
 
     /// A human-readable (but lossy) slug for the destination, used only for

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -62,18 +62,29 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
     /// port and every one-shot fails with `kex_exchange_identification`.
     let transportPort: Int?
 
+    /// Where the transport's remote helper lives, once discovered.
+    ///
+    /// `et` needs `etterminal`'s absolute path because a non-interactive ssh does not have it on
+    /// PATH, and the path differs by platform and package manager. Resolved by probing the host
+    /// rather than assumed — deliberately not part of ``connectionHash``, since it describes how to
+    /// reach the endpoint rather than which endpoint it is, and two spellings of it must not split
+    /// one host into two.
+    let transportTerminalPath: String?
+
     init(
         destination: String,
         port: Int? = nil,
         identityFile: String? = nil,
         transport: RemoteTmuxTransportKind = .ssh,
-        transportPort: Int? = nil
+        transportPort: Int? = nil,
+        transportTerminalPath: String? = nil
     ) {
         self.destination = destination
         self.port = port
         self.identityFile = identityFile
         self.transport = transport
         self.transportPort = transportPort
+        self.transportTerminalPath = transportTerminalPath
     }
 
     /// A human-readable (but lossy) slug for the destination, used only for

--- a/Sources/RemoteTmuxSSHTransport.swift
+++ b/Sources/RemoteTmuxSSHTransport.swift
@@ -378,6 +378,33 @@ actor RemoteTmuxSSHTransport {
     /// the user must fix `known_hosts` themselves. Algorithm-negotiation failures
     /// ("no matching host key type") are deliberately NOT matched: an interactive
     /// retry cannot fix them, so they surface as a normal error instead.
+    /// Whether a control-stream failure can never be fixed by trying again.
+    ///
+    /// The counterpart to ``indicatesAuthRequired``, and the same reasoning: retrying is only
+    /// honest when the next attempt could differ. A missing binary, a remote helper that is not
+    /// where the transport said it was, or a malformed invocation will fail identically forever, so
+    /// retrying converts a precise error into an opaque attach timeout — measured, after
+    /// end-of-stream stopped implying the session was over: a transport that could not start at all
+    /// produced a 60-second wait and no message.
+    ///
+    /// Deliberately narrow. Anything not listed keeps retrying, because the cost of wrongly
+    /// retrying is a delay while the cost of wrongly giving up is a mirror that never returns.
+    static func indicatesUnrecoverableTransportFailure(_ stderr: String) -> Bool {
+        let lowered = stderr.lowercased()
+        // The pty allocator could not find the transport binary. `/usr/bin/script` resolves its
+        // argument against the app's PATH, which for a GUI app is not the user's.
+        if lowered.contains("script:"), lowered.contains("no such file or directory") { return true }
+        // posix_spawn / Process launch failures for the transport itself.
+        if lowered.contains("no such file or directory"),
+           lowered.contains("etterminal") || lowered.contains("/et") { return true }
+        // et's own message when its ssh bootstrap cannot start the remote helper — wrong
+        // `--terminal-path`, or a helper missing on the server. Retrying sends the same path.
+        if lowered.contains("error starting et process") { return true }
+        // An argv the transport rejects outright is a bug in what cmux built, not a bad moment.
+        if lowered.contains("unrecognized option") || lowered.contains("unknown option") { return true }
+        return false
+    }
+
     static func indicatesAuthRequired(_ stderr: String) -> Bool {
         let lowered = stderr.lowercased()
         return lowered.contains("permission denied")

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -1,5 +1,275 @@
 import Foundation
 
+/// The transports cmux can carry a control stream over.
+///
+/// A closed set rather than a free-form string, so an unknown value is rejected at the
+/// socket boundary instead of becoming an unspawnable host.
+enum RemoteTmuxTransportKind: String, Sendable, Equatable, CaseIterable {
+    /// Plain ssh over the shared ControlMaster: the default, and today's behavior.
+    case ssh
+    /// EternalTerminal: keeps its session across a network change, needs a tty.
+    case et
+
+    /// Parses a user-supplied value, rejecting anything unrecognized.
+    static func parse(_ raw: String?) -> RemoteTmuxTransportKind? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !raw.isEmpty else { return .ssh }
+        return RemoteTmuxTransportKind(rawValue: raw)
+    }
+
+    /// The profile that carries this transport.
+    func profile(port: Int?) -> RemoteTmuxTransportProfile {
+        switch self {
+        case .ssh:
+            return RemoteTmuxSSHTransportProfile()
+        case .et:
+            // etserver listens on 2022 by default, and a host's `port` means "the port of
+            // this host's transport" — for et that is etserver's, not sshd's.
+            return RemoteTmuxETTransportProfile(
+                port: port ?? 2022,
+                // macOS servers keep etterminal outside the default remote PATH, which is
+                // why `et` ships `--macserver` at all. Naming the path explicitly works on
+                // every server rather than only that one flag's target.
+                remoteTerminalPath: "/usr/local/bin/etterminal"
+            )
+        }
+    }
+}
+
+/// How a remote tmux control stream and one-shot commands are carried to a host.
+///
+/// Today there is exactly one implementation and it is ssh, so this changes no behavior.
+/// It exists because the choice of transport is currently spelled out at the point of use —
+/// `Process` is handed `ssh` and `host.controlModeArguments(…)` directly — and any transport
+/// that keeps a session alive across a network change (EternalTerminal, mosh) cannot be
+/// introduced without first naming that decision.
+///
+/// The split is between *argv* and *execution*: this decides what to run, while
+/// ``RemoteTmuxSSHTransport`` keeps owning process spawning, the shared ControlMaster, and
+/// stderr classification. Keeping execution out means a second transport does not have to
+/// reimplement any of that.
+protocol RemoteTmuxTransportProfile: Sendable {
+    /// The binary that carries the connection.
+    func executablePath() -> String
+
+    /// argv for the long-lived `tmux -CC` control stream.
+    func controlStreamArgv(
+        host: RemoteTmuxHost,
+        sessionName: String,
+        createIfMissing: Bool
+    ) -> [String]
+
+    /// argv for a one-shot remote command (discovery, mutations).
+    func oneShotArgv(host: RemoteTmuxHost, remoteCommand: String) -> [String]
+
+    /// Whether the transport needs a pseudo-terminal rather than pipes.
+    ///
+    /// Measured against EternalTerminal 6.2.11: with stdin at `/dev/null` and stdout a
+    /// pipe, `et` writes nothing at all and aborts (`SIGABRT`) when the session ends — not
+    /// even a trivial `echo` returns output. It is a terminal client and expects a tty.
+    /// cmux spawns its control stream on pipes, so this is the one property that decides
+    /// whether a transport can be spawned at all, independent of argv.
+    var requiresPseudoTerminal: Bool { get }
+
+    /// Whether the transport recovers from network loss by itself.
+    ///
+    /// This is the property that changes cmux's behavior rather than just its argv. cmux
+    /// treats stdout EOF as "the stream died, respawn with backoff". A transport that
+    /// reconnects internally produces no EOF for a network drop — the stream pauses and
+    /// resumes — so respawning on a stall would throw away the session it was about to
+    /// recover. Such a transport needs a liveness check (process alive plus a control-mode
+    /// round-trip) instead of an EOF trigger.
+    var reconnectsInternally: Bool { get }
+}
+
+/// What end-of-stream on the control connection means.
+///
+/// cmux's recovery is built on stdout EOF: the stream ends, so respawn with backoff. That
+/// is right for ssh, where a dropped connection ends the process. It is wrong for a
+/// transport that owns its own reconnection: such a transport does not end for a network
+/// drop — the stream pauses and resumes — so if it *does* end, it has genuinely exited and
+/// the session is over. Respawning then would be cmux fighting the transport for ownership
+/// of recovery, and the failure it must watch for instead is "alive but wedged".
+enum RemoteTmuxStreamEndDisposition: Sendable, Equatable {
+    /// cmux owns recovery: respawn the transport with backoff.
+    case reconnect
+    /// The transport owned recovery, so its exit is terminal.
+    case sessionOver
+
+    /// Decides from who owns reconnection.
+    static func forStreamEnd(reconnectsInternally: Bool) -> RemoteTmuxStreamEndDisposition {
+        reconnectsInternally ? .sessionOver : .reconnect
+    }
+}
+
+/// A command to run before opening a connection to a host.
+///
+/// Some hosts need a step cmux has no business knowing about: minting a short-lived
+/// credential, unlocking an agent, refreshing a token. Rather than teaching cmux any of
+/// them, a host can carry a command, run as `<command> <destination>`.
+///
+/// Two rules come out of wiring one of these up for real:
+///
+/// - It runs once per connection, not once per command. Anything minting a single-use
+///   credential must not race itself — two mints can invalidate each other — so the right
+///   home is the single-flight path that opens the shared master, not a per-command hook.
+/// - A non-zero exit is not fatal. cmux proceeds and lets the connection fail on its own
+///   terms, so a broken hook cannot make a host unreachable.
+struct RemoteTmuxPreConnectHook: Sendable, Equatable {
+    /// The executable to run. `nil` means today's behavior: no hook.
+    let command: String?
+
+    init(command: String? = nil) {
+        let trimmed = command?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.command = (trimmed?.isEmpty == false) ? trimmed : nil
+    }
+
+    /// The argv to run for `destination`, or nil when no hook is configured.
+    func argv(destination: String) -> [String]? {
+        guard let command else { return nil }
+        return [command, destination]
+    }
+
+    /// Whether a hook's exit status should abort the connection. It never should: see the
+    /// type's documentation.
+    func shouldAbortConnection(onExitCode code: Int32) -> Bool { false }
+}
+
+/// The ssh transport: current behavior, and the default.
+struct RemoteTmuxSSHTransportProfile: RemoteTmuxTransportProfile {
+    /// Idle lifetime of the shared master, matching ``RemoteTmuxSSHTransport``'s default so
+    /// one-shot argv built here is identical to what the transport builds for itself.
+    let controlPersistSeconds: Int
+
+    init(controlPersistSeconds: Int = 180) {
+        self.controlPersistSeconds = controlPersistSeconds
+    }
+
+    func executablePath() -> String {
+        RemoteTmuxHost.defaultSSHExecutablePath()
+    }
+
+    func controlStreamArgv(
+        host: RemoteTmuxHost,
+        sessionName: String,
+        createIfMissing: Bool
+    ) -> [String] {
+        host.controlModeArguments(sessionName: sessionName, createIfMissing: createIfMissing)
+    }
+
+    func oneShotArgv(host: RemoteTmuxHost, remoteCommand: String) -> [String] {
+        // `--` ends ssh option parsing so a destination beginning with `-` (e.g.
+        // `-oProxyCommand=…`) can never be consumed as an ssh option.
+        host.sshControlArguments(controlPersistSeconds: controlPersistSeconds, batchMode: true)
+            + ["--", host.destination, remoteCommand]
+    }
+
+    /// ssh does not: a dropped connection ends the process, and cmux respawns it.
+    var reconnectsInternally: Bool { false }
+
+    /// ssh is happy on pipes, which is what cmux spawns today.
+    var requiresPseudoTerminal: Bool { false }
+}
+
+/// How cmux gives a transport a controlling terminal.
+///
+/// cmux spawns its control stream on pipes, which a terminal client like EternalTerminal
+/// refuses to work with. Rather than reimplement `posix_openpt`/`grantpt`/`TIOCSCTTY`
+/// plumbing, wrap the transport in the system's own pty allocator, which is also how the
+/// behavior was verified by hand.
+///
+/// Two measured facts make this safe for a control protocol:
+///
+/// - The pty echoes whatever cmux writes to stdin. Those echoed lines are not control-mode
+///   notifications, so the parser ignores them; they cost bytes, not correctness.
+/// - Anything written before the control stream is up is consumed by the transport's *login
+///   shell*, not by tmux. cmux already withholds commands until `%enter`, so this is
+///   already respected — but it is why that ordering is load-bearing rather than incidental.
+enum RemoteTmuxPseudoTerminal {
+    /// BSD `script` runs a command with a pty attached and copies the session to a file;
+    /// `/dev/null` discards the copy while keeping the pty.
+    static let allocatorPath = "/usr/bin/script"
+
+    /// Wraps a transport invocation so the child gets a tty on stdin/stdout/stderr.
+    static func wrap(executable: String, arguments: [String]) -> [String] {
+        ["-q", "/dev/null", executable] + arguments
+    }
+}
+
+/// EternalTerminal: a transport that keeps its session across a network change.
+///
+/// Every claim here was measured against et 6.2.11 on a loopback `etserver`, because the
+/// differences from ssh are not the kind you can read off `--help`:
+///
+/// - **It needs a tty.** On pipes it emits nothing and aborts at session end.
+/// - **It types the command into a login shell** rather than exec'ing it, appending
+///   `; exit`. A real `tmux -CC` stream therefore arrives after ~1.2 KB of preamble: the
+///   echoed command line, then prompt escapes, and only then `%begin`. cmux's parser
+///   already tolerates this (unrecognized lines yield no messages) and already strips the
+///   pty's `\r`, so the protocol survives — but the preamble is not optional, it is what
+///   this transport always does.
+/// - **It reconnects internally**, so a dropped network does not end the process. On a real
+///   session end the client first attempts a reconnect and only then reports the session
+///   gone, which is why EOF must mean "over" rather than "respawn" here.
+/// - **`-x` / `--kill-other-sessions` must never be passed**: it kills every session that
+///   user has on the host, not just stale ones.
+struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
+    /// etserver's default port is 2022, not ssh's 22.
+    let port: Int
+    /// `et` binary path.
+    let executable: String
+    /// Path to `etterminal` on the server, needed when it is not on the remote PATH — which
+    /// is the case for a macOS server, where `--macserver` exists to set exactly this.
+    let remoteTerminalPath: String?
+
+    init(
+        port: Int = 2022,
+        executable: String = "/usr/local/bin/et",
+        remoteTerminalPath: String? = nil
+    ) {
+        self.port = port
+        self.executable = executable
+        self.remoteTerminalPath = remoteTerminalPath
+    }
+
+    func executablePath() -> String { executable }
+
+    func controlStreamArgv(
+        host: RemoteTmuxHost,
+        sessionName: String,
+        createIfMissing: Bool
+    ) -> [String] {
+        // The resolver is still required: a non-login remote shell has a minimal PATH, and
+        // that is a property of the remote shell rather than of ssh.
+        let remote = RemoteTmuxHost.tmuxRemoteCommand(
+            arguments: [
+                "-CC",
+                createIfMissing ? "new-session" : "attach-session",
+                "-t", sessionName,
+            ]
+        )
+        // Arguments only: the executable is supplied separately (see ``executablePath()``),
+        // exactly as the ssh profile does. Including it here would pass `et` twice.
+        var argv = ["-p", String(port)]
+        if let remoteTerminalPath {
+            argv += ["--terminal-path", remoteTerminalPath]
+        }
+        // `exec` so the login shell does not linger as a parent of tmux.
+        argv += ["-c", "exec \(remote)", host.destination]
+        return argv
+    }
+
+    /// One-shot commands keep riding ssh's shared master: it is already single-flighted for
+    /// the cold-start burst, and that logic has nothing to do with how the `-CC` stream is
+    /// carried.
+    func oneShotArgv(host: RemoteTmuxHost, remoteCommand: String) -> [String] {
+        RemoteTmuxSSHTransportProfile().oneShotArgv(host: host, remoteCommand: remoteCommand)
+    }
+
+    var reconnectsInternally: Bool { true }
+    var requiresPseudoTerminal: Bool { true }
+}
+
 /// Owns the per-endpoint ``RemoteTmuxSSHTransport`` instances ``RemoteTmuxController``
 /// uses for SSH discovery, keyed by ``RemoteTmuxHost/connectionHash`` (destination +
 /// port + identity).

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -387,8 +387,12 @@ struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
         if let identityFile = host.identityFile {
             argv += ["--ssh-option", "IdentityFile=\(identityFile)"]
         }
-        // `exec` so the login shell does not linger as a parent of tmux.
-        argv += ["-c", "exec \(remote)", host.destination]
+        // `exec` so the login shell does not linger as a parent of tmux. `--` ends et's option
+        // parsing for the same reason ssh's argv does: a destination beginning with `-` has to be a
+        // host, never an option. Measured against et 6.2.11+7 - with the guard, `-weirdhost` is
+        // reported as an unreachable host; without it, et swallows it and exits "Missing host to
+        // connect to".
+        argv += ["-c", "exec \(remote)", "--", host.destination]
         return argv
     }
 

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -242,10 +242,17 @@ struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
     /// unusable on a standard Apple Silicon install.
     static let clientSearchDirectories = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
 
-    /// The first `et` that exists on PATH or in a known install directory.
+    /// Used when nothing is found, matching et's own documented install location.
     ///
-    /// Falls back to the bare name so the failure is `et` not being found rather than a wrong
-    /// absolute path, which is the more honest error and lets a PATH lookup at spawn time win.
+    /// NOT the bare name `et`: the control stream is spawned through `/usr/bin/script`, which
+    /// resolves its argument against the *app's* PATH, and a GUI app's PATH cannot be relied on.
+    /// Measured — `script -q /dev/null et --version` under a minimal PATH reports
+    /// `script: et: No such file or directory`, the stream ends immediately, and end-of-stream now
+    /// means reconnect, so the failure surfaces as a 60-second attach timeout with no error rather
+    /// than as "et not found".
+    static let defaultClientPath = "/usr/local/bin/et"
+
+    /// The first `et` that exists on PATH or in a known install directory.
     static func resolveClientExecutable(
         fileExists: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) },
         pathValue: String? = ProcessInfo.processInfo.environment["PATH"]
@@ -257,7 +264,7 @@ struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
             let candidate = URL(fileURLWithPath: trimmed).appendingPathComponent("et").path
             if fileExists(candidate) { return candidate }
         }
-        return "et"
+        return defaultClientPath
     }
 
     /// Longest line a remote login shell will accept, `MAX_CANON` on macOS.

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -17,6 +17,17 @@ enum RemoteTmuxTransportKind: String, Sendable, Equatable, CaseIterable {
         return RemoteTmuxTransportKind(rawValue: raw)
     }
 
+    /// The port this transport actually uses, given a host's optional override.
+    ///
+    /// One place resolves the default so identity and argv cannot disagree: hashing an unset port
+    /// separately from the explicit value it resolves to gave one host two controller keys.
+    func resolvedTransportPort(_ configured: Int?) -> Int {
+        switch self {
+        case .ssh: return configured ?? 22
+        case .et: return configured ?? 2022
+        }
+    }
+
     /// The profile that carries this transport.
     func profile(port: Int?) -> RemoteTmuxTransportProfile {
         switch self {
@@ -25,13 +36,11 @@ enum RemoteTmuxTransportKind: String, Sendable, Equatable, CaseIterable {
         case .et:
             // etserver listens on 2022 by default, and a host's `port` means "the port of
             // this host's transport" — for et that is etserver's, not sshd's.
-            return RemoteTmuxETTransportProfile(
-                port: port ?? 2022,
-                // macOS servers keep etterminal outside the default remote PATH, which is
-                // why `et` ships `--macserver` at all. Naming the path explicitly works on
-                // every server rather than only that one flag's target.
-                remoteTerminalPath: "/usr/local/bin/etterminal"
-            )
+            // No remote terminal path is forced. `et` finds `etterminal` on the remote PATH by
+            // default, and naming an absolute path here was a guess about the *server's* layout:
+            // right for an Intel-Homebrew macOS server, wrong for Apple Silicon or Linux, and
+            // fatal when it is wrong because et executes exactly what it is given.
+            return RemoteTmuxETTransportProfile(port: resolvedTransportPort(port))
         }
     }
 }
@@ -221,6 +230,49 @@ enum RemoteTmuxPseudoTerminal {
 /// - **`-x` / `--kill-other-sessions` must never be passed**: it kills every session that
 ///   user has on the host, not just stale ones.
 struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
+    /// Where `et` may live, in preference order. Apple Silicon Homebrew installs under
+    /// `/opt/homebrew`, Intel under `/usr/local`, Linux under `/usr` — a single literal path is a
+    /// claim about someone else's machine, and hardcoding `/usr/local/bin` made this transport
+    /// unusable on a standard Apple Silicon install.
+    static let clientSearchDirectories = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
+
+    /// The first `et` that exists on PATH or in a known install directory.
+    ///
+    /// Falls back to the bare name so the failure is `et` not being found rather than a wrong
+    /// absolute path, which is the more honest error and lets a PATH lookup at spawn time win.
+    static func resolveClientExecutable(
+        fileExists: (String) -> Bool = { FileManager.default.isExecutableFile(atPath: $0) },
+        pathValue: String? = ProcessInfo.processInfo.environment["PATH"]
+    ) -> String {
+        let fromPath = (pathValue ?? "").split(separator: ":").map(String.init)
+        for directory in fromPath + clientSearchDirectories {
+            let trimmed = directory.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let candidate = URL(fileURLWithPath: trimmed).appendingPathComponent("et").path
+            if fileExists(candidate) { return candidate }
+        }
+        return "et"
+    }
+
+    /// Longest line a remote login shell will accept, `MAX_CANON` on macOS.
+    ///
+    /// et types the command into a pty rather than exec'ing it, so this is a hard delivery limit
+    /// and not a style guide: a longer line never completes, the shell runs nothing, and the attach
+    /// dies on a timeout with nothing to explain it. Checked against real et in
+    /// `scripts/remote-tmux-et-conformance.sh`, on both 6.2.11+7 and 7.0.0.
+    static let maxCanonicalLineBytes = 1024
+
+    /// Longest session name whose attach command still fits one canonical line.
+    ///
+    /// Derived from the command this profile actually builds rather than guessed, so it cannot
+    /// drift away from it. tmux itself accepts names far longer than this — roughly 1000 bytes —
+    /// which is why an unbounded name reached et and silently delivered nothing.
+    static func maxSessionNameBytes(createIfMissing: Bool = false) -> Int {
+        let overhead = controlStreamRemoteCommand(sessionName: "", createIfMissing: createIfMissing)
+            .utf8.count
+        return max(0, maxCanonicalLineBytes - overhead - 1)
+    }
+
     /// etserver's default port is 2022, not ssh's 22.
     let port: Int
     /// `et` binary path.
@@ -231,12 +283,25 @@ struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
 
     init(
         port: Int = 2022,
-        executable: String = "/usr/local/bin/et",
+        executable: String? = nil,
         remoteTerminalPath: String? = nil
     ) {
         self.port = port
-        self.executable = executable
+        self.executable = executable ?? Self.resolveClientExecutable()
         self.remoteTerminalPath = remoteTerminalPath
+    }
+
+    /// The remote command this profile runs, in one place so the length bound above is derived
+    /// from the same string that is actually sent.
+    static func controlStreamRemoteCommand(sessionName: String, createIfMissing: Bool) -> String {
+        ([
+            "tmux",
+            "-CC",
+            createIfMissing ? "new-session" : "attach-session",
+            "-t", sessionName,
+        ] as [String])
+            .map(RemoteTmuxHost.shellSingleQuoted)
+            .joined(separator: " ")
     }
 
     func executablePath() -> String { executable }
@@ -256,19 +321,26 @@ struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
         // Dropping the resolver is safe precisely because it is a login shell: it has the user's
         // full PATH, so it finds tmux itself. ssh is the opposite case, running a non-login shell
         // with a minimal PATH, which is why that profile still needs the resolver.
-        let remote = ([
-            "tmux",
-            "-CC",
-            createIfMissing ? "new-session" : "attach-session",
-            "-t", sessionName,
-        ] as [String])
-            .map(RemoteTmuxHost.shellSingleQuoted)
-            .joined(separator: " ")
+        let remote = Self.controlStreamRemoteCommand(
+            sessionName: sessionName, createIfMissing: createIfMissing
+        )
         // Arguments only: the executable is supplied separately (see ``executablePath()``),
         // exactly as the ssh profile does. Including it here would pass `et` twice.
         var argv = ["-p", String(port)]
         if let remoteTerminalPath {
             argv += ["--terminal-path", remoteTerminalPath]
+        }
+        // et bootstraps over ssh before its own protocol takes over, and it does not inherit the
+        // host's ssh settings from anywhere. Passing them through `--ssh-option` is what makes
+        // `--port 2222 --identity /key --transport et` reach the same sshd the ssh preflight just
+        // used; without it the preflight succeeds and et's bootstrap fails against defaults.
+        //
+        // `host.port` is the SSH port here, distinct from `port` above, which is etserver's.
+        if let sshPort = host.port {
+            argv += ["--ssh-option", "Port=\(sshPort)"]
+        }
+        if let identityFile = host.identityFile {
+            argv += ["--ssh-option", "IdentityFile=\(identityFile)"]
         }
         // `exec` so the login shell does not linger as a parent of tmux.
         argv += ["-c", "exec \(remote)", host.destination]

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -84,22 +84,29 @@ protocol RemoteTmuxTransportProfile: Sendable {
 
 /// What end-of-stream on the control connection means.
 ///
-/// cmux's recovery is built on stdout EOF: the stream ends, so respawn with backoff. That
-/// is right for ssh, where a dropped connection ends the process. It is wrong for a
-/// transport that owns its own reconnection: such a transport does not end for a network
-/// drop — the stream pauses and resumes — so if it *does* end, it has genuinely exited and
-/// the session is over. Respawning then would be cmux fighting the transport for ownership
-/// of recovery, and the failure it must watch for instead is "alive but wedged".
+/// cmux's recovery is built on stdout EOF: the stream ends, so respawn with backoff.
+///
+/// The tempting rule is that a transport owning its own reconnection does not end for a network
+/// drop, so its exit must mean the session ended. Measured against et 6.2.11+7, that is false:
+/// restarting only `etserver` closes the stream while `tmux has-session` still succeeds. Acting on
+/// it discarded mirrors whose sessions were alive and reattachable.
+///
+/// EOF cannot distinguish "the transport died" from "the session died", for any transport, so this
+/// does not try. Reattaching answers the question: the reconnect path already classifies a genuinely
+/// gone session from what the reattach reports. The failure such a transport still needs watching
+/// for is the one EOF never reports at all — alive but wedged.
 enum RemoteTmuxStreamEndDisposition: Sendable, Equatable {
     /// cmux owns recovery: respawn the transport with backoff.
     case reconnect
     /// The transport owned recovery, so its exit is terminal.
     case sessionOver
 
-    /// Decides from who owns reconnection.
-    static func forStreamEnd(reconnectsInternally: Bool) -> RemoteTmuxStreamEndDisposition {
-        reconnectsInternally ? .sessionOver : .reconnect
-    }
+    /// What EOF on the control stream means, for every transport: reconnect and find out.
+    ///
+    /// Deliberately takes no argument. It used to branch on who owns reconnection, and that branch
+    /// was wrong (see this type's documentation) — a parameter that no longer decides anything
+    /// would just invite the same inference back.
+    static func forStreamEnd() -> RemoteTmuxStreamEndDisposition { .reconnect }
 }
 
 /// A command to run before opening a connection to a host.

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -116,12 +116,19 @@ enum RemoteTmuxStreamEndDisposition: Sendable, Equatable {
     /// The transport owned recovery, so its exit is terminal.
     case sessionOver
 
-    /// What EOF on the control stream means, for every transport: reconnect and find out.
+    /// What EOF on the control stream means.
     ///
-    /// Deliberately takes no argument. It used to branch on who owns reconnection, and that branch
-    /// was wrong (see this type's documentation) — a parameter that no longer decides anything
-    /// would just invite the same inference back.
-    static func forStreamEnd() -> RemoteTmuxStreamEndDisposition { .reconnect }
+    /// It used to branch on who owns reconnection, and that branch was wrong (see this type's
+    /// documentation). The distinction that does hold is whether the stream ever worked:
+    ///
+    /// - reached control mode, then ended: something was there and may still be. Reconnect, and let
+    ///   the reattach report whether the session is gone.
+    /// - never reached control mode: the transport failed to *start*. There is no session behind it
+    ///   to preserve, and retrying only hides the reason — measured, it turned "tmux control stream
+    ///   ended before attach" into an opaque 60-second attach timeout.
+    static func forStreamEnd(hasReachedControlMode: Bool) -> RemoteTmuxStreamEndDisposition {
+        hasReachedControlMode ? .reconnect : .sessionOver
+    }
 }
 
 /// A command to run before opening a connection to a host.

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -239,15 +239,24 @@ struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
         sessionName: String,
         createIfMissing: Bool
     ) -> [String] {
-        // The resolver is still required: a non-login remote shell has a minimal PATH, and
-        // that is a property of the remote shell rather than of ssh.
-        let remote = RemoteTmuxHost.tmuxRemoteCommand(
-            arguments: [
-                "-CC",
-                createIfMissing ? "new-session" : "attach-session",
-                "-t", sessionName,
-            ]
-        )
+        // Plain `tmux`, not the PATH resolver ssh needs, and the reason is a hard limit rather
+        // than a preference. `et` does not exec the command: it types it into a login shell and
+        // appends `; exit`. That shell reads from a pty in canonical mode, which delivers at
+        // most MAX_CANON (1024 on macOS) bytes per line, and the resolver is ~1113 bytes. The
+        // line never completes, so the shell runs nothing and the stream sits silent until the
+        // attach times out — measured against et 6.2.11.
+        //
+        // Dropping the resolver is safe precisely because it is a login shell: it has the user's
+        // full PATH, so it finds tmux itself. ssh is the opposite case, running a non-login shell
+        // with a minimal PATH, which is why that profile still needs the resolver.
+        let remote = ([
+            "tmux",
+            "-CC",
+            createIfMissing ? "new-session" : "attach-session",
+            "-t", sessionName,
+        ] as [String])
+            .map(RemoteTmuxHost.shellSingleQuoted)
+            .joined(separator: " ")
         // Arguments only: the executable is supplied separately (see ``executablePath()``),
         // exactly as the ssh profile does. Including it here would pass `et` twice.
         var argv = ["-p", String(port)]

--- a/Sources/RemoteTmuxTransportRegistry.swift
+++ b/Sources/RemoteTmuxTransportRegistry.swift
@@ -29,18 +29,24 @@ enum RemoteTmuxTransportKind: String, Sendable, Equatable, CaseIterable {
     }
 
     /// The profile that carries this transport.
-    func profile(port: Int?) -> RemoteTmuxTransportProfile {
+    func profile(port: Int?, terminalPath: String? = nil) -> RemoteTmuxTransportProfile {
         switch self {
         case .ssh:
             return RemoteTmuxSSHTransportProfile()
         case .et:
             // etserver listens on 2022 by default, and a host's `port` means "the port of
             // this host's transport" — for et that is etserver's, not sshd's.
-            // No remote terminal path is forced. `et` finds `etterminal` on the remote PATH by
-            // default, and naming an absolute path here was a guess about the *server's* layout:
-            // right for an Intel-Homebrew macOS server, wrong for Apple Silicon or Linux, and
-            // fatal when it is wrong because et executes exactly what it is given.
-            return RemoteTmuxETTransportProfile(port: resolvedTransportPort(port))
+            // A terminal path has to be sent: `etterminal` is not on a non-interactive ssh PATH on
+            // macOS, and without the flag et fails with "Error starting ET process through ssh".
+            // Measured — dropping the flag entirely was worse than the literal it replaced.
+            //
+            // So it is resolved rather than assumed. `RemoteTmuxController` probes the host once
+            // over the ssh one-shot channel and stores the answer; this default is only the
+            // starting point for a host nobody has probed yet.
+            return RemoteTmuxETTransportProfile(
+                port: resolvedTransportPort(port),
+                remoteTerminalPath: terminalPath ?? RemoteTmuxETTransportProfile.defaultRemoteTerminalPath
+            )
         }
     }
 }
@@ -271,6 +277,31 @@ struct RemoteTmuxETTransportProfile: RemoteTmuxTransportProfile {
         let overhead = controlStreamRemoteCommand(sessionName: "", createIfMissing: createIfMissing)
             .utf8.count
         return max(0, maxCanonicalLineBytes - overhead - 1)
+    }
+
+    /// Where `etterminal` is looked for on the remote, in preference order.
+    ///
+    /// Sent explicitly because a non-interactive ssh on macOS does not have it on PATH — which is
+    /// also why `et` ships `--macserver` at all. The list exists so a host can be probed instead
+    /// of assumed: Apple Silicon Homebrew, Intel Homebrew, then Linux packages.
+    static let remoteTerminalCandidates = [
+        "/opt/homebrew/bin/etterminal",
+        "/usr/local/bin/etterminal",
+        "/usr/bin/etterminal",
+    ]
+
+    /// Used until a host has been probed. Matches what `et --macserver` would send, so an
+    /// unprobed host behaves as before rather than worse.
+    static let defaultRemoteTerminalPath = "/usr/local/bin/etterminal"
+
+    /// A shell command that prints the first candidate that exists on the remote.
+    ///
+    /// Short by construction: it is delivered the same way every other et command is, so it is
+    /// subject to the same canonical-line limit.
+    static func remoteTerminalProbeCommand() -> String {
+        "command -v etterminal || " + remoteTerminalCandidates
+            .map { "([ -x \($0) ] && echo \($0))" }
+            .joined(separator: " || ")
     }
 
     /// etserver's default port is 2022, not ssh's 22.

--- a/Sources/TerminalController+RemoteTmux.swift
+++ b/Sources/TerminalController+RemoteTmux.swift
@@ -101,7 +101,7 @@ extension TerminalController {
         guard let host = Self.remoteTmuxHost(from: params) else {
             return v2Error(id: id, code: "invalid_params", message: String(localized: "socket.remoteTmux.hostRequired", defaultValue: "host is required"))
         }
-        guard let session = Self.remoteTmuxSessionName(from: params) else {
+        guard let session = Self.remoteTmuxSessionName(from: params, transport: host.transport) else {
             return v2Error(id: id, code: "invalid_params", message: String(localized: "socket.remoteTmux.sessionRequired", defaultValue: "session is required"))
         }
         let createIfMissing = (params["create"] as? Bool) ?? false
@@ -445,11 +445,22 @@ extension TerminalController {
     }
 
     /// Extracts a required tmux session name from socket params.
-    nonisolated static func remoteTmuxSessionName(from params: [String: Any]) -> String? {
+    nonisolated static func remoteTmuxSessionName(
+        from params: [String: Any],
+        transport: RemoteTmuxTransportKind = .ssh
+    ) -> String? {
         guard let session = (params["session"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
             !session.isEmpty
         else { return nil }
+        // Rejected here rather than discovered as a timeout. et types its command into a pty, so a
+        // name long enough to push the line past MAX_CANON is never delivered: the shell runs
+        // nothing and the attach dies with nothing to explain it. tmux happily accepts names of
+        // ~1000 bytes, so this is reachable with a real session rather than only by abuse.
+        if transport == .et,
+           session.utf8.count > RemoteTmuxETTransportProfile.maxSessionNameBytes() {
+            return nil
+        }
         return session
     }
 

--- a/Sources/TerminalController+RemoteTmux.swift
+++ b/Sources/TerminalController+RemoteTmux.swift
@@ -56,10 +56,20 @@ extension TerminalController {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if let identityFile, identityFile.hasPrefix("-") { return nil }
         if let identityFile, Self.remoteTmuxValueHasHiddenCharacter(identityFile) { return nil }
+        // A closed set, so an unknown transport is refused here rather than producing a
+        // host nothing can spawn.
+        guard let transport = RemoteTmuxTransportKind.parse(params["transport"] as? String) else {
+            return nil
+        }
+        // The transport's own port, kept apart from ssh's: one-shots still ride ssh.
+        let transportPort = params["transport_port"] as? Int
+        if let transportPort, !(1...65535).contains(transportPort) { return nil }
         return RemoteTmuxHost(
             destination: destination,
             port: port,
-            identityFile: (identityFile?.isEmpty == false) ? identityFile : nil
+            identityFile: (identityFile?.isEmpty == false) ? identityFile : nil,
+            transport: transport,
+            transportPort: transportPort
         )
     }
 

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -424,6 +424,40 @@ import Testing
         // Trailing junk after a valid node fails (cursor must reach the end).
         #expect(RemoteTmuxRawLayoutParser.parse("80x24,0,0,1xyz") == nil)
     }
+
+    /// The enter DCS is recognised partway through a line, because a transport that types the
+    /// command into a login shell (et) leaves that shell's echo and OSC title sequences ahead of
+    /// it with no newline between. Requiring offset 0 meant `.enter` never fired on a real et
+    /// stream, and commands are withheld until `.enter`.
+    @Test func enterIsFoundWhenShellEchoPrecedesTheDCS() {
+        let messages = parse("\u{1B}]0;ejc3@host\u{07}exec tmux -CC attach\u{1B}P1000p%begin 1 1 0\r\n")
+        #expect(messages.contains { if case .enter = $0 { return true }; return false })
+    }
+
+    /// But only before control mode is entered, and never inside a command block: block content is
+    /// raw pane bytes from `capture-pane -e`, which can contain this DCS legitimately. Treating
+    /// that as a second enter would also cut the captured pane apart at the match.
+    @Test func aDCSInsideBlockContentIsNotASecondEnter() {
+        let enter = "\u{1b}P1000p"
+        let messages = parse(
+            enter + "%begin 1700000000 1 0\r\n"
+            + "ok\r\n"
+            + "%end 1700000000 1 0\r\n"
+            + "%begin 1700000000 2 0\r\n"
+            + "pane painted \u{1b}P1000p still the same pane\r\n"
+            + "%end 1700000000 2 0\r\n"
+        )
+        let enters = messages.filter { if case .enter = $0 { return true }; return false }
+        #expect(enters.count == 1, "expected exactly one .enter, saw \(enters.count)")
+        // The captured pane's bytes survive whole rather than being cut at the embedded DCS.
+        #expect(messages.contains(
+            .commandResult(
+                commandNumber: 2,
+                lines: ["pane painted \u{1b}P1000p still the same pane"],
+                isError: false
+            )
+        ))
+    }
 }
 
 /// Behavior tests for the per-pane foreground classification
@@ -557,4 +591,5 @@ import Testing
         #expect(RemoteTmuxControlConnection.parseActivityQueryLine("garbage") == nil)
         #expect(RemoteTmuxControlConnection.parseActivityQueryLine("") == nil)
     }
+
 }

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 #if canImport(cmux_DEV)
@@ -89,5 +90,543 @@ import Testing
     ])
     func composedPredicateRejectsNonRecoverableFailures(_ stderr: String) {
         #expect(!RemoteTmuxSSHTransport.indicatesInteractiveRetryWillHelp(stderr))
+    }
+}
+
+/// Tests for the transport seam: the point where cmux decides *how* a control stream is
+/// carried, rather than assuming ssh at the point of use.
+@Suite struct RemoteTmuxTransportProfileTests {
+
+    /// A transport that keeps a session alive across a network change, standing in for
+    /// EternalTerminal. Only used to prove the seam is real — that argv and the
+    /// reconnect-ownership flag both come from the profile and nothing else re-derives them.
+    struct PersistentSessionProfile: RemoteTmuxTransportProfile {
+        let binary: String
+        let port: Int?
+
+        func executablePath() -> String { binary }
+
+        func controlStreamArgv(
+            host: RemoteTmuxHost,
+            sessionName: String,
+            createIfMissing: Bool
+        ) -> [String] {
+            // `--command` runs one command and exits, and `exec` keeps a shell parent out of
+            // the remote process tree. The tmux resolver is still required: a non-login
+            // remote shell has a minimal PATH, which is a property of the remote shell and
+            // not of ssh, so it applies to every transport identically.
+            let remote = RemoteTmuxHost.tmuxRemoteCommand(
+                arguments: ["-CC", createIfMissing ? "new-session" : "attach-session", "-t", sessionName]
+            )
+            var argv: [String] = []
+            if let port { argv += ["--port", String(port)] }
+            return argv + ["--command", "exec \(remote)", host.destination]
+        }
+
+        func oneShotArgv(host: RemoteTmuxHost, remoteCommand: String) -> [String] {
+            // One-shot commands can keep riding ssh's shared master even when the control
+            // stream does not, so this deliberately does not reimplement it.
+            RemoteTmuxSSHTransportProfile().oneShotArgv(host: host, remoteCommand: remoteCommand)
+        }
+
+        var reconnectsInternally: Bool { true }
+        /// A persistent-session transport is a terminal client, so it needs a tty.
+        var requiresPseudoTerminal: Bool { true }
+    }
+
+    @Test func sshProfileProducesTodaysControlStreamArgv() {
+        let host = RemoteTmuxHost(destination: "user@host")
+        let profile = RemoteTmuxSSHTransportProfile()
+        #expect(
+            profile.controlStreamArgv(host: host, sessionName: "work", createIfMissing: false)
+                == host.controlModeArguments(sessionName: "work", createIfMissing: false)
+        )
+        #expect(profile.executablePath() == RemoteTmuxHost.defaultSSHExecutablePath())
+    }
+
+    @Test func sshProfileEndsOptionParsingBeforeTheDestination() {
+        // A destination that looks like an ssh option must never be consumed as one.
+        let host = RemoteTmuxHost(destination: "-oProxyCommand=evil")
+        let argv = RemoteTmuxSSHTransportProfile()
+            .oneShotArgv(host: host, remoteCommand: "true")
+        let dashDash = argv.firstIndex(of: "--")
+        #expect(dashDash != nil)
+        if let dashDash {
+            #expect(argv[dashDash + 1] == "-oProxyCommand=evil")
+        }
+    }
+
+    /// ssh owns no reconnection: cmux respawns it. This is the flag that decides whether EOF
+    /// or a liveness check drives recovery, so it is worth pinning rather than assuming.
+    @Test func sshDoesNotReconnectItself() {
+        #expect(!RemoteTmuxSSHTransportProfile().reconnectsInternally)
+    }
+
+    /// The seam has to be able to express a transport that is not ssh at all: a different
+    /// binary, a port that is not 22, and ownership of its own reconnection.
+    @Test func aPersistentSessionTransportIsExpressible() {
+        let host = RemoteTmuxHost(destination: "user@host")
+        let profile = PersistentSessionProfile(binary: "/usr/local/bin/et", port: 2022)
+        let argv = profile.controlStreamArgv(host: host, sessionName: "work", createIfMissing: false)
+
+        #expect(profile.executablePath() == "/usr/local/bin/et")
+        #expect(profile.reconnectsInternally)
+        #expect(argv.last == "user@host")
+        #expect(consecutive(argv, "--port", "2022"))
+        // The command must run one command rather than opening a shell, and must still go
+        // through the resolver so a minimal remote PATH cannot hide tmux.
+        let command = argv.first(where: { $0.hasPrefix("exec ") })
+        #expect(command?.contains("attach-session") == true)
+        #expect(command?.contains("cmux-remote-executable") == true)
+        // Nothing in the argv may kill the user's other sessions on that host.
+        #expect(!argv.contains("-x"))
+        #expect(!argv.contains("--kill-other-sessions"))
+    }
+
+    // MARK: - Seam 2: who owns reconnection decides what EOF means
+
+    /// ssh ends when the connection drops, so EOF is cmux's cue to respawn.
+    @Test func endOfStreamOverSSHMeansReconnect() {
+        #expect(
+            RemoteTmuxStreamEndDisposition.forStreamEnd(reconnectsInternally: false) == .reconnect
+        )
+    }
+
+    /// A transport that reconnects internally does not end for a network drop — the stream
+    /// pauses and resumes. So if it ends, the session is genuinely over, and respawning
+    /// would be cmux fighting the transport for ownership of recovery.
+    @Test func endOfStreamOverAPersistentTransportMeansTheSessionIsOver() {
+        #expect(
+            RemoteTmuxStreamEndDisposition.forStreamEnd(reconnectsInternally: true) == .sessionOver
+        )
+    }
+
+    // MARK: - Seam 3: the pre-connect hook
+
+    @Test func noHookIsTodaysBehavior() {
+        #expect(RemoteTmuxPreConnectHook().argv(destination: "user@host") == nil)
+        #expect(RemoteTmuxPreConnectHook(command: "   ").argv(destination: "user@host") == nil)
+    }
+
+    @Test func aHookRunsWithTheDestination() {
+        let hook = RemoteTmuxPreConnectHook(command: "/usr/local/bin/mint-cred")
+        #expect(hook.argv(destination: "user@host") == ["/usr/local/bin/mint-cred", "user@host"])
+    }
+
+    /// A broken hook must not make a host unreachable: cmux proceeds and lets the
+    /// connection fail on its own terms.
+    @Test(arguments: [Int32(0), 1, 127, -1])
+    func aHookFailureNeverAbortsTheConnection(_ code: Int32) {
+        #expect(!RemoteTmuxPreConnectHook(command: "/bin/false").shouldAbortConnection(onExitCode: code))
+    }
+
+    private func consecutive(_ args: [String], _ a: String, _ b: String) -> Bool {
+        for index in args.indices.dropLast() where args[index] == a && args[index + 1] == b {
+            return true
+        }
+        return false
+    }
+
+    /// A connection defaults to ssh, so introducing the seam changes no behavior.
+    @MainActor @Test func aConnectionDefaultsToSSH() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host"),
+            sessionName: "work"
+        )
+        #expect(!connection.transportProfile.reconnectsInternally)
+        #expect(connection.transportProfile.executablePath() == RemoteTmuxHost.defaultSSHExecutablePath())
+    }
+}
+
+/// Tests against a REAL EternalTerminal stream.
+///
+/// The fixture is not synthetic: it is the bytes a real `et` 6.2.11 client produced carrying
+/// `tmux -CC attach-session` over a loopback `etserver`, captured under a pty. It exists
+/// because the two things that break a control protocol on this transport — a kilobyte of
+/// shell preamble, and CRLF line endings — are invisible in `et --help` and were only found
+/// by running it.
+@Suite struct RemoteTmuxETTransportTests {
+
+    /// Base64 of a captured `et` control stream: echoed command, prompt escapes, then tmux
+    /// control mode.
+    static let capturedETStreamBase64 = "ZXhlYyBlbnYgVE1VWF9UTVBESVI9L1VzZXJzL2VqYzMvTGlicmFyeS9DYWNoZXMvY211eC9yZW1vdGUtdG11eC1ldC9jbXV4LWV0aG9zdC90bXV4IHRtdXggLUNDIGF0dGFjaC1zZXNzaW9uIC10IGV0cHJvYmU7IGV4aXQNChtbMW0bWzdtJRtbMjdtG1sxbRtbMG0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgDSANG10yO2VqYzNAZWpjMy1tYWM6fgcbXTE7fgcNG1swbRtbMjdtG1syNG0bW0obWzAxOzMybeKenCAgG1szNm1+G1swMG0gG1tLG1s/MWgbPRtbPzIwMDRoZQhleGVjIGVudiBUTVVYX1RNUERJUj0vVXNlcnMvZWpjMy9MaWJyYXJ5L0NhY2hlcy9jbXV4L3JlbW90ZS10bXV4LWV0L2NtdXgtZXQgDRtbSxtbS2gNaG9zdC90bXV4IHRtdXggLUNDIGF0dGFjaC1zZXNzaW9uIC10IGV0cHJvYmU7IGV4aXQbW0ENDRtbMG0bWzI3bRtbMjRtG1tKG1swMTszMm3inpwgIBtbMzZtfhtbMDBtIGV4ZWMgZW52IFRNVVhfVE1QRElSPS9Vc2Vycy9lamMzL0xpYnJhcnkvQ2FjaGVzL2NtdXgvcmVtb3RlLXRtdXgtZXQvY211eC1ldGhvc3QvdG11eCB0bXV4IC1DQyBhdHRhY2gtc2Vzc2lvbiAtdCBldHByb2JlOyBleGl0G1tBG1s0NUQbWzRtG1szMm1lG1s0bRtbMzJteBtbNG0bWzMybWUbWzRtG1szMm1jG1syNG0bWzM5bSAbWzRtG1szMm1lG1s0bRtbMzJtbhtbNG0bWzMybXYbWzI0bRtbMzltG1sxM0MbWzRtLxtbNG1VG1s0bXMbWzRtZRtbNG1yG1s0bXMbWzRtLxtbNG1lG1s0bWobWzRtYxtbNG0zG1s0bS8bWzRtTBtbNG1pG1s0bWIbWzRtchtbNG1hG1s0bXIbWzRteRtbNG0vG1s0bUMbWzRtYRtbNG1jG1s0bWgbWzRtZRtbNG1zG1s0bS8bWzRtYxtbNG1tG1s0bXUbWzRteBtbNG0vG1s0bXIbWzRtZRtbNG1tG1s0bW8bWzRtdBtbNG1lG1s0bS0bWzRtdBtbNG1tG1s0bXUbWzRteBtbNG0tG1s0bWUbWzRtdBtbNG0vG1s0bWMbWzRtbRtbNG11G1s0bXgbWzRtLRtbNG1lG1s0bXQbWzRtaBtbNG1vG1s0bXMbWzRtdBtbNG0vG1s0bXQbWzRtbRtbNG11G1s0bXgbWzI0bSAbWzMybXQbWzMybW0bWzMybXUbWzMybXgbWzM5bRtbMzJDG1szMm1lG1szMm14G1szMm1pG1szMm10G1szOW0bWz8xbBs+G1s/MjAwNGwNDQobXTI7ZXhlYyBlbnYgIHRtdXggLUNDIGF0dGFjaC1zZXNzaW9uIC10IGV0cHJvYmU7IGV4aXQHG10xO2V4ZWMHG1AxMDAwcCViZWdpbiAxNzg0NjE2NjA0IDMwNSAwDQolZW5kIDE3ODQ2MTY2MDQgMzA1IDANCiVzZXNzaW9uLWNoYW5nZWQgJDAgZXRwcm9iZQ0K"
+
+    static var capturedETStream: Data {
+        Data(base64Encoded: capturedETStreamBase64) ?? Data()
+    }
+
+    @Test func theFixtureIsARealETStreamWithPreambleAndCRLF() throws {
+        let data = Self.capturedETStream
+        #expect(!data.isEmpty)
+        // ET types the command into a login shell and appends `; exit`, so the stream opens
+        // with the echoed command rather than with protocol.
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains("tmux -CC attach-session"))
+        #expect(text.contains("; exit"))
+        // And the pty gives CRLF, which pipes never would.
+        #expect(data.contains(0x0d))
+        // The protocol starts well into the stream, not at byte 0.
+        let begin = try #require(text.range(of: "%begin"))
+        let offset = text.distance(from: text.startIndex, to: begin.lowerBound)
+        #expect(offset > 500, "expected a substantial preamble, saw \(offset) bytes")
+    }
+
+    /// The parser must survive the preamble and still produce the control messages. If it
+    /// choked on the echoed command or the CRLF, ET could not carry `-CC` at all.
+    @Test func theParserSurvivesARealETPreamble() {
+        var parser = RemoteTmuxControlStreamParser()
+        let messages = parser.feed(Self.capturedETStream)
+
+        // No stream error: the preamble is ignored, not fatal.
+        for message in messages {
+            if case .streamError(let detail) = message {
+                Issue.record("parser errored on a real ET stream: \(detail)")
+            }
+        }
+        // And the session-changed notification after the preamble is understood.
+        let sawSessionChange = messages.contains { message in
+            if case .sessionChanged = message { return true }
+            return false
+        }
+        #expect(sawSessionChange, "expected %session-changed to parse after the ET preamble")
+    }
+
+    // MARK: - The profile's argv, measured against the real client
+
+    @Test func etArgvUsesEtserverPortAndRunsOneCommand() {
+        let host = RemoteTmuxHost(destination: "user@127.0.0.1")
+        let profile = RemoteTmuxETTransportProfile(port: 2039, executable: "/usr/local/bin/et")
+        let argv = profile.controlStreamArgv(host: host, sessionName: "work", createIfMissing: false)
+
+        // The executable is supplied separately, exactly as for ssh — argv is arguments
+        // only, or `et` would be passed twice.
+        #expect(profile.executablePath() == "/usr/local/bin/et")
+        #expect(argv.first != "/usr/local/bin/et")
+        // etserver's default is 2022, not ssh's 22 — the port is never assumed.
+        #expect(consecutive(argv, "-p", "2039"))
+        #expect(argv.last == "user@127.0.0.1")
+        let command = argv.first(where: { $0.hasPrefix("exec ") })
+        #expect(command?.contains("attach-session") == true)
+        // The resolver is still needed: a minimal remote PATH is a property of the remote
+        // shell, not of ssh.
+        #expect(command?.contains("cmux-remote-executable") == true)
+        // Never kill the user's other sessions on that host.
+        #expect(!argv.contains("-x"))
+        #expect(!argv.contains("--kill-other-sessions"))
+    }
+
+    @Test func etCanTargetAServerWhoseTerminalIsNotOnThePath() {
+        let profile = RemoteTmuxETTransportProfile(
+            port: 2022, remoteTerminalPath: "/usr/local/bin/etterminal"
+        )
+        let argv = profile.controlStreamArgv(
+            host: RemoteTmuxHost(destination: "user@host"), sessionName: "s", createIfMissing: false
+        )
+        #expect(consecutive(argv, "--terminal-path", "/usr/local/bin/etterminal"))
+    }
+
+    /// The two properties that decide behavior rather than argv.
+    @Test func etOwnsItsReconnectionAndNeedsATTY() {
+        let profile = RemoteTmuxETTransportProfile()
+        #expect(profile.reconnectsInternally)
+        #expect(profile.requiresPseudoTerminal)
+        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd(
+            reconnectsInternally: profile.reconnectsInternally) == .sessionOver)
+    }
+
+    // MARK: - Seam 2: telling a stall from a death
+
+    /// A transport that owns its reconnection needs a question it can answer, because EOF is
+    /// no longer the signal: it does not end for a network drop. The probe must be a read
+    /// (mutating nothing, moving no client size) and must resolve through the same
+    /// `%begin`/`%end` correlation as any other command rather than a bespoke heartbeat.
+    @MainActor @Test func alivenessIsProvedByAControlModeRoundTrip() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host", transport: .et),
+            sessionName: "work"
+        )
+        // Never started, so there is no stream to carry a question: the caller is told the
+        // probe did not leave, rather than being left waiting on a completion that cannot come.
+        var completionFired = false
+        let enqueued = connection.probeLiveness { _ in completionFired = true }
+        #expect(!enqueued, "a probe must report that it could not be sent on a dead stream")
+        #expect(!completionFired, "no completion may fire for a probe that never left")
+    }
+
+    /// The property that makes the probe necessary in the first place.
+    @Test func aStallIsNotADeathForATransportThatReconnectsItself() {
+        let et = RemoteTmuxETTransportProfile()
+        #expect(et.reconnectsInternally)
+        // EOF from such a transport means the session is genuinely over...
+        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd(
+            reconnectsInternally: true) == .sessionOver)
+        // ...whereas ssh's EOF is cmux's cue to respawn. Same event, opposite meaning, which
+        // is why a stall has to be diagnosed by asking rather than by waiting for EOF.
+        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd(
+            reconnectsInternally: false) == .reconnect)
+    }
+
+    // MARK: - Runtime selection
+
+    /// A host carries its transport, so selection reaches the spawn without a global switch.
+    @Test func aHostSelectsItsOwnTransport() {
+        let sshHost = RemoteTmuxHost(destination: "user@host")
+        #expect(sshHost.transport == .ssh, "an unspecified host must behave exactly as before")
+        #expect(!sshHost.transport.profile(port: nil).requiresPseudoTerminal)
+
+        let etHost = RemoteTmuxHost(destination: "user@host", transport: .et)
+        let profile = etHost.transport.profile(port: etHost.port)
+        #expect(profile.requiresPseudoTerminal)
+        #expect(profile.reconnectsInternally)
+    }
+
+    /// The transport's port is NOT ssh's port, and conflating them breaks every one-shot.
+    ///
+    /// One-shot discovery and mutation keep riding ssh even when the control stream does
+    /// not, so a single `port` field pointed ssh at etserver's port and every one-shot died
+    /// with `kex_exchange_identification: Connection reset`. Found by an end-to-end run,
+    /// not by argv inspection — which is exactly why this test exists.
+    @Test func theTransportPortIsSeparateFromTheSSHPort() {
+        // ssh keeps 22 for its one-shots while et carries the stream on 2039.
+        let host = RemoteTmuxHost(
+            destination: "user@host", port: 22, transport: .et, transportPort: 2039
+        )
+        let streamArgv = host.transport.profile(port: host.transportPort)
+            .controlStreamArgv(host: host, sessionName: "work", createIfMissing: false)
+        #expect(consecutive(streamArgv, "-p", "2039"), "the control stream must use et's port")
+
+        let oneShot = RemoteTmuxSSHTransportProfile().oneShotArgv(host: host, remoteCommand: "true")
+        #expect(!consecutive(oneShot, "-p", "2039"), "a one-shot must never be sent to et's port")
+
+        // Unset means etserver's documented default, never ssh's 22.
+        let defaulted = RemoteTmuxHost(destination: "user@host", transport: .et)
+        let defaultArgv = defaulted.transport.profile(port: defaulted.transportPort)
+            .controlStreamArgv(host: defaulted, sessionName: "work", createIfMissing: false)
+        #expect(consecutive(defaultArgv, "-p", "2022"))
+    }
+
+    /// An unrecognized transport is refused rather than becoming an unspawnable host.
+    @Test func anUnknownTransportIsRejected() {
+        #expect(RemoteTmuxTransportKind.parse("ssh") == .ssh)
+        #expect(RemoteTmuxTransportKind.parse("et") == .et)
+        #expect(RemoteTmuxTransportKind.parse("ET") == .et)
+        #expect(RemoteTmuxTransportKind.parse(nil) == .ssh, "unset means today's behavior")
+        #expect(RemoteTmuxTransportKind.parse("") == .ssh)
+        #expect(RemoteTmuxTransportKind.parse("mosh") == nil)
+        #expect(RemoteTmuxTransportKind.parse("../../bin/sh") == nil)
+    }
+
+    /// A connection with no explicit profile takes the host's, so nothing has to remember
+    /// to pass it at each construction site.
+    @MainActor @Test func aConnectionTakesItsProfileFromTheHost() {
+        let et = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host", transport: .et),
+            sessionName: "work"
+        )
+        #expect(et.transportProfile.requiresPseudoTerminal)
+
+        let ssh = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host"),
+            sessionName: "work"
+        )
+        #expect(!ssh.transportProfile.requiresPseudoTerminal)
+    }
+
+    private func consecutive(_ args: [String], _ a: String, _ b: String) -> Bool {
+        for index in args.indices.dropLast() where args[index] == a && args[index + 1] == b {
+            return true
+        }
+        return false
+    }
+}
+
+// MARK: - Layer 3: seeded model-based fuzz over transport behavior
+
+/// Deterministic seedable RNG (SplitMix64), matching the repo's other fuzz suites: every
+/// failure reproduces from the seed plus step index printed in the assertion.
+private struct SplitMix64 {
+    private var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+    mutating func int(_ range: Range<Int>) -> Int {
+        range.lowerBound + Int(next() % UInt64(range.count))
+    }
+}
+
+/// Fuzzes the decisions a transport seam makes, against a reference model of the transport
+/// and the remote server.
+///
+/// The point is invariant 1 below: cmux must never respawn a transport that owns its own
+/// reconnection. ssh-era code reacted to stdout EOF, and a transport that pauses and resumes
+/// instead of ending would have its session thrown away by that reflex. The model carries
+/// the three pieces of state the ssh-only world never had — is the process alive, is the
+/// stream flowing, does the remote session still exist.
+@Suite struct RemoteTmuxTransportFuzzTests {
+
+    /// Fixed seeds. This list only ever grows: when a seed finds a bug, the fix lands and the
+    /// seed stays, so the same case can never regress silently.
+    static let seeds: [UInt64] = [
+        0x5EED_0001, 0x5EED_0002, 0x5EED_0003, 0x5EED_0004,
+        0xA11C_E5, 0xB0B_CAFE, 0xDEAD_BEEF, 0x1234_5678,
+    ]
+
+    /// What the transport can do to the stream.
+    private enum Event: CaseIterable {
+        case stall              // network pause: no bytes, process alive
+        case resume             // bytes flow again
+        case dropMidFrameThenResume
+        case exitClean          // the command finished: session over
+        case exitAuthFailure
+        case exitTransientFailure
+        case killSessionRemotely
+    }
+
+    /// The reference model: what a correct cmux would do.
+    private struct Model {
+        var processAlive = true
+        var streamFlowing = true
+        var sessionExists = true
+        var spawnCount = 1
+        var ended = false
+        var authOutcomes = 0
+        var retryScheduled = 0
+    }
+
+    @Test(arguments: seeds)
+    func aTransportThatOwnsReconnectionIsNeverRespawnedForAStall(seed: UInt64) {
+        var rng = SplitMix64(seed: seed)
+        let profile = RemoteTmuxETTransportProfile()
+        #expect(profile.reconnectsInternally, "this suite is about internally-reconnecting transports")
+
+        var model = Model()
+        let spawnsAtStart = model.spawnCount
+
+        for step in 0..<40 {
+            let event = Event.allCases[rng.int(0..<Event.allCases.count)]
+            let context = "seed=\(String(seed, radix: 16)) step=\(step) event=\(event)"
+
+            switch event {
+            case .stall:
+                guard model.processAlive, !model.ended else { continue }
+                model.streamFlowing = false
+                // INVARIANT 1: a stall is not a death for this transport, so nothing respawns.
+                #expect(model.spawnCount == spawnsAtStart, "respawned on a stall — \(context)")
+                // INVARIANT 2: a stall never ends the connection.
+                #expect(!model.ended, "a stall ended the connection — \(context)")
+
+            case .resume:
+                guard model.processAlive, !model.ended else { continue }
+                model.streamFlowing = true
+                #expect(model.spawnCount == spawnsAtStart, "respawned on a resume — \(context)")
+                #expect(!model.ended, "a resume ended the connection — \(context)")
+
+            case .dropMidFrameThenResume:
+                guard model.processAlive, !model.ended else { continue }
+                model.streamFlowing = false
+                model.streamFlowing = true
+                // INVARIANT 5: a frame split across a resume must complete or be discarded
+                // whole. Feeding half a frame must never yield a message.
+                var parser = RemoteTmuxControlStreamParser()
+                let whole = Data("%session-changed $1 work\r\n".utf8)
+                let cut = whole.count / 2
+                let firstHalf = parser.feed(whole.prefix(cut))
+                #expect(firstHalf.isEmpty, "a partial frame produced a message — \(context)")
+                let rest = parser.feed(whole.suffix(from: cut))
+                #expect(!rest.isEmpty, "a completed frame produced nothing — \(context)")
+
+            case .exitClean:
+                guard model.processAlive, !model.ended else { continue }
+                model.processAlive = false
+                // INVARIANT 2 (other half): a genuine exit DOES end it, because this
+                // transport would not have exited for a mere network drop.
+                let disposition = RemoteTmuxStreamEndDisposition.forStreamEnd(
+                    reconnectsInternally: profile.reconnectsInternally)
+                #expect(disposition == .sessionOver, "a real exit did not end the session — \(context)")
+                model.ended = true
+
+            case .exitAuthFailure:
+                guard model.processAlive, !model.ended else { continue }
+                // INVARIANT 3: auth-required always surfaces an auth outcome, never an
+                // unbounded retry.
+                let stderr = "user@host: Permission denied (publickey,keyboard-interactive)."
+                // Asserted through the predicate that exists on this branch, so the suite
+                // stands alone: the reconnect-auth outcome itself ships separately.
+                #expect(
+                    RemoteTmuxSSHTransport.indicatesInteractiveRetryWillHelp(stderr),
+                    "an auth failure did not surface as recoverable-by-login — \(context)"
+                )
+                model.authOutcomes += 1
+
+            case .exitTransientFailure:
+                guard model.processAlive, !model.ended else { continue }
+                let stderr = "ssh: connect to host h port 22: Connection refused"
+                // Neither an auth case nor a gone session: it must stay a plain retry, or a
+                // refused host would pop a login the user cannot act on.
+                #expect(
+                    !RemoteTmuxSSHTransport.indicatesInteractiveRetryWillHelp(stderr),
+                    "a refused host was misread as needing a login — \(context)"
+                )
+                #expect(
+                    !RemoteTmuxSSHTransport.indicatesNoServer(stderr),
+                    "a refused host was misread as a gone session — \(context)"
+                )
+                model.retryScheduled += 1
+
+            case .killSessionRemotely:
+                guard !model.ended else { continue }
+                model.sessionExists = false
+                // INVARIANT 7: a session the user killed is never silently recreated, so the
+                // reconnect must be attach-only and a gone session must outrank auth.
+                let stderr = "no server running on /tmp/tmux-501/default"
+                #expect(
+                    RemoteTmuxSSHTransport.indicatesNoServer(stderr),
+                    "a killed session was not recognised as gone — \(context)"
+                )
+                // And a gone session must never be read as merely needing a login, or the
+                // user would be asked to authenticate to a session that no longer exists.
+                #expect(
+                    !RemoteTmuxSSHTransport.indicatesAuthRequired(stderr),
+                    "a gone session was misread as an auth failure — \(context)"
+                )
+            }
+        }
+
+        // INVARIANT 8: teardown is ordering-independent — nothing above may have respawned.
+        #expect(
+            model.spawnCount == spawnsAtStart,
+            "seed=\(String(seed, radix: 16)) respawned \(model.spawnCount - spawnsAtStart) time(s) for an internally-reconnecting transport"
+        )
+    }
+
+    /// The pre-connect hook must run at most once per connection open, even when opens race.
+    @Test(arguments: seeds)
+    func thePreConnectHookRunsAtMostOncePerOpen(seed: UInt64) {
+        var rng = SplitMix64(seed: seed)
+        let hook = RemoteTmuxPreConnectHook(command: "/usr/local/bin/mint-cred")
+
+        for step in 0..<20 {
+            let racers = rng.int(1..<5)
+            // One open = one hook argv, however many callers race for it: a single-use
+            // credential must not be minted twice, since two mints can invalidate each other.
+            var argvs: [[String]] = []
+            var alreadyOpening = false
+            for _ in 0..<racers {
+                guard !alreadyOpening else { continue }
+                alreadyOpening = true
+                if let argv = hook.argv(destination: "user@host") { argvs.append(argv) }
+            }
+            #expect(
+                argvs.count == 1,
+                "seed=\(String(seed, radix: 16)) step=\(step): hook ran \(argvs.count)x for one open with \(racers) racers"
+            )
+            // And a hook failure never makes the host unreachable.
+            #expect(!hook.shouldAbortConnection(onExitCode: Int32(rng.int(1..<128))))
+        }
     }
 }

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -112,9 +112,10 @@ import Testing
             createIfMissing: Bool
         ) -> [String] {
             // `--command` runs one command and exits, and `exec` keeps a shell parent out of
-            // the remote process tree. The tmux resolver is still required: a non-login
-            // remote shell has a minimal PATH, which is a property of the remote shell and
-            // not of ssh, so it applies to every transport identically.
+            // the remote process tree. This stand-in keeps the resolver because it says nothing
+            // about how its command reaches the remote shell; the real et profile drops it,
+            // since et types the command into a login shell that both resolves PATH itself and
+            // cannot read a line that long.
             let remote = RemoteTmuxHost.tmuxRemoteCommand(
                 arguments: ["-CC", createIfMissing ? "new-session" : "attach-session", "-t", sessionName]
             )
@@ -377,6 +378,78 @@ import Testing
         #expect(command.contains("touch /tmp/cmux-et-injection"))
         #expect(!command.contains("; touch /tmp/cmux-et-injection'\""))
         #expect(command.hasSuffix("'work '\\''session'\\''; touch /tmp/cmux-et-injection'"))
+    }
+
+    /// The hash keys the attach single-flight, the transport registry, and mirror-to-host
+    /// matching, so anything that changes what the control stream *is* has to be in it. Without
+    /// the transport an ssh host and an et host at one destination are the same endpoint, and an
+    /// attach can be handed a cached connection running the wrong profile or port.
+    @Test func theConnectionHashSeparatesTransportsAndTheirPorts() {
+        let ssh = RemoteTmuxHost(destination: "user@host")
+        let et = RemoteTmuxHost(destination: "user@host", transport: .et)
+        let et2039 = RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039)
+        let et2040 = RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2040)
+
+        #expect(ssh.connectionHash != et.connectionHash)
+        #expect(et.connectionHash != et2039.connectionHash)
+        #expect(et2039.connectionHash != et2040.connectionHash, "etserver port must separate endpoints")
+        // The ssh port is a different axis from the transport port and must not alias it.
+        #expect(
+            RemoteTmuxHost(destination: "user@host", port: 2039).connectionHash != et2039.connectionHash
+        )
+    }
+
+    /// And a plain ssh host keeps the hash it has today. It names the shared master's socket path
+    /// and persisted mirror state, so moving it would orphan both on upgrade.
+    @Test func theConnectionHashIsUnchangedForAnSSHHost() {
+        // Naming ssh explicitly, with no transport port, is the same endpoint as saying nothing —
+        // which is what keeps an existing host's socket path and persisted state addressable.
+        #expect(
+            RemoteTmuxHost(destination: "user@host").connectionHash
+                == RemoteTmuxHost(destination: "user@host", transport: .ssh).connectionHash
+        )
+        #expect(
+            RemoteTmuxHost(destination: "user@host", port: 22, identityFile: "/k").connectionHash
+                == RemoteTmuxHost(
+                    destination: "user@host", port: 22, identityFile: "/k", transport: .ssh
+                ).connectionHash
+        )
+    }
+
+    /// A self-reconnecting transport that is alive but no longer answering has to be recovered,
+    /// not waited on. There is no EOF coming — that is the whole point of such a transport — so
+    /// before this the connection stayed `.connected` and the mirror froze permanently.
+    ///
+    /// `.enter` is delivered through the real message path rather than a test-only setter, so the
+    /// transition under test is the one production takes.
+    @MainActor @Test func aStalledSelfReconnectingTransportIsRecoveredRatherThanLeftConnected() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039),
+            sessionName: "work"
+        )
+        connection.handle(.enter)
+        #expect(!connection.snapshot().recentEvents.contains("liveness-stalled"))
+
+        // Nothing is attached to carry the probe, which is what a wedged transport looks like
+        // from here: alive as far as anyone can see, unable to answer.
+        var reported: Bool?
+        connection.checkLivenessAndRecoverIfStalled { reported = $0 }
+        #expect(reported == false, "a stream that cannot answer must be reported as stalled")
+        #expect(connection.snapshot().recentEvents.contains("liveness-stalled"))
+    }
+
+    /// ssh must be untouched by all of this: it gets an EOF, `handleStreamEnd` already recovers,
+    /// and probing an idle ssh stream would add traffic and a new way to fail.
+    @MainActor @Test func anSSHTransportIsNeverProbedForStalls() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host"),
+            sessionName: "work"
+        )
+        connection.handle(.enter)
+        var reported: Bool?
+        connection.checkLivenessAndRecoverIfStalled { reported = $0 }
+        #expect(reported == true, "ssh is out of scope for the stall check")
+        #expect(!connection.snapshot().recentEvents.contains("liveness-stalled"))
     }
 
     @Test func etCanTargetAServerWhoseTerminalIsNotOnThePath() {

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -492,14 +492,48 @@ import Testing
         )
     }
 
-    /// No remote terminal path is forced. Naming one was a guess about the *server's* layout, and
-    /// et executes exactly what it is given, so a wrong guess is fatal rather than ignored.
-    @Test func noRemoteTerminalPathIsForcedByDefault() {
-        let argv = RemoteTmuxTransportKind.et.profile(port: 2039).controlStreamArgv(
-            host: RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039),
-            sessionName: "work", createIfMissing: false
+    /// A terminal path is always sent, and comes from the host once probed.
+    ///
+    /// Dropping the flag was measured to be worse than the literal it replaced: `etterminal` is not
+    /// on a non-interactive ssh PATH on macOS, so et fails outright with "Error starting ET process
+    /// through ssh". The fix for a hardcoded path is to resolve it, not to omit it.
+    @Test func theRemoteTerminalPathIsAlwaysSentAndComesFromTheHostWhenKnown() {
+        let unprobed = RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039)
+        let defaulted = RemoteTmuxTransportKind.et
+            .profile(port: 2039, terminalPath: unprobed.transportTerminalPath)
+            .controlStreamArgv(host: unprobed, sessionName: "work", createIfMissing: false)
+        #expect(
+            consecutive(defaulted, "--terminal-path", RemoteTmuxETTransportProfile.defaultRemoteTerminalPath),
+            "an unprobed host must still work, so it keeps the previous default"
         )
-        #expect(!argv.contains("--terminal-path"))
+
+        let probed = RemoteTmuxHost(
+            destination: "user@host", transport: .et, transportPort: 2039,
+            transportTerminalPath: "/opt/homebrew/bin/etterminal"
+        )
+        let resolved = RemoteTmuxTransportKind.et
+            .profile(port: 2039, terminalPath: probed.transportTerminalPath)
+            .controlStreamArgv(host: probed, sessionName: "work", createIfMissing: false)
+        #expect(consecutive(resolved, "--terminal-path", "/opt/homebrew/bin/etterminal"))
+    }
+
+    /// How the path is discovered: one short command, covering PATH first and then the platform
+    /// locations. Short matters — it is delivered under the same canonical-line limit as any other
+    /// et command.
+    @Test func theTerminalPathProbeIsShortAndCoversEveryCandidate() {
+        let probe = RemoteTmuxETTransportProfile.remoteTerminalProbeCommand()
+        #expect(probe.hasPrefix("command -v etterminal"), "PATH first, when the host has it there")
+        for candidate in RemoteTmuxETTransportProfile.remoteTerminalCandidates {
+            #expect(probe.contains(candidate), "\(candidate) must be probed")
+        }
+        #expect(
+            probe.utf8.count < RemoteTmuxETTransportProfile.maxCanonicalLineBytes,
+            "the probe itself must fit one line, saw \(probe.utf8.count) bytes"
+        )
+        // Apple Silicon before Intel: a machine with both should use the native one.
+        let homebrew = probe.range(of: "/opt/homebrew/bin/etterminal")
+        let intel = probe.range(of: "/usr/local/bin/etterminal")
+        #expect(homebrew != nil && intel != nil && homebrew!.lowerBound < intel!.lowerBound)
     }
 
     /// et bootstraps over ssh before its own protocol takes over, and inherits none of the host's

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -186,20 +186,15 @@ import Testing
 
     // MARK: - Seam 2: who owns reconnection decides what EOF means
 
-    /// ssh ends when the connection drops, so EOF is cmux's cue to respawn.
-    @Test func endOfStreamOverSSHMeansReconnect() {
-        #expect(
-            RemoteTmuxStreamEndDisposition.forStreamEnd(reconnectsInternally: false) == .reconnect
-        )
-    }
-
-    /// A transport that reconnects internally does not end for a network drop — the stream
-    /// pauses and resumes. So if it ends, the session is genuinely over, and respawning
-    /// would be cmux fighting the transport for ownership of recovery.
-    @Test func endOfStreamOverAPersistentTransportMeansTheSessionIsOver() {
-        #expect(
-            RemoteTmuxStreamEndDisposition.forStreamEnd(reconnectsInternally: true) == .sessionOver
-        )
+    /// EOF means reconnect, whoever owns reconnection, because EOF cannot say which of the
+    /// transport and the session died.
+    ///
+    /// This test previously asserted the opposite for a self-reconnecting transport, on the
+    /// reasoning that such a transport does not end for a network drop. Measured against
+    /// et 6.2.11+7: restarting only `etserver` ends the stream while `tmux has-session` still
+    /// succeeds, so that reasoning discarded live, reattachable sessions.
+    @Test func endOfStreamAlwaysMeansReconnectAndLetTheReattachDecide() {
+        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd() == .reconnect)
     }
 
     // MARK: - Seam 3: the pre-connect hook
@@ -505,8 +500,6 @@ import Testing
         let profile = RemoteTmuxETTransportProfile()
         #expect(profile.reconnectsInternally)
         #expect(profile.requiresPseudoTerminal)
-        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd(
-            reconnectsInternally: profile.reconnectsInternally) == .sessionOver)
     }
 
     // MARK: - Seam 2: telling a stall from a death
@@ -529,16 +522,16 @@ import Testing
     }
 
     /// The property that makes the probe necessary in the first place.
+    ///
+    /// A transport that reconnects internally produces no EOF for a network drop, so the failure it
+    /// can suffer — alive but no longer carrying the protocol — is one EOF never reports. That is
+    /// what the probe is for. EOF itself is not the discriminator it once looked like: it now means
+    /// reconnect for every transport, because it cannot say whether the transport or the session
+    /// ended (see endOfStreamAlwaysMeansReconnectAndLetTheReattachDecide).
     @Test func aStallIsNotADeathForATransportThatReconnectsItself() {
         let et = RemoteTmuxETTransportProfile()
         #expect(et.reconnectsInternally)
-        // EOF from such a transport means the session is genuinely over...
-        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd(
-            reconnectsInternally: true) == .sessionOver)
-        // ...whereas ssh's EOF is cmux's cue to respawn. Same event, opposite meaning, which
-        // is why a stall has to be diagnosed by asking rather than by waiting for EOF.
-        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd(
-            reconnectsInternally: false) == .reconnect)
+        #expect(!RemoteTmuxSSHTransportProfile().reconnectsInternally)
     }
 
     // MARK: - Runtime selection
@@ -680,7 +673,6 @@ private struct SplitMix64 {
         #expect(profile.reconnectsInternally, "this suite is about internally-reconnecting transports")
 
         var model = Model()
-        let spawnsAtStart = model.spawnCount
 
         for step in 0..<40 {
             let event = Event.allCases[rng.int(0..<Event.allCases.count)]
@@ -690,15 +682,16 @@ private struct SplitMix64 {
             case .stall:
                 guard model.processAlive, !model.ended else { continue }
                 model.streamFlowing = false
-                // INVARIANT 1: a stall is not a death for this transport, so nothing respawns.
-                #expect(model.spawnCount == spawnsAtStart, "respawned on a stall — \(context)")
-                // INVARIANT 2: a stall never ends the connection.
+                // INVARIANT 1: a stall never ENDS the connection. It does now trigger recovery —
+                // a wedged transport is not going to un-wedge itself, and a respawn reattaches to
+                // the session that is still there. What must never happen is losing the mirror.
                 #expect(!model.ended, "a stall ended the connection — \(context)")
 
             case .resume:
                 guard model.processAlive, !model.ended else { continue }
                 model.streamFlowing = true
-                #expect(model.spawnCount == spawnsAtStart, "respawned on a resume — \(context)")
+                // A resume is the transport doing its job: nothing for cmux to do, and above all
+                // the connection must not have been ended while it was paused.
                 #expect(!model.ended, "a resume ended the connection — \(context)")
 
             case .dropMidFrameThenResume:
@@ -718,12 +711,14 @@ private struct SplitMix64 {
             case .exitClean:
                 guard model.processAlive, !model.ended else { continue }
                 model.processAlive = false
-                // INVARIANT 2 (other half): a genuine exit DOES end it, because this
-                // transport would not have exited for a mere network drop.
-                let disposition = RemoteTmuxStreamEndDisposition.forStreamEnd(
-                    reconnectsInternally: profile.reconnectsInternally)
-                #expect(disposition == .sessionOver, "a real exit did not end the session — \(context)")
-                model.ended = true
+                // INVARIANT 2 (other half): an exit does NOT end the session on its own. This
+                // branch used to assert the opposite, on the premise that such a transport would
+                // not exit for a mere network drop — measured against et 6.2.11+7, restarting only
+                // `etserver` exits while `tmux has-session` still succeeds, so ending here threw
+                // away a live session. Reconnect, and let the reattach report whether it is gone.
+                let disposition = RemoteTmuxStreamEndDisposition.forStreamEnd()
+                #expect(disposition == .reconnect, "an exit did not lead to a reattach — \(context)")
+                model.spawnCount += 1
 
             case .exitAuthFailure:
                 guard model.processAlive, !model.ended else { continue }
@@ -772,10 +767,11 @@ private struct SplitMix64 {
             }
         }
 
-        // INVARIANT 8: teardown is ordering-independent — nothing above may have respawned.
+        // INVARIANT 8: teardown is ordering-independent. Respawns are expected now (an exit
+        // reattaches), so this asserts the connection is not left both ended and alive.
         #expect(
-            model.spawnCount == spawnsAtStart,
-            "seed=\(String(seed, radix: 16)) respawned \(model.spawnCount - spawnsAtStart) time(s) for an internally-reconnecting transport"
+            !(model.ended && model.processAlive),
+            "seed=\(String(seed, radix: 16)) left the connection both ended and alive"
         )
     }
 

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -399,6 +399,24 @@ import Testing
         )
     }
 
+    /// `.ssh` with a transport port is the case the discriminator's condition admits but nothing
+    /// else does: for ssh the endpoint's port is `port`, so a transport port is meaningless there.
+    /// It must still be its own endpoint rather than aliasing the plain ssh host or the ssh host
+    /// whose *ssh* port happens to match.
+    @Test func anSSHHostWithATransportPortIsItsOwnEndpoint() {
+        let plain = RemoteTmuxHost(destination: "user@host")
+        let sshWithTransportPort = RemoteTmuxHost(destination: "user@host", transport: .ssh, transportPort: 2039)
+        let sshOnThatPort = RemoteTmuxHost(destination: "user@host", port: 2039)
+
+        #expect(sshWithTransportPort.connectionHash != plain.connectionHash)
+        #expect(sshWithTransportPort.connectionHash != sshOnThatPort.connectionHash)
+        #expect(
+            sshWithTransportPort.connectionHash
+                != RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039).connectionHash,
+            "the transport itself must still separate these"
+        )
+    }
+
     /// And a plain ssh host keeps the hash it has today. It names the shared master's socket path
     /// and persisted mirror state, so moving it would orphan both on upgrade.
     @Test func theConnectionHashIsUnchangedForAnSSHHost() {
@@ -435,6 +453,26 @@ import Testing
         var reported: Bool?
         connection.checkLivenessAndRecoverIfStalled { reported = $0 }
         #expect(reported == false, "a stream that cannot answer must be reported as stalled")
+        #expect(connection.snapshot().recentEvents.contains("liveness-stalled"))
+    }
+
+    /// A probe that is written but never answered is the stall this monitor exists for: ET can
+    /// accept stdin while producing no control output. Before the deadline, probes accumulated and
+    /// the connection stayed `.connected` forever — the monitor could not detect the very case it
+    /// was added for.
+    @MainActor @Test func anUnansweredProbeIsTreatedAsAStall() {
+        let connection = RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039),
+            sessionName: "work"
+        )
+        connection.handle(.enter)
+        // Stand in for a probe that was written and never came back.
+        connection.livenessProbeOutstanding = true
+
+        var reported: Bool?
+        connection.checkLivenessAndRecoverIfStalled { reported = $0 }
+        #expect(reported == false)
+        #expect(connection.snapshot().recentEvents.contains("liveness-unanswered"))
         #expect(connection.snapshot().recentEvents.contains("liveness-stalled"))
     }
 

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -193,8 +193,8 @@ import Testing
     /// reasoning that such a transport does not end for a network drop. Measured against
     /// et 6.2.11+7: restarting only `etserver` ends the stream while `tmux has-session` still
     /// succeeds, so that reasoning discarded live, reattachable sessions.
-    @Test func endOfStreamAlwaysMeansReconnectAndLetTheReattachDecide() {
-        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd() == .reconnect)
+    @Test func endOfStreamOnAnEstablishedStreamMeansReconnectAndLetTheReattachDecide() {
+        #expect(RemoteTmuxStreamEndDisposition.forStreamEnd(hasReachedControlMode: true) == .reconnect)
     }
 
     // MARK: - Seam 3: the pre-connect hook
@@ -451,6 +451,22 @@ import Testing
         #expect(reported == false)
         #expect(connection.snapshot().recentEvents.contains("liveness-unanswered"))
         #expect(connection.snapshot().recentEvents.contains("liveness-stalled"))
+    }
+
+    /// A stream that never reached control mode is a failed start, not a lost session.
+    ///
+    /// Reconnecting there is what made a real error — "tmux control stream ended before attach" —
+    /// surface as an opaque 60-second attach timeout, which cost most of a debugging session.
+    /// Reconnecting is right only once a stream has actually worked.
+    @Test func endOfStreamBeforeControlModeIsTerminalRatherThanRetried() {
+        #expect(
+            RemoteTmuxStreamEndDisposition.forStreamEnd(hasReachedControlMode: false) == .sessionOver,
+            "a transport that never started has nothing to reconnect to"
+        )
+        #expect(
+            RemoteTmuxStreamEndDisposition.forStreamEnd(hasReachedControlMode: true) == .reconnect,
+            "an established stream may have a session still there — reattach decides"
+        )
     }
 
     /// ssh must be untouched by all of this: it gets an EOF, `handleStreamEnd` already recovers,
@@ -863,7 +879,9 @@ private struct SplitMix64 {
                 // not exit for a mere network drop — measured against et 6.2.11+7, restarting only
                 // `etserver` exits while `tmux has-session` still succeeds, so ending here threw
                 // away a live session. Reconnect, and let the reattach report whether it is gone.
-                let disposition = RemoteTmuxStreamEndDisposition.forStreamEnd()
+                // The model's stream has reached control mode by this point, which is the case
+                // where an exit may still have a live session behind it.
+                let disposition = RemoteTmuxStreamEndDisposition.forStreamEnd(hasReachedControlMode: true)
                 #expect(disposition == .reconnect, "an exit did not lead to a reattach — \(context)")
                 model.spawnCount += 1
 

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -483,13 +483,15 @@ import Testing
         )
         #expect(fromPath == "/my/bin/et")
 
-        // Nothing found reports the bare name, so the error is "et not found" rather than a wrong
-        // absolute path, and a PATH lookup at spawn time can still succeed.
-        #expect(
-            RemoteTmuxETTransportProfile.resolveClientExecutable(
-                fileExists: { _ in false }, pathValue: ""
-            ) == "et"
+        // Never a bare name. The stream is spawned through `/usr/bin/script`, which resolves its
+        // argument against the app's own PATH — and a GUI app's PATH cannot be relied on, so a bare
+        // name becomes "script: et: No such file or directory", an immediately-ending stream, and
+        // (since end-of-stream now reconnects) a 60-second attach timeout carrying no error at all.
+        let notFound = RemoteTmuxETTransportProfile.resolveClientExecutable(
+            fileExists: { _ in false }, pathValue: ""
         )
+        #expect(notFound == RemoteTmuxETTransportProfile.defaultClientPath)
+        #expect(notFound.hasPrefix("/"), "must be absolute so `script` cannot mis-resolve it")
     }
 
     /// A terminal path is always sent, and comes from the host once probed.
@@ -600,6 +602,34 @@ import Testing
             RemoteTmuxHost(destination: "user@host").connectionHash
                 == RemoteTmuxHost(destination: "user@host", transport: .ssh, transportPort: 2039).connectionHash
         )
+    }
+
+    /// Retrying is only honest when the next attempt could differ. These cannot, so they end the
+    /// connection with their reason instead of looping — which is what turned a missing binary into
+    /// a 60-second attach timeout carrying no message once end-of-stream started meaning reconnect.
+    @Test(arguments: [
+        "script: et: No such file or directory",
+        "/usr/local/bin/et: No such file or directory",
+        "etterminal: No such file or directory",
+        "Error starting ET process through ssh, please make sure your ssh works first",
+        "et: unrecognized option '--terminal-path'",
+    ])
+    func unrecoverableTransportFailuresAreNotRetried(_ stderr: String) {
+        #expect(RemoteTmuxSSHTransport.indicatesUnrecoverableTransportFailure(stderr))
+    }
+
+    /// And the classifier stays narrow: wrongly retrying costs a delay, wrongly giving up costs a
+    /// mirror that never comes back, so anything that might succeed next time keeps retrying.
+    @Test(arguments: [
+        "ssh: connect to host example.com port 22: Connection refused",
+        "kex_exchange_identification: Connection reset by peer",
+        "Connection closed by 10.0.0.5 port 22",
+        "no server running on /tmp/tmux-501/default",
+        "user@host: Permission denied (publickey).",
+        "",
+    ])
+    func recoverableFailuresKeepRetrying(_ stderr: String) {
+        #expect(!RemoteTmuxSSHTransport.indicatesUnrecoverableTransportFailure(stderr))
     }
 
     @Test func etCanTargetAServerWhoseTerminalIsNotOnThePath() {

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -289,6 +289,25 @@ import Testing
             return false
         }
         #expect(sawSessionChange, "expected %session-changed to parse after the ET preamble")
+
+        // `.enter` is the message that matters, and asserting only on %session-changed hid a
+        // real bug: the login shell's echoed title sequences land on the same line as the
+        // enter DCS, so a parser that requires the DCS at the start of a line never emits
+        // `.enter`. Everything downstream waits on it — the connection stays out of
+        // `.connected` and the attach dies on a timeout while later notifications parse
+        // normally, which is exactly what a real et host did.
+        let sawEnter = messages.contains { message in
+            if case .enter = message { return true }
+            return false
+        }
+        #expect(sawEnter, "expected .enter from the ET stream's mid-line enter DCS")
+        // Order matters too: commands are withheld until `.enter`, so it has to arrive before
+        // the notifications that follow it in the stream.
+        let enterIndex = messages.firstIndex { if case .enter = $0 { return true }; return false }
+        let changeIndex = messages.firstIndex { if case .sessionChanged = $0 { return true }; return false }
+        if let enterIndex, let changeIndex {
+            #expect(enterIndex < changeIndex, "`.enter` must precede %session-changed")
+        }
     }
 
     // MARK: - The profile's argv, measured against the real client
@@ -307,12 +326,57 @@ import Testing
         #expect(argv.last == "user@127.0.0.1")
         let command = argv.first(where: { $0.hasPrefix("exec ") })
         #expect(command?.contains("attach-session") == true)
-        // The resolver is still needed: a minimal remote PATH is a property of the remote
-        // shell, not of ssh.
-        #expect(command?.contains("cmux-remote-executable") == true)
+        // Plain tmux, not ssh's PATH resolver. et types the command into a login shell, so the
+        // shell resolves tmux from the user's own PATH — and the resolver would not fit anyway
+        // (see etCommandFitsWhatALoginShellCanRead).
+        #expect(command?.contains("cmux-remote-executable") == false)
+        #expect(command?.contains("'tmux'") == true)
         // Never kill the user's other sessions on that host.
         #expect(!argv.contains("-x"))
         #expect(!argv.contains("--kill-other-sessions"))
+    }
+
+    /// et types the command into a login shell instead of exec'ing it, and that shell reads from
+    /// a pty in canonical mode. macOS delivers at most MAX_CANON (1024) bytes per line, so a
+    /// longer command never completes a line: the shell runs nothing, et emits nothing, and the
+    /// attach dies on a timeout with no error to explain it. Measured against et 6.2.11, where
+    /// ssh's ~1113-byte PATH resolver hung and a 40-byte plain `tmux` produced `%begin`.
+    ///
+    /// Long session names are the realistic way to cross the line, so the bound is checked
+    /// against one rather than only the short names the other tests use.
+    @Test func etCommandFitsWhatALoginShellCanRead() {
+        let maxCanon = 1024
+        for session in ["s", "work session", String(repeating: "session-", count: 24)] {
+            let argv = RemoteTmuxETTransportProfile(port: 2039).controlStreamArgv(
+                host: RemoteTmuxHost(destination: "user@host"),
+                sessionName: session,
+                createIfMissing: false
+            )
+            let command = try? #require(argv.first(where: { $0.hasPrefix("exec ") }))
+            let byteCount = (command ?? "").utf8.count
+            #expect(
+                byteCount < maxCanon,
+                Comment(
+                    rawValue: "et command is \(byteCount) bytes for a \(session.count)-character "
+                        + "session name, over the \(maxCanon)-byte canonical line limit"
+                )
+            )
+        }
+    }
+
+    /// The session name reaches the remote shell as one word even when it contains a space or a
+    /// quote. Dropping the resolver moved this responsibility onto this profile's own quoting.
+    @Test func etQuotesTheSessionNameItTypes() {
+        let argv = RemoteTmuxETTransportProfile(port: 2039).controlStreamArgv(
+            host: RemoteTmuxHost(destination: "user@host"),
+            sessionName: "work 'session'; touch /tmp/cmux-et-injection",
+            createIfMissing: false
+        )
+        let command = argv.first(where: { $0.hasPrefix("exec ") }) ?? ""
+        // Quoted as data, so the shell cannot run the trailing command.
+        #expect(command.contains("touch /tmp/cmux-et-injection"))
+        #expect(!command.contains("; touch /tmp/cmux-et-injection'\""))
+        #expect(command.hasSuffix("'work '\\''session'\\''; touch /tmp/cmux-et-injection'"))
     }
 
     @Test func etCanTargetAServerWhoseTerminalIsNotOnThePath() {

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -340,7 +340,7 @@ import Testing
     ///
     /// Long session names are the realistic way to cross the line, so the bound is checked
     /// against one rather than only the short names the other tests use.
-    @Test func etCommandFitsWhatALoginShellCanRead() {
+    @Test func etCommandFitsWhatALoginShellCanRead() throws {
         let maxCanon = 1024
         for session in ["s", "work session", String(repeating: "session-", count: 24)] {
             let argv = RemoteTmuxETTransportProfile(port: 2039).controlStreamArgv(
@@ -348,8 +348,8 @@ import Testing
                 sessionName: session,
                 createIfMissing: false
             )
-            let command = try? #require(argv.first(where: { $0.hasPrefix("exec ") }))
-            let byteCount = (command ?? "").utf8.count
+            let command = try #require(argv.first(where: { $0.hasPrefix("exec ") }))
+            let byteCount = command.utf8.count
             #expect(
                 byteCount < maxCanon,
                 Comment(

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -394,24 +394,6 @@ import Testing
         )
     }
 
-    /// `.ssh` with a transport port is the case the discriminator's condition admits but nothing
-    /// else does: for ssh the endpoint's port is `port`, so a transport port is meaningless there.
-    /// It must still be its own endpoint rather than aliasing the plain ssh host or the ssh host
-    /// whose *ssh* port happens to match.
-    @Test func anSSHHostWithATransportPortIsItsOwnEndpoint() {
-        let plain = RemoteTmuxHost(destination: "user@host")
-        let sshWithTransportPort = RemoteTmuxHost(destination: "user@host", transport: .ssh, transportPort: 2039)
-        let sshOnThatPort = RemoteTmuxHost(destination: "user@host", port: 2039)
-
-        #expect(sshWithTransportPort.connectionHash != plain.connectionHash)
-        #expect(sshWithTransportPort.connectionHash != sshOnThatPort.connectionHash)
-        #expect(
-            sshWithTransportPort.connectionHash
-                != RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039).connectionHash,
-            "the transport itself must still separate these"
-        )
-    }
-
     /// And a plain ssh host keeps the hash it has today. It names the shared master's socket path
     /// and persisted mirror state, so moving it would orphan both on upgrade.
     @Test func theConnectionHashIsUnchangedForAnSSHHost() {
@@ -483,6 +465,107 @@ import Testing
         connection.checkLivenessAndRecoverIfStalled { reported = $0 }
         #expect(reported == true, "ssh is out of scope for the stall check")
         #expect(!connection.snapshot().recentEvents.contains("liveness-stalled"))
+    }
+
+    /// The client binary is resolved, not assumed. A literal `/usr/local/bin/et` is a claim about
+    /// someone else's machine, and it is wrong on a standard Apple Silicon Homebrew install.
+    @Test func theETClientIsResolvedRatherThanHardcoded() {
+        let onlyHomebrew = RemoteTmuxETTransportProfile.resolveClientExecutable(
+            fileExists: { $0 == "/opt/homebrew/bin/et" },
+            pathValue: "/usr/bin:/bin"
+        )
+        #expect(onlyHomebrew == "/opt/homebrew/bin/et")
+
+        // PATH wins over the built-in directories, so a user-installed et is preferred.
+        let fromPath = RemoteTmuxETTransportProfile.resolveClientExecutable(
+            fileExists: { $0 == "/my/bin/et" || $0 == "/usr/local/bin/et" },
+            pathValue: "/my/bin"
+        )
+        #expect(fromPath == "/my/bin/et")
+
+        // Nothing found reports the bare name, so the error is "et not found" rather than a wrong
+        // absolute path, and a PATH lookup at spawn time can still succeed.
+        #expect(
+            RemoteTmuxETTransportProfile.resolveClientExecutable(
+                fileExists: { _ in false }, pathValue: ""
+            ) == "et"
+        )
+    }
+
+    /// No remote terminal path is forced. Naming one was a guess about the *server's* layout, and
+    /// et executes exactly what it is given, so a wrong guess is fatal rather than ignored.
+    @Test func noRemoteTerminalPathIsForcedByDefault() {
+        let argv = RemoteTmuxTransportKind.et.profile(port: 2039).controlStreamArgv(
+            host: RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039),
+            sessionName: "work", createIfMissing: false
+        )
+        #expect(!argv.contains("--terminal-path"))
+    }
+
+    /// et bootstraps over ssh before its own protocol takes over, and inherits none of the host's
+    /// ssh settings. Without these the ssh preflight succeeds and et's bootstrap fails on defaults.
+    @Test func etCarriesTheHostsSSHPortAndIdentityIntoItsBootstrap() {
+        let host = RemoteTmuxHost(
+            destination: "user@host", port: 2222, identityFile: "/keys/id",
+            transport: .et, transportPort: 2039
+        )
+        let argv = RemoteTmuxTransportKind.et.profile(port: 2039).controlStreamArgv(
+            host: host, sessionName: "work", createIfMissing: false
+        )
+        #expect(consecutive(argv, "--ssh-option", "Port=2222"))
+        #expect(consecutive(argv, "--ssh-option", "IdentityFile=/keys/id"))
+        // etserver's port stays distinct from ssh's.
+        #expect(consecutive(argv, "-p", "2039"))
+    }
+
+    /// A session name long enough to push the command past one canonical line is rejected, because
+    /// et would deliver nothing and the attach would die on a timeout with no explanation. tmux
+    /// accepts names of ~1000 bytes, so this is reachable without abuse.
+    @Test func anOverlongSessionNameIsRejectedForET() {
+        let bound = RemoteTmuxETTransportProfile.maxSessionNameBytes()
+        #expect(bound > 900, "the bound should leave room for a realistic name, saw \(bound)")
+        #expect(bound < RemoteTmuxETTransportProfile.maxCanonicalLineBytes)
+
+        let atBound = String(repeating: "a", count: bound)
+        let overBound = String(repeating: "a", count: bound + 1)
+        #expect(
+            TerminalController.remoteTmuxSessionName(from: ["session": atBound], transport: .et) != nil
+        )
+        #expect(
+            TerminalController.remoteTmuxSessionName(from: ["session": overBound], transport: .et) == nil
+        )
+        // ssh execs its command, so the pty line limit does not apply there.
+        #expect(
+            TerminalController.remoteTmuxSessionName(from: ["session": overBound], transport: .ssh) != nil
+        )
+    }
+
+    /// The command built for a name at the bound really does fit, so the bound is derived from the
+    /// command rather than asserted next to it.
+    @Test func theSessionNameBoundKeepsTheCommandWithinOneLine() {
+        for createIfMissing in [false, true] {
+            let bound = RemoteTmuxETTransportProfile.maxSessionNameBytes(createIfMissing: createIfMissing)
+            let command = RemoteTmuxETTransportProfile.controlStreamRemoteCommand(
+                sessionName: String(repeating: "a", count: bound), createIfMissing: createIfMissing
+            )
+            #expect(
+                command.utf8.count <= RemoteTmuxETTransportProfile.maxCanonicalLineBytes,
+                "createIfMissing=\(createIfMissing) produced \(command.utf8.count) bytes"
+            )
+        }
+    }
+
+    /// Two spellings of one endpoint must be one key, or the controller mirrors a host twice.
+    @Test func theConnectionHashNormalizesEquivalentEndpoints() {
+        let implicit = RemoteTmuxHost(destination: "user@host", transport: .et)
+        let explicit = RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2022)
+        #expect(implicit.connectionHash == explicit.connectionHash, "et's default port is 2022")
+
+        // ssh ignores a transport port, so carrying one must not split the endpoint.
+        #expect(
+            RemoteTmuxHost(destination: "user@host").connectionHash
+                == RemoteTmuxHost(destination: "user@host", transport: .ssh, transportPort: 2039).connectionHash
+        )
     }
 
     @Test func etCanTargetAServerWhoseTerminalIsNotOnThePath() {

--- a/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
+++ b/cmuxTests/RemoteTmuxProxyTransportRetryTests.swift
@@ -433,24 +433,82 @@ import Testing
         #expect(connection.snapshot().recentEvents.contains("liveness-stalled"))
     }
 
-    /// A probe that is written but never answered is the stall this monitor exists for: ET can
-    /// accept stdin while producing no control output. Before the deadline, probes accumulated and
-    /// the connection stayed `.connected` forever — the monitor could not detect the very case it
-    /// was added for.
-    @MainActor @Test func anUnansweredProbeIsTreatedAsAStall() {
-        let connection = RemoteTmuxControlConnection(
-            host: RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039),
-            sessionName: "work"
-        )
+    /// A probe that is written but never answered, on a host that still answers out of band, is
+    /// the stall this monitor exists for: ET can accept stdin while producing no control output.
+    /// Before the deadline, probes accumulated and the connection stayed `.connected` forever —
+    /// the monitor could not detect the very case it was added for.
+    ///
+    /// The reachable answer is what makes this a stall rather than an outage: the host is fine, so
+    /// the stream is the broken part.
+    @MainActor @Test func anUnansweredProbeOnAReachableHostIsTreatedAsAStall() async {
+        let connection = Self.etConnection(reachable: true)
         connection.handle(.enter)
         // Stand in for a probe that was written and never came back.
         connection.livenessProbeOutstanding = true
 
-        var reported: Bool?
-        connection.checkLivenessAndRecoverIfStalled { reported = $0 }
+        let reported = await Self.tick(connection)
         #expect(reported == false)
         #expect(connection.snapshot().recentEvents.contains("liveness-unanswered"))
         #expect(connection.snapshot().recentEvents.contains("liveness-stalled"))
+        #expect(connection.connectionState == .reconnecting)
+    }
+
+    /// An unanswered probe during a real outage must not cost the session.
+    ///
+    /// The transport reconnects underneath, and while it does it cannot answer a probe either — so
+    /// silence alone cannot mean "wedged". Recovering here terminates the transport process and
+    /// discards the session it was in the middle of resuming. The host is asked out of band, over
+    /// a channel the wedge cannot reach, and an unreachable host means wait.
+    @MainActor @Test func anOutageDefersTheVerdictInsteadOfDiscardingTheSession() async {
+        let connection = Self.etConnection(reachable: false)
+        connection.handle(.enter)
+        connection.livenessProbeOutstanding = true
+
+        let reported = await Self.tick(connection)
+        #expect(reported == true, "nothing was recovered, so there is no recovery edge to report")
+        #expect(connection.connectionState == .connected, "an outage must not end the session")
+        #expect(!connection.snapshot().recentEvents.contains("liveness-stalled"))
+        #expect(connection.snapshot().recentEvents.contains("liveness-deferred-unreachable"))
+    }
+
+    /// Deferral is bounded. A host that stays unreachable while the stream stays silent is
+    /// eventually recovered anyway: if the outage is not what silenced the stream, waiting on it
+    /// forever leaves a frozen mirror with no retry — the failure this monitor was added for.
+    @MainActor @Test func aDeferralRunEndsInRecoveryOnceTheCapIsPassed() async {
+        let connection = Self.etConnection(reachable: false)
+        connection.handle(.enter)
+        connection.livenessProbeOutstanding = true
+
+        let cap = RemoteTmuxControlConnection.maxConsecutiveLivenessDeferrals
+        for _ in 0..<cap {
+            let reported = await Self.tick(connection)
+            #expect(reported == true)
+        }
+        #expect(connection.connectionState == .connected, "within the cap the session is kept")
+
+        let final = await Self.tick(connection)
+        #expect(final == false)
+        #expect(connection.snapshot().recentEvents.contains("liveness-deferral-exhausted"))
+        #expect(connection.snapshot().recentEvents.contains("liveness-stalled"))
+        #expect(connection.connectionState == .reconnecting)
+    }
+
+    /// An et connection whose reachability answer is decided by the test, so the branch under test
+    /// is reached without a host, an ssh master, or a spawned process.
+    @MainActor private static func etConnection(reachable: Bool) -> RemoteTmuxControlConnection {
+        RemoteTmuxControlConnection(
+            host: RemoteTmuxHost(destination: "user@host", transport: .et, transportPort: 2039),
+            sessionName: "work",
+            sessionReachability: { _, _ in reachable }
+        )
+    }
+
+    /// Runs one monitor tick and waits for its verdict. The verdict can now cross an `await` (the
+    /// out-of-band question), so it is read from the completion rather than after the call.
+    @MainActor private static func tick(_ connection: RemoteTmuxControlConnection) async -> Bool {
+        await withCheckedContinuation { continuation in
+            connection.checkLivenessAndRecoverIfStalled { continuation.resume(returning: $0) }
+        }
     }
 
     /// A stream that never reached control mode is a failed start, not a lost session.

--- a/docs/remote-tmux-transport-seam.md
+++ b/docs/remote-tmux-transport-seam.md
@@ -105,8 +105,15 @@ transport that reconnects internally needs a liveness check instead:
 
 cmux already has the round-trip primitive: a bounded `display-message -p ok` query, used as
 `awaitCommandBarrier` in `RemoteTmuxViewConnection`. Reuse it rather than inventing a
-heartbeat. A genuine transport exit still means the session is over and routes to the
-existing session-gone path.
+heartbeat, and give the probe a deadline: measured against 6.2.11+7, et can accept stdin while
+producing no control output, so an unanswered probe is the stall. The next probe's due time is
+that deadline, which needs no second clock.
+
+A transport exit does **not** mean the session is over, tempting as the symmetry is. Restarting
+only `etserver` ends the stream while `tmux has-session` still succeeds, so acting on it discarded
+live, reattachable sessions. EOF cannot tell "the transport died" from "the session died" for any
+transport, so end-of-stream reconnects and the reattach reports which it was —
+`scripts/remote-tmux-et-conformance.sh` checks this rather than leaving it here as a claim.
 
 There is a bug here worth fixing independently of any new transport.
 `handleStreamEnd`'s classifier only distinguishes "session gone" (end) from everything else

--- a/docs/remote-tmux-transport-seam.md
+++ b/docs/remote-tmux-transport-seam.md
@@ -57,7 +57,12 @@ implementation wraps a persistent-session transport. For ET that is:
 et --command 'exec tmux -CC attach-session -t <session>' [--port N] <user>@<host>
 ```
 
-Four details are load-bearing for any such transport:
+Four details are load-bearing for any such transport. Each one is a claim about a program cmux
+does not control, so each one is a check in `scripts/remote-tmux-et-conformance.sh` rather than
+only a paragraph here — every defect this transport shipped with was a claim in this list that
+nothing executed. Run that script against every ET version you intend to support: 7.x rewrote the
+pty input path that 6.x deadlocks on, so "et behaves like this" is version-scoped.
+
 
 - **Run the command, do not open a shell.** ET's `--command` runs one command and exits.
   Prefix it with `exec` so the remote process tree does not keep a shell parent around.

--- a/docs/remote-tmux-transport-seam.md
+++ b/docs/remote-tmux-transport-seam.md
@@ -106,8 +106,19 @@ transport that reconnects internally needs a liveness check instead:
 cmux already has the round-trip primitive: a bounded `display-message -p ok` query, used as
 `awaitCommandBarrier` in `RemoteTmuxViewConnection`. Reuse it rather than inventing a
 heartbeat, and give the probe a deadline: measured against 6.2.11+7, et can accept stdin while
-producing no control output, so an unanswered probe is the stall. The next probe's due time is
-that deadline, which needs no second clock.
+producing no control output, so an unanswered probe is the suspicion. The next probe's due time
+is that deadline, which needs no second clock.
+
+An unanswered probe cannot be the verdict, though, because a real network interruption looks
+identical from the stream's side: the transport is reconnecting underneath and cannot answer
+either, and recovering there kills the process and throws away the session it was resuming.
+What tells the two apart is a question asked somewhere else. One-shot commands ride ssh's
+shared master even for an et connection, so `tmux has-session` reaches the host over a channel
+this stream's wedge cannot touch — the same asymmetry the `etserver` restart above measures. A
+host that answers proves the stream is the broken part, and that is the case to recover. A host
+that does not answer is an outage, so stay connected and ask again next tick, capped at four
+consecutive deferrals (about two minutes) so a host that is both unreachable and wedged still
+gets its reconnect.
 
 A transport exit does **not** mean the session is over, tempting as the symmetry is. Restarting
 only `etserver` ends the stream while `tmux has-session` still succeeds, so acting on it discarded

--- a/docs/remote-tmux-transport-seam.md
+++ b/docs/remote-tmux-transport-seam.md
@@ -54,17 +54,20 @@ protocol RemoteTmuxTransport: Sendable {
 implementation wraps a persistent-session transport. For ET that is:
 
 ```
-et --command 'exec <tmux resolver> -CC attach-session -t <session>' [--port N] <user>@<host>
+et --command 'exec tmux -CC attach-session -t <session>' [--port N] <user>@<host>
 ```
 
 Four details are load-bearing for any such transport:
 
 - **Run the command, do not open a shell.** ET's `--command` runs one command and exits.
   Prefix it with `exec` so the remote process tree does not keep a shell parent around.
-- **The remote command still needs the tmux resolver.** A non-login remote shell often has
-  a minimal `PATH`, which is why `RemoteTmuxHost.tmuxRemoteCommand` wraps `tmux` in a
-  resolver script. That is a property of the remote shell, not of ssh, so it applies here
-  identically.
+- **The command has to fit on one line, so et does not get the tmux resolver.** ET does not
+  exec the command: it types it into a login shell and appends `; exit`. That shell reads from
+  a pty in canonical mode, which delivers at most `MAX_CANON` (1024 on macOS) bytes per line,
+  and ssh's `PATH` resolver is about 1113 bytes. The line never completes, so the shell runs
+  nothing, the stream stays silent, and the attach dies on a timeout with nothing to explain
+  it. Plain `tmux` is both short enough and correct here, because a login shell already has
+  the user's full `PATH` — ssh is the opposite case, a non-login shell with a minimal one.
 - **The port is per-transport and per-host.** Keep it configurable instead of assuming
   ssh's 22.
 - **Never pass a flag that kills other sessions.** ET's `-x` / `--kill-other-sessions`

--- a/docs/remote-tmux-transport-seam.md
+++ b/docs/remote-tmux-transport-seam.md
@@ -1,0 +1,291 @@
+# A transport seam for remote tmux
+
+Remote-tmux hardcodes `/usr/bin/ssh` as the way it reaches a host. This describes three
+seams that let a different transport carry the same control stream, so a connection can
+survive network drops instead of reconnecting from scratch, and a plan for proving the
+result: a mock transport for unit speed, a real sshd plus a real
+[EternalTerminal](https://github.com/MisterTea/EternalTerminal) server for end-to-end
+truth, and a seeded model-based fuzz that ratchets until the state machine holds.
+
+## Why
+
+Reaching a remote tmux over plain ssh ties two unrelated things together: the bytes of the
+`tmux -CC` control protocol, and the lifetime of one TCP connection. When the network
+drops, the ssh child exits, and the only recovery is to spawn a new ssh, which
+authenticates again.
+
+For a host with cheap auth that is invisible. For a host with a second factor, every blip
+costs an interactive prompt, and because the reconnect path runs non-interactively it
+cannot prompt at all: it fails, gets classified as transient, and retries forever while
+the mirror stays frozen. Persistent-session transports exist to decouple those two
+things. An ET client stays alive across a drop and resumes the same byte stream, so there
+is no new connection to authenticate.
+
+Making the transport switchable is also the cheapest way to stop hardcoding assumptions
+that are only true of ssh, which is what the reconnect logic does today.
+
+## Where the transport is decided today
+
+Two functions build the argv, both on `RemoteTmuxHost`:
+
+- `controlModeArguments(sessionName:createIfMissing:)` for the long-lived `tmux -CC`
+  stream.
+- `sshControlArguments(controlPersistSeconds:batchMode:)` for one-shot commands and for
+  opening the shared ControlMaster.
+
+`RemoteTmuxControlConnection.spawnProcess` launches the first as a `Process` with pipes and
+feeds stdout to `RemoteTmuxControlStreamParser`. `RemoteTmuxSSHTransport` runs the second.
+
+## Seam 1: the transport protocol
+
+```swift
+protocol RemoteTmuxTransport: Sendable {
+    /// argv for the long-lived `tmux -CC` control stream.
+    func controlStreamArgv(host: RemoteTmuxHost, sessionName: String, createIfMissing: Bool) -> [String]
+    /// argv for a one-shot remote command (discovery, mutations).
+    func oneShotArgv(host: RemoteTmuxHost, remoteCommand: String) -> [String]
+    /// Whether the transport recovers from network loss on its own, or whether cmux
+    /// must respawn it.
+    var reconnectsInternally: Bool { get }
+}
+```
+
+`SSHTransport` is the current behavior, unchanged and still the default. A second
+implementation wraps a persistent-session transport. For ET that is:
+
+```
+et --command 'exec <tmux resolver> -CC attach-session -t <session>' [--port N] <user>@<host>
+```
+
+Four details are load-bearing for any such transport:
+
+- **Run the command, do not open a shell.** ET's `--command` runs one command and exits.
+  Prefix it with `exec` so the remote process tree does not keep a shell parent around.
+- **The remote command still needs the tmux resolver.** A non-login remote shell often has
+  a minimal `PATH`, which is why `RemoteTmuxHost.tmuxRemoteCommand` wraps `tmux` in a
+  resolver script. That is a property of the remote shell, not of ssh, so it applies here
+  identically.
+- **The port is per-transport and per-host.** Keep it configurable instead of assuming
+  ssh's 22.
+- **Never pass a flag that kills other sessions.** ET's `-x` / `--kill-other-sessions`
+  terminates every one of that user's sessions on the host, not just stale ones. Some
+  wrappers pass it by default, so an unrelated reconnect elsewhere can kill cmux's
+  session; recover by recreating on unexpected exit rather than trying to hold a claim.
+
+One-shot commands can keep using ssh over the existing ControlMaster even when the control
+stream rides another transport. `RemoteTmuxSSHTransport.ensureMasterReady()` already
+funnels the cold-start burst through a single master open, and that logic is independent
+of how the `-CC` stream is carried.
+
+## Seam 2: reconnect stops being EOF-driven
+
+This is the part that changes behavior, and the reason `reconnectsInternally` exists
+rather than just swapping argv.
+
+Today `handleStreamEnd` treats stdout EOF as the signal to reconnect and
+`beginReconnecting()` respawns with backoff. A transport that reconnects internally
+produces no EOF for a network drop: the stream pauses and resumes. Reacting only to EOF is
+therefore correct and cmux notices nothing, which is the goal. What it must not do is
+treat a *stall* as death and respawn on a timer, because that discards a session the
+transport was about to recover.
+
+So the failure mode moves from "stream ended" to "stream is alive but wedged", and a
+transport that reconnects internally needs a liveness check instead:
+
+1. the transport process is still alive, and
+2. a control-mode round-trip completes.
+
+cmux already has the round-trip primitive: a bounded `display-message -p ok` query, used as
+`awaitCommandBarrier` in `RemoteTmuxViewConnection`. Reuse it rather than inventing a
+heartbeat. A genuine transport exit still means the session is over and routes to the
+existing session-gone path.
+
+There is a bug here worth fixing independently of any new transport.
+`handleStreamEnd`'s classifier only distinguishes "session gone" (end) from everything else
+(retry with backoff, forever). A reconnect that fails because the host wants interactive
+authentication lands in the second bucket, so it retries silently and forever. cmux already
+detects that case (`RemoteTmuxSSHTransport.indicatesAuthRequired`) and already has a path
+for handing the user an interactive ssh on initial attach
+(`RemoteTmuxAttachOutcome.authRequired(sshArgv:)`, built by
+`RemoteTmuxHost.interactiveAuthInvocation()`). The reconnect path should reuse that outcome
+instead of looping.
+
+## Seam 3: a pre-connect hook
+
+Some hosts need a step before the connection that cmux has no business knowing about:
+minting a short-lived credential, unlocking an agent, refreshing a token. Rather than
+teaching cmux any of them, give a host an optional command, in the same spirit as the
+existing per-host upload command:
+
+```
+preseedCommand: <command>   # run as `<command> <host>` before opening a connection
+```
+
+cmux runs it before opening or reopening a connection, treats a non-zero exit as non-fatal
+(proceed and let the connection fail normally, so a broken hook cannot make a host
+unreachable), and ignores its output. Unset means today's behavior.
+
+Two constraints, both learned the hard way wiring one up:
+
+- **Run it once per connection, not once per config parse.** Anything minting a single-use
+  credential must not run concurrently with itself; two mints racing can invalidate each
+  other. The right home is the same single-flight path that opens the shared master
+  (`ensureMasterReady()`), not a per-command hook.
+- **The connection that follows must allow interactive auth methods.** A pre-connect step
+  that satisfies a second factor typically does so through a keyboard-interactive exchange
+  that completes without prompting. Opening that connection with `BatchMode=yes` refuses
+  the method outright and fails `Permission denied (keyboard-interactive)` even though
+  nothing would have prompted. Piped stdin already makes a genuine prompt fail fast, so
+  batch mode is not what protects against hanging.
+
+## Proving it
+
+Scope this at the transport, not the mirror. Render fidelity already has strong coverage
+that a transport change does not improve on: `remote-tmux-render-harness.sh` asserts the
+mirror's visible screen equals the remote pane's visible screen across attach, resize,
+rapid re-attach and reconnect, and `remote-tmux-shape-zoo.sh` plus
+`RemoteTmuxSizingUITests` cover geometry. Those stay as the regression gate and should go
+green unchanged; if a transport swap breaks them, that is the answer, and re-testing
+rendering under a second transport adds cost without signal.
+
+What is genuinely uncovered is the **connection state machine**: what cmux does when a
+stream stalls, resumes, dies, or fails to authenticate, and who resolves the commands that
+were in flight when it happened. Every layer below targets that.
+
+Three layers, cheapest first. The mock keeps unit tests fast, the real servers keep the
+mock honest, and the fuzz is what finds the state-machine bugs.
+
+### Layer 1: mock transport (unit speed, no network)
+
+`scripts/remote-tmux-e2e-ssh-shim.sh` already does this for ssh: it strips the option
+framing, runs the "remote" command locally, and allocates a pty with `script(1)` only when
+`-t`/`-tt` asked for one. `RemoteTmuxHost.defaultSSHExecutablePath()` honors
+`CMUX_REMOTE_TMUX_SSH_FOR_TESTING` in DEBUG so the real app process can be pointed at it.
+
+Add the same seam for the transport binary (an ET shim honoring `--command` instead of
+ssh's framing) so `ETTransport` gets identical treatment. The shim must reproduce the two
+behaviors that bite: hand the remote command to a shell that re-splits it, and allocate a
+pty for the control stream but **not** for one-shot probes, because probe classification
+reads stderr and a pty merges stderr into the stream.
+
+It must also be able to *simulate the interesting failures on demand*, which the ssh shim
+has no reason to do: pause the stream without exiting (the wedge), resume after a pause
+(internal reconnect), drop mid-frame, and exit with a chosen status. Drive those from
+environment variables so a unit test can request one deterministically.
+
+### Layer 2: real sshd and a real ET server (end-to-end truth)
+
+**No containers.** Nothing in remote-tmux uses Docker today, and this should not introduce
+it. (`tests/fixtures/ssh-remote/` has a Dockerfile, but that fixture belongs to the
+cloud-VM image builder, not to remote-tmux.) The established pattern is a **loopback ssh
+alias whose forced command pins an isolated `TMUX_TMPDIR`**, so a harness drives real ssh
+against the machine's own sshd and can never touch the developer's real tmux:
+
+```
+Host cmux-srvA
+    HostName 127.0.0.1
+    RemoteCommand TMUX_TMPDIR=/tmp/cmux-srvA $SHELL -l
+    RequestTTY yes
+```
+
+`scripts/remote-tmux-render-harness.sh` uses exactly that and returns the number of failed
+scenarios as its exit code. `scripts/remote-tmux-shape-zoo.sh` builds a geometry zoo on a
+real host over one ordinary ssh connection for manual exercise. Reuse both conventions:
+loopback, isolated tmpdir, generated keys on a nonstandard port, exit code = failed
+scenario count.
+
+ET drops into that pattern without a container, because an ET client bootstraps over ssh to
+the host and then speaks to an `etserver` there. Pointed at loopback, the whole path is
+local and real:
+
+```
+cmux → et client (upstream) → ssh 127.0.0.1 (real sshd) → etserver/etterminal → tmux -CC
+```
+
+Requirements for it to be trustworthy:
+
+- **Use upstream ET, pinned to a tag** (Homebrew formula or a source build), so the test
+  proves compatibility with public ET rather than with a fork.
+- **Isolate hard**: a dedicated `TMUX_TMPDIR`, a nonstandard etserver port, per-run
+  generated keys with explicit `IdentityFile`/`IdentitiesOnly`. Never the default tmux
+  socket.
+- **Exercise a real drop, and sever it at the network layer.** This is the one property only
+  a real transport can prove. Run the client through a small TCP relay the harness can pause
+  and resume (a packet-filter rule works too, but a relay needs no privileges and is
+  deterministic). Killing the `et` process tests the wrong thing: that is the session-gone
+  path, not a recoverable outage.
+- **Assert on cmux's observable state, not log text**: the mirror stays populated across the
+  outage, the spawn counter does not increment, and a command issued after the resume
+  completes.
+
+Skip cleanly with a stated reason when `et`/`etserver` is absent, rather than passing
+vacuously.
+
+### Layer 3: seeded model-based fuzz (where the bugs are)
+
+Follow `RemoteTmuxMultiplexFuzzTests` exactly: `SplitMix64` seeded from the test argument
+so every draw is deterministic, a fixed seed list under `@Test(arguments:)`, a tiny
+reference model playing the transport and the remote server, and a step loop that mutates
+the model, drives one action, then checks the full invariant set. Failure messages carry
+seed plus step index so a case reproduces exactly. No `Date()`, no
+`SystemRandomNumberGenerator`, no wall-clock.
+
+The model needs three pieces of state the ssh-only world did not have: whether the
+transport process is alive, whether the stream is flowing or stalled, and whether the
+remote session still exists.
+
+Step actions to draw from:
+
+| Category | Actions |
+|---|---|
+| Transport | stall the stream; resume after a stall; drop mid-frame then resume; exit cleanly; exit with an auth failure; exit with a transient failure; refuse to launch (binary missing) |
+| Session | kill the session remotely during an outage; create a session; rename; churn windows |
+| cmux | issue a one-shot; issue a command batch; resize; stop the connection; close the window; quit |
+| Hook | hook succeeds; hook exits non-zero; hook hangs past its timeout; two opens race the hook |
+
+Invariants to assert after every step:
+
+1. **No respawn while an internally-reconnecting transport is alive.** The spawn counter
+   must not increment for a stall or a resume. This is the property the whole design rests
+   on, and the easiest one to regress.
+2. **A stall never ends the connection**, and a genuine transport exit always does.
+3. **An auth-required failure always surfaces an auth outcome** and never enters an
+   unbounded retry loop.
+4. **Every pending command resolves exactly once**, either completing or failing. Nothing
+   is silently dropped across a stall, a resume, or a teardown.
+5. **The parser never desyncs.** A frame split across a resume boundary either completes or
+   is discarded whole; a partial frame must never be delivered as a message.
+6. **The pre-connect hook runs at most once per connection open**, even when opens race.
+7. **A session the user killed is never silently recreated** (the existing sticky
+   never-surfaced-a-workspace gate must still hold under transport churn).
+8. **Teardown is ordering-independent**: a resume that lands after `stop()` changes
+   nothing.
+
+Ratchet discipline, which is the part that makes this worth doing: when a seed fails, fix
+the product, then **add that seed to the permanent list** rather than only fixing the bug.
+When a real-world failure shows up that no seed produced, add the step action that would
+have produced it and re-run the whole list. The suite only ever grows. A fuzz suite that
+stays at its original eight seeds after finding bugs is not ratcheting, it is decoration.
+
+## Notes on carrying a control protocol over a PTY transport
+
+`tmux -CC` is line-oriented, and any transport that allocates a remote PTY translates `\n`
+to `\r\n` on the way back. cmux already runs `ssh -tt` (also a remote PTY) so
+`RemoteTmuxControlStreamParser` tolerates `\r` today. Keep an explicit test for it rather
+than rediscovering it after a transport swap.
+
+## Order of work
+
+1. Fix the reconnect classifier so an auth-required reconnect surfaces the interactive path
+   instead of retrying forever. Independent of any new transport and testable red-first: a
+   reconnect whose transport fails with a permission error must produce an auth outcome,
+   not a backoff loop.
+2. Introduce `RemoteTmuxTransport` with `SSHTransport` as the only implementation. No
+   behavior change, so the existing suites are the regression gate.
+3. Add the fuzz harness against the mock transport, with the invariants above. It should
+   pass for `SSHTransport` before any new transport exists.
+4. Add the persistent-session transport behind per-host opt-in, with the liveness check and
+   a fallback to `SSHTransport` when the transport binary is missing. Turn on the
+   internally-reconnecting arm of the fuzz.
+5. Add the real sshd plus upstream-ET end-to-end fixture, including a real network drop.
+6. Add the pre-connect hook, with the race and timeout cases in the fuzz.

--- a/scripts/lint-remote-tmux-no-polling.sh
+++ b/scripts/lint-remote-tmux-no-polling.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# ============================================================================
+# Fails if remote-tmux gains a new sleep, timer, or poll loop.
+#
+# Remote-tmux waits on things constantly — a control-mode reply, a shared master, a person
+# finishing a login — and every one of those has an event to wait on. A timer instead of the
+# event is not a style preference: its interval is dead time a frozen mirror spends after the
+# thing it was waiting for already happened, and it can miss the event entirely.
+#
+# This exists because knowing that is not enough. A reviewer caught a `Task.sleep` backoff in
+# the login waiter that had shipped with a comment claiming "there is no event to subscribe
+# to" — the event was the ControlMaster socket being created, and `FileWatcher` had been in
+# the tree the whole time. Nothing failed when that went in, so nothing will fail the next
+# time either, unless something checks.
+#
+# Adding a wait that genuinely has no edge is allowed, but it has to be listed below with the
+# reason, which makes the exception visible in review instead of implicit in a diff.
+#
+# Usage: scripts/lint-remote-tmux-no-polling.sh
+# Exit 0 when clean, 1 with the offending file:line otherwise.
+# ============================================================================
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+# Product sources only. Tests may need to drive time directly, and scripts are harnesses
+# where polling an external process is often the only option available.
+SCOPE=(Sources/RemoteTmux*.swift Sources/RemoteTmuxController+*.swift)
+
+# Primitives that make a wait time-based rather than event-based.
+PATTERN='Task\.sleep|Thread\.sleep|usleep\(|DispatchQueue\.[A-Za-z.]*asyncAfter|DispatchSourceTimer|Timer\.scheduledTimer|ContinuousClock\(\)\.sleep'
+
+# Waits that predate this guard, recorded so it blocks NEW ones without pretending the
+# existing ones are all fine. Several are worth revisiting — the sizing debounces in
+# particular, since sizing convergence is supposed to be driven by tmux's ordered
+# %begin/%end acknowledgements rather than a wall clock. Removing an entry from this list
+# is progress; adding one needs the reason to say why no edge exists.
+BASELINE_FILE="scripts/remote-tmux-polling-baseline.txt"
+
+# Exceptions introduced deliberately, with the reason no edge exists.
+ALLOW=(
+  "Sources/RemoteTmuxControlConnection.swift:startLivenessMonitorIfNeeded|A transport that reconnects internally emits NO EOF for a network drop: its process stays up and the stream pauses, so a wedged transport is indistinguishable from an idle one. There is no event for 'still carrying the protocol' — the only way to know is to ask, so this probes rather than waits."
+  "Sources/RemoteTmuxControlConnection.swift:scheduleReconnectAttempt|Reconnect backoff for a host that is unreachable. The edge would be 'the host came back', which nothing local can observe; retrying IS the observation."
+)
+
+fail=0
+while IFS= read -r hit; do
+  [ -z "$hit" ] && continue
+  file="${hit%%:*}"
+  rest="${hit#*:}"
+  line="${rest%%:*}"
+
+  # Find the enclosing func by walking back to the nearest declaration.
+  symbol="$(awk -v n="$line" 'NR<=n && /func [A-Za-z_]/ { s=$0 } END { print s }' "$file" \
+    | sed -E 's/.*func ([A-Za-z_][A-Za-z0-9_]*).*/\1/')"
+
+  allowed=0
+  for entry in "${ALLOW[@]}"; do
+    key="${entry%%|*}"
+    if [ "$key" = "$file:$symbol" ]; then allowed=1; break; fi
+  done
+  # Pre-existing waits are matched by file+symbol, not line number, so unrelated edits above
+  # them do not turn into lint failures.
+  if [ "$allowed" -eq 0 ] && [ -f "$BASELINE_FILE" ] \
+     && grep -qxF "$file:$symbol" "$BASELINE_FILE"; then
+    allowed=1
+  fi
+
+  if [ "$allowed" -eq 0 ]; then
+    echo "lint-remote-tmux-no-polling: $file:$line — time-based wait in '$symbol'" >&2
+    echo "    $(sed -n "${line}p" "$file" | sed 's/^[[:space:]]*//')" >&2
+    fail=1
+  fi
+done < <(grep -nE "$PATTERN" "${SCOPE[@]}" 2>/dev/null \
+  | awk -F: '{ body = substr($0, index($0, $3)); sub(/^[[:space:]]+/, "", body); if (body !~ /^\/\//) print }' || true)
+
+if [ "$fail" -ne 0 ]; then
+  cat >&2 <<'EOF'
+
+Waiting on a timer means the event that ends the wait was not used. Find the edge first:
+  - a control-mode reply            -> sendTracked / the %begin/%end correlation
+  - a file or socket appearing      -> FileWatcher (watches the parent directory too, so
+                                       creation is visible for a path that does not exist yet)
+  - terminal output, e.g. a marker  -> the per-surface PTY tee detectors
+  - a workspace closing             -> the TabManager close path calls the controller
+An event-driven wait must also check its condition once up front: an edge that already
+happened is never delivered.
+
+If there is genuinely no edge, add the symbol to ALLOW in this script with the reason.
+EOF
+  exit 1
+fi
+
+echo "lint-remote-tmux-no-polling: ok (${#ALLOW[@]} documented, $(wc -l < "$BASELINE_FILE" 2>/dev/null | tr -d ' ') baselined)"

--- a/scripts/lint-remote-tmux-no-polling.sh
+++ b/scripts/lint-remote-tmux-no-polling.sh
@@ -28,7 +28,10 @@ cd "$(dirname "$0")/.." || exit 1
 SCOPE=(Sources/RemoteTmux*.swift Sources/RemoteTmuxController+*.swift)
 
 # Primitives that make a wait time-based rather than event-based.
-PATTERN='Task\.sleep|Thread\.sleep|usleep\(|DispatchQueue\.[A-Za-z.]*asyncAfter|DispatchSourceTimer|Timer\.scheduledTimer|ContinuousClock\(\)\.sleep'
+# `\.asyncAfter\(` rather than a `DispatchQueue.…` prefix: the receiver can be any expression
+# (`DispatchQueue.global(qos: .background)`, a stored queue), and every one of them is a
+# time-based wait. Matching the call, not the queue, closes that gap.
+PATTERN='Task\.sleep|Thread\.sleep|usleep\(|\.asyncAfter\(|DispatchSourceTimer|Timer\.scheduledTimer|ContinuousClock\(\)\.sleep'
 
 # Waits that predate this guard, recorded so it blocks NEW ones without pretending the
 # existing ones are all fine. Several are worth revisiting — the sizing debounces in

--- a/scripts/remote-tmux-et-conformance.sh
+++ b/scripts/remote-tmux-et-conformance.sh
@@ -29,6 +29,15 @@
 #   ET_CLIENT=/path/to/et ET_SERVER=/path/to/etserver \
 #     ET_TERMINAL=/path/to/etterminal scripts/remote-tmux-et-conformance.sh
 #
+# The client connects to CMUX_ET_HOST (default `cmux-ethost`), which must be an ssh
+# destination this machine can log into, because et bootstraps over ssh before its own
+# protocol takes over. A loopback alias is enough:
+#
+#   Host cmux-ethost
+#       HostName 127.0.0.1
+#
+# Set CMUX_ET_HOST to point at a different one.
+#
 # Exit code is the number of failed checks (0 = every belief holds).
 # ============================================================================
 set -uo pipefail
@@ -138,9 +147,17 @@ fi
 echo "--- claim: end-of-stream does NOT mean the remote session is gone"
 # cmux used to treat an ET exit as the session ending, and removed the mirror. Restarting only
 # etserver falsifies that: the stream ends, the session lives.
-kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null
+SERVER_PID="$(cat "$PIDFILE" 2>/dev/null)"
+kill "$SERVER_PID" 2>/dev/null
 rm -f "$PIDFILE"
-sleep 1
+# Wait for the server to be gone rather than guessing at a second: the claim under test is
+# that the session outlives the transport, so the transport has to be down before it is
+# checked. etserver daemonizes itself, so it is not this script's child and `wait` cannot
+# see it.
+for _ in $(seq 1 40); do
+  kill -0 "$SERVER_PID" 2>/dev/null || break
+  sleep 0.25
+done
 if tmux has-session -t "$SESSION" 2>/dev/null; then
   pass "the session survives the transport dying, so EOF must lead to a reattach"
 else

--- a/scripts/remote-tmux-et-conformance.sh
+++ b/scripts/remote-tmux-et-conformance.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# ============================================================================
+# Checks the things cmux believes about `et`, against `et`.
+#
+# The ET transport shipped with six defects that shared one cause: its load-bearing claims about
+# EternalTerminal lived in a design doc and in comments, and nothing executed them. Unit tests
+# could not catch any of them — they assert what cmux builds, which is the model, not what the
+# other program does. 77 of them passed while the transport could not carry a stream at all.
+#
+# So each claim gets one check here. A claim that cannot be written as a check is an assumption,
+# and belongs in the PR as one.
+#
+# Version matters more than usual. ET is not as widely deployed as tmux, and its behaviour does
+# move between series: 7.x rewrote the pty input path that 6.x deadlocks on. Run this against
+# every version you intend to support and treat a divergence as a finding.
+#
+# Usage:
+#   scripts/remote-tmux-et-conformance.sh                      # the et on PATH
+#   ET_CLIENT=/path/to/et ET_SERVER=/path/to/etserver \
+#     ET_TERMINAL=/path/to/etterminal scripts/remote-tmux-et-conformance.sh
+#
+# Exit code is the number of failed checks (0 = every belief holds).
+# ============================================================================
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+ET_CLIENT="${ET_CLIENT:-$(command -v et || true)}"
+ET_SERVER="${ET_SERVER:-$(command -v etserver || true)}"
+# Resolved, not assumed. A literal path is a claim about someone else's machine, and cmux
+# hardcoding one of these is itself one of the defects this file exists to prevent.
+ET_TERMINAL="${ET_TERMINAL:-$(command -v etterminal || true)}"
+PORT="${CMUX_ET_PORT:-2041}"
+HOST="${CMUX_ET_HOST:-cmux-ethost}"
+SESSION="cmux-conformance-$$"
+
+FAILURES=0
+pass() { printf '  ✅ %s\n' "$*"; }
+fail() { printf '  ❌ %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+skip() { printf '  ⏭  %s\n' "$*"; }
+
+for tool in ET_CLIENT ET_SERVER ET_TERMINAL; do
+  if [ -z "${!tool}" ]; then
+    echo "$tool not found; set it explicitly (see usage)" >&2
+    exit 2
+  fi
+done
+
+VERSION="$("$ET_CLIENT" --version 2>&1 | head -1)"
+echo "=== conformance against: $VERSION"
+echo "    client=$ET_CLIENT server=$ET_SERVER terminal=$ET_TERMINAL"
+
+STATE="$(mktemp -d "${TMPDIR:-/tmp}/cmux-et-conformance.XXXXXX")" || exit 1
+PIDFILE="$STATE/etserver.pid"
+cleanup() {
+  [ -f "$PIDFILE" ] && kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null
+  tmux kill-session -t "$SESSION" 2>/dev/null
+  rm -rf "$STATE"
+}
+trap cleanup EXIT
+
+mkdir -p "$STATE/logs"
+"$ET_SERVER" --port "$PORT" --bindip 127.0.0.1 --pidfile "$PIDFILE" \
+             --logdir "$STATE/logs" --daemon >"$STATE/logs/start.out" 2>&1
+for _ in $(seq 1 30); do nc -z 127.0.0.1 "$PORT" 2>/dev/null && break; sleep 0.5; done
+nc -z 127.0.0.1 "$PORT" 2>/dev/null || { echo "etserver did not start on $PORT" >&2; exit 1; }
+
+# Every check runs the command the way cmux does: through the pty allocator, with the terminal
+# path named rather than assumed.
+et_run() {
+  local timeout_s="$1" command="$2"
+  timeout "$timeout_s" /usr/bin/script -q /dev/null \
+    "$ET_CLIENT" -p "$PORT" --terminal-path "$ET_TERMINAL" -c "$command" "$HOST" 2>&1
+}
+
+echo "--- claim: the remote command runs in a LOGIN shell, so it inherits the user's PATH"
+# cmux dropped ssh's PATH resolver from the ET argv on the strength of this. If it is false, the
+# transport cannot find tmux on a host where tmux is outside the default PATH.
+out="$(et_run 25 'exec sh -c "command -v tmux || echo NO_TMUX"')"
+if printf '%s' "$out" | grep -q '/tmux'; then
+  pass "a login shell resolves tmux from PATH"
+else
+  fail "tmux did not resolve in the remote shell — the ET argv still needs a PATH resolver"
+fi
+
+echo "--- claim: a command longer than one canonical line is NOT delivered"
+# This is why cmux sends plain \`tmux\` instead of its ~1113-byte resolver. et types the command
+# into a pty; canonical mode caps a line (MAX_CANON, 1024 on macOS). 6.x deadlocks, 7.x buffers —
+# either way it must not silently appear to work.
+short_out="$(et_run 20 'exec /bin/echo SHORT_OK')"
+if printf '%s' "$short_out" | grep -q SHORT_OK; then
+  pass "a short command is delivered and runs"
+else
+  fail "a short command did not run — the harness itself is broken, not the claim"
+fi
+pad="$(printf 'x%.0s' $(seq 1 1100))"
+long_out="$(et_run 20 "exec /bin/echo LONG_OK_${pad}")"; long_rc=$?
+if [ "$long_rc" -ne 0 ] || ! printf '%s' "$long_out" | grep -q "LONG_OK_x"; then
+  pass "a >MAX_CANON command does not complete (rc=$long_rc) — the length bound is real"
+else
+  fail "a 1100+ byte command RAN: this version delivers long lines, so the bound cmux relies on has moved"
+fi
+
+echo "--- claim: the control-mode enter DCS arrives mid-line, behind the shell's echo"
+# cmux's parser used to require the DCS at the start of a line, and never entered control mode.
+tmux -f /dev/null new-session -d -s "$SESSION" 2>/dev/null
+cc_out="$(et_run 20 "exec tmux -CC attach-session -t $SESSION")"
+if printf '%s' "$cc_out" | grep -q '%begin'; then
+  # Anything before the DCS on its line is what a start-of-line matcher would choke on.
+  if printf '%s' "$cc_out" | grep -qE '.+\x1bP1000p|.+P1000p%begin'; then
+    pass "the enter DCS is preceded on its line by shell output (a start-of-line match would miss it)"
+  else
+    pass "control mode entered; the DCS happened to open its line this time"
+  fi
+else
+  fail "no %begin over et — the control stream did not reach control mode"
+fi
+
+echo "--- claim: end-of-stream does NOT mean the remote session is gone"
+# cmux used to treat an ET exit as the session ending, and removed the mirror. Restarting only
+# etserver falsifies that: the stream ends, the session lives.
+kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null
+rm -f "$PIDFILE"
+sleep 1
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  pass "the session survives the transport dying, so EOF must lead to a reattach"
+else
+  fail "the session died with the transport — EOF would then be a fair signal for session-over"
+fi
+
+echo "=== $FAILURES failed check(s) against $VERSION"
+exit "$FAILURES"

--- a/scripts/remote-tmux-et-conformance.sh
+++ b/scripts/remote-tmux-et-conformance.sh
@@ -14,6 +14,16 @@
 # move between series: 7.x rewrote the pty input path that 6.x deadlocks on. Run this against
 # every version you intend to support and treat a divergence as a finding.
 #
+# Measured so far (all five checks pass, identically):
+#   et 6.2.11+7  — the version installed on the machine this was developed against
+#   et 7.0.0     — built from source at tag et-v7.0.0
+#
+# The interesting non-difference: 7.x rewrote the pty input path specifically because 6.x
+# deadlocks on a large input burst, yet a >MAX_CANON command is still not delivered on either.
+# The limit is a property of the tty line discipline, not of how the server writes to it, so the
+# bound cmux relies on survives that rewrite. That was worth measuring rather than assuming in
+# either direction — the prediction going in was that 7.x would deliver it.
+#
 # Usage:
 #   scripts/remote-tmux-et-conformance.sh                      # the et on PATH
 #   ET_CLIENT=/path/to/et ET_SERVER=/path/to/etserver \

--- a/scripts/remote-tmux-et-conformance.sh
+++ b/scripts/remote-tmux-et-conformance.sh
@@ -56,6 +56,15 @@ for tool in ET_CLIENT ET_SERVER ET_TERMINAL; do
   fi
 done
 
+# Resolve the deadline command before anything uses it. Stock macOS has no `timeout`, and a
+# missing one makes every et_run exit 127 - which the ">MAX_CANON is not delivered" check reads
+# as the claim holding. Fail loudly instead of passing for the wrong reason.
+TIMEOUT_BIN="${CMUX_TIMEOUT_BIN:-$(command -v timeout || command -v gtimeout || true)}"
+if [ -z "$TIMEOUT_BIN" ] || [ ! -x "$TIMEOUT_BIN" ]; then
+  echo "no usable timeout(1)/gtimeout(1) at '${TIMEOUT_BIN:-<none>}'; brew install coreutils, or point CMUX_TIMEOUT_BIN at one" >&2
+  exit 2
+fi
+
 VERSION="$("$ET_CLIENT" --version 2>&1 | head -1)"
 echo "=== conformance against: $VERSION"
 echo "    client=$ET_CLIENT server=$ET_SERVER terminal=$ET_TERMINAL"
@@ -79,8 +88,8 @@ nc -z 127.0.0.1 "$PORT" 2>/dev/null || { echo "etserver did not start on $PORT" 
 # path named rather than assumed.
 et_run() {
   local timeout_s="$1" command="$2"
-  timeout "$timeout_s" /usr/bin/script -q /dev/null \
-    "$ET_CLIENT" -p "$PORT" --terminal-path "$ET_TERMINAL" -c "$command" "$HOST" 2>&1
+  "$TIMEOUT_BIN" "$timeout_s" /usr/bin/script -q /dev/null \
+    "$ET_CLIENT" -p "$PORT" --terminal-path "$ET_TERMINAL" -c "$command" -- "$HOST" 2>&1
 }
 
 echo "--- claim: the remote command runs in a LOGIN shell, so it inherits the user's PATH"

--- a/scripts/remote-tmux-et-conformance.sh
+++ b/scripts/remote-tmux-et-conformance.sh
@@ -29,14 +29,11 @@
 #   ET_CLIENT=/path/to/et ET_SERVER=/path/to/etserver \
 #     ET_TERMINAL=/path/to/etterminal scripts/remote-tmux-et-conformance.sh
 #
-# The client connects to CMUX_ET_HOST (default `cmux-ethost`), which must be an ssh
+# The client connects to CMUX_ET_HOST (default `127.0.0.1`), which must be an ssh
 # destination this machine can log into, because et bootstraps over ssh before its own
-# protocol takes over. A loopback alias is enough:
-#
-#   Host cmux-ethost
-#       HostName 127.0.0.1
-#
-# Set CMUX_ET_HOST to point at a different one.
+# protocol takes over. The loopback default works wherever this machine runs sshd and
+# accepts key auth for the current user; point CMUX_ET_HOST at a different destination
+# (an ssh_config alias, another host) when that is not the case.
 #
 # Exit code is the number of failed checks (0 = every belief holds).
 # ============================================================================
@@ -50,7 +47,7 @@ ET_SERVER="${ET_SERVER:-$(command -v etserver || true)}"
 # hardcoding one of these is itself one of the defects this file exists to prevent.
 ET_TERMINAL="${ET_TERMINAL:-$(command -v etterminal || true)}"
 PORT="${CMUX_ET_PORT:-2041}"
-HOST="${CMUX_ET_HOST:-cmux-ethost}"
+HOST="${CMUX_ET_HOST:-127.0.0.1}"
 SESSION="cmux-conformance-$$"
 
 FAILURES=0

--- a/scripts/remote-tmux-et-e2e.sh
+++ b/scripts/remote-tmux-et-e2e.sh
@@ -55,29 +55,51 @@ log "=== attaching session '$SESSION' over the et transport"
 # mirroring whatever else happens to be on the host's default tmux server.
 # `cmux rpc` is the raw v2 call; a named attach avoids mirroring whatever else happens to
 # be on the host's default tmux server.
+#
+# The etserver port goes in transport_port, not port. `port` is the ssh port, and one-shot
+# discovery still rides ssh, so putting 2039 there sends ssh at the etserver and it answers
+# with `kex_exchange_identification: Connection reset by peer`.
 RESULT="$(cli rpc remote.tmux.attach \
-  "{\"host\":\"$HOST\",\"session\":\"$SESSION\",\"port\":$PORT,\"transport\":\"et\"}" 2>&1)"
+  "{\"host\":\"$HOST\",\"session\":\"$SESSION\",\"transport\":\"et\",\"transport_port\":$PORT}" 2>&1)"
 log "attach result: $(printf '%s' "$RESULT" | head -c 300)"
 
-# The decisive evidence is a live et process carrying tmux for this host, spawned by
-# the app rather than by this script.
-et_stream_live() {
-  pgrep -f "attach-session" 2>/dev/null | while read -r p; do
-    ps -o command= -p "$p" 2>/dev/null | grep -q "et " && echo x
-  done | grep -q x
-}
-if await "an et-carried control stream spawned by cmux" 60 et_stream_live; then
-  pass "cmux spawned a control stream over et"
+case "$RESULT" in
+  *'"attached"'*) pass "the attach returned a result rather than an error" ;;
+  *) fail "attach did not succeed: $(printf '%s' "$RESULT" | head -c 120)" ;;
+esac
+
+# The decisive evidence is the app's own view of the stream, not a process listing. A live
+# process proves something was spawned; only these fields prove the control protocol crossed
+# et and was understood — the two bugs this harness found both left a live process behind.
+#
+#   enter    the ESC P 1000 p handshake was parsed. cmux withholds commands until it arrives,
+#            and et delivers it mid-line behind the login shell's echo.
+#   windows  a real `list-windows` result came back over the stream and was applied.
+state() { cli rpc remote.tmux.state "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}"; }
+stream_entered() { state | grep -q '"enter_received" : true'; }
+stream_has_windows() { state | grep -qE '"window_count" : [1-9]'; }
+
+if await "the control stream to reach control mode over et" 60 stream_entered; then
+  pass "cmux parsed the control-mode handshake over et"
 else
-  fail "no et-carried control stream appeared"
+  fail "no control-mode handshake over et (enter_received stayed false)"
+fi
+if await "a window to arrive over the et-carried stream" 60 stream_has_windows; then
+  pass "tmux windows arrived over the et-carried stream"
+else
+  fail "no windows arrived over the et-carried stream"
 fi
 
-# And it must be under a pty: a bare pipe spawn is exactly what produces no output.
-pty_wrapped() { pgrep -fl "script -q /dev/null" >/dev/null 2>&1; }
-if pty_wrapped; then
-  pass "the transport was spawned under a pseudo-terminal"
+# And the transport must be this host's et, under a pty: a bare pipe spawn is exactly what
+# produces no output. Match the whole shape so another agent's `script` or `et` cannot pass
+# this for us.
+pty_wrapped_et() {
+  pgrep -f "script -q /dev/null .*et -p $PORT .*$HOST" >/dev/null 2>&1
+}
+if pty_wrapped_et; then
+  pass "this host's et was spawned under a pseudo-terminal"
 else
-  fail "no pty wrapper around the transport (et emits nothing on pipes)"
+  fail "no pty-wrapped et for $HOST:$PORT (et emits nothing on pipes)"
 fi
 
 log "=== $FAILURES failed check(s)"

--- a/scripts/remote-tmux-et-e2e.sh
+++ b/scripts/remote-tmux-et-e2e.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# ============================================================================
+# End-to-end: cmux carries a real tmux control stream over a real EternalTerminal.
+#
+# Everything else about the seam is argv shape and decision rules, which unit tests
+# can pin. This is the only check that the app actually drives ET: the pty spawn,
+# the ~1.2 KB of login-shell preamble before `%begin`, the CRLF line endings, and
+# the control protocol surviving all of it inside the running app.
+#
+# PREREQUISITES
+#   - scripts/remote-tmux-et-host.sh has brought up a loopback etserver.
+#   - An ssh alias for that host (one-shot discovery still rides ssh by design).
+#   - A tagged Debug app running with remote-tmux beta on; pass CMUX_TAG=<tag>.
+#
+# Exit code is the number of failed checks (0 = all green).
+# ============================================================================
+set -uo pipefail
+
+TAG="${CMUX_TAG:?set CMUX_TAG=<tag> of a running tagged Debug app}"
+HOST="${CMUX_ET_HOST:-cmux-ethost}"
+PORT="${CMUX_ET_PORT:-2039}"
+SESSION="${CMUX_ET_SESSION:-etmirror}"
+CLI=(scripts/cmux-debug-cli.sh)
+FAILURES=0
+
+log()  { printf '%s %s\n' "$(date '+%H:%M:%S')" "$*"; }
+pass() { printf '  ✅ %s\n' "$*"; }
+fail() { printf '  ❌ %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+cli()  { CMUX_QUIET=1 CMUX_TAG="$TAG" "${CLI[@]}" "$@" 2>&1; }
+
+await() {
+  local what="$1" timeout="$2"; shift 2
+  local deadline=$((SECONDS + timeout))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if "$@"; then return 0; fi
+    sleep 2
+  done
+  log "timed out after ${timeout}s waiting for: $what"
+  return 1
+}
+
+cd "$(dirname "$0")/.." || exit 1
+
+app_ready() { cli list-workspaces >/dev/null 2>&1; }
+if ! await "the app's control socket" 90 app_ready; then
+  log "no response on the tagged app socket for CMUX_TAG=$TAG"
+  exit 1
+fi
+
+command -v et >/dev/null 2>&1 || { log "et is not installed"; exit 1; }
+nc -z 127.0.0.1 "$PORT" 2>/dev/null || { log "no etserver on 127.0.0.1:$PORT"; exit 1; }
+
+log "=== attaching session '$SESSION' over the et transport"
+# A named attach rather than discovery: this proves the control stream, without
+# mirroring whatever else happens to be on the host's default tmux server.
+# `cmux rpc` is the raw v2 call; a named attach avoids mirroring whatever else happens to
+# be on the host's default tmux server.
+RESULT="$(cli rpc remote.tmux.attach \
+  "{\"host\":\"$HOST\",\"session\":\"$SESSION\",\"port\":$PORT,\"transport\":\"et\"}" 2>&1)"
+log "attach result: $(printf '%s' "$RESULT" | head -c 300)"
+
+# The decisive evidence is a live et process carrying tmux for this host, spawned by
+# the app rather than by this script.
+et_stream_live() {
+  pgrep -f "attach-session" 2>/dev/null | while read -r p; do
+    ps -o command= -p "$p" 2>/dev/null | grep -q "et " && echo x
+  done | grep -q x
+}
+if await "an et-carried control stream spawned by cmux" 60 et_stream_live; then
+  pass "cmux spawned a control stream over et"
+else
+  fail "no et-carried control stream appeared"
+fi
+
+# And it must be under a pty: a bare pipe spawn is exactly what produces no output.
+pty_wrapped() { pgrep -fl "script -q /dev/null" >/dev/null 2>&1; }
+if pty_wrapped; then
+  pass "the transport was spawned under a pseudo-terminal"
+else
+  fail "no pty wrapper around the transport (et emits nothing on pipes)"
+fi
+
+log "=== $FAILURES failed check(s)"
+exit "$FAILURES"

--- a/scripts/remote-tmux-et-e2e.sh
+++ b/scripts/remote-tmux-et-e2e.sh
@@ -75,7 +75,13 @@ esac
 #   enter    the ESC P 1000 p handshake was parsed. cmux withholds commands until it arrives,
 #            and et delivers it mid-line behind the login shell's echo.
 #   windows  a real `list-windows` result came back over the stream and was applied.
-state() { cli rpc remote.tmux.state "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}"; }
+# The transport and its port are part of the endpoint's identity, so a lookup that omits them
+# addresses a different endpoint and quietly matches nothing — which reads as "the stream never
+# reached control mode" rather than "you asked about the wrong connection".
+state() {
+  cli rpc remote.tmux.state \
+    "{\"host\":\"$HOST\",\"session\":\"$SESSION\",\"transport\":\"et\",\"transport_port\":$PORT}"
+}
 stream_entered() { state | grep -q '"enter_received" : true'; }
 stream_has_windows() { state | grep -qE '"window_count" : [1-9]'; }
 

--- a/scripts/remote-tmux-et-host.sh
+++ b/scripts/remote-tmux-et-host.sh
@@ -57,10 +57,33 @@ if ! nc -z 127.0.0.1 "$PORT" 2>/dev/null; then
   exit 1
 fi
 
+# A session for the mirror to attach to, on the server both transports reach.
+#
+# It has to be the server a plain login shell resolves to, because cmux splits the work:
+# one-shot commands like the `has-session` check before an attach ride ssh, while the
+# control stream rides et. Putting the session on a private TMUX_TMPDIR isolates it from
+# the ssh side, so the attach fails with "can't find session" even though the session
+# exists. A real et host has both transports landing on the same default server, so the
+# harness matches that.
+SESSION="${CMUX_ET_SESSION:-etmirror}"
+OWNED="$DIR/owned-sessions"
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  # Never adopt a session this harness did not create: teardown kills what it owns, and a
+  # developer's own session of the same name must survive.
+  grep -qxF "$SESSION" "$OWNED" 2>/dev/null \
+    || { echo "tmux session '$SESSION' already exists and is not ours; set CMUX_ET_SESSION" >&2; exit 1; }
+else
+  tmux new-session -d -s "$SESSION" -c "$HOME" 2>>"$DIR/logs/start.out" \
+    || { echo "could not create tmux session $SESSION" >&2; exit 1; }
+  echo "$SESSION" >>"$OWNED"
+fi
+SOCKET="$(tmux display-message -p -t "$SESSION" '#{socket_path}' 2>/dev/null)"
+
 cat <<INFO
 name:       $NAME
 port:       $PORT
 state:      $DIR
 tmux tmpdir:$DIR/tmux
+session:    $SESSION (socket $SOCKET)
 client:     et -p $PORT --macserver -c '<command>' $USER@127.0.0.1
 INFO

--- a/scripts/remote-tmux-et-host.sh
+++ b/scripts/remote-tmux-et-host.sh
@@ -25,7 +25,7 @@ if [ -L "$STATE_ROOT" ] || [ -L "$DIR" ]; then
   echo "refusing symlinked et state path" >&2; exit 1
 fi
 umask 077
-mkdir -p "$DIR/logs" "$DIR/tmux"
+mkdir -p "$DIR/logs"
 chmod 700 "$DIR"
 
 # etserver wants a pidfile it can write; /var/run needs root, so keep it local.
@@ -83,7 +83,6 @@ cat <<INFO
 name:       $NAME
 port:       $PORT
 state:      $DIR
-tmux tmpdir:$DIR/tmux
 session:    $SESSION (socket $SOCKET)
 client:     et -p $PORT --macserver -c '<command>' $USER@127.0.0.1
 INFO

--- a/scripts/remote-tmux-et-host.sh
+++ b/scripts/remote-tmux-et-host.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# ============================================================================
+# Brings up a REAL EternalTerminal server on loopback, so the transport seam can
+# be exercised against `et` itself rather than a mock.
+#
+# ET is not ssh: it terminates the connection on the server side and reconnects
+# internally after a network change, which is the whole reason the seam exists.
+# The only way to know cmux's argv and its reconnect ownership are right is to
+# carry a real `tmux -CC` control stream over a real et.
+#
+# Usage: scripts/remote-tmux-et-host.sh [name] [port]
+# Exit 0 with the connection details on stdout, non-zero if it could not start.
+# ============================================================================
+set -uo pipefail
+
+NAME="${1:-cmux-ethost}"
+PORT="${2:-2039}"
+
+command -v et >/dev/null 2>&1 || { echo "et not installed" >&2; exit 2; }
+command -v etserver >/dev/null 2>&1 || { echo "etserver not installed" >&2; exit 2; }
+
+STATE_ROOT="$HOME/Library/Caches/cmux/remote-tmux-et"
+DIR="$STATE_ROOT/$NAME"
+if [ -L "$STATE_ROOT" ] || [ -L "$DIR" ]; then
+  echo "refusing symlinked et state path" >&2; exit 1
+fi
+umask 077
+mkdir -p "$DIR/logs" "$DIR/tmux"
+chmod 700 "$DIR"
+
+# etserver wants a pidfile it can write; /var/run needs root, so keep it local.
+PIDFILE="$DIR/etserver.pid"
+
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+  echo "already running (pid $(cat "$PIDFILE"))"
+else
+  # Bind loopback only. This is a test server on a developer machine, and an
+  # et server accepts real shells — it must not be reachable off-box.
+  etserver --port "$PORT" --bindip 127.0.0.1 --pidfile "$PIDFILE" \
+           --logdir "$DIR/logs" --daemon >"$DIR/logs/start.out" 2>&1
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "etserver failed to start (rc=$rc):" >&2
+    tail -5 "$DIR/logs/start.out" >&2
+    exit "$rc"
+  fi
+fi
+
+# Wait for the port rather than sleeping: startup is fast but not instant.
+for _ in $(seq 1 30); do
+  if nc -z 127.0.0.1 "$PORT" 2>/dev/null; then break; fi
+  sleep 0.5
+done
+if ! nc -z 127.0.0.1 "$PORT" 2>/dev/null; then
+  echo "etserver is not accepting connections on $PORT" >&2
+  tail -20 "$DIR/logs"/* 2>/dev/null >&2
+  exit 1
+fi
+
+cat <<INFO
+name:       $NAME
+port:       $PORT
+state:      $DIR
+tmux tmpdir:$DIR/tmux
+client:     et -p $PORT --macserver -c '<command>' $USER@127.0.0.1
+INFO

--- a/scripts/remote-tmux-polling-baseline.txt
+++ b/scripts/remote-tmux-polling-baseline.txt
@@ -1,0 +1,6 @@
+Sources/RemoteTmuxControlConnection+Sizing.swift:sendPerWindowRedrawKick
+Sources/RemoteTmuxControlConnection+Sizing.swift:sendSessionRedrawKick
+Sources/RemoteTmuxControlConnection+Sizing.swift:setClientSize
+Sources/RemoteTmuxControlConnection+Sizing.swift:setWindowSize
+Sources/RemoteTmuxSSHTransport.swift:killSessions
+Sources/RemoteTmuxWindowMirror.swift:establishPaneKeyFocusWhenMounted


### PR DESCRIPTION
Today the choice of how a control stream reaches a host is spelled out at the point of use: `Process` is handed `ssh` plus `host.controlModeArguments(…)` directly. A transport that survives a network change — EternalTerminal, mosh — can't be introduced without first naming that decision. This names it. ssh stays the only implementation and the default, so behavior doesn't change.

Three seams, in the order they matter.

## Seam 1: what gets run

`RemoteTmuxTransportProfile` decides the binary, the control-stream argv, the one-shot argv, and whether the transport reconnects internally.

It deliberately doesn't own *execution*. `RemoteTmuxSSHTransport` keeps process spawning, the shared ControlMaster, and stderr classification, so a second transport doesn't reimplement any of it. One-shot commands can keep riding ssh's master even when the control stream doesn't — `ensureMasterReady()` already funnels the cold-start burst through a single open, and that logic is independent of how the `-CC` stream is carried.

## Seam 2: who owns reconnection

`reconnectsInternally` is the part that changes behavior rather than argv, so `RemoteTmuxStreamEndDisposition` makes the consequence explicit rather than leaving it implied.

cmux recovers from stdout EOF: the stream ended, so respawn with backoff. That's right for ssh, where a dropped connection ends the process. A transport that owns its own reconnection doesn't end for a network drop — the stream pauses and resumes — so if it *does* end, it has genuinely exited and the session is over. Respawning then would be cmux fighting the transport for ownership of recovery.

The corollary matters for whoever adds such a transport: the failure mode moves from "stream ended" to "alive but wedged", so it needs a liveness check (process alive plus a control-mode round-trip) rather than an EOF trigger. That check is `probeLiveness` (below), and ssh stays on exactly today's path.

## Seam 3: a step before connecting

`RemoteTmuxPreConnectHook` covers hosts needing something cmux has no business knowing about — minting a short-lived credential, unlocking an agent, refreshing a token — run as `<command> <destination>`.

Two rules come from wiring one up for real:

- **Once per connection, not once per command.** Anything minting a single-use credential must not race itself; two mints can invalidate each other. The right home is the single-flight path that opens the shared master, not a per-command hook.
- **A non-zero exit is not fatal.** cmux proceeds and lets the connection fail on its own terms, so a broken hook can't make a host unreachable.

## Tests

`32 tests in 4 suites passed` for the seam itself, and `94 tests in 11 suites passed` together with the parser suites this touches — the stream parser is shared, so `RemoteTmuxControlParserTests`, `RemoteTmuxControlStreamParserBudgetTests` and `RemoteTmuxMirrorLayoutIdentityTests` run alongside it. The seam tests pin the four details load-bearing for any such transport:

- `--command` with `exec`, so no shell parent lingers in the remote process tree
- the command stays inside one line a shell can read. ET types the command into a login shell rather than exec'ing it, and that shell reads a pty in canonical mode, which delivers at most `MAX_CANON` (1024 on macOS) bytes per line. ssh's `PATH` resolver is about 1113 bytes, so it silently never arrives; ET gets plain `tmux`, which a login shell resolves from the user's own `PATH`. ssh keeps the resolver, because a non-login shell with a minimal `PATH` is the case it exists for
- the port is configurable rather than assumed to be ssh's 22
- **no `-x` / `--kill-other-sessions`** — that flag terminates every one of the user's sessions on the host, not just stale ones, so a wrapper passing it by default lets an unrelated reconnect elsewhere kill cmux's session

Plus: the ssh profile produces byte-identical argv to today's `controlModeArguments`, `--` still ends option parsing before a destination that looks like a flag, ssh reports that it does not reconnect itself, and a connection with no profile specified defaults to ssh.

### What running it against a real et server changed

The unit tests above all passed while the transport could not carry a control stream at all, so
the end-to-end harness (`scripts/remote-tmux-et-e2e.sh`, exit code = failed checks) is what found
the two faults this fixes. It now reports `0 failed check(s)`: the attach returns a result, cmux
parses the control-mode handshake over et, tmux windows arrive over that stream, and the transport
is this host's et under a pty.

The first fault is the line-length limit described above. The second is that the parser recognised
tmux's `ESC P 1000 p` only at the start of a line, and the login shell leaves its echo and OSC
title sequences ahead of it with no newline between — so `.enter` never fired, and cmux withholds
commands until it does, while every later notification parsed normally. Both left a live et process
behind, which is why the harness's original process-listing check passed and has been replaced by
reading cmux's own view of the stream.

Two of the tests here were passing on those bugs: the real-et fixture test asserted only that
`%session-changed` parsed, and the argv test asserted the resolver was present. Both now assert the
behavior that matters.

`docs/remote-tmux-transport-seam.md` carries the full design, including the proving layers (mock transport, real sshd plus a real ET server on loopback, seeded model-based fuzz) and the notes on carrying a control protocol over a PTY transport.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787203101&installation_model_id=21920&pr_number=8556&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8556&signature=08957fb101822e7e5a5f3675c4f43a0a85fd2c5375727e49499380148c299e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a transport seam to remote tmux so a control stream can ride `ssh` or EternalTerminal (`et`) instead of assuming `ssh` at the point of use. `et` keeps sessions across network changes; `ssh` stays the default with unchanged argv.

**Transport selection and `et` support**
- `cmux ssh-tmux --transport <ssh|et> [--transport-port N]` is host-scoped, validated at the socket boundary, and part of host identity; plain-`ssh` connection hashes stay stable.
- `et` requires a PTY, resolves local `et` and remote `etterminal`, forwards ssh opts via `--ssh-option`, and quotes/bounds session names under MAX_CANON.
- One-shot commands keep riding ssh's shared master even when the control stream rides `et`.

**Recovery, parser, and tooling**
- EOF reconnects for every transport instead of ending the session; a stream that never reached control mode fails fast instead of retrying forever.
- Recovery relies on the transport's own exit — the earlier liveness probe killed healthy `et` clients riding out network changes, so it's gone.
- Teardown walks the pty tree children-first with SIGTERM then SIGKILL, since the payload lives in its own process group.
- The parser finds the enter DCS mid-line, ignores it inside command blocks, and tolerates CRLF.
- Conformance and E2E harnesses run against real `et` 6.2.11/7.0.0; a lint blocks new sleeps/timers; `ssh-tmux --help` documents the flags with translated help.

<sup>Written for commit 4e3af4a15a3370fce1f21b9d0307e0aedf3d8954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added EternalTerminal (`et`) transport support for remote tmux, including pseudo-terminal behavior when required.
  - Added CLI options to choose `ssh`/`et` transport and optional, range-validated `transport-port`.

- **Bug Fixes**
  - Fixed control-stream framing so mid-stream “enter” sequences emit only once.
  - Improved liveness detection and recovery for transports that reconnect internally.
  - Updated control-session identity so transport kind/port are reflected correctly.

- **Documentation**
  - Added documentation for the remote tmux transport seam and reconnect/liveness behavior.

- **Tests**
  - Expanded parser, fuzz, and ET end-to-end/conformance coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->