### PR TITLE
fix(window): enable native macOS tiling

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -90,7 +90,9 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
 @MainActor
 func configureCmuxMainWindowDragBehavior(_ window: NSWindow) {
     window.isMovableByWindowBackground = false
-    window.isMovable = false
+    if activeWindowMoveSuppressionSequenceReason(window: window) == nil {
+        window.isMovable = true
+    }
 }
 
 @MainActor
@@ -99,9 +101,8 @@ final class CmuxMainWindow: NSWindow {
     /// No content may resize this window past the attached display union. The content view
     /// hosts AppKit subtrees whose subviews carry REQUIRED autoresizing-mask
     /// constraints, and if any of them is ever laid out oversized, AppKit
-    /// satisfies those constraints by growing the WINDOW — and since this
-    /// window is non-movable, nothing ever constrains it back. A layout bug
-    /// then compounds through everything derived from window geometry
+    /// satisfies those constraints by growing the WINDOW. A layout bug then
+    /// compounds through everything derived from window geometry
     /// (observed live: the window at 29,000 points wide, growing every
     /// pass). The user sizes this window; layout does not.
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
@@ -290,11 +291,10 @@ final class CmuxMainWindow: NSWindow {
     ///
     /// "Reachable" means a grabbable slice of the window's *titlebar* — its top
     /// strip — is on some screen's visible area, not merely that some corner of
-    /// the window overlaps a screen. The main window is non-movable
-    /// (``configureCmuxMainWindowDragBehavior`` sets `isMovable = false`) and can
-    /// only be dragged by ``WindowDragHandleView`` in the titlebar band, so a
-    /// window whose titlebar is off-screen cannot be recovered by the user even
-    /// when its body still overlaps a display. Requiring the top strip to remain
+    /// the window overlaps a screen. The main window can only be dragged by
+    /// ``WindowDragHandleView`` in the titlebar band, so a window whose titlebar
+    /// is off-screen cannot be recovered by the user even when its body still
+    /// overlaps a display. Requiring the top strip to remain
     /// reachable lets AppKit re-clamp a window stranded above the screen (e.g.
     /// after disconnecting an external monitor that sat above the built-in
     /// display) while still leaving a genuinely on-screen frame untouched, which
@@ -318,11 +318,10 @@ final class CmuxMainWindow: NSWindow {
     /// (``shouldPreserveFrameDuringConstrain``) and the reactive/restore-time
     /// clamp (`AppDelegate`).
     ///
-    /// The window is non-movable (``configureCmuxMainWindowDragBehavior`` sets
-    /// `isMovable = false`) and can only be dragged by ``WindowDragHandleView``
-    /// in the titlebar band, so a window whose titlebar is off-screen cannot be
-    /// recovered even when its body still overlaps a display. Requiring the top
-    /// strip to remain reachable lets a stranded window be re-clamped while a
+    /// The window can only be dragged by ``WindowDragHandleView`` in the titlebar
+    /// band, so a window whose titlebar is off-screen cannot be recovered even
+    /// when its body still overlaps a display. Requiring the top strip to remain
+    /// reachable lets a stranded window be re-clamped while a
     /// genuinely on-screen frame is left untouched (which is what stops the
     /// sleep/wake drift, #6305).
     ///

--- a/Sources/AppDelegate+WindowFramePolicy.swift
+++ b/Sources/AppDelegate+WindowFramePolicy.swift
@@ -78,15 +78,12 @@ extension AppDelegate {
     /// grabbable slice of its titlebar is already reachable on some display, or
     /// there are no displays to reason about.
     ///
-    /// This is the reactive counterpart to `CmuxMainWindow.constrainFrameRect`:
-    /// a cmux main window sets `isMovable = false` for its custom titlebar drag
-    /// handling, and a non-movable `NSWindow` is excluded from AppKit's automatic
-    /// on-screen constraining when displays change -- so `constrainFrameRect` is
-    /// never invoked on that path and nothing pulls a stranded window back. When
-    /// an external monitor that sat above the built-in display is disconnected,
-    /// the window is left with its titlebar in the now-gone monitor's coordinate
-    /// space, above every remaining screen and unreachable (the user cannot drag
-    /// it back because the only drag affordance is that off-screen titlebar).
+    /// This is the reactive counterpart to `CmuxMainWindow.constrainFrameRect`.
+    /// Custom-titlebar windows have not always received a reliable AppKit
+    /// constraining pass when displays change, so this path repairs a window left
+    /// with its titlebar in the now-gone monitor's coordinate space. The user
+    /// cannot drag that window back because the only drag affordance is the
+    /// off-screen titlebar.
     ///
     /// Pure and `nonisolated` so it is unit-testable without live `NSScreen`s.
     nonisolated static func reconciledFrameAfterScreenChange(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3243,9 +3243,10 @@ struct ContentView: View {
         window.isRestorable = false
         setMinimalModeSidebarTitlebarControlsAvailable(sidebarState.isVisible, in: window)
         window.titlebarAppearsTransparent = true
-        // Native AppKit titlebar dragging steals pane-tab drags in minimal
-        // mode. Keep the main window immovable by default; explicit chrome
-        // drag zones temporarily enable performDrag for real app moves.
+        // Native background dragging steals pane-tab drags in minimal mode.
+        // Keep background dragging disabled; explicit chrome drag zones own
+        // performDrag while the movable window remains eligible for AppKit
+        // window-management commands.
         configureCmuxMainWindowDragBehavior(window)
         window.styleMask.insert(.fullSizeContentView)
 

--- a/cmuxTests/AppDelegateWindowFrameReconcileTests.swift
+++ b/cmuxTests/AppDelegateWindowFrameReconcileTests.swift
@@ -10,8 +10,8 @@ import XCTest
 final class AppDelegateWindowFrameReconcileTests: XCTestCase {
     // A window stranded above the only remaining display after disconnecting an
     // external monitor that sat above the built-in must be pulled back so its
-    // titlebar is reachable. AppKit does not auto-constrain the non-movable main
-    // window on a display change, so this reactive reconcile is the only defense.
+    // titlebar is reachable. AppKit has not reliably auto-constrained cmux's
+    // custom-titlebar window on display changes, so keep this reactive defense.
     func testReconciledFrameAfterScreenChangePullsBackStrandedWindow() {
         // Built-in display only; the window's titlebar (top ~64pt near y~=1520)
         // is far above the built-in's visible top (944), with only its bottom

--- a/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
+++ b/cmuxTests/CmuxMainWindowConstrainFrameTests.swift
@@ -111,8 +111,8 @@ final class CmuxMainWindowConstrainFrameTests: XCTestCase {
     // {300,884 1000x700}: its bottom 60pt still overlaps the built-in display, but
     // its titlebar (top 64pt) is at y≈1520, far above the built-in's visible top
     // (944) — i.e. off the top of every remaining screen and unreachable. Because
-    // the window is non-movable (isMovable=false) and only draggable via the
-    // titlebar handle, the user cannot pull it back down.
+    // only the titlebar handle initiates user dragging, the user cannot pull the
+    // window back down.
     //
     // AppKit's default constrain pass would clamp this window back onto the
     // built-in display. The #6305 override must NOT veto that clamp here: a frame

--- a/cmuxTests/TitlebarInteractiveControlTests.swift
+++ b/cmuxTests/TitlebarInteractiveControlTests.swift
@@ -174,7 +174,7 @@ struct TitlebarInteractiveControlTests {
         #expect(window.performDragCallCount == 1)
         #expect(
             window.isMovableDuringPerformDrag == true,
-            "Empty accessory chrome should temporarily enable main-window movement before calling performDrag(with:)."
+            "Empty accessory chrome must keep main-window movement enabled while calling performDrag(with:)."
         )
         #expect(window.isMovable, "Explicit accessory dragging must preserve the AppKit-movable baseline.")
     }

--- a/cmuxTests/TitlebarInteractiveControlTests.swift
+++ b/cmuxTests/TitlebarInteractiveControlTests.swift
@@ -149,7 +149,7 @@ struct TitlebarInteractiveControlTests {
             defer: false
         )
         defer { window.orderOut(nil) }
-        window.isMovable = false
+        window.isMovable = true
 
         let controller = TitlebarControlsAccessoryViewController(notificationStore: TerminalNotificationStore.shared, settingsRuntime: nil)
         let container = controller.view
@@ -165,7 +165,7 @@ struct TitlebarInteractiveControlTests {
         #expect(hitView === container)
         #expect(
             !hitView.mouseDownCanMoveWindow,
-            "Empty accessory chrome must not rely on native AppKit window dragging because main windows are normally immovable."
+            "Empty accessory chrome must use the explicit drag path instead of implicit AppKit background dragging."
         )
 
         let event = Self.makeLeftMouseDownEvent(location: emptyTopRightPoint, window: window)
@@ -176,10 +176,7 @@ struct TitlebarInteractiveControlTests {
             window.isMovableDuringPerformDrag == true,
             "Empty accessory chrome should temporarily enable main-window movement before calling performDrag(with:)."
         )
-        #expect(
-            !window.isMovable,
-            "Explicit accessory dragging must restore the main window to its normal immovable state."
-        )
+        #expect(window.isMovable, "Explicit accessory dragging must preserve the AppKit-movable baseline.")
     }
 
     @Test func accessoryControlsRemainNonDraggable() {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2023,16 +2023,47 @@ final class DraggableFolderHitTests: XCTestCase {
 }
 
 @MainActor
-final class MainWindowDragBehaviorTests: XCTestCase {
-    func testMainWindowHostingViewCannotMoveWindowViaMouseDown() {
+@Suite("Main window drag behavior")
+struct MainWindowDragBehaviorTests {
+    @Test func mainWindowHostingViewCannotMoveWindowViaMouseDown() {
         let view = MainWindowHostingView(rootView: Color.clear)
-        XCTAssertFalse(
-            view.mouseDownCanMoveWindow,
+        #expect(
+            !view.mouseDownCanMoveWindow,
             "Main content must never become an implicit AppKit window-drag region; explicit titlebar chrome owns app-window dragging"
         )
     }
 
-    func testMainWindowDragBehaviorRequiresExplicitDragZones() {
+    @Test func mainWindowDragBehaviorKeepsNativeWindowMovementEligible() {
+        let window = CmuxMainWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        window.isMovable = false
+        window.isMovableByWindowBackground = true
+
+        configureCmuxMainWindowDragBehavior(window)
+
+        #expect(
+            window.isMovable,
+            "Main windows must remain eligible for AppKit window-management commands"
+        )
+        #expect(!window.isMovableByWindowBackground)
+
+        let previous = withTemporaryWindowMovableEnabled(window: window) {
+            #expect(window.isMovable)
+        }
+
+        #expect(previous == true)
+        #expect(
+            window.isMovable,
+            "Explicit chrome drag zones must preserve the AppKit-movable baseline"
+        )
+    }
+
+    @Test func mainWindowDragBehaviorPreservesActiveMoveSuppression() {
         let window = CmuxMainWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
@@ -2041,25 +2072,21 @@ final class MainWindowDragBehaviorTests: XCTestCase {
         )
         defer { window.orderOut(nil) }
         window.isMovable = true
-        window.isMovableByWindowBackground = true
+
+        #expect(
+            beginWindowMoveSuppressionSequence(window: window, reason: .bonsplitPaneTabDrag)
+                == .bonsplitPaneTabDrag
+        )
+        #expect(!window.isMovable)
 
         configureCmuxMainWindowDragBehavior(window)
 
-        XCTAssertFalse(
-            window.isMovable,
-            "Main windows must not use native AppKit titlebar dragging because pane tabs live in the titlebar band"
+        #expect(
+            !window.isMovable,
+            "A titlebar refresh must not re-enable whole-window movement during a pane-tab drag"
         )
-        XCTAssertFalse(window.isMovableByWindowBackground)
-
-        let previous = withTemporaryWindowMovableEnabled(window: window) {
-            XCTAssertTrue(window.isMovable)
-        }
-
-        XCTAssertEqual(previous, false)
-        XCTAssertFalse(
-            window.isMovable,
-            "Explicit chrome drag zones may temporarily enable movement, but the main window must return to pane-tab-safe immovable state"
-        )
+        #expect(finishWindowMoveSuppressionSequence(window: window) == .bonsplitPaneTabDrag)
+        #expect(window.isMovable)
     }
 }
 
@@ -2457,7 +2484,7 @@ final class WindowMoveSuppressionHitPathTests: XCTestCase {
         XCTAssertNil(activeWindowMoveSuppressionSequenceReason(window: window))
     }
 
-    func testBonsplitPaneTabSuppressionRestoresImmovableMainWindow() {
+    func testBonsplitPaneTabSuppressionRestoresPreexistingImmovableWindow() {
         let (window, contentView) = makeWindowWithContentView()
         window.isMovable = false
         let tabRegion = FakeBonsplitTabItemRegionView(frame: NSRect(x: 20, y: 132, width: 240, height: 30))
@@ -2477,7 +2504,7 @@ final class WindowMoveSuppressionHitPathTests: XCTestCase {
         XCTAssertEqual(finishWindowMoveSuppressionSequence(window: window), .bonsplitPaneTabDrag)
         XCTAssertFalse(
             window.isMovable,
-            "Tab-drag suppression must not restore native AppKit window dragging when the main window baseline is immovable"
+            "Tab-drag suppression must preserve a preexisting immovable baseline"
         )
     }
 


### PR DESCRIPTION
## Summary

- Restore native macOS **Window → Fill / Center / Move & Resize** by keeping the main window AppKit-movable while leaving background dragging disabled.
- Preserve CMUX's explicit titlebar drag path and current pane-tab/folder-drag suppression; a titlebar refresh cannot re-enable whole-window movement during an active tab drag.
- Add runtime regressions for native window-management eligibility, explicit titlebar dragging, and active move suppression.

This is a narrowly scoped replacement for the window-management portion of #2348 by @chrislemmer. That PR identified `isMovable = false` as the blocker and deserves credit for the original implementation and validation. Current `main` now includes the hosting-view and full mouse-sequence suppression infrastructure that landed after #2348, so this replacement does not require a Bonsplit submodule change and intentionally leaves the unrelated Dock-menu/localization work out.

Fixes #1613.
Fixes #7446.
Related: #1765, #1383, #3652.

## Testing

- `./scripts/lint-pbxproj-test-wiring.sh`
- Swift parser validation for all touched Swift files
- Standalone AppKit runtime harness, red before the implementation and green after it:
  - native AppKit window-management eligibility remains enabled
  - implicit background dragging remains disabled
  - explicit titlebar dragging preserves the movable baseline
  - active pane-tab suppression remains immovable across a titlebar refresh
- Focused macOS unit runs (both `Run selected tests` steps passed; the fork jobs finish red only because the final upstream artifacts-post step has no `DEV_ARTIFACTS_TOKEN`):
  - `MainWindowDragBehaviorTests`: https://github.com/baynk/cmux/actions/runs/29824274243
  - `TitlebarInteractiveControlTests`: https://github.com/baynk/cmux/actions/runs/29824284523
- Tagged macOS build: https://github.com/baynk/cmux/actions/runs/29824294443
- Manual tagged-app verification with the user's existing macOS App Shortcuts:
  - Right half: `x=1280, y=30, width=1280, height=1410`
  - Left half: `x=0, y=30, width=1280, height=1410`
  - Fill: `x=0, y=30, width=2560, height=1410`
  - Return to previous size: `x=274, y=38, width=1001, height=701`
  - Explicit custom-titlebar drag still moved the window to `x=1004, y=825` without regressing pane/tab behavior.

The local machine only has Command Line Tools, not the full Xcode app, so the tagged Xcode build and focused app-host tests run on GitHub's macOS runner.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- [Verified demo: left half, right half, fill, top-right quadrant, return to previous size](https://github.com/user-attachments/assets/1a4ce82f-7917-473f-b46b-c3f38ff5be2f)
- Privacy review: all other applications and Finder desktop icons were hidden before capture; the menu bar was cropped, audio was removed, and the final video was visually reviewed end-to-end at 250 ms intervals plus full-resolution key frames.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787223582&installation_model_id=21920&pr_number=8559&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8559&signature=c00be91852399358e7f9d083502842d6e92cce8330852b0f5a9c02c00d98d217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables native macOS tiling and Window → Fill/Center/Move & Resize by keeping the main window AppKit‑movable while background dragging stays disabled. Preserves explicit titlebar drag and active move suppression so pane tabs and folders don’t get hijacked. Fixes #1613, #7446.

- **Bug Fixes**
  - Set `isMovable = true` when no active move‑suppression; keep `isMovableByWindowBackground = false`.
  - Prevent titlebar refresh from re‑enabling movement during pane‑tab drags; accessory drags keep the movable baseline.
  - Add focused tests for window‑management eligibility, background‑drag disablement, titlebar drag behavior, and suppression lifecycle.

<sup>Written for commit 42a1d3cc38a2a95c308a5cc13ac8b1468827768f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window dragging behavior so main windows remain movable for window-management actions.
  * Prevented pane and tab drag operations from accidentally re-enabling whole-window movement.
  * Preserved each window’s existing movability state after drag operations.
  * Improved recovery when display changes leave a custom-titlebar window partially off-screen.

* **Tests**
  * Expanded coverage for window movement, titlebar dragging, and display-change recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->