### PR TITLE
Fix symlinked cmux.json live-reload: key parse cache on stat(2), not lstat

### DIFF
--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -2984,9 +2984,20 @@ final class CmuxConfigStore: ObservableObject {
             return ParsedConfigResult(config: nil, issue: nil)
         }
 
-        let attributes = try? fileManager.attributesOfItem(atPath: path)
-        let fileSize = (attributes?[.size] as? NSNumber)?.uint64Value ?? 0
-        let modificationDate = attributes?[.modificationDate] as? Date
+        // Key the parse cache on stat(2), which follows symlinks, rather than
+        // attributesOfItem(atPath:), which has lstat semantics and does not.
+        // When cmux.json is a symlink into a dotfiles repo, editing the target
+        // leaves the link's own size/mtime unchanged, so an lstat-based key would
+        // never invalidate and reload-config / file watching would appear to do
+        // nothing until a full app restart. contents(atPath:) below also follows
+        // the symlink, so this keeps the cache key consistent with what we read.
+        var statBuffer = stat()
+        let statSucceeded = stat(path, &statBuffer) == 0
+        let fileSize = statSucceeded ? UInt64(statBuffer.st_size) : 0
+        let modificationDate: Date? = statSucceeded
+            ? Date(timeIntervalSince1970: TimeInterval(statBuffer.st_mtimespec.tv_sec)
+                + TimeInterval(statBuffer.st_mtimespec.tv_nsec) / 1_000_000_000)
+            : nil
         let paletteFingerprint = WorkspaceTabColorSettings.paletteCacheFingerprint()
 
         if let cached = parsedConfigCache[path],

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -674,6 +674,60 @@ final class CmuxConfigDecodingTests: XCTestCase {
     }
 
     @MainActor
+    func testSymlinkedConfigReloadsWhenTargetChanges() throws {
+        // Regression for the symlinked cmux.json live-reload bug: the parse cache
+        // was keyed on attributesOfItem(atPath:) (lstat), which does NOT follow
+        // symlinks. Editing the symlink target left the link's own size/mtime
+        // unchanged, so the cache never invalidated and reload-config / file
+        // watching appeared to do nothing until a full app restart.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-config-symlink-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // dotfiles-style real file, with cmux.json as a symlink pointing at it.
+        let realConfig = root.appendingPathComponent("dotfiles-cmux.json")
+        try """
+        {
+          "actions": {
+            "first": { "type": "command", "command": "echo first" }
+          }
+        }
+        """.write(to: realConfig, atomically: true, encoding: .utf8)
+
+        let linkPath = root.appendingPathComponent("cmux.json").path
+        try FileManager.default.createSymbolicLink(
+            atPath: linkPath,
+            withDestinationPath: realConfig.path
+        )
+
+        let store = CmuxConfigStore(
+            globalConfigPath: linkPath,
+            localConfigPath: root.appendingPathComponent("missing-local.json").path,
+            startFileWatchers: false
+        )
+        store.loadAll()
+        XCTAssertNotNil(store.resolvedAction(id: "first"))
+
+        // Edit the symlink TARGET in place. The link's own lstat size/mtime stay
+        // constant; only the target's change. A longer action id makes the size
+        // difference alone distinguish the payloads regardless of mtime
+        // resolution, so this is a deterministic red/green.
+        try """
+        {
+          "actions": {
+            "second-longer-identifier": { "type": "command", "command": "echo second" }
+          }
+        }
+        """.write(to: realConfig, atomically: true, encoding: .utf8)
+        store.loadAll()
+
+        // Fails before the fix (stale cache keeps "first"); passes after.
+        XCTAssertNotNil(store.resolvedAction(id: "second-longer-identifier"))
+        XCTAssertNil(store.resolvedAction(id: "first"))
+    }
+
+    @MainActor
     func testConfigChangesRequireExplicitLoadByDefault() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(
             "cmux-config-store-\(UUID().uuidString)",


### PR DESCRIPTION
## Summary

**What:** Live-reload of `~/.config/cmux/cmux.json` silently breaks when the file is a symlink (the common dotfiles setup). After editing the config, `cmux reload-config`, the file watcher, and the **Reload Configuration** menu item all appear to do nothing — only a full app restart picks up the change.

**Why:** `CmuxConfigStore.parseConfig(at:)` keyed its parse cache on `attributesOfItem(atPath:)`, which has `lstat` semantics and returns the *symlink's own* size/mtime (the link's target-path length and its creation time — both constant when you edit the target in place). Meanwhile `contents(atPath:)` follows the link and reads the up-to-date target. So the cache key never changed and stale config was returned indefinitely; only a cold start (empty cache) ever saw new content.

This is the same `attributesOfItem` + symlink pitfall previously fixed for Ghostty config in #2813 (`GhosttyConfig`), but on the separate cmux.json cache path, which #2813 did not touch.

**Fix:** Key the cache on `stat(2)` instead, which follows symlinks and matches the target that `contents(atPath:)` reads. Regular files are unaffected (`lstat` and `stat` agree), and a broken symlink is still short-circuited by the existing `fileExists` check above. `stat` is used only for the cache fingerprint; the read path and cache dictionary key are unchanged, so this avoids the `resolvingSymlinksInPath` / URL-normalization macOS-version drift called out in the repo notes (#4529).

Fixes #4532.

## Testing

Two-commit red/green structure (`cmux-unit` scheme):

- **Commit 1** (test only): `Executed 1 test, with 2 failures` — the stale cache keeps the old action and never sees the rewritten one.
- **Commit 2** (fix): `Executed 1 test, with 0 failures` → `** TEST SUCCEEDED **`.

```
xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
  -destination 'platform=macOS' \
  -only-testing:cmuxTests/CmuxConfigDecodingTests/testSymlinkedConfigReloadsWhenTargetChanges
```

The test symlinks `cmux.json` to a real file, loads it, rewrites the target in place with a different-length payload, and reloads — asserting the new action is picked up and the old one is gone. The differing byte length lets the size alone distinguish the payloads, so red/green is deterministic regardless of mtime resolution. The full `CmuxConfigDecodingTests` class passes (no regression for regular-file configs).

Manual: symlink `~/.config/cmux/cmux.json` into a dotfiles repo, edit the target, run `cmux reload-config` — the change now applies without an app restart.

## Demo Video

N/A — internal cache-invalidation logic with no UI surface. Behavior is covered by the red/green regression test above.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (red/green above)
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed — not needed (internal fix, no user-facing string, UI, or config-schema change)
- [x] I requested bot reviews after my latest commit (comment above)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787232867&installation_model_id=21920&pr_number=8562&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8562&signature=de3b09666231f8297fb0df9b16f0e1fd901ab6d8ef808b68b478c31232ef4fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live-reload when `~/.config/cmux/cmux.json` is a symlink by keying the parse cache on `stat(2)` (follows links) to match the read path, so edits apply without restarting. Fixes #4532.

- **Bug Fixes**
  - Use `stat(2)` for the cache fingerprint in `CmuxConfigStore.parseConfig(at:)` instead of `attributesOfItem(atPath:)` (lstat); regular files unchanged, broken links still skipped.
  - Add regression test `CmuxConfigDecodingTests.testSymlinkedConfigReloadsWhenTargetChanges`.

<sup>Written for commit 625d32522f917034241977ae1eb5977356e023d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration changes are now detected correctly when `cmux.json` is a symlink and its target is updated.
  - Updated configuration values are reliably loaded instead of serving stale cached results.

- **Tests**
  - Added coverage to verify configuration reloads after changes to a symlink target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->