### PR TITLE
Tell coding agents workspace todos are user-owned

### DIFF
--- a/CLI/CMUXCLI+WorkspaceTodo.swift
+++ b/CLI/CMUXCLI+WorkspaceTodo.swift
@@ -334,6 +334,10 @@ extension CMUXCLI {
     `set auto` clears the pin immediately. `cycle` advances the manual override
     one lane forward (todo → working → needs-attention → review → done → todo).
 
+    Note for coding agents: manual status pins belong to the user; the lane
+    already tracks your activity automatically. Do not `set` or `cycle` the
+    status unless the user explicitly asks you to.
+
     Lanes: todo, working, needs-attention, review, done
 
     Examples:
@@ -346,8 +350,13 @@ extension CMUXCLI {
     static let todoUsage = String(localized: "cli.todo.usage", defaultValue: """
     Usage: cmux todo <subcommand> [--workspace <id|ref|index>] [--window <id|ref|index>] [--json]
 
-    Per-workspace checklist, writable by you and by agents. Targets the
+    Per-workspace checklist shown in the sidebar and todo pane. Targets the
     caller's workspace by default. Items are capped at 50 per workspace.
+
+    Note for coding agents: this checklist belongs to the user. Do not add,
+    edit, complete, remove, or replace items on your own initiative — only
+    manage it when the user explicitly asks you to. Use your own internal
+    task tracking for your plans.
 
     Subcommands:
       add "text" [--state <pending|in-progress|completed>] [--origin <user|agent>]

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -472,6 +472,13 @@ shared by the sidebar row, the checklist popover, the todo pane, `cmux todo`
 / `cmux workspace status`, and the `workspace.todo.*` / `workspace.status.*`
 socket verbs (all funnel through the same mutation entry points).
 
+Agent policy: the checklist and manual status pins belong to the user.
+Coding agents must not create, edit, complete, remove, or replace checklist
+items, and must not `set`/`cycle` the status, unless the user explicitly
+asks them to manage workspace todos. The status lane already tracks agent
+activity automatically through inference; agents should keep their own
+plans in their internal task tracking.
+
 Item schema (wire and `todo list --json` shape):
 
 | Field | Contract |

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -475,9 +475,10 @@ socket verbs (all funnel through the same mutation entry points).
 Agent policy: the checklist and manual status pins belong to the user.
 Coding agents must not create, edit, complete, remove, or replace checklist
 items, and must not `set`/`cycle` the status, unless the user explicitly
-asks them to manage workspace todos. The status lane already tracks agent
-activity automatically through inference; agents should keep their own
-plans in their internal task tracking.
+asks them to manage that surface — a request to manage checklist items or
+a request to manage manual status pins. The status lane already tracks
+agent activity automatically through inference; agents should keep their
+own plans in their internal task tracking.
 
 Item schema (wire and `todo list --json` shape):
 


### PR DESCRIPTION
Colleagues' coding agents have been populating workspace checklists and pinning completion statuses unprompted. Two causes: the `workspace-todo-controls-enabled-release` flag enabled the feature org-wide, and `cmux todo --help` described the checklist as "writable by you and by agents" — agents exploring the CLI read that as an invitation to mirror their internal plans into the sidebar. (Status lane changes are mostly not agents at all: lanes are inferred automatically from live signals like agent-running and open PRs; only manual pins come from callers.)

This states the ownership policy in the surfaces agents actually read: `cmux todo` and `cmux workspace status` help now carry a "Note for coding agents" saying items and status pins belong to the user and must not be touched unless the user explicitly asks, and docs/cli-contract.md records the same policy. en/ja catalog entries updated to match.

This is guidance, not enforcement — a socket-level gate that rejects todo mutations from agent-owned surfaces (cmux already tracks agent sessions per surface) is possible as a follow-up if instructions prove insufficient.

Verified on a tagged build: `cmux todo --help` and `cmux workspace status` usage print the new notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787246182&installation_model_id=21920&pr_number=8566&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8566&signature=fd02219dd6bfacb003a3ed7ee389d58c76a5c0c00ba7574d8c353ea714292922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified that the workspace checklist and manual status pins are user-owned; coding agents must not change items or set/cycle status unless the user explicitly asks. Added a “Note for coding agents” in `cmux todo` and `cmux workspace status` help and in `docs/cli-contract.md` (en/ja); guidance only—status inference still tracks agent activity automatically.

<sup>Written for commit 323c2f85b75751cf6d798f05e8d507361e59a260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help for `workspace status` and `todo` with clearer guidance that manual status pins and workspace checklist items are user-managed.
  * Added an explicit agent policy in the CLI help/docs: agents should not set/cycle status or add/edit/complete/remove/replace todo items unless the user explicitly asks.
  * Refreshed the `todo` description to match the sidebar/todo pane experience and the 50-item cap.
  * Updated Japanese localized help text accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->