### PR TITLE
Update Set Up Computer and Switch Computer copy for zero-touch pairing

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
@@ -20,7 +20,7 @@ struct MobileHostPickerView: View {
             List {
                 Section {
                     if store.pairedMacs.isEmpty {
-                        Text(L10n.string("mobile.hostPicker.empty", defaultValue: "No paired computers yet."))
+                        Text(L10n.string("mobile.hostPicker.empty", defaultValue: "No computers yet. Sign in to cmux on your computer with this account and it appears here automatically."))
                             .foregroundStyle(.secondary)
                     }
                     ForEach(store.pairedMacs) { mac in
@@ -31,7 +31,7 @@ struct MobileHostPickerView: View {
                 } footer: {
                     Text(L10n.string(
                         "mobile.hostPicker.footer",
-                        defaultValue: "Switch which computer this device controls. Pairing another computer keeps the others, so you can hop between them."
+                        defaultValue: "Switch which computer this device controls. Computers on your account appear here automatically while cmux is running on them. Pairing another keeps the ones you already have."
                     ))
                 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
@@ -31,7 +31,7 @@ struct MobileHostPickerView: View {
                 } footer: {
                     Text(L10n.string(
                         "mobile.hostPicker.footer",
-                        defaultValue: "Switch which computer this device controls. Computers on your account appear here automatically while cmux is running on them. Pairing another keeps the ones you already have."
+                        defaultValue: "Switch which computer this device controls. A computer joins this list automatically the first time this phone connects to it. Pair Another Computer adds more without removing the ones you have."
                     ))
                 }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
@@ -20,7 +20,7 @@ struct MobileHostPickerView: View {
             List {
                 Section {
                     if store.pairedMacs.isEmpty {
-                        Text(L10n.string("mobile.hostPicker.empty", defaultValue: "No computers yet. Sign in to cmux on your computer with this account and it appears here automatically."))
+                        Text(L10n.string("mobile.hostPicker.empty", defaultValue: "No computers yet. Sign in to cmux on your computer with this account and it appears here automatically. If it does not, tap Pair Another Computer and scan its QR code."))
                             .foregroundStyle(.secondary)
                     }
                     ForEach(store.pairedMacs) { mac in

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
@@ -23,7 +23,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.signInTitle", defaultValue: "Sign in"),
                 body: L10n.string(
                     "mobile.setupHelp.signInBody",
-                    defaultValue: "Sign in to cmux on this phone with the same account the paired computer uses. Without that, there is nothing to connect to."
+                    defaultValue: "Sign in to cmux on this phone with the same account your computer uses. Computers on your account are found automatically once you sign in."
                 ),
                 link: nil,
                 identifierSuffix: "notSignedIn",
@@ -35,7 +35,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.macAppTitle", defaultValue: "Run cmux on your computer"),
                 body: L10n.string(
                     "mobile.setupHelp.macAppBody",
-                    defaultValue: "Install cmux on your computer and leave it running, signed in to the same account. The phone pairs to a running cmux build, so a quit or never-installed app is the most common reason pairing does nothing."
+                    defaultValue: "Install cmux on your computer, sign in to the same account, and leave it running. The computer then appears on this phone automatically. If it does not, open Pair iPhone in cmux on the computer and scan its QR code."
                 ),
                 link: nil,
                 identifierSuffix: "signedInNeverPaired",
@@ -47,7 +47,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.unreachableTitle", defaultValue: "Wake the computer"),
                 body: L10n.string(
                     "mobile.setupHelp.unreachableBody",
-                    defaultValue: "You paired this computer before, but it is not reachable now. Wake it and make sure cmux is running. Iroh will retry direct and relay paths; if you rely on a private network, connect both devices to it, then reconnect."
+                    defaultValue: "You paired this computer before, but it is not reachable now. Wake it and make sure cmux is running; this phone reconnects on its own."
                 ),
                 link: nil,
                 identifierSuffix: "macUnreachable",
@@ -59,7 +59,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.mismatchTitle", defaultValue: "Match the account"),
                 body: L10n.string(
                     "mobile.setupHelp.mismatchBody",
-                    defaultValue: "If the computer rejects this device's sign-in, the two are on different cmux accounts or this device's session is stale. Sign this phone in to the computer's account (or sign the computer in to this one), then pair again."
+                    defaultValue: "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign both in to the same account and try again."
                 ),
                 link: nil,
                 identifierSuffix: "accountMismatch",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
@@ -59,7 +59,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.mismatchTitle", defaultValue: "Match the account"),
                 body: L10n.string(
                     "mobile.setupHelp.mismatchBody",
-                    defaultValue: "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign both in to the same account and try again."
+                    defaultValue: "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign this phone out and back in with the computer's account, then try again."
                 ),
                 link: nil,
                 identifierSuffix: "accountMismatch",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
@@ -59,7 +59,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.mismatchTitle", defaultValue: "Match the account"),
                 body: L10n.string(
                     "mobile.setupHelp.mismatchBody",
-                    defaultValue: "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign this phone out and back in with the computer's account, then try again."
+                    defaultValue: "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign either one out and back in so both use the same account, then try again."
                 ),
                 link: nil,
                 identifierSuffix: "accountMismatch",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
@@ -23,7 +23,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.signInTitle", defaultValue: "Sign in"),
                 body: L10n.string(
                     "mobile.setupHelp.signInBody",
-                    defaultValue: "Sign in to cmux on this phone with the same account your computer uses. Computers on your account are found automatically once you sign in."
+                    defaultValue: "Sign in to cmux on this phone with the same account your computer uses. Once you sign in, your computer is found automatically."
                 ),
                 link: nil,
                 identifierSuffix: "notSignedIn",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpView.swift
@@ -73,11 +73,11 @@ struct SetupHelpView: View {
             Text(highlight == nil
                 ? L10n.string(
                     "mobile.setupHelp.introReference",
-                    defaultValue: "To see your computer's terminals here, four things have to line up."
+                    defaultValue: "To see your computer's terminals here, sign in to the same cmux account on both devices and keep cmux running on the computer. Connection is automatic after that."
                 )
                 : L10n.string(
                     "mobile.setupHelp.intro",
-                    defaultValue: "To see your computer's terminals here, four things have to line up. The step you are on is marked below."
+                    defaultValue: "To see your computer's terminals here, sign in to the same cmux account on both devices and keep cmux running on the computer. The step you are on is marked below."
                 ))
             .font(.subheadline)
             .foregroundStyle(.secondary)
@@ -124,7 +124,7 @@ struct SetupHelpView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text(L10n.string(
                     "mobile.setupHelp.networkBody",
-                    defaultValue: "Scan the Iroh code shown by cmux on the Mac. Iroh connects directly when possible and uses a cmux relay when needed, while verifying the Mac identity and your cmux account end to end. Tailscale is not required."
+                    defaultValue: "cmux connects through Iroh, which links this phone to your computer directly when possible and through an encrypted cmux relay when not. Both devices verify your account, and the relay cannot read your terminals. No network setup is required."
                 ))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -150,7 +150,7 @@ struct SetupHelpView: View {
 
                 Text(L10n.string(
                     "mobile.setupHelp.lanBody",
-                    defaultValue: "After cmux admits both devices over Iroh, Tailscale, another VPN, or the same LAN may become a faster direct path. The Iroh session keeps peer identity and application traffic authenticated on every path."
+                    defaultValue: "If both devices are on Tailscale, another VPN, or the same network, cmux can use it as a faster direct path. The connection stays encrypted and verified either way."
                 ))
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -162,12 +162,12 @@ struct SetupHelpView: View {
             HStack(spacing: 8) {
                 Image(systemName: "lock.laptopcomputer")
                     .foregroundStyle(.tint)
-                Text(L10n.string("mobile.setupHelp.networkTitle", defaultValue: "Connect with Iroh"))
+                Text(L10n.string("mobile.setupHelp.networkTitle", defaultValue: "How it connects"))
             }
         } footer: {
             Text(L10n.string(
                 "mobile.setupHelp.sameAccountFooter",
-                defaultValue: "The computer and this phone must be signed in to the same cmux account. Any private network changes reachability only; it never replaces Iroh's identity and authorization checks."
+                defaultValue: "Both devices must be signed in to the same cmux account. A private network never replaces that check."
             ))
         }
         .accessibilityIdentifier("MobileSetupHelpNetworkSection")

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2733,7 +2733,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このデバイスが操作するコンピュータを切り替えます。アカウントのコンピュータは、cmuxの実行中に自動的にここに追加されます。別のコンピュータをペアリングしても、今あるコンピュータはそのまま残ります。"
+            "value": "このデバイスが操作するコンピュータを切り替えます。アカウントのコンピュータは、cmuxの実行中に自動的にここに表示されます。別のコンピュータをペアリングしても、今あるコンピュータはそのまま残ります。"
           }
         }
       }
@@ -6015,13 +6015,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign both in to the same account and try again."
+            "value": "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign this phone out and back in with the computer's account, then try again."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータがこの端末のサインインを拒否しました。両者が別々のcmuxアカウントになっているか、この端末のセッションが古くなっています。両方を同じアカウントでサインインし直して、もう一度お試しください。"
+            "value": "コンピュータがこの端末のサインインを拒否しました。両者が別々のcmuxアカウントになっているか、この端末のセッションが古くなっています。この端末でいったんサインアウトし、コンピュータと同じアカウントでサインインし直してから、もう一度お試しください。"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2727,13 +2727,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Switch which computer this device controls. Computers on your account appear here automatically while cmux is running on them. Pairing another keeps the ones you already have."
+            "value": "Switch which computer this device controls. A computer joins this list automatically the first time this phone connects to it. Pair Another Computer adds more without removing the ones you have."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このデバイスが操作するコンピュータを切り替えます。アカウントのコンピュータは、cmuxの実行中に自動的にここに表示されます。別のコンピュータをペアリングしても、今あるコンピュータはそのまま残ります。"
+            "value": "このデバイスが操作するコンピュータを切り替えます。コンピュータは、この端末が最初に接続したときに自動的にこの一覧に追加されます。「別のコンピュータをペアリング」で、今あるコンピュータを残したまま追加できます。"
           }
         }
       }
@@ -6100,13 +6100,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sign in to cmux on this phone with the same account your computer uses. Computers on your account are found automatically once you sign in."
+            "value": "Sign in to cmux on this phone with the same account your computer uses. Once you sign in, your computer is found automatically."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "この端末で、コンピュータと同じアカウントを使ってcmuxにサインインします。サインインすると、アカウントのコンピュータは自動的に見つかります。"
+            "value": "この端末で、コンピュータと同じアカウントを使ってcmuxにサインインします。サインインすると、コンピュータは自動的に見つかります。"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2710,13 +2710,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No paired computers yet."
+            "value": "No computers yet. Sign in to cmux on your computer with this account and it appears here automatically."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ペアリング済みのコンピュータはまだありません。"
+            "value": "コンピュータはまだありません。コンピュータのcmuxにこのアカウントでサインインすると、ここに自動的に表示されます。"
           }
         }
       }
@@ -2727,13 +2727,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Switch which computer this device controls. Pairing another computer keeps the others, so you can hop between them."
+            "value": "Switch which computer this device controls. Computers on your account appear here automatically while cmux is running on them. Pairing another keeps the ones you already have."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このデバイスが操作するコンピュータを切り替えます。別のコンピュータをペアリングしても他のコンピュータは保持されるので、行き来できます。"
+            "value": "このデバイスが操作するコンピュータを切り替えます。アカウントのコンピュータは、cmuxの実行中に自動的にここに追加されます。別のコンピュータをペアリングしても、今あるコンピュータはそのまま残ります。"
           }
         }
       }
@@ -5913,13 +5913,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "To see your computer's terminals here, four things have to line up. The step you are on is marked below."
+            "value": "To see your computer's terminals here, sign in to the same cmux account on both devices and keep cmux running on the computer. The step you are on is marked below."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ここでコンピュータのターミナルを表示するには、4つの条件がそろう必要があります。今いるステップは下に印が付いています。"
+            "value": "ここでコンピュータのターミナルを表示するには、両方の端末で同じcmuxアカウントにサインインし、コンピュータでcmuxを起動したままにします。今いるステップは下に印が付いています。"
           }
         }
       }
@@ -5930,13 +5930,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "To see your computer's terminals here, four things have to line up."
+            "value": "To see your computer's terminals here, sign in to the same cmux account on both devices and keep cmux running on the computer. Connection is automatic after that."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ここでコンピュータのターミナルを表示するには、4つの条件がそろう必要があります。"
+            "value": "ここでコンピュータのターミナルを表示するには、両方の端末で同じcmuxアカウントにサインインし、コンピュータでcmuxを起動したままにします。あとは自動的に接続されます。"
           }
         }
       }
@@ -5947,13 +5947,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "After cmux admits both devices over Iroh, Tailscale, another VPN, or the same LAN may become a faster direct path. The Iroh session keeps peer identity and application traffic authenticated on every path."
+            "value": "If both devices are on Tailscale, another VPN, or the same network, cmux can use it as a faster direct path. The connection stays encrypted and verified either way."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmuxがIroh上で両方の端末を認証した後、Tailscale、別のVPN、または同じLANが、より高速な直接経路になる場合があります。Irohセッションは、どの経路でもピアIDとアプリ通信を認証します。"
+            "value": "両方の端末がTailscale、別のVPN、または同じネットワーク上にある場合、cmuxはそれをより高速な直接経路として使うことがあります。どの経路でも接続の暗号化と検証は保たれます。"
           }
         }
       }
@@ -5964,13 +5964,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install cmux on your computer and leave it running, signed in to the same account. The phone pairs to a running cmux build, so a quit or never-installed app is the most common reason pairing does nothing."
+            "value": "Install cmux on your computer, sign in to the same account, and leave it running. The computer then appears on this phone automatically. If it does not, open Pair iPhone in cmux on the computer and scan its QR code."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータにcmuxをインストールし、同じアカウントでサインインしたまま起動しておきます。iPhoneは起動中のcmuxビルドとペアリングするため、アプリが終了している、または未インストールであることが、ペアリングが進まない最も多い原因です。"
+            "value": "コンピュータにcmuxをインストールし、同じアカウントでサインインしたまま起動しておきます。コンピュータは自動的にこの端末に表示されます。表示されない場合は、コンピュータのcmuxで「iPhone をペアリング」を開き、QRコードをスキャンしてください。"
           }
         }
       }
@@ -6015,13 +6015,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "If the computer rejects this device's sign-in, the two are on different cmux accounts or this device's session is stale. Sign this phone in to the computer's account (or sign the computer in to this one), then pair again."
+            "value": "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign both in to the same account and try again."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータがこの端末のサインインを拒否する場合、両者が別々のcmuxアカウントになっているか、この端末のセッションが古くなっています。この端末をコンピュータのアカウントでサインインし（またはコンピュータをこの端末のアカウントでサインインし）、もう一度ペアリングしてください。"
+            "value": "コンピュータがこの端末のサインインを拒否しました。両者が別々のcmuxアカウントになっているか、この端末のセッションが古くなっています。両方を同じアカウントでサインインし直して、もう一度お試しください。"
           }
         }
       }
@@ -6049,13 +6049,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scan the Iroh code shown by cmux on the Mac. Iroh connects directly when possible and uses a cmux relay when needed, while verifying the Mac identity and your cmux account end to end. Tailscale is not required."
+            "value": "cmux connects through Iroh, which links this phone to your computer directly when possible and through an encrypted cmux relay when not. Both devices verify your account, and the relay cannot read your terminals. No network setup is required."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Macのcmuxに表示されるIrohコードをスキャンします。Irohは可能な場合は直接接続し、必要な場合はcmuxリレーを使いながら、MacのIDとcmuxアカウントをエンドツーエンドで検証します。Tailscaleは必須ではありません。"
+            "value": "cmuxはIrohで接続します。可能な場合はこの端末とコンピュータを直接つなぎ、できない場合は暗号化されたcmuxリレーを経由します。両方の端末でアカウントを検証するため、リレーがターミナルの内容を読むことはできません。ネットワークの設定は不要です。"
           }
         }
       }
@@ -6066,13 +6066,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connect with Iroh"
+            "value": "How it connects"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Irohで接続"
+            "value": "接続のしくみ"
           }
         }
       }
@@ -6083,13 +6083,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The computer and this phone must be signed in to the same cmux account. Any private network changes reachability only; it never replaces Iroh's identity and authorization checks."
+            "value": "Both devices must be signed in to the same cmux account. A private network never replaces that check."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータとこの端末は同じcmuxアカウントでサインインする必要があります。プライベートネットワークは到達経路を変えるだけで、IrohのID検証と認可を置き換えることはありません。"
+            "value": "両方の端末は同じcmuxアカウントでサインインする必要があります。プライベートネットワークがこの確認を置き換えることはありません。"
           }
         }
       }
@@ -6100,13 +6100,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sign in to cmux on this phone with the same account the paired computer uses. Without that, there is nothing to connect to."
+            "value": "Sign in to cmux on this phone with the same account your computer uses. Computers on your account are found automatically once you sign in."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "この端末で、ペアリング済みコンピュータと同じアカウントを使ってcmuxにサインインします。サインインしないと、接続先がありません。"
+            "value": "この端末で、コンピュータと同じアカウントを使ってcmuxにサインインします。サインインすると、アカウントのコンピュータは自動的に見つかります。"
           }
         }
       }
@@ -6185,13 +6185,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "You paired this computer before, but it is not reachable now. Wake it and make sure cmux is running. Iroh will retry direct and relay paths; if you rely on a private network, connect both devices to it, then reconnect."
+            "value": "You paired this computer before, but it is not reachable now. Wake it and make sure cmux is running; this phone reconnects on its own."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このコンピュータは以前ペアリング済みですが、今は到達できません。コンピュータを起こしてcmuxが実行中か確認してください。Irohは直接経路とリレー経路を再試行します。プライベートネットワークを使っている場合は両方の端末を接続してから再接続してください。"
+            "value": "このコンピュータは以前ペアリング済みですが、今は到達できません。コンピュータを起こしてcmuxが実行中か確認してください。この端末は自動的に再接続します。"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2710,13 +2710,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No computers yet. Sign in to cmux on your computer with this account and it appears here automatically."
+            "value": "No computers yet. Sign in to cmux on your computer with this account and it appears here automatically. If it does not, tap Pair Another Computer and scan its QR code."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータはまだありません。コンピュータのcmuxにこのアカウントでサインインすると、ここに自動的に表示されます。"
+            "value": "コンピュータはまだありません。コンピュータのcmuxにこのアカウントでサインインすると、ここに自動的に表示されます。表示されない場合は、「別のコンピュータをペアリング」からQRコードをスキャンしてください。"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -6015,13 +6015,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign this phone out and back in with the computer's account, then try again."
+            "value": "The computer rejected this phone's sign-in, so the two are on different cmux accounts or this phone's session is stale. Sign either one out and back in so both use the same account, then try again."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータがこの端末のサインインを拒否しました。両者が別々のcmuxアカウントになっているか、この端末のセッションが古くなっています。この端末でいったんサインアウトし、コンピュータと同じアカウントでサインインし直してから、もう一度お試しください。"
+            "value": "コンピュータがこの端末のサインインを拒否しました。両者が別々のcmuxアカウントになっているか、この端末のセッションが古くなっています。どちらかでいったんサインアウトし、両方が同じアカウントになるようにサインインし直してから、もう一度お試しください。"
           }
         }
       }


### PR DESCRIPTION
The Set Up Computer sheet predates zero-touch Iroh discovery (https://github.com/manaflow-ai/cmux/pull/7908 wrote the copy; discovery landed later) and still taught QR scanning as the only way to connect, with protocol detail like "Iroh will retry direct and relay paths" and "After cmux admits both devices over Iroh". Switch Computer implied pairing is the only way a computer enters the list.

Both sheets now describe current behavior: a computer signed in to the same cmux account appears and connects automatically while cmux runs on it, and QR pairing (the Mac's Pair iPhone window) is the manual fallback. Iroh is mentioned once, with a plain explanation: direct connection when possible, encrypted cmux relay when not, both ends verify your account. The "Connect with Iroh" section header is now "How it connects".

Changed surfaces, English and Japanese together in ios/cmux/Resources/Localizable.xcstrings:
- Set Up Computer intro, all four gate bodies, network section title/body, LAN footnote, same-account footer
- Switch Computer footer and empty state

The onboarding pages keep their old copy on purpose; https://github.com/manaflow-ai/cmux/pull/8455 rebuilds onboarding from scratch and owns those files.

No behavior change, strings only. No practical behavior-level test applies; existing SetupHelpGateContentTests (link policy) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787251198&installation_model_id=21920&pr_number=8570&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8570&signature=07e81e85906914082c0fbf99b626cfb4b3c196e5a070fcbe6621bf022eb04238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite setup and switch‑computer copy for zero‑touch pairing. When both devices use the same `cmux` account and `cmux` is running on the computer, this phone connects automatically; the list adds a computer only after this phone’s first authenticated connect; the empty list now points to Pair Another Computer (QR) as the fallback; “How it connects” replaces “Connect with Iroh” with a plain `Iroh` explainer; and the account‑mismatch help says to sign out and back in on either device so both use the same account (also clears stale sessions). English and Japanese strings only.

<sup>Written for commit 3b2189cb49c2b85b7e1e3d0533ed7d7e2bf05ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated mobile host picker text to explain the paired-computers empty state and how computers appear automatically after signing in while cmux is running.
  * Refined paired-computers wording to clarify that “Pair Another Computer” adds entries without removing existing ones.
  * Reworded setup help across multiple states with clearer same-account sign-in guidance, account-mismatch recovery steps, and improved unreachable guidance.
  * Updated networking explanations (direct vs encrypted relay) and clarified relay privacy and that private-network setup doesn’t replace account verification, in both English and Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->