### PR TITLE
iOS: stop seeding fake placeholder workspaces on sign-out

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1259,27 +1259,24 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         terminalFullReplacementSeqBySurfaceID = [:]
         terminalFullReplacementGenerationBySurfaceID = [:]
         terminalFullReplacementGeneration = 0
-        // Reset foreground identity to anonymous BEFORE seeding the anonymous
-        // preview entry below: otherwise `foregroundMacKey` stays the old real Mac
-        // id, the seeded entry lands under the anonymous key, and the next
-        // `connect()` captures the stale real id as `previousForegroundKey` — so
-        // `dropStalePreviousForeground` drops the wrong key and the preview rows
-        // survive alongside the newly-connected Mac. Also drop the foreground
-        // connection-pool entry so a stale per-Mac connection can't be reused.
+        // Reset foreground identity to anonymous BEFORE clearing the per-Mac
+        // state below: otherwise the next `connect()` captures the stale real Mac
+        // id as `previousForegroundKey` and `dropStalePreviousForeground` drops
+        // the wrong key. Also drop the foreground connection-pool entry so a
+        // stale per-Mac connection can't be reused.
         foregroundMacDeviceID = nil
         connections = [:]
-        // Local preview / disconnected placeholder: seed the foreground (anonymous)
-        // entry as the source of truth; `workspaces`/`workspaceGroups` derive from
-        // it. Group sections are account-scoped like `pairedMacs`/`registryDevices`
-        // above: the placeholder workspaces are ungrouped, and the previous
-        // account's group names must not survive into the next session.
-        workspacesByMac = [Self.foregroundAnonymousKey: MacWorkspaceState(
-            macDeviceID: Self.foregroundAnonymousKey,
-            workspaces: PreviewMobileHost.workspaces,
-            groups: []
-        )]
-        resetStableMacColorSlotsForSignOut(); selectedWorkspaceID = workspaces.first?.id
-        selectedTerminalID = workspaces.first?.terminals.first?.id
+        // A signed-out store owns no Macs: clear the per-Mac source of truth so
+        // `workspaces`/`workspaceGroups` derive to empty. Group sections are
+        // account-scoped like `pairedMacs`/`registryDevices` above: the previous
+        // account's group names must not survive into the next session. Never
+        // seed `PreviewMobileHost` fixtures here — those fake "cmux"/"Docs" rows
+        // rendered as real disconnected workspaces on first launch and lingered
+        // after sign-in until the Mac connected.
+        workspacesByMac = [:]
+        resetStableMacColorSlotsForSignOut()
+        selectedWorkspaceID = nil
+        selectedTerminalID = nil
         // Selection resets above are done; allow draft saving again so a
         // subsequent sign-in restores drafts normally.
         isLoadingDraft = false

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerDefaultOpenTests.swift
@@ -1,3 +1,4 @@
+import CmuxMobileRPC
 import Foundation
 import Testing
 @testable import CmuxMobileShell
@@ -66,13 +67,20 @@ import CmuxMobileShellModel
 
     @Test func signOutForgetsComposerDismissals() throws {
         let store = MobileShellComposite.preview()
+        let terminal = try #require(store.selectedTerminalID)
         store.dismissComposer()
         #expect(store.isComposerPresented == false)
 
-        // Sign-out resets to the preview workspaces with the SAME terminal ids;
-        // the next account must get the default-open composer everywhere, not
-        // inherit the previous user's per-terminal dismissals.
+        // Sign-out empties the workspace list AND drops the per-terminal
+        // dismissals. When the next account's Mac reports the SAME terminal
+        // ids, the composer must be default-open again, not inherit the
+        // previous user's dismissals.
         store.signOut()
+        #expect(store.isComposerPresented == false)
+
+        store.replaceForegroundWorkspaceState(PreviewMobileHost.workspaces)
+        store.selectedWorkspaceID = store.workspaces.first?.id
+        store.selectedTerminalID = terminal
 
         #expect(store.isComposerPresented)
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePreviewTests.swift
@@ -131,7 +131,7 @@ import Testing
         #expect(store.connectedHostName == "cmux-macbook")
     }
 
-    @Test func signOutReturnsToPreviewHostState() {
+    @Test func signOutReturnsToSignInStateWithNoWorkspaces() {
         let store = MobileShellComposite.preview()
         store.signIn()
         store.pairingCode = "debug"
@@ -153,7 +153,10 @@ import Testing
         #expect(store.phase == .signIn)
         #expect(store.connectionState == .disconnected)
         #expect(store.connectedHostName.isEmpty)
-        #expect(store.selectedWorkspace?.name == "cmux")
+        // No placeholder workspaces survive sign-out: the next session starts
+        // from an empty list, not the `PreviewMobileHost` fixtures.
+        #expect(store.selectedWorkspace == nil)
+        #expect(store.workspaces.isEmpty)
         #expect(store.workspaceGroups.isEmpty)
     }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileSignOutPlaceholderWorkspaceTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileSignOutPlaceholderWorkspaceTests.swift
@@ -1,0 +1,37 @@
+import CmuxMobileShellModel
+import Testing
+@testable import CmuxMobileShell
+
+/// First launch runs an unauthenticated auth sync that calls `signOut()`, and
+/// signing out of an account calls it too. Neither may seed the
+/// `PreviewMobileHost` fixtures ("cmux", "Docs") into the live store: those
+/// fake rows rendered as real disconnected workspaces on first launch and
+/// stayed after sign-in until the Mac connected. The list must be empty
+/// instead; the fixtures are for SwiftUI previews and the UITest preview
+/// harness only.
+@MainActor
+@Suite struct MobileSignOutPlaceholderWorkspaceTests {
+    @Test func firstLaunchAuthSyncLeavesWorkspaceListEmpty() {
+        let store = CMUXMobileShellStore(
+            deliveredNotificationClearer: NoopDeliveredNotificationClearer()
+        )
+
+        store.signOut()
+
+        #expect(store.workspaces.isEmpty)
+        #expect(store.selectedWorkspaceID == nil)
+        #expect(store.selectedTerminalID == nil)
+    }
+
+    @Test func signOutClearsWorkspacesWithoutSeedingPlaceholders() {
+        let store = MobileShellComposite.preview()
+        store.signIn()
+        #expect(!store.workspaces.isEmpty)
+
+        store.signOut()
+
+        #expect(store.workspaces.isEmpty)
+        #expect(store.selectedWorkspaceID == nil)
+        #expect(store.selectedTerminalID == nil)
+    }
+}


### PR DESCRIPTION
signOut() runs on every unauthenticated auth sync, including first launch, and seeded the PreviewMobileHost fixtures ("cmux"/"Build", "Docs"/"Notes") into workspacesByMac as a "disconnected placeholder". Nothing cleared them on sign-in, so users saw fake disconnected workspaces that have nothing to do with their Mac on the login screen and after first sign-in until the real Mac connected (screenshot in report: two rows "cmux / Build" and "Docs / Notes", both "Disconnected").

The fix seeds an empty per-Mac map in signOut() instead, so `workspaces`/`workspaceGroups` derive to empty and the list shows nothing until a real Mac reports state. The fixtures remain for SwiftUI previews and the CMUX_UITEST_WORKSPACE_LIST_PREVIEW harness via MobileShellComposite.preview().

Two-commit structure: the first commit adds the failing regression test (CmuxMobileShell package, runs headlessly via swift test in CI), the second adds the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787251292&installation_model_id=21920&pr_number=8571&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8571&signature=4d59428fa48885b3f7fc51165b088e8355a055a6fe53363895f24dc4d34fdcf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop seeding placeholder workspaces on iOS sign-out so the list stays empty until a real Mac connects. This removes fake “cmux/Build” and “Docs/Notes” rows on first launch and after sign-in.

- **Bug Fixes**
  - On `signOut()`, clear `workspacesByMac`, reset `selectedWorkspaceID`/`selectedTerminalID`, and do not seed `PreviewMobileHost` fixtures; also drop the foreground connection pool to avoid reuse.
  - Keep fixtures only for SwiftUI previews and the UITest harness via `MobileShellComposite.preview()`.
  - Updated tests: added `MobileSignOutPlaceholderWorkspaceTests`; updated preview and composer tests to the no-placeholder contract and to verify composer default-open after reseeding the same terminal ids.

<sup>Written for commit 2175708fc8e1126142f8b17b652eb4d91eab22d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sign-out behavior to fully clear workspaces and unset the currently selected workspace and terminal.
  * Removed any preview/placeholder workspace seeding so the signed-out state always starts empty.
  * Aligned derived workspace/group lists with an empty post–sign-out state.
* **Tests**
  * Added coverage to verify sign-out leaves no workspaces and no selected IDs, including first-launch unauthenticated flow.
  * Updated existing sign-out-related preview/composer tests to match the new empty-state expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->