### PR TITLE
Reject non-canonical (leading-zero) IPv4 spellings when classifying Tailscale peers

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTailscalePeerAddress.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTailscalePeerAddress.swift
@@ -49,9 +49,9 @@ public struct CmxTailscalePeerAddress: Hashable, Sendable {
         var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
         guard inet_ntop(AF_INET, &address, &buffer, socklen_t(buffer.count)) != nil else { return nil }
         let canonical = decode(buffer)
-        // Older Darwin inet_pton accepts leading-zero octets as decimal while
-        // the dialer's inet_aton reads them as octal. Refuse any non-canonical
-        // spelling so classification never diverges from dialing, on any macOS.
+        // Darwin's inet_pton accepts leading-zero octets as decimal while the
+        // dialer's inet_aton reads them as octal. Refuse any non-canonical
+        // spelling so classification never diverges from dialing.
         guard canonical == value else { return nil }
         return (canonical, bytes)
     }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTailscalePeerAddress.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxTailscalePeerAddress.swift
@@ -48,7 +48,12 @@ public struct CmxTailscalePeerAddress: Hashable, Sendable {
         let bytes = withUnsafeBytes(of: &address) { Array($0) }
         var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
         guard inet_ntop(AF_INET, &address, &buffer, socklen_t(buffer.count)) != nil else { return nil }
-        return (decode(buffer), bytes)
+        let canonical = decode(buffer)
+        // Older Darwin inet_pton accepts leading-zero octets as decimal while
+        // the dialer's inet_aton reads them as octal. Refuse any non-canonical
+        // spelling so classification never diverges from dialing, on any macOS.
+        guard canonical == value else { return nil }
+        return (canonical, bytes)
     }
 
     private static func parseIPv6(_ value: String) -> (canonical: String, bytes: [UInt8])? {

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxTailscalePeerAddressTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxTailscalePeerAddressTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Testing
+@testable import CMUXMobileCore
+
+@Suite struct CmxTailscalePeerAddressTests {
+    @Test func acceptsCanonicalTailscalePeerIPv4() {
+        #expect(CmxTailscalePeerAddress("100.64.1.2")?.value == "100.64.1.2")
+    }
+
+    @Test func rejectsLeadingZeroIPv4Spellings() {
+        // inet_pton accepts leading-zero octets as decimal on some Darwin versions,
+        // while the dialer reads them as octal. A peer classifier must refuse the
+        // non-canonical spelling so it never diverges from what actually gets dialed.
+        #expect(CmxTailscalePeerAddress("0100.64.1.2") == nil)
+        #expect(CmxTailscalePeerAddress("100.064.1.2") == nil)
+    }
+}


### PR DESCRIPTION
## What you'd hit

`CmxTailscalePeerAddress` classifies `0100.64.1.2` and `100.064.1.2` as Tailscale peers. Those are leading-zero IPv4 spellings, and they are a trap. `inet_pton(AF_INET)` on some macOS versions parses `0100` as decimal 100, while the code that actually dials a host reads `0100` as octal (64). So the classifier says "this is peer 100.64.1.2, attachable" for a string that, once dialed, points somewhere else. That is a classify-versus-dial split on a trust boundary.

It is also OS-dependent. `inet_pton` rejects leading zeros on newer macOS and accepts them on older ones, so the same input classifies differently depending on where cmux runs.

## Fix

In `parseIPv4`, after `inet_ntop` produces the canonical dotted-decimal spelling, refuse any input that does not round-trip to it. A canonical address passes through unchanged; a leading-zero spelling is rejected. IPv6 is left alone, since `inet_pton(AF_INET6)` has no octal ambiguity and the code already canonicalizes compressed forms there.

## Tests

`RemotesClientTests.rejectsNonTailscaleHostsAsNotAttachable` already pins this policy with the two leading-zero tokens. It passed where `inet_pton` is strict and failed where it is lenient; with the fix it passes on both. Added a package-level `CmxTailscalePeerAddressTests` that checks the canonical-accept and leading-zero-reject cases against the type directly.

Verified on macOS 15, where the parse was lenient: `RemotesClientTests` went from failing with two issues to `Test run with 25 tests in 1 suite passed`, and the new package suite passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-canonical (leading-zero) IPv4 spellings when classifying Tailscale peers so classification matches what gets dialed. IPv6 is unchanged.

- **Bug Fixes**
  - In `CmxTailscalePeerAddress.parseIPv4`, require an exact round-trip to canonical dotted-decimal via `inet_ntop`; reject inputs that don’t match to avoid `inet_pton` vs `inet_aton` splits on Darwin.
  - Tests: added `CmxTailscalePeerAddressTests` to verify canonical accept and leading-zero reject.

<sup>Written for commit 20ea85aeb0b3e69f7c47135f64002987d3ddc242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252121&installation_model_id=21920&pr_number=8572&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8572&signature=570158fbc5e82132c291cb99f175482854e5d51055d356539fc7643bf81e2ba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv4 address validation to reject non-canonical formats, including addresses with leading-zero octets.
  * Ensured accepted IPv4 addresses retain their exact canonical representation.

* **Tests**
  * Added coverage for valid canonical addresses and invalid leading-zero formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->