### PR TITLE
Notify only after Pi agent settles

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -92,11 +92,17 @@ function normalizedLaunchArgv(): string[] {
 }
 
 function detectedPiVersion(): string | null {
-  const testVersion = firstString(process.env.CMUX_TEST_PI_VERSION);
-  if (testVersion) return testVersion;
-  const script = process.argv.slice(0, 2).find((value) => looksLikePiScript(String(value)));
+  const script = process.argv.slice(0, 2).find((value) => {
+    const candidate = String(value);
+    return looksLikePiScript(candidate) || looksLikePiExecutable(candidate);
+  });
   if (!script) return null;
-  let directory = path.dirname(path.resolve(String(script)));
+  let scriptPath = path.resolve(String(script));
+  try {
+    // npm launches through bin symlinks, so inspect the package containing the resolved script.
+    scriptPath = fs.realpathSync(scriptPath);
+  } catch (_) {}
+  let directory = path.dirname(scriptPath);
   for (let depth = 0; depth < 8; depth += 1) {
     try {
       const packageJSON = JSON.parse(fs.readFileSync(path.join(directory, "package.json"), "utf8"));

--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -91,6 +91,40 @@ function normalizedLaunchArgv(): string[] {
   return [resolveExecutable("pi"), ...raw.slice(1)];
 }
 
+function detectedPiVersion(): string | null {
+  const testVersion = firstString(process.env.CMUX_TEST_PI_VERSION);
+  if (testVersion) return testVersion;
+  const script = process.argv.slice(0, 2).find((value) => looksLikePiScript(String(value)));
+  if (!script) return null;
+  let directory = path.dirname(path.resolve(String(script)));
+  for (let depth = 0; depth < 8; depth += 1) {
+    try {
+      const packageJSON = JSON.parse(fs.readFileSync(path.join(directory, "package.json"), "utf8"));
+      if (
+        packageJSON?.name === "@earendil-works/pi-coding-agent" ||
+        packageJSON?.name === "@mariozechner/pi-coding-agent"
+      ) {
+        return firstString(packageJSON.version);
+      }
+    } catch (_) {}
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return null;
+}
+
+function supportsAgentSettled(): boolean {
+  const version = detectedPiVersion();
+  if (!version) return true;
+  const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!match) return true;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const patch = Number(match[3]);
+  return major > 0 || minor > 80 || (minor === 80 && patch >= 5);
+}
+
 function base64NulSeparated(values: string[]): string {
   const bytes: Buffer[] = [];
   for (const value of values) {

--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -12,9 +12,16 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 
 type HookExtra = Record<string, unknown>;
 
+interface PendingCompletion {
+  lastAssistantMessage?: string;
+  notificationType: string;
+  turnId: string;
+}
+
 interface SessionState {
   nextTurn: number;
   activeTurnId?: string;
+  pendingCompletion?: PendingCompletion;
   stopped: boolean;
 }
 
@@ -232,6 +239,7 @@ function beginTurn(sessionId: string, event: unknown): string {
   const turnId = eventTurnId(event) || `${sessionId}:turn-${state.nextTurn + 1}`;
   if (!eventTurnId(event)) state.nextTurn += 1;
   state.activeTurnId = turnId;
+  state.pendingCompletion = undefined;
   state.stopped = false;
   return turnId;
 }
@@ -248,8 +256,19 @@ function finishTurn(sessionId: string, event: unknown): string {
   const turnId = eventTurnId(event) || state.activeTurnId || `${sessionId}:turn-${state.nextTurn + 1}`;
   if (!eventTurnId(event) && !state.activeTurnId) state.nextTurn += 1;
   state.activeTurnId = undefined;
+  state.pendingCompletion = undefined;
   state.stopped = true;
   return turnId;
+}
+
+function settleTurn(sessionId: string): PendingCompletion | undefined {
+  const state = sessionStates.get(sessionId);
+  const completion = state?.pendingCompletion;
+  if (!state || !completion || state.stopped) return undefined;
+  state.activeTurnId = undefined;
+  state.pendingCompletion = undefined;
+  state.stopped = true;
+  return completion;
 }
 
 function warn(ctx: ExtensionContext | null, message: string, details: Record<string, unknown> = {}): void {

--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -122,9 +122,9 @@ function detectedPiVersion(): string | null {
 
 function supportsAgentSettled(): boolean {
   const version = detectedPiVersion();
-  if (!version) return true;
+  if (!version) return false;
   const match = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
-  if (!match) return true;
+  if (!match) return false;
   const major = Number(match[1]);
   const minor = Number(match[2]);
   const patch = Number(match[3]);

--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -228,7 +228,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     const sessionId = sessionIdFrom(ctx);
     const cwd = cwdFrom(ctx);
-    if (sessionId) stateFor(sessionId).stopped = false;
+    if (sessionId) {
+      const state = stateFor(sessionId);
+      state.pendingCompletion = undefined;
+      state.stopped = false;
+    }
     const ok = sendHook("session-start", ctx);
     if (ok && sessionId) ensureResumeBinding(ctx, sessionId, cwd);
   });
@@ -252,18 +256,31 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
   pi.on("agent_end", async (event, ctx) => {
     const sessionId = sessionIdFrom(ctx);
-    const turnId = sessionId ? finishTurn(sessionId, event) : undefined;
+    if (!sessionId) return;
+    const state = stateFor(sessionId);
     const message = lastAssistantMessage(event);
+    // Preserve the latest low-level result until Pi confirms no automatic work remains.
+    state.pendingCompletion = {
+      lastAssistantMessage: message || state.pendingCompletion?.lastAssistantMessage,
+      notificationType: firstString(objectValue(event, ["stopReason", "reason", "terminationReason"])) || "completed",
+      turnId: currentTurnId(sessionId, event),
+    };
+  });
+
+  pi.on("agent_settled", async (_event, ctx) => {
+    const sessionId = sessionIdFrom(ctx);
+    if (!sessionId) return;
+    // Consume pending completion before subprocess calls so duplicate settlement cannot notify twice.
+    const completion = settleTurn(sessionId);
+    if (!completion) return;
     const notificationRouted = sendHook("notification", ctx, {
-      message: message || "Task completed",
-      turn_id: turnId,
-      notification: {
-        type: firstString(objectValue(event, ["stopReason", "reason", "terminationReason"])) || "completed",
-      },
+      message: completion.lastAssistantMessage || "Task completed",
+      turn_id: completion.turnId,
+      notification: { type: completion.notificationType },
     });
     const stopPayload: HookExtra = {
-      last_assistant_message: message,
-      turn_id: turnId,
+      last_assistant_message: completion.lastAssistantMessage,
+      turn_id: completion.turnId,
     };
     if (notificationRouted) stopPayload.cmux_notification_routed = true;
     sendHook("stop", ctx, stopPayload);

--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -224,6 +224,22 @@ function sendFeed(eventName: "PreToolUse" | "PostToolUse", ctx: ExtensionContext
   } catch (_) {}
 }
 
+function publishPendingCompletion(ctx: ExtensionContext, sessionId: string): void {
+  const completion = settleTurn(sessionId);
+  if (!completion) return;
+  const notificationRouted = sendHook("notification", ctx, {
+    message: completion.lastAssistantMessage || "Task completed",
+    turn_id: completion.turnId,
+    notification: { type: completion.notificationType },
+  });
+  const stopPayload: HookExtra = {
+    last_assistant_message: completion.lastAssistantMessage,
+    turn_id: completion.turnId,
+  };
+  if (notificationRouted) stopPayload.cmux_notification_routed = true;
+  sendHook("stop", ctx, stopPayload);
+}
+
 export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     const sessionId = sessionIdFrom(ctx);
@@ -265,25 +281,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
       notificationType: firstString(objectValue(event, ["stopReason", "reason", "terminationReason"])) || "completed",
       turnId: currentTurnId(sessionId, event),
     };
+    // Older Pi versions do not emit agent_settled, so retain their established completion behavior.
+    if (!supportsAgentSettled()) publishPendingCompletion(ctx, sessionId);
   });
 
   pi.on("agent_settled", async (_event, ctx) => {
     const sessionId = sessionIdFrom(ctx);
-    if (!sessionId) return;
+    if (!sessionId || !ctx.isIdle()) return;
     // Consume pending completion before subprocess calls so duplicate settlement cannot notify twice.
-    const completion = settleTurn(sessionId);
-    if (!completion) return;
-    const notificationRouted = sendHook("notification", ctx, {
-      message: completion.lastAssistantMessage || "Task completed",
-      turn_id: completion.turnId,
-      notification: { type: completion.notificationType },
-    });
-    const stopPayload: HookExtra = {
-      last_assistant_message: completion.lastAssistantMessage,
-      turn_id: completion.turnId,
-    };
-    if (notificationRouted) stopPayload.cmux_notification_routed = true;
-    sendHook("stop", ctx, stopPayload);
+    publishPendingCompletion(ctx, sessionId);
   });
 
   pi.on("session_shutdown", async (event, ctx) => {

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -206,6 +206,7 @@ for (const name of [
   "session_start",
   "before_agent_start",
   "agent_end",
+  "agent_settled",
   "session_shutdown",
   "tool_execution_start",
   "tool_execution_end",
@@ -226,6 +227,13 @@ const ctx = {
     getSessionId() { return "pi-session-test"; }
   }
 };
+async function completionHookCount() {
+  // Count observable completion commands so lifecycle timing is tested without source inspection.
+  const path = process.env.CMUX_TEST_PI_ARGS_LOG;
+  if (!path || !Bun.file(path).size) return 0;
+  const lines = (await Bun.file(path).text()).split("\\n");
+  return lines.filter((line) => line.includes("hooks pi notification") || line.includes("hooks pi stop")).length;
+}
 await handlers.get("session_start")({}, ctx);
 await handlers.get("before_agent_start")({ prompt: "hello pi" }, ctx);
 await handlers.get("tool_execution_start")({
@@ -241,6 +249,15 @@ await handlers.get("tool_execution_end")({
   result: { content: [{ type: "text", text: "ok" }] },
   isError: false
 }, ctx);
+let completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [
+    { role: "user", content: "hello pi" },
+    { role: "assistant", content: [{ type: "text", text: "intermediate" }] }
+  ],
+  stopReason: "retrying"
+}, ctx);
+if (await completionHookCount() !== completionCount) throw new Error("agent_end emitted completion before settlement");
 await handlers.get("agent_end")({
   messages: [
     { role: "user", content: "hello pi" },
@@ -248,6 +265,12 @@ await handlers.get("agent_end")({
   ],
   stopReason: "completed"
 }, ctx);
+if (await completionHookCount() !== completionCount) throw new Error("repeated agent_end emitted completion before settlement");
+await handlers.get("agent_settled")({}, ctx);
+completionCount += 2;
+if (await completionHookCount() !== completionCount) throw new Error("agent_settled did not emit notification and stop");
+await handlers.get("agent_settled")({}, ctx);
+if (await completionHookCount() !== completionCount) throw new Error("duplicate agent_settled emitted completion twice");
 await handlers.get("session_shutdown")({ reason: "quit" }, ctx);
 const interruptedCtx = {
   cwd: "/tmp/pi-project",
@@ -257,7 +280,17 @@ const interruptedCtx = {
 };
 await handlers.get("session_start")({}, interruptedCtx);
 await handlers.get("before_agent_start")({ prompt: "interrupt me" }, interruptedCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [{ role: "assistant", content: "not yet settled" }],
+  stopReason: "completed"
+}, interruptedCtx);
+if (await completionHookCount() !== completionCount) throw new Error("interrupted agent emitted completion before settlement");
 await handlers.get("session_shutdown")({ reason: "terminated" }, interruptedCtx);
+completionCount += 1;
+if (await completionHookCount() !== completionCount) throw new Error("interrupted shutdown did not emit one stop");
+await handlers.get("agent_settled")({}, interruptedCtx);
+if (await completionHookCount() !== completionCount) throw new Error("late settlement emitted completion after shutdown");
 process.env.CMUX_PI_HOOKS_DISABLED = "1";
 const disabledCtx = {
   cwd: "/tmp/pi-project",
@@ -276,6 +309,7 @@ const notificationFailureCtx = {
 };
 await handlers.get("session_start")({}, notificationFailureCtx);
 await handlers.get("before_agent_start")({ prompt: "finish without routed notification" }, notificationFailureCtx);
+completionCount = await completionHookCount();
 await handlers.get("agent_end")({
   messages: [
     { role: "user", content: "finish without routed notification" },
@@ -283,6 +317,12 @@ await handlers.get("agent_end")({
   ],
   stopReason: "completed"
 }, notificationFailureCtx);
+if (await completionHookCount() !== completionCount) throw new Error("failed notification was attempted before settlement");
+await handlers.get("agent_settled")({}, notificationFailureCtx);
+completionCount += 2;
+if (await completionHookCount() !== completionCount) throw new Error("settlement did not attempt failed notification and stop");
+await handlers.get("agent_settled")({}, notificationFailureCtx);
+if (await completionHookCount() !== completionCount) throw new Error("failed notification was retried after duplicate settlement");
 """
         check = subprocess.run(
             [bun, "--eval", check_source],

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -311,6 +311,7 @@ if (await completionHookCount() !== completionCount) throw new Error("agent_sett
 await handlers.get("agent_settled")({}, ctx);
 if (await completionHookCount() !== completionCount) throw new Error("duplicate agent_settled emitted completion twice");
 await handlers.get("session_shutdown")({ reason: "quit" }, ctx);
+if (await completionHookCount() !== completionCount) throw new Error("shutdown after settlement emitted a duplicate stop");
 const interruptedCtx = {
   cwd: "/tmp/pi-project",
   isIdle() { return true; },

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -98,7 +98,15 @@ def main() -> int:
         bin_dir.mkdir()
         fake_pi = bin_dir / "pi"
         make_executable(fake_pi, "#!/usr/bin/env bash\nexit 0\n")
-        legacy_package = root / "node_modules" / "@earendil-works" / "pi-coding-agent"
+        modern_package = root / "modern-node-modules" / "@earendil-works" / "pi-coding-agent"
+        modern_cli = modern_package / "dist" / "cli.js"
+        modern_cli.parent.mkdir(parents=True)
+        make_executable(modern_cli, "#!/usr/bin/env node\n")
+        (modern_package / "package.json").write_text(
+            json.dumps({"name": "@earendil-works/pi-coding-agent", "version": "0.80.5"}),
+            encoding="utf-8",
+        )
+        legacy_package = root / "legacy-node-modules" / "@earendil-works" / "pi-coding-agent"
         legacy_cli = legacy_package / "dist" / "cli.js"
         legacy_cli.parent.mkdir(parents=True)
         make_executable(legacy_cli, "#!/usr/bin/env node\n")
@@ -192,7 +200,9 @@ esac
         check_env["CMUX_TEST_PI_STDIN_LOG"] = str(fake_stdin_log)
         check_env["CMUX_TEST_PI_ENV_LOG"] = str(fake_env_log)
         check_env["CMUX_TEST_PI_BINDING_FILE"] = str(fake_binding)
+        check_env["CMUX_TEST_PI_MODERN_SCRIPT_PATH"] = str(modern_cli)
         check_env["CMUX_TEST_PI_LEGACY_SCRIPT_PATH"] = str(legacy_pi)
+        check_env["CMUX_TEST_PI_UNKNOWN_SCRIPT_PATH"] = str(root / "unknown-bin" / "pi")
         check_env["OPENAI_API_KEY"] = "openai-secret-should-not-leak"
         check_env["ANTHROPIC_AUTH_TOKEN"] = "anthropic-secret-should-not-leak"
         check_env["CUSTOM_PASSWORD"] = "password-should-not-leak"
@@ -231,7 +241,7 @@ process.argv.splice(
   0,
   process.argv.length,
   "/opt/homebrew/bin/node",
-  "/tmp/node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
+  process.env.CMUX_TEST_PI_MODERN_SCRIPT_PATH,
   "--model",
   "anthropic/claude-sonnet-4-5"
 );
@@ -368,6 +378,28 @@ await handlers.get("agent_end")({
 }, legacyCtx);
 completionCount += 2;
 if (await completionHookCount() !== completionCount) throw new Error("legacy Pi agent_end did not emit completion fallback");
+process.argv.splice(
+  0,
+  process.argv.length,
+  "/opt/homebrew/bin/node",
+  process.env.CMUX_TEST_PI_UNKNOWN_SCRIPT_PATH
+);
+const unknownCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-unknown"; }
+  }
+};
+await handlers.get("session_start")({}, unknownCtx);
+await handlers.get("before_agent_start")({ prompt: "unknown pi" }, unknownCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [{ role: "assistant", content: "unknown done" }],
+  stopReason: "completed"
+}, unknownCtx);
+completionCount += 2;
+if (await completionHookCount() !== completionCount) throw new Error("unknown Pi agent_end did not emit completion fallback");
 """
         check = subprocess.run(
             [bun, "--eval", check_source],
@@ -412,7 +444,13 @@ if (await completionHookCount() !== completionCount) throw new Error("legacy Pi 
                 resume_ops.append("set")
             elif "surface resume clear" in line:
                 resume_ops.append("clear")
-        expected_resume_ops = ["set", "get", "clear", "set", "get", "clear", "set", "get", "set", "get"]
+        expected_resume_ops = [
+            "set", "get", "clear",
+            "set", "get", "clear",
+            "set", "get",
+            "set", "get",
+            "set", "get",
+        ]
         if resume_ops != expected_resume_ops:
             print(f"FAIL: extension did not verify resume binding after set, got {resume_ops!r}")
             return 1
@@ -483,6 +521,18 @@ if (await completionHookCount() !== completionCount) throw new Error("legacy Pi 
         )
         if legacy_stop_payload is None or legacy_stop_payload.get("last_assistant_message") != "legacy done":
             print(f"FAIL: legacy Pi agent_end did not emit its completion payload, got {payloads!r}")
+            return 1
+        unknown_stop_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-unknown"
+                and payload.get("hook_event_name") == "Stop"
+            ),
+            None,
+        )
+        if unknown_stop_payload is None or unknown_stop_payload.get("last_assistant_message") != "unknown done":
+            print(f"FAIL: unknown Pi agent_end did not emit its completion payload, got {payloads!r}")
             return 1
         interrupted_stop_payload = next(
             (payload for payload in payloads if payload.get("terminationReason") == "terminated"),

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -98,6 +98,19 @@ def main() -> int:
         bin_dir.mkdir()
         fake_pi = bin_dir / "pi"
         make_executable(fake_pi, "#!/usr/bin/env bash\nexit 0\n")
+        legacy_package = root / "node_modules" / "@earendil-works" / "pi-coding-agent"
+        legacy_cli = legacy_package / "dist" / "cli.js"
+        legacy_cli.parent.mkdir(parents=True)
+        make_executable(legacy_cli, "#!/usr/bin/env node\n")
+        (legacy_package / "package.json").write_text(
+            json.dumps({"name": "@earendil-works/pi-coding-agent", "version": "0.74.0"}),
+            encoding="utf-8",
+        )
+        # Match npm's launcher shape so version detection exercises the unresolved bin/pi symlink.
+        legacy_bin_dir = root / "legacy-bin"
+        legacy_bin_dir.mkdir()
+        legacy_pi = legacy_bin_dir / "pi"
+        legacy_pi.symlink_to(legacy_cli)
 
         fake_cmux = root / "fake-cmux"
         fake_args_log = root / "fake-cmux-args.log"
@@ -179,6 +192,7 @@ esac
         check_env["CMUX_TEST_PI_STDIN_LOG"] = str(fake_stdin_log)
         check_env["CMUX_TEST_PI_ENV_LOG"] = str(fake_env_log)
         check_env["CMUX_TEST_PI_BINDING_FILE"] = str(fake_binding)
+        check_env["CMUX_TEST_PI_LEGACY_SCRIPT_PATH"] = str(legacy_pi)
         check_env["OPENAI_API_KEY"] = "openai-secret-should-not-leak"
         check_env["ANTHROPIC_AUTH_TOKEN"] = "anthropic-secret-should-not-leak"
         check_env["CUSTOM_PASSWORD"] = "password-should-not-leak"
@@ -332,7 +346,12 @@ completionCount += 2;
 if (await completionHookCount() !== completionCount) throw new Error("settlement did not attempt failed notification and stop");
 await handlers.get("agent_settled")({}, notificationFailureCtx);
 if (await completionHookCount() !== completionCount) throw new Error("failed notification was retried after duplicate settlement");
-process.env.CMUX_TEST_PI_VERSION = "0.74.0";
+process.argv.splice(
+  0,
+  process.argv.length,
+  "/opt/homebrew/bin/node",
+  process.env.CMUX_TEST_PI_LEGACY_SCRIPT_PATH
+);
 const legacyCtx = {
   cwd: "/tmp/pi-project",
   isIdle() { return true; },
@@ -349,7 +368,6 @@ await handlers.get("agent_end")({
 }, legacyCtx);
 completionCount += 2;
 if (await completionHookCount() !== completionCount) throw new Error("legacy Pi agent_end did not emit completion fallback");
-delete process.env.CMUX_TEST_PI_VERSION;
 """
         check = subprocess.run(
             [bun, "--eval", check_source],

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -490,7 +490,13 @@ if (await completionHookCount() !== completionCount) throw new Error("malformed 
             print(f"FAIL: extension did not verify resume binding after set, got {resume_ops!r}")
             return 1
         payloads = payloads_from_log(stdin_log)
-        for session_id in ["pi-session-test", "pi-session-notification-fails"]:
+        for session_id in [
+            "pi-session-test",
+            "pi-session-notification-fails",
+            "pi-session-legacy",
+            "pi-session-unknown",
+            "pi-session-malformed",
+        ]:
             # Verify each completion path routes its notification before suppressing the native stop fallback.
             completion_events = [
                 payload.get("hook_event_name")

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -114,6 +114,14 @@ def main() -> int:
             json.dumps({"name": "@earendil-works/pi-coding-agent", "version": "0.74.0"}),
             encoding="utf-8",
         )
+        malformed_package = root / "malformed-node-modules" / "@earendil-works" / "pi-coding-agent"
+        malformed_cli = malformed_package / "dist" / "cli.js"
+        malformed_cli.parent.mkdir(parents=True)
+        make_executable(malformed_cli, "#!/usr/bin/env node\n")
+        (malformed_package / "package.json").write_text(
+            json.dumps({"name": "@earendil-works/pi-coding-agent", "version": "development"}),
+            encoding="utf-8",
+        )
         # Match npm's launcher shape so version detection exercises the unresolved bin/pi symlink.
         legacy_bin_dir = root / "legacy-bin"
         legacy_bin_dir.mkdir()
@@ -203,6 +211,7 @@ esac
         check_env["CMUX_TEST_PI_MODERN_SCRIPT_PATH"] = str(modern_cli)
         check_env["CMUX_TEST_PI_LEGACY_SCRIPT_PATH"] = str(legacy_pi)
         check_env["CMUX_TEST_PI_UNKNOWN_SCRIPT_PATH"] = str(root / "unknown-bin" / "pi")
+        check_env["CMUX_TEST_PI_MALFORMED_SCRIPT_PATH"] = str(malformed_cli)
         check_env["OPENAI_API_KEY"] = "openai-secret-should-not-leak"
         check_env["ANTHROPIC_AUTH_TOKEN"] = "anthropic-secret-should-not-leak"
         check_env["CUSTOM_PASSWORD"] = "password-should-not-leak"
@@ -400,6 +409,28 @@ await handlers.get("agent_end")({
 }, unknownCtx);
 completionCount += 2;
 if (await completionHookCount() !== completionCount) throw new Error("unknown Pi agent_end did not emit completion fallback");
+process.argv.splice(
+  0,
+  process.argv.length,
+  "/opt/homebrew/bin/node",
+  process.env.CMUX_TEST_PI_MALFORMED_SCRIPT_PATH
+);
+const malformedCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-malformed"; }
+  }
+};
+await handlers.get("session_start")({}, malformedCtx);
+await handlers.get("before_agent_start")({ prompt: "malformed pi" }, malformedCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [{ role: "assistant", content: "malformed done" }],
+  stopReason: "completed"
+}, malformedCtx);
+completionCount += 2;
+if (await completionHookCount() !== completionCount) throw new Error("malformed Pi agent_end did not emit completion fallback");
 """
         check = subprocess.run(
             [bun, "--eval", check_source],
@@ -417,9 +448,9 @@ if (await completionHookCount() !== completionCount) throw new Error("unknown Pi
             print(f"stderr={check.stderr.strip()}")
             return 1
 
-        args_log = wait_for_text(fake_args_log, 21, timeout=20.0)
-        stdin_log = wait_for_text(fake_stdin_log, 34, timeout=20.0)
-        env_log = wait_for_text(fake_env_log, 21 * 3, timeout=20.0)
+        args_log = wait_for_text(fake_args_log, 39, timeout=20.0)
+        stdin_log = wait_for_text(fake_stdin_log, 64, timeout=20.0)
+        env_log = wait_for_text(fake_env_log, 39 * 3, timeout=20.0)
         for expected in [
             "hooks pi session-start",
             "hooks pi prompt-submit",
@@ -450,30 +481,23 @@ if (await completionHookCount() !== completionCount) throw new Error("unknown Pi
             "set", "get",
             "set", "get",
             "set", "get",
+            "set", "get",
         ]
         if resume_ops != expected_resume_ops:
             print(f"FAIL: extension did not verify resume binding after set, got {resume_ops!r}")
             return 1
-        stop_notification_ops = []
-        for line in arg_lines:
-            if "hooks pi notification" in line:
-                stop_notification_ops.append("notification")
-            elif "hooks pi stop" in line:
-                stop_notification_ops.append("stop")
-        if stop_notification_ops[:2] != ["notification", "stop"]:
-            print(
-                "FAIL: Pi completion stop suppressed native fallback before custom notification, "
-                f"got {stop_notification_ops!r}"
-            )
-            return 1
-        if stop_notification_ops[-2:] != ["notification", "stop"]:
-            print(
-                "FAIL: Pi notification failure path did not attempt custom notification before stop, "
-                f"got {stop_notification_ops!r}"
-            )
-            return 1
-
         payloads = payloads_from_log(stdin_log)
+        for session_id in ["pi-session-test", "pi-session-notification-fails"]:
+            # Verify each completion path routes its notification before suppressing the native stop fallback.
+            completion_events = [
+                payload.get("hook_event_name")
+                for payload in payloads
+                if payload.get("session_id") == session_id
+                and payload.get("hook_event_name") in {"Notification", "Stop"}
+            ]
+            if completion_events != ["Notification", "Stop"]:
+                print(f"FAIL: completion hooks were out of order for {session_id}: {completion_events!r}")
+                return 1
         if not any(payload.get("session_id") == "pi-session-test" for payload in payloads):
             print(f"FAIL: extension did not pass session id, got {payloads!r}")
             return 1
@@ -533,6 +557,18 @@ if (await completionHookCount() !== completionCount) throw new Error("unknown Pi
         )
         if unknown_stop_payload is None or unknown_stop_payload.get("last_assistant_message") != "unknown done":
             print(f"FAIL: unknown Pi agent_end did not emit its completion payload, got {payloads!r}")
+            return 1
+        malformed_stop_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-malformed"
+                and payload.get("hook_event_name") == "Stop"
+            ),
+            None,
+        )
+        if malformed_stop_payload is None or malformed_stop_payload.get("last_assistant_message") != "malformed done":
+            print(f"FAIL: malformed Pi agent_end did not emit its completion payload, got {payloads!r}")
             return 1
         interrupted_stop_payload = next(
             (payload for payload in payloads if payload.get("terminationReason") == "terminated"),

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -333,6 +333,7 @@ if (await completionHookCount() !== completionCount) throw new Error("interrupte
 await handlers.get("agent_settled")({}, interruptedCtx);
 if (await completionHookCount() !== completionCount) throw new Error("late settlement emitted completion after shutdown");
 process.env.CMUX_PI_HOOKS_DISABLED = "1";
+const disabledCompletionCount = await completionHookCount();
 const disabledCtx = {
   cwd: "/tmp/pi-project",
   isIdle() { return true; },
@@ -342,6 +343,7 @@ const disabledCtx = {
 };
 await handlers.get("session_start")({}, disabledCtx);
 await handlers.get("session_shutdown")({ reason: "disabled" }, disabledCtx);
+if (await completionHookCount() !== disabledCompletionCount) throw new Error("hooks-disabled mode emitted completion hooks");
 delete process.env.CMUX_PI_HOOKS_DISABLED;
 const notificationFailureCtx = {
   cwd: "/tmp/pi-project",

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -221,8 +221,10 @@ process.argv.splice(
   "--model",
   "anthropic/claude-sonnet-4-5"
 );
+let agentIdle = true;
 const ctx = {
   cwd: "/tmp/pi-project",
+  isIdle() { return agentIdle; },
   sessionManager: {
     getSessionId() { return "pi-session-test"; }
   }
@@ -266,6 +268,10 @@ await handlers.get("agent_end")({
   stopReason: "completed"
 }, ctx);
 if (await completionHookCount() !== completionCount) throw new Error("repeated agent_end emitted completion before settlement");
+agentIdle = false;
+await handlers.get("agent_settled")({}, ctx);
+if (await completionHookCount() !== completionCount) throw new Error("busy settlement emitted completion while another run was active");
+agentIdle = true;
 await handlers.get("agent_settled")({}, ctx);
 completionCount += 2;
 if (await completionHookCount() !== completionCount) throw new Error("agent_settled did not emit notification and stop");
@@ -274,6 +280,7 @@ if (await completionHookCount() !== completionCount) throw new Error("duplicate 
 await handlers.get("session_shutdown")({ reason: "quit" }, ctx);
 const interruptedCtx = {
   cwd: "/tmp/pi-project",
+  isIdle() { return true; },
   sessionManager: {
     getSessionId() { return "pi-session-interrupted"; }
   }
@@ -294,6 +301,7 @@ if (await completionHookCount() !== completionCount) throw new Error("late settl
 process.env.CMUX_PI_HOOKS_DISABLED = "1";
 const disabledCtx = {
   cwd: "/tmp/pi-project",
+  isIdle() { return true; },
   sessionManager: {
     getSessionId() { return "pi-session-disabled"; }
   }
@@ -303,6 +311,7 @@ await handlers.get("session_shutdown")({ reason: "disabled" }, disabledCtx);
 delete process.env.CMUX_PI_HOOKS_DISABLED;
 const notificationFailureCtx = {
   cwd: "/tmp/pi-project",
+  isIdle() { return true; },
   sessionManager: {
     getSessionId() { return "pi-session-notification-fails"; }
   }
@@ -323,6 +332,24 @@ completionCount += 2;
 if (await completionHookCount() !== completionCount) throw new Error("settlement did not attempt failed notification and stop");
 await handlers.get("agent_settled")({}, notificationFailureCtx);
 if (await completionHookCount() !== completionCount) throw new Error("failed notification was retried after duplicate settlement");
+process.env.CMUX_TEST_PI_VERSION = "0.74.0";
+const legacyCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-legacy"; }
+  }
+};
+await handlers.get("session_start")({}, legacyCtx);
+await handlers.get("before_agent_start")({ prompt: "legacy pi" }, legacyCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [{ role: "assistant", content: "legacy done" }],
+  stopReason: "completed"
+}, legacyCtx);
+completionCount += 2;
+if (await completionHookCount() !== completionCount) throw new Error("legacy Pi agent_end did not emit completion fallback");
+delete process.env.CMUX_TEST_PI_VERSION;
 """
         check = subprocess.run(
             [bun, "--eval", check_source],
@@ -367,7 +394,7 @@ if (await completionHookCount() !== completionCount) throw new Error("failed not
                 resume_ops.append("set")
             elif "surface resume clear" in line:
                 resume_ops.append("clear")
-        expected_resume_ops = ["set", "get", "clear", "set", "get", "clear", "set", "get"]
+        expected_resume_ops = ["set", "get", "clear", "set", "get", "clear", "set", "get", "set", "get"]
         if resume_ops != expected_resume_ops:
             print(f"FAIL: extension did not verify resume binding after set, got {resume_ops!r}")
             return 1
@@ -426,6 +453,18 @@ if (await completionHookCount() !== completionCount) throw new Error("failed not
                 "FAIL: failed Pi completion notification still suppressed native notification fallback, "
                 f"got {fallback_stop_payload!r}"
             )
+            return 1
+        legacy_stop_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-legacy"
+                and payload.get("hook_event_name") == "Stop"
+            ),
+            None,
+        )
+        if legacy_stop_payload is None or legacy_stop_payload.get("last_assistant_message") != "legacy done":
+            print(f"FAIL: legacy Pi agent_end did not emit its completion payload, got {payloads!r}")
             return 1
         interrupted_stop_payload = next(
             (payload for payload in payloads if payload.get("terminationReason") == "terminated"),


### PR DESCRIPTION
## Context
Pi's `agent_end` marks a low-level run, so cmux can announce completion before automatic retries, compaction, or follow-up work. Fixes manaflow-ai/cmux#8568.

## Summary
- Defer modern Pi completion hooks until `agent_settled` and idle
- Preserve pre-0.80.5 behavior through package-version detection
- Cover retries, duplicate settlement, shutdown, notification failure, and npm-linked installations

## Dependencies
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787255943&installation_model_id=21920&pr_number=8574&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8574&signature=ee64f5c5b33cebe70e64d23ad10f9440b5464dd52b166b9c24c933dd77c9e6f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay Pi completion notifications until the agent has settled and the context is idle to avoid premature “done” signals during retries. Preserves legacy behavior for Pi versions before 0.80.5 and handles npm-linked, unknown, or malformed installs. Fixes manaflow-ai/cmux#8568.

- **Bug Fixes**
  - Publish completion on `agent_settled` only when `ctx.isIdle()`; de-duplicate settlements.
  - Track pending completion per session; preserve the latest assistant message and notification type; consume once.
  - Fall back to `agent_end` for legacy/unknown/malformed Pi with correct stop payload.
  - Send `notification` before `stop` and set `cmux_notification_routed` when delivered.
  - On shutdown before settlement, emit a single `stop`; ignore late settlements; respect hooks-disabled mode.
  - Detect Pi version by walking to the nearest `package.json` (realpath of npm bin symlink); supports `@earendil-works/pi-coding-agent` and `@mariozechner/pi-coding-agent`; gate modern behavior to >= 0.80.5.
  - Tests cover idle/busy settlement, retries, duplicates, shutdown, notification failure, legacy/unknown/malformed fallback, npm-linked detection, and hook order.

<sup>Written for commit 2c70f1442192353390ef000398c55eeadd33c829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pi turn lifecycle to defer completion notification and stop updates until the session settles, preventing duplicate events.
  * Added cross-turn pending completion tracking and ensured stop payloads include the latest assistant message.
  * Implemented Pi CLI version detection with feature gating, including correct behavior for modern, legacy, unknown, and malformed CLI layouts and proper busy/idle handling.
* **Tests**
  * Expanded the Pi extension regression test suite with more realistic fake CLI/package scenarios and stronger assertions for hook sequencing, event suppression, and stop payload contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->