### PR TITLE
iOS: native soft scroll edge effect under the workspace list chrome

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListBarUnderlap.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListBarUnderlap.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+#if os(iOS)
+/// Extends the workspace table under the vertical bars on iOS 26, where the
+/// scroll edge effect and `WorkspaceListScrollEdgeCoordinator`'s bar
+/// registration render the App Store-style soft blur over the underlap.
+///
+/// SwiftUI fits a `UIViewRepresentable` inside the safe area, so without this
+/// the table's frame starts below the search drawer and ends above the tab
+/// bar: rows hard-clip at the chrome and no scroll edge effect can render.
+/// The real UIKit bars still contribute safe area, so the table's automatic
+/// content-inset adjustment keeps rows and indicators clear of the chrome,
+/// and the keyboard region stays respected. Earlier releases keep the fitted
+/// frame: the coordinator's registration is iOS 26-gated, and underlapping
+/// without it would scroll full-opacity rows beneath legacy bars.
+struct WorkspaceListBarUnderlap: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.ignoresSafeArea(.container, edges: .vertical)
+        } else {
+            content
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -209,6 +209,14 @@ public struct WorkspaceListLayoutPreviewView: View {
         ProcessInfo.processInfo.environment["CMUX_UITEST_NOTIFICATION_BANNER"] == "1"
     }
 
+    /// `CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS=1` wraps the list in a tab
+    /// scaffold mirroring the shell's TabView, so scroll-edge behavior against
+    /// the real floating tab bar can be exercised without Mac pairing. Off by
+    /// default: the App Store screenshot rig expects the bare list chrome.
+    private var showsTabScaffold: Bool {
+        ProcessInfo.processInfo.environment["CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS"] == "1"
+    }
+
     public var body: some View {
         let workspacesBinding = $model.workspaces
         let refreshGenerationBinding = $refreshGeneration
@@ -220,7 +228,7 @@ public struct WorkspaceListLayoutPreviewView: View {
             } else if UITestConfig.workspaceDetailDelayedTerminalPreviewEnabled {
                 WorkspaceDetailDelayedTerminalPreviewView()
             } else {
-                NavigationStack {
+                let workspaceListStack = NavigationStack {
                     WorkspaceListSearchHost { searchText in
                         WorkspaceListView(
                             workspaces: model.workspaces,
@@ -301,6 +309,19 @@ public struct WorkspaceListLayoutPreviewView: View {
                             .frame(width: 1, height: 1)
                             .accessibilityHidden(true)
                     }
+                }
+                if showsTabScaffold {
+                    TabView {
+                        Tab("Workspaces", systemImage: "rectangle.stack") {
+                            workspaceListStack
+                        }
+                        Tab("Notifications", systemImage: "bell") {
+                            Text("Notification feed fixture")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                } else {
+                    workspaceListStack
                 }
             }
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
@@ -32,9 +32,22 @@ final class WorkspaceListScrollEdgeCoordinator {
             hosting: scrollView, inParentOfKind: UITabBarController.self
         )
         guard navigationContent != nil || tabContent != nil else { return }
+        // Compare the controllers' EFFECTIVE registration, not just cached
+        // identities: a transient replacement table can take a registration
+        // over and then clear it on departure, leaving this surviving table's
+        // cache claiming ownership it no longer holds. Re-registering on the
+        // next layout pass makes the handoff self-healing in both directions.
+        let topIsCurrent = navigationContent.map {
+            $0.contentScrollView(for: .top) === scrollView
+        } ?? true
+        let bottomIsCurrent = tabContent.map {
+            $0.contentScrollView(for: .bottom) === scrollView
+        } ?? true
         guard navigationContent !== navigationContentController
             || tabContent !== tabContentController
             || scrollView !== registeredScrollView
+            || !topIsCurrent
+            || !bottomIsCurrent
         else { return }
         unregister()
         registeredScrollView = scrollView

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
@@ -16,12 +16,19 @@ final class WorkspaceListScrollEdgeCoordinator {
     private weak var navigationContentController: UIViewController?
     private weak var tabContentController: UIViewController?
 
-    /// Re-resolves the bar-owning controllers for `scrollView` and registers
-    /// it with them. Called on every layout pass: the controller chain can
-    /// assemble incrementally (navigation controller before tab controller)
-    /// or reparent without the window changing, so a one-shot registration
-    /// would strand a partially registered edge. The identity guard makes the
-    /// repeated call a no-op (a few pointer hops) when nothing changed.
+    /// Re-resolves the bar-owning controllers for `scrollView` and claims any
+    /// edge whose registration is vacant. Called on every layout pass: the
+    /// controller chain can assemble incrementally (navigation controller
+    /// before tab controller) or reparent without the window changing, so a
+    /// one-shot registration would strand a partially registered edge.
+    ///
+    /// Ownership arbitration: an edge is claimed only when its current
+    /// registration is nil or held by a detached scroll view. A different
+    /// LIVE table keeps its registration, so coexisting tables (SwiftUI
+    /// transition overlap) never steal from each other; when the owner
+    /// departs it clears the edge and the survivor reclaims on its next
+    /// layout pass. When nothing changed this is a no-op costing a short
+    /// parent walk and two getter comparisons.
     func registerIfNeeded(for scrollView: UIScrollView) {
         guard #available(iOS 26.0, *) else { return }
         guard scrollView.window != nil else { return }
@@ -32,49 +39,56 @@ final class WorkspaceListScrollEdgeCoordinator {
             hosting: scrollView, inParentOfKind: UITabBarController.self
         )
         guard navigationContent != nil || tabContent != nil else { return }
-        // Compare the controllers' EFFECTIVE registration, not just cached
-        // identities: a transient replacement table can take a registration
-        // over and then clear it on departure, leaving this surviving table's
-        // cache claiming ownership it no longer holds. Re-registering on the
-        // next layout pass makes the handoff self-healing in both directions.
-        let topIsCurrent = navigationContent.map {
-            $0.contentScrollView(for: .top) === scrollView
-        } ?? true
-        let bottomIsCurrent = tabContent.map {
-            $0.contentScrollView(for: .bottom) === scrollView
-        } ?? true
-        guard navigationContent !== navigationContentController
-            || tabContent !== tabContentController
-            || scrollView !== registeredScrollView
-            || !topIsCurrent
-            || !bottomIsCurrent
-        else { return }
-        unregister()
+
+        if navigationContent !== navigationContentController
+            || scrollView !== registeredScrollView {
+            clearEdgeIfOwned(on: navigationContentController, edge: .top)
+        }
+        if tabContent !== tabContentController || scrollView !== registeredScrollView {
+            clearEdgeIfOwned(on: tabContentController, edge: .bottom)
+        }
         registeredScrollView = scrollView
         navigationContentController = navigationContent
         tabContentController = tabContent
-        navigationContent?.setContentScrollView(scrollView, for: .top)
-        tabContent?.setContentScrollView(scrollView, for: .bottom)
+
+        if let navigationContent,
+           Self.canClaim(current: navigationContent.contentScrollView(for: .top),
+                         claimant: scrollView) {
+            navigationContent.setContentScrollView(scrollView, for: .top)
+        }
+        if let tabContent,
+           Self.canClaim(current: tabContent.contentScrollView(for: .bottom),
+                         claimant: scrollView) {
+            tabContent.setContentScrollView(scrollView, for: .bottom)
+        }
     }
 
-    /// Clears this coordinator's registrations. A registration already taken
-    /// over by a replacement table (same controller, different scroll view)
-    /// is left intact.
+    /// Clears this coordinator's registrations. A registration held by
+    /// another table (same controller, different scroll view) is left intact.
     func unregister() {
         guard #available(iOS 26.0, *) else { return }
-        if let controller = navigationContentController,
-           let scrollView = registeredScrollView,
-           controller.contentScrollView(for: .top) === scrollView {
-            controller.setContentScrollView(nil, for: .top)
-        }
-        if let controller = tabContentController,
-           let scrollView = registeredScrollView,
-           controller.contentScrollView(for: .bottom) === scrollView {
-            controller.setContentScrollView(nil, for: .bottom)
-        }
+        clearEdgeIfOwned(on: navigationContentController, edge: .top)
+        clearEdgeIfOwned(on: tabContentController, edge: .bottom)
         navigationContentController = nil
         tabContentController = nil
         registeredScrollView = nil
+    }
+
+    private func clearEdgeIfOwned(on controller: UIViewController?, edge: NSDirectionalRectEdge) {
+        guard let controller,
+              let scrollView = registeredScrollView,
+              controller.contentScrollView(for: edge) === scrollView else { return }
+        controller.setContentScrollView(nil, for: edge)
+    }
+
+    /// Vacant (nil) and stale (holder departed its window without clearing,
+    /// e.g. deallocated mid-transition) registrations are claimable. An edge
+    /// already held by the claimant needs no re-set, and a different live
+    /// scroll view keeps ownership.
+    private static func canClaim(current: UIScrollView?, claimant: UIScrollView) -> Bool {
+        guard let current else { return true }
+        if current === claimant { return false }
+        return current.window == nil
     }
 
     /// The last view controller on `view`'s parent chain before the first

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
@@ -32,10 +32,10 @@ final class WorkspaceListScrollEdgeCoordinator {
     func registerIfNeeded(for scrollView: UIScrollView) {
         guard #available(iOS 26.0, *) else { return }
         guard scrollView.window != nil else { return }
-        let navigationContent = Self.contentController(
+        let navigationContent = contentController(
             hosting: scrollView, inParentOfKind: UINavigationController.self
         )
-        let tabContent = Self.contentController(
+        let tabContent = contentController(
             hosting: scrollView, inParentOfKind: UITabBarController.self
         )
         guard navigationContent != nil || tabContent != nil else { return }
@@ -52,13 +52,13 @@ final class WorkspaceListScrollEdgeCoordinator {
         tabContentController = tabContent
 
         if let navigationContent,
-           Self.canClaim(current: navigationContent.contentScrollView(for: .top),
-                         claimant: scrollView) {
+           canClaim(current: navigationContent.contentScrollView(for: .top),
+                    claimant: scrollView) {
             navigationContent.setContentScrollView(scrollView, for: .top)
         }
         if let tabContent,
-           Self.canClaim(current: tabContent.contentScrollView(for: .bottom),
-                         claimant: scrollView) {
+           canClaim(current: tabContent.contentScrollView(for: .bottom),
+                    claimant: scrollView) {
             tabContent.setContentScrollView(scrollView, for: .bottom)
         }
     }
@@ -83,14 +83,14 @@ final class WorkspaceListScrollEdgeCoordinator {
         // owned the edge, and UIKit does not guarantee it another layout pass
         // after this teardown. Nudge it so its next pass claims the vacancy;
         // the woken table still runs its own claim arbitration.
-        if let waiting = Self.firstWorkspaceTable(
+        if let waiting = firstWorkspaceTable(
             under: controller.viewIfLoaded, excluding: scrollView
         ) {
             waiting.setNeedsLayout()
         }
     }
 
-    private static func firstWorkspaceTable(
+    private func firstWorkspaceTable(
         under view: UIView?, excluding departing: UIScrollView
     ) -> WorkspaceListUITableView? {
         guard let view else { return nil }
@@ -109,7 +109,7 @@ final class WorkspaceListScrollEdgeCoordinator {
     /// e.g. deallocated mid-transition) registrations are claimable. An edge
     /// already held by the claimant needs no re-set, and a different live
     /// scroll view keeps ownership.
-    private static func canClaim(current: UIScrollView?, claimant: UIScrollView) -> Bool {
+    private func canClaim(current: UIScrollView?, claimant: UIScrollView) -> Bool {
         guard let current else { return true }
         if current === claimant { return false }
         return current.window == nil
@@ -118,7 +118,7 @@ final class WorkspaceListScrollEdgeCoordinator {
     /// The last view controller on `view`'s parent chain before the first
     /// container of `Kind`: the content controller whose bars that container
     /// derives from `setContentScrollView(_:for:)` registrations.
-    private static func contentController<Kind: UIViewController>(
+    private func contentController<Kind: UIViewController>(
         hosting view: UIView, inParentOfKind kind: Kind.Type
     ) -> UIViewController? {
         var responder: UIResponder? = view.next

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
@@ -1,0 +1,86 @@
+#if os(iOS)
+import UIKit
+
+/// Registers the workspace table as the content scroll view of its enclosing
+/// navigation and tab bar controllers so UIKit renders the scroll edge effect
+/// under the top chrome (navigation bar + search drawer) and behind the tab
+/// bar, App Store-style.
+///
+/// SwiftUI only drives bar scroll edge effects for its own scroll views. The
+/// workspace list is a `UIViewRepresentable` `UITableView`, invisible to that
+/// machinery, so without this registration the table's `.soft` top edge style
+/// never renders and rows hard-clip at the search bar's bottom edge.
+@MainActor
+final class WorkspaceListScrollEdgeCoordinator {
+    private weak var registeredScrollView: UIScrollView?
+    private weak var navigationContentController: UIViewController?
+    private weak var tabContentController: UIViewController?
+
+    /// Re-resolves the bar-owning controllers for `scrollView` and registers
+    /// it with them. Safe to call repeatedly; no-ops when nothing changed.
+    /// Returns false when no enclosing bar controller is reachable yet (the
+    /// view-controller parent chain may still be assembling), so the caller
+    /// can retry after the next layout pass.
+    @discardableResult
+    func registerIfNeeded(for scrollView: UIScrollView) -> Bool {
+        guard #available(iOS 26.0, *) else { return true }
+        guard scrollView.window != nil else { return false }
+        let navigationContent = Self.contentController(
+            hosting: scrollView, inParentOfKind: UINavigationController.self
+        )
+        let tabContent = Self.contentController(
+            hosting: scrollView, inParentOfKind: UITabBarController.self
+        )
+        guard navigationContent != nil || tabContent != nil else { return false }
+        if navigationContent !== navigationContentController
+            || tabContent !== tabContentController
+            || scrollView !== registeredScrollView {
+            unregister()
+            registeredScrollView = scrollView
+            navigationContentController = navigationContent
+            tabContentController = tabContent
+            navigationContent?.setContentScrollView(scrollView, for: .top)
+            tabContent?.setContentScrollView(scrollView, for: .bottom)
+        }
+        return true
+    }
+
+    /// Clears this coordinator's registrations. A registration already taken
+    /// over by a replacement table (same controller, different scroll view)
+    /// is left intact.
+    func unregister() {
+        guard #available(iOS 26.0, *) else { return }
+        if let controller = navigationContentController,
+           let scrollView = registeredScrollView,
+           controller.contentScrollView(for: .top) === scrollView {
+            controller.setContentScrollView(nil, for: .top)
+        }
+        if let controller = tabContentController,
+           let scrollView = registeredScrollView,
+           controller.contentScrollView(for: .bottom) === scrollView {
+            controller.setContentScrollView(nil, for: .bottom)
+        }
+        navigationContentController = nil
+        tabContentController = nil
+        registeredScrollView = nil
+    }
+
+    /// The last view controller on `view`'s parent chain before the first
+    /// container of `Kind`: the content controller whose bars that container
+    /// derives from `setContentScrollView(_:for:)` registrations.
+    private static func contentController<Kind: UIViewController>(
+        hosting view: UIView, inParentOfKind kind: Kind.Type
+    ) -> UIViewController? {
+        var responder: UIResponder? = view.next
+        while let current = responder, !(current is UIViewController) {
+            responder = current.next
+        }
+        guard var content = responder as? UIViewController else { return nil }
+        while let parent = content.parent {
+            if parent is Kind { return content }
+            content = parent
+        }
+        return nil
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
@@ -79,6 +79,30 @@ final class WorkspaceListScrollEdgeCoordinator {
               let scrollView = registeredScrollView,
               controller.contentScrollView(for: edge) === scrollView else { return }
         controller.setContentScrollView(nil, for: edge)
+        // Deterministic handoff: a waiting table stood down while this one
+        // owned the edge, and UIKit does not guarantee it another layout pass
+        // after this teardown. Nudge it so its next pass claims the vacancy;
+        // the woken table still runs its own claim arbitration.
+        if let waiting = Self.firstWorkspaceTable(
+            under: controller.viewIfLoaded, excluding: scrollView
+        ) {
+            waiting.setNeedsLayout()
+        }
+    }
+
+    private static func firstWorkspaceTable(
+        under view: UIView?, excluding departing: UIScrollView
+    ) -> WorkspaceListUITableView? {
+        guard let view else { return nil }
+        if let table = view as? WorkspaceListUITableView, table !== departing {
+            return table
+        }
+        for subview in view.subviews {
+            if let found = firstWorkspaceTable(under: subview, excluding: departing) {
+                return found
+            }
+        }
+        return nil
     }
 
     /// Vacant (nil) and stale (holder departed its window without clearing,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListScrollEdgeCoordinator.swift
@@ -17,32 +17,31 @@ final class WorkspaceListScrollEdgeCoordinator {
     private weak var tabContentController: UIViewController?
 
     /// Re-resolves the bar-owning controllers for `scrollView` and registers
-    /// it with them. Safe to call repeatedly; no-ops when nothing changed.
-    /// Returns false when no enclosing bar controller is reachable yet (the
-    /// view-controller parent chain may still be assembling), so the caller
-    /// can retry after the next layout pass.
-    @discardableResult
-    func registerIfNeeded(for scrollView: UIScrollView) -> Bool {
-        guard #available(iOS 26.0, *) else { return true }
-        guard scrollView.window != nil else { return false }
+    /// it with them. Called on every layout pass: the controller chain can
+    /// assemble incrementally (navigation controller before tab controller)
+    /// or reparent without the window changing, so a one-shot registration
+    /// would strand a partially registered edge. The identity guard makes the
+    /// repeated call a no-op (a few pointer hops) when nothing changed.
+    func registerIfNeeded(for scrollView: UIScrollView) {
+        guard #available(iOS 26.0, *) else { return }
+        guard scrollView.window != nil else { return }
         let navigationContent = Self.contentController(
             hosting: scrollView, inParentOfKind: UINavigationController.self
         )
         let tabContent = Self.contentController(
             hosting: scrollView, inParentOfKind: UITabBarController.self
         )
-        guard navigationContent != nil || tabContent != nil else { return false }
-        if navigationContent !== navigationContentController
+        guard navigationContent != nil || tabContent != nil else { return }
+        guard navigationContent !== navigationContentController
             || tabContent !== tabContentController
-            || scrollView !== registeredScrollView {
-            unregister()
-            registeredScrollView = scrollView
-            navigationContentController = navigationContent
-            tabContentController = tabContent
-            navigationContent?.setContentScrollView(scrollView, for: .top)
-            tabContent?.setContentScrollView(scrollView, for: .bottom)
-        }
-        return true
+            || scrollView !== registeredScrollView
+        else { return }
+        unregister()
+        registeredScrollView = scrollView
+        navigationContentController = navigationContent
+        tabContentController = tabContent
+        navigationContent?.setContentScrollView(scrollView, for: .top)
+        tabContent?.setContentScrollView(scrollView, for: .bottom)
     }
 
     /// Clears this coordinator's registrations. A registration already taken

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListUITableView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListUITableView.swift
@@ -8,7 +8,6 @@ final class WorkspaceListUITableView: UITableView {
 
     private var measuredWidth: CGFloat = 0
     private let scrollEdgeCoordinator = WorkspaceListScrollEdgeCoordinator()
-    private var needsScrollEdgeRegistration = false
 
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
@@ -23,10 +22,9 @@ final class WorkspaceListUITableView: UITableView {
     override func didMoveToWindow() {
         super.didMoveToWindow()
         if window == nil {
-            needsScrollEdgeRegistration = false
             scrollEdgeCoordinator.unregister()
         } else {
-            needsScrollEdgeRegistration = !scrollEdgeCoordinator.registerIfNeeded(for: self)
+            scrollEdgeCoordinator.registerIfNeeded(for: self)
         }
     }
 
@@ -37,8 +35,8 @@ final class WorkspaceListUITableView: UITableView {
         if previousWidth > 0, abs(previousWidth - measuredWidth) > 0.5 {
             layoutMetricsDidChange?()
         }
-        if needsScrollEdgeRegistration {
-            needsScrollEdgeRegistration = !scrollEdgeCoordinator.registerIfNeeded(for: self)
+        if window != nil {
+            scrollEdgeCoordinator.registerIfNeeded(for: self)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListUITableView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListUITableView.swift
@@ -7,6 +7,8 @@ final class WorkspaceListUITableView: UITableView {
     var layoutMetricsDidChange: (() -> Void)?
 
     private var measuredWidth: CGFloat = 0
+    private let scrollEdgeCoordinator = WorkspaceListScrollEdgeCoordinator()
+    private var needsScrollEdgeRegistration = false
 
     override init(frame: CGRect, style: UITableView.Style) {
         super.init(frame: frame, style: style)
@@ -18,12 +20,25 @@ final class WorkspaceListUITableView: UITableView {
         configureTopScrollEdgeEffect()
     }
 
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil {
+            needsScrollEdgeRegistration = false
+            scrollEdgeCoordinator.unregister()
+        } else {
+            needsScrollEdgeRegistration = !scrollEdgeCoordinator.registerIfNeeded(for: self)
+        }
+    }
+
     override func layoutSubviews() {
         let previousWidth = measuredWidth
         super.layoutSubviews()
         measuredWidth = bounds.width
         if previousWidth > 0, abs(previousWidth - measuredWidth) > 0.5 {
             layoutMetricsDidChange?()
+        }
+        if needsScrollEdgeRegistration {
+            needsScrollEdgeRegistration = !scrollEdgeCoordinator.registerIfNeeded(for: self)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -251,7 +251,15 @@ struct WorkspaceListView: View {
             visibleSelection: currentVisibleMacSelection
         )
         #if os(iOS)
+        // SwiftUI fits a UIViewRepresentable inside the safe area, so without
+        // this the table's frame starts below the search drawer and ends above
+        // the tab bar: rows hard-clip at the chrome and no scroll edge effect
+        // can render. Extending under the vertical bars restores the native
+        // underlap; the real UIKit bars still contribute safe area, so the
+        // table's automatic content-inset adjustment keeps rows and indicators
+        // clear of the chrome. The keyboard region stays respected.
         let baseList = workspaceTable
+            .ignoresSafeArea(.container, edges: .vertical)
         #else
         let baseList = List {
             switch connectionChrome {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -739,27 +739,3 @@ struct MobileDisconnectedFailureCopy {
         return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
     }
 }
-
-#if os(iOS)
-/// Extends the workspace table under the vertical bars on iOS 26, where the
-/// scroll edge effect and `WorkspaceListScrollEdgeCoordinator`'s bar
-/// registration render the App Store-style soft blur over the underlap.
-///
-/// SwiftUI fits a `UIViewRepresentable` inside the safe area, so without this
-/// the table's frame starts below the search drawer and ends above the tab
-/// bar: rows hard-clip at the chrome and no scroll edge effect can render.
-/// The real UIKit bars still contribute safe area, so the table's automatic
-/// content-inset adjustment keeps rows and indicators clear of the chrome,
-/// and the keyboard region stays respected. Earlier releases keep the fitted
-/// frame: the coordinator's registration is iOS 26-gated, and underlapping
-/// without it would scroll full-opacity rows beneath legacy bars.
-private struct WorkspaceListBarUnderlap: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
-            content.ignoresSafeArea(.container, edges: .vertical)
-        } else {
-            content
-        }
-    }
-}
-#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -251,15 +251,8 @@ struct WorkspaceListView: View {
             visibleSelection: currentVisibleMacSelection
         )
         #if os(iOS)
-        // SwiftUI fits a UIViewRepresentable inside the safe area, so without
-        // this the table's frame starts below the search drawer and ends above
-        // the tab bar: rows hard-clip at the chrome and no scroll edge effect
-        // can render. Extending under the vertical bars restores the native
-        // underlap; the real UIKit bars still contribute safe area, so the
-        // table's automatic content-inset adjustment keeps rows and indicators
-        // clear of the chrome. The keyboard region stays respected.
         let baseList = workspaceTable
-            .ignoresSafeArea(.container, edges: .vertical)
+            .modifier(WorkspaceListBarUnderlap())
         #else
         let baseList = List {
             switch connectionChrome {
@@ -746,3 +739,27 @@ struct MobileDisconnectedFailureCopy {
         return parts.isEmpty ? nil : parts.joined(separator: "\n\n")
     }
 }
+
+#if os(iOS)
+/// Extends the workspace table under the vertical bars on iOS 26, where the
+/// scroll edge effect and `WorkspaceListScrollEdgeCoordinator`'s bar
+/// registration render the App Store-style soft blur over the underlap.
+///
+/// SwiftUI fits a `UIViewRepresentable` inside the safe area, so without this
+/// the table's frame starts below the search drawer and ends above the tab
+/// bar: rows hard-clip at the chrome and no scroll edge effect can render.
+/// The real UIKit bars still contribute safe area, so the table's automatic
+/// content-inset adjustment keeps rows and indicators clear of the chrome,
+/// and the keyboard region stays respected. Earlier releases keep the fitted
+/// frame: the coordinator's registration is iOS 26-gated, and underlapping
+/// without it would scroll full-opacity rows beneath legacy bars.
+private struct WorkspaceListBarUnderlap: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content.ignoresSafeArea(.container, edges: .vertical)
+        } else {
+            content
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
@@ -83,20 +83,22 @@ import UIKit
         #expect(fixture.navigation.contentScrollView(for: .bottom) === fixture.tableView)
     }
 
-    /// When the owning table departs it clears the edges, and the surviving
-    /// table reclaims them on its next layout pass.
+    /// When the owning table departs it clears the edges and nudges the
+    /// waiting table, which claims them on the next layout flush. The test
+    /// only flushes pending window layout; the survivor is never marked
+    /// dirty by hand, so a missing wake fails the assertions.
     @Test func survivingTableReclaimsRegistrationAfterOwnerDeparts() throws {
         guard #available(iOS 26.0, *) else { return }
         let fixture = Fixture()
         let second = WorkspaceListUITableView(frame: .zero, style: .plain)
         fixture.content.view.addSubview(second)
         second.layoutIfNeeded()
+        #expect(fixture.content.contentScrollView(for: .top) === fixture.tableView)
 
         fixture.tableView.removeFromSuperview()
         #expect(fixture.content.contentScrollView(for: .top) == nil)
 
-        second.setNeedsLayout()
-        second.layoutIfNeeded()
+        fixture.window.layoutIfNeeded()
 
         #expect(fixture.content.contentScrollView(for: .top) === second)
         #expect(fixture.navigation.contentScrollView(for: .bottom) === second)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
@@ -55,20 +55,20 @@ import UIKit
         #expect(navigation.contentScrollView(for: .bottom) === tableView)
     }
 
-    /// Reverse handoff: a transient replacement takes the registration over
-    /// and clears it when it departs. The surviving table must reclaim the
-    /// registration on its next layout pass instead of trusting its cache.
-    @Test func survivingTableRestoresRegistrationAfterReplacementDeparts() throws {
+    /// While two live tables coexist (SwiftUI transition overlap), the later
+    /// one must not steal the registration: ownership would otherwise become
+    /// layout-order dependent and thrash on every pass.
+    @Test func coexistingTablesDoNotStealRegistrationFromEachOther() throws {
         guard #available(iOS 26.0, *) else { return }
         let fixture = Fixture()
-        let replacement = WorkspaceListUITableView(frame: .zero, style: .plain)
-        fixture.content.view.addSubview(replacement)
-        replacement.layoutIfNeeded()
-        #expect(fixture.content.contentScrollView(for: .top) === replacement)
+        let second = WorkspaceListUITableView(frame: .zero, style: .plain)
 
-        replacement.removeFromSuperview()
-        #expect(fixture.content.contentScrollView(for: .top) == nil)
+        fixture.content.view.addSubview(second)
+        second.layoutIfNeeded()
+        #expect(fixture.content.contentScrollView(for: .top) === fixture.tableView)
 
+        second.setNeedsLayout()
+        second.layoutIfNeeded()
         fixture.tableView.setNeedsLayout()
         fixture.tableView.layoutIfNeeded()
 
@@ -76,16 +76,23 @@ import UIKit
         #expect(fixture.navigation.contentScrollView(for: .bottom) === fixture.tableView)
     }
 
-    @Test func departingTableDoesNotClobberReplacementRegistration() throws {
+    /// When the owning table departs it clears the edges, and the surviving
+    /// table reclaims them on its next layout pass.
+    @Test func survivingTableReclaimsRegistrationAfterOwnerDeparts() throws {
         guard #available(iOS 26.0, *) else { return }
         let fixture = Fixture()
-        let replacement = WorkspaceListUITableView(frame: .zero, style: .plain)
+        let second = WorkspaceListUITableView(frame: .zero, style: .plain)
+        fixture.content.view.addSubview(second)
+        second.layoutIfNeeded()
 
-        fixture.content.view.addSubview(replacement)
-        replacement.layoutIfNeeded()
         fixture.tableView.removeFromSuperview()
+        #expect(fixture.content.contentScrollView(for: .top) == nil)
 
-        #expect(fixture.content.contentScrollView(for: .top) === replacement)
+        second.setNeedsLayout()
+        second.layoutIfNeeded()
+
+        #expect(fixture.content.contentScrollView(for: .top) === second)
+        #expect(fixture.navigation.contentScrollView(for: .bottom) === second)
     }
 
     /// Table hosted under `UITabBarController > UINavigationController >

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
@@ -1,0 +1,67 @@
+#if os(iOS)
+import Testing
+import UIKit
+@testable import CmuxMobileShellUI
+
+/// The workspace table is a `UIViewRepresentable`, so SwiftUI never registers
+/// it with the enclosing bars. These tests pin the UIKit contract that makes
+/// the soft scroll edge effect render: once hosted under a navigation and tab
+/// bar controller, the table must be each container's content scroll view.
+@MainActor
+@Suite struct WorkspaceListScrollEdgeEffectTests {
+    @Test func hostedTableDrivesNavigationAndTabBarScrollEdgeEffects() throws {
+        guard #available(iOS 26.0, *) else { return }
+        let fixture = Fixture()
+
+        #expect(fixture.content.contentScrollView(for: .top) === fixture.tableView)
+        #expect(fixture.navigation.contentScrollView(for: .bottom) === fixture.tableView)
+    }
+
+    @Test func tableLeavingTheWindowReleasesBarRegistrations() throws {
+        guard #available(iOS 26.0, *) else { return }
+        let fixture = Fixture()
+
+        fixture.tableView.removeFromSuperview()
+
+        #expect(fixture.content.contentScrollView(for: .top) == nil)
+        #expect(fixture.navigation.contentScrollView(for: .bottom) == nil)
+    }
+
+    @Test func departingTableDoesNotClobberReplacementRegistration() throws {
+        guard #available(iOS 26.0, *) else { return }
+        let fixture = Fixture()
+        let replacement = WorkspaceListUITableView(frame: .zero, style: .plain)
+
+        fixture.content.view.addSubview(replacement)
+        replacement.layoutIfNeeded()
+        fixture.tableView.removeFromSuperview()
+
+        #expect(fixture.content.contentScrollView(for: .top) === replacement)
+    }
+
+    /// Table hosted under `UITabBarController > UINavigationController >
+    /// content`, mirroring the shell's TabView + NavigationStack chrome.
+    @MainActor
+    private struct Fixture {
+        let tableView: WorkspaceListUITableView
+        let content: UIViewController
+        let navigation: UINavigationController
+        let tabs: UITabBarController
+        let window: UIWindow
+
+        init() {
+            tableView = WorkspaceListUITableView(frame: .zero, style: .plain)
+            content = UIViewController()
+            content.view.addSubview(tableView)
+            navigation = UINavigationController(rootViewController: content)
+            tabs = UITabBarController()
+            tabs.viewControllers = [navigation]
+            window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+            window.rootViewController = tabs
+            window.isHidden = false
+            window.layoutIfNeeded()
+            content.view.layoutIfNeeded()
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
@@ -55,6 +55,27 @@ import UIKit
         #expect(navigation.contentScrollView(for: .bottom) === tableView)
     }
 
+    /// Reverse handoff: a transient replacement takes the registration over
+    /// and clears it when it departs. The surviving table must reclaim the
+    /// registration on its next layout pass instead of trusting its cache.
+    @Test func survivingTableRestoresRegistrationAfterReplacementDeparts() throws {
+        guard #available(iOS 26.0, *) else { return }
+        let fixture = Fixture()
+        let replacement = WorkspaceListUITableView(frame: .zero, style: .plain)
+        fixture.content.view.addSubview(replacement)
+        replacement.layoutIfNeeded()
+        #expect(fixture.content.contentScrollView(for: .top) === replacement)
+
+        replacement.removeFromSuperview()
+        #expect(fixture.content.contentScrollView(for: .top) == nil)
+
+        fixture.tableView.setNeedsLayout()
+        fixture.tableView.layoutIfNeeded()
+
+        #expect(fixture.content.contentScrollView(for: .top) === fixture.tableView)
+        #expect(fixture.navigation.contentScrollView(for: .bottom) === fixture.tableView)
+    }
+
     @Test func departingTableDoesNotClobberReplacementRegistration() throws {
         guard #available(iOS 26.0, *) else { return }
         let fixture = Fixture()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
@@ -29,7 +29,14 @@ import UIKit
 
     /// The controller chain can assemble incrementally: the navigation
     /// controller can host the table before it joins a tab bar controller.
-    /// A one-shot registration would strand the bottom edge unregistered.
+    /// Whichever lifecycle path fires for the move (UIKit container
+    /// attachment always relocates the child's view, so `didMoveToWindow`
+    /// and layout passes both run), the bottom edge must end registered.
+    /// UIKit's hierarchy-consistency check forbids re-parenting a controller
+    /// whose view stays in a foreign hierarchy, so a window-stable variant of
+    /// this scenario is not constructible; the window-stable layout-retry
+    /// path is covered by
+    /// ``survivingTableReclaimsRegistrationAfterOwnerDeparts()``.
     @Test func lateTabControllerAttachmentStillRegistersBottomEdge() throws {
         guard #available(iOS 26.0, *) else { return }
         let tableView = WorkspaceListUITableView(frame: .zero, style: .plain)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollEdgeEffectTests.swift
@@ -27,6 +27,34 @@ import UIKit
         #expect(fixture.navigation.contentScrollView(for: .bottom) == nil)
     }
 
+    /// The controller chain can assemble incrementally: the navigation
+    /// controller can host the table before it joins a tab bar controller.
+    /// A one-shot registration would strand the bottom edge unregistered.
+    @Test func lateTabControllerAttachmentStillRegistersBottomEdge() throws {
+        guard #available(iOS 26.0, *) else { return }
+        let tableView = WorkspaceListUITableView(frame: .zero, style: .plain)
+        let content = UIViewController()
+        content.view.addSubview(tableView)
+        let navigation = UINavigationController(rootViewController: content)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = navigation
+        window.isHidden = false
+        window.layoutIfNeeded()
+        content.view.layoutIfNeeded()
+        #expect(content.contentScrollView(for: .top) === tableView)
+        #expect(navigation.contentScrollView(for: .bottom) == nil)
+
+        let tabs = UITabBarController()
+        window.rootViewController = tabs
+        tabs.viewControllers = [navigation]
+        window.layoutIfNeeded()
+        tableView.setNeedsLayout()
+        tableView.layoutIfNeeded()
+
+        #expect(content.contentScrollView(for: .top) === tableView)
+        #expect(navigation.contentScrollView(for: .bottom) === tableView)
+    }
+
     @Test func departingTableDoesNotClobberReplacementRegistration() throws {
         guard #available(iOS 26.0, *) else { return }
         let fixture = Fixture()


### PR DESCRIPTION
The workspace list never rendered a scroll edge effect: rows scrolled under the search bar at full opacity and hard-clipped, instead of soft-fading under the chrome like the App Store list.

Two root causes, one per commit pair:

1. The table is a `UIViewRepresentable` `UITableView`, and SwiftUI only drives bar scroll edge effects for its own scroll views. A new `WorkspaceListScrollEdgeCoordinator` (same approach as the chat screen's `ChatScrollEdgeCoordinator`) registers the table as the content scroll view of its enclosing bar controllers via `setContentScrollView(_:for:)`, resolved by walking from the table to the last view controller before the nearest `UINavigationController` (top) and `UITabBarController` (bottom), iOS 26-gated. Registration happens in `didMoveToWindow` with a `layoutSubviews` retry; unregistration only clears registrations the departing table still owns.

2. SwiftUI fits a representable inside the safe area, so the table's frame started below the search drawer and ended above the tab bar; content clipped at the table's own bounds and the effect had no covered region to render into. `ignoresSafeArea(.container, edges: .vertical)` restores the native underlap; the real UIKit bars still contribute safe area, so automatic content-inset adjustment keeps rows and indicators clear of the chrome.

Result: App Store-style progressive soft blur under the toolbar + search bar and behind the floating tab bar, verified in dark and light mode on an isolated iPhone 17 sim (iOS 26.5) with the preview fixture and against a live paired tagged Mac. Red/green commit structure: the registration tests land first and fail, the fix follows.

The DEBUG preview fixture gains `CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS=1` to wrap the list in a TabView so the tab bar's bottom edge is dogfoodable without Mac pairing (off by default; the App Store screenshot rig keeps its bare chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787261195&installation_model_id=21920&pr_number=8575&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8575&signature=4977b32f6734bf331d89c13dc97e7a1d9beb38d016977cb0f704f2a070bb2ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced iOS workspace list scroll-edge behavior to support correct rendering when embedded in navigation and tab bar containers.
  - Added a DEBUG-only option to display an optional tab scaffold in the workspace list layout preview.
- **Bug Fixes**
  - Workspace list content now extends under the vertical safe-area chrome for better alignment with surrounding UI.
  - Improved scroll-edge registration/unregistration tied to the view’s window lifecycle, including incremental container attachment and table replacement/overlap handling.
- **Tests**
  - Added iOS UI tests covering scroll-edge container registration, cleanup on removal, delayed container assembly, and multi-table replacement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->