### PR TITLE
Show git status in the file explorer for repos reached through a symlink

### DIFF
--- a/Sources/GitStatusProvider.swift
+++ b/Sources/GitStatusProvider.swift
@@ -23,10 +23,15 @@ struct GitStatusProvider: Sendable {
 
     func fetchStatus(directory: String) -> [String: GitFileStatus] {
         guard let repoRoot = gitRepoRoot(for: directory) else { return [:] }
+        // git reports the repo root physically (/private/var/...) while the caller may spell
+        // the explorer root through a symlink (/var, /tmp, a symlinked project dir). Resolve
+        // both to one spelling for the containment check, and emit keys under the caller's
+        // spelling so FileExplorerStore lookups match.
         return parseGitStatus(
             output: runGit(in: repoRoot, arguments: ["status", "--porcelain=v1", "-z"]),
-            repoRoot: repoRoot,
-            explorerRoot: directory
+            repoRoot: Self.canonicalPath(repoRoot),
+            explorerRoot: Self.canonicalPath(directory),
+            keyRoot: directory
         )
     }
 
@@ -49,16 +54,19 @@ struct GitStatusProvider: Sendable {
         let parts = output.components(separatedBy: "---GIT_STATUS---\n")
         guard parts.count == 2 else { return [:] }
         let repoRoot = parts[0].trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-        return parseGitStatus(output: parts[1], repoRoot: repoRoot, explorerRoot: directory)
+        // Remote paths must not be resolved against the local filesystem, so the comparison
+        // space and the key space are both the caller's spelling here.
+        return parseGitStatus(output: parts[1], repoRoot: repoRoot, explorerRoot: directory, keyRoot: directory)
     }
 
     private func parseGitStatus(
-        output: String?, repoRoot: String, explorerRoot: String
+        output: String?, repoRoot: String, explorerRoot: String, keyRoot: String
     ) -> [String: GitFileStatus] {
         guard let output, !output.isEmpty else { return [:] }
         var statusMap: [String: GitFileStatus] = [:]
         let normalizedRepoRoot = Self.pathWithoutTrailingSlashes(repoRoot)
         let normalizedExplorerRoot = Self.pathWithoutTrailingSlashes(explorerRoot)
+        let normalizedKeyRoot = Self.pathWithoutTrailingSlashes(keyRoot)
         let entries = output.split(separator: "\0", omittingEmptySubsequences: true).map(String.init)
 
         var entryIndex = 0
@@ -77,11 +85,22 @@ struct GitStatusProvider: Sendable {
 
             let absolutePath = Self.absolutePath(repoRoot: normalizedRepoRoot, relativePath: path)
             guard Self.path(absolutePath, isContainedIn: normalizedExplorerRoot) else { continue }
+            // Re-spell the key under the caller's root. When the two roots already match
+            // (the common case) the path is used as-is; the root == "/" branch keeps the
+            // leading slash that dropFirst would otherwise eat.
+            let key: String
+            if normalizedKeyRoot == normalizedExplorerRoot {
+                key = absolutePath
+            } else if normalizedExplorerRoot == "/" {
+                key = normalizedKeyRoot + absolutePath
+            } else {
+                key = normalizedKeyRoot + String(absolutePath.dropFirst(normalizedExplorerRoot.count))
+            }
 
-            statusMap[absolutePath] = status
+            statusMap[key] = status
             markParentDirectories(
-                absolutePath: absolutePath,
-                explorerRoot: normalizedExplorerRoot,
+                absolutePath: key,
+                explorerRoot: normalizedKeyRoot,
                 status: status,
                 in: &statusMap
             )
@@ -117,6 +136,10 @@ struct GitStatusProvider: Sendable {
 
     private static func statusUsesSecondPath(index: Character, workTree: Character) -> Bool {
         index == "R" || workTree == "R" || index == "C" || workTree == "C"
+    }
+
+    private static func canonicalPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
     }
 
     private static func absolutePath(repoRoot: String, relativePath: String) -> String {

--- a/Sources/GitStatusProvider.swift
+++ b/Sources/GitStatusProvider.swift
@@ -86,8 +86,9 @@ struct GitStatusProvider: Sendable {
             let absolutePath = Self.absolutePath(repoRoot: normalizedRepoRoot, relativePath: path)
             guard Self.path(absolutePath, isContainedIn: normalizedExplorerRoot) else { continue }
             // Re-spell the key under the caller's root. When the two roots already match
-            // (the common case) the path is used as-is; the root == "/" branch keeps the
-            // leading slash that dropFirst would otherwise eat.
+            // (the common case) the path is used as-is. The root == "/" branch is reached
+            // when the caller's root is a symlink to "/" (the canonical root is "/" while
+            // keyRoot is not) and keeps the leading slash that dropFirst would otherwise eat.
             let key: String
             if normalizedKeyRoot == normalizedExplorerRoot {
                 key = absolutePath


### PR DESCRIPTION
## What you'd hit

Open a workspace whose path goes through a symlink and the file explorer shows no git status at all, no modified/added/untracked markers, however dirty the tree is. Every macOS temporary directory is such a path (`/var` and `/tmp` are symlinks to `/private/var` and `/private/tmp`), and so is any project kept behind a symlink.

## Why

`GitStatusProvider` asks git for the repo root, and git answers with the physical path (`/private/var/...`). The caller passes the explorer root as the user spelled it (`/var/...`). The provider then keeps only the status entries whose absolute path is a string prefix of the explorer root. `/private/var/...` is not a prefix of `/var/...`, so every entry is dropped and the status map comes back empty.

## Fix

Resolve both roots to one spelling before the containment check (`resolvingSymlinksInPath` collapses `/private/var` and `/var` to the same path), and emit the result keys under the caller's original spelling so the file explorer's lookups still match. The ssh path keeps the caller's spelling on both axes, because a remote path must never be resolved against the local filesystem.

## Tests

The suite's two failing tests, `statusQueryPreservesQuotedAndEscapedFilenames` and `statusQueryExcludesSiblingPathPrefixes`, build repos under the temp dir and had been red on every macOS for exactly this reason, so they serve as the regression pins. Before: the suite fails with those two nil-lookup issues. After: `Test run with 6 tests in 1 suite passed`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787257657&installation_model_id=21920&pr_number=8577&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8577&signature=05d2efc076ae2705f57690189edc216e4abb7484a73adb993e5262f369a575d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing git status markers in the file explorer when the workspace path goes through a symlink (e.g., macOS `/var` → `/private/var`). Status now appears for files and folders in symlinked repos; SSH/remote paths are unchanged.

- **Bug Fixes**
  - Resolve symlinks for repo and explorer roots before the containment check using a canonical path.
  - Emit status keys under the caller’s original path and mark parent dirs there; explicitly handle explorer roots that resolve to “/” to keep the leading slash.
  - For SSH/remote: compare and key using the caller’s spelling only; never resolve against the local filesystem.

<sup>Written for commit 48ce43306be952eabfbe371b443c18885ec66baa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git status accuracy for repositories and folders accessed through symbolic links.
  * Preserved the original directory spelling when displaying file and folder status.
  * Improved consistency between local and remote Git status results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->