### PR TITLE
Command palette: index a branch short name as one searchable token

### DIFF
--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSwitcherSearchIndexer.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Search/CommandPaletteSwitcherSearchIndexer.swift
@@ -99,8 +99,12 @@ public struct CommandPaletteSwitcherSearchIndexer: Sendable {
         case .workspace:
             return [trimmed]
         case .surface:
+            // Index the branch short name (after the last "/") as one whole token, the way a
+            // directory basename is, so "cmd-palette-indexing" matches "feature/cmd-palette-indexing"
+            // even though "-" is a token delimiter.
+            let shortName = trimmed.components(separatedBy: "/").last ?? trimmed
             let components = trimmed.components(separatedBy: metadataDelimiters).filter { !$0.isEmpty }
-            return uniqueNormalizedPreservingOrder([trimmed] + components)
+            return uniqueNormalizedPreservingOrder([trimmed, shortName] + components)
         }
     }
 


### PR DESCRIPTION
## What you'd hit

Type a branch's short name into the command palette switcher and it doesn't find the workspace. For a branch like `feature/cmd-palette-indexing`, searching `cmd-palette-indexing` matches nothing.

## Why

`branchTokensForSearch` (surface detail) splits the branch ref on the metadata delimiters, and that set includes `-`. So `feature/cmd-palette-indexing` becomes the tokens `feature`, `cmd`, `palette`, `indexing`, and the hyphenated short name `cmd-palette-indexing` is never indexed as a whole. Directories don't have this gap, because the directory tokenizer already adds the path basename as one whole token.

## Fix

In the surface case of `branchTokensForSearch`, emit the branch short name (the part after the last `/`) as a whole token, mirroring the directory basename. The delimiter-split tokens are still added, so partial matches keep working.

## Tests

`CommandPaletteSwitcherSearchIndexerTests.testKeywordsIncludeDirectoryBranchAndPortMetadata` already asserts the branch short name is indexed, and it had been red since the feature shipped. Before: the suite fails that assertion. After: `Executed 4 tests, with 0 failures`, and the CmuxCommandPalette package suite stays green (81 tests, ranking fixtures unaffected).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787258263&installation_model_id=21920&pr_number=8578&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8578&signature=f1d1f7add62f15d9198f27deb640f6a345aae62b2fa32e916083a914ac9da443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes command palette search so typing a branch’s short name finds its workspace. Indexes the short name (after the last "/") as one token so hyphenated names match.

- **Bug Fixes**
  - In `CmuxCommandPalette`, for `.surface` refs, include the short name as a whole token, mirroring directory basename indexing, while keeping delimiter-split tokens for partial matches.

<sup>Written for commit 26489abb798a543634b8bcfb7e684def24debdd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

