### PR TITLE
Keyboard shortcuts: let a user shortcut win over the settings file

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -960,8 +960,8 @@ enum KeyboardShortcutSettings {
     }
 
     static func setShortcut(_ shortcut: StoredShortcut, for action: Action) {
-        guard !isManagedBySettingsFile(action) else { return }
-
+        // The settings file is a default source, not a lock: a UI edit of a file-managed
+        // shortcut persists a user override that wins over the file (see shortcutIfBound).
         guard let storedShortcut = storedShortcutForPersistence(shortcut, action: action) else {
             return
         }

--- a/Sources/KeyboardShortcutSettingsLookup.swift
+++ b/Sources/KeyboardShortcutSettingsLookup.swift
@@ -8,16 +8,18 @@ extension KeyboardShortcutSettings {
         shortcutLookupObserver?(action)
         #endif
 
+        // Precedence: user explicit choice (UserDefaults) > cmux.json imported default >
+        // built-in default. A persisted value (including an explicit unbind) wins over the
+        // settings file; the file is a default source, not a lock.
+        if let data = UserDefaults.standard.data(forKey: action.defaultsKey),
+           let shortcut = try? JSONDecoder().decode(StoredShortcut.self, from: data) {
+            return shortcut.isUnbound ? nil : shortcut
+        }
         if let managedShortcut = settingsFileStore.override(for: action) {
             return managedShortcut.isUnbound ? nil : managedShortcut
         }
-
-        guard let data = UserDefaults.standard.data(forKey: action.defaultsKey),
-              let shortcut = try? JSONDecoder().decode(StoredShortcut.self, from: data) else {
-            let defaultShortcut = action.defaultShortcut
-            return defaultShortcut.isUnbound ? nil : defaultShortcut
-        }
-        return shortcut.isUnbound ? nil : shortcut
+        let defaultShortcut = action.defaultShortcut
+        return defaultShortcut.isUnbound ? nil : defaultShortcut
     }
 
     static func shortcut(for action: Action) -> StoredShortcut {


### PR DESCRIPTION
## What you'd hit

A keyboard shortcut you set yourself does not stick when cmux.json also binds that action. Two ways in:
- You persist a shortcut (say Cmd+N for New Tab), then a workspace's cmux.json binds the same action to something else; the file's binding wins and your choice is ignored.
- You edit a file-managed shortcut from the settings UI; the edit is silently dropped and the file's binding comes back.

## Why

PR #3462 established that the settings file is a default source, not a lock: a user's persisted shortcut wins over the file, and the UI can edit a file-managed shortcut. One day later PR #3335 (Ctrl+P remapping) reintroduced the old order while adding unbound-shortcut support, without mentioning precedence:
- `shortcutIfBound` returns the settings-file override before it reads the user's persisted UserDefaults value.
- `setShortcut` bails on `guard !isManagedBySettingsFile(action)`.

The two regression tests #3462 shipped have failed ever since. They never gated CI because the shard step treats a run as passing whenever XCTest reports "(0 unexpected)", and swift-testing assertion failures do not increment that count.

## Fix

Restore #3462's precedence inside #3335's architecture:
- `shortcutIfBound` reads the persisted value first, then the file, then the built-in default. An explicit persisted unbind still unbinds.
- `setShortcut` drops the managed-lock guard, so a UI edit persists a user override, which then wins by the lookup order above.

`isManagedBySettingsFile` is unchanged, so the "Managed in cmux.json" subtitle still shows as information rather than a lock.

## Tests

`KeyboardShortcutSettingsFileStoreTests.testPersistedShortcutOverridesSettingsFileShortcutValues` and `testSettingsFileShortcutCanBeOverriddenFromUI` are the existing red/green pins. Before: the suite fails those two. After: `Executed 32 tests, with 0 failures`.

## Note

`swapShortcutConflict` still carries the same `!isManagedBySettingsFile` guards on both actions, which #3462 also removed. Leaving them means a conflict-swap refuses an edit the direct path now allows. I kept that out of this change because no test pins it either way; happy to follow up if you want the conflict-swap path to match.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787259253&installation_model_id=21920&pr_number=8579&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8579&signature=f047f1e9360bbc8ebef69ce90cb00446f170db5d1044269ef32b9b1e1f2d1fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make a user’s keyboard shortcut win over the workspace settings file so their choice always sticks. UI edits now persist even when the shortcut is managed by cmux.json.

- **Bug Fixes**
  - Precedence: persisted user value > settings file override > built-in default; explicit unbind still unbinds.
  - Removed the managed-lock in setShortcut so UI edits persist for file-managed actions.
  - “Managed in cmux.json” remains informational only.

<sup>Written for commit 06a1a15247c1964a800c30da1f6b485d3c1f6d0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

