### PR TITLE
Restore Kimi Code sessions after relaunch

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchCaptureTrust.swift
@@ -30,6 +30,7 @@ public enum AgentLaunchCaptureTrust {
         "gemini": ["gemini"],
         "grok": ["grok", "grok-macos-aarch64", "grok-macos-aarch"],
         "kiro": ["kiro", "kiro-cli"],
+        "kimi": ["kimi", "kimi-cli", "kimi-code"],
         "omp": ["omp"],
         "opencode": ["opencode", "omo", "omx", "omc"],
         "pi": ["pi", "omp"],

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -98,6 +98,7 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         "KIRO_HOME",
         "KIRO_LOG_LEVEL",
         "KIRO_LOG_NO_COLOR",
+        "KIMI_SHARE_DIR",
         "NODE_OPTIONS",
         "OPENCODE_CONFIG_DIR",
         "OLLAMA_EDITOR",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -193,6 +193,8 @@ public enum AgentLaunchSanitizer {
             return preserveOptions(args, policy: factoryPolicy)
         case "qoder":
             return preserveOptions(args, policy: qoderPolicy)
+        case "kimi":
+            return preserveOptions(args, policy: kimiPolicy)
         case "ollama":
             return OllamaLaunchArgumentsPreserver().preservedArguments(args)
         default:

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerKimiPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerKimiPolicy.swift
@@ -34,6 +34,7 @@ extension AgentLaunchSanitizer {
             "--session", "--resume", "-S", "-r",
             "--continue", "-C",
             "--prompt", "--command", "-p", "-c",
+            "--yolo", "--yes", "--auto-approve", "-y", "--afk",
             "--config", "--mcp-config",
             "--output-format", "--final-message-only",
         ],

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerKimiPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerKimiPolicy.swift
@@ -34,7 +34,7 @@ extension AgentLaunchSanitizer {
             "--session", "--resume", "-S", "-r",
             "--continue", "-C",
             "--prompt", "--command", "-p", "-c",
-            "--yolo", "--yes", "--auto-approve", "-y", "--afk",
+            "--yolo", "--yes", "--auto-approve", "-y", "--afk", "--plan",
             "--config", "--mcp-config",
             "--output-format", "--final-message-only",
         ],

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerKimiPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerKimiPolicy.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+extension AgentLaunchSanitizer {
+    /// Preserves interactive Kimi configuration without replaying a prior session selector or one-shot mode.
+    static let kimiPolicy = Policy(
+        valueOptions: [
+            "--work-dir", "-w",
+            "--add-dir",
+            "--session", "--resume", "-S", "-r",
+            "--config", "--config-file",
+            "--model", "-m",
+            "--prompt", "--command", "-p", "-c",
+            "--input-format", "--output-format",
+            "--agent", "--agent-file",
+            "--mcp-config-file", "--mcp-config", "--skills-dir",
+            "--max-steps-per-turn", "--max-retries-per-step", "--max-ralph-iterations",
+        ],
+        optionalValueOptions: [
+            "--session", "--resume", "-S", "-r",
+        ],
+        booleanOptions: [
+            "--verbose", "--debug",
+            "--continue", "-C",
+            "--thinking", "--no-thinking",
+            "--yolo", "--yes", "--auto-approve", "-y",
+            "--plan", "--afk",
+            "--print", "--acp", "--wire",
+            "--final-message-only", "--quiet",
+        ],
+        nonRestorableCommands: [
+            "login", "logout", "term", "acp", "info", "export", "mcp", "plugin", "vis", "web",
+        ],
+        droppedOptions: [
+            "--session", "--resume", "-S", "-r",
+            "--continue", "-C",
+            "--prompt", "--command", "-p", "-c",
+            "--config", "--mcp-config",
+            "--output-format", "--final-message-only",
+        ],
+        droppedOptionPrefixes: [
+            "--session=", "--resume=", "-S=", "-r=",
+            "--prompt=", "--command=", "-p=", "-c=",
+            "--config=", "--mcp-config=",
+            "--output-format=",
+        ],
+        rejectOptions: [
+            "--print", "--acp", "--wire",
+            "--input-format", "--quiet",
+        ]
+    )
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -379,6 +379,8 @@ public struct AgentResumeArgv: Sendable, Equatable {
             return withOption("factory", executable: "droid", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         case "qoder":
             return withOption("qoder", executable: "qodercli", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
+        case "kimi":
+            return withOption("kimi", executable: "kimi", option: "--resume", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         default:
             return nil
         }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
@@ -83,7 +83,7 @@ struct KimiAgentResumeTests {
 
     @Test(
         "Drops stale Kimi auto-approval modes while preserving following options",
-        arguments: ["--yolo", "--yes", "--auto-approve", "-y", "--afk"]
+        arguments: ["--yolo", "--yes", "--auto-approve", "-y", "--afk", "--plan"]
     )
     func dropsStaleAutoApprovalMode(_ option: String) {
         #expect(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
@@ -1,0 +1,77 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("Kimi agent resume")
+struct KimiAgentResumeTests {
+    @Test("Builds Kimi's documented session-id resume argv")
+    func buildsSessionResumeArgv() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "kimi",
+                sessionId: "72124c21-7b09-40a1-a98f-718164c46431",
+                executablePath: nil,
+                arguments: ["kimi"]
+            ) == ["kimi", "--resume", "72124c21-7b09-40a1-a98f-718164c46431"]
+        )
+    }
+
+    @Test("Drops stale Kimi session selectors and prompt modes while preserving interactive configuration")
+    func sanitizesCapturedLaunchArguments() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "/Users/example/.local/bin/kimi",
+                    "--session", "old-session",
+                    "--model", "kimi-k2",
+                    "--thinking",
+                    "--add-dir", "/tmp/extra repo",
+                    "--config-file", "/tmp/kimi config.toml",
+                    "initial prompt should not replay",
+                ],
+                launcher: "kimi",
+                fallbackKind: "kimi"
+            ) == [
+                "/Users/example/.local/bin/kimi",
+                "--model", "kimi-k2",
+                "--thinking",
+                "--add-dir", "/tmp/extra repo",
+                "--config-file", "/tmp/kimi config.toml",
+            ]
+        )
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["kimi", "--continue", "--model", "kimi-k2"],
+                launcher: "kimi",
+                fallbackKind: "kimi"
+            ) == ["kimi", "--model", "kimi-k2"]
+        )
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["kimi", "--print", "--prompt", "one shot"],
+                launcher: "kimi",
+                fallbackKind: "kimi"
+            ) == nil
+        )
+    }
+
+    @Test("Kimi lookup stays in its launch directory and custom share directory")
+    func preservesSessionNamespace() {
+        #expect(AgentResumeWorkingDirectory().cwdNamespacing(forKind: "kimi") == .byDirectory)
+        #expect(
+            AgentResumeWorkingDirectory().resolve(
+                kind: "kimi",
+                runtimeCwd: "/Users/example/repo/worktree",
+                launchWorkingDirectory: "/Users/example/repo"
+            ) == "/Users/example/repo"
+        )
+        #expect(
+            AgentLaunchEnvironmentPolicy().selectedEnvironment(
+                from: [
+                    "KIMI_SHARE_DIR": "/Users/example/.local/share/kimi-custom",
+                    "MOONSHOT_API_KEY": "secret",
+                ],
+                kind: "kimi"
+            ) == ["KIMI_SHARE_DIR": "/Users/example/.local/share/kimi-custom"]
+        )
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
@@ -82,10 +82,10 @@ struct KimiAgentResumeTests {
     }
 
     @Test(
-        "Drops stale Kimi auto-approval modes while preserving following options",
+        "Drops stale Kimi approval and plan modes while preserving following options",
         arguments: ["--yolo", "--yes", "--auto-approve", "-y", "--afk", "--plan"]
     )
-    func dropsStaleAutoApprovalMode(_ option: String) {
+    func dropsStaleApprovalAndPlanMode(_ option: String) {
         #expect(
             AgentLaunchSanitizer.sanitizedLaunchArguments(
                 ["kimi", option, "--model", "kimi-k2"],

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
@@ -47,6 +47,26 @@ struct KimiAgentResumeTests {
         )
         #expect(
             AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "kimi",
+                    "--add-dir", "/tmp/extra-a",
+                    "--add-dir", "/tmp/extra-b",
+                    "--skills-dir", "/tmp/skills-a",
+                    "--skills-dir", "/tmp/skills-b",
+                    "initial prompt should not become another directory",
+                ],
+                launcher: "kimi",
+                fallbackKind: "kimi"
+            ) == [
+                "kimi",
+                "--add-dir", "/tmp/extra-a",
+                "--add-dir", "/tmp/extra-b",
+                "--skills-dir", "/tmp/skills-a",
+                "--skills-dir", "/tmp/skills-b",
+            ]
+        )
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
                 ["kimi", "--print", "--prompt", "one shot"],
                 launcher: "kimi",
                 fallbackKind: "kimi"

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/KimiAgentResumeTests.swift
@@ -47,6 +47,13 @@ struct KimiAgentResumeTests {
         )
         #expect(
             AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["kimi", "-c", "initial prompt", "--model", "kimi-k2"],
+                launcher: "kimi",
+                fallbackKind: "kimi"
+            ) == ["kimi", "--model", "kimi-k2"]
+        )
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
                 [
                     "kimi",
                     "--add-dir", "/tmp/extra-a",
@@ -71,6 +78,20 @@ struct KimiAgentResumeTests {
                 launcher: "kimi",
                 fallbackKind: "kimi"
             ) == nil
+        )
+    }
+
+    @Test(
+        "Drops stale Kimi auto-approval modes while preserving following options",
+        arguments: ["--yolo", "--yes", "--auto-approve", "-y", "--afk"]
+    )
+    func dropsStaleAutoApprovalMode(_ option: String) {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["kimi", option, "--model", "kimi-k2"],
+                launcher: "kimi",
+                fallbackKind: "kimi"
+            ) == ["kimi", "--model", "kimi-k2"]
         )
     }
 

--- a/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
+++ b/Sources/AgentHibernation/AgentHibernationLifecycleState.swift
@@ -70,6 +70,7 @@ enum AgentHibernationLifecycleStatusKeys {
         "grok",
         "hermes-agent",
         "kiro",
+        "kimi",
         "omp",
         "opencode",
         "pi",

--- a/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
+++ b/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
@@ -52,7 +52,7 @@ extension CmuxTaskManagerCodingAgentDefinition {
             displayName: String(localized: "agent.kimi.displayName", defaultValue: "Kimi Code"),
             assetName: nil,
             launchKinds: ["kimi"],
-            directBasenames: ["kimi", "kimi-cli", "kimi-code"],
+            directBasenames: ["kimi", "kimi-cli", "kimi-code", "kimi code"],
             argumentNeedles: ["kimi-cli", "kimi-code"]
         ),
         .init(

--- a/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
+++ b/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
@@ -48,6 +48,14 @@ extension CmuxTaskManagerCodingAgentDefinition {
         .init(id: "qoder", displayName: "Qoder", assetName: nil,
               launchKinds: ["qoder"], directBasenames: ["qoder", "qodercli"], argumentNeedles: ["qoder", "qodercli"]),
         .init(
+            id: "kimi",
+            displayName: String(localized: "agent.kimi.displayName", defaultValue: "Kimi Code"),
+            assetName: nil,
+            launchKinds: ["kimi"],
+            directBasenames: ["kimi", "kimi-cli", "kimi-code"],
+            argumentNeedles: ["kimi-cli", "kimi-code"]
+        ),
+        .init(
             id: "ollama",
             displayName: String(localized: "agent.ollama.displayName", defaultValue: "Ollama"),
             assetName: nil,

--- a/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
+++ b/Sources/CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift
@@ -52,6 +52,9 @@ extension CmuxTaskManagerCodingAgentDefinition {
             displayName: String(localized: "agent.kimi.displayName", defaultValue: "Kimi Code"),
             assetName: nil,
             launchKinds: ["kimi"],
+            // Kimi's Python entrypoint deliberately overwrites its OS process title and argv with
+            // "Kimi Code". This is process-status/foreground detection only; session persistence
+            // still requires cmux-owned launch metadata or native executable aliases.
             directBasenames: ["kimi", "kimi-cli", "kimi-code", "kimi code"],
             argumentNeedles: ["kimi-cli", "kimi-code"]
         ),

--- a/Sources/RestorableAgentSession+Kimi.swift
+++ b/Sources/RestorableAgentSession+Kimi.swift
@@ -6,7 +6,7 @@ extension AgentResumeCommandBuilder {
         sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?
     ) -> [String]? {
-        guard customRegistration == CmuxVaultAgentRegistration.builtInKimi else { return nil }
+        guard customRegistration.isBuiltInKimi else { return nil }
         return AgentResumeArgv().builtInKind(
             kind: "kimi",
             sessionId: sessionId,

--- a/Sources/RestorableAgentSession+Kimi.swift
+++ b/Sources/RestorableAgentSession+Kimi.swift
@@ -1,0 +1,17 @@
+import CMUXAgentLaunch
+
+extension AgentResumeCommandBuilder {
+    static func kimiBuiltInResumeArguments(
+        customRegistration: CmuxVaultAgentRegistration,
+        sessionId: String,
+        launchCommand: AgentLaunchCommandSnapshot?
+    ) -> [String]? {
+        guard customRegistration == CmuxVaultAgentRegistration.builtInKimi else { return nil }
+        return AgentResumeArgv().builtInKind(
+            kind: "kimi",
+            sessionId: sessionId,
+            executablePath: launchCommand?.executablePath,
+            arguments: launchCommand?.arguments ?? []
+        )
+    }
+}

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -515,7 +515,7 @@ enum AgentResumeCommandBuilder {
         }
         if case .custom = kind {
             guard let customRegistration else { return nil }
-            if let arguments = campfireBuiltInResumeArguments(customRegistration: customRegistration, sessionId: sessionId, launchCommand: launchCommand) { return arguments }
+            if let arguments = campfireBuiltInResumeArguments(customRegistration: customRegistration, sessionId: sessionId, launchCommand: launchCommand) ?? kimiBuiltInResumeArguments(customRegistration: customRegistration, sessionId: sessionId, launchCommand: launchCommand) { return arguments }
             if customRegistration.id == CmuxVaultAgentRegistration.builtInAntigravity.id {
                 return resumeWithOption(
                     kind: "antigravity",

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1597,7 +1597,7 @@ struct RestorableAgentSessionIndex: Sendable {
         // launch dir. `.ignore` agents resume from the current directory, so the snapshot must carry
         // no saved cwd at all (downstream restore consumers read `workingDirectory` directly, not just
         // the command builder). The by-directory namespace below is only for built-in agents.
-        if let registration {
+        if let registration, !registration.isBuiltInKimi {
             return registration.cwd == .ignore ? nil : (recordedCwd ?? launchCwd)
         }
 

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -40,9 +40,8 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         .codebuddy,
         .factory,
         .qoder,
-        .kimi,
-        // Ollama is registry-owned like Pi/Grok/Antigravity: leaving it out
-        // keeps the id available to pre-existing custom Vault registrations
+        // Kimi and Ollama are registry-owned like Pi/Grok/Antigravity: leaving them
+        // out keeps their ids available to pre-existing custom Vault registrations
         // while direct native values still encode.
     ]
 

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -18,6 +18,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
     case codebuddy
     case factory
     case qoder
+    case kimi
     case ollama
     case custom(String)
 
@@ -39,6 +40,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         .codebuddy,
         .factory,
         .qoder,
+        .kimi,
         // Ollama is registry-owned like Pi/Grok/Antigravity: leaving it out
         // keeps the id available to pre-existing custom Vault registrations
         // while direct native values still encode.
@@ -63,6 +65,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case "codebuddy": self = .codebuddy
         case "factory": self = .factory
         case "qoder": self = .qoder
+        case "kimi": self = .kimi
         case "ollama": self = .ollama
         default:
             guard CmuxVaultAgentRegistration.isValidID(value) else { return nil }
@@ -88,6 +91,7 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .codebuddy: return "codebuddy"
         case .factory: return "factory"
         case .qoder: return "qoder"
+        case .kimi: return "kimi"
         case .ollama: return "ollama"
         case .custom(let id): return id
         }
@@ -118,6 +122,8 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
         case .codebuddy: return "CodeBuddy"
         case .factory: return "Factory"
         case .qoder: return "Qoder"
+        case .kimi:
+            return String(localized: "agent.kimi.displayName", defaultValue: "Kimi Code")
         case .ollama:
             return String(localized: "agent.ollama.displayName", defaultValue: "Ollama")
         case .custom(let id): return id

--- a/Sources/SessionRestorableAgentSnapshot+Commands.swift
+++ b/Sources/SessionRestorableAgentSnapshot+Commands.swift
@@ -20,10 +20,10 @@ extension SessionRestorableAgentSnapshot {
         // Registry-detected snapshots persist `.custom(id)`, whose raw string
         // collapses to the native case on decode when the id matches a
         // built-in raw value. Restore the write-side identity whenever that
-        // collapse would change command semantics (registry-owned Pi or
+        // collapse would change command semantics (registry-owned Pi/Kimi or
         // relaunch-only natives such as Ollama), so the stored registration
         // keeps owning resume and fork behavior.
-        if (kind.restoreMode == .relaunchCommand || kind == .pi),
+        if (kind.restoreMode == .relaunchCommand || kind == .pi || kind == .kimi),
            let registration,
            registration.id == kind.rawValue {
             kind = .custom(registration.id)

--- a/Sources/TerminalForegroundCommandCapture.swift
+++ b/Sources/TerminalForegroundCommandCapture.swift
@@ -134,11 +134,11 @@ enum TerminalForegroundCommandCapture {
     }
 
     /// `allCases` intentionally omits the registry-owned kinds (grok, pi,
-    /// antigravity, ollama) so Vault registrations can override them; the
+    /// antigravity, kimi, ollama) so Vault registrations can override them; the
     /// sanitizer still understands those kinds, so add their exact
     /// executables back.
     private static let knownAgentExecutables = Set(RestorableAgentKind.allCases.map(\.rawValue))
-        .union(["grok", "pi", "antigravity", "ollama"])
+        .union(["grok", "pi", "antigravity", "kimi", "ollama"])
 
     private static let agentExecutableAliases: [String: String] = [
         "agy": "antigravity",
@@ -146,6 +146,8 @@ enum TerminalForegroundCommandCapture {
         "acli": "rovodev",
         "cursor-agent": "cursor",
         "hermes": "hermes-agent",
+        "kimi-cli": "kimi",
+        "kimi-code": "kimi",
     ]
 
     private static let unquotedArgumentScalars: CharacterSet = {

--- a/Sources/VaultAgentRegistry+Kimi.swift
+++ b/Sources/VaultAgentRegistry+Kimi.swift
@@ -1,0 +1,12 @@
+extension CmuxVaultAgentRegistration {
+    static var builtInKimi: CmuxVaultAgentRegistration {
+        CmuxVaultAgentRegistration(
+            id: "kimi",
+            name: RestorableAgentKind.kimi.displayName,
+            detect: CmuxVaultAgentDetectRule(processNames: ["kimi", "kimi-cli", "kimi-code"]),
+            sessionIdSource: .argvOption("--resume"),
+            resumeCommand: "{{executable}} --resume {{sessionId}}",
+            cwd: .preserve
+        )
+    }
+}

--- a/Sources/VaultAgentRegistry+Kimi.swift
+++ b/Sources/VaultAgentRegistry+Kimi.swift
@@ -1,3 +1,5 @@
+import CMUXAgentLaunch
+
 extension CmuxVaultAgentRegistration {
     static var builtInKimi: CmuxVaultAgentRegistration {
         CmuxVaultAgentRegistration(
@@ -7,6 +9,22 @@ extension CmuxVaultAgentRegistration {
             sessionIdSource: .argvOption("--resume"),
             resumeCommand: "{{executable}} --resume {{sessionId}}",
             cwd: .preserve
+        )
+    }
+}
+
+extension AgentResumeCommandBuilder {
+    static func kimiBuiltInResumeArguments(
+        customRegistration: CmuxVaultAgentRegistration,
+        sessionId: String,
+        launchCommand: AgentLaunchCommandSnapshot?
+    ) -> [String]? {
+        guard customRegistration == CmuxVaultAgentRegistration.builtInKimi else { return nil }
+        return AgentResumeArgv().builtInKind(
+            kind: "kimi",
+            sessionId: sessionId,
+            executablePath: launchCommand?.executablePath,
+            arguments: launchCommand?.arguments ?? []
         )
     }
 }

--- a/Sources/VaultAgentRegistry+Kimi.swift
+++ b/Sources/VaultAgentRegistry+Kimi.swift
@@ -1,5 +1,3 @@
-import CMUXAgentLaunch
-
 extension CmuxVaultAgentRegistration {
     static var builtInKimi: CmuxVaultAgentRegistration {
         CmuxVaultAgentRegistration(
@@ -9,22 +7,6 @@ extension CmuxVaultAgentRegistration {
             sessionIdSource: .argvOption("--resume"),
             resumeCommand: "{{executable}} --resume {{sessionId}}",
             cwd: .preserve
-        )
-    }
-}
-
-extension AgentResumeCommandBuilder {
-    static func kimiBuiltInResumeArguments(
-        customRegistration: CmuxVaultAgentRegistration,
-        sessionId: String,
-        launchCommand: AgentLaunchCommandSnapshot?
-    ) -> [String]? {
-        guard customRegistration == CmuxVaultAgentRegistration.builtInKimi else { return nil }
-        return AgentResumeArgv().builtInKind(
-            kind: "kimi",
-            sessionId: sessionId,
-            executablePath: launchCommand?.executablePath,
-            arguments: launchCommand?.arguments ?? []
         )
     }
 }

--- a/Sources/VaultAgentRegistry+Kimi.swift
+++ b/Sources/VaultAgentRegistry+Kimi.swift
@@ -1,4 +1,9 @@
 extension CmuxVaultAgentRegistration {
+    /// True only for cmux's exact built-in registration, not user registrations reusing its id.
+    var isBuiltInKimi: Bool {
+        self == Self.builtInKimi
+    }
+
     static var builtInKimi: CmuxVaultAgentRegistration {
         CmuxVaultAgentRegistration(
             id: "kimi",

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -437,7 +437,7 @@ struct CmuxVaultAgentRegistry: Sendable {
             CmuxVaultAgentRegistration.builtInOmp,
             CmuxVaultAgentRegistration.builtInCampfire,
             CmuxVaultAgentRegistration.builtInAntigravity,
-            CmuxVaultAgentRegistration.builtInGrok,
+            CmuxVaultAgentRegistration.builtInGrok, CmuxVaultAgentRegistration.builtInKimi,
         ]
         for path in configPaths(homeDirectory: homeDirectory, workingDirectory: workingDirectory, environment: environment, fileManager: fileManager) {
             guard let config = decodeConfig(at: path, fileManager: fileManager) else { continue }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -995,6 +995,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */; };
 		827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827300000000000000000003 /* KimiHookConfigLocationTests.swift */; };
 		858200000000000000000002 /* KimiRestorableAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858200000000000000000001 /* KimiRestorableAgentTests.swift */; };
+		8582A1000000000000000002 /* KimiResumeReviewRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8582A1000000000000000001 /* KimiResumeReviewRegressionTests.swift */; };
 		87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */; };
 		A11CE0060000000000000001 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = A11CE0050000000000000001 /* LICENSE */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
@@ -3117,6 +3118,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutTestSettingsIsolation.swift; sourceTree = "<group>"; };
 		827300000000000000000003 /* KimiHookConfigLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiHookConfigLocationTests.swift; sourceTree = "<group>"; };
 		858200000000000000000001 /* KimiRestorableAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiRestorableAgentTests.swift; sourceTree = "<group>"; };
+		8582A1000000000000000001 /* KimiResumeReviewRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiResumeReviewRegressionTests.swift; sourceTree = "<group>"; };
 		F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastSurfaceClosePreferenceTests.swift; sourceTree = "<group>"; };
 		A11CE0050000000000000001 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -6208,6 +6210,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					C12985000000000000000003 /* CMUXCLISentryTelemetryRegressionTests.swift */,
 					827300000000000000000003 /* KimiHookConfigLocationTests.swift */,
 					858200000000000000000001 /* KimiRestorableAgentTests.swift */,
+					8582A1000000000000000001 /* KimiResumeReviewRegressionTests.swift */,
 				C47110010000000000000002 /* ProcessPipeReadCrashRegressionTests.swift */,
 				F50030040000000000000002 /* TitlebarInteractiveControlTests.swift */,
 				E30760060000000000000001 /* TmuxWorkspacePaneOverlayModelTests.swift */,
@@ -8701,6 +8704,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */,
 				827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */,
 				858200000000000000000002 /* KimiRestorableAgentTests.swift in Sources */,
+				8582A1000000000000000002 /* KimiResumeReviewRegressionTests.swift in Sources */,
 				87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */,
 				A7C0F0010000000000000002 /* MacPairedMacBackupPublisherScopeTests.swift in Sources */,
 				6512F0C06512F0C06512F002 /* MainWindowFocusRestoreTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1966,6 +1966,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B35750000000000000000012 /* VaultAgentProcessScannerDetectRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000011 /* VaultAgentProcessScannerDetectRules.swift */; };
 		B35750000000000000000010 /* VaultAgentProcessScannerSessionDirectories.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3575000000000000000000F /* VaultAgentProcessScannerSessionDirectories.swift */; };
 		B3575000000000000000000E /* VaultAgentRegistry+Campfire.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3575000000000000000000D /* VaultAgentRegistry+Campfire.swift */; };
+		858200000000000000000004 /* VaultAgentRegistry+Kimi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858200000000000000000003 /* VaultAgentRegistry+Kimi.swift */; };
 		B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000001 /* VaultAgentRegistry.swift */; };
 		F76550060000000000000001 /* VaultObservedAgentProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550060000000000000002 /* VaultObservedAgentProcess.swift */; };
 		F7216001000000000000001 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7216001000000000000002 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift */; };
@@ -4069,6 +4070,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B35750000000000000000011 /* VaultAgentProcessScannerDetectRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentProcessScannerDetectRules.swift; sourceTree = "<group>"; };
 		B3575000000000000000000F /* VaultAgentProcessScannerSessionDirectories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentProcessScannerSessionDirectories.swift; sourceTree = "<group>"; };
 		B3575000000000000000000D /* VaultAgentRegistry+Campfire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentRegistry+Campfire.swift"; sourceTree = "<group>"; };
+		858200000000000000000003 /* VaultAgentRegistry+Kimi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentRegistry+Kimi.swift"; sourceTree = "<group>"; };
 		B35750000000000000000001 /* VaultAgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAgentRegistry.swift; sourceTree = "<group>"; };
 		F76550060000000000000002 /* VaultObservedAgentProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultObservedAgentProcess.swift; sourceTree = "<group>"; };
 		F7216001000000000000002 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+EmptyAreasAndFooter.swift"; sourceTree = "<group>"; };
@@ -5033,6 +5035,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B3575000000000000000000B /* SessionIndexModels.swift */,
 				F0ACC0DE0000000000000008 /* SharedLiveAgentIndexLoader.swift */,
 				B3575000000000000000000D /* VaultAgentRegistry+Campfire.swift */,
+				858200000000000000000003 /* VaultAgentRegistry+Kimi.swift */,
 				B35750000000000000000001 /* VaultAgentRegistry.swift */,
 				D3284102A1B2C3D4E5F60718 /* GhosttyTextInputSupport.swift */,
 				77F5AB36771F1414A95E3330 /* GhosttyKeyModifiers.swift */,
@@ -8159,6 +8162,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B35750000000000000000012 /* VaultAgentProcessScannerDetectRules.swift in Sources */,
 				B35750000000000000000010 /* VaultAgentProcessScannerSessionDirectories.swift in Sources */,
 				B3575000000000000000000E /* VaultAgentRegistry+Campfire.swift in Sources */,
+				858200000000000000000004 /* VaultAgentRegistry+Kimi.swift in Sources */,
 				B35750000000000000000002 /* VaultAgentRegistry.swift in Sources */,
 				F76550060000000000000001 /* VaultObservedAgentProcess.swift in Sources */,
 				F7216001000000000000001 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1400,6 +1400,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C6711A060000000000000001 /* RestorableAgentHookSessionStoreFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6711B060000000000000001 /* RestorableAgentHookSessionStoreFile.swift */; };
 		F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */; };
 		A5001662 /* RestorableAgentSession+Campfire.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001663 /* RestorableAgentSession+Campfire.swift */; };
+		858200000000000000000006 /* RestorableAgentSession+Kimi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858200000000000000000005 /* RestorableAgentSession+Kimi.swift */; };
 		A5001660 /* RestorableAgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001661 /* RestorableAgentSession.swift */; };
 		C6711A020000000000000001 /* RestorableAgentSessionIndexCodexWeakRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6711B020000000000000001 /* RestorableAgentSessionIndexCodexWeakRecordTests.swift */; };
 		F5410006A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5410007A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift */; };
@@ -3516,6 +3517,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C6711B060000000000000001 /* RestorableAgentHookSessionStoreFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentHookSessionStoreFile.swift; sourceTree = "<group>"; };
 		F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentNonInteractiveTests.swift; sourceTree = "<group>"; };
 		A5001663 /* RestorableAgentSession+Campfire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestorableAgentSession+Campfire.swift"; sourceTree = "<group>"; };
+		858200000000000000000005 /* RestorableAgentSession+Kimi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestorableAgentSession+Kimi.swift"; sourceTree = "<group>"; };
 		A5001661 /* RestorableAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentSession.swift; sourceTree = "<group>"; };
 		C6711B020000000000000001 /* RestorableAgentSessionIndexCodexWeakRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentSessionIndexCodexWeakRecordTests.swift; sourceTree = "<group>"; };
 		F5410007A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentSessionIndexTests.swift; sourceTree = "<group>"; };
@@ -5672,6 +5674,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C6711B040000000000000001 /* RestorableAgentHookSessionRecord.swift */,
 				C6711B060000000000000001 /* RestorableAgentHookSessionStoreFile.swift */,
 				A5001663 /* RestorableAgentSession+Campfire.swift */,
+				858200000000000000000005 /* RestorableAgentSession+Kimi.swift */,
 				A5001661 /* RestorableAgentSession.swift */,
 				F0ACC0DE0000000000000012 /* SharedLiveAgentIndex.swift */,
 				F0ACC0DE0000000000000010 /* SurfaceResumeBindingIndex.swift */,
@@ -7758,6 +7761,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C6711A040000000000000001 /* RestorableAgentHookSessionRecord.swift in Sources */,
 				C6711A060000000000000001 /* RestorableAgentHookSessionStoreFile.swift in Sources */,
 				A5001662 /* RestorableAgentSession+Campfire.swift in Sources */,
+				858200000000000000000006 /* RestorableAgentSession+Kimi.swift in Sources */,
 				A5001660 /* RestorableAgentSession.swift in Sources */,
 				C13519000000000000000005 /* RestorableAgentTypes.swift in Sources */,
 				C7C5FAF3145342F395DB4C40 /* RestoredAgentCompletedGeneration.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -994,6 +994,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */; };
 		C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */; };
 		827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827300000000000000000003 /* KimiHookConfigLocationTests.swift */; };
+		858200000000000000000002 /* KimiRestorableAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 858200000000000000000001 /* KimiRestorableAgentTests.swift */; };
 		87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */; };
 		A11CE0060000000000000001 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = A11CE0050000000000000001 /* LICENSE */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
@@ -3113,6 +3114,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSpaceKeyTests.swift; sourceTree = "<group>"; };
 		C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutTestSettingsIsolation.swift; sourceTree = "<group>"; };
 		827300000000000000000003 /* KimiHookConfigLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiHookConfigLocationTests.swift; sourceTree = "<group>"; };
+		858200000000000000000001 /* KimiRestorableAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiRestorableAgentTests.swift; sourceTree = "<group>"; };
 		F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastSurfaceClosePreferenceTests.swift; sourceTree = "<group>"; };
 		A11CE0050000000000000001 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -6199,6 +6201,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					C0DE64950000000000000004 /* CMUXCLITestAssertions.swift */,
 					C12985000000000000000003 /* CMUXCLISentryTelemetryRegressionTests.swift */,
 					827300000000000000000003 /* KimiHookConfigLocationTests.swift */,
+					858200000000000000000001 /* KimiRestorableAgentTests.swift */,
 				C47110010000000000000002 /* ProcessPipeReadCrashRegressionTests.swift */,
 				F50030040000000000000002 /* TitlebarInteractiveControlTests.swift */,
 				E30760060000000000000001 /* TmuxWorkspacePaneOverlayModelTests.swift */,
@@ -8689,6 +8692,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */,
 				C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */,
 				827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */,
+				858200000000000000000002 /* KimiRestorableAgentTests.swift in Sources */,
 				87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */,
 				A7C0F0010000000000000002 /* MacPairedMacBackupPublisherScopeTests.swift in Sources */,
 				6512F0C06512F0C06512F002 /* MainWindowFocusRestoreTests.swift in Sources */,

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -24,6 +24,25 @@ struct KimiRestorableAgentTests {
         #expect(try JSONDecoder().decode(RestorableAgentKind.self, from: encoded) == kind)
     }
 
+    @Test("Pre-existing custom Kimi Vault registrations remain decodable")
+    func customVaultRegistrationStaysDecodable() throws {
+        let registration = try JSONDecoder().decode(
+            CmuxVaultAgentRegistration.self,
+            from: Data("""
+            {
+              "id": "kimi",
+              "name": "Custom Kimi",
+              "sessionIdSource": "--resume",
+              "resumeCommand": "custom-kimi --resume {{sessionId}}"
+            }
+            """.utf8)
+        )
+
+        #expect(registration.id == "kimi")
+        #expect(registration.name == "Custom Kimi")
+        #expect(registration.resumeCommand == "custom-kimi --resume {{sessionId}}")
+    }
+
     @Test("Kimi hook sessions are discovered and produce a resume command")
     func hookSessionLoadsIntoResumePipeline() throws {
         let fileManager = FileManager.default

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -134,14 +134,16 @@ struct KimiRestorableAgentTests {
         #expect(decoded.forkCommand == "'custom-kimi' '--fork' 'custom-session'")
     }
 
-    @Test("Kimi hook sessions are discovered and produce a resume command")
+    @Test("Kimi hook sessions resume from their launch directory namespace")
     func hookSessionLoadsIntoResumePipeline() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
             .appendingPathComponent("cmux-kimi-restore-\(UUID().uuidString)", isDirectory: true)
-        let workingDirectory = root.appendingPathComponent("repo", isDirectory: true)
+        let launchWorkingDirectory = root.appendingPathComponent("launch-repo", isDirectory: true)
+        let runtimeWorkingDirectory = root.appendingPathComponent("runtime-worktree", isDirectory: true)
         defer { try? fileManager.removeItem(at: root) }
-        try fileManager.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: launchWorkingDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: runtimeWorkingDirectory, withIntermediateDirectories: true)
 
         let workspaceID = UUID()
         let panelID = UUID()
@@ -156,7 +158,15 @@ struct KimiRestorableAgentTests {
                         "sessionId": sessionID,
                         "workspaceId": workspaceID.uuidString,
                         "surfaceId": panelID.uuidString,
-                        "cwd": workingDirectory.path,
+                        "cwd": runtimeWorkingDirectory.path,
+                        "launchCommand": [
+                            "launcher": "kimi",
+                            "executablePath": "/Users/example/.local/bin/kimi",
+                            "arguments": ["/Users/example/.local/bin/kimi"],
+                            "workingDirectory": launchWorkingDirectory.path,
+                            "capturedAt": 1_750_000_000.0,
+                            "source": "test",
+                        ],
                         "isRestorable": true,
                         "updatedAt": 1_750_000_000.0,
                     ],
@@ -177,10 +187,79 @@ struct KimiRestorableAgentTests {
         #expect(snapshot.kind.rawValue == "kimi")
         #expect(snapshot.registration?.id == "kimi")
         #expect(snapshot.sessionId == sessionID)
-        #expect(snapshot.workingDirectory == workingDirectory.path)
+        #expect(snapshot.workingDirectory == launchWorkingDirectory.path)
 
         let resumeCommand = try #require(snapshot.resumeCommand)
-        #expect(resumeCommand.contains("'kimi' '--resume' '\(sessionID)'"))
-        #expect(resumeCommand.hasPrefix("cd -- '\(workingDirectory.path)'"))
+        #expect(resumeCommand.contains("'/Users/example/.local/bin/kimi' '--resume' '\(sessionID)'"))
+        #expect(resumeCommand.hasPrefix("cd -- '\(launchWorkingDirectory.path)'"))
+    }
+
+    @Test("Custom Kimi registrations preserve their runtime working directory")
+    func customKimiRegistrationKeepsRuntimeDirectory() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-custom-kimi-restore-\(UUID().uuidString)", isDirectory: true)
+        let launchWorkingDirectory = root.appendingPathComponent("launch-repo", isDirectory: true)
+        let runtimeWorkingDirectory = root.appendingPathComponent("runtime-worktree", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+        try fileManager.createDirectory(at: launchWorkingDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: runtimeWorkingDirectory, withIntermediateDirectories: true)
+
+        let workspaceID = UUID()
+        let panelID = UUID()
+        let sessionID = "custom-kimi-session"
+        let stateDirectory = root.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fileManager.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        let store = try JSONSerialization.data(
+            withJSONObject: [
+                "version": 1,
+                "sessions": [
+                    sessionID: [
+                        "sessionId": sessionID,
+                        "workspaceId": workspaceID.uuidString,
+                        "surfaceId": panelID.uuidString,
+                        "cwd": runtimeWorkingDirectory.path,
+                        "launchCommand": [
+                            "launcher": "kimi",
+                            "executablePath": "/Users/example/.local/bin/custom-kimi",
+                            "arguments": ["/Users/example/.local/bin/custom-kimi"],
+                            "workingDirectory": launchWorkingDirectory.path,
+                            "capturedAt": 1_750_000_000.0,
+                            "source": "test",
+                        ],
+                        "isRestorable": true,
+                        "updatedAt": 1_750_000_000.0,
+                    ],
+                ],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try store.write(
+            to: stateDirectory.appendingPathComponent("kimi-hook-sessions.json", isDirectory: false),
+            options: .atomic
+        )
+        let customRegistration = CmuxVaultAgentRegistration(
+            id: "kimi",
+            name: "Custom Kimi",
+            detect: CmuxVaultAgentDetectRule(processName: "custom-kimi"),
+            sessionIdSource: .argvOption("--resume"),
+            resumeCommand: "custom-kimi --resume {{sessionId}}"
+        )
+        let registry = CmuxVaultAgentRegistry(registrations: [customRegistration])
+
+        let snapshot = try #require(
+            RestorableAgentSessionIndex.load(
+                homeDirectory: root.path,
+                fileManager: fileManager,
+                registry: registry,
+                detectedSnapshots: [:],
+                processArgumentsProvider: { _ in nil }
+            ).snapshot(workspaceId: workspaceID, panelId: panelID)
+        )
+        #expect(snapshot.registration == customRegistration)
+        #expect(snapshot.workingDirectory == runtimeWorkingDirectory.path)
+
+        let resumeCommand = try #require(snapshot.resumeCommand)
+        #expect(resumeCommand.hasPrefix("cd -- '\(runtimeWorkingDirectory.path)'"))
     }
 }

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -31,6 +31,34 @@ struct KimiRestorableAgentTests {
         #expect(registration.resumeCommand == "{{executable}} --resume {{sessionId}}")
     }
 
+    @Test("Built-in Kimi registry resume preserves safe launch options")
+    func builtInRegistryResumeUsesKimiSanitizer() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .custom("kimi"),
+            sessionId: "kimi-session",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "kimi",
+                executablePath: "/opt/kimi/bin/kimi",
+                arguments: [
+                    "/opt/kimi/bin/kimi",
+                    "--model", "kimi-k2",
+                    "--config-file", "/tmp/kimi.toml",
+                    "--yolo",
+                ],
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: 123,
+                source: "test"
+            ),
+            registration: .builtInKimi
+        )
+
+        #expect(
+            snapshot.resumeCommand == "'/opt/kimi/bin/kimi' '--resume' 'kimi-session' '--model' 'kimi-k2' '--config-file' '/tmp/kimi.toml'"
+        )
+    }
+
     @Test("Kimi's OS process title remains detectable")
     func processTitleDetection() {
         let definition = CmuxTaskManagerCodingAgentDefinition.matchingDefinition(

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Kimi restorable agent")
+struct KimiRestorableAgentTests {
+    @Test("Kimi is a first-class codable restorable kind")
+    func firstClassKindRoundTrip() throws {
+        let kind = try #require(RestorableAgentKind(rawValue: "kimi"))
+
+        #expect(RestorableAgentKind.allCases.contains(kind))
+        #expect(kind.rawValue == "kimi")
+        #expect(kind.displayName == "Kimi Code")
+        #expect(kind.restoreMode == .resumeSession)
+        #expect(kind.cwdNamespacing == .byDirectory)
+
+        let encoded = try JSONEncoder().encode(kind)
+        #expect(String(decoding: encoded, as: UTF8.self) == #""kimi""#)
+        #expect(try JSONDecoder().decode(RestorableAgentKind.self, from: encoded) == kind)
+    }
+
+    @Test("Kimi hook sessions are discovered and produce a resume command")
+    func hookSessionLoadsIntoResumePipeline() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-kimi-restore-\(UUID().uuidString)", isDirectory: true)
+        let workingDirectory = root.appendingPathComponent("repo", isDirectory: true)
+        defer { try? fileManager.removeItem(at: root) }
+        try fileManager.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+
+        let workspaceID = UUID()
+        let panelID = UUID()
+        let sessionID = "72124c21-7b09-40a1-a98f-718164c46431"
+        let stateDirectory = root.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fileManager.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        let store = try JSONSerialization.data(
+            withJSONObject: [
+                "version": 1,
+                "sessions": [
+                    sessionID: [
+                        "sessionId": sessionID,
+                        "workspaceId": workspaceID.uuidString,
+                        "surfaceId": panelID.uuidString,
+                        "cwd": workingDirectory.path,
+                        "isRestorable": true,
+                        "updatedAt": Date.now.timeIntervalSince1970,
+                    ],
+                ],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try store.write(
+            to: stateDirectory.appendingPathComponent("kimi-hook-sessions.json", isDirectory: false),
+            options: .atomic
+        )
+
+        let snapshot = try #require(
+            RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fileManager)
+                .snapshot(workspaceId: workspaceID, panelId: panelID)
+        )
+        #expect(snapshot.kind.rawValue == "kimi")
+        #expect(snapshot.sessionId == sessionID)
+        #expect(snapshot.workingDirectory == workingDirectory.path)
+
+        let resumeCommand = try #require(snapshot.resumeCommand)
+        #expect(resumeCommand.contains("'kimi' '--resume' '\(sessionID)'"))
+        #expect(resumeCommand.hasPrefix("cd -- '\(workingDirectory.path)'"))
+    }
+}

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -9,11 +9,11 @@ import Testing
 
 @Suite("Kimi restorable agent")
 struct KimiRestorableAgentTests {
-    @Test("Kimi is a first-class codable restorable kind")
-    func firstClassKindRoundTrip() throws {
+    @Test("Kimi is a codable registry-owned restorable kind")
+    func registryOwnedKindRoundTrip() throws {
         let kind = try #require(RestorableAgentKind(rawValue: "kimi"))
 
-        #expect(RestorableAgentKind.allCases.contains(kind))
+        #expect(!RestorableAgentKind.allCases.contains(kind))
         #expect(kind.rawValue == "kimi")
         #expect(kind.displayName == "Kimi Code")
         #expect(kind.restoreMode == .resumeSession)
@@ -22,6 +22,41 @@ struct KimiRestorableAgentTests {
         let encoded = try JSONEncoder().encode(kind)
         #expect(String(decoding: encoded, as: UTF8.self) == #""kimi""#)
         #expect(try JSONDecoder().decode(RestorableAgentKind.self, from: encoded) == kind)
+
+        let registration = CmuxVaultAgentRegistration.builtInKimi
+        #expect(registration.id == "kimi")
+        #expect(registration.name == "Kimi Code")
+        #expect(registration.detect.processNames == ["kimi", "kimi-cli", "kimi-code"])
+        #expect(registration.sessionIdSource == .argvOption("--resume"))
+        #expect(registration.resumeCommand == "{{executable}} --resume {{sessionId}}")
+    }
+
+    @Test("Kimi's OS process title remains detectable")
+    func processTitleDetection() {
+        let definition = CmuxTaskManagerCodingAgentDefinition.matchingDefinition(
+            processName: "Kimi Code",
+            processPath: "/Users/example/.local/share/uv/tools/kimi-cli/bin/python",
+            arguments: ["Kimi Code"],
+            environment: [:]
+        )
+
+        #expect(definition?.id == "kimi")
+    }
+
+    @Test(
+        "Kimi executable aliases use the shared foreground sanitizer",
+        arguments: ["kimi-cli", "kimi-code"]
+    )
+    func foregroundExecutableAlias(_ executable: String) {
+        #expect(
+            TerminalForegroundCommandCapture.commandLine(
+                fromArgv: [
+                    "/Users/example/.local/bin/\(executable)",
+                    "--resume", "stale-session",
+                    "--model", "kimi-k2",
+                ]
+            ) == "/Users/example/.local/bin/\(executable) --model kimi-k2"
+        )
     }
 
     @Test("Pre-existing custom Kimi Vault registrations remain decodable")
@@ -82,7 +117,9 @@ struct KimiRestorableAgentTests {
             RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fileManager)
                 .snapshot(workspaceId: workspaceID, panelId: panelID)
         )
+        #expect(snapshot.kind == .custom("kimi"))
         #expect(snapshot.kind.rawValue == "kimi")
+        #expect(snapshot.registration?.id == "kimi")
         #expect(snapshot.sessionId == sessionID)
         #expect(snapshot.workingDirectory == workingDirectory.path)
 

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -48,7 +48,7 @@ struct KimiRestorableAgentTests {
                         "surfaceId": panelID.uuidString,
                         "cwd": workingDirectory.path,
                         "isRestorable": true,
-                        "updatedAt": Date.now.timeIntervalSince1970,
+                        "updatedAt": 1_750_000_000.0,
                     ],
                 ],
             ],

--- a/cmuxTests/KimiRestorableAgentTests.swift
+++ b/cmuxTests/KimiRestorableAgentTests.swift
@@ -78,6 +78,34 @@ struct KimiRestorableAgentTests {
         #expect(registration.resumeCommand == "custom-kimi --resume {{sessionId}}")
     }
 
+    @Test("Custom Kimi registration keeps command ownership across snapshot persistence")
+    func customVaultRegistrationSurvivesSnapshotRoundTrip() throws {
+        let registration = CmuxVaultAgentRegistration(
+            id: "kimi",
+            name: "Custom Kimi",
+            detect: CmuxVaultAgentDetectRule(processName: "custom-kimi"),
+            sessionIdSource: .argvOption("--resume"),
+            resumeCommand: "custom-kimi --resume {{sessionId}}",
+            forkCommand: "custom-kimi --fork {{sessionId}}"
+        )
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .custom("kimi"),
+            sessionId: "custom-session",
+            workingDirectory: nil,
+            launchCommand: nil,
+            registration: registration
+        )
+
+        let decoded = try JSONDecoder().decode(
+            SessionRestorableAgentSnapshot.self,
+            from: JSONEncoder().encode(snapshot)
+        )
+
+        #expect(decoded.kind == .custom("kimi"))
+        #expect(decoded.resumeCommand == "'custom-kimi' '--resume' 'custom-session'")
+        #expect(decoded.forkCommand == "'custom-kimi' '--fork' 'custom-session'")
+    }
+
     @Test("Kimi hook sessions are discovered and produce a resume command")
     func hookSessionLoadsIntoResumePipeline() throws {
         let fileManager = FileManager.default

--- a/cmuxTests/KimiResumeReviewRegressionTests.swift
+++ b/cmuxTests/KimiResumeReviewRegressionTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-import XCTest
+@_implementationOnly import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -66,7 +66,7 @@ struct KimiResumeReviewRegressionTests {
         #expect(process.terminationStatus == 0)
 
         let capture = try String(contentsOf: captureURL, encoding: .utf8)
-        let fields = Dictionary(uniqueKeysWithValues: capture.split(separator: "\n").compactMap { line in
+        let fields: [String: String] = Dictionary(uniqueKeysWithValues: capture.split(separator: "\n").compactMap { line in
             let parts = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
             guard parts.count == 2 else { return nil }
             return (String(parts[0]), String(parts[1]))

--- a/cmuxTests/KimiResumeReviewRegressionTests.swift
+++ b/cmuxTests/KimiResumeReviewRegressionTests.swift
@@ -1,0 +1,262 @@
+import Foundation
+import Testing
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Kimi resume review regressions")
+struct KimiResumeReviewRegressionTests {
+    @Test("Bundled Kimi wrapper captures launch metadata before exec")
+    func bundledWrapperCapturesLaunchMetadata() throws {
+        let fileManager = FileManager.default
+        let bundledCLIURL = try BundledCLITestSupport.bundledCLIURL(
+            for: CLINotifyProcessIntegrationRegressionTests.self
+        )
+        let wrapperURL = bundledCLIURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("kimi", isDirectory: false)
+        let executableWrapperURL = try #require(
+            fileManager.isExecutableFile(atPath: wrapperURL.path) ? wrapperURL : nil
+        )
+
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-kimi-wrapper-\(UUID().uuidString)", isDirectory: true)
+        let realBinURL = root.appendingPathComponent("real-bin", isDirectory: true)
+        let launchDirectoryURL = root.appendingPathComponent("launch-repo", isDirectory: true)
+        let captureURL = root.appendingPathComponent("capture.txt", isDirectory: false)
+        let configURL = root.appendingPathComponent("kimi.toml", isDirectory: false)
+        try fileManager.createDirectory(at: realBinURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: launchDirectoryURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let realKimiURL = realBinURL.appendingPathComponent("kimi", isDirectory: false)
+        try """
+        #!/bin/sh
+        {
+          printf 'kind=%s\n' "${CMUX_AGENT_LAUNCH_KIND-}"
+          printf 'executable=%s\n' "${CMUX_AGENT_LAUNCH_EXECUTABLE-}"
+          printf 'argv=%s\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-}"
+          printf 'cwd=%s\n' "${CMUX_AGENT_LAUNCH_CWD-}"
+        } > "$CMUX_KIMI_TEST_CAPTURE"
+        """.write(to: realKimiURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: realKimiURL.path)
+
+        let process = Process()
+        process.executableURL = executableWrapperURL
+        process.arguments = [
+            "--model", "kimi-k2",
+            "--config-file", configURL.path,
+        ]
+        process.currentDirectoryURL = launchDirectoryURL
+        process.environment = [
+            "HOME": root.path,
+            "PATH": "\(realBinURL.path):/usr/bin:/bin",
+            "PWD": launchDirectoryURL.path,
+            "CMUX_SURFACE_ID": UUID().uuidString,
+            "CMUX_KIMI_TEST_CAPTURE": captureURL.path,
+        ]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+
+        let capture = try String(contentsOf: captureURL, encoding: .utf8)
+        let fields = Dictionary(uniqueKeysWithValues: capture.split(separator: "\n").compactMap { line in
+            let parts = line.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { return nil }
+            return (String(parts[0]), String(parts[1]))
+        })
+        #expect(fields["kind"] == "kimi")
+        #expect(fields["executable"] == realKimiURL.path)
+        #expect(fields["cwd"] == launchDirectoryURL.path)
+
+        let encodedArgv = try #require(fields["argv"])
+        let argvData = try #require(Data(base64Encoded: encodedArgv))
+        let capturedArgv = argvData
+            .split(separator: 0)
+            .map { String(decoding: $0, as: UTF8.self) }
+        #expect(capturedArgv == [
+            realKimiURL.path,
+            "--model", "kimi-k2",
+            "--config-file", configURL.path,
+        ])
+    }
+
+    @Test("Value-identical user Kimi registration keeps runtime cwd ownership")
+    func valueIdenticalCustomRegistrationKeepsRuntimeDirectory() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-custom-kimi-equal-\(UUID().uuidString)", isDirectory: true)
+        let launchWorkingDirectory = root.appendingPathComponent("launch-repo", isDirectory: true)
+        let runtimeWorkingDirectory = root.appendingPathComponent("runtime-worktree", isDirectory: true)
+        let stateDirectory = root.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fileManager.createDirectory(at: launchWorkingDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: runtimeWorkingDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: stateDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let userRegistration = try JSONDecoder().decode(
+            CmuxVaultAgentRegistration.self,
+            from: JSONEncoder().encode(CmuxVaultAgentRegistration.builtInKimi)
+        )
+        let registry = CmuxVaultAgentRegistry(registrations: [
+            .builtInKimi,
+            userRegistration,
+        ])
+        let workspaceID = UUID()
+        let panelID = UUID()
+        let sessionID = "user-kimi-session"
+        let store = try JSONSerialization.data(
+            withJSONObject: [
+                "version": 1,
+                "sessions": [
+                    sessionID: [
+                        "sessionId": sessionID,
+                        "workspaceId": workspaceID.uuidString,
+                        "surfaceId": panelID.uuidString,
+                        "cwd": runtimeWorkingDirectory.path,
+                        "launchCommand": [
+                            "launcher": "kimi",
+                            "executablePath": "/Users/example/.local/bin/kimi",
+                            "arguments": ["/Users/example/.local/bin/kimi"],
+                            "workingDirectory": launchWorkingDirectory.path,
+                            "capturedAt": 1_750_000_000.0,
+                            "source": "test",
+                        ],
+                        "isRestorable": true,
+                        "updatedAt": 1_750_000_000.0,
+                    ],
+                ],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try store.write(
+            to: stateDirectory.appendingPathComponent("kimi-hook-sessions.json", isDirectory: false),
+            options: .atomic
+        )
+
+        let snapshot = try #require(
+            RestorableAgentSessionIndex.load(
+                homeDirectory: root.path,
+                fileManager: fileManager,
+                registry: registry,
+                detectedSnapshots: [:],
+                processArgumentsProvider: { _ in nil }
+            ).snapshot(workspaceId: workspaceID, panelId: panelID)
+        )
+        #expect(snapshot.registration == userRegistration)
+        #expect(snapshot.workingDirectory == runtimeWorkingDirectory.path)
+        #expect(snapshot.resumeCommand?.hasPrefix("cd -- '\(runtimeWorkingDirectory.path)'") == true)
+    }
+
+    @Test("Custom Kimi snapshot owns restore over generic hook binding")
+    @MainActor
+    func customSnapshotOwnsRestoreOverHookBinding() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-custom-kimi-binding-\(UUID().uuidString)", isDirectory: true)
+        let runtimeWorkingDirectory = root.appendingPathComponent("runtime-worktree", isDirectory: true)
+        try fileManager.createDirectory(at: runtimeWorkingDirectory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let defaultsName = "cmux-custom-kimi-binding-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let sessionID = "custom-kimi-binding-session"
+        let customRegistration = CmuxVaultAgentRegistration(
+            id: "kimi",
+            name: "Custom Kimi",
+            detect: CmuxVaultAgentDetectRule(processName: "custom-kimi"),
+            sessionIdSource: .argvOption("--resume"),
+            resumeCommand: "custom-kimi --resume {{sessionId}}"
+        )
+        let source = Workspace(agentSessionAutoResumeDefaults: defaults)
+        let sourcePanelID = try #require(source.focusedPanelId)
+        source.updatePanelDirectory(panelId: sourcePanelID, directory: runtimeWorkingDirectory.path)
+        source.updatePanelShellActivityState(panelId: sourcePanelID, state: .commandRunning)
+        source.setRestoredAgentSnapshotForTesting(
+            SessionRestorableAgentSnapshot(
+                kind: .custom("kimi"),
+                sessionId: sessionID,
+                workingDirectory: runtimeWorkingDirectory.path,
+                launchCommand: nil,
+                registration: customRegistration
+            ),
+            panelId: sourcePanelID
+        )
+        let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+            SurfaceResumeBindingIndex.PanelKey(
+                workspaceId: source.id,
+                panelId: sourcePanelID
+            ): SurfaceResumeBindingSnapshot(
+                name: "Kimi Code",
+                kind: "kimi",
+                command: "'kimi' '--resume' '\(sessionID)'",
+                cwd: runtimeWorkingDirectory.path,
+                checkpointId: sessionID,
+                source: "agent-hook",
+                autoResume: true,
+                updatedAt: 1_750_000_000
+            ),
+        ])
+
+        let persisted = source.sessionSnapshot(
+            includeScrollback: false,
+            surfaceResumeBindingIndex: bindingIndex
+        )
+        #expect(persisted.panels.first?.terminal?.agent?.kind == .custom("kimi"))
+        #expect(persisted.panels.first?.terminal?.resumeBinding?.kind == "kimi")
+
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        restored.restoreSessionSnapshot(persisted)
+        let restoredPanelID = try #require(restored.focusedPanelId)
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelID))
+        let launcherCommand = try #require(restoredPanel.surface.debugInitialCommand())
+        let launcherWords = TerminalStartupWorkingDirectoryPrefix
+            .shellWordRanges(launcherCommand)
+            .map(\.value)
+        #expect(launcherWords.first == "/bin/zsh", "\(launcherCommand)")
+        let launcherPath = try #require(launcherWords.dropFirst().first)
+        let launcher = try String(contentsOfFile: launcherPath, encoding: .utf8)
+        #expect(launcher.contains("'custom-kimi' '--resume' '\(sessionID)'"), "\(launcher)")
+        #expect(!launcher.contains("'kimi' '--resume' '\(sessionID)'"), "\(launcher)")
+    }
+}
+
+extension CLINotifyProcessIntegrationRegressionTests {
+    func testKimiHookAcceptsAndSanitizesWrapperLaunchCapture() throws {
+        try runGenericHookPersistenceScenario(
+            GenericHookPersistenceScenario(
+                agent: "kimi",
+                subcommand: "session-start",
+                sessionId: "kimi-wrapper-session",
+                executable: "/Users/example/.local/bin/kimi",
+                launchArguments: [
+                    "/Users/example/.local/bin/kimi",
+                    "--resume", "stale-session",
+                    "--model", "kimi-k2",
+                    "--config-file", "/tmp/kimi.toml",
+                    "-c", "stale prompt",
+                    "--plan",
+                ],
+                extraEnvironment: [
+                    "KIMI_SHARE_DIR": "/tmp/kimi-share",
+                    "MOONSHOT_API_KEY": "secret",
+                ],
+                expectedArguments: [
+                    "/Users/example/.local/bin/kimi",
+                    "--model", "kimi-k2",
+                    "--config-file", "/tmp/kimi.toml",
+                ],
+                expectedEnvironment: ["KIMI_SHARE_DIR": "/tmp/kimi-share"]
+            )
+        )
+    }
+}

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1638,7 +1638,7 @@ final class SessionPersistenceTests: XCTestCase {
                 includeScrollback: false,
                 restorableAgentIndex: staleIndex
             )
-            let expectedKind: RestorableAgentKind = scenario.kind == .pi ? .custom("pi") : scenario.kind
+            let expectedKind: RestorableAgentKind = [.pi, .kimi].contains(scenario.kind) ? .custom(scenario.kind.rawValue) : scenario.kind
             XCTAssertEqual(initialSnapshot.panels.first?.terminal?.agent?.kind, expectedKind)
 
             workspace.updatePanelShellActivityState(panelId: panelId, state: .promptIdle)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1614,6 +1614,14 @@ final class SessionPersistenceTests: XCTestCase {
                     "gemini-2.5-pro",
                 ]
             ),
+            (
+                .kimi,
+                [
+                    "/usr/local/bin/kimi",
+                    "--model",
+                    "kimi-k2",
+                ]
+            ),
         ]
 
         for scenario in scenarios {
@@ -1786,6 +1794,8 @@ final class SessionPersistenceTests: XCTestCase {
                 resolvedEnvironment = ["CODEBUDDY_CONFIG_DIR": "/tmp/codebuddy"]
             case .qoder:
                 resolvedEnvironment = ["QODER_CONFIG_DIR": "/tmp/qoder"]
+            case .kimi:
+                resolvedEnvironment = ["KIMI_SHARE_DIR": "/tmp/kimi"]
             }
         }
         let resolvedExecutablePath = executablePath ?? arguments.first ?? "/usr/local/bin/\(kind.rawValue)"


### PR DESCRIPTION
Closes #8582

Registers Kimi Code as a registry-owned restorable agent so the shared hook-store loader discovers `kimi-hook-sessions.json` after relaunch while preserving pre-existing custom Vault registrations that use the `kimi` id.

Implementation:
- resumes exact sessions with `kimi --resume <session-id>`, verified against Kimi CLI 1.49.0 help and installed source
- sanitizes captured Kimi argv, removing stale session selectors, approval/plan modes, prompts, and one-shot/server modes while retaining safe interactive configuration
- preserves `KIMI_SHARE_DIR` but not `MOONSHOT_API_KEY`
- adds a built-in, project-overridable Kimi Vault registration and keeps the native Codable enum case for persisted round trips
- recognizes `kimi`, `kimi-cli`, and `kimi-code` through the shared foreground sanitizer, plus Kimi's actual `Kimi Code` OS process title in task-manager/lifecycle detection
- localizes the Kimi Code display name in English and Japanese

No Kimi-specific process-scanner or resume-canonicalizer branch is needed: Kimi's hook record provides the deterministic session id, the shared registry hook loader consumes it, and canonicalizer special cases are limited to wrapper-routed Claude/Codex executables.

Testing:
- regression tests and implementations are split across red/green commits
- intentionally red CI run 29874920961 proved the new `--plan` sanitizer case and custom `kimi` Vault registration case fail before the final fix
- static Swift parsing, project normalization/wiring, workspace package grouping, `Package.resolved` policy, localization catalog/locale audit, and diff checks pass locally
- local Xcode tests and builds intentionally not run per task instructions; CI is the test authority
- the Swift file-length budget script and TSV referenced by the issue are absent on current main; the new Swift file is 12 lines, the existing 503-line registry file did not grow, and `swift-warning-budget.tsv` is unchanged
