### PR TITLE
Preserve Subrouter Codex placeholder across session resumes

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -111,6 +111,8 @@ public struct AgentLaunchEnvironmentPolicy: Sendable {
         "PI_PACKAGE_DIR",
         "PI_SKIP_VERSION_CHECK",
         "QODER_CONFIG_DIR",
+        // Subrouter's Codex provider config references this fixed, non-secret placeholder.
+        "SUBROUTER_CODEX_DUMMY_API_KEY",
         "USE_BUILTIN_RIPGREP"
     ]
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchEnvironmentPolicyTests.swift
@@ -3,6 +3,21 @@ import Testing
 
 @Suite("AgentLaunchEnvironmentPolicy")
 struct AgentLaunchEnvironmentPolicyTests {
+    @Test("Preserves Subrouter's non-secret Codex placeholder without persisting real API keys")
+    func preservesSubrouterCodexPlaceholderWithoutPersistingSecrets() {
+        let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(
+            from: [
+                "OPENAI_API_KEY": "secret-should-not-persist",
+                "SUBROUTER_CODEX_DUMMY_API_KEY": "subrouter-placeholder",
+            ],
+            kind: "codex"
+        )
+
+        #expect(selected == [
+            "SUBROUTER_CODEX_DUMMY_API_KEY": "subrouter-placeholder",
+        ])
+    }
+
     @Test("Preserves OMP config roots without persisting secrets")
     func preservesOmpConfigRootsWithoutPersistingSecrets() {
         let selected = AgentLaunchEnvironmentPolicy().selectedEnvironment(


### PR DESCRIPTION
## Summary

- preserve Subrouter's non-secret Codex placeholder when cmux captures and replays a Codex launch environment
- continue dropping real API-key variables from persisted resume state
- add behavioral regression coverage for the exact resume-policy failure

## Root cause

`subrouter codex` injects `SUBROUTER_CODEX_DUMMY_API_KEY` because its generated Codex provider configuration references that environment key. cmux resumes the inner Codex process directly, but `AgentLaunchEnvironmentPolicy` currently drops the placeholder. The resumed argv still references it, so Codex exits with `Missing environment variable: SUBROUTER_CODEX_DUMMY_API_KEY`.

## Validation

The first commit intentionally contains only the regression test. It fails because the selected environment is empty, while confirming `OPENAI_API_KEY` remains excluded. A follow-up commit will add the narrow policy fix and make the test green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787261495&installation_model_id=21920&pr_number=8585&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8585&signature=b73b3d881a75329ff2bc4af33d07c24087431d1b9ffbb6d324169d349b3d80f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Subrouter’s non‑secret Codex placeholder `SUBROUTER_CODEX_DUMMY_API_KEY` across resumes by allowlisting it, while still stripping real keys like `OPENAI_API_KEY`, preventing Codex restarts from failing. Adds a regression test.

<sup>Written for commit a513e84644298b344fd2b85ec82b37d8a7a1d8e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that Codex subrouter placeholder settings are preserved without storing sensitive API key values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->