### PR TITLE
File explorer briefly lists the old local path through a new SSH connection

### DIFF
--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -1024,6 +1024,10 @@ final class FileExplorerStore: ObservableObject {
 
     @MainActor
     private func loadChildren(for parentNode: FileExplorerNode?, at path: String, silent: Bool = false) async {
+        // A load cancelled by cancelAllLoads (e.g. a root reload during an SSH provider swap) must not
+        // reach provider.listDirectory: the provider may have been replaced, so a stale in-flight load
+        // would list the old path through the new transport. Bail before any listing.
+        guard !Task.isCancelled else { return }
         guard let provider else { return }
 
         if !silent {


### PR DESCRIPTION
## What you'd hit

Open the file explorer on a local workspace, then point that workspace at a remote SSH host. The explorer should repoint to the remote home directory, but it can briefly list the old local directory's path through the remote connection before settling.

## Why

File-explorer directory loads run as cancellable tasks. `loadChildren` only checked for cancellation *after* calling `provider.listDirectory`. When the root reloads during the swap to the SSH provider (the root path is cleared, all in-flight loads are cancelled, then the provider is replaced), the cancelled local root load still ran its body: it bound the now-current provider (the SSH one) and called `listDirectory` on the stale local path, so the post-list cancellation check discarded the result but the spurious listing had already gone out over the remote transport.

## Fix

Bail at the top of `loadChildren` when the task is already cancelled, before any listing. `cancelAllLoads` is the only place load tasks are cancelled and it clears the load bookkeeping, so an early return strands no state; the stretch from entry to `listDirectory` is synchronous on the main actor, so this closes the window where a cancelled load could list through a swapped provider.

## Tests

`FileExplorerStoreTests.testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath` is the red/green pin. Before, `transport.listedPaths` is the stale local path followed by the remote home; after, it is just the remote home. The full suite goes from 15 tests with 1 failure to `15 tests in 1 suite passed`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787263915&installation_model_id=21920&pr_number=8595&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8595&signature=811a3041522ec0affe7b00a9e09187a2cc56007235e41327cc9ae7f5f4137495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flicker where the file explorer briefly showed the old local path after switching a workspace to SSH. We now exit cancelled `loadChildren` tasks before calling `provider.listDirectory`, so a cancelled local load can’t list the stale path over the new SSH transport.

<sup>Written for commit 11d5fa4a293288d1f740a9b4ac39d0baab791253. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented canceled file and directory loads from continuing after a provider or connection changes.
  * Improved reliability when switching SSH providers or transports during active loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->