### PR TITLE
Attach plain cmux-tui launches to existing sessions

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -128,10 +128,10 @@ struct Args {
 }
 
 impl Args {
-    fn should_attach_existing(&self) -> bool {
+    fn should_attach_existing(&self, ws_addr: &Option<String>, ws_token: &Option<String>) -> bool {
         !self.headless
-            && self.ws.is_none()
-            && self.ws_token.is_none()
+            && ws_addr.is_none()
+            && ws_token.is_none()
             && !self.ws_insecure_bind
             && self.term.is_none()
     }
@@ -232,13 +232,16 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
 }
 
 fn run_server(args: Args) -> anyhow::Result<()> {
+    let config = config::load();
+    let ws_addr = args.ws.clone().or(config.server.ws.clone());
+    let ws_token = args.ws_token.clone().or(config.server.ws_token.clone());
     // Compute the socket path up front so a normal interactive launch can
     // reuse an existing local session and surface children inherit it.
     let socket_path = args
         .socket
         .clone()
         .unwrap_or_else(|| cmux_tui_core::server::default_socket_path(&args.session));
-    if args.should_attach_existing()
+    if args.should_attach_existing(&ws_addr, &ws_token)
         && socket_path.exists()
         && let Ok(remote) = RemoteSession::connect(&socket_path)
     {
@@ -246,9 +249,6 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     }
 
     let mut surface_options = SurfaceOptions::default();
-    let config = config::load();
-    let ws_addr = args.ws.or(config.server.ws.clone());
-    let ws_token = args.ws_token.or(config.server.ws_token.clone());
     config::apply_browser_to_surface_options(&config, &mut surface_options);
     if let Some(term) = args.term {
         surface_options.term = term;

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -23,6 +23,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use cmux_tui_core::platform::transport;
 use cmux_tui_core::{Mux, SurfaceOptions};
 use session::{RemoteSession, Session};
 
@@ -127,6 +128,16 @@ struct Args {
     term: Option<String>,
 }
 
+impl Args {
+    fn should_attach_existing(&self) -> bool {
+        !self.headless
+            && self.ws.is_none()
+            && self.ws_token.is_none()
+            && !self.ws_insecure_bind
+            && self.term.is_none()
+    }
+}
+
 fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
     let mut out = Args {
         attach: false,
@@ -222,6 +233,17 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
 }
 
 fn run_server(args: Args) -> anyhow::Result<()> {
+    // Compute the socket path up front so a normal interactive launch can
+    // reuse an existing local session and surface children inherit it.
+    let socket_path = args
+        .socket
+        .clone()
+        .unwrap_or_else(|| cmux_tui_core::server::default_socket_path(&args.session));
+    if args.should_attach_existing() && transport::connect(&socket_path).is_ok() {
+        let remote = RemoteSession::connect(&socket_path)?;
+        return run_tui(Session::Remote(remote), args.session);
+    }
+
     let mut surface_options = SurfaceOptions::default();
     let config = config::load();
     let ws_addr = args.ws.or(config.server.ws.clone());
@@ -230,9 +252,6 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     if let Some(term) = args.term {
         surface_options.term = term;
     }
-    // Compute the socket path up front so surface children inherit it.
-    let socket_path =
-        args.socket.unwrap_or_else(|| cmux_tui_core::server::default_socket_path(&args.session));
     surface_options.extra_env.push(("CMUX_TUI_SOCKET".into(), socket_path.display().to_string()));
     surface_options.extra_env.push(("CMUX_MUX_SOCKET".into(), socket_path.display().to_string()));
 

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -23,7 +23,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use cmux_tui_core::platform::transport;
 use cmux_tui_core::{Mux, SurfaceOptions};
 use session::{RemoteSession, Session};
 
@@ -239,8 +238,10 @@ fn run_server(args: Args) -> anyhow::Result<()> {
         .socket
         .clone()
         .unwrap_or_else(|| cmux_tui_core::server::default_socket_path(&args.session));
-    if args.should_attach_existing() && transport::connect(&socket_path).is_ok() {
-        let remote = RemoteSession::connect(&socket_path)?;
+    if args.should_attach_existing()
+        && socket_path.exists()
+        && let Ok(remote) = RemoteSession::connect(&socket_path)
+    {
         return run_tui(Session::Remote(remote), args.session);
     }
 

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1,6 +1,8 @@
 use std::fs;
 #[cfg(unix)]
 use std::fs::File;
+#[cfg(unix)]
+use std::io::Read;
 use std::io::{BufRead, BufReader, Write};
 #[cfg(unix)]
 use std::os::fd::FromRawFd;
@@ -58,7 +60,7 @@ impl Drop for HeadlessServer {
 #[cfg(unix)]
 struct PtyChild {
     child: Child,
-    _master: File,
+    output_drain: Option<std::thread::JoinHandle<()>>,
 }
 
 #[cfg(unix)]
@@ -77,8 +79,12 @@ impl PtyChild {
             )
         };
         assert_eq!(opened, 0, "openpty failed: {}", std::io::Error::last_os_error());
-        let master = unsafe { File::from_raw_fd(master) };
+        let mut master = unsafe { File::from_raw_fd(master) };
         let slave = unsafe { File::from_raw_fd(slave) };
+        let output_drain = std::thread::spawn(move || {
+            let mut buffer = [0; 8192];
+            while master.read(&mut buffer).is_ok_and(|read| read > 0) {}
+        });
         let child = Command::new(bin())
             .args(args)
             .env_remove("CMUX_TUI_SOCKET")
@@ -87,7 +93,7 @@ impl PtyChild {
             .stderr(Stdio::from(slave))
             .spawn()
             .unwrap();
-        Self { child, _master: master }
+        Self { child, output_drain: Some(output_drain) }
     }
 }
 
@@ -96,6 +102,9 @@ impl Drop for PtyChild {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
+        if let Some(output_drain) = self.output_drain.take() {
+            let _ = output_drain.join();
+        }
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -1,5 +1,9 @@
 use std::fs;
+#[cfg(unix)]
+use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
 use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use std::sync::mpsc;
@@ -49,6 +53,79 @@ impl Drop for HeadlessServer {
         let _ = fs::remove_file(&self.socket);
         let _ = fs::remove_dir_all(&self.dir);
     }
+}
+
+#[cfg(unix)]
+struct PtyChild {
+    child: Child,
+    _master: File,
+}
+
+#[cfg(unix)]
+impl PtyChild {
+    fn start(args: &[&str]) -> Self {
+        let mut master = -1;
+        let mut slave = -1;
+        let mut size = libc::winsize { ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0 };
+        let opened = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut size,
+            )
+        };
+        assert_eq!(opened, 0, "openpty failed: {}", std::io::Error::last_os_error());
+        let master = unsafe { File::from_raw_fd(master) };
+        let slave = unsafe { File::from_raw_fd(slave) };
+        let child = Command::new(bin())
+            .args(args)
+            .env_remove("CMUX_TUI_SOCKET")
+            .stdin(Stdio::from(slave.try_clone().unwrap()))
+            .stdout(Stdio::from(slave.try_clone().unwrap()))
+            .stderr(Stdio::from(slave))
+            .spawn()
+            .unwrap();
+        Self { child, _master: master }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PtyChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn plain_launch_attaches_to_existing_local_session() {
+    let server = HeadlessServer::start("plain-launch-attach");
+    let mut tui = PtyChild::start(&["--socket", server.socket.to_str().unwrap()]);
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    while Instant::now() < deadline {
+        if let Some(status) = tui.child.try_wait().unwrap() {
+            panic!("plain launch exited instead of attaching: {status}");
+        }
+        let clients = cli(&server, &["--json", "list-clients"]);
+        if clients.status.success() {
+            let clients: serde_json::Value = serde_json::from_slice(&clients.stdout).unwrap();
+            if clients
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|client| client["kind"].as_str() == Some("tui"))
+            {
+                return;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    panic!("plain launch never attached as a TUI client");
 }
 
 #[test]

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -66,6 +66,10 @@ struct PtyChild {
 #[cfg(unix)]
 impl PtyChild {
     fn start(args: &[&str]) -> Self {
+        Self::start_with_env(args, &[])
+    }
+
+    fn start_with_env(args: &[&str], env: &[(&str, &std::ffi::OsStr)]) -> Self {
         let mut master = -1;
         let mut slave = -1;
         let mut size = libc::winsize { ws_row: 24, ws_col: 80, ws_xpixel: 0, ws_ypixel: 0 };
@@ -85,9 +89,12 @@ impl PtyChild {
             let mut buffer = [0; 8192];
             while master.read(&mut buffer).is_ok_and(|read| read > 0) {}
         });
-        let child = Command::new(bin())
-            .args(args)
-            .env_remove("CMUX_TUI_SOCKET")
+        let mut command = Command::new(bin());
+        command.args(args).env_remove("CMUX_TUI_SOCKET");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let child = command
             .stdin(Stdio::from(slave.try_clone().unwrap()))
             .stdout(Stdio::from(slave.try_clone().unwrap()))
             .stderr(Stdio::from(slave))
@@ -135,6 +142,29 @@ fn plain_launch_attaches_to_existing_local_session() {
     }
 
     panic!("plain launch never attached as a TUI client");
+}
+
+#[cfg(unix)]
+#[test]
+fn configured_websocket_server_does_not_attach_to_existing_session() {
+    let server = HeadlessServer::start("configured-websocket-server");
+    let config = server.dir.join("config.json");
+    fs::write(&config, r#"{"server":{"ws":"127.0.0.1:0"}}"#).unwrap();
+    let mut tui = PtyChild::start_with_env(
+        &["--socket", server.socket.to_str().unwrap()],
+        &[("CMUX_TUI_CONFIG", config.as_os_str())],
+    );
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    while Instant::now() < deadline {
+        if let Some(status) = tui.child.try_wait().unwrap() {
+            assert!(!status.success(), "server launch unexpectedly succeeded");
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    panic!("configured WebSocket server attached instead of preserving server mode");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- attach a plain interactive launch to an existing local session socket
- preserve explicit server behavior for `--headless`, WebSocket, and `--term` launches
- cover the second-launch path with a real-PTY regression test in a test-only commit

## Testing

- `cargo test -p cmux-tui`
- `cargo clippy -p cmux-tui --all-targets -- -D warnings`
- `cargo fmt --all --check`
- two plain worktree-binary launches registered as TUI clients on the same session

Tagged app reload is blocked on current `main`: Xcode 26.5 rejects `public convenience init()` on `GitHubPullRequestRequestCoordinator` in [cloud run 29873113791](https://github.com/manaflow-ai/cmux/actions/runs/29873113791). This PR does not touch that Swift package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal interface launches now automatically attach to an existing local session when available, avoiding duplicate sessions.
* **Bug Fixes**
  * Improved detection and routing to the correct session during startup.
  * Ensures configured WebSocket server mode does not attach to an already-running local session.
* **Tests**
  * Added Unix-only integration tests validating both attachment-on-normal-launch and non-attachment for configured WebSocket mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->