### PR TITLE
Right-sidebar mode shortcuts do nothing when the key view briefly clears

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6837,7 +6837,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func shouldRouteRightSidebarModeShortcut(in window: NSWindow?) -> Bool {
         guard let window else { return false }
         let sidebarIntentActive = keyboardFocusCoordinator(for: window)?.activeRightSidebarMode != nil
-        guard let responder = window.firstResponder else { return sidebarIntentActive }
+        // makeFirstResponder(nil) parks firstResponder on the window itself, so responder === window
+        // means there is no real responder, so treat it like nil and route on the active sidebar intent.
+        guard let responder = window.firstResponder, responder !== window else { return sidebarIntentActive }
         if isRightSidebarFocusResponder(responder, in: window) { return true }
         if sidebarIntentActive, responder is NSWindow { return true }
         if terminalKeyboardFocusRequest(for: responder) != nil { return false }


### PR DESCRIPTION
## What you'd hit

Focus the right sidebar (files, sessions, and so on), then do something that briefly clears the key view. Press a right-sidebar mode shortcut (Ctrl+1..5 by default) during that window and nothing happens, instead of switching the sidebar mode.

## Why

`shouldRouteRightSidebarModeShortcut` decides whether a mode shortcut routes to the sidebar. It bails to the active sidebar intent only when there is no first responder:

```swift
guard let responder = window.firstResponder else { return sidebarIntentActive }
```

But `makeFirstResponder(nil)` does not leave `firstResponder` nil. AppKit parks the first responder on the window itself, so `window.firstResponder` is the window. The guard treats that as a real responder and falls through to the terminal-surface checks, which can't resolve a view from a window and return false, so the shortcut does nothing even though a sidebar intent is active. The nil-responder fallback was added for exactly this "responder temporarily clears" case (#6472), but it keyed on a state AppKit essentially never produces.

## Fix

Treat a responder that is the window itself like no responder:

```swift
guard let responder = window.firstResponder, responder !== window else { return sidebarIntentActive }
```

This only changes the one case where the responder is parked on the window and a sidebar intent is active. With no intent the result is unchanged, and a real view responder still takes the terminal path.

## Tests

`AppDelegateSurfaceShortcutRoutingTests.rightSidebarModeShortcutsDoNotFallThroughWhenResponderTemporarilyClears` already exists (it shipped with the fallback in #6472) and is red on `main`, because the fallback keyed on `nil` while AppKit parks the responder on the window. Before, the mode shortcut falls through to `selectSurfaceByNumber` (the recorded issues are three keys across ten cycles). After, all 9 tests in the suite pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787264704&installation_model_id=21920&pr_number=8599&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8599&signature=3a3a47f8c7ca9d8853f4015b8f67dc247b39f51f1441bfcf0686e27a5c9484dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix right-sidebar mode shortcuts (Ctrl+1–5) to still switch modes when the key view briefly clears. When `makeFirstResponder(nil)` parks focus on the window, treat `window.firstResponder === window` as no responder and route to the active right-sidebar intent.

<sup>Written for commit 7c3659b61ae842b3b001f8a484141fa459efefe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved right-sidebar keyboard shortcut handling when no specific window control is focused.
  * Shortcuts now correctly follow the active right-sidebar mode in this situation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->