### PR TITLE
CLI tab reorder by index silently no-ops on a forward move

### DIFF
--- a/Sources/TerminalController+RemoteTmuxControlTopology.swift
+++ b/Sources/TerminalController+RemoteTmuxControlTopology.swift
@@ -92,7 +92,11 @@ extension TerminalController {
 
         let targetIndex: Int
         if let index = inputs.index {
-            targetIndex = index
+            // The CLI sends a final tab position; reorderSurface takes a bonsplit insertion gap.
+            // Moving a tab to a higher slot must target index + 1 so the gap lands after the tab
+            // currently occupying that slot; otherwise a move to sourceIndex + 1 is a silent no-op.
+            guard let currentIndex = ws.indexInPane(forPanelId: sourcePanelID) else { return .reorderFailed }
+            targetIndex = index > currentIndex ? index + 1 : index
         } else if let beforeSurfaceID = inputs.beforeSurfaceID {
             guard let anchorPanelID = ws.controlReorderContainerPanelID(for: beforeSurfaceID),
                   let anchorPane = ws.paneId(forPanelId: anchorPanelID),


### PR DESCRIPTION
## What you'd hit

Reorder a mirror tab through the CLI by its final position (for example, move the first tab to index 1). The tab does not move, but the command reports success.

## Why

`controlSurfaceReorder` passes the CLI's requested final position straight to `reorderSurface`:

```swift
targetIndex = index
```

`reorderSurface` takes a bonsplit insertion gap, not a final position. Moving a tab from slot 0 to slot 1 asks bonsplit to move to gap `sourceIndex + 1`, which bonsplit treats as a no-op while still returning success, so the reorder silently does nothing and replies `.reordered`. Every farther forward move lands one slot short.

## Fix

Convert the final position to an insertion gap, the same conversion the other reorder call sites already do:

```swift
guard let currentIndex = ws.indexInPane(forPanelId: sourcePanelID) else { return .reorderFailed }
targetIndex = index > currentIndex ? index + 1 : index
```

A forward move targets the gap after the tab currently in that slot; a backward or same-slot move is unchanged. The before/after-anchor branches already used gap semantics and are untouched, and the shared `reorderSurface` is not changed.

## Tests

`RemoteTmuxMirrorCLIObservabilityTests.advertisedMirrorSurfaceReordersItsOwningWindowTab` already exists (it shipped with the buggy line in #8405) and is red on `main`. Before, moving tab 0 to index 1 leaves the order unchanged (`[outer, peer]`); after, it becomes `[peer, outer]`. The full suite goes from 23 tests with 1 failure to 23 tests passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787264706&installation_model_id=21920&pr_number=8600&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8600&signature=b70456607bc76b0c0d09e05e811a880622fcb837da2849d4447a9fdbac815efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI tab reordering by final index for remote tmux mirrors. Forward moves no longer silently no-op and tabs land in the correct slot.

- **Bug Fixes**
  - Convert final position to bonsplit insertion gap (`index > currentIndex ? index + 1 : index`); return `.reorderFailed` if the current index is missing.

<sup>Written for commit 02c66f0f8c39d30667e2a4b4ab65d0db3097e17e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed panel reordering when moving a panel to a higher position.
  * Reordering now places panels in the correct target position and reports a failure when the current panel position cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->