### PR TITLE
Fix browser navigation for terminal-wrapped URL pastes

### DIFF
--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserSurfaceState.swift
@@ -126,7 +126,7 @@ public final class BrowserSurfaceState: Identifiable {
     ///   Defaults to ``BrowserURLResolver`` semantics.
     /// - Returns: `true` if a URL was resolved and a load was requested.
     @discardableResult
-    public func submitAddress(using resolve: (String) -> URL? = { BrowserURLResolver.resolve($0) }) -> Bool {
+    public func submitAddress(using resolve: (String) -> URL? = { BrowserURLResolver().resolve($0) }) -> Bool {
         guard let url = resolve(addressText) else { return false }
         load(url)
         return true

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
@@ -90,7 +90,7 @@ public struct BrowserURLResolver: Sendable {
         if isWebURL(compacted) {
             return hasCompleteWebAuthorityBeforeFirstCompactedCharacter(in: original)
         }
-        guard hasSchemeLessURLEvidenceBeforeFirstLineBreak(in: original) else { return false }
+        guard hasCompleteSchemeLessAuthorityBeforeFirstCompactedCharacter(in: original) else { return false }
         return isSchemeLessHostWithStructure(compacted)
     }
 
@@ -109,13 +109,15 @@ public struct BrowserURLResolver: Sendable {
         return authorityEnd < compactedCharacter
     }
 
-    /// Rejects free text whose first URL-like token starts only after a line break.
-    private func hasSchemeLessURLEvidenceBeforeFirstLineBreak(in input: String) -> Bool {
-        guard let lineBreak = input.firstIndex(where: \.isNewline) else { return false }
-        return input[..<lineBreak].contains { character in
-            character == "." || character == ":" || character == "/" ||
-                character == "?" || character == "#"
+    /// Allows scheme-less wrap removal only after the authority is complete.
+    private func hasCompleteSchemeLessAuthorityBeforeFirstCompactedCharacter(in input: String) -> Bool {
+        guard let compactedCharacter = input.firstIndex(where: { $0.isNewline || $0 == "\t" }),
+              let authorityEnd = input.firstIndex(where: { character in
+                  character == "/" || character == "?" || character == "#"
+              }) else {
+            return false
         }
+        return authorityEnd < compactedCharacter
     }
 
     private func isWebURL(_ input: String) -> Bool {

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
@@ -59,6 +59,9 @@ public struct BrowserURLResolver: Sendable {
         if let schemed = schemedURL(from: trimmed) {
             return schemed
         }
+        guard !hasSchemeLessUserInfo(in: trimmed) else {
+            return searchURL(for: searchText)
+        }
         if looksLikeHost(trimmed) {
             // Local dev servers (localhost, loopback, private LAN) listen on
             // plain HTTP, and opening a local dev server is a central cmux
@@ -139,6 +142,15 @@ public struct BrowserURLResolver: Sendable {
             character != "/" && character != "?" && character != "#"
         }
         return !authority.isEmpty && !authority.contains(where: \.isWhitespace)
+    }
+
+    /// Rejects scheme-less userinfo while allowing `@` in paths and queries.
+    private func hasSchemeLessUserInfo(in input: String) -> Bool {
+        guard !input.contains("://") else { return false }
+        let authority = input.prefix { character in
+            character != "/" && character != "?" && character != "#"
+        }
+        return authority.contains("@")
     }
 
     private func isSchemeLessHostWithStructure(_ input: String) -> Bool {

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
@@ -52,6 +52,9 @@ public struct BrowserURLResolver: Sendable {
         let searchText = input.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmed = canonicalNavigationText(searchText)
         guard !trimmed.isEmpty else { return nil }
+        guard !trimmed.contains(where: { $0.isNewline || $0 == "\t" }) else {
+            return searchURL(for: searchText)
+        }
 
         if let schemed = schemedURL(from: trimmed) {
             return schemed
@@ -85,10 +88,25 @@ public struct BrowserURLResolver: Sendable {
     private func isWhitespaceCompactionSafe(_ compacted: String, original: String) -> Bool {
         guard !compacted.isEmpty else { return false }
         if isWebURL(compacted) {
-            return true
+            return hasCompleteWebAuthorityBeforeFirstCompactedCharacter(in: original)
         }
         guard hasSchemeLessURLEvidenceBeforeFirstLineBreak(in: original) else { return false }
         return isSchemeLessHostWithStructure(compacted)
+    }
+
+    /// Allows wrap removal only after the explicit URL's authority is complete.
+    private func hasCompleteWebAuthorityBeforeFirstCompactedCharacter(in input: String) -> Bool {
+        guard let compactedCharacter = input.firstIndex(where: { $0.isNewline || $0 == "\t" }),
+              let schemeSeparator = input.range(of: "://"),
+              schemeSeparator.upperBound < compactedCharacter else {
+            return false
+        }
+        guard let authorityEnd = input[schemeSeparator.upperBound...].firstIndex(where: { character in
+            character == "/" || character == "?" || character == "#"
+        }) else {
+            return false
+        }
+        return authorityEnd < compactedCharacter
     }
 
     /// Rejects free text whose first URL-like token starts only after a line break.
@@ -101,7 +119,8 @@ public struct BrowserURLResolver: Sendable {
     }
 
     private func isWebURL(_ input: String) -> Bool {
-        guard let components = URLComponents(string: input),
+        guard hasWhitespaceFreeAuthority(in: input),
+              let components = URLComponents(string: input),
               let scheme = components.scheme?.lowercased(),
               scheme == "http" || scheme == "https",
               let host = components.host,
@@ -109,6 +128,15 @@ public struct BrowserURLResolver: Sendable {
             return false
         }
         return true
+    }
+
+    /// Rejects whitespace that Foundation would otherwise encode inside URL userinfo.
+    private func hasWhitespaceFreeAuthority(in input: String) -> Bool {
+        guard let schemeSeparator = input.range(of: "://") else { return false }
+        let authority = input[schemeSeparator.upperBound...].prefix { character in
+            character != "/" && character != "?" && character != "#"
+        }
+        return !authority.isEmpty && !authority.contains(where: \.isWhitespace)
     }
 
     private func isSchemeLessHostWithStructure(_ input: String) -> Bool {
@@ -179,7 +207,8 @@ public struct BrowserURLResolver: Sendable {
     /// usable scheme. Schemes other than `http`/`https` are rejected so a typed
     /// `file:` or `javascript:` cannot be loaded from the address bar.
     private func schemedURL(from input: String) -> URL? {
-        guard let components = URLComponents(string: input),
+        guard hasWhitespaceFreeAuthority(in: input),
+              let components = URLComponents(string: input),
               let scheme = components.scheme?.lowercased() else {
             return nil
         }

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
@@ -87,8 +87,17 @@ public struct BrowserURLResolver: Sendable {
         if isWebURL(compacted) {
             return true
         }
-        guard original.contains(where: \.isNewline) else { return false }
+        guard hasSchemeLessURLEvidenceBeforeFirstLineBreak(in: original) else { return false }
         return isSchemeLessHostWithStructure(compacted)
+    }
+
+    /// Rejects free text whose first URL-like token starts only after a line break.
+    private func hasSchemeLessURLEvidenceBeforeFirstLineBreak(in input: String) -> Bool {
+        guard let lineBreak = input.firstIndex(where: \.isNewline) else { return false }
+        return input[..<lineBreak].contains { character in
+            character == "." || character == ":" || character == "/" ||
+                character == "?" || character == "#"
+        }
     }
 
     private func isWebURL(_ input: String) -> Bool {

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
@@ -8,19 +8,26 @@ public import Foundation
 ///
 /// - A full URL with a scheme (`https://example.com`) loads verbatim.
 /// - A bare host or path that looks like a domain (`example.com`,
-///   `localhost:3000`) is treated as an `https://` URL.
+///   `localhost:3000`) becomes a web URL, defaulting local hosts to `http://`.
 /// - Anything else (free text, multiple words) becomes a web search.
 ///
 /// It is a pure value type with no I/O so it can be unit-tested in isolation,
 /// which is where the address-bar correctness actually lives.
-public struct BrowserURLResolver {
+public struct BrowserURLResolver: Sendable {
     /// The default search-engine query template. `%@` is replaced with the
     /// percent-encoded query.
     public static let defaultSearchTemplate = "https://duckduckgo.com/?q=%@"
 
-    /// The resolver is a unit of pure static functions; it is never
-    /// instantiated.
-    private init() {}
+    /// The search-engine query template used for free-text input.
+    public let searchTemplate: String
+
+    /// Creates a resolver with an injectable search-engine query template.
+    ///
+    /// - Parameter searchTemplate: A template whose `%@` placeholder receives
+    ///   the percent-encoded query.
+    public init(searchTemplate: String = defaultSearchTemplate) {
+        self.searchTemplate = searchTemplate
+    }
 
     /// Resolve raw address-bar text into a URL to load.
     ///
@@ -34,7 +41,16 @@ public struct BrowserURLResolver {
         _ input: String,
         searchTemplate: String = defaultSearchTemplate
     ) -> URL? {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        BrowserURLResolver(searchTemplate: searchTemplate).resolve(input)
+    }
+
+    /// Resolves raw address-bar text into a URL to load.
+    ///
+    /// - Parameter input: The raw text the user submitted.
+    /// - Returns: A URL to load, or `nil` when `input` is empty after trimming.
+    public func resolve(_ input: String) -> URL? {
+        let searchText = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = canonicalNavigationText(searchText)
         guard !trimmed.isEmpty else { return nil }
 
         if let schemed = schemedURL(from: trimmed) {
@@ -54,13 +70,60 @@ public struct BrowserURLResolver {
                 return host
             }
         }
-        return searchURL(for: trimmed, template: searchTemplate)
+        return searchURL(for: searchText)
+    }
+
+    private func canonicalNavigationText(_ trimmed: String) -> String {
+        let compacted = trimmed.filter { !$0.isWhitespace }
+        guard compacted != trimmed, isWhitespaceCompactionSafe(compacted) else {
+            return trimmed
+        }
+        return compacted
+    }
+
+    private func isWhitespaceCompactionSafe(_ compacted: String) -> Bool {
+        guard !compacted.isEmpty else { return false }
+        if isWebURL(compacted) {
+            return true
+        }
+        return isSchemeLessHostWithStructure(compacted)
+    }
+
+    private func isWebURL(_ input: String) -> Bool {
+        guard let components = URLComponents(string: input),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              !host.isEmpty else {
+            return false
+        }
+        return true
+    }
+
+    private func isSchemeLessHostWithStructure(_ input: String) -> Bool {
+        guard !input.contains("://"),
+              let components = URLComponents(string: "https://\(input)"),
+              let host = components.host,
+              !host.isEmpty else {
+            return false
+        }
+
+        let isHostLike = host == "localhost" ||
+            host.hasSuffix(".localhost") ||
+            host.contains(".") ||
+            host.contains(":")
+        guard isHostLike else { return false }
+
+        let hasPathQueryOrFragment = !components.path.isEmpty ||
+            components.query != nil ||
+            components.fragment != nil
+        return hasPathQueryOrFragment || components.port != nil
     }
 
     /// Whether `input` is an unbracketed IPv6 literal (two or more colons, not
     /// already bracketed and without a path), so it must be wrapped in `[...]`
     /// to form a valid URL authority.
-    private static func needsIPv6Brackets(_ input: String) -> Bool {
+    private func needsIPv6Brackets(_ input: String) -> Bool {
         guard !input.hasPrefix("["), !input.contains("/") else { return false }
         return input.filter { $0 == ":" }.count >= 2
     }
@@ -87,16 +150,24 @@ public struct BrowserURLResolver {
     ///     separators in the input are escaped).
     /// - Returns: The search URL, or `nil` if the template is malformed.
     public static func searchURL(for query: String, template: String = defaultSearchTemplate) -> URL? {
+        BrowserURLResolver(searchTemplate: template).searchURL(for: query)
+    }
+
+    /// Builds a search URL for free-text input using ``searchTemplate``.
+    ///
+    /// - Parameter query: The user's free-text query.
+    /// - Returns: The search URL, or `nil` if ``searchTemplate`` is malformed.
+    public func searchURL(for query: String) -> URL? {
         let encoded = query.addingPercentEncoding(
-            withAllowedCharacters: queryValueAllowed
+            withAllowedCharacters: Self.queryValueAllowed
         ) ?? query
-        return URL(string: template.replacingOccurrences(of: "%@", with: encoded))
+        return URL(string: searchTemplate.replacingOccurrences(of: "%@", with: encoded))
     }
 
     /// A URL with an explicit, http(s)-like scheme, or `nil` if `input` has no
     /// usable scheme. Schemes other than `http`/`https` are rejected so a typed
     /// `file:` or `javascript:` cannot be loaded from the address bar.
-    private static func schemedURL(from input: String) -> URL? {
+    private func schemedURL(from input: String) -> URL? {
         guard let components = URLComponents(string: input),
               let scheme = components.scheme?.lowercased() else {
             return nil
@@ -112,8 +183,8 @@ public struct BrowserURLResolver {
     /// visit rather than a search query. A token is host-like when it has no
     /// spaces and contains a dot (`a.com`) or is a known local host
     /// (`localhost`, optionally with a port or path).
-    private static func looksLikeHost(_ input: String) -> Bool {
-        guard !input.contains(" ") else { return false }
+    private func looksLikeHost(_ input: String) -> Bool {
+        guard !input.contains(where: \.isWhitespace) else { return false }
         let host = bareHost(of: input)
         if host == "localhost" { return true }
         // An IPv6 literal (the bare-host extraction keeps the colons) is a host,
@@ -132,7 +203,7 @@ public struct BrowserURLResolver {
     /// IPv6 loopback `::1`, or a private-LAN address (`10.x`, `192.168.x`,
     /// `172.16-31.x`). Opening a local dev server is a central cmux workflow and
     /// those servers listen on plain HTTP.
-    private static func isLocalHost(_ input: String) -> Bool {
+    private func isLocalHost(_ input: String) -> Bool {
         let host = bareHost(of: input).lowercased()
         if host == "localhost" || host == "::1" { return true }
         let octets = host.split(separator: ".", omittingEmptySubsequences: false)
@@ -153,7 +224,7 @@ public struct BrowserURLResolver {
     /// token containing multiple colons is treated as a bare IPv6 literal
     /// (`::1`) so the loopback comparison can match. A single-colon token is a
     /// `host:port` pair and keeps only the host.
-    private static func bareHost(of input: String) -> String {
+    private func bareHost(of input: String) -> String {
         let hostAndPort = input.split(separator: "/", maxSplits: 1).first.map(String.init) ?? input
         if hostAndPort.hasPrefix("[") {
             // Bracketed IPv6: take everything inside the brackets.

--- a/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Sources/CmuxMobileBrowser/BrowserURLResolver.swift
@@ -74,18 +74,20 @@ public struct BrowserURLResolver: Sendable {
     }
 
     private func canonicalNavigationText(_ trimmed: String) -> String {
-        let compacted = trimmed.filter { !$0.isWhitespace }
-        guard compacted != trimmed, isWhitespaceCompactionSafe(compacted) else {
+        let compacted = trimmed.filter { !$0.isNewline && $0 != "\t" }
+        guard compacted != trimmed,
+              isWhitespaceCompactionSafe(compacted, original: trimmed) else {
             return trimmed
         }
         return compacted
     }
 
-    private func isWhitespaceCompactionSafe(_ compacted: String) -> Bool {
+    private func isWhitespaceCompactionSafe(_ compacted: String, original: String) -> Bool {
         guard !compacted.isEmpty else { return false }
         if isWebURL(compacted) {
             return true
         }
+        guard original.contains(where: \.isNewline) else { return false }
         return isSchemeLessHostWithStructure(compacted)
     }
 

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -76,6 +76,10 @@ import Testing
         let input = "https://trusted.example\n@evil.example/path"
 
         #expect(BrowserURLResolver.resolve(input)?.host == "duckduckgo.com")
+        #expect(
+            BrowserURLResolver.resolve(input.replacingOccurrences(of: "\n", with: " "))?.host ==
+                "duckduckgo.com"
+        )
     }
 
     @Test func httpSchemeIsPreserved() {

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -7,6 +7,14 @@ import Testing
 /// concrete loads. These guard that mapping, which is where omnibox correctness
 /// lives.
 @Suite struct BrowserURLResolverTests {
+    private let oauthURL =
+        "https://auth.openai.com/oauth/authorize?client_id=app_1234567890" +
+        "&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback" +
+        "&response_type=code&scope=openid%20profile%20email%20offline_access" +
+        "&code_challenge=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+        "&code_challenge_method=S256&state=state_abcdefghijklmnopqrstuvwxyz0123456789" +
+        "&codex_cli_simplified_flow=true"
+
     @Test func emptyOrWhitespaceResolvesToNil() {
         #expect(BrowserURLResolver.resolve("") == nil)
         #expect(BrowserURLResolver.resolve("   ") == nil)
@@ -16,6 +24,32 @@ import Testing
     @Test func fullHTTPSURLLoadsVerbatim() {
         let url = BrowserURLResolver.resolve("https://example.com/path?q=1")
         #expect(url?.absoluteString == "https://example.com/path?q=1")
+    }
+
+    @Test func longOAuthURLLoadsWithoutRewriting() {
+        let url = BrowserURLResolver.resolve(oauthURL)
+
+        #expect(url?.absoluteString == oauthURL)
+    }
+
+    @Test func terminalWrappedOAuthURLLoadsWithoutRewriting() {
+        let wrapped = oauthURL.replacingOccurrences(of: "&scope=", with: "&\nscope=")
+        let url = BrowserURLResolver.resolve(wrapped)
+
+        #expect(url?.absoluteString == oauthURL)
+    }
+
+    @Test func singleLineFieldWrappedOAuthURLLoadsWithoutSearching() {
+        let fieldValue = oauthURL.replacingOccurrences(of: "&scope=", with: "& scope=")
+        let url = BrowserURLResolver.resolve(fieldValue)
+
+        #expect(url?.absoluteString == oauthURL)
+    }
+
+    @Test func surroundingWhitespaceDoesNotRewriteOAuthURL() {
+        let url = BrowserURLResolver.resolve("  \n\t\(oauthURL)\r\n  ")
+
+        #expect(url?.absoluteString == oauthURL)
     }
 
     @Test func httpSchemeIsPreserved() {
@@ -35,6 +69,15 @@ import Testing
         #expect(url?.scheme == "https")
         #expect(url?.host == "example.com")
         #expect(url?.path == "/docs/page")
+    }
+
+    @Test func URLAndSearchBoundariesRemainStable() {
+        #expect(BrowserURLResolver.resolve("localhost:3000")?.absoluteString == "http://localhost:3000")
+        #expect(
+            BrowserURLResolver.resolve("example.com/path?x=1")?.absoluteString ==
+                "https://example.com/path?x=1"
+        )
+        #expect(BrowserURLResolver.resolve("node.js tutorial")?.host == "duckduckgo.com")
     }
 
     @Test func localhostWithPortDefaultsToHTTP() {

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -39,11 +39,30 @@ import Testing
         #expect(url?.absoluteString == oauthURL)
     }
 
-    @Test func singleLineFieldWrappedOAuthURLLoadsWithoutSearching() {
-        let fieldValue = oauthURL.replacingOccurrences(of: "&scope=", with: "& scope=")
-        let url = BrowserURLResolver.resolve(fieldValue)
+    @Test func tabWrappedOAuthURLLoadsWithoutRewriting() {
+        let wrapped = oauthURL.replacingOccurrences(of: "&scope=", with: "&\tscope=")
+        let url = BrowserURLResolver.resolve(wrapped)
 
         #expect(url?.absoluteString == oauthURL)
+    }
+
+    @Test func meaningfulSpacesArePreservedInNavigationOrSearch() throws {
+        let spacedURL = "https://example.com/search?q=hello world"
+        let spacedHost = "a b.com/path?x=1"
+        let resolvedURL = try #require(BrowserURLResolver.resolve(spacedURL))
+        let searchURL = try #require(BrowserURLResolver.resolve(spacedHost))
+
+        #expect(resolvedURL.host == "example.com")
+        #expect(
+            URLComponents(url: resolvedURL, resolvingAgainstBaseURL: false)?
+                .queryItems?.first?.value == "hello world"
+        )
+        #expect(searchURL.host == "duckduckgo.com")
+        #expect(
+            URLComponents(url: searchURL, resolvingAgainstBaseURL: false)?
+                .queryItems?.first?.value == spacedHost
+        )
+        #expect(BrowserURLResolver.resolve("go\texample.com/path")?.host == "duckduckgo.com")
     }
 
     @Test func surroundingWhitespaceDoesNotRewriteOAuthURL() {
@@ -75,6 +94,10 @@ import Testing
         #expect(BrowserURLResolver.resolve("localhost:3000")?.absoluteString == "http://localhost:3000")
         #expect(
             BrowserURLResolver.resolve("example.com/path?x=1")?.absoluteString ==
+                "https://example.com/path?x=1"
+        )
+        #expect(
+            BrowserURLResolver.resolve("example.\ncom/path?x=1")?.absoluteString ==
                 "https://example.com/path?x=1"
         )
         #expect(BrowserURLResolver.resolve("node.js tutorial")?.host == "duckduckgo.com")
@@ -110,6 +133,13 @@ import Testing
         let url = BrowserURLResolver.resolve("8.8.8.8")
         #expect(url?.scheme == "https")
         #expect(url?.host == "8.8.8.8")
+    }
+
+    @Test func deceptiveLoopbackPrefixDefaultsToHTTPS() {
+        let url = BrowserURLResolver.resolve("localhost.evil.com")
+
+        #expect(url?.scheme == "https")
+        #expect(url?.host == "localhost.evil.com")
     }
 
     @Test func bareIPv6LoopbackIsBracketedHTTP() {

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -63,6 +63,7 @@ import Testing
                 .queryItems?.first?.value == spacedHost
         )
         #expect(BrowserURLResolver.resolve("go\texample.com/path")?.host == "duckduckgo.com")
+        #expect(BrowserURLResolver.resolve("go\nexample.com/path")?.host == "duckduckgo.com")
     }
 
     @Test func surroundingWhitespaceDoesNotRewriteOAuthURL() {

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -154,6 +154,9 @@ import Testing
 
         #expect(url?.scheme == "https")
         #expect(url?.host == "localhost.evil.com")
+        #expect(BrowserURLResolver.resolve("localhost:80@evil.example/path")?.host == "duckduckgo.com")
+        #expect(BrowserURLResolver.resolve("127.0.0.1:80@evil.example")?.host == "duckduckgo.com")
+        #expect(BrowserURLResolver.resolve("example.com/path?email=user@example.com")?.host == "example.com")
     }
 
     @Test func bareIPv6LoopbackIsBracketedHTTP() {

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -72,6 +72,12 @@ import Testing
         #expect(url?.absoluteString == oauthURL)
     }
 
+    @Test func wrappedTextCannotConstructADifferentAuthority() {
+        let input = "https://trusted.example\n@evil.example/path"
+
+        #expect(BrowserURLResolver.resolve(input)?.host == "duckduckgo.com")
+    }
+
     @Test func httpSchemeIsPreserved() {
         let url = BrowserURLResolver.resolve("http://example.com")
         #expect(url?.scheme == "http")

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -78,6 +78,7 @@ import Testing
                 "https://example.com/path?x=1"
         )
         #expect(BrowserURLResolver.resolve("node.js tutorial")?.host == "duckduckgo.com")
+        #expect(BrowserURLResolver.resolve("node.js\ttutorial")?.host == "duckduckgo.com")
     }
 
     @Test func localhostWithPortDefaultsToHTTP() {

--- a/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
+++ b/Packages/iOS/CmuxMobileBrowser/Tests/CmuxMobileBrowserTests/BrowserURLResolverTests.swift
@@ -73,13 +73,15 @@ import Testing
     }
 
     @Test func wrappedTextCannotConstructADifferentAuthority() {
-        let input = "https://trusted.example\n@evil.example/path"
+        let explicitInput = "https://trusted.example\n@evil.example/path"
+        let schemeLessInput = "trusted.example\n@evil.example/path"
 
-        #expect(BrowserURLResolver.resolve(input)?.host == "duckduckgo.com")
+        #expect(BrowserURLResolver.resolve(explicitInput)?.host == "duckduckgo.com")
         #expect(
-            BrowserURLResolver.resolve(input.replacingOccurrences(of: "\n", with: " "))?.host ==
+            BrowserURLResolver.resolve(explicitInput.replacingOccurrences(of: "\n", with: " "))?.host ==
                 "duckduckgo.com"
         )
+        #expect(BrowserURLResolver.resolve(schemeLessInput)?.host == "duckduckgo.com")
     }
 
     @Test func httpSchemeIsPreserved() {
@@ -107,8 +109,9 @@ import Testing
             BrowserURLResolver.resolve("example.com/path?x=1")?.absoluteString ==
                 "https://example.com/path?x=1"
         )
+        #expect(BrowserURLResolver.resolve("example.\ncom/path?x=1")?.host == "duckduckgo.com")
         #expect(
-            BrowserURLResolver.resolve("example.\ncom/path?x=1")?.absoluteString ==
+            BrowserURLResolver.resolve("example.com/path?\nx=1")?.absoluteString ==
                 "https://example.com/path?x=1"
         )
         #expect(BrowserURLResolver.resolve("node.js tutorial")?.host == "duckduckgo.com")

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteFieldEditor.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteFieldEditor.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+/// Field editor that preserves raw pasteboard text until omnibar URL classification.
+final class BrowserOmnibarPasteFieldEditor: NSTextView {
+    override var isFieldEditor: Bool {
+        get { true }
+        set {}
+    }
+
+    override func readSelection(from pasteboard: NSPasteboard) -> Bool {
+        guard let rawText = pasteboard.string(forType: .string) else {
+            return super.readSelection(from: pasteboard)
+        }
+
+        let preparedText = BrowserURLResolver().textForPaste(rawText)
+        guard preparedText != rawText else {
+            return super.readSelection(from: pasteboard)
+        }
+
+        insertText(preparedText, replacementRange: selectedRange())
+        return true
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteFieldEditor.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteFieldEditor.swift
@@ -8,14 +8,32 @@ final class BrowserOmnibarPasteFieldEditor: NSTextView {
     }
 
     override func readSelection(from pasteboard: NSPasteboard) -> Bool {
-        guard let rawText = pasteboard.string(forType: .string) else {
+        guard insertPreparedText(from: pasteboard, type: .string) else {
             return super.readSelection(from: pasteboard)
         }
 
-        let preparedText = BrowserURLResolver().textForPaste(rawText)
-        guard preparedText != rawText else {
-            return super.readSelection(from: pasteboard)
+        return true
+    }
+
+    override func readSelection(
+        from pasteboard: NSPasteboard,
+        type: NSPasteboard.PasteboardType
+    ) -> Bool {
+        guard insertPreparedText(from: pasteboard, type: type) else {
+            return super.readSelection(from: pasteboard, type: type)
         }
+
+        return true
+    }
+
+    private func insertPreparedText(
+        from pasteboard: NSPasteboard,
+        type: NSPasteboard.PasteboardType
+    ) -> Bool {
+        guard type == .string, let rawText = pasteboard.string(forType: type) else { return false }
+
+        let preparedText = BrowserURLResolver().textForPaste(rawText)
+        guard preparedText != rawText else { return false }
 
         insertText(preparedText, replacementRange: selectedRange())
         return true

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteTextFieldCell.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteTextFieldCell.swift
@@ -18,6 +18,10 @@ public final class BrowserOmnibarPasteTextFieldCell: NSTextFieldCell {
         super.init(coder: coder)
     }
 
+    /// Supplies the field editor that sanitizes raw pasted URL text.
+    ///
+    /// - Parameter controlView: The text field beginning an editing session.
+    /// - Returns: The cell's reusable omnibar paste field editor.
     public override func fieldEditor(for controlView: NSView) -> NSTextView? {
         pasteFieldEditor
     }

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteTextFieldCell.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserOmnibarPasteTextFieldCell.swift
@@ -1,0 +1,24 @@
+public import AppKit
+
+/// Text-field cell that supplies an omnibar-aware field editor for every paste entrypoint.
+public final class BrowserOmnibarPasteTextFieldCell: NSTextFieldCell {
+    private lazy var pasteFieldEditor = BrowserOmnibarPasteFieldEditor()
+
+    /// Creates an editable, selectable omnibar text-field cell.
+    ///
+    /// - Parameter string: The initial field value.
+    public override init(textCell string: String) {
+        super.init(textCell: string)
+        isEditable = true
+        isSelectable = true
+    }
+
+    /// Restores an omnibar text-field cell from an archive.
+    public required init(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    public override func fieldEditor(for controlView: NSView) -> NSTextView? {
+        pasteFieldEditor
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -33,6 +33,7 @@ public struct BrowserURLResolver: Sendable {
             input.trimmingCharacters(in: .whitespacesAndNewlines)
         )
         guard !trimmed.isEmpty else { return nil }
+        guard !trimmed.contains(where: { $0.isNewline || $0 == "\t" }) else { return nil }
         if let url = webURL(from: trimmed) {
             return url
         }
@@ -41,7 +42,7 @@ public struct BrowserURLResolver: Sendable {
         let lower = trimmed.lowercased()
         let bareHost = bareHostCandidate(lower)
         if bareHost == "localhost" ||
-            bareHost == "127.0.0.1" ||
+            isIPv4Loopback(bareHost) ||
             bareHost == "::1" ||
             (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
             return URL(string: "http://\(trimmed)")
@@ -75,10 +76,25 @@ public struct BrowserURLResolver: Sendable {
     private func isWhitespaceCompactionSafe(_ compacted: String, original: String) -> Bool {
         guard !compacted.isEmpty else { return false }
         if isWebURL(compacted) {
-            return true
+            return hasCompleteWebAuthorityBeforeFirstCompactedCharacter(in: original)
         }
         guard hasSchemeLessURLEvidenceBeforeFirstLineBreak(in: original) else { return false }
         return isSchemeLessHostWithStructure(compacted)
+    }
+
+    /// Allows wrap removal only after the explicit URL's authority is complete.
+    private func hasCompleteWebAuthorityBeforeFirstCompactedCharacter(in input: String) -> Bool {
+        guard let compactedCharacter = input.firstIndex(where: { $0.isNewline || $0 == "\t" }),
+              let schemeSeparator = input.range(of: "://"),
+              schemeSeparator.upperBound < compactedCharacter else {
+            return false
+        }
+        guard let authorityEnd = input[schemeSeparator.upperBound...].firstIndex(where: { character in
+            character == "/" || character == "?" || character == "#"
+        }) else {
+            return false
+        }
+        return authorityEnd < compactedCharacter
     }
 
     /// Rejects free text whose first URL-like token starts only after a line break.
@@ -95,7 +111,8 @@ public struct BrowserURLResolver: Sendable {
     }
 
     private func webURL(from input: String) -> URL? {
-        guard let components = URLComponents(string: input),
+        guard hasWhitespaceFreeAuthority(in: input),
+              let components = URLComponents(string: input),
               let scheme = components.scheme?.lowercased(),
               scheme == "http" || scheme == "https",
               let host = components.host,
@@ -103,6 +120,15 @@ public struct BrowserURLResolver: Sendable {
             return nil
         }
         return components.url
+    }
+
+    /// Rejects whitespace that Foundation would otherwise encode inside URL userinfo.
+    private func hasWhitespaceFreeAuthority(in input: String) -> Bool {
+        guard let schemeSeparator = input.range(of: "://") else { return false }
+        let authority = input[schemeSeparator.upperBound...].prefix { character in
+            character != "/" && character != "?" && character != "#"
+        }
+        return !authority.isEmpty && !authority.contains(where: \.isWhitespace)
     }
 
     private func isSchemeLessHostWithStructure(_ input: String) -> Bool {
@@ -134,6 +160,13 @@ public struct BrowserURLResolver: Sendable {
             character == ":" || character == "/" || character == "?" || character == "#"
         } ?? lowercasedInput.endIndex
         return String(lowercasedInput[..<end])
+    }
+
+    /// Recognizes IPv4 loopback addresses without accepting dotted-host lookalikes.
+    private func isIPv4Loopback(_ host: String) -> Bool {
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4, octets.allSatisfy({ UInt8($0) != nil }) else { return false }
+        return octets[0] == "127"
     }
 
     private func isDottedHostWithPort(_ input: String, schemeCandidate: String) -> Bool {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -78,7 +78,7 @@ public struct BrowserURLResolver: Sendable {
         if isWebURL(compacted) {
             return hasCompleteWebAuthorityBeforeFirstCompactedCharacter(in: original)
         }
-        guard hasSchemeLessURLEvidenceBeforeFirstLineBreak(in: original) else { return false }
+        guard hasCompleteSchemeLessAuthorityBeforeFirstCompactedCharacter(in: original) else { return false }
         return isSchemeLessHostWithStructure(compacted)
     }
 
@@ -97,13 +97,15 @@ public struct BrowserURLResolver: Sendable {
         return authorityEnd < compactedCharacter
     }
 
-    /// Rejects free text whose first URL-like token starts only after a line break.
-    private func hasSchemeLessURLEvidenceBeforeFirstLineBreak(in input: String) -> Bool {
-        guard let lineBreak = input.firstIndex(where: \.isNewline) else { return false }
-        return input[..<lineBreak].contains { character in
-            character == "." || character == ":" || character == "/" ||
-                character == "?" || character == "#"
+    /// Allows scheme-less wrap removal only after the authority is complete.
+    private func hasCompleteSchemeLessAuthorityBeforeFirstCompactedCharacter(in input: String) -> Bool {
+        guard let compactedCharacter = input.firstIndex(where: { $0.isNewline || $0 == "\t" }),
+              let authorityEnd = input.firstIndex(where: { character in
+                  character == "/" || character == "?" || character == "#"
+              }) else {
+            return false
         }
+        return authorityEnd < compactedCharacter
     }
 
     private func isWebURL(_ input: String) -> Bool {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -37,6 +37,7 @@ public struct BrowserURLResolver: Sendable {
         if let url = webURL(from: trimmed) {
             return url
         }
+        guard !hasSchemeLessUserInfo(in: trimmed) else { return nil }
         guard !trimmed.contains(where: \.isWhitespace) else { return nil }
 
         let lower = trimmed.lowercased()
@@ -131,6 +132,15 @@ public struct BrowserURLResolver: Sendable {
             character != "/" && character != "?" && character != "#"
         }
         return !authority.isEmpty && !authority.contains(where: \.isWhitespace)
+    }
+
+    /// Rejects scheme-less userinfo while allowing `@` in paths and queries.
+    private func hasSchemeLessUserInfo(in input: String) -> Bool {
+        guard !input.contains("://") else { return false }
+        let authority = input.prefix { character in
+            character != "/" && character != "?" && character != "#"
+        }
+        return authority.contains("@")
     }
 
     private func isSchemeLessHostWithStructure(_ input: String) -> Bool {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -1,0 +1,116 @@
+public import Foundation
+
+/// Resolves macOS browser omnibar text into a URL that can be loaded directly.
+///
+/// Search-engine fallback remains the caller's responsibility. The resolver
+/// handles web URLs, local development hosts, scheme-less hosts, and absolute
+/// file URLs after canonicalizing whitespace introduced by wrapped pastes.
+public struct BrowserURLResolver: Sendable {
+    /// Creates a browser URL resolver.
+    public init() {}
+
+    /// Resolves submitted address text into a directly navigable URL.
+    ///
+    /// - Parameter input: Raw text submitted by the omnibar or another browser entrypoint.
+    /// - Returns: A navigable URL, or `nil` when the text should be treated as a search query.
+    public func navigableURL(from input: String) -> URL? {
+        let trimmed = canonicalNavigationText(
+            input.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        guard !trimmed.isEmpty else { return nil }
+        guard !trimmed.contains(where: \.isWhitespace) else { return nil }
+
+        let lower = trimmed.lowercased()
+        let bareHost = bareHostCandidate(lower)
+        if lower.hasPrefix("localhost") ||
+            lower.hasPrefix("127.0.0.1") ||
+            lower.hasPrefix("[::1]") ||
+            (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
+            return URL(string: "http://\(trimmed)")
+        }
+
+        if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
+            if scheme == "http" || scheme == "https" {
+                return url
+            }
+            if scheme == "file", url.isFileURL, url.path.hasPrefix("/") {
+                return url
+            }
+            if isDottedHostWithPort(trimmed, schemeCandidate: scheme) {
+                return URL(string: "https://\(trimmed)")
+            }
+            return nil
+        }
+
+        if trimmed.contains(":") || trimmed.contains("/") || trimmed.contains(".") {
+            return URL(string: "https://\(trimmed)")
+        }
+        return nil
+    }
+
+    private func canonicalNavigationText(_ trimmed: String) -> String {
+        let compacted = trimmed.filter { !$0.isWhitespace }
+        guard compacted != trimmed, isWhitespaceCompactionSafe(compacted) else {
+            return trimmed
+        }
+        return compacted
+    }
+
+    private func isWhitespaceCompactionSafe(_ compacted: String) -> Bool {
+        guard !compacted.isEmpty else { return false }
+        if isWebURL(compacted) {
+            return true
+        }
+        return isSchemeLessHostWithStructure(compacted)
+    }
+
+    private func isWebURL(_ input: String) -> Bool {
+        guard let components = URLComponents(string: input),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              !host.isEmpty else {
+            return false
+        }
+        return true
+    }
+
+    private func isSchemeLessHostWithStructure(_ input: String) -> Bool {
+        guard !input.contains("://"),
+              let components = URLComponents(string: "https://\(input)"),
+              let host = components.host,
+              !host.isEmpty else {
+            return false
+        }
+
+        let isHostLike = host == "localhost" ||
+            host.hasSuffix(".localhost") ||
+            host.contains(".") ||
+            host.contains(":")
+        guard isHostLike else { return false }
+
+        let hasPathQueryOrFragment = !components.path.isEmpty ||
+            components.query != nil ||
+            components.fragment != nil
+        return hasPathQueryOrFragment || components.port != nil
+    }
+
+    private func bareHostCandidate(_ lowercasedInput: String) -> String {
+        let end = lowercasedInput.firstIndex { character in
+            character == ":" || character == "/" || character == "?" || character == "#"
+        } ?? lowercasedInput.endIndex
+        return String(lowercasedInput[..<end])
+    }
+
+    private func isDottedHostWithPort(_ input: String, schemeCandidate: String) -> Bool {
+        guard schemeCandidate.contains(".") else { return false }
+        guard input.count > schemeCandidate.count else { return false }
+        let afterScheme = input.dropFirst(schemeCandidate.count)
+        guard afterScheme.first == ":" else { return false }
+        let portAndRest = afterScheme.dropFirst()
+        let port = portAndRest.prefix(while: { $0.isNumber })
+        guard !port.isEmpty, UInt16(port) != nil else { return false }
+        let rest = portAndRest.dropFirst(port.count)
+        return rest.isEmpty || rest.first == "/" || rest.first == "?" || rest.first == "#"
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -77,8 +77,17 @@ public struct BrowserURLResolver: Sendable {
         if isWebURL(compacted) {
             return true
         }
-        guard original.contains(where: \.isNewline) else { return false }
+        guard hasSchemeLessURLEvidenceBeforeFirstLineBreak(in: original) else { return false }
         return isSchemeLessHostWithStructure(compacted)
+    }
+
+    /// Rejects free text whose first URL-like token starts only after a line break.
+    private func hasSchemeLessURLEvidenceBeforeFirstLineBreak(in input: String) -> Bool {
+        guard let lineBreak = input.firstIndex(where: \.isNewline) else { return false }
+        return input[..<lineBreak].contains { character in
+            character == "." || character == ":" || character == "/" ||
+                character == "?" || character == "#"
+        }
     }
 
     private func isWebURL(_ input: String) -> Bool {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Omnibar/BrowserURLResolver.swift
@@ -4,10 +4,25 @@ public import Foundation
 ///
 /// Search-engine fallback remains the caller's responsibility. The resolver
 /// handles web URLs, local development hosts, scheme-less hosts, and absolute
-/// file URLs after canonicalizing whitespace introduced by wrapped pastes.
+/// file URLs after canonicalizing line breaks introduced by wrapped pastes.
 public struct BrowserURLResolver: Sendable {
     /// Creates a browser URL resolver.
     public init() {}
+
+    /// Prepares raw pasteboard text for insertion into a single-line omnibar.
+    ///
+    /// AppKit replaces pasted line breaks with spaces before the field value is
+    /// submitted. This method removes terminal-wrap line breaks and tabs only
+    /// when the compacted text is a navigable URL, preserving ordinary spaces
+    /// and free-text searches exactly as pasted.
+    ///
+    /// - Parameter input: Raw string content read from the pasteboard.
+    /// - Returns: URL text with safe wrap artifacts removed, or `input` unchanged.
+    public func textForPaste(_ input: String) -> String {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prepared = canonicalNavigationText(trimmed)
+        return prepared == trimmed ? input : prepared
+    }
 
     /// Resolves submitted address text into a directly navigable URL.
     ///
@@ -18,21 +33,21 @@ public struct BrowserURLResolver: Sendable {
             input.trimmingCharacters(in: .whitespacesAndNewlines)
         )
         guard !trimmed.isEmpty else { return nil }
+        if let url = webURL(from: trimmed) {
+            return url
+        }
         guard !trimmed.contains(where: \.isWhitespace) else { return nil }
 
         let lower = trimmed.lowercased()
         let bareHost = bareHostCandidate(lower)
-        if lower.hasPrefix("localhost") ||
-            lower.hasPrefix("127.0.0.1") ||
-            lower.hasPrefix("[::1]") ||
+        if bareHost == "localhost" ||
+            bareHost == "127.0.0.1" ||
+            bareHost == "::1" ||
             (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
             return URL(string: "http://\(trimmed)")
         }
 
         if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
-            if scheme == "http" || scheme == "https" {
-                return url
-            }
             if scheme == "file", url.isFileURL, url.path.hasPrefix("/") {
                 return url
             }
@@ -49,30 +64,36 @@ public struct BrowserURLResolver: Sendable {
     }
 
     private func canonicalNavigationText(_ trimmed: String) -> String {
-        let compacted = trimmed.filter { !$0.isWhitespace }
-        guard compacted != trimmed, isWhitespaceCompactionSafe(compacted) else {
+        let compacted = trimmed.filter { !$0.isNewline && $0 != "\t" }
+        guard compacted != trimmed,
+              isWhitespaceCompactionSafe(compacted, original: trimmed) else {
             return trimmed
         }
         return compacted
     }
 
-    private func isWhitespaceCompactionSafe(_ compacted: String) -> Bool {
+    private func isWhitespaceCompactionSafe(_ compacted: String, original: String) -> Bool {
         guard !compacted.isEmpty else { return false }
         if isWebURL(compacted) {
             return true
         }
+        guard original.contains(where: \.isNewline) else { return false }
         return isSchemeLessHostWithStructure(compacted)
     }
 
     private func isWebURL(_ input: String) -> Bool {
+        webURL(from: input) != nil
+    }
+
+    private func webURL(from input: String) -> URL? {
         guard let components = URLComponents(string: input),
               let scheme = components.scheme?.lowercased(),
               scheme == "http" || scheme == "https",
               let host = components.host,
               !host.isEmpty else {
-            return false
+            return nil
         }
-        return true
+        return components.url
     }
 
     private func isSchemeLessHostWithStructure(_ input: String) -> Bool {
@@ -96,6 +117,10 @@ public struct BrowserURLResolver: Sendable {
     }
 
     private func bareHostCandidate(_ lowercasedInput: String) -> String {
+        if lowercasedInput.hasPrefix("["),
+           let closingBracket = lowercasedInput.firstIndex(of: "]") {
+            return String(lowercasedInput[lowercasedInput.index(after: lowercasedInput.startIndex)..<closingBracket])
+        }
         let end = lowercasedInput.firstIndex { character in
             character == ":" || character == "/" || character == "?" || character == "#"
         } ?? lowercasedInput.endIndex

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -82,6 +82,7 @@ import Testing
 
         #expect(resolver.textForPaste(input) == input)
         #expect(resolver.navigableURL(from: input) == nil)
+        #expect(resolver.navigableURL(from: input.replacingOccurrences(of: "\n", with: " ")) == nil)
     }
 
     @Test func preservesExistingNavigationAndSearchBoundaries() throws {

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Foundation
 import Testing
 
 @testable import CmuxBrowser
@@ -15,11 +17,41 @@ import Testing
         #expect(try #require(resolver.navigableURL(from: wrapped)).absoluteString == expected)
     }
 
-    @Test func resolvesSingleLineFieldRepresentationWithoutSearching() throws {
+    @Test func preparesWrappedPasteBeforeSingleLineFieldRewritesIt() {
         let expected = "https://example.com/callback?scope=openid%20profile&state=abc123"
-        let fieldValue = expected.replacingOccurrences(of: "&state=", with: "& state=")
+        let wrapped = expected.replacingOccurrences(of: "&state=", with: "&\tstate=")
 
-        #expect(try #require(resolver.navigableURL(from: fieldValue)).absoluteString == expected)
+        #expect(resolver.textForPaste(wrapped) == expected)
+    }
+
+    @Test @MainActor func fieldEditorSanitizesStandardPastePath() throws {
+        let expected = "https://example.com/callback?scope=openid%20profile&state=abc123"
+        let wrapped = expected.replacingOccurrences(of: "&state=", with: "&\nstate=")
+        let padded = "  \n\t\(wrapped)\r\n  "
+        let pasteboard = NSPasteboard(name: .init("cmux.omnibar.tests.\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(padded, forType: .string)
+        let editor = BrowserOmnibarPasteFieldEditor()
+
+        #expect(editor.readSelection(from: pasteboard))
+        #expect(editor.string == expected)
+        let cell = BrowserOmnibarPasteTextFieldCell(textCell: "")
+        #expect(cell.isEditable)
+        #expect(cell.isSelectable)
+    }
+
+    @Test func preservesMeaningfulSpacesInExplicitURLsAndSearchTerms() throws {
+        let queryWithSpace = "https://example.com/search?q=hello world"
+        let resolvedURL = try #require(resolver.navigableURL(from: queryWithSpace))
+
+        #expect(resolver.textForPaste(queryWithSpace) == queryWithSpace)
+        #expect(resolvedURL.host == "example.com")
+        #expect(
+            URLComponents(url: resolvedURL, resolvingAgainstBaseURL: false)?
+                .queryItems?.first?.value == "hello world"
+        )
+        #expect(resolver.navigableURL(from: "a b.com/path?x=1") == nil)
+        #expect(resolver.navigableURL(from: "go\texample.com/path") == nil)
     }
 
     @Test func preservesExistingNavigationAndSearchBoundaries() throws {
@@ -28,8 +60,20 @@ import Testing
             try #require(resolver.navigableURL(from: "example.com/path?x=1")).absoluteString ==
                 "https://example.com/path?x=1"
         )
+        #expect(
+            try #require(resolver.navigableURL(from: "example.\ncom/path?x=1")).absoluteString ==
+                "https://example.com/path?x=1"
+        )
         #expect(resolver.navigableURL(from: "node.js tutorial") == nil)
         #expect(resolver.navigableURL(from: "node.js\ttutorial") == nil)
+    }
+
+    @Test func onlyExactLoopbackHostsDefaultToHTTP() throws {
+        #expect(try #require(resolver.navigableURL(from: "localhost:3000")).scheme == "http")
+        #expect(try #require(resolver.navigableURL(from: "dev.localhost:3000")).scheme == "http")
+        #expect(try #require(resolver.navigableURL(from: "[::1]:3000")).scheme == "http")
+        #expect(try #require(resolver.navigableURL(from: "localhost.evil.com")).scheme == "https")
+        #expect(try #require(resolver.navigableURL(from: "127.0.0.10")).scheme == "https")
     }
 
     @Test func preservesSupportedAndRejectedSchemes() throws {

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -31,11 +31,13 @@ import Testing
         let pasteboard = NSPasteboard(name: .init("cmux.omnibar.tests.\(UUID().uuidString)"))
         pasteboard.clearContents()
         pasteboard.setString(padded, forType: .string)
-        let editor = BrowserOmnibarPasteFieldEditor()
+        let cell = BrowserOmnibarPasteTextFieldCell(textCell: "")
+        let editor = try #require(
+            cell.fieldEditor(for: NSView()) as? BrowserOmnibarPasteFieldEditor
+        )
 
         #expect(editor.readSelection(from: pasteboard))
         #expect(editor.string == expected)
-        let cell = BrowserOmnibarPasteTextFieldCell(textCell: "")
         #expect(cell.isEditable)
         #expect(cell.isSelectable)
     }

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -1,0 +1,40 @@
+import Testing
+
+@testable import CmuxBrowser
+
+@Suite struct BrowserURLResolverTests {
+    private let resolver = BrowserURLResolver()
+
+    @Test func resolvesWrappedOAuthURLWithoutRewriting() throws {
+        let expected =
+            "https://auth.openai.com/oauth/authorize?client_id=app_123" +
+            "&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fcallback" +
+            "&scope=openid%20profile&state=abc123"
+        let wrapped = expected.replacingOccurrences(of: "&scope=", with: "&\nscope=")
+
+        #expect(try #require(resolver.navigableURL(from: wrapped)).absoluteString == expected)
+    }
+
+    @Test func resolvesSingleLineFieldRepresentationWithoutSearching() throws {
+        let expected = "https://example.com/callback?scope=openid%20profile&state=abc123"
+        let fieldValue = expected.replacingOccurrences(of: "&state=", with: "& state=")
+
+        #expect(try #require(resolver.navigableURL(from: fieldValue)).absoluteString == expected)
+    }
+
+    @Test func preservesExistingNavigationAndSearchBoundaries() throws {
+        #expect(try #require(resolver.navigableURL(from: "localhost:3000")).absoluteString == "http://localhost:3000")
+        #expect(
+            try #require(resolver.navigableURL(from: "example.com/path?x=1")).absoluteString ==
+                "https://example.com/path?x=1"
+        )
+        #expect(resolver.navigableURL(from: "node.js tutorial") == nil)
+        #expect(resolver.navigableURL(from: "node.js\ttutorial") == nil)
+    }
+
+    @Test func preservesSupportedAndRejectedSchemes() throws {
+        #expect(try #require(resolver.navigableURL(from: "file:///tmp/example.html")).isFileURL)
+        #expect(resolver.navigableURL(from: "mailto:test@example.com") == nil)
+        #expect(resolver.navigableURL(from: "ftp://example.com/file.html") == nil)
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -36,7 +36,12 @@ import Testing
             cell.fieldEditor(for: NSView()) as? BrowserOmnibarPasteFieldEditor
         )
 
-        #expect(editor.readSelection(from: pasteboard))
+        #expect(
+            editor.tryToPerform(
+                #selector(NSTextView.readSelection(from:)),
+                with: pasteboard
+            )
+        )
         #expect(editor.string == expected)
         #expect(cell.isEditable)
         #expect(cell.isSelectable)

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -74,6 +74,7 @@ import Testing
         )
         #expect(resolver.navigableURL(from: "a b.com/path?x=1") == nil)
         #expect(resolver.navigableURL(from: "go\texample.com/path") == nil)
+        #expect(resolver.navigableURL(from: "go\nexample.com/path") == nil)
     }
 
     @Test func preservesExistingNavigationAndSearchBoundaries() throws {

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -42,6 +42,21 @@ import Testing
         #expect(cell.isSelectable)
     }
 
+    @Test @MainActor func fieldEditorSanitizesTypeSpecificPastePath() throws {
+        let expected = "https://example.com/callback?scope=openid%20profile&state=abc123"
+        let wrapped = expected.replacingOccurrences(of: "&state=", with: "&\nstate=")
+        let pasteboard = NSPasteboard(name: .init("cmux.omnibar.tests.\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setString(wrapped, forType: .string)
+        let cell = BrowserOmnibarPasteTextFieldCell(textCell: "")
+        let editor = try #require(
+            cell.fieldEditor(for: NSView()) as? BrowserOmnibarPasteFieldEditor
+        )
+
+        #expect(editor.readSelection(from: pasteboard, type: .string))
+        #expect(editor.string == expected)
+    }
+
     @Test func preservesMeaningfulSpacesInExplicitURLsAndSearchTerms() throws {
         let queryWithSpace = "https://example.com/search?q=hello world"
         let resolvedURL = try #require(resolver.navigableURL(from: queryWithSpace))

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -77,6 +77,13 @@ import Testing
         #expect(resolver.navigableURL(from: "go\nexample.com/path") == nil)
     }
 
+    @Test func doesNotCompactTextThatConstructsADifferentAuthority() {
+        let input = "https://trusted.example\n@evil.example/path"
+
+        #expect(resolver.textForPaste(input) == input)
+        #expect(resolver.navigableURL(from: input) == nil)
+    }
+
     @Test func preservesExistingNavigationAndSearchBoundaries() throws {
         #expect(try #require(resolver.navigableURL(from: "localhost:3000")).absoluteString == "http://localhost:3000")
         #expect(
@@ -91,12 +98,13 @@ import Testing
         #expect(resolver.navigableURL(from: "node.js\ttutorial") == nil)
     }
 
-    @Test func onlyExactLoopbackHostsDefaultToHTTP() throws {
+    @Test func onlyLoopbackHostsDefaultToHTTP() throws {
         #expect(try #require(resolver.navigableURL(from: "localhost:3000")).scheme == "http")
         #expect(try #require(resolver.navigableURL(from: "dev.localhost:3000")).scheme == "http")
         #expect(try #require(resolver.navigableURL(from: "[::1]:3000")).scheme == "http")
+        #expect(try #require(resolver.navigableURL(from: "127.0.0.10:3000")).scheme == "http")
         #expect(try #require(resolver.navigableURL(from: "localhost.evil.com")).scheme == "https")
-        #expect(try #require(resolver.navigableURL(from: "127.0.0.10")).scheme == "https")
+        #expect(try #require(resolver.navigableURL(from: "127.0.0.1.evil.com")).scheme == "https")
     }
 
     @Test func preservesSupportedAndRejectedSchemes() throws {

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -112,6 +112,12 @@ import Testing
         #expect(try #require(resolver.navigableURL(from: "127.0.0.10:3000")).scheme == "http")
         #expect(try #require(resolver.navigableURL(from: "localhost.evil.com")).scheme == "https")
         #expect(try #require(resolver.navigableURL(from: "127.0.0.1.evil.com")).scheme == "https")
+        #expect(resolver.navigableURL(from: "localhost:80@evil.example/path") == nil)
+        #expect(resolver.navigableURL(from: "127.0.0.1:80@evil.example") == nil)
+        #expect(
+            try #require(resolver.navigableURL(from: "example.com/path?email=user@example.com")).host ==
+                "example.com"
+        )
     }
 
     @Test func preservesSupportedAndRejectedSchemes() throws {

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Omnibar/BrowserURLResolverTests.swift
@@ -78,11 +78,16 @@ import Testing
     }
 
     @Test func doesNotCompactTextThatConstructsADifferentAuthority() {
-        let input = "https://trusted.example\n@evil.example/path"
+        let explicitInput = "https://trusted.example\n@evil.example/path"
+        let schemeLessInput = "trusted.example\n@evil.example/path"
 
-        #expect(resolver.textForPaste(input) == input)
-        #expect(resolver.navigableURL(from: input) == nil)
-        #expect(resolver.navigableURL(from: input.replacingOccurrences(of: "\n", with: " ")) == nil)
+        #expect(resolver.textForPaste(explicitInput) == explicitInput)
+        #expect(resolver.navigableURL(from: explicitInput) == nil)
+        #expect(
+            resolver.navigableURL(from: explicitInput.replacingOccurrences(of: "\n", with: " ")) == nil
+        )
+        #expect(resolver.textForPaste(schemeLessInput) == schemeLessInput)
+        #expect(resolver.navigableURL(from: schemeLessInput) == nil)
     }
 
     @Test func preservesExistingNavigationAndSearchBoundaries() throws {
@@ -91,8 +96,9 @@ import Testing
             try #require(resolver.navigableURL(from: "example.com/path?x=1")).absoluteString ==
                 "https://example.com/path?x=1"
         )
+        #expect(resolver.navigableURL(from: "example.\ncom/path?x=1") == nil)
         #expect(
-            try #require(resolver.navigableURL(from: "example.\ncom/path?x=1")).absoluteString ==
+            try #require(resolver.navigableURL(from: "example.com/path?\nx=1")).absoluteString ==
                 "https://example.com/path?x=1"
         )
         #expect(resolver.navigableURL(from: "node.js tutorial") == nil)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6212,66 +6212,8 @@ extension BrowserPanel {
     }
 }
 
-private func browserBareHostCandidate(_ lowercasedInput: String) -> String {
-    let end = lowercasedInput.firstIndex { character in
-        character == ":" || character == "/" || character == "?" || character == "#"
-    } ?? lowercasedInput.endIndex
-    return String(lowercasedInput[..<end])
-}
-
 func resolveBrowserNavigableURL(_ input: String) -> URL? {
-    let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmed.isEmpty else { return nil }
-    guard !trimmed.contains(" ") else { return nil }
-
-    // Check localhost/loopback before generic URL parsing because
-    // URL(string: "localhost:3777") treats "localhost" as a scheme.
-    let lower = trimmed.lowercased()
-    let bareHost = browserBareHostCandidate(lower)
-    if lower.hasPrefix("localhost") ||
-        lower.hasPrefix("127.0.0.1") ||
-        lower.hasPrefix("[::1]") ||
-        (bareHost != ".localhost" && bareHost.hasSuffix(".localhost")) {
-        return URL(string: "http://\(trimmed)")
-    }
-
-    if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
-        if scheme == "http" || scheme == "https" {
-            return url
-        }
-        if scheme == "file", url.isFileURL, url.path.hasPrefix("/") {
-            return url
-        }
-        // URL(string: "example.com:8443") parses "example.com" as the scheme.
-        // No real scheme contains a dot, so a dotted "scheme" followed by a
-        // numeric port is a bare host:port that must navigate, not search.
-        if browserDottedHostWithPortCandidate(trimmed, schemeCandidate: scheme) {
-            return URL(string: "https://\(trimmed)")
-        }
-        return nil
-    }
-
-    if trimmed.contains(":") || trimmed.contains("/") {
-        return URL(string: "https://\(trimmed)")
-    }
-
-    if trimmed.contains(".") {
-        return URL(string: "https://\(trimmed)")
-    }
-
-    return nil
-}
-
-private func browserDottedHostWithPortCandidate(_ input: String, schemeCandidate: String) -> Bool {
-    guard schemeCandidate.contains(".") else { return false }
-    guard input.count > schemeCandidate.count else { return false }
-    let afterScheme = input.dropFirst(schemeCandidate.count)
-    guard afterScheme.first == ":" else { return false }
-    let portAndRest = afterScheme.dropFirst()
-    let port = portAndRest.prefix(while: { $0.isNumber })
-    guard !port.isEmpty, UInt16(port) != nil else { return false }
-    let rest = portAndRest.dropFirst(port.count)
-    return rest.isEmpty || rest.first == "/" || rest.first == "?" || rest.first == "#"
+    BrowserURLResolver().navigableURL(from: input)
 }
 
 extension BrowserPanel {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3977,6 +3977,7 @@ final class OmnibarNativeTextField: NSTextField {
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
+        cell = BrowserOmnibarPasteTextFieldCell(textCell: "")
         isBordered = false
         isBezeled = false
         drawsBackground = false
@@ -3988,7 +3989,6 @@ final class OmnibarNativeTextField: NSTextField {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
     override func resetCursorRects() {
         super.resetCursorRects()
         addCursorRect(bounds, cursor: .iBeam)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		BCBC0A0E0000000000000E21 /* BrowserMediaPlaybackAudioActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCBC0A0E0000000000000E22 /* BrowserMediaPlaybackAudioActivityTests.swift */; };
 		A500MH01 /* BrowserMediaPlaybackMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MH00 /* BrowserMediaPlaybackMessageHandler.swift */; };
 		A500MR01 /* BrowserMediaPlaybackReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500MR00 /* BrowserMediaPlaybackReport.swift */; };
+		A85970000000000000000001 /* BrowserNavigableURLPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A85970000000000000000002 /* BrowserNavigableURLPasteTests.swift */; };
 		C67540080000000000000001 /* BrowserNavigationDebugURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540080000000000000002 /* BrowserNavigationDebugURL.swift */; };
 		BABA25000000000000000009 /* BrowserNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABA2500000000000000000A /* BrowserNavigationDelegate.swift */; };
 		B424PWNP000000000000PW01 /* BrowserNavigationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424PWNP000000000000PW02 /* BrowserNavigationPolicy.swift */; };
@@ -2470,6 +2471,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		BCBC0A0E0000000000000E22 /* BrowserMediaPlaybackAudioActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserMediaPlaybackAudioActivityTests.swift; sourceTree = "<group>"; };
 		A500MH00 /* BrowserMediaPlaybackMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserMediaPlaybackMessageHandler.swift; sourceTree = "<group>"; };
 		A500MR00 /* BrowserMediaPlaybackReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserMediaPlaybackReport.swift; sourceTree = "<group>"; };
+		A85970000000000000000002 /* BrowserNavigableURLPasteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserNavigableURLPasteTests.swift; sourceTree = "<group>"; };
 		C67540080000000000000002 /* BrowserNavigationDebugURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationDebugURL.swift; sourceTree = "<group>"; };
 		BABA2500000000000000000A /* BrowserNavigationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationDelegate.swift; sourceTree = "<group>"; };
 		B424PWNP000000000000PW02 /* BrowserNavigationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserNavigationPolicy.swift; sourceTree = "<group>"; };
@@ -6072,6 +6074,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */,
 				730600010000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift */,
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */,
+				A85970000000000000000002 /* BrowserNavigableURLPasteTests.swift */,
 				B1F0C0070000000000000002 /* BrowserDeveloperToolsLifecycleTests.swift */,
 				B1F0C0060000000000000002 /* BrowserDeveloperToolsDockControlNormalizerTests.swift */,
 				B1F0C0020000000000000002 /* BrowserInspectorFocusHandoffTests.swift */,
@@ -8500,6 +8503,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B1F0C0020000000000000001 /* BrowserInspectorFocusHandoffTests.swift in Sources */,
 				BCBC0A0E0000000000000E11 /* BrowserMediaActivityAggregationTests.swift in Sources */,
 				BCBC0A0E0000000000000E21 /* BrowserMediaPlaybackAudioActivityTests.swift in Sources */,
+				A85970000000000000000001 /* BrowserNavigableURLPasteTests.swift in Sources */,
 				C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */,
 				B7380002B7380002B7380002 /* BrowserOmnibarSuggestionClickRoutingTests.swift in Sources */,
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,

--- a/cmuxTests/BrowserNavigableURLPasteTests.swift
+++ b/cmuxTests/BrowserNavigableURLPasteTests.swift
@@ -29,11 +29,9 @@ import Testing
         #expect(resolved.absoluteString == oauthURL)
     }
 
-    @Test func singleLineFieldWrappedOAuthURLNavigatesWithoutSearching() throws {
-        // AppKit's single-line field editor converts a pasted newline to a space
-        // before Return submits the live field value.
-        let fieldValue = oauthURL.replacingOccurrences(of: "&scope=", with: "& scope=")
-        let resolved = try #require(resolveBrowserNavigableURL(fieldValue))
+    @Test func tabWrappedOAuthURLNavigatesWithoutSearching() throws {
+        let wrapped = oauthURL.replacingOccurrences(of: "&scope=", with: "&\tscope=")
+        let resolved = try #require(resolveBrowserNavigableURL(wrapped))
 
         #expect(resolved.absoluteString == oauthURL)
     }

--- a/cmuxTests/BrowserNavigableURLPasteTests.swift
+++ b/cmuxTests/BrowserNavigableURLPasteTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct BrowserNavigableURLPasteTests {
+    private let oauthURL =
+        "https://auth.openai.com/oauth/authorize?client_id=app_1234567890" +
+        "&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback" +
+        "&response_type=code&scope=openid%20profile%20email%20offline_access" +
+        "&code_challenge=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+        "&code_challenge_method=S256&state=state_abcdefghijklmnopqrstuvwxyz0123456789" +
+        "&codex_cli_simplified_flow=true"
+
+    @Test func longOAuthURLNavigatesWithoutRewriting() throws {
+        let resolved = try #require(resolveBrowserNavigableURL(oauthURL))
+
+        #expect(resolved.absoluteString == oauthURL)
+    }
+
+    @Test func terminalWrappedOAuthURLNavigatesWithoutRewriting() throws {
+        let wrapped = oauthURL.replacingOccurrences(of: "&scope=", with: "&\nscope=")
+        let resolved = try #require(resolveBrowserNavigableURL(wrapped))
+
+        #expect(resolved.absoluteString == oauthURL)
+    }
+
+    @Test func singleLineFieldWrappedOAuthURLNavigatesWithoutSearching() throws {
+        // AppKit's single-line field editor converts a pasted newline to a space
+        // before Return submits the live field value.
+        let fieldValue = oauthURL.replacingOccurrences(of: "&scope=", with: "& scope=")
+        let resolved = try #require(resolveBrowserNavigableURL(fieldValue))
+
+        #expect(resolved.absoluteString == oauthURL)
+    }
+
+    @Test func surroundingWhitespaceDoesNotRewriteOAuthURL() throws {
+        let resolved = try #require(resolveBrowserNavigableURL("  \n\t\(oauthURL)\r\n  "))
+
+        #expect(resolved.absoluteString == oauthURL)
+    }
+
+    @Test func URLAndSearchBoundariesRemainStable() throws {
+        #expect(try #require(resolveBrowserNavigableURL("localhost:3000")).absoluteString == "http://localhost:3000")
+        #expect(
+            try #require(resolveBrowserNavigableURL("example.com/path?x=1")).absoluteString ==
+                "https://example.com/path?x=1"
+        )
+        #expect(resolveBrowserNavigableURL("node.js tutorial") == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- intercept raw omnibar pasteboard text in the AppKit field editor before a single-line text field flattens terminal soft-wrap line breaks into spaces
- canonicalize safe wrap artifacts in pure, package-owned macOS and iOS URL resolvers while preserving each platform's existing navigation/search policy
- route both generic and typed AppKit paste entrypoints through one insertion helper and keep both Return submission paths on the same live field-editor snapshot
- remove wrap characters only after the URL authority is complete, preventing multiline text from constructing a different destination host for explicit or scheme-less URLs
- reject scheme-less userinfo so a local-looking prefix cannot downgrade a remote destination to HTTP; `@` remains valid in paths and queries
- preserve meaningful spaces and searches such as `node.js tutorial`, `go\nexample.com/path`, and `go\texample.com/path`
- preserve navigation for long OAuth URLs, wrapped scheme-less paths/queries, `localhost:3000`, the IPv4 loopback range, and `example.com/path?x=1`

## Reproduction

A long unwrapped OAuth URL navigated correctly. The same URL with embedded terminal-wrap line breaks did not: AppKit converted the pasted newline to a space in the single-line field, and the previous macOS classifier rejected whitespace and fell through to Google search. The iOS resolver accepted the raw newline but produced malformed, double-encoded navigation.

The regression was reproduced deterministically at the resolver and AppKit field-editor boundaries, so a Cloud Mac UI repro was unnecessary.

Regression-test-only commits precede their fixes:

- `faf0923c14` — wrapped OAuth URL classification
- `92f92800b5` — typed AppKit paste path
- `1b54cbe8e1` — newline-separated free text remains a search
- `e4c2bd07ba` — explicit authority-confusion and IPv4 loopback boundaries
- `7728749b50` — scheme-less authority remains immutable
- `4e0217a39c` — scheme-less userinfo cannot spoof loopback

## Verification

- `arch -arm64 swift test --filter BrowserURLResolverTests` in `Packages/macOS/CmuxBrowser` — 9/9 passed
- `arch -arm64 swift test --filter BrowserURLResolverTests` in `Packages/iOS/CmuxMobileBrowser` — 26/26 passed
- `scripts/lint-pbxproj-test-wiring.sh` — passed (552 files checked)
- `scripts/check-pbxproj.sh` — passed
- `python3 scripts/check-workspace-package-groups.py --check` — passed
- `git diff --check origin/main...HEAD` — passed
- no changes to `.github/swift-file-length-budget.tsv` or `.github/swift-warning-budget.tsv`; all new Swift files remain below 500 lines and the large panel view remains 7,849 lines
- no user-facing strings changed; no localization catalog changes required
- no app build, local `xcodebuild`, or XCUITest run, per issue instructions

Focused GitHub Actions run [29877095983](https://github.com/manaflow-ai/cmux/actions/runs/29877095983) failed before reaching this PR's tests because current `main` does not compile `CmuxGit` under that workflow's Xcode (`convenience init` on an actor). The unrelated fix is open in #8604. This PR's required checks are green.

Closes #8597
