### PR TITLE
Fix main build: drop convenience from actor initializer

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -60,7 +60,9 @@ public actor GitHubPullRequestRequestCoordinator {
     /// `PullRequestProbeService(requestCoordinator:)`. The session and cache
     /// tuning knobs stay internal (tests reach that initializer through
     /// `@testable import`), keeping the public surface to a plain default.
-    public convenience init() {
+    /// Actor initializers delegate without `convenience` (SE-0327); marking
+    /// one `convenience` is a hard error on current toolchains.
+    public init() {
         self.init(session: nil)
     }
 


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/8521 added `public convenience init()` to the `GitHubPullRequestRequestCoordinator` actor. Actor initializers delegate without `convenience` (SE-0327) and current Swift toolchains reject the keyword as a hard error, so every fleet reload-cloud build and CI compile of main fails with `initializers in actors are not marked with 'convenience'` (example: https://github.com/manaflow-ai/cmux/actions/runs/29874585488). It landed silently because PR CI is currently disabled. Dropping the keyword keeps the same public surface and the same delegation to `init(session:)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787266350&installation_model_id=21920&pr_number=8604&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8604&signature=6d1bf907bbf2cb7b91c2c7d77005d419f1b5ceec6594498739d97c1d2d2d89c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `convenience` keyword from the default initializer of the `GitHubPullRequestRequestCoordinator` actor to comply with SE-0327 and fix a hard compiler error. Public API stays the same (still delegates to `init(session:)`), restoring main and CI builds.

<sup>Written for commit ada07624ee0e7d6e6659ad360a127a24e96f344a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the pull request request coordinator’s initialization behavior to align with Swift language requirements.
  * No user-visible functionality or workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->