### PR TITLE
main does not compile: actor initializer marked 'convenience' in CmuxGit

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -60,7 +60,7 @@ public actor GitHubPullRequestRequestCoordinator {
     /// `PullRequestProbeService(requestCoordinator:)`. The session and cache
     /// tuning knobs stay internal (tests reach that initializer through
     /// `@testable import`), keeping the public surface to a plain default.
-    public convenience init() {
+    public init() {
         self.init(session: nil)
     }
 


### PR DESCRIPTION
## What's broken

`main` does not compile. `Packages/macOS/CmuxGit` fails to emit its module, which takes the app build and every test target with it:

```
GitHubPullRequestRequestCoordinator.swift:63:24: error: initializers in actors are not marked with 'convenience'
 63 |     public convenience init() {
    |                        `- error: initializers in actors are not marked with 'convenience'
```

`build-nightly-app` is failing on `main` for this. It is easy to miss because the commit's legacy combined status still reads `success`; only the check run shows it.

## Why

#8521 made `GitHubPullRequestRequestCoordinator` a `public actor` and added a `public convenience init()` that delegates to the internal initializer. Actors do not take convenience initializers, so the declaration is rejected.

## Fix

Drop the keyword. Delegation to the internal initializer and the public surface are unchanged, and the internal initializer already defaults every parameter:

```swift
public init() {
    self.init(session: nil)
}
```

## Verification

`swift build` on the package goes from the error above to `Build complete!`.

On a macOS builder, running a test suite through the app host on `main` produces three occurrences of that error, zero tests executed, and `** TEST FAILED **`. With this one-line change the error count drops to zero and suites execute normally.

Worth flagging separately: the failure is invisible to a runner that trusts exit status, because `xcodebuild` here is invoked through `launchctl asuser`, which reports its own status rather than the child's. A failed build comes back as `rc=0` with an empty log summary, which reads as a pass. Verdicts have to come from log content.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787267261&installation_model_id=21920&pr_number=8607&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8607&signature=53a5ab56d4c0680576af92d913123bf0fe69f597e79147d707c4b569fecf1636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `main` build by removing 'convenience' from the public initializer of the `GitHubPullRequestRequestCoordinator` actor in `CmuxGit`. Actors don't support convenience initializers, so this restores the module build and unblocks the app and tests.

<sup>Written for commit fd3381893b421aa81ddc93b43e24bb7c8528007f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the pull request coordinator’s public initialization behavior without changing its user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->