### PR TITLE
Fix remote tmux new-window routing in release builds

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -31,8 +31,7 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
 #if DEBUG
         if method == "remote.tmux.test_exec" || method == "remote.tmux.test_set_frame"
             || method == "remote.tmux.test_perturb_divider"
-            || method == "remote.tmux.root_frames"
-            || method == "remote.tmux.window" {
+            || method == "remote.tmux.root_frames" {
             self = .socketWorker(mainThreadCallable: false)
             return
         }
@@ -130,7 +129,8 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         "remote.tmux.attach",
         "remote.tmux.detach",
         "remote.tmux.state",
-        "remote.tmux.mirror", "remote.tmux.pane_grids", "remote.tmux.pane_surfaces",
+        "remote.tmux.mirror", "remote.tmux.window",
+        "remote.tmux.pane_grids", "remote.tmux.pane_surfaces",
         "sidebar.custom.validate",
         "sidebar.custom.reload",
         "sidebar.custom.select",

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
@@ -72,8 +72,6 @@ struct ControlCommandExecutionPolicyTests {
         for method in [
             "remote.tmux.test_exec", "remote.tmux.test_set_frame",
             "remote.tmux.test_perturb_divider",
-            // window is a DEBUG-only alias of mirror; it must share the worker lane.
-            "remote.tmux.window",
         ] {
             let policy = ControlCommandExecutionPolicy(forMethod: method)
 #if DEBUG
@@ -82,6 +80,14 @@ struct ControlCommandExecutionPolicyTests {
             #expect(policy == .mainActor, "\(method)")
 #endif
         }
+    }
+
+    @Test func remoteTmuxWindowRunsOnTheReleaseWorkerLane() {
+        #expect(ControlCommandExecutionPolicy.socketWorkerMethods.contains("remote.tmux.window"))
+        #expect(
+            ControlCommandExecutionPolicy(forMethod: "remote.tmux.window")
+                == .socketWorker(mainThreadCallable: false)
+        )
     }
 
     @Test func v2ResolutionReadsRunOnTheWorkerAndAreMainThreadCallable() {


### PR DESCRIPTION
## Summary

- route `remote.tmux.window` through the socket worker in release builds
- keep only test-only remote tmux methods behind `#if DEBUG`
- add a regression test that pins `remote.tmux.window` in the release worker registry

## Root cause

`remote.tmux.window` has a production handler and is advertised by the CLI/capabilities surface, but its execution policy was registered only inside a `#if DEBUG` block. Debug builds therefore routed the method correctly, while release builds sent it to the main-actor dispatcher, which has no handler for it and returned `method_not_found`.

This makes `cmux ssh-tmux <host> --new-window` fail in the v0.64.20 release even though the same path works in Debug dogfood.

## User impact

Dedicated-window remote tmux attach works in release builds again. Existing `remote.tmux.mirror` behavior is unchanged.

## Verification

- red regression commit: `481fa6b` fails `remoteTmuxWindowRunsOnTheReleaseWorkerLane`
- Debug targeted test: passed
- Release targeted test: passed
- full `CmuxControlSocket` package: 278 tests passed
- `./scripts/lint-pbxproj-test-wiring.sh`: passed (551 test files)
- `git diff --check`: passed
- tagged app build attempted after repository setup; current upstream `main` is blocked locally by an unrelated `CmuxGit` compile error in `GitHubPullRequestRequestCoordinator.swift:63` (`initializers in actors are not marked with 'convenience'`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787268735&installation_model_id=21920&pr_number=8608&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8608&signature=1386961936616f9687d7697a2189570ca5cf2cce37c853411e1c17f58c1ba3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release routing for `remote.tmux.window` by sending it to the socket worker, restoring `cmux ssh-tmux <host> --new-window` in release builds. Adds a regression test in `CmuxControlSocket` to pin this behavior.

- **Bug Fixes**
  - Route `remote.tmux.window` via the socket worker in release (was hitting main actor and returning `method_not_found`).
  - Keep only test-only remote tmux methods under `#if DEBUG`.
  - Add `remoteTmuxWindowRunsOnTheReleaseWorkerLane` test to assert policy and registry inclusion.

<sup>Written for commit 3a3ae410db50f73057be3ac6e56153e369068c63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated command routing so window-related tmux operations consistently run through the socket worker.
  * Improved behavior consistency between debug and release configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->