### PR TITLE
iOS: stop open menus from flickering when their parent views re-render

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFileActionPresentation.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFileActionPresentation.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import UIKit
 
 /// A system presentation prepared by an artifact file action.
-public enum ChatArtifactFileActionPresentation: Identifiable, Equatable {
+public enum ChatArtifactFileActionPresentation: Identifiable, Equatable, Sendable {
     /// Presents the standard activity controller for a local file.
     case share(URL)
     /// Presents the Files document picker in export-as-copy mode.

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerActionsMenu.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerActionsMenu.swift
@@ -1,0 +1,200 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+struct ChatArtifactViewerActionsMenu: View, Equatable {
+    let value: ChatArtifactViewerActionsMenuValue
+    let actions: ChatArtifactViewerActionsMenuActions
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    private var snapshot: ChatArtifactViewerPageSnapshot { value.snapshot }
+
+    var body: some View {
+        Menu {
+            if snapshot.hasFileActions {
+                Section {
+                    fileActionButtons
+                }
+            }
+            if snapshot.shouldShowTextJumpControls {
+                Section {
+                    textViewerActionButtons
+                }
+            }
+            if snapshot.state == .markdown,
+               snapshot.markdownPresentation.isRenderedAvailable {
+                Section {
+                    Picker(
+                        String(
+                            localized: "chat.artifact.markdown.view",
+                            defaultValue: "Markdown view",
+                            bundle: .module
+                        ),
+                        selection: Binding(
+                            get: { snapshot.markdownPresentation.mode },
+                            set: { actions.selectMarkdownMode(snapshot.path, $0) }
+                        )
+                    ) {
+                        Text(String(
+                            localized: "chat.artifact.markdown.raw",
+                            defaultValue: "Raw",
+                            bundle: .module
+                        ))
+                        .tag(ChatArtifactMarkdownMode.raw)
+                        Text(String(
+                            localized: "chat.artifact.markdown.rendered",
+                            defaultValue: "Rendered",
+                            bundle: .module
+                        ))
+                        .tag(ChatArtifactMarkdownMode.rendered)
+                    }
+                }
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.viewer.actions",
+                    defaultValue: "Viewer actions",
+                    bundle: .module
+                ),
+                systemImage: "ellipsis.circle"
+            )
+        }
+        .disabled(snapshot.fileActionState.isRunning)
+    }
+
+    @ViewBuilder
+    private var fileActionButtons: some View {
+        Button {
+            actions.prepareShare(snapshot.path)
+        } label: {
+            Label(
+                String(localized: "chat.artifact.share", defaultValue: "Share", bundle: .module),
+                systemImage: "square.and.arrow.up"
+            )
+        }
+        Button {
+            actions.prepareSave(snapshot.path)
+        } label: {
+            Label(
+                String(localized: "chat.artifact.save_to_files", defaultValue: "Save to Files", bundle: .module),
+                systemImage: "folder.badge.plus"
+            )
+        }
+        if snapshot.isTextFile {
+            Button {
+                UIPasteboard.general.string = snapshot.renderedText
+                actions.notifyCopied()
+            } label: {
+                Label(
+                    String(localized: "chat.artifact.copy_contents", defaultValue: "Copy contents", bundle: .module),
+                    systemImage: "doc.on.doc"
+                )
+            }
+            .disabled(!snapshot.canCopyContents)
+        }
+        Button {
+            UIPasteboard.general.string = snapshot.path
+            actions.notifyPathCopied()
+        } label: {
+            Label(
+                String(localized: "chat.artifact.copy_path", defaultValue: "Copy path", bundle: .module),
+                systemImage: "link"
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var textViewerActionButtons: some View {
+        Button {
+            withAnimation(.snappy) {
+                actions.toggleSearch(snapshot.path)
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.search.title",
+                    defaultValue: "Search",
+                    bundle: .module
+                ),
+                systemImage: "magnifyingglass"
+            )
+        }
+        Button {
+            withAnimation(.snappy) {
+                actions.toggleGoToLine(snapshot.path)
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.line.goto",
+                    defaultValue: "Go to line",
+                    bundle: .module
+                ),
+                systemImage: "text.line.first.and.arrowtriangle.forward"
+            )
+        }
+        Button {
+            actions.requestTop(snapshot.path)
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.jump.top",
+                    defaultValue: "Top",
+                    bundle: .module
+                ),
+                systemImage: "arrow.up.to.line"
+            )
+        }
+        Button {
+            actions.requestBottom(snapshot.path)
+        } label: {
+            Label(jumpToEndTitle, systemImage: "arrow.down.to.line")
+        }
+        Button {
+            actions.toggleLineNumbers(snapshot.path)
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.line.numbers",
+                    defaultValue: "Line numbers",
+                    bundle: .module
+                ),
+                systemImage: snapshot.showsLineNumbers ? "checkmark" : "number"
+            )
+        }
+        Button {
+            actions.toggleWordWrap(snapshot.path)
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.wrap",
+                    defaultValue: "Word wrap",
+                    bundle: .module
+                ),
+                systemImage: snapshot.wrapsLines ? "checkmark" : "text.justify.left"
+            )
+        }
+    }
+
+    private var jumpToEndTitle: String {
+        switch ChatArtifactTextEndJumpTarget(reachedEOF: snapshot.textReachedEOF) {
+        case .end:
+            return String(
+                localized: "chat.artifact.jump.end",
+                defaultValue: "End",
+                bundle: .module
+            )
+        case .latest:
+            return String(
+                localized: "chat.artifact.jump.latest",
+                defaultValue: "Latest",
+                bundle: .module
+            )
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerActionsMenuActions.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerActionsMenuActions.swift
@@ -1,0 +1,15 @@
+#if os(iOS)
+struct ChatArtifactViewerActionsMenuActions {
+    let prepareShare: (String) -> Void
+    let prepareSave: (String) -> Void
+    let toggleSearch: (String) -> Void
+    let toggleGoToLine: (String) -> Void
+    let requestTop: (String) -> Void
+    let requestBottom: (String) -> Void
+    let toggleLineNumbers: (String) -> Void
+    let toggleWordWrap: (String) -> Void
+    let selectMarkdownMode: (String, ChatArtifactMarkdownMode) -> Void
+    let notifyCopied: () -> Void
+    let notifyPathCopied: () -> Void
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerActionsMenuValue.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerActionsMenuValue.swift
@@ -1,0 +1,8 @@
+#if os(iOS)
+struct ChatArtifactViewerActionsMenuValue: Equatable, Sendable {
+    let snapshot: ChatArtifactViewerPageSnapshot
+    let loaderScope: ChatArtifactLoaderScope
+    let loaderSupportsArtifacts: Bool
+    let loaderSupportsDirectoryBrowsing: Bool
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerFileActionState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerFileActionState.swift
@@ -1,5 +1,5 @@
 /// Immutable system-presentation state owned by one artifact page.
-struct ChatArtifactViewerFileActionState: Equatable {
+struct ChatArtifactViewerFileActionState: Equatable, Sendable {
     #if os(iOS)
     var presentation: ChatArtifactFileActionPresentation? = nil
     #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageSnapshot.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageSnapshot.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Immutable render state for one path-keyed artifact viewer page.
-struct ChatArtifactViewerPageSnapshot: Identifiable, Equatable {
+struct ChatArtifactViewerPageSnapshot: Identifiable, Equatable, Sendable {
     let path: String
     let state: ChatArtifactViewerState
     let textChunks: [String]

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
@@ -48,7 +48,16 @@ struct ChatArtifactViewerPager: View {
                 #if os(iOS)
                 ToolbarItemGroup(placement: .topBarTrailing) {
                     if model.toolbarSnapshot.hasViewerActions {
-                        viewerActionsMenu(snapshot: model.toolbarSnapshot)
+                        ChatArtifactViewerActionsMenu(
+                            value: ChatArtifactViewerActionsMenuValue(
+                                snapshot: model.toolbarSnapshot,
+                                loaderScope: loader.scope,
+                                loaderSupportsArtifacts: loader.supportsArtifacts,
+                                loaderSupportsDirectoryBrowsing: loader.supportsDirectoryBrowsing
+                            ),
+                            actions: viewerActionsMenuActions
+                        )
+                        .equatable()
                     }
                     doneButton
                 }
@@ -169,175 +178,25 @@ struct ChatArtifactViewerPager: View {
     }
 
     #if os(iOS)
-    private func viewerActionsMenu(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
-        Menu {
-            if snapshot.hasFileActions {
-                Section {
-                    fileActionButtons(snapshot: snapshot)
-                }
+    private var viewerActionsMenuActions: ChatArtifactViewerActionsMenuActions {
+        ChatArtifactViewerActionsMenuActions(
+            prepareShare: { path in
+                Task { await model.prepareShare(for: path, loader: loader) }
+            },
+            prepareSave: { path in
+                Task { await model.prepareSave(for: path, loader: loader) }
+            },
+            toggleSearch: model.toggleSearch,
+            toggleGoToLine: model.toggleGoToLine,
+            requestTop: model.requestTop,
+            requestBottom: model.requestBottom,
+            toggleLineNumbers: model.toggleLineNumbers,
+            toggleWordWrap: model.toggleWordWrap,
+            selectMarkdownMode: model.selectMarkdownMode,
+            notifyCopied: { toasts.present(.copied()) },
+            notifyPathCopied: {
+                toasts.present(.copied(L10n.string("mobile.toast.pathCopied", defaultValue: "Path copied")))
             }
-            if snapshot.shouldShowTextJumpControls {
-                Section {
-                    textViewerActionButtons(snapshot: snapshot)
-                }
-            }
-            if snapshot.state == .markdown,
-               snapshot.markdownPresentation.isRenderedAvailable {
-                Section {
-                    Picker(
-                        String(
-                            localized: "chat.artifact.markdown.view",
-                            defaultValue: "Markdown view",
-                            bundle: .module
-                        ),
-                        selection: markdownModeBinding
-                    ) {
-                        Text(String(
-                            localized: "chat.artifact.markdown.raw",
-                            defaultValue: "Raw",
-                            bundle: .module
-                        ))
-                        .tag(ChatArtifactMarkdownMode.raw)
-                        Text(String(
-                            localized: "chat.artifact.markdown.rendered",
-                            defaultValue: "Rendered",
-                            bundle: .module
-                        ))
-                        .tag(ChatArtifactMarkdownMode.rendered)
-                    }
-                }
-            }
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.viewer.actions",
-                    defaultValue: "Viewer actions",
-                    bundle: .module
-                ),
-                systemImage: "ellipsis.circle"
-            )
-        }
-        .disabled(snapshot.fileActionState.isRunning)
-    }
-
-    @ViewBuilder
-    private func fileActionButtons(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
-        Button {
-            Task { await model.prepareShare(loader: loader) }
-        } label: {
-            Label(
-                String(localized: "chat.artifact.share", defaultValue: "Share", bundle: .module),
-                systemImage: "square.and.arrow.up"
-            )
-        }
-        Button {
-            Task { await model.prepareSave(loader: loader) }
-        } label: {
-            Label(
-                String(localized: "chat.artifact.save_to_files", defaultValue: "Save to Files", bundle: .module),
-                systemImage: "folder.badge.plus"
-            )
-        }
-        if snapshot.isTextFile {
-            Button {
-                UIPasteboard.general.string = snapshot.renderedText
-                toasts.present(.copied())
-            } label: {
-                Label(
-                    String(localized: "chat.artifact.copy_contents", defaultValue: "Copy contents", bundle: .module),
-                    systemImage: "doc.on.doc"
-                )
-            }
-            .disabled(!snapshot.canCopyContents)
-        }
-        Button {
-            UIPasteboard.general.string = snapshot.path
-            toasts.present(.copied(L10n.string("mobile.toast.pathCopied", defaultValue: "Path copied")))
-        } label: {
-            Label(
-                String(localized: "chat.artifact.copy_path", defaultValue: "Copy path", bundle: .module),
-                systemImage: "link"
-            )
-        }
-    }
-
-    @ViewBuilder
-    private func textViewerActionButtons(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
-        Button {
-            withAnimation(.snappy) {
-                model.toggleSearch()
-            }
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.search.title",
-                    defaultValue: "Search",
-                    bundle: .module
-                ),
-                systemImage: "magnifyingglass"
-            )
-        }
-        Button {
-            withAnimation(.snappy) {
-                model.toggleGoToLine()
-            }
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.line.goto",
-                    defaultValue: "Go to line",
-                    bundle: .module
-                ),
-                systemImage: "text.line.first.and.arrowtriangle.forward"
-            )
-        }
-        Button {
-            model.requestTop()
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.jump.top",
-                    defaultValue: "Top",
-                    bundle: .module
-                ),
-                systemImage: "arrow.up.to.line"
-            )
-        }
-        Button {
-            model.requestBottom()
-        } label: {
-            Label(jumpToEndTitle(snapshot: snapshot), systemImage: "arrow.down.to.line")
-        }
-        Button {
-            model.toggleLineNumbers()
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.line.numbers",
-                    defaultValue: "Line numbers",
-                    bundle: .module
-                ),
-                systemImage: snapshot.showsLineNumbers ? "checkmark" : "number"
-            )
-        }
-        Button {
-            model.toggleWordWrap()
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.wrap",
-                    defaultValue: "Word wrap",
-                    bundle: .module
-                ),
-                systemImage: snapshot.wrapsLines ? "checkmark" : "text.justify.left"
-            )
-        }
-    }
-
-    private var markdownModeBinding: Binding<ChatArtifactMarkdownMode> {
-        Binding(
-            get: { model.toolbarSnapshot.markdownPresentation.mode },
-            set: { model.selectMarkdownMode($0) }
         )
     }
 
@@ -364,21 +223,5 @@ struct ChatArtifactViewerPager: View {
         )
     }
 
-    private func jumpToEndTitle(snapshot: ChatArtifactViewerPageSnapshot) -> String {
-        switch ChatArtifactTextEndJumpTarget(reachedEOF: snapshot.textReachedEOF) {
-        case .end:
-            return String(
-                localized: "chat.artifact.jump.end",
-                defaultValue: "End",
-                bundle: .module
-            )
-        case .latest:
-            return String(
-                localized: "chat.artifact.jump.latest",
-                defaultValue: "Latest",
-                bundle: .module
-            )
-        }
-    }
     #endif
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPagerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPagerModel.swift
@@ -83,42 +83,42 @@ final class ChatArtifactViewerPagerModel {
         )
     }
 
-    func toggleSearch() {
-        selectedPage.toggleSearch()
+    func toggleSearch(for path: String) {
+        pageModel(for: path)?.toggleSearch()
     }
 
-    func toggleGoToLine() {
-        selectedPage.toggleGoToLine()
+    func toggleGoToLine(for path: String) {
+        pageModel(for: path)?.toggleGoToLine()
     }
 
-    func requestTop() {
-        selectedPage.requestTop()
+    func requestTop(for path: String) {
+        pageModel(for: path)?.requestTop()
     }
 
-    func requestBottom() {
-        selectedPage.requestBottom()
+    func requestBottom(for path: String) {
+        pageModel(for: path)?.requestBottom()
     }
 
-    func toggleLineNumbers() {
-        selectedPage.toggleLineNumbers()
+    func toggleLineNumbers(for path: String) {
+        pageModel(for: path)?.toggleLineNumbers()
     }
 
-    func toggleWordWrap() {
-        selectedPage.toggleWordWrap()
+    func toggleWordWrap(for path: String) {
+        pageModel(for: path)?.toggleWordWrap()
     }
 
-    func selectMarkdownMode(_ mode: ChatArtifactMarkdownMode) {
-        selectedPage.selectMarkdownMode(mode)
+    func selectMarkdownMode(for path: String, _ mode: ChatArtifactMarkdownMode) {
+        pageModel(for: path)?.selectMarkdownMode(mode)
     }
 
     #if os(iOS)
-    func prepareShare(loader: ChatArtifactLoader) async {
-        let page = selectedPage
+    func prepareShare(for path: String, loader: ChatArtifactLoader) async {
+        guard let page = pageModel(for: path) else { return }
         await page.prepareShare(loader: loader)
     }
 
-    func prepareSave(loader: ChatArtifactLoader) async {
-        let page = selectedPage
+    func prepareSave(for path: String, loader: ChatArtifactLoader) async {
+        guard let page = pageModel(for: path) else { return }
         await page.prepareSave(loader: loader)
     }
 
@@ -134,8 +134,8 @@ final class ChatArtifactViewerPagerModel {
     }
     #endif
 
-    private var selectedPage: ChatArtifactViewerPageModel {
-        selectedPageModel
+    private func pageModel(for path: String) -> ChatArtifactViewerPageModel? {
+        path == selectedPath ? selectedPageModel : pagesByPath[path]
     }
 
     private var pagePaths: [String] {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
@@ -2,7 +2,7 @@ import CmuxAgentChat
 import Foundation
 
 /// Renderable states for one stat-driven artifact path.
-enum ChatArtifactViewerState: Equatable {
+enum ChatArtifactViewerState: Equatable, Sendable {
     case loading
     case folder
     case image(data: Data)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatMessageRowView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatMessageRowView.swift
@@ -32,6 +32,7 @@ public struct ChatMessageRowView: View {
                     onShowCodeDetail: actions.showCodeBlockDetail,
                     onCopied: actions.notifyCopied
                 )
+                .equatable()
             case .thought:
                 ChatThoughtRowView(
                     rowID: rowID,

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/Rows/ChatProseBubbleView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/Rows/ChatProseBubbleView.swift
@@ -7,7 +7,7 @@ import UIKit
 /// The core prose bubble: user prompts render trailing-aligned plain text
 /// on the outgoing fill; agent prose renders leading-aligned with markdown
 /// text runs and embedded monospace code blocks.
-public struct ChatProseBubbleView: View {
+public struct ChatProseBubbleView: View, Equatable {
     private let prose: ChatProse
     private let message: ChatMessage
     private let groupPosition: ChatGroupPosition
@@ -44,6 +44,13 @@ public struct ChatProseBubbleView: View {
         self.showsTimestamp = showsTimestamp
         self.onShowCodeDetail = onShowCodeDetail
         self.onCopied = onCopied
+    }
+
+    nonisolated public static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.prose == rhs.prose
+            && lhs.message == rhs.message
+            && lhs.groupPosition == rhs.groupPosition
+            && lhs.showsTimestamp == rhs.showsTimestamp
     }
 
     public var body: some View {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
@@ -159,7 +159,7 @@ struct ChatArtifactViewerPagerModelTests {
         )
         let identity = try #require(model.pageIdentity(for: path))
 
-        model.requestTop()
+        model.requestTop(for: path)
         let requestID = model.toolbarSnapshot.topRequestID
         let actions = model.actions(
             for: path,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/AgentChatDemoScreen.swift
@@ -1,4 +1,5 @@
 #if DEBUG
+import CMUXMobileCore
 import CmuxAgentChat
 import CmuxAgentChatUI
 import CmuxMobileSupport
@@ -59,6 +60,26 @@ struct AgentChatDemoScreen: View {
                     }
                 }
         case .inlineWorkspace:
+            let value = WorkspaceTitleMenuValue(
+                contentWidth: contentWidth,
+                hasBackButton: true,
+                hasTrailingCluster: true,
+                hasChatToggle: true,
+                isEnabled: true,
+                workspaceName: inlineWorkspaceTitle ?? "",
+                hasUnread: false,
+                canRenameWorkspace: true,
+                canToggleReadState: true,
+                canCloseWorkspace: false,
+                labelToken: .chat(
+                    descriptor: stack.store.descriptor,
+                    agentState: stack.store.agentState,
+                    isConnected: stack.store.isConnected,
+                    titleOverride: inlineWorkspaceTitle,
+                    subtitle: inlineWorkspaceSubtitle
+                ),
+                terminalTheme: .monokai
+            )
             baseChatScreen(for: stack)
                 .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { contentWidth = $0 }
                 .toolbar {
@@ -71,18 +92,33 @@ struct AgentChatDemoScreen: View {
                     }
                     ToolbarItem(placement: .principal) {
                         WorkspaceTitleMenu(
-                            contentWidth: contentWidth,
-                            hasBackButton: true,
-                            hasTrailingCluster: true,
-                            hasChatToggle: true
-                        ) {
-                            Button(L10n.string("mobile.workspace.rename.title", defaultValue: "Rename Workspace")) {}
-                                .accessibilityIdentifier("MobileWorkspaceTitleRenameMenuItem")
-                            Button(L10n.string("mobile.workspace.markRead", defaultValue: "Mark as Read")) {}
-                                .accessibilityIdentifier("MobileWorkspaceTitleReadStateMenuItem")
-                        } label: {
-                            header(for: stack)
-                        }
+                            value: value,
+                            menuContent: {
+                                Button(L10n.string("mobile.workspace.rename.title", defaultValue: "Rename Workspace")) {}
+                                    .accessibilityIdentifier("MobileWorkspaceTitleRenameMenuItem")
+                                Button(L10n.string("mobile.workspace.markRead", defaultValue: "Mark as Read")) {}
+                                    .accessibilityIdentifier("MobileWorkspaceTitleReadStateMenuItem")
+                            },
+                            label: {
+                                if case .chat(
+                                    let descriptor,
+                                    let agentState,
+                                    let isConnected,
+                                    let titleOverride,
+                                    let subtitle
+                                ) = value.labelToken {
+                                    ChatSessionHeaderView(
+                                        descriptor: descriptor,
+                                        agentState: agentState,
+                                        isConnected: isConnected,
+                                        titleOverride: titleOverride,
+                                        subtitle: subtitle,
+                                        style: .toolbarCompact
+                                    )
+                                }
+                            }
+                        )
+                        .equatable()
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedPreviewView.swift
@@ -38,7 +38,8 @@ public struct NotificationFeedPreviewView: View {
                                 defaultValue: "All Computers"
                             ),
                             isLoading: false,
-                            selection: $macSelection,
+                            selection: macSelection,
+                            select: { macSelection = $0 },
                             machines: [],
                             showAddDevice: nil
                         )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedRow.swift
@@ -3,9 +3,13 @@ import CmuxMobileShellModel
 import CmuxMobileSupport
 import SwiftUI
 
-struct NotificationFeedRow: View {
+struct NotificationFeedRow: View, Equatable {
     let item: MobileNotificationFeedItem
     let actions: NotificationFeedActions
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.item == rhs.item
+    }
 
     var body: some View {
         let presentation = NotificationFeedRowPresentation(item: item)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedView.swift
@@ -110,6 +110,7 @@ private struct NotificationFeedList: View {
                     Section {
                         ForEach(section.items) { item in
                             NotificationFeedRow(item: item, actions: actions)
+                                .equatable()
                         }
                     } header: {
                         NotificationFeedDayHeader(section: section)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAgentMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAgentMenu.swift
@@ -5,38 +5,35 @@ import SwiftUI
 
 /// Keeps the selected agent attached to the prompt while leaving every
 /// template and the editor one tap away.
-struct TaskComposerAgentMenu: View {
-    let templates: [MobileTaskTemplate]
-    let selectedTemplateID: MobileTaskTemplate.ID?
-    let isDisabled: Bool
-    let selectTemplate: (MobileTaskTemplate) -> Void
-    let editTemplates: () -> Void
+struct TaskComposerAgentMenu: View, Equatable {
+    let value: TaskComposerAgentMenuValue
+    let actions: TaskComposerAgentMenuActions
 
-    private var selectedTemplate: MobileTaskTemplate? {
-        selectedTemplateID.flatMap { id in
-            templates.first { $0.id == id }
-        }
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
     }
 
-    private var templateSelection: Binding<MobileTaskTemplate.ID?> {
-        Binding(
-            get: { selectedTemplateID },
-            set: { id in
-                guard let id,
-                      let template = templates.first(where: { $0.id == id }) else { return }
-                selectTemplate(template)
-            }
-        )
+    private var selectedTemplate: MobileTaskTemplate? {
+        value.selectedTemplateID.flatMap { id in
+            value.templates.first { $0.id == id }
+        }
     }
 
     var body: some View {
         Menu {
-            if !templates.isEmpty {
+            if !value.templates.isEmpty {
                 Picker(
                     L10n.string("mobile.taskComposer.agent", defaultValue: "Agent"),
-                    selection: templateSelection
+                    selection: Binding(
+                        get: { value.selectedTemplateID },
+                        set: { id in
+                            guard let id,
+                                  value.templates.contains(where: { $0.id == id }) else { return }
+                            actions.selectTemplate(id)
+                        }
+                    )
                 ) {
-                    ForEach(templates) { template in
+                    ForEach(value.templates) { template in
                         Text(template.name)
                             .tag(Optional(template.id))
                     }
@@ -47,7 +44,7 @@ struct TaskComposerAgentMenu: View {
 
             Divider()
 
-            Button(action: editTemplates) {
+            Button(action: actions.editTemplates) {
                 Label(
                     L10n.string(
                         "mobile.taskComposer.agent.edit",
@@ -103,7 +100,7 @@ struct TaskComposerAgentMenu: View {
         .buttonStyle(.plain)
         // Keep the menu reachable when every template has been deleted so the
         // editor remains the recovery path for adding an agent.
-        .disabled(isDisabled)
+        .disabled(value.isDisabled)
         .accessibilityLabel(L10n.string("mobile.taskComposer.agent", defaultValue: "Agent"))
         .accessibilityValue(selectedTemplate?.name ?? "")
         .accessibilityHint(TaskComposerSheet.templateAccessibilityHint)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAgentMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAgentMenuActions.swift
@@ -1,0 +1,8 @@
+#if os(iOS)
+import CmuxMobileShellModel
+
+struct TaskComposerAgentMenuActions {
+    let selectTemplate: (MobileTaskTemplate.ID) -> Void
+    let editTemplates: () -> Void
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAgentMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerAgentMenuValue.swift
@@ -1,0 +1,9 @@
+#if os(iOS)
+import CmuxMobileShellModel
+
+struct TaskComposerAgentMenuValue: Equatable {
+    let templates: [MobileTaskTemplate]
+    let selectedTemplateID: MobileTaskTemplate.ID?
+    let isDisabled: Bool
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerContextSection.swift
@@ -9,12 +9,8 @@ struct TaskComposerContextSection: View {
     let selectedMacDeviceID: String
     let directory: String
     let isDisabled: Bool
-    let selectMachine: (MobilePairedMac) -> Void
+    let selectMachine: (String) -> Void
     let selectDirectory: () -> Void
-
-    private var selectedMachine: MobilePairedMac? {
-        machines.first { $0.macDeviceID == selectedMacDeviceID }
-    }
 
     var body: some View {
         HStack(spacing: 8) {
@@ -88,48 +84,17 @@ struct TaskComposerContextSection: View {
             }
             .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
         } else {
-            Menu {
-                ForEach(machines) { mac in
-                    Button {
-                        selectMachine(mac)
-                    } label: {
-                        Label(mac.resolvedName, systemImage: "desktopcomputer")
-                    }
-                    .accessibilityAddTraits(mac.macDeviceID == selectedMacDeviceID ? .isSelected : [])
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    if let selectedMachine {
-                        machineIcon(selectedMachine)
-                    } else {
-                        contextSymbol("desktopcomputer", tint: .accentColor)
-                    }
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(L10n.string("mobile.taskComposer.machine", defaultValue: "Machine"))
-                            .font(.caption2.weight(.medium))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                        Text(selectedMachine?.resolvedName ?? selectedMacDeviceID)
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.72)
-                    }
-                    Spacer(minLength: 0)
-                    Image(systemName: "chevron.up.chevron.down")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(.tertiary)
-                        .accessibilityHidden(true)
-                }
-                .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
-                .contentShape(Rectangle())
-            }
-            .disabled(isDisabled)
-            .accessibilityLabel(L10n.string("mobile.taskComposer.machine", defaultValue: "Machine"))
-            .accessibilityValue(selectedMachine?.resolvedName ?? selectedMacDeviceID)
-            .accessibilityHint(TaskComposerSheet.machineAccessibilityHint)
-            .accessibilityIdentifier("MobileTaskComposerMachineMenu")
+            TaskComposerMachineMenu(
+                value: TaskComposerMachineMenuValue(
+                    machines: machines,
+                    selectedMacDeviceID: selectedMacDeviceID,
+                    isDisabled: isDisabled
+                ),
+                actions: TaskComposerMachineMenuActions(
+                    selectMachine: selectMachine
+                )
+            )
+            .equatable()
         }
     }
 
@@ -142,29 +107,5 @@ struct TaskComposerContextSection: View {
             .accessibilityHidden(true)
     }
 
-    private func machineIcon(_ mac: MobilePairedMac) -> some View {
-        ZStack {
-            Circle()
-                .fill(
-                    MachineAvatarColors.gradient(
-                        customColor: mac.customColor,
-                        fallbackIndex: nil,
-                        machineID: mac.macDeviceID,
-                        fallbackID: mac.id
-                    )
-                )
-            switch MacAvatarIcon.resolve(custom: mac.customIcon, defaultSymbol: "desktopcomputer") {
-            case .symbol(let name):
-                Image(systemName: name)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.white)
-            case .emoji(let emoji):
-                Text(emoji)
-                    .font(.system(size: 17))
-            }
-        }
-        .frame(width: 28, height: 28)
-        .accessibilityHidden(true)
-    }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenu.swift
@@ -1,0 +1,97 @@
+#if os(iOS)
+import CmuxMobilePairedMac
+import CmuxMobileSupport
+import SwiftUI
+
+struct TaskComposerMachineMenu: View, Equatable {
+    let value: TaskComposerMachineMenuValue
+    let actions: TaskComposerMachineMenuActions
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    private var selectedMachine: MobilePairedMac? {
+        value.machines.first { $0.macDeviceID == value.selectedMacDeviceID }
+    }
+
+    var body: some View {
+        Menu {
+            ForEach(value.machines) { mac in
+                Button {
+                    actions.selectMachine(mac.macDeviceID)
+                } label: {
+                    Label(mac.resolvedName, systemImage: "desktopcomputer")
+                }
+                .accessibilityAddTraits(mac.macDeviceID == value.selectedMacDeviceID ? .isSelected : [])
+            }
+        } label: {
+            HStack(spacing: 8) {
+                if let selectedMachine {
+                    machineIcon(selectedMachine)
+                } else {
+                    contextSymbol("desktopcomputer", tint: .accentColor)
+                }
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(L10n.string("mobile.taskComposer.machine", defaultValue: "Machine"))
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                    Text(selectedMachine?.resolvedName ?? value.selectedMacDeviceID)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .disabled(value.isDisabled)
+        .accessibilityLabel(L10n.string("mobile.taskComposer.machine", defaultValue: "Machine"))
+        .accessibilityValue(selectedMachine?.resolvedName ?? value.selectedMacDeviceID)
+        .accessibilityHint(TaskComposerSheet.machineAccessibilityHint)
+        .accessibilityIdentifier("MobileTaskComposerMachineMenu")
+    }
+
+    private func contextSymbol(_ name: String, tint: Color) -> some View {
+        Image(systemName: name)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(tint)
+            .frame(width: 28, height: 28)
+            .background(tint.opacity(0.12), in: Circle())
+            .accessibilityHidden(true)
+    }
+
+    private func machineIcon(_ mac: MobilePairedMac) -> some View {
+        ZStack {
+            Circle()
+                .fill(
+                    MachineAvatarColors.gradient(
+                        customColor: mac.customColor,
+                        fallbackIndex: nil,
+                        machineID: mac.macDeviceID,
+                        fallbackID: mac.id
+                    )
+                )
+            switch MacAvatarIcon.resolve(custom: mac.customIcon, defaultSymbol: "desktopcomputer") {
+            case .symbol(let name):
+                Image(systemName: name)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+            case .emoji(let emoji):
+                Text(emoji)
+                    .font(.system(size: 17))
+            }
+        }
+        .frame(width: 28, height: 28)
+        .accessibilityHidden(true)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenuActions.swift
@@ -1,0 +1,5 @@
+#if os(iOS)
+struct TaskComposerMachineMenuActions {
+    let selectMachine: (String) -> Void
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenuValue.swift
@@ -1,0 +1,9 @@
+#if os(iOS)
+import CmuxMobilePairedMac
+
+struct TaskComposerMachineMenuValue: Equatable {
+    let machines: [MobilePairedMac]
+    let selectedMacDeviceID: String
+    let isDisabled: Bool
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPromptCard.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerPromptCard.swift
@@ -13,7 +13,7 @@ struct TaskComposerPromptCard: View {
     let isDisabled: Bool
     let templates: [MobileTaskTemplate]
     let selectedTemplateID: MobileTaskTemplate.ID?
-    let selectTemplate: (MobileTaskTemplate) -> Void
+    let selectTemplate: (MobileTaskTemplate.ID) -> Void
     let editTemplates: () -> Void
 
     @FocusState private var isFocused: Bool
@@ -22,12 +22,17 @@ struct TaskComposerPromptCard: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
                 TaskComposerAgentMenu(
-                    templates: templates,
-                    selectedTemplateID: selectedTemplateID,
-                    isDisabled: isDisabled,
-                    selectTemplate: selectTemplate,
-                    editTemplates: editTemplates
+                    value: TaskComposerAgentMenuValue(
+                        templates: templates,
+                        selectedTemplateID: selectedTemplateID,
+                        isDisabled: isDisabled
+                    ),
+                    actions: TaskComposerAgentMenuActions(
+                        selectTemplate: selectTemplate,
+                        editTemplates: editTemplates
+                    )
                 )
+                .equatable()
                 Spacer(minLength: 0)
             }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerSheet.swift
@@ -442,8 +442,9 @@ struct TaskComposerSheet: View {
         )
     }
 
-    private func selectTemplateFromPicker(_ template: MobileTaskTemplate) {
-        guard !submissionPhase.disablesRequestEditing else { return }
+    private func selectTemplateFromPicker(_ id: MobileTaskTemplate.ID) {
+        guard !submissionPhase.disablesRequestEditing,
+              let template = templates.first(where: { $0.id == id }) else { return }
         withAnimation(accessibilityReduceMotion ? nil : .snappy(duration: 0.2)) {
             selectTemplate(template)
             failureText = nil
@@ -455,10 +456,11 @@ struct TaskComposerSheet: View {
         isEditorPresented = true
     }
 
-    private func selectMachine(_ mac: MobilePairedMac) {
-        guard !submissionPhase.disablesRequestEditing else { return }
+    private func selectMachine(_ macDeviceID: String) {
+        guard !submissionPhase.disablesRequestEditing,
+              machines.contains(where: { $0.macDeviceID == macDeviceID }) else { return }
         updateSubmissionRequest {
-            selectedMacDeviceID = mac.macDeviceID
+            selectedMacDeviceID = macDeviceID
             syncSuggestedDirectory()
         }
         failureText = nil

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -310,11 +310,12 @@ extension TerminalArtifactFilesSheet {
                                     ),
                                     layout: .list,
                                     loader: sessionLoader,
-                                    open: {
-                                        open(item.path, scope: .session, swipeOrder: swipeOrder)
-                                    },
+                                    scope: .session,
+                                    swipeOrder: swipeOrder,
+                                    open: open,
                                     onCopiedPath: notifyPathCopied
                                 )
+                                .equatable()
                                 Divider().padding(.leading, 72)
                             }
                             if !usesCompleteSessionSnapshot,
@@ -335,11 +336,12 @@ extension TerminalArtifactFilesSheet {
                                         ),
                                         layout: .grid,
                                         loader: sessionLoader,
-                                        open: {
-                                            open(item.path, scope: .session, swipeOrder: swipeOrder)
-                                        },
+                                        scope: .session,
+                                        swipeOrder: swipeOrder,
+                                        open: open,
                                         onCopiedPath: notifyPathCopied
                                     )
+                                    .equatable()
                                 }
                             } footer: {
                                 if !usesCompleteSessionSnapshot,
@@ -377,11 +379,12 @@ extension TerminalArtifactFilesSheet {
                             artifact: TerminalArtifactGalleryDisplayItem(galleryItem: item),
                             layout: .list,
                             loader: sessionLoader,
-                            open: {
-                                open(item.path, scope: .session, swipeOrder: swipeOrder)
-                            },
+                            scope: .session,
+                            swipeOrder: swipeOrder,
+                            open: open,
                             onCopiedPath: notifyPathCopied
                         )
+                        .equatable()
                         Divider().padding(.leading, 72)
                     }
                     if let pagingCursor {
@@ -398,11 +401,12 @@ extension TerminalArtifactFilesSheet {
                                 artifact: TerminalArtifactGalleryDisplayItem(galleryItem: item),
                                 layout: .grid,
                                 loader: sessionLoader,
-                                open: {
-                                    open(item.path, scope: .session, swipeOrder: swipeOrder)
-                                },
+                                scope: .session,
+                                swipeOrder: swipeOrder,
+                                open: open,
                                 onCopiedPath: notifyPathCopied
                             )
+                            .equatable()
                         }
                     } footer: {
                         if let pagingCursor {
@@ -438,11 +442,12 @@ extension TerminalArtifactFilesSheet {
                             artifact: artifact,
                             layout: .list,
                             loader: loader,
-                            open: {
-                                open(artifact.path, scope: scope, swipeOrder: swipeOrder)
-                            },
+                            scope: scope,
+                            swipeOrder: swipeOrder,
+                            open: open,
                             onCopiedPath: notifyPathCopied
                         )
+                        .equatable()
                         Divider().padding(.leading, 72)
                     }
                 }
@@ -455,11 +460,12 @@ extension TerminalArtifactFilesSheet {
                             artifact: artifact,
                             layout: .grid,
                             loader: loader,
-                            open: {
-                                open(artifact.path, scope: scope, swipeOrder: swipeOrder)
-                            },
+                            scope: scope,
+                            swipeOrder: swipeOrder,
+                            open: open,
                             onCopiedPath: notifyPathCopied
                         )
+                        .equatable()
                     }
                 }
                 .padding(16)
@@ -595,23 +601,13 @@ extension TerminalArtifactFilesSheet {
                 }
             }
 
-            Menu {
-                Picker(
-                    String(
-                        localized: "terminal.artifact.gallery.sort",
-                        defaultValue: "Sort",
-                        bundle: .module
-                    ),
-                    selection: $gallerySort
-                ) {
-                    ForEach(ChatArtifactGallerySort.allCases, id: \.self) { sort in
-                        Text(sortTitle(sort)).tag(sort)
-                    }
-                }
-            } label: {
-                Label(sortTitle(gallerySort), systemImage: "arrow.up.arrow.down")
-                    .font(.subheadline.weight(.medium))
-            }
+            TerminalArtifactGallerySortMenu(
+                value: TerminalArtifactGallerySortMenuValue(sort: gallerySort),
+                actions: TerminalArtifactGallerySortMenuActions(
+                    setSort: { gallerySort = $0 }
+                )
+            )
+            .equatable()
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
@@ -631,17 +627,6 @@ extension TerminalArtifactFilesSheet {
             String(localized: "terminal.artifact.gallery.filter.docs", defaultValue: "Docs", bundle: .module)
         case .folders:
             String(localized: "terminal.artifact.gallery.filter.folders", defaultValue: "Folders", bundle: .module)
-        }
-    }
-
-    private func sortTitle(_ sort: ChatArtifactGallerySort) -> String {
-        switch sort {
-        case .recent:
-            String(localized: "terminal.artifact.gallery.sort.recent", defaultValue: "Recent", bundle: .module)
-        case .name:
-            String(localized: "terminal.artifact.gallery.sort.name", defaultValue: "Name", bundle: .module)
-        case .size:
-            String(localized: "terminal.artifact.gallery.sort.size", defaultValue: "Size", bundle: .module)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemActions.swift
@@ -1,0 +1,14 @@
+#if os(iOS)
+import CmuxAgentChat
+import CmuxAgentChatUI
+
+struct TerminalArtifactGalleryItemActions {
+    let loader: ChatArtifactLoader
+    let open: (
+        String,
+        TerminalArtifactFilesSheet.Scope,
+        ChatArtifactGallerySwipeOrder
+    ) -> Void
+    let copiedPath: () -> Void
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemValue.swift
@@ -1,0 +1,14 @@
+#if os(iOS)
+import CmuxAgentChat
+import CmuxAgentChatUI
+
+struct TerminalArtifactGalleryItemValue: Equatable {
+    let artifact: TerminalArtifactGalleryDisplayItem
+    let layout: TerminalArtifactGalleryItemView.Layout
+    let loaderScope: ChatArtifactLoaderScope
+    let loaderSupportsArtifacts: Bool
+    let loaderSupportsDirectoryBrowsing: Bool
+    let openScope: TerminalArtifactFilesSheet.Scope
+    let swipeOrder: ChatArtifactGallerySwipeOrder
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
@@ -6,19 +6,50 @@ import SwiftUI
 import UIKit
 
 /// One immutable artifact snapshot rendered in the terminal gallery.
-struct TerminalArtifactGalleryItemView: View {
-    enum Layout {
+struct TerminalArtifactGalleryItemView: View, Equatable {
+    enum Layout: Equatable {
         case list
         case grid
     }
 
-    let artifact: TerminalArtifactGalleryDisplayItem
-    let layout: Layout
-    let loader: ChatArtifactLoader
-    let open: () -> Void
-    /// Reports a completed "Copy path" so the host confirms it (rows stay
-    /// below the snapshot boundary and never hold the toast center).
-    var onCopiedPath: () -> Void = {}
+    let value: TerminalArtifactGalleryItemValue
+    let actions: TerminalArtifactGalleryItemActions
+
+    init(
+        artifact: TerminalArtifactGalleryDisplayItem,
+        layout: Layout,
+        loader: ChatArtifactLoader,
+        scope: TerminalArtifactFilesSheet.Scope,
+        swipeOrder: ChatArtifactGallerySwipeOrder,
+        open: @escaping (
+            String,
+            TerminalArtifactFilesSheet.Scope,
+            ChatArtifactGallerySwipeOrder
+        ) -> Void,
+        onCopiedPath: @escaping () -> Void = {}
+    ) {
+        value = TerminalArtifactGalleryItemValue(
+            artifact: artifact,
+            layout: layout,
+            loaderScope: loader.scope,
+            loaderSupportsArtifacts: loader.supportsArtifacts,
+            loaderSupportsDirectoryBrowsing: loader.supportsDirectoryBrowsing,
+            openScope: scope,
+            swipeOrder: swipeOrder
+        )
+        actions = TerminalArtifactGalleryItemActions(
+            loader: loader,
+            open: open,
+            copiedPath: onCopiedPath
+        )
+    }
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    private var artifact: TerminalArtifactGalleryDisplayItem { value.artifact }
+    private var layout: Layout { value.layout }
 
     @State private var thumbnail: ChatArtifactThumbnail?
     @State private var fileActionPresentation: ChatArtifactFileActionPresentation?
@@ -61,7 +92,7 @@ struct TerminalArtifactGalleryItemView: View {
             }
             Button {
                 UIPasteboard.general.string = artifact.path
-                onCopiedPath()
+                actions.copiedPath()
             } label: {
                 Label(
                     String(
@@ -105,7 +136,7 @@ struct TerminalArtifactGalleryItemView: View {
         }
         .task(id: "\(artifact.path)#\(Self.thumbnailDimension)") {
             guard artifact.kind == .image, artifact.exists else { return }
-            thumbnail = try? await loader.thumbnail(
+            thumbnail = try? await actions.loader.thumbnail(
                 path: artifact.path,
                 maxDimension: Self.thumbnailDimension,
                 modifiedAt: artifact.modifiedAt,
@@ -121,7 +152,7 @@ struct TerminalArtifactGalleryItemView: View {
             do {
                 let fileURL = try await ChatArtifactFileActionStore.applicationDefault.materialize(
                     path: artifact.path,
-                    loader: loader
+                    loader: actions.loader
                 )
                 try Task.checkCancellation()
                 fileActionPresentation = .share(fileURL)
@@ -132,6 +163,10 @@ struct TerminalArtifactGalleryItemView: View {
             }
             isFileActionRunning = false
         }
+    }
+
+    private func open() {
+        actions.open(artifact.path, value.openScope, value.swipeOrder)
     }
 
     private var listContent: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGallerySortMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGallerySortMenu.swift
@@ -1,0 +1,47 @@
+#if os(iOS)
+import CmuxAgentChat
+import SwiftUI
+
+struct TerminalArtifactGallerySortMenu: View, Equatable {
+    let value: TerminalArtifactGallerySortMenuValue
+    let actions: TerminalArtifactGallerySortMenuActions
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    var body: some View {
+        Menu {
+            Picker(
+                String(
+                    localized: "terminal.artifact.gallery.sort",
+                    defaultValue: "Sort",
+                    bundle: .module
+                ),
+                selection: Binding(
+                    get: { value.sort },
+                    set: { actions.setSort($0) }
+                )
+            ) {
+                ForEach(ChatArtifactGallerySort.allCases, id: \.self) { sort in
+                    Text(sortTitle(sort)).tag(sort)
+                }
+            }
+        } label: {
+            Label(sortTitle(value.sort), systemImage: "arrow.up.arrow.down")
+                .font(.subheadline.weight(.medium))
+        }
+    }
+
+    private func sortTitle(_ sort: ChatArtifactGallerySort) -> String {
+        switch sort {
+        case .recent:
+            String(localized: "terminal.artifact.gallery.sort.recent", defaultValue: "Recent", bundle: .module)
+        case .name:
+            String(localized: "terminal.artifact.gallery.sort.name", defaultValue: "Name", bundle: .module)
+        case .size:
+            String(localized: "terminal.artifact.gallery.sort.size", defaultValue: "Size", bundle: .module)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGallerySortMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGallerySortMenuActions.swift
@@ -1,0 +1,7 @@
+#if os(iOS)
+import CmuxAgentChat
+
+struct TerminalArtifactGallerySortMenuActions {
+    let setSort: (ChatArtifactGallerySort) -> Void
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGallerySortMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGallerySortMenuValue.swift
@@ -1,0 +1,7 @@
+#if os(iOS)
+import CmuxAgentChat
+
+struct TerminalArtifactGallerySortMenuValue: Equatable {
+    let sort: ChatArtifactGallerySort
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -174,38 +174,80 @@ struct WorkspaceDetailView: View {
     }
 
     private var workspaceTitleToolbarMenu: some View {
-        WorkspaceTitleMenu(
+        let value = WorkspaceTitleMenuValue(
             contentWidth: contentWidth,
             hasBackButton: backButtonConfiguration != nil,
             hasTrailingCluster: true,
             hasChatToggle: shouldShowChatToggle,
             isEnabled: hasTitleMenuActions,
-            menuContent: { titleMenuContent }
-        ) {
-            toolbarTitleLabel
-        }
+            workspaceName: workspace.name,
+            hasUnread: workspace.hasUnread,
+            canRenameWorkspace: renameWorkspace != nil,
+            canToggleReadState: setWorkspaceUnread != nil,
+            canCloseWorkspace: closeWorkspace != nil,
+            labelToken: toolbarTitleLabelToken,
+            terminalTheme: store.activeTerminalTheme
+        )
+        return WorkspaceTitleMenu(
+            value: value,
+            menuContent: {
+                WorkspaceTitleMenuContent(
+                    workspaceName: value.workspaceName,
+                    hasUnread: value.hasUnread,
+                    canRenameWorkspace: value.canRenameWorkspace,
+                    canToggleReadState: value.canToggleReadState,
+                    canCloseWorkspace: value.canCloseWorkspace,
+                    presentRename: presentRenameFromMenu,
+                    toggleReadState: toggleWorkspaceReadStateFromMenu,
+                    requestClose: requestCloseWorkspaceFromMenu
+                )
+            },
+            label: {
+                switch value.labelToken {
+                case .chat(
+                    let descriptor,
+                    let agentState,
+                    let isConnected,
+                    let titleOverride,
+                    let subtitle
+                ):
+                    ChatSessionHeaderView(
+                        descriptor: descriptor,
+                        agentState: agentState,
+                        isConnected: isConnected,
+                        titleOverride: titleOverride,
+                        subtitle: subtitle,
+                        style: .toolbarCompact
+                    )
+                case .browser(let title):
+                    Text(title)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundStyle(value.terminalTheme.terminalChromeForegroundColor)
+                case .standard(let title, let subtitle):
+                    WorkspaceToolbarTitleView(title: title, subtitle: subtitle)
+                }
+            }
+        )
+        .equatable()
     }
-    @ViewBuilder
-    private var toolbarTitleLabel: some View {
+
+    private var toolbarTitleLabelToken: WorkspaceTitleMenuLabelToken {
         if isChatMode,
            let session = chosenChatSession,
            let conversation = chatConversationStores[session.id] {
-            ChatSessionHeaderView(
+            return .chat(
                 descriptor: conversation.descriptor,
                 agentState: conversation.agentState,
                 isConnected: conversation.isConnected,
                 titleOverride: workspace.name,
-                subtitle: tabName(for: session),
-                style: .toolbarCompact
+                subtitle: tabName(for: session)
             )
         } else if let browser = activeBrowser {
-            Text(browser.title ?? workspace.name)
-                .font(.headline)
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .foregroundStyle(store.activeTerminalTheme.terminalChromeForegroundColor)
+            return .browser(title: browser.title ?? workspace.name)
         } else {
-            WorkspaceToolbarTitleView(title: workspace.name, subtitle: selectedToolbarSubtitle)
+            return .standard(title: workspace.name, subtitle: selectedToolbarSubtitle)
         }
     }
     #endif
@@ -398,18 +440,6 @@ struct WorkspaceDetailView: View {
                 action: backButtonConfiguration.action
             )
         }
-    }
-
-    var titleMenuContent: some View {
-        WorkspaceTitleMenuContent(
-            workspace: workspace,
-            canRenameWorkspace: renameWorkspace != nil,
-            canToggleReadState: setWorkspaceUnread != nil,
-            canCloseWorkspace: closeWorkspace != nil,
-            presentRename: presentRenameFromMenu,
-            toggleReadState: toggleWorkspaceReadStateFromMenu,
-            requestClose: requestCloseWorkspaceFromMenu
-        )
     }
 
     #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRow.swift
@@ -9,33 +9,23 @@ import SwiftUI
 /// the name/body selects (and, in push navigation, opens) the anchor workspace.
 /// The anchor is represented by this header and never rendered as a separate row,
 /// so this split is what keeps the anchor's terminals reachable from the phone.
-struct WorkspaceGroupHeaderRow: View {
-    let group: MobileWorkspaceGroupPreview
+struct WorkspaceGroupHeaderRow: View, Equatable {
+    let value: WorkspaceGroupHeaderRowValue
+    let actions: WorkspaceGroupHeaderRowActions
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    private var group: MobileWorkspaceGroupPreview { value.group }
     /// Aggregate unread state for the header dot, computed by
     /// `MobileWorkspaceListItem.items`: the anchor's unread while expanded,
     /// the whole group's (anchor included) while collapsed, mirroring the Mac
     /// sidebar header badge so collapsing a group never hides activity.
-    let hasUnread: Bool
-    let navigationStyle: WorkspaceNavigationStyle
+    private var hasUnread: Bool { value.hasUnread }
+    private var navigationStyle: WorkspaceNavigationStyle { value.navigationStyle }
     /// Whether the anchor workspace is the current selection (sidebar style only).
-    let isAnchorSelected: Bool
-    /// Select the anchor workspace in sidebar layouts.
-    let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
-    /// Create a new workspace inside this group. Hidden when `nil`.
-    var createWorkspaceInGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil
-    /// Rename the group on the Mac. Hidden when `nil`.
-    var renameGroup: ((MobileWorkspaceGroupPreview.ID, String) -> Void)? = nil
-    /// Pin or unpin the group on the Mac. Hidden when `nil`.
-    var setGroupPinned: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)? = nil
-    /// Dissolve the group on the Mac, keeping its workspaces. Hidden when `nil`.
-    var ungroupWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil
-    /// Delete the group on the Mac, including its workspaces. Hidden when `nil`.
-    var deleteWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil
-    /// Toggle the group's collapsed state on the Mac. When `nil` (previews, or a
-    /// Mac without the groups capability), the chevron renders without a tap
-    /// action.
-    let toggleCollapsed: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
-    var unreadIndicatorLeftShift: Double = MobileDisplaySettings.defaultUnreadIndicatorLeftShift
+    private var isAnchorSelected: Bool { value.isAnchorSelected }
 
     @State private var isRenaming = false
     @State private var pendingDestructiveAction: WorkspaceGroupHeaderPendingDestructiveAction?
@@ -54,7 +44,7 @@ struct WorkspaceGroupHeaderRow: View {
         // can press to no effect. The collapsed/expanded state stays readable
         // through the label either way.
         return Group {
-            if let toggleCollapsed {
+            if value.canToggleCollapsed, let toggleCollapsed = actions.toggleCollapsed {
                 Button {
                     toggleCollapsed(group.id, !group.isCollapsed)
                 } label: {
@@ -102,14 +92,14 @@ struct WorkspaceGroupHeaderRow: View {
         switch navigationStyle {
         case .push:
             Button {
-                selectWorkspace(group.anchorWorkspaceID)
+                actions.selectWorkspace(group.anchorWorkspaceID)
             } label: {
                 nameLabel
             }
             .buttonStyle(.plain)
         case .sidebar:
             Button {
-                selectWorkspace(group.anchorWorkspaceID)
+                actions.selectWorkspace(group.anchorWorkspaceID)
             } label: {
                 nameLabel
             }
@@ -121,7 +111,7 @@ struct WorkspaceGroupHeaderRow: View {
         HStack(spacing: 6) {
             // Same leading unread gutter as workspace rows (dot hidden when
             // read) so headers and top-level rows keep their columns aligned.
-            WorkspaceUnreadDot(isUnread: hasUnread, leftShift: unreadIndicatorLeftShift)
+            WorkspaceUnreadDot(isUnread: hasUnread, leftShift: value.unreadIndicatorLeftShift)
             chevron
             anchorTarget
                 // The dot itself is accessibility-hidden; VoiceOver hears the
@@ -146,7 +136,7 @@ struct WorkspaceGroupHeaderRow: View {
         .contextMenu { contextMenu }
         .sheet(isPresented: $isRenaming) {
             WorkspaceGroupRenameSheet(currentName: group.name) { newName in
-                renameGroup?(group.id, newName)
+                actions.renameGroup?(group.id, newName)
             }
         }
         .confirmationDialog(
@@ -154,7 +144,9 @@ struct WorkspaceGroupHeaderRow: View {
             isPresented: destructiveDialogIsPresented,
             titleVisibility: .visible
         ) {
-            if pendingDestructiveAction == .ungroup, let ungroupWorkspaceGroup {
+            if pendingDestructiveAction == .ungroup,
+               value.canUngroupWorkspaceGroup,
+               let ungroupWorkspaceGroup = actions.ungroupWorkspaceGroup {
                 Button(
                     L10n.string("mobile.workspaceGroup.ungroup.confirmAction", defaultValue: "Ungroup"),
                     role: .destructive
@@ -164,7 +156,9 @@ struct WorkspaceGroupHeaderRow: View {
                 }
                 .accessibilityIdentifier("MobileWorkspaceGroupUngroupConfirmButton-\(group.id.rawValue)")
             }
-            if pendingDestructiveAction == .delete, let deleteWorkspaceGroup {
+            if pendingDestructiveAction == .delete,
+               value.canDeleteWorkspaceGroup,
+               let deleteWorkspaceGroup = actions.deleteWorkspaceGroup {
                 Button(
                     L10n.string("mobile.workspaceGroup.delete.confirmAction", defaultValue: "Delete Group"),
                     role: .destructive
@@ -186,7 +180,7 @@ struct WorkspaceGroupHeaderRow: View {
 
     @ViewBuilder
     private var contextMenu: some View {
-        if let setGroupPinned {
+        if value.canSetGroupPinned, let setGroupPinned = actions.setGroupPinned {
             Button {
                 setGroupPinned(group.id, !group.isPinned)
             } label: {
@@ -198,7 +192,7 @@ struct WorkspaceGroupHeaderRow: View {
             }
             .accessibilityIdentifier("MobileWorkspaceGroupPinButton-\(group.id.rawValue)")
         }
-        if renameGroup != nil {
+        if value.canRenameGroup {
             Button {
                 isRenaming = true
             } label: {
@@ -206,10 +200,11 @@ struct WorkspaceGroupHeaderRow: View {
             }
             .accessibilityIdentifier("MobileWorkspaceGroupRenameButton-\(group.id.rawValue)")
         }
-        if renameGroup != nil || setGroupPinned != nil {
+        if value.canRenameGroup || value.canSetGroupPinned {
             Divider()
         }
-        if let createWorkspaceInGroup {
+        if value.canCreateWorkspaceInGroup,
+           let createWorkspaceInGroup = actions.createWorkspaceInGroup {
             Button {
                 createWorkspaceInGroup(group.id)
             } label: {
@@ -220,10 +215,10 @@ struct WorkspaceGroupHeaderRow: View {
             }
             .accessibilityIdentifier("MobileWorkspaceGroupNewWorkspace-\(group.id.rawValue)")
         }
-        if ungroupWorkspaceGroup != nil || deleteWorkspaceGroup != nil {
+        if value.canUngroupWorkspaceGroup || value.canDeleteWorkspaceGroup {
             Divider()
         }
-        if ungroupWorkspaceGroup != nil {
+        if value.canUngroupWorkspaceGroup {
             Button(role: .destructive) {
                 pendingDestructiveAction = .ungroup
             } label: {
@@ -234,7 +229,7 @@ struct WorkspaceGroupHeaderRow: View {
             }
             .accessibilityIdentifier("MobileWorkspaceGroupUngroupButton-\(group.id.rawValue)")
         }
-        if deleteWorkspaceGroup != nil {
+        if value.canDeleteWorkspaceGroup {
             Button(role: .destructive) {
                 pendingDestructiveAction = .delete
             } label: {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRowActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRowActions.swift
@@ -1,0 +1,11 @@
+import CmuxMobileShellModel
+
+struct WorkspaceGroupHeaderRowActions {
+    let selectWorkspace: (MobileWorkspacePreview.ID) -> Void
+    let createWorkspaceInGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)?
+    let renameGroup: ((MobileWorkspaceGroupPreview.ID, String) -> Void)?
+    let setGroupPinned: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
+    let ungroupWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)?
+    let deleteWorkspaceGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)?
+    let toggleCollapsed: ((MobileWorkspaceGroupPreview.ID, Bool) -> Void)?
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRowValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceGroupHeaderRowValue.swift
@@ -1,0 +1,15 @@
+import CmuxMobileShellModel
+
+struct WorkspaceGroupHeaderRowValue: Equatable {
+    let group: MobileWorkspaceGroupPreview
+    let hasUnread: Bool
+    let navigationStyle: WorkspaceNavigationStyle
+    let isAnchorSelected: Bool
+    let canCreateWorkspaceInGroup: Bool
+    let canRenameGroup: Bool
+    let canSetGroupPinned: Bool
+    let canUngroupWorkspaceGroup: Bool
+    let canDeleteWorkspaceGroup: Bool
+    let canToggleCollapsed: Bool
+    let unreadIndicatorLeftShift: Double
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterControls.swift
@@ -8,11 +8,16 @@ import SwiftUI
 /// — so you can express e.g. "unread on Mac X and Mac Y". The machine section
 /// only appears when more than one machine is present, so single-Mac users see
 /// exactly the old All / Unread control.
-struct WorkspaceListFilterMenu: View {
-    @Binding var filter: MobileWorkspaceListFilter
+struct WorkspaceListFilterMenu: View, Equatable {
+    let filter: MobileWorkspaceListFilter
     /// Machines available to filter by. When fewer than two, the machine section
     /// is hidden (nothing to disambiguate).
-    var machines: [WorkspaceFilterMachine] = []
+    let machines: [WorkspaceFilterMachine]
+    let actions: WorkspaceListFilterMenuActions
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.filter == rhs.filter && lhs.machines == rhs.machines
+    }
 
     private var showsMachineSection: Bool { machines.count > 1 }
 
@@ -20,7 +25,7 @@ struct WorkspaceListFilterMenu: View {
         Menu {
             Picker(
                 L10n.string("mobile.workspaces.filter.readState", defaultValue: "Show"),
-                selection: $filter.readState
+                selection: Binding(get: { filter.readState }, set: { actions.setReadState($0) })
             ) {
                 ForEach(MobileWorkspaceReadStateFilter.allCases, id: \.self) { state in
                     Text(state.displayName).tag(state)
@@ -30,7 +35,7 @@ struct WorkspaceListFilterMenu: View {
             if showsMachineSection {
                 Section(L10n.string("mobile.workspaces.filter.machines", defaultValue: "Machines")) {
                     Button {
-                        filter.machines.removeAll()
+                        actions.clearMachines()
                     } label: {
                         Label(
                             L10n.string("mobile.workspaces.filter.allMachines", defaultValue: "All Machines"),
@@ -39,7 +44,7 @@ struct WorkspaceListFilterMenu: View {
                     }
                     ForEach(machines) { machine in
                         Button {
-                            filter.toggleMachine(machine.id)
+                            actions.toggleMachine(machine.id)
                         } label: {
                             Label(
                                 machine.name,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListFilterMenuActions.swift
@@ -1,0 +1,7 @@
+import CmuxMobileShellModel
+
+struct WorkspaceListFilterMenuActions {
+    let setReadState: (MobileWorkspaceReadStateFilter) -> Void
+    let clearMachines: () -> Void
+    let toggleMachine: (String) -> Void
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListNewWorkspaceMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListNewWorkspaceMenu.swift
@@ -1,0 +1,43 @@
+import CmuxMobileSupport
+import SwiftUI
+
+struct WorkspaceListNewWorkspaceMenu: View, Equatable {
+    let value: WorkspaceListNewWorkspaceMenuValue
+    let actions: WorkspaceListNewWorkspaceMenuActions
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    var body: some View {
+        Menu {
+            Button {
+                guard value.canCreate else { return }
+                actions.createWorkspace()
+            } label: {
+                Label(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"), systemImage: "plus")
+            }
+            .accessibilityIdentifier("MobileNewWorkspaceMenuItem")
+            if value.canCreateGroup {
+                Button {
+                    guard value.canCreate else { return }
+                    actions.createWorkspaceGroup?()
+                } label: {
+                    Label(
+                        L10n.string("mobile.workspaceGroup.new", defaultValue: "New Workspace Group"),
+                        systemImage: "folder.badge.plus"
+                    )
+                }
+                .accessibilityIdentifier("MobileNewWorkspaceGroupMenuItem")
+            }
+        } label: {
+            Image(systemName: "plus")
+        } primaryAction: {
+            guard value.canCreate else { return }
+            actions.createWorkspace()
+        }
+        .disabled(!value.canCreate)
+        .accessibilityLabel(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"))
+        .accessibilityIdentifier("MobileNewWorkspaceButton")
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListNewWorkspaceMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListNewWorkspaceMenuActions.swift
@@ -1,0 +1,4 @@
+struct WorkspaceListNewWorkspaceMenuActions {
+    let createWorkspace: () -> Void
+    let createWorkspaceGroup: (() -> Void)?
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListNewWorkspaceMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListNewWorkspaceMenuValue.swift
@@ -1,0 +1,4 @@
+struct WorkspaceListNewWorkspaceMenuValue: Equatable {
+    let canCreate: Bool
+    let canCreateGroup: Bool
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
@@ -481,24 +481,35 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
                 .actionCapabilities ?? .none
             return AnyView(
                 WorkspaceGroupHeaderRow(
-                    group: group,
-                    hasUnread: configuration.groupHasUnreadByID[groupID, default: false],
-                    navigationStyle: configuration.navigationStyle,
-                    isAnchorSelected: configuration.navigationStyle == .sidebar
-                        && configuration.selectedWorkspaceID == group.anchorWorkspaceID,
-                    selectWorkspace: configuration.selectWorkspace,
-                    createWorkspaceInGroup: configuration.createWorkspaceInGroup,
-                    renameGroup: capabilities.supportsGroupActions
-                        ? configuration.renameWorkspaceGroup : nil,
-                    setGroupPinned: capabilities.supportsGroupActions
-                        ? configuration.setGroupPinned : nil,
-                    ungroupWorkspaceGroup: capabilities.supportsGroupActions
-                        ? configuration.ungroupWorkspaceGroup : nil,
-                    deleteWorkspaceGroup: capabilities.supportsGroupActions
-                        ? configuration.deleteWorkspaceGroup : nil,
-                    toggleCollapsed: configuration.toggleGroupCollapsed,
-                    unreadIndicatorLeftShift: configuration.unreadIndicatorLeftShift
+                    value: WorkspaceGroupHeaderRowValue(
+                        group: group,
+                        hasUnread: configuration.groupHasUnreadByID[groupID, default: false],
+                        navigationStyle: configuration.navigationStyle,
+                        isAnchorSelected: configuration.navigationStyle == .sidebar
+                            && configuration.selectedWorkspaceID == group.anchorWorkspaceID,
+                        canCreateWorkspaceInGroup: configuration.createWorkspaceInGroup != nil,
+                        canRenameGroup: capabilities.supportsGroupActions
+                            && configuration.renameWorkspaceGroup != nil,
+                        canSetGroupPinned: capabilities.supportsGroupActions
+                            && configuration.setGroupPinned != nil,
+                        canUngroupWorkspaceGroup: capabilities.supportsGroupActions
+                            && configuration.ungroupWorkspaceGroup != nil,
+                        canDeleteWorkspaceGroup: capabilities.supportsGroupActions
+                            && configuration.deleteWorkspaceGroup != nil,
+                        canToggleCollapsed: configuration.toggleGroupCollapsed != nil,
+                        unreadIndicatorLeftShift: configuration.unreadIndicatorLeftShift
+                    ),
+                    actions: WorkspaceGroupHeaderRowActions(
+                        selectWorkspace: configuration.selectWorkspace,
+                        createWorkspaceInGroup: configuration.createWorkspaceInGroup,
+                        renameGroup: configuration.renameWorkspaceGroup,
+                        setGroupPinned: configuration.setGroupPinned,
+                        ungroupWorkspaceGroup: configuration.ungroupWorkspaceGroup,
+                        deleteWorkspaceGroup: configuration.deleteWorkspaceGroup,
+                        toggleCollapsed: configuration.toggleGroupCollapsed
+                    )
                 )
+                .equatable()
                 .frame(minHeight: 32)
             )
         case .groupFooter(let groupID):

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
@@ -3,33 +3,17 @@ import CmuxMobileSupport
 import SwiftUI
 
 extension WorkspaceListView {
-    var newWorkspaceButton: some View {
-        Menu {
-            Button {
-                guard canCreateWorkspaceForMacSelection else { return }
-                createWorkspace()
-            } label: {
-                Label(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"), systemImage: "plus")
-            }
-            .accessibilityIdentifier("MobileNewWorkspaceMenuItem")
-            if let createWorkspaceGroup {
-                Button {
-                    guard canCreateWorkspaceForMacSelection else { return }
-                    createWorkspaceGroup()
-                } label: {
-                    Label(L10n.string("mobile.workspaceGroup.new", defaultValue: "New Workspace Group"), systemImage: "folder.badge.plus")
-                }
-                .accessibilityIdentifier("MobileNewWorkspaceGroupMenuItem")
-            }
-        } label: {
-            Image(systemName: "plus")
-        } primaryAction: {
-            guard canCreateWorkspaceForMacSelection else { return }
-            createWorkspace()
-        }
-        .disabled(!canCreateWorkspaceForMacSelection)
-        .accessibilityLabel(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"))
-        .accessibilityIdentifier("MobileNewWorkspaceButton")
+    var newWorkspaceButton: WorkspaceListNewWorkspaceMenu {
+        WorkspaceListNewWorkspaceMenu(
+            value: WorkspaceListNewWorkspaceMenuValue(
+                canCreate: canCreateWorkspaceForMacSelection,
+                canCreateGroup: createWorkspaceGroup != nil
+            ),
+            actions: WorkspaceListNewWorkspaceMenuActions(
+                createWorkspace: createWorkspace,
+                createWorkspaceGroup: createWorkspaceGroup
+            )
+        )
     }
 
     @discardableResult

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+MacSelection.swift
@@ -121,21 +121,22 @@ extension WorkspaceListView {
         }
     }
 
-    var macTitlePickerSelection: Binding<WorkspaceMacSelection> {
-        Binding(
-            get: { currentMacTitlePickerSelection },
-            set: { _ = handleMacTitlePickerSelection($0) }
-        )
-    }
-
     func macTitlePicker(machineSnapshots: WorkspaceMachineSnapshots) -> some View {
         WorkspaceMacTitlePicker(
-            title: macTitlePickerTitle(machineSnapshots: machineSnapshots),
-            isLoading: macTitlePickerShowsProgress,
-            selection: macTitlePickerSelection,
-            machines: machineSnapshots.macPickerMachines,
-            showAddDevice: showAddDevice
+            value: WorkspaceMacTitlePickerValue(
+                title: macTitlePickerTitle(machineSnapshots: machineSnapshots),
+                isLoading: macTitlePickerShowsProgress,
+                selection: currentMacTitlePickerSelection,
+                machines: machineSnapshots.macPickerMachines,
+                canAddDevice: showAddDevice != nil,
+                labelWidth: 155
+            ),
+            actions: WorkspaceMacTitlePickerActions(
+                select: { _ = handleMacTitlePickerSelection($0) },
+                addDevice: showAddDevice
+            )
         )
+        .equatable()
     }
 
     var showsDevicesButton: Bool {
@@ -156,47 +157,31 @@ extension WorkspaceListView {
 }
 
 #if os(iOS)
-struct WorkspaceMacTitlePicker: View {
-    let title: String
-    let isLoading: Bool
-    @Binding var selection: WorkspaceMacSelection
-    let machines: [WorkspaceFilterMachine]
-    let showAddDevice: (() -> Void)?
-    let labelWidth: CGFloat
+struct WorkspaceMacTitlePicker: View, Equatable {
+    let value: WorkspaceMacTitlePickerValue
+    let actions: WorkspaceMacTitlePickerActions
 
-    init(
-        title: String,
-        isLoading: Bool,
-        selection: Binding<WorkspaceMacSelection>,
-        machines: [WorkspaceFilterMachine],
-        showAddDevice: (() -> Void)?,
-        labelWidth: CGFloat = 155
-    ) {
-        self.title = title
-        self.isLoading = isLoading
-        _selection = selection
-        self.machines = machines
-        self.showAddDevice = showAddDevice
-        self.labelWidth = labelWidth
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
     }
 
     var body: some View {
         Menu {
             Picker(
                 L10n.string("mobile.workspaces.macPicker.title", defaultValue: "Choose Computer"),
-                selection: $selection
+                selection: Binding(get: { value.selection }, set: { actions.select($0) })
             ) {
                 Text(L10n.string("mobile.workspaces.macPicker.allMacs", defaultValue: "All Computers"))
                     .tag(WorkspaceMacSelection.all)
-                ForEach(machines) { machine in
+                ForEach(value.machines) { machine in
                     Text(machine.name)
                         .tag(WorkspaceMacSelection.machine(machine.id))
                 }
             }
             .labelsVisibility(.visible)
-            if let showAddDevice {
+            if value.canAddDevice {
                 Divider()
-                Button(action: showAddDevice) {
+                Button(action: { actions.addDevice?() }) {
                     Label(
                         L10n.string("mobile.computers.add", defaultValue: "Add Computer"),
                         systemImage: "plus"
@@ -206,9 +191,9 @@ struct WorkspaceMacTitlePicker: View {
             }
         } label: {
             WorkspaceMacTitlePickerLabel(
-                title: title,
-                isLoading: isLoading,
-                width: labelWidth
+                title: value.title,
+                isLoading: value.isLoading,
+                width: value.labelWidth
             )
         }
         .buttonStyle(.plain)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 
 extension WorkspaceListView {
+    var workspaceListFilterMenuActions: WorkspaceListFilterMenuActions {
+        WorkspaceListFilterMenuActions(
+            setReadState: { filter.readState = $0 },
+            clearMachines: { filter.machines.removeAll() },
+            toggleMachine: { filter.toggleMachine($0) }
+        )
+    }
+
     @ViewBuilder
     func workspaceListWithToolbar<Content: View>(
         _ content: Content,
@@ -33,9 +41,14 @@ extension WorkspaceListView {
                                     dismiss: dismissMacUpdateHint
                                 )
                             }
-                            WorkspaceListFilterMenu(filter: $filter, machines: filterMachines)
+                            WorkspaceListFilterMenu(
+                                filter: filter,
+                                machines: filterMachines,
+                                actions: workspaceListFilterMenuActions
+                            )
+                            .equatable()
                             if canCreateWorkspace {
-                                newWorkspaceButton
+                                newWorkspaceButton.equatable()
                             }
                         }
                     }
@@ -46,9 +59,14 @@ extension WorkspaceListView {
             content
                 .toolbar {
                     ToolbarItemGroup {
-                        WorkspaceListFilterMenu(filter: $filter, machines: filterMachines)
+                        WorkspaceListFilterMenu(
+                            filter: filter,
+                            machines: filterMachines,
+                            actions: workspaceListFilterMenuActions
+                        )
+                        .equatable()
                         if canCreateWorkspace {
-                            newWorkspaceButton
+                            newWorkspaceButton.equatable()
                         }
                     }
                 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -600,20 +600,36 @@ struct WorkspaceListView: View {
             case .groupHeader(let group, let hasUnread):
                 let anchorCapabilities = workspaces.first(where: { $0.id == group.anchorWorkspaceID })?.actionCapabilities ?? .none
                 WorkspaceGroupHeaderRow(
-                    group: group,
-                    hasUnread: hasUnread,
-                    navigationStyle: navigationStyle,
-                    isAnchorSelected: navigationStyle == .sidebar
-                        && selectedWorkspaceID == group.anchorWorkspaceID,
-                    selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
-                    createWorkspaceInGroup: canCreateWorkspaceInGroups ? createWorkspaceInGroup : nil,
-                    renameGroup: anchorCapabilities.supportsGroupActions ? renameWorkspaceGroup : nil,
-                    setGroupPinned: anchorCapabilities.supportsGroupActions ? setGroupPinned : nil,
-                    ungroupWorkspaceGroup: anchorCapabilities.supportsGroupActions ? ungroupWorkspaceGroup : nil,
-                    deleteWorkspaceGroup: anchorCapabilities.supportsGroupActions ? deleteWorkspaceGroup : nil,
-                    toggleCollapsed: toggleGroupCollapsed,
-                    unreadIndicatorLeftShift: unreadIndicatorLeftShift
+                    value: WorkspaceGroupHeaderRowValue(
+                        group: group,
+                        hasUnread: hasUnread,
+                        navigationStyle: navigationStyle,
+                        isAnchorSelected: navigationStyle == .sidebar
+                            && selectedWorkspaceID == group.anchorWorkspaceID,
+                        canCreateWorkspaceInGroup: canCreateWorkspaceInGroups
+                            && createWorkspaceInGroup != nil,
+                        canRenameGroup: anchorCapabilities.supportsGroupActions
+                            && renameWorkspaceGroup != nil,
+                        canSetGroupPinned: anchorCapabilities.supportsGroupActions
+                            && setGroupPinned != nil,
+                        canUngroupWorkspaceGroup: anchorCapabilities.supportsGroupActions
+                            && ungroupWorkspaceGroup != nil,
+                        canDeleteWorkspaceGroup: anchorCapabilities.supportsGroupActions
+                            && deleteWorkspaceGroup != nil,
+                        canToggleCollapsed: toggleGroupCollapsed != nil,
+                        unreadIndicatorLeftShift: unreadIndicatorLeftShift
+                    ),
+                    actions: WorkspaceGroupHeaderRowActions(
+                        selectWorkspace: { id in _ = selectWorkspaceFromList(id) },
+                        createWorkspaceInGroup: createWorkspaceInGroup,
+                        renameGroup: renameWorkspaceGroup,
+                        setGroupPinned: setGroupPinned,
+                        ungroupWorkspaceGroup: ungroupWorkspaceGroup,
+                        deleteWorkspaceGroup: deleteWorkspaceGroup,
+                        toggleCollapsed: toggleGroupCollapsed
+                    )
                 )
+                .equatable()
                 // The list-wide minimum row height is lowered for the
                 // invisible end-of-group spacer; interactive rows keep the
                 // 44pt tap target (32 content + 6/6 insets) explicitly.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacTitlePickerActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacTitlePickerActions.swift
@@ -1,0 +1,4 @@
+struct WorkspaceMacTitlePickerActions {
+    let select: (WorkspaceMacSelection) -> Void
+    let addDevice: (() -> Void)?
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacTitlePickerValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceMacTitlePickerValue.swift
@@ -1,0 +1,10 @@
+import CoreGraphics
+
+struct WorkspaceMacTitlePickerValue: Equatable {
+    let title: String
+    let isLoading: Bool
+    let selection: WorkspaceMacSelection
+    let machines: [WorkspaceFilterMachine]
+    let canAddDevice: Bool
+    let labelWidth: CGFloat
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -68,7 +68,8 @@ struct WorkspaceRootToolbarContent: ToolbarContent {
     let openDevices: () -> Void
     let title: String
     let isLoading: Bool
-    @Binding var selection: WorkspaceMacSelection
+    let selection: WorkspaceMacSelection
+    let select: (WorkspaceMacSelection) -> Void
     let machines: [WorkspaceFilterMachine]
     let showAddDevice: (() -> Void)?
 
@@ -82,13 +83,20 @@ struct WorkspaceRootToolbarContent: ToolbarContent {
         }
         ToolbarItem(id: "workspace-list-title", placement: .principal) {
             WorkspaceMacTitlePicker(
-                title: title,
-                isLoading: isLoading,
-                selection: $selection,
-                machines: machines,
-                showAddDevice: showAddDevice,
-                labelWidth: WorkspaceRootToolbarSizing.pickerWidth(for: contentWidth)
+                value: WorkspaceMacTitlePickerValue(
+                    title: title,
+                    isLoading: isLoading,
+                    selection: selection,
+                    machines: machines,
+                    canAddDevice: showAddDevice != nil,
+                    labelWidth: WorkspaceRootToolbarSizing.pickerWidth(for: contentWidth)
+                ),
+                actions: WorkspaceMacTitlePickerActions(
+                    select: select,
+                    addDevice: showAddDevice
+                )
             )
+            .equatable()
         }
         ToolbarItem(id: "workspace-list-devices", placement: .topBarLeading) {
             Button(action: openDevices) {
@@ -115,10 +123,8 @@ private struct WorkspaceRootToolbarLiveContent: ToolbarContent {
             openDevices: openDevices,
             title: renderContext.title,
             isLoading: pendingSelection != nil,
-            selection: Binding(
-                get: { pendingSelection ?? renderContext.visibleSelection },
-                set: select
-            ),
+            selection: pendingSelection ?? renderContext.visibleSelection,
+            select: select,
             machines: renderContext.machines,
             showAddDevice: showAddDevice
         )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenu.swift
@@ -1,17 +1,17 @@
 import SwiftUI
 
-struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View {
-    let contentWidth: CGFloat
-    let hasBackButton: Bool
-    let hasTrailingCluster: Bool
-    let hasChatToggle: Bool
-    var isEnabled = true
+struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View, Equatable {
+    let value: WorkspaceTitleMenuValue
     @ViewBuilder let menuContent: () -> MenuContent
     @ViewBuilder let label: () -> Label
 
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
     @ViewBuilder
     var body: some View {
-        if isEnabled {
+        if value.isEnabled {
             Menu {
                 menuContent()
             } label: {
@@ -30,10 +30,10 @@ struct WorkspaceTitleMenu<Label: View, MenuContent: View>: View {
 
     private var fittedLabel: some View {
         let cap = MobileLeadingToolbarTitleWidth(
-            contentWidth: contentWidth,
-            hasBackButton: hasBackButton,
-            hasTrailingCluster: hasTrailingCluster,
-            hasChatToggle: hasChatToggle
+            contentWidth: value.contentWidth,
+            hasBackButton: value.hasBackButton,
+            hasTrailingCluster: value.hasTrailingCluster,
+            hasChatToggle: value.hasChatToggle
         ).cap
 
         return label()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuContent.swift
@@ -1,9 +1,9 @@
-import CmuxMobileShellModel
 import CmuxMobileSupport
 import SwiftUI
 
 struct WorkspaceTitleMenuContent: View {
-    let workspace: MobileWorkspacePreview
+    let workspaceName: String
+    let hasUnread: Bool
     let canRenameWorkspace: Bool
     let canToggleReadState: Bool
     let canCloseWorkspace: Bool
@@ -13,7 +13,7 @@ struct WorkspaceTitleMenuContent: View {
 
     var body: some View {
         if canRenameWorkspace || canToggleReadState || canCloseWorkspace {
-            Section(workspace.name) {
+            Section(workspaceName) {
                 if canRenameWorkspace {
                     Button(action: presentRename) {
                         Label(
@@ -27,10 +27,10 @@ struct WorkspaceTitleMenuContent: View {
                 if canToggleReadState {
                     Button(action: toggleReadState) {
                         Label(
-                            workspace.hasUnread
+                            hasUnread
                                 ? L10n.string("mobile.workspace.markRead", defaultValue: "Mark as Read")
                                 : L10n.string("mobile.workspace.markUnread", defaultValue: "Mark as Unread"),
-                            systemImage: workspace.hasUnread ? "envelope.open" : "envelope.badge"
+                            systemImage: hasUnread ? "envelope.open" : "envelope.badge"
                         )
                     }
                     .accessibilityIdentifier("MobileWorkspaceTitleReadStateMenuItem")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuLabelToken.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuLabelToken.swift
@@ -1,0 +1,13 @@
+import CmuxAgentChat
+
+enum WorkspaceTitleMenuLabelToken: Equatable {
+    case chat(
+        descriptor: ChatSessionDescriptor,
+        agentState: ChatAgentState,
+        isConnected: Bool,
+        titleOverride: String?,
+        subtitle: String?
+    )
+    case browser(title: String)
+    case standard(title: String, subtitle: String?)
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceTitleMenuValue.swift
@@ -1,0 +1,17 @@
+import CMUXMobileCore
+import CoreGraphics
+
+struct WorkspaceTitleMenuValue: Equatable {
+    let contentWidth: CGFloat
+    let hasBackButton: Bool
+    let hasTrailingCluster: Bool
+    let hasChatToggle: Bool
+    let isEnabled: Bool
+    let workspaceName: String
+    let hasUnread: Bool
+    let canRenameWorkspace: Bool
+    let canToggleReadState: Bool
+    let canCloseWorkspace: Bool
+    let labelToken: WorkspaceTitleMenuLabelToken
+    let terminalTheme: TerminalTheme
+}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceTitleMenuValueTests.swift
@@ -1,0 +1,51 @@
+import CMUXMobileCore
+import CmuxAgentChat
+import Testing
+@testable import CmuxMobileShellUI
+
+@Suite struct WorkspaceTitleMenuValueTests {
+    @Test func labelBranchChangesInvalidateTheMenuValue() {
+        let standard = menuValue(
+            labelToken: .standard(title: "Workspace", subtitle: "Terminal")
+        )
+        let browser = menuValue(
+            labelToken: .browser(title: "Workspace")
+        )
+        let chat = menuValue(
+            labelToken: .chat(
+                descriptor: ChatSessionDescriptor(
+                    id: "session-1",
+                    agentKind: .codex,
+                    title: "Build",
+                    state: .idle
+                ),
+                agentState: .idle,
+                isConnected: true,
+                titleOverride: "Workspace",
+                subtitle: "Terminal"
+            )
+        )
+
+        #expect(menuValue(labelToken: standard.labelToken) == standard)
+        #expect(browser != standard)
+        #expect(chat != standard)
+        #expect(chat != browser)
+    }
+
+    private func menuValue(labelToken: WorkspaceTitleMenuLabelToken) -> WorkspaceTitleMenuValue {
+        WorkspaceTitleMenuValue(
+            contentWidth: 390,
+            hasBackButton: true,
+            hasTrailingCluster: true,
+            hasChatToggle: true,
+            isEnabled: true,
+            workspaceName: "Workspace",
+            hasUnread: false,
+            canRenameWorkspace: true,
+            canToggleReadState: true,
+            canCloseWorkspace: true,
+            labelToken: labelToken,
+            terminalTheme: .monokai
+        )
+    }
+}


### PR DESCRIPTION
Extends the terminal-picker menu isolation from https://github.com/manaflow-ai/cmux/pull/7959 to every remaining flicker-prone menu in the iOS app.

When a SwiftUI `Menu`-owning view's body re-runs while the menu is presented, iOS rebuilds the UIMenu, producing a continuous cross-fade flicker and canceling scroll gestures. Parents like the workspace list and workspace detail re-render constantly during live sync and agent streaming, so any open menu mounted on them flickered.

Each affected menu is now an `Equatable` view compared over an immutable value snapshot (everything the label and menu content render), with action closures excluded from equality and applied via `.equatable()`. Bindings are built inside the gated child from value + action so parents stop passing fresh `Binding(get:set:)` closures. Actions key on stable IDs and resolve current state at invocation, so gated snapshots cannot act on stale rows.

Gated in this PR, by churn risk:

High (toolbar menus on streaming parents): the computer title picker (`WorkspaceMacTitlePicker`, both mounts), the workspace-detail title menu (`WorkspaceTitleMenu`, full label token incl. chat/browser/standard branches), the new-workspace split menu, and the workspace list filter menu.

Medium: workspace group header context menu, notification feed row context menu, artifact gallery item context menu and sort menu, chat artifact viewer toolbar menu, chat prose bubble copy menu, and both task composer pickers (agent/template and machine).

Intentionally unchanged: settings/iroh/editor form menus (parents don't re-render while open), segmented/inline pickers, PhotosPicker/ColorPicker/document pickers, macOS-only branches, and the workspace-row UIKit `UIMenu` (already immune, built per long-press).

Tests: `WorkspaceTitleMenuValueTests` pins that label branch changes invalidate the title-menu value. Existing `ChatArtifactViewerPagerModelTests` updated for the path-keyed toolbar actions. Note: `TerminalSurfaceMountOwnershipTests` in `CmuxMobileShellUI` does not compile on current `main` (missing `terminalFolderTapEnabled` argument, pre-existing, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787271368&installation_model_id=21920&pr_number=8611&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8611&signature=dc5ce53c53d0b167ed1c4c3ba3c74f0ec9357cf0c9ace9eca0929033306282df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops iOS menus from flickering or canceling gestures when their parent views re-render by gating them behind Equatable, snapshot-driven subviews. Open menus now stay stable during live sync and agent streaming.

- Bug Fixes
  - Prevented flicker for: workspace title menu, Mac title picker, new workspace menu, workspace list filter, group header/context menus, notification feed row, artifact gallery (items + sort), chat viewer toolbar, chat prose bubble, and task composer pickers.
  - Chat artifact viewer toolbar actions are now path-keyed; share/save/copy work without rebuilding the menu.

- Refactors
  - Introduced lightweight Value and Actions structs per menu, marked menu views Equatable, and applied .equatable() to stabilize open `UIMenu`s.
  - Built bindings inside children and routed actions via stable IDs; extracted focused components (e.g., TerminalArtifactGallerySortMenu, TaskComposerMachineMenu, WorkspaceListNewWorkspaceMenu).
  - Marked related types Sendable and tightened equality on frequently updated views (e.g., ChatProseBubbleView, NotificationFeedRow).
  - Added WorkspaceTitleMenuValueTests and updated ChatArtifactViewerPagerModelTests for path-keyed actions.

<sup>Written for commit 59996dfe858bea0ff8d9fc0e7d2b07e9ad2de562. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an artifact viewer actions menu with sharing, saving, copying, search, navigation, line-number, word-wrap, and Markdown display controls.
  * Added clearer menus for artifact sorting, machine selection, task agents, workspace creation, and workspace titles.
  * Improved workspace and notification interactions with more consistent action availability and accessibility labels.

* **Performance**
  * Improved UI update efficiency across artifact galleries, notifications, transcripts, and workspace lists.

* **Tests**
  * Added coverage for workspace title menu state and artifact viewer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->