### PR TITLE
cmuxTests: repair twenty suites, including one that was taking the test host down with it

### DIFF
--- a/Sources/Panels/BrowserDownloadFilenameResolver.swift
+++ b/Sources/Panels/BrowserDownloadFilenameResolver.swift
@@ -288,29 +288,36 @@ struct BrowserDownloadFilenameResolver: Sendable {
 
 extension URL {
     func cmuxApplyWebDownloadQuarantine(sourceURL: URL?) throws {
-        guard let sourceURL,
-              !sourceURL.isFileURL else {
+        guard let quarantineProperties = Self.cmuxWebDownloadQuarantineProperties(sourceURL: sourceURL) else {
             return
-        }
-
-        var quarantineProperties: [String: Any] = [
-            kLSQuarantineTypeKey as String: kLSQuarantineTypeWebDownload as String,
-            kLSQuarantineTimeStampKey as String: Date(),
-            kLSQuarantineAgentNameKey as String: Self.cmuxDownloadQuarantineAgentName(),
-        ]
-        if let bundleIdentifier = Bundle.main.bundleIdentifier,
-           !bundleIdentifier.isEmpty {
-            quarantineProperties[kLSQuarantineAgentBundleIdentifierKey as String] = bundleIdentifier
-        }
-        if let sanitizedSourceURL = Self.cmuxSanitizedDownloadSourceURL(sourceURL) {
-            quarantineProperties[kLSQuarantineDataURLKey as String] = sanitizedSourceURL
-            quarantineProperties[kLSQuarantineOriginURLKey as String] = sanitizedSourceURL
         }
 
         var resourceValues = URLResourceValues()
         resourceValues.quarantineProperties = quarantineProperties
         var fileURL = self
         try fileURL.setResourceValues(resourceValues)
+    }
+
+    static func cmuxWebDownloadQuarantineProperties(sourceURL: URL?) -> [String: Any]? {
+        guard let sourceURL,
+              !sourceURL.isFileURL else {
+            return nil
+        }
+
+        var quarantineProperties: [String: Any] = [
+            kLSQuarantineTypeKey as String: kLSQuarantineTypeWebDownload as String,
+            kLSQuarantineTimeStampKey as String: Date(),
+            kLSQuarantineAgentNameKey as String: cmuxDownloadQuarantineAgentName(),
+        ]
+        if let bundleIdentifier = Bundle.main.bundleIdentifier,
+           !bundleIdentifier.isEmpty {
+            quarantineProperties[kLSQuarantineAgentBundleIdentifierKey as String] = bundleIdentifier
+        }
+        if let sanitizedSourceURL = cmuxSanitizedDownloadSourceURL(sourceURL) {
+            quarantineProperties[kLSQuarantineDataURLKey as String] = sanitizedSourceURL
+            quarantineProperties[kLSQuarantineOriginURLKey as String] = sanitizedSourceURL
+        }
+        return quarantineProperties
     }
 
     private static func cmuxDownloadQuarantineAgentName() -> String {

--- a/cmuxTests/AgentChatSessionRegistryObservationTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryObservationTests.swift
@@ -279,7 +279,11 @@ struct AgentChatSessionRegistryObservationTests {
 
         let session = try #require(observed.first)
         #expect(observed.count == 1)
-        #expect(detailReadCount == 0)
+        // The scan reads a matched agent's process details exactly once and memoizes
+        // them (it needs the environment for the working directory and argv for the
+        // session-id fallback), so one read is correct here; a regression that re-read
+        // per use would push this past 1.
+        #expect(detailReadCount == 1)
         #expect(session.sessionID == sessionID)
         #expect(session.agentKind == .codex)
         #expect(session.workspaceID == workspaceID.uuidString)

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2681,13 +2681,21 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
-            if panel.preferredURLStringForOmnibar() == url.absoluteString && !panel.isLoading {
+            // Read live WebKit state instead of the panel's published mirrors.
+            // `BrowserPanel.init` publishes `currentURL` synchronously and the
+            // `isLoading` mirror only turns true after a KVO -> main-actor hop,
+            // so the mirrored predicate reads true before the load has started.
+            // `backForwardList.currentItem` appears only once a navigation
+            // commits, so this cannot pass on a load that has not begun.
+            if panel.webView.url?.absoluteString == url.absoluteString,
+               !panel.webView.isLoading,
+               panel.webView.backForwardList.currentItem?.url.absoluteString == url.absoluteString {
                 return
             }
         }
 
         XCTFail(
-            "Timed out waiting for browser panel to load \(url.absoluteString). Current=\(panel.preferredURLStringForOmnibar() ?? "nil") loading=\(panel.isLoading)",
+            "Timed out waiting for browser panel to load \(url.absoluteString). Live=\(panel.webView.url?.absoluteString ?? "nil") committed=\(panel.webView.backForwardList.currentItem?.url.absoluteString ?? "nil") loading=\(panel.webView.isLoading)",
             file: file,
             line: line
         )
@@ -2804,13 +2812,22 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         let server = try ProvisionalNavigationRaceServer()
         defer { server.stop() }
 
+        // WebKit appends to the back-forward list only when a navigation
+        // commits, so one committed page leaves `canGoBack` false and a back
+        // raced against the held page B request would have nowhere to go.
+        // Commit two pages first, then race the back from page A.
+        let pagePrevious = server.url(path: "/previous")
         let pageA = server.url(path: "/a")
         let pageB = server.url(path: "/b")
-        let panel = BrowserPanel(workspaceId: UUID(), initialURL: pageA)
+        let panel = BrowserPanel(workspaceId: UUID(), initialURL: pagePrevious)
         defer { panel.close() }
 
+        waitForBrowserPanel(panel, url: pagePrevious)
+        panel.navigate(to: pageA)
         waitForBrowserPanel(panel, url: pageA)
-        XCTAssertEqual(panel.pageTitle, "Race A")
+        // The published title arrives one main-actor hop after the load
+        // finishes, so wait for it rather than reading it immediately.
+        waitUntil("page A title to publish") { panel.pageTitle == "Race A" }
 
         panel.navigate(to: pageB)
         waitUntil("server to receive provisional page B request") {
@@ -2819,25 +2836,35 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         waitUntil("browser back availability during provisional page B navigation") {
             panel.canGoBack && panel.webView.isLoading
         }
-        XCTAssertFalse(panel.canGoForward)
+        XCTAssertFalse(panel.canGoForward, "held page B must not enter history")
 
         panel.goBack()
-        waitUntil("back action to expose page B as forward history before it can commit") {
-            panel.currentURL?.path == pageA.path && !panel.webView.isLoading
+        // Back cancels the held page B navigation and returns to the page behind
+        // page A. Page A, the page the user left, becomes the forward entry, and
+        // the published URL has to match the page WebKit actually committed.
+        waitUntil("back to cancel page B and settle on the previous page") {
+            panel.currentURL?.path == pagePrevious.path
+                && panel.webView.backForwardList.currentItem?.url.path == pagePrevious.path
+                && !panel.webView.isLoading
                 && panel.canGoForward
         }
 
         let releasedBResponseCount = server.releaseHeldBResponses()
         XCTAssertGreaterThan(releasedBResponseCount, 0)
-        waitUntil("browser to remain on page A after held page B response is released") {
+        waitUntil("released page B response to stay out of the pane") {
             !panel.webView.isLoading &&
                 panel.pageTitle == "Race A" &&
-                panel.currentURL?.path == pageA.path
+                panel.currentURL?.path == pagePrevious.path
         }
 
         let publishedURL = try XCTUnwrap(panel.currentURL)
-        XCTAssertEqual(publishedURL.path, pageA.path)
+        XCTAssertEqual(publishedURL.path, pagePrevious.path)
+        XCTAssertEqual(panel.webView.url?.path, pagePrevious.path)
         XCTAssertEqual(panel.pageTitle, "Race A")
+        XCTAssertEqual(
+            panel.webView.backForwardList.forwardList.map(\.url.path),
+            [pageA.path]
+        )
     }
 
     func testWebViewReplacementAfterProcessTerminationUpdatesInstanceIdentity() {

--- a/cmuxTests/BrowserDownloadFilenameResolverTests.swift
+++ b/cmuxTests/BrowserDownloadFilenameResolverTests.swift
@@ -209,8 +209,13 @@ import WebKit
         #expect(properties[kLSQuarantineTypeKey as String] as? String == kLSQuarantineTypeWebDownload as String)
         #expect(properties[kLSQuarantineAgentNameKey as String] as? String != nil)
         #expect(properties[kLSQuarantineTimeStampKey as String] is Date)
-        #expect((properties[kLSQuarantineDataURLKey as String] as? URL)?.absoluteString == "https://example.test/report.csv")
-        #expect((properties[kLSQuarantineOriginURLKey as String] as? URL)?.absoluteString == "https://example.test/report.csv")
+
+        // LaunchServices keeps the quarantine URLs in its own events database, and a
+        // quarantineProperties readback only returns what lives in the com.apple.quarantine
+        // xattr, so check the sanitized source URL on the dictionary the write path builds.
+        let writtenProperties = try #require(URL.cmuxWebDownloadQuarantineProperties(sourceURL: sourceURL))
+        #expect((writtenProperties[kLSQuarantineDataURLKey as String] as? URL)?.absoluteString == "https://example.test/report.csv")
+        #expect((writtenProperties[kLSQuarantineOriginURLKey as String] as? URL)?.absoluteString == "https://example.test/report.csv")
     }
 
     @Test func webDownloadQuarantineMetadataSkipsLocalFileSources() throws {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -350,16 +350,27 @@ final class BrowserPanelVisualAutomationRestoreHostTests: XCTestCase {
         )
         defer { panel.close() }
 
-        let deadline = Date().addingTimeInterval(1.0)
-        while panel.webView.isLoading,
-              RunLoop.main.run(mode: .default, before: deadline),
-              Date() < deadline {}
+        // The discard blocker reads the panel's debounced `isLoading` indicator, not the raw
+        // WebKit flag. When WebKit finishes faster than `minLoadingIndicatorDuration` (0.35s),
+        // the panel keeps `isLoading` true and clears it from a queued work item, so waiting
+        // only on `webView.isLoading` leaves a "loading" blocker armed on any machine slow
+        // enough that the load is still in flight at the first check. Wait for both, and drain
+        // the run loop in the body: `run(mode:before:)` returns false when it cannot start,
+        // which as a loop condition exits while the page is still loading.
+        let deadline = Date().addingTimeInterval(30.0)
+        while panel.webView.isLoading || panel.isLoading, Date() < deadline {
+            _ = RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
         XCTAssertFalse(panel.webView.isLoading, "Timed out waiting for about:blank to finish loading")
+        XCTAssertFalse(panel.isLoading, "Timed out waiting for the loading indicator to clear")
 
         panel.noteWebViewVisibility(false, reason: "test.hidden", now: discardedAt)
         let originalWebView = panel.webView
 
-        XCTAssertTrue(panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt))
+        XCTAssertTrue(
+            panel.discardHiddenWebViewForMemory(reason: "test.discard", now: discardedAt),
+            "blockers: \(panel.webViewLifecycleTopPayload()["discard_blockers"] as? [String] ?? [])"
+        )
         XCTAssertFalse(panel.webView === originalWebView)
         XCTAssertNil(panel.webView.superview)
         XCTAssertFalse(panel.hasBackgroundPreloadHost)

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -154,34 +154,38 @@ struct BrowserWebContentProcessTests {
             baseURL: URL(string: "https://example.com/")!
         )
 
-        let result = try await webView.evaluateJavaScript(
+        // The bridge's navigator.credentials.get returns a promise, and
+        // evaluateJavaScript cannot serialize a promise (WKError 5). Call the body
+        // as an async function instead, in the page world that holds the override.
+        let result = try await webView.callAsyncJavaScript(
             """
-            (async () => {
-              const handlerVisible = !!(
-                window.webkit &&
-                window.webkit.messageHandlers &&
-                window.webkit.messageHandlers.cmuxWebAuthn &&
-                typeof window.webkit.messageHandlers.cmuxWebAuthn.postMessage === "function"
-              );
-              const credential = await navigator.credentials.get({
-                publicKey: {
-                  challenge: new Uint8Array([1, 2, 3, 4]).buffer,
-                  rpId: "example.com",
-                  userVerification: "preferred"
-                }
-              });
-              return {
-                handlerVisible,
-                credentialId: credential && credential.id,
-                rawIDLength: credential && credential.rawId && credential.rawId.byteLength,
-                signatureLength:
-                  credential &&
-                  credential.response &&
-                  credential.response.signature &&
-                  credential.response.signature.byteLength
-              };
-            })()
-            """
+            const handlerVisible = !!(
+              window.webkit &&
+              window.webkit.messageHandlers &&
+              window.webkit.messageHandlers.cmuxWebAuthn &&
+              typeof window.webkit.messageHandlers.cmuxWebAuthn.postMessage === "function"
+            );
+            const credential = await navigator.credentials.get({
+              publicKey: {
+                challenge: new Uint8Array([1, 2, 3, 4]).buffer,
+                rpId: "example.com",
+                userVerification: "preferred"
+              }
+            });
+            return {
+              handlerVisible,
+              credentialId: credential && credential.id,
+              rawIDLength: credential && credential.rawId && credential.rawId.byteLength,
+              signatureLength:
+                credential &&
+                credential.response &&
+                credential.response.signature &&
+                credential.response.signature.byteLength
+            };
+            """,
+            arguments: [:],
+            in: nil,
+            contentWorld: .page
         ) as? [String: Any]
 
         #expect(result?["handlerVisible"] as? Bool == false)
@@ -419,8 +423,12 @@ struct BrowserWebContentProcessTests {
 
         #expect(popupWebView.navigationDelegate == nil)
         #expect(popupWebView.uiDelegate == nil)
-        #expect(popupWebView.window == nil)
         #expect(!popupWindow.isVisible)
+        // Teardown closes the panel and unregisters the popup from its opener, but
+        // it never detaches the web view, and this test holds the panel alive
+        // (isReleasedWhenClosed is false), so popupWebView.window still points at
+        // the closed panel.
+        #expect(!panel.hiddenWebViewDiscardSnapshot.hasPopups)
     }
 }
 

--- a/cmuxTests/BundledCLILinkageTests.swift
+++ b/cmuxTests/BundledCLILinkageTests.swift
@@ -56,8 +56,17 @@ final class BundledCLILinkageTests: XCTestCase {
     func testBundledCLIDoesNotDependOnPrivateRPathFrameworks() throws {
         let cliURL = try bundledCLIURL()
         let linkedLibraries = try linkedLibraries(for: cliURL)
+        // Xcode links a target's automatic SwiftPM products as dynamic
+        // <Name>_<hash>_PackageProduct.framework variants under the test action, so the
+        // helper in a test-built app bundle picks those up even though a plain build links
+        // the same products statically. Those names are toolchain-generated and do not
+        // appear in a shipped bundle. A dependency that would abort dyld keeps its real
+        // framework name (the v0.64.1 crash was @rpath/Sentry.framework, from the
+        // Sentry-Dynamic product) and still fails this assert in every build style.
         let privateRPathFrameworks = linkedLibraries.filter {
-            $0.hasPrefix("@rpath/") && $0.contains(".framework/")
+            $0.hasPrefix("@rpath/")
+                && $0.contains(".framework/")
+                && !$0.contains("_PackageProduct.framework/")
         }
 
         XCTAssertEqual(

--- a/cmuxTests/CLIHookNoResponseTests.swift
+++ b/cmuxTests/CLIHookNoResponseTests.swift
@@ -220,6 +220,10 @@ struct CLIHookNoResponseTests {
         }
 
         let server = try Self.startAcceptedSocketThatDoesNotRead(listenerFD: listenerFD, holdFor: 1.0)
+        // Stay under the CLI's 1 MiB codex feed-hook stdin cap so the payload still
+        // reaches the socket, but far above what the non-reading peer will absorb
+        // (the fixture pins its receive buffer to 4 KiB) so the write stalls and has
+        // to be abandoned by the 0.05s write timeout.
         let largeToolInput = String(repeating: "x", count: 512 * 1024)
         let input = """
         {"hook_event_name":"PreToolUse","session_id":"codex-session-no-read","cwd":"\(root.path)","tool_name":"apply_patch","tool_input":{"payload":"\(largeToolInput)"}}

--- a/cmuxTests/ClaudeConfigDirectoryPathTests.swift
+++ b/cmuxTests/ClaudeConfigDirectoryPathTests.swift
@@ -60,7 +60,7 @@ final class ClaudeConfigDirectoryPathTests: XCTestCase {
         )
 
         XCTAssertFalse(command.contains("CLAUDE_CONFIG_DIR="))
-        XCTAssertTrue(command.hasPrefix("cd /tmp/repo && "))
+        XCTAssertTrue(command.hasPrefix("cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ] && "))
         XCTAssertTrue(command.contains(
             AgentResumeArgv.claudeWrapperShellExecutableToken
                 .replacingOccurrences(of: "'", with: "'\\''") + " --resume session-123"

--- a/cmuxTests/CmuxConfigNewWorkspaceMenuTests.swift
+++ b/cmuxTests/CmuxConfigNewWorkspaceMenuTests.swift
@@ -271,27 +271,32 @@ struct CmuxConfigNewWorkspaceMenuTests {
         let (store, root) = try loadStore(globalJSON: twoLayoutConfig(defaultActionID: "review-layout"))
         defer { try? FileManager.default.removeItem(at: root) }
 
-        try withNewWorkspaceContextMenu(store: store) { menu in
-            let layoutsHeader = String(localized: "menu.newWorkspace.layoutsHeader", defaultValue: "Layouts")
-            let headerIndex = try #require(menu.items.firstIndex { $0.title == layoutsHeader })
-            let saveTitle = String(localized: "menu.newWorkspace.saveWorkspaceAsLayout", defaultValue: "Save Workspace as Layout…")
-            let saveIndex = try #require(menu.items.firstIndex { $0.title == saveTitle })
-            let newWorkspaceIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newWorkspace.configID))
-            let agentChatIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newAgentChat.configID))
-            let reviewIndex = try #require(firstContextMenuIndex(menu, actionID: "review-layout"))
-            let devIndex = try #require(firstContextMenuIndex(menu, actionID: "dev-layout"))
+        // Agent chat is behind a default-off flag, and this test is about where
+        // the create entries sit relative to the Layouts section rather than
+        // about that default, so turn it on to get the item into the menu.
+        try withAgentChatUIFlag(true) {
+            try withNewWorkspaceContextMenu(store: store) { menu in
+                let layoutsHeader = String(localized: "menu.newWorkspace.layoutsHeader", defaultValue: "Layouts")
+                let headerIndex = try #require(menu.items.firstIndex { $0.title == layoutsHeader })
+                let saveTitle = String(localized: "menu.newWorkspace.saveWorkspaceAsLayout", defaultValue: "Save Workspace as Layout…")
+                let saveIndex = try #require(menu.items.firstIndex { $0.title == saveTitle })
+                let newWorkspaceIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newWorkspace.configID))
+                let agentChatIndex = try #require(firstContextMenuIndex(menu, actionID: CmuxSurfaceTabBarBuiltInAction.newAgentChat.configID))
+                let reviewIndex = try #require(firstContextMenuIndex(menu, actionID: "review-layout"))
+                let devIndex = try #require(firstContextMenuIndex(menu, actionID: "dev-layout"))
 
-            #expect(newWorkspaceIndex < headerIndex)
-            #expect(agentChatIndex < headerIndex)
-            #expect(headerIndex < reviewIndex)
-            #expect(headerIndex < devIndex)
-            #expect(reviewIndex < saveIndex)
-            #expect(devIndex < saveIndex)
-            let layoutRange = (headerIndex + 1)..<saveIndex
-            let nonLayoutIDs = menu.items[layoutRange].compactMap(contextMenuActionID).filter {
-                $0 != "review-layout" && $0 != "dev-layout"
+                #expect(newWorkspaceIndex < headerIndex)
+                #expect(agentChatIndex < headerIndex)
+                #expect(headerIndex < reviewIndex)
+                #expect(headerIndex < devIndex)
+                #expect(reviewIndex < saveIndex)
+                #expect(devIndex < saveIndex)
+                let layoutRange = (headerIndex + 1)..<saveIndex
+                let nonLayoutIDs = menu.items[layoutRange].compactMap(contextMenuActionID).filter {
+                    $0 != "review-layout" && $0 != "dev-layout"
+                }
+                #expect(nonLayoutIDs.isEmpty)
             }
-            #expect(nonLayoutIDs.isEmpty)
         }
     }
 

--- a/cmuxTests/CrashDiagnosticSessionPolicyTests.swift
+++ b/cmuxTests/CrashDiagnosticSessionPolicyTests.swift
@@ -27,13 +27,31 @@ struct CrashDiagnosticSessionPolicyTests {
 
     @Test
     func terminalDefaultFileOpenIgnoresSymlinkedGhosttyCrashReportsInCmuxCrashDirectory() throws {
-        let crashReport = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".local/state/cmux/crash/cmux.ghosttycrash", isDirectory: false)
-        let symlink = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-symlinked-crash-\(UUID().uuidString).ghosttycrash", isDirectory: false)
+        // The fixture owns its crash directory instead of borrowing the real one.
+        // resolvingSymlinksInPath() only resolves a symlink whose target exists, so the report has
+        // to be created, and planting one in ~/.local/state/cmux/crash would look like a pending
+        // crash on the next launch. XDG_STATE_HOME is the product's own second crash location.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-symlinked-crash-\(UUID().uuidString)", isDirectory: true)
+        let stateHome = root.appendingPathComponent("state", isDirectory: true)
+        let crashReport = stateHome
+            .appendingPathComponent("cmux/crash/cmux.ghosttycrash", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: crashReport.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("MDMP".utf8).write(to: crashReport)
+        let symlink = root.appendingPathComponent("crash-link.ghosttycrash", isDirectory: false)
         try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: crashReport)
+        let previousStateHome = ProcessInfo.processInfo.environment["XDG_STATE_HOME"]
+        setenv("XDG_STATE_HOME", stateHome.path(percentEncoded: false), 1)
         defer {
-            try? FileManager.default.removeItem(at: symlink)
+            if let previousStateHome {
+                setenv("XDG_STATE_HOME", previousStateHome, 1)
+            } else {
+                unsetenv("XDG_STATE_HOME")
+            }
+            try? FileManager.default.removeItem(at: root)
         }
 
         #expect(

--- a/cmuxTests/CrashDiagnosticSessionPolicyTests.swift
+++ b/cmuxTests/CrashDiagnosticSessionPolicyTests.swift
@@ -43,7 +43,10 @@ struct CrashDiagnosticSessionPolicyTests {
         try Data("MDMP".utf8).write(to: crashReport)
         let symlink = root.appendingPathComponent("crash-link.ghosttycrash", isDirectory: false)
         try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: crashReport)
-        let previousStateHome = ProcessInfo.processInfo.environment["XDG_STATE_HOME"]
+        // Read the live value with getenv: ProcessInfo caches the environment at first
+        // access, so if an earlier test setenv'd this variable at runtime, restoring the
+        // ProcessInfo snapshot in the defer below would clobber that test's state.
+        let previousStateHome = getenv("XDG_STATE_HOME").map { String(cString: $0) }
         setenv("XDG_STATE_HOME", stateHome.path(percentEncoded: false), 1)
         defer {
             if let previousStateHome {

--- a/cmuxTests/DeflatedAssetTestSupport.swift
+++ b/cmuxTests/DeflatedAssetTestSupport.swift
@@ -1,18 +1,43 @@
 import Foundation
+import zlib
 
+/// Writes and reads `.deflate` fixtures in the format the shipped assets use: zlib-wrapped
+/// deflate (RFC 1950), which is what `scripts/compress-markdown-viewer-assets.sh` produces and
+/// the only thing `DiffViewerAssetReader`/`MarkdownViewerAssets` can inflate. Foundation's
+/// `.zlib` algorithm emits header-less raw deflate (RFC 1951), which those readers reject.
 enum DeflatedAssetTestSupport {
     static func writeText(_ text: String, to url: URL, addingDeflateExtension: Bool = false) throws {
         let targetURL = addingDeflateExtension ? url.appendingPathExtension("deflate") : url
-        let compressed = try (Data(text.utf8) as NSData).compressed(using: .zlib) as Data
-        try compressed.write(to: targetURL, options: .atomic)
+        try Self.zlibCompressed(Array(text.utf8)).write(to: targetURL, options: .atomic)
     }
 
     static func loadText(path: String) throws -> String {
-        let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        let decompressed = try (data as NSData).decompressed(using: .zlib) as Data
-        guard let text = String(bytes: decompressed, encoding: .utf8) else {
+        let compressed = [UInt8](try Data(contentsOf: URL(fileURLWithPath: path)))
+        guard let text = String(bytes: try Self.zlibDecompressed(compressed), encoding: .utf8) else {
             throw CocoaError(.fileReadCorruptFile)
         }
         return text
+    }
+
+    private static func zlibCompressed(_ source: [UInt8]) throws -> Data {
+        var destinationCount = compressBound(uLong(source.count))
+        var destination = [UInt8](repeating: 0, count: Int(destinationCount))
+        guard compress2(&destination, &destinationCount, source, uLong(source.count), 9) == Z_OK else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        return Data(destination[0..<Int(destinationCount)])
+    }
+
+    private static func zlibDecompressed(_ compressed: [UInt8]) throws -> [UInt8] {
+        var capacity = max(compressed.count * 8, 64 * 1024)
+        while capacity <= 64 * 1024 * 1024 {
+            var destinationCount = uLong(capacity)
+            var destination = [UInt8](repeating: 0, count: capacity)
+            let status = uncompress(&destination, &destinationCount, compressed, uLong(compressed.count))
+            if status == Z_OK { return Array(destination[0..<Int(destinationCount)]) }
+            guard status == Z_BUF_ERROR else { throw CocoaError(.fileReadCorruptFile) }
+            capacity *= 4
+        }
+        throw CocoaError(.fileReadTooLarge)
     }
 }

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -960,6 +960,10 @@ struct FileSearchControllerTests {
         // updateVisibility runs on every store/content update and is unguarded; a second
         // identical pass must not invalidate layout.
         container.updateVisibility(hasContent: true, isLoading: false, statusMessage: nil)
+        // This container is windowless and never runs a layout pass, so the real invalidations
+        // above leave layout pending and `needsLayout = false` does not take effect. Run the
+        // pending pass first so each probe below measures only new invalidations.
+        container.layoutSubtreeIfNeeded()
         container.needsLayout = false
         container.updateVisibility(hasContent: true, isLoading: false, statusMessage: nil)
         #expect(
@@ -969,6 +973,7 @@ struct FileSearchControllerTests {
 
         // The guard-else in updatePresentation(.find) re-runs updateSearchLayout on every
         // redundant pass (the Cmd+Shift+F re-entry path); it must be a no-op too.
+        container.layoutSubtreeIfNeeded()
         container.needsLayout = false
         container.updatePresentation(.find)
         #expect(
@@ -978,6 +983,7 @@ struct FileSearchControllerTests {
 
         // Positive control: a genuine visibility change must still invalidate layout, so
         // the no-op assertions above are meaningful rather than vacuous.
+        container.layoutSubtreeIfNeeded()
         container.needsLayout = false
         container.updateVisibility(hasContent: false, isLoading: false, statusMessage: nil)
         #expect(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2347,6 +2347,18 @@ final class BrowserNewTabNavigationSeedTests: XCTestCase {
 
 @MainActor
 final class BrowserPanelRemoteStoreTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // A local browser panel resolves its website data store through the
+        // last-used browser profile, and only the built-in default profile maps
+        // to `WKWebsiteDataStore.default()`. That selection is persisted in
+        // `UserDefaults`, so a profile some other test switched to (in this run
+        // or an earlier one) leaves the local-panel checks below resolving a
+        // leftover profile's store. Pin the built-in default so this suite
+        // tests store scoping instead of machine state.
+        BrowserProfileStore.shared.noteUsed(BrowserProfileStore.shared.builtInDefaultProfileID)
+    }
+
     func testRemoteWorkspacePanelsShareWorkspaceScopedWebsiteDataStore() {
         let localPanel = BrowserPanel(workspaceId: UUID(), isRemoteWorkspace: false)
         let remoteWorkspaceId = UUID()

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2347,8 +2347,11 @@ final class BrowserNewTabNavigationSeedTests: XCTestCase {
 
 @MainActor
 final class BrowserPanelRemoteStoreTests: XCTestCase {
+    private var previousProfileID: UUID?
+
     override func setUp() {
         super.setUp()
+        previousProfileID = BrowserProfileStore.shared.lastUsedProfileID
         // A local browser panel resolves its website data store through the
         // last-used browser profile, and only the built-in default profile maps
         // to `WKWebsiteDataStore.default()`. That selection is persisted in
@@ -2357,6 +2360,15 @@ final class BrowserPanelRemoteStoreTests: XCTestCase {
         // leftover profile's store. Pin the built-in default so this suite
         // tests store scoping instead of machine state.
         BrowserProfileStore.shared.noteUsed(BrowserProfileStore.shared.builtInDefaultProfileID)
+    }
+
+    override func tearDown() {
+        // The pin above persists through UserDefaults, so put back whatever profile was
+        // selected before this suite ran rather than leaking the built-in default forward.
+        if let previousProfileID {
+            BrowserProfileStore.shared.noteUsed(previousProfileID)
+        }
+        super.tearDown()
     }
 
     func testRemoteWorkspacePanelsShareWorkspaceScopedWebsiteDataStore() {

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -320,6 +320,11 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertFalse(panel.isFileUnavailable)
 
         let reloaded = expectation(description: "markdown file change reloaded")
+        // An atomic write is a rename, so the watcher can re-read and republish the
+        // same content more than once. Over-fulfilling a one-shot expectation raises
+        // XCTest's API-violation exception while this test is suspended in
+        // `fulfillment(of:)`, which kills the test host instead of failing the test.
+        reloaded.assertForOverFulfill = false
         let cancellable = panel.$content.dropFirst().sink { content in
             if content == updatedContent {
                 reloaded.fulfill()
@@ -1586,23 +1591,34 @@ final class MarkdownPanelTests: XCTestCase {
 private final class MarkdownShellLoadDelegate: NSObject, WKNavigationDelegate {
     let expectation: XCTestExpectation
     var error: Error?
+    private var didSettle = false
 
     init(expectation: XCTestExpectation) {
         self.expectation = expectation
     }
 
-    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    /// WebKit can report more than one terminal outcome for a single load (a
+    /// provisional failure followed by a finish, for instance), so only the first
+    /// one counts. Fulfilling the same one-shot expectation twice raises XCTest's
+    /// API-violation exception from inside the callback, which takes the test host
+    /// down instead of failing the test.
+    private func settle(_ error: Error?) {
+        guard !didSettle else { return }
+        didSettle = true
+        self.error = error
         expectation.fulfill()
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        settle(nil)
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        self.error = error
-        expectation.fulfill()
+        settle(error)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        self.error = error
-        expectation.fulfill()
+        settle(error)
     }
 }
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -836,6 +836,25 @@ final class BrowserOmnibarNativeFieldRegistryWindowSelectionTests: XCTestCase {
 final class BrowserPortalOmnibarSuggestionsTests: XCTestCase {
     func testPortalSuggestionsOverlayPassesHitTestingOutsidePopupFrame() {
         let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 420, height: 260))
+        // The suggestions overlay is a SwiftUI hosting view, and SwiftUI only builds
+        // the content that answers a hit test once the view is in a window and has
+        // been through a layout/display pass. Host the slot in a window so the
+        // overlay reports real hits instead of nil for every point.
+        let window = NSWindow(
+            contentRect: slot.frame,
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = slot
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            window.contentView = nil
+            window.orderOut(nil)
+            window.close()
+        }
+
         let item = OmnibarSuggestion.search(engineName: "Google", query: "news")
         let popupFrame = CGRect(
             x: 40,
@@ -859,6 +878,9 @@ final class BrowserPortalOmnibarSuggestionsTests: XCTestCase {
             )
         )
         slot.layoutSubtreeIfNeeded()
+        slot.displayIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        slot.layoutSubtreeIfNeeded()
 
         let overlay = slot.subviews.first {
             String(describing: type(of: $0)).contains("OmnibarSuggestionsHostingView")
@@ -866,13 +888,29 @@ final class BrowserPortalOmnibarSuggestionsTests: XCTestCase {
         XCTAssertNotNil(overlay)
         guard let overlay else { return }
 
+        // The overlay is pinned to the slot with constraints, so it only has a
+        // usable coordinate space once layout has run. Hit-testing a zero-sized
+        // overlay would report "outside the popup" for every point, including
+        // points that must hit.
+        XCTAssertEqual(overlay.bounds.size, slot.bounds.size, "Overlay must fill the slot before hit-testing")
+
         XCTAssertNil(overlay.hitTest(NSPoint(x: 8, y: 8)))
 
+        // `popupFrame` is in the overlay's own top-left space, while `hitTest`
+        // takes a point in the superview's space. Convert through AppKit rather
+        // than flipping by hand: the overlay is a flipped hosting view inside an
+        // unflipped slot, so the two spaces disagree about y and a hand-rolled
+        // flip lands outside the popup.
         let insideTopLeftPoint = NSPoint(x: popupFrame.midX, y: popupFrame.midY)
-        let insidePoint = overlay.isFlipped
+        let overlayLocalPoint = overlay.isFlipped
             ? insideTopLeftPoint
             : NSPoint(x: insideTopLeftPoint.x, y: overlay.bounds.height - insideTopLeftPoint.y)
-        XCTAssertNotNil(overlay.hitTest(insidePoint))
+        let insidePoint = overlay.convert(overlayLocalPoint, to: overlay.superview)
+        XCTAssertNotNil(
+            overlay.hitTest(insidePoint),
+            "isFlipped=\(overlay.isFlipped) bounds=\(overlay.bounds) popup=\(popupFrame) "
+                + "point=\(insidePoint) inWindow=\(overlay.window != nil) subviews=\(overlay.subviews.count)"
+        )
     }
 }
 

--- a/cmuxTests/RemoteTmuxMirrorFeedForwardTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorFeedForwardTests.swift
@@ -418,6 +418,12 @@ import Testing
             lines: ["@1 f92f,80x24,0,0,0 f92f,80x24,0,0,0 [] one"],
             isError: false
         ))
+        // Staging @1 for the first time subscribes its pane-border-status
+        // (refresh-client -B) before the rects fetch goes out, and tmux answers
+        // every command with its own result block. Ack the subscription so the
+        // rects reply below pops the rects slot of the command FIFO.
+        #expect(connection.pendingCommandKindsForTesting.count == 2)
+        connection.handleMessageForTesting(.commandResult(commandNumber: 0, lines: [], isError: false))
         connection.handleMessageForTesting(.commandResult(
             commandNumber: 0,
             lines: ["%0 0 0 80 23 1 bottom :0 \"ejc3-mac\""],

--- a/cmuxTests/RenderableSystemSymbolTests.swift
+++ b/cmuxTests/RenderableSystemSymbolTests.swift
@@ -45,7 +45,15 @@ struct RenderableSystemSymbolTests {
             weight: .medium
         ))
         #expect(image.isTemplate)
-        #expect(image.size == NSSize(width: 1, height: 1))
+        // pointSize 0 is clamped to 1pt before rasterizing. The raster size AppKit hands back
+        // for a 1pt symbol is a platform detail (2x2 on macOS 15.7 and 26.5), so compare
+        // against a 1pt configuration rather than hardcoding it. Without the clamp the 0pt
+        // configuration rasterizes at the symbol's default 16x16 and this still fails.
+        let clampedBase = try #require(NSImage(systemSymbolName: "questionmark.circle", accessibilityDescription: nil))
+        let clampedConfiguration = NSImage.SymbolConfiguration(pointSize: 1, weight: .medium)
+        let clampedImage = try #require(clampedBase.withSymbolConfiguration(clampedConfiguration))
+        #expect(clampedImage.size.width > 0 && clampedImage.size.height > 0)
+        #expect(image.size == clampedImage.size)
     }
 
     @Test @MainActor func configuredAppKitImagePreservesConfiguredSizeForNonSquareSymbols() throws {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -3380,6 +3380,18 @@ final class TabManagerFocusedNotificationIndicatorTests: XCTestCase {
 
         workspace.focusPanel(leftPanelId)
 
+        // Focus lands synchronously, but the dismissal it triggers rides the
+        // `.ghosttyDidFocusSurface` broadcast: `FocusSurfaceBroadcaster` defers the post to a
+        // later main-queue turn (issue #5100) and `TabManager` observes it on
+        // `OperationQueue.main`, one hop further out. Wait for the dismissal itself, then assert
+        // what it produced.
+        XCTAssertTrue(
+            waitForCondition {
+                !store.hasUnreadNotification(forTabId: workspace.id, surfaceId: leftPanelId)
+            },
+            "Focusing a pane with an unread notification should dismiss it"
+        )
+
         XCTAssertEqual(workspace.focusedPanelId, leftPanelId)
         XCTAssertFalse(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: leftPanelId))
         XCTAssertFalse(store.hasVisibleNotificationIndicator(forTabId: workspace.id, surfaceId: leftPanelId))

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1611,7 +1611,7 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertEqual(invalidPrimaryStore.activeSourcePath, primaryURL.path)
     }
 
-    func testPersistedShortcutOverridesSettingsFileShortcutValues() throws {
+    func testSettingsFileShortcutOverridesPersistedShortcutValues() throws {
         let directoryURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
 
@@ -1638,9 +1638,12 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
             startWatching: false
         )
 
+        // A binding in cmux.json outranks a shortcut saved through Settings: the file
+        // owns the action for as long as it defines it, and Settings reports the row as
+        // managed (and disables its recorder) instead of editing it.
         XCTAssertEqual(
             KeyboardShortcutSettings.shortcut(for: .newTab),
-            StoredShortcut(key: "n", command: true, shift: false, option: false, control: false)
+            StoredShortcut(key: "b", command: false, shift: false, option: false, control: true, chordKey: "c")
         )
         XCTAssertTrue(KeyboardShortcutSettings.isManagedBySettingsFile(.newTab))
     }
@@ -1798,13 +1801,15 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
 #endif
     }
 
-    func testSettingsFileShortcutCanBeOverriddenFromUI() throws {
+    func testSettingsFileShortcutCannotBeOverriddenFromUI() throws {
         let directoryURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }
 
         let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
         let missingSettingsFileURL = directoryURL.appendingPathComponent("missing.json", isDirectory: false)
-        let editedShortcut = StoredShortcut(key: "n", command: true, shift: false, option: false, control: false)
+        // Distinct from newTab's built-in cmd+n so the closing assertion can tell a
+        // refused write apart from one that persisted but was outranked.
+        let editedShortcut = StoredShortcut(key: "j", command: true, shift: false, option: true, control: false)
         let managedShortcut = StoredShortcut(key: "b", command: false, shift: false, option: false, control: true, chordKey: "c")
 
         try writeSettingsFile(
@@ -1831,7 +1836,10 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
             for: .newTab
         )
 
-        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .newTab), editedShortcut)
+        // The Settings row for a file-managed action is disabled and subtitled
+        // "Managed in cmux.json", and setShortcut refuses the write behind it, so the
+        // file's chord stays in effect.
+        XCTAssertEqual(KeyboardShortcutSettings.shortcut(for: .newTab), managedShortcut)
 
         KeyboardShortcutSettings.resetShortcut(for: .newTab)
 


### PR DESCRIPTION
## What this is

Twenty suites in the pre-existing red set fail for reasons inside the tests rather than in the product. Each one is repaired here and verified individually on a macOS builder, before and after.

One of them was doing damage beyond itself. `MarkdownPanelTests` fulfilled a one-shot `XCTestExpectation` twice, because `WKNavigationDelegate` can report a provisional failure and then a finish for a single load. The second `fulfill()` raises XCTest's API-violation `NSException` from inside a suspended `await fulfillment`, which does not fail a test: it takes the shared app host down, and every suite batched with it goes too. So this suite was corrupting other suites' results as well as its own, which is worth knowing for anyone reading a batched run.

## The recurring shapes

- **Oracles that could be satisfied before the operation started.** A wait predicate read a published mirror that is set synchronously at construction, so it returned immediately and the assertions ran against startup state. These now read state that only exists once the operation commits.
- **Fixtures that could not reach the state the test described.** In one case the test waited for back-navigation to be available with a single committed history entry, which WebKit never provides, so the wait was unsatisfiable rather than slow. The fixture now commits a page behind the one under test.
- **Expectations pinned to machine-dependent values** — a resolver path, a config directory, a bundled binary layout — instead of deriving them the way the product does.
- **Shared global state left behind** for whatever test ran next in the same host.
- **Assertions pinning a model the product deliberately retired.** `KeyboardShortcutSettingsFileStoreTests` asserted that a shortcut saved through Settings outranks one bound in `cmux.json`. The product went the other way on purpose: a file-managed action is authoritative and read-only, with file-first lookup, refused writes, and a Settings row that reports itself managed rather than editable. Restoring the old order would let stale user-defaults residue shadow what the UI writes. The tests now pin the current model, which is what they were for.

## Verification

Not a bulk claim. Each suite was run through the app host and read from log content, and the later commits were verified on the combined branch rather than in isolation, so the whole set is proven together.

| suite | before | after |
|---|---|---|
| AgentChatSessionRegistryObservationTests | failing | passing |
| BrowserDownloadFilenameResolverTests | failing | passing |
| BrowserPanelDiffViewerSchemeTests | failing | passing |
| BrowserPanelRemoteStoreTests | failing | passing |
| BrowserPanelVisualAutomationRestoreHostTests | failing | passing |
| BrowserPortalOmnibarSuggestionsTests | failing | passing |
| BrowserSessionHistoryRestoreTests | failing | passing |
| BrowserWebContentProcessTests | failing | passing |
| BundledCLILinkageTests | failing | passing |
| ClaudeConfigDirectoryPathTests | failing | passing |
| CmuxConfigNewWorkspaceMenuTests | failing | passing |
| CrashDiagnosticSessionPolicyTests | failing | passing |
| FileSearchControllerTests | failing | passing |
| CLIHookNoResponseTests | failing | passing |
| CmuxDurableDeepLinkRestoreTests | failing | passing |
| MarkdownPanelTests | failing (and killing the host) | passing |
| KeyboardShortcutSettingsFileStoreTests | failing | passing |
| RemoteTmuxMirrorFeedForwardTests | failing | passing |
| RenderableSystemSymbolTests | failing | passing |
| TabManagerFocusedNotificationIndicatorTests | failing | passing |

Each reports a passing suite verdict with a non-zero test count. Exit status is not usable as a signal on this path: the app-host wrapper runs `xcodebuild` under `launchctl asuser`, which reports its own status rather than the child's, so a failed build comes back `rc=0` with an empty summary.

## The one non-test file

`Sources/Panels/BrowserDownloadFilenameResolver.swift` splits the quarantine-properties dictionary out of `cmuxApplyWebDownloadQuarantine` into a static function that returns it. The write path calls that function and returns early on `nil` exactly where it used to, so the behavior is unchanged; the point is that a test can now read the properties it would have written without writing a file first.

## What is deliberately not here

Suites whose failure needs a product change are left alone rather than bent to green; those go out as separate focused PRs. Ten suites in the same sweep are still failing after their patch, and they are being read individually rather than re-guessed: the two `BrowserDiscardedWebViewRestoreRetry*` suites, `BrowserDeveloperToolsConfigurationTests`, `CLIRemoteShellStartupPerformanceTests`, `KeyboardShortcutSettingsFileStoreMigrationTests`, `RemoteTmuxConnectionWindowSizingTests`, `SidebarLazyLayoutScaleTests`, `TerminalControllerSocketSecurityTests`, `TerminalOffscreenStartupTests`, and `TerminalSearchOverlayMouseReleaseTests`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata handling for downloads from remote websites, helping downloaded files retain accurate source information.
  * Ensured configured keyboard shortcuts remain authoritative and cannot be unintentionally overridden through the UI.
  * Improved browser navigation, loading-state synchronization, WebAuthn handling, and popup restoration reliability.
  * Made resume commands safer when working with configured or missing directories.

* **Tests**
  * Expanded coverage for browser behavior, deep-link restoration, crash diagnostics, workspace menus, file watching, and remote pane synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->