### PR TITLE
Fix main build on Xcode 26.6: drop convenience from CmuxGit actor init

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -60,7 +60,7 @@ public actor GitHubPullRequestRequestCoordinator {
     /// `PullRequestProbeService(requestCoordinator:)`. The session and cache
     /// tuning knobs stay internal (tests reach that initializer through
     /// `@testable import`), keeping the public surface to a plain default.
-    public convenience init() {
+    public init() {
         self.init(session: nil)
     }
 


### PR DESCRIPTION
Current main fails to compile the macOS app on Xcode 26.6 (locally and on Blacksmith reload runners):

```
Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift:63:24: error: initializers in actors are not marked with 'convenience'
```

The `public convenience init()` came in with https://github.com/manaflow-ai/cmux/pull/8521 while PR CI was disabled, so nothing caught it. Swift 6 mode rejects `convenience` on actor initializers; delegation has not needed the keyword since Swift 5.7 (SE-0327), so dropping it also compiles on older toolchains. One-word change, no behavior difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787273749&installation_model_id=21920&pr_number=8616&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8616&signature=2aa62e91c5361da7f95f1d3271552448fa9654436d33cfec352288ac8fdbe8f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS app build on Xcode 26.6 by removing `convenience` from the `GitHubPullRequestRequestCoordinator` actor initializer. Restores Swift 6 compatibility with no behavior changes and remains compatible with Swift 5.7+.

<sup>Written for commit 69210e3dfb263e8d64159503ad50a250e495bbea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization behavior for GitHub pull request data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->