### PR TITLE
Fix legacy browser theme migration

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -145,19 +145,20 @@ enum BrowserThemeSettings {
     }
 
     static func mode(defaults: UserDefaults = .standard) -> BrowserThemeMode {
-        let resolvedMode = mode(for: defaults.string(forKey: modeKey))
-        if defaults.string(forKey: modeKey) != nil {
-            return resolvedMode
-        }
+        mode(for: defaults.string(forKey: modeKey))
+    }
 
-        // Migrate the legacy bool toggle only when the new mode key is unset.
-        if defaults.object(forKey: legacyForcedDarkModeEnabledKey) != nil {
-            let migratedMode: BrowserThemeMode = defaults.bool(forKey: legacyForcedDarkModeEnabledKey) ? .dark : .system
-            defaults.set(migratedMode.rawValue, forKey: modeKey)
-            return migratedMode
-        }
+    static func migrateLegacyModeIfNeeded(
+        defaults: UserDefaults,
+        persistentDomain: [String: Any]
+    ) {
+        // Registration-domain fallbacks must not count as a persisted new setting.
+        guard persistentDomain[modeKey] == nil,
+              let legacyEnabled = persistentDomain[legacyForcedDarkModeEnabledKey] as? Bool
+        else { return }
 
-        return defaultMode
+        let migratedMode: BrowserThemeMode = legacyEnabled ? .dark : .system
+        defaults.set(migratedMode.rawValue, forKey: modeKey)
     }
 
     static func apply(_ mode: BrowserThemeMode, to webView: WKWebView) {
@@ -3915,11 +3916,23 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     /// Registers fallback defaults and writes back canonical values for any stored
-    /// browser setting whose raw value is legacy or out of range.
+    /// browser setting whose raw value is legacy or out of range. The persistent
+    /// domain name keeps migrations distinct from process-wide registered defaults.
     ///
     /// Pure with respect to the injected `defaults`, so it is unit-testable against
     /// a scratch `UserDefaults(suiteName:)` without touching `UserDefaults.standard`.
-    static func normalizeBrowserDefaults(defaults: UserDefaults) {
+    static func normalizeBrowserDefaults(
+        defaults: UserDefaults,
+        persistentDomainName: String? = Bundle.main.bundleIdentifier
+    ) {
+        let persistentDomain = persistentDomainName
+            .flatMap { defaults.persistentDomain(forName: $0) }
+            ?? [:]
+        BrowserThemeSettings.migrateLegacyModeIfNeeded(
+            defaults: defaults,
+            persistentDomain: persistentDomain
+        )
+
         defaults.register(defaults: [
             BrowserSearchSettingsStore.searchEngineKey: BrowserSearchSettingsStore.defaultSearchEngine.rawValue,
             BrowserSearchSettingsStore.customSearchEngineNameKey: BrowserSearchSettingsStore.defaultCustomSearchEngineName,

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1778,46 +1778,75 @@ final class BrowserDevToolsButtonDebugSettingsTests: XCTestCase {
 }
 
 
-final class BrowserThemeSettingsTests: XCTestCase {
-    private func makeIsolatedDefaults() -> UserDefaults {
+@Suite
+struct BrowserThemeSettingsTests {
+    private func makeIsolatedDefaults() throws -> (defaults: UserDefaults, suiteName: String) {
         let suiteName = "BrowserThemeSettingsTests.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            fatalError("Failed to create defaults suite")
-        }
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
-        addTeardownBlock {
-            defaults.removePersistentDomain(forName: suiteName)
-        }
-        return defaults
+        return (defaults, suiteName)
     }
 
-    func testDefaultsMatchConfiguredFallbacks() {
-        let defaults = makeIsolatedDefaults()
-        XCTAssertEqual(
-            BrowserThemeSettings.mode(defaults: defaults),
-            BrowserThemeSettings.defaultMode
+    @Test
+    func defaultsMatchConfiguredFallbacks() throws {
+        let fixture = try makeIsolatedDefaults()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == BrowserThemeSettings.defaultMode)
+    }
+
+    @Test
+    func modeReadsPersistedValue() throws {
+        let fixture = try makeIsolatedDefaults()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        fixture.defaults.set(BrowserThemeMode.dark.rawValue, forKey: BrowserThemeSettings.modeKey)
+        #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == .dark)
+
+        fixture.defaults.set(BrowserThemeMode.light.rawValue, forKey: BrowserThemeSettings.modeKey)
+        #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == .light)
+    }
+
+    @Test
+    func normalizationMigratesLegacyForcedDarkModeFlagDespiteRegisteredFallback() throws {
+        let fixture = try makeIsolatedDefaults()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+
+        fixture.defaults.register(defaults: [
+            BrowserThemeSettings.modeKey: BrowserThemeSettings.defaultMode.rawValue,
+        ])
+        fixture.defaults.set(true, forKey: BrowserThemeSettings.legacyForcedDarkModeEnabledKey)
+
+        BrowserPanel.normalizeBrowserDefaults(
+            defaults: fixture.defaults,
+            persistentDomainName: fixture.suiteName
         )
+
+        #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == .dark)
+        #expect(fixture.defaults.string(forKey: BrowserThemeSettings.modeKey) == BrowserThemeMode.dark.rawValue)
     }
 
-    func testModeReadsPersistedValue() {
-        let defaults = makeIsolatedDefaults()
-        defaults.set(BrowserThemeMode.dark.rawValue, forKey: BrowserThemeSettings.modeKey)
-        XCTAssertEqual(BrowserThemeSettings.mode(defaults: defaults), .dark)
+    @Test
+    func normalizationPreservesPersistedModeOverLegacyFlag() throws {
+        let fixture = try makeIsolatedDefaults()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
 
-        defaults.set(BrowserThemeMode.light.rawValue, forKey: BrowserThemeSettings.modeKey)
-        XCTAssertEqual(BrowserThemeSettings.mode(defaults: defaults), .light)
+        fixture.defaults.set(BrowserThemeMode.system.rawValue, forKey: BrowserThemeSettings.modeKey)
+        fixture.defaults.set(true, forKey: BrowserThemeSettings.legacyForcedDarkModeEnabledKey)
+
+        BrowserPanel.normalizeBrowserDefaults(
+            defaults: fixture.defaults,
+            persistentDomainName: fixture.suiteName
+        )
+
+        #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == .system)
+        #expect(fixture.defaults.string(forKey: BrowserThemeSettings.modeKey) == BrowserThemeMode.system.rawValue)
     }
+}
 
-    func testModeMigratesLegacyForcedDarkModeFlag() {
-        let defaults = makeIsolatedDefaults()
-        defaults.set(true, forKey: BrowserThemeSettings.legacyForcedDarkModeEnabledKey)
-        XCTAssertEqual(BrowserThemeSettings.mode(defaults: defaults), .dark)
-        XCTAssertEqual(defaults.string(forKey: BrowserThemeSettings.modeKey), BrowserThemeMode.dark.rawValue)
-
-        let otherDefaults = makeIsolatedDefaults()
-        otherDefaults.set(false, forKey: BrowserThemeSettings.legacyForcedDarkModeEnabledKey)
-        XCTAssertEqual(BrowserThemeSettings.mode(defaults: otherDefaults), .system)
-        XCTAssertEqual(otherDefaults.string(forKey: BrowserThemeSettings.modeKey), BrowserThemeMode.system.rawValue)
+private extension BrowserPanel {
+    static func normalizeBrowserDefaults(defaults: UserDefaults, persistentDomainName _: String) {
+        normalizeBrowserDefaults(defaults: defaults)
     }
 }
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1809,21 +1809,27 @@ struct BrowserThemeSettingsTests {
 
     @Test
     func normalizationMigratesLegacyForcedDarkModeFlagDespiteRegisteredFallback() throws {
-        let fixture = try makeIsolatedDefaults()
-        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        for legacyEnabled in [true, false] {
+            let fixture = try makeIsolatedDefaults()
+            defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
 
-        fixture.defaults.register(defaults: [
-            BrowserThemeSettings.modeKey: BrowserThemeSettings.defaultMode.rawValue,
-        ])
-        fixture.defaults.set(true, forKey: BrowserThemeSettings.legacyForcedDarkModeEnabledKey)
+            fixture.defaults.register(defaults: [
+                BrowserThemeSettings.modeKey: BrowserThemeSettings.defaultMode.rawValue,
+            ])
+            fixture.defaults.set(legacyEnabled, forKey: BrowserThemeSettings.legacyForcedDarkModeEnabledKey)
 
-        BrowserPanel.normalizeBrowserDefaults(
-            defaults: fixture.defaults,
-            persistentDomainName: fixture.suiteName
-        )
+            BrowserPanel.normalizeBrowserDefaults(
+                defaults: fixture.defaults,
+                persistentDomainName: fixture.suiteName
+            )
 
-        #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == .dark)
-        #expect(fixture.defaults.string(forKey: BrowserThemeSettings.modeKey) == BrowserThemeMode.dark.rawValue)
+            let expectedMode: BrowserThemeMode = legacyEnabled ? .dark : .system
+            let persistedMode = fixture.defaults.persistentDomain(forName: fixture.suiteName)?[
+                BrowserThemeSettings.modeKey
+            ] as? String
+            #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == expectedMode)
+            #expect(persistedMode == expectedMode.rawValue)
+        }
     }
 
     @Test
@@ -1841,12 +1847,6 @@ struct BrowserThemeSettingsTests {
 
         #expect(BrowserThemeSettings.mode(defaults: fixture.defaults) == .system)
         #expect(fixture.defaults.string(forKey: BrowserThemeSettings.modeKey) == BrowserThemeMode.system.rawValue)
-    }
-}
-
-private extension BrowserPanel {
-    static func normalizeBrowserDefaults(defaults: UserDefaults, persistentDomainName _: String) {
-        normalizeBrowserDefaults(defaults: defaults)
     }
 }
 


### PR DESCRIPTION
## Summary

- Preserve the legacy `browserForcedDarkModeEnabled` upgrade path even when `browserThemeMode` has a process-wide registered fallback.
- Treat an explicitly persisted `browserThemeMode` as authoritative over the legacy boolean.
- Convert `BrowserThemeSettingsTests` to Swift Testing and cover both migration values plus persisted-setting precedence.

Root cause: `BrowserPanel.normalizeBrowserDefaults` registered `browserThemeMode = system` before migration. `UserDefaults.string(forKey:)` therefore saw the registration-domain fallback as though the new key already existed, making the legacy branch unreachable.

Commit `392d262f4a` is the deliberately failing regression checkpoint. The following commit moves migration into production normalization and bases precedence on the persistent domain rather than the effective registered value.

## Testing

| suite | before | class | after-evidence |
|---|---|---|---|
| `BrowserThemeSettingsTests` | Catalog: RED, legacy migration dead; local shared baseline rerun blocked because `/tmp/cmux-8565-baseline-dd/Build/Products/Debug/cmux DEV.app` contains no executable | product-bug | Pending local `build-for-testing`, 3 isolated green runs, and tagged app launch |

- Local build/test validation is queued under the issue-wide three-slot and 20 GB free-disk protocol.
- The requested `scripts/swift_file_length_budget.py` is absent from base commit `4daa93725694`; no budget files were changed.

## Demo Video

- Not applicable: this is startup defaults migration with no new UI.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed for this migration fix)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [x] All human review comments are resolved (none received)

Part of #8565
