### PR TITLE
Fix workspace shortcuts from hosted tmux terminals

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -765,8 +765,12 @@ func cmuxOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
     cmuxOwningGhosttyView(for: responder, includingHostedSurfaceDescendants: false)
 }
 
-func cmuxTerminalKeyEquivalentOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
+func cmuxTerminalFocusOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
     cmuxOwningGhosttyView(for: responder, includingHostedSurfaceDescendants: true)
+}
+
+func cmuxTerminalKeyEquivalentOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
+    cmuxTerminalFocusOwningGhosttyView(for: responder)
 }
 
 private func cmuxOwningGhosttyView(

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -762,20 +762,37 @@ func shouldRouteInlineVSCodeCommandPaletteShortcutThroughWebContentFirst(
 }
 
 func cmuxOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
+    cmuxOwningGhosttyView(for: responder, includingHostedSurfaceDescendants: false)
+}
+
+func cmuxTerminalKeyEquivalentOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
+    cmuxOwningGhosttyView(for: responder, includingHostedSurfaceDescendants: true)
+}
+
+private func cmuxOwningGhosttyView(
+    for responder: NSResponder?,
+    includingHostedSurfaceDescendants: Bool
+) -> GhosttyNSView? {
     guard let responder else { return nil }
     if let ghosttyView = responder as? GhosttyNSView {
         return ghosttyView
     }
 
     if let view = responder as? NSView,
-       let ghosttyView = cmuxOwningGhosttyView(for: view) {
+       let ghosttyView = cmuxOwningGhosttyView(
+           for: view,
+           includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
+       ) {
         return ghosttyView
     }
 
     if let textView = responder as? NSTextView {
         if textView.isFieldEditor,
            let ownerView = cmuxFieldEditorOwnerView(textView),
-           let ghosttyView = cmuxOwningGhosttyView(for: ownerView) {
+           let ghosttyView = cmuxOwningGhosttyView(
+               for: ownerView,
+               includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
+           ) {
             return ghosttyView
         }
     }
@@ -786,7 +803,10 @@ func cmuxOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
             return ghosttyView
         }
         if let view = next as? NSView,
-           let ghosttyView = cmuxOwningGhosttyView(for: view) {
+           let ghosttyView = cmuxOwningGhosttyView(
+               for: view,
+               includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
+           ) {
             return ghosttyView
         }
         current = next.nextResponder
@@ -809,7 +829,10 @@ func cmuxFieldEditorOwnerView(_ editor: NSTextView) -> NSView? {
     return editor.superview
 }
 
-private func cmuxOwningGhosttyView(for view: NSView) -> GhosttyNSView? {
+private func cmuxOwningGhosttyView(
+    for view: NSView,
+    includingHostedSurfaceDescendants: Bool
+) -> GhosttyNSView? {
     if let ghosttyView = view as? GhosttyNSView {
         return ghosttyView
     }
@@ -818,6 +841,10 @@ private func cmuxOwningGhosttyView(for view: NSView) -> GhosttyNSView? {
     while let candidate = current {
         if let ghosttyView = candidate as? GhosttyNSView {
             return ghosttyView
+        }
+        if includingHostedSurfaceDescendants,
+           let hostedView = candidate as? GhosttySurfaceScrollView {
+            return hostedView.surfaceView
         }
         current = candidate.superview
     }

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -761,93 +761,107 @@ func shouldRouteInlineVSCodeCommandPaletteShortcutThroughWebContentFirst(
     return shortcutForAction(.commandPalette).matches(event: event)
 }
 
-enum CmuxGhosttyResponderResolution {
+extension NSResponder {
     /// Strict owner lookup for direct Ghostty responder chains, sidebar ownership,
     /// and call sites that must not treat hosted surface descendants as Ghostty.
-    static func strictOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
-        owningGhosttyView(for: responder, includingHostedSurfaceDescendants: false)
+    func cmuxStrictOwningGhosttyView() -> GhosttyNSView? {
+        cmuxOwningGhosttyView(for: self, includingHostedSurfaceDescendants: false)
     }
 
     /// Terminal focus lookup for AppKit responders hosted below
     /// GhosttySurfaceScrollView, where keyboard focus still belongs to Ghostty.
-    static func terminalFocusOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
-        owningGhosttyView(for: responder, includingHostedSurfaceDescendants: true)
+    func cmuxTerminalFocusOwningGhosttyView() -> GhosttyNSView? {
+        cmuxOwningGhosttyView(for: self, includingHostedSurfaceDescendants: true)
     }
 
     /// Terminal key-equivalent routing lookup; hosted surface descendants should
     /// count as terminal-owned so app shortcuts can be repaired or forwarded.
-    static func terminalKeyEquivalentOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
-        terminalFocusOwningGhosttyView(for: responder)
+    func cmuxTerminalKeyEquivalentOwningGhosttyView() -> GhosttyNSView? {
+        cmuxTerminalFocusOwningGhosttyView()
+    }
+}
+
+extension Optional where Wrapped: NSResponder {
+    func cmuxStrictOwningGhosttyView() -> GhosttyNSView? {
+        self?.cmuxStrictOwningGhosttyView()
     }
 
-    private static func owningGhosttyView(
-        for responder: NSResponder?,
-        includingHostedSurfaceDescendants: Bool
-    ) -> GhosttyNSView? {
-        guard let responder else { return nil }
-        if let ghosttyView = responder as? GhosttyNSView {
+    func cmuxTerminalFocusOwningGhosttyView() -> GhosttyNSView? {
+        self?.cmuxTerminalFocusOwningGhosttyView()
+    }
+
+    func cmuxTerminalKeyEquivalentOwningGhosttyView() -> GhosttyNSView? {
+        self?.cmuxTerminalKeyEquivalentOwningGhosttyView()
+    }
+}
+
+private func cmuxOwningGhosttyView(
+    for responder: NSResponder?,
+    includingHostedSurfaceDescendants: Bool
+) -> GhosttyNSView? {
+    guard let responder else { return nil }
+    if let ghosttyView = responder as? GhosttyNSView {
+        return ghosttyView
+    }
+
+    if let view = responder as? NSView,
+       let ghosttyView = cmuxOwningGhosttyView(
+           for: view,
+           includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
+       ) {
+        return ghosttyView
+    }
+
+    if let textView = responder as? NSTextView {
+        if textView.isFieldEditor,
+           let ownerView = cmuxFieldEditorOwnerView(textView),
+           let ghosttyView = cmuxOwningGhosttyView(
+               for: ownerView,
+               includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
+           ) {
             return ghosttyView
         }
+    }
 
-        if let view = responder as? NSView,
-           let ghosttyView = owningGhosttyView(
+    var current = responder.nextResponder
+    while let next = current {
+        if let ghosttyView = next as? GhosttyNSView {
+            return ghosttyView
+        }
+        if let view = next as? NSView,
+           let ghosttyView = cmuxOwningGhosttyView(
                for: view,
                includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
            ) {
             return ghosttyView
         }
-
-        if let textView = responder as? NSTextView {
-            if textView.isFieldEditor,
-               let ownerView = cmuxFieldEditorOwnerView(textView),
-               let ghosttyView = owningGhosttyView(
-                   for: ownerView,
-                   includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
-               ) {
-                return ghosttyView
-            }
-        }
-
-        var current = responder.nextResponder
-        while let next = current {
-            if let ghosttyView = next as? GhosttyNSView {
-                return ghosttyView
-            }
-            if let view = next as? NSView,
-               let ghosttyView = owningGhosttyView(
-                   for: view,
-                   includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
-               ) {
-                return ghosttyView
-            }
-            current = next.nextResponder
-        }
-
-        return nil
+        current = next.nextResponder
     }
 
-    private static func owningGhosttyView(
-        for view: NSView,
-        includingHostedSurfaceDescendants: Bool
-    ) -> GhosttyNSView? {
-        if let ghosttyView = view as? GhosttyNSView {
+    return nil
+}
+
+private func cmuxOwningGhosttyView(
+    for view: NSView,
+    includingHostedSurfaceDescendants: Bool
+) -> GhosttyNSView? {
+    if let ghosttyView = view as? GhosttyNSView {
+        return ghosttyView
+    }
+
+    var current: NSView? = view.superview
+    while let candidate = current {
+        if let ghosttyView = candidate as? GhosttyNSView {
             return ghosttyView
         }
-
-        var current: NSView? = view.superview
-        while let candidate = current {
-            if let ghosttyView = candidate as? GhosttyNSView {
-                return ghosttyView
-            }
-            if includingHostedSurfaceDescendants,
-               let hostedView = candidate as? GhosttySurfaceScrollView {
-                return hostedView.surfaceView
-            }
-            current = candidate.superview
+        if includingHostedSurfaceDescendants,
+           let hostedView = candidate as? GhosttySurfaceScrollView {
+            return hostedView.surfaceView
         }
-
-        return nil
+        current = candidate.superview
     }
+
+    return nil
 }
 
 func cmuxFieldEditorOwnerView(_ editor: NSTextView) -> NSView? {

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -762,61 +762,96 @@ func shouldRouteInlineVSCodeCommandPaletteShortcutThroughWebContentFirst(
 }
 
 func cmuxOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
-    cmuxOwningGhosttyView(for: responder, includingHostedSurfaceDescendants: false)
+    CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder)
 }
 
-func cmuxTerminalFocusOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
-    cmuxOwningGhosttyView(for: responder, includingHostedSurfaceDescendants: true)
-}
-
-func cmuxTerminalKeyEquivalentOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
-    cmuxTerminalFocusOwningGhosttyView(for: responder)
-}
-
-private func cmuxOwningGhosttyView(
-    for responder: NSResponder?,
-    includingHostedSurfaceDescendants: Bool
-) -> GhosttyNSView? {
-    guard let responder else { return nil }
-    if let ghosttyView = responder as? GhosttyNSView {
-        return ghosttyView
+enum CmuxGhosttyResponderResolution {
+    /// Strict owner lookup for direct Ghostty responder chains, sidebar ownership,
+    /// and call sites that must not treat hosted surface descendants as Ghostty.
+    static func strictOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
+        owningGhosttyView(for: responder, includingHostedSurfaceDescendants: false)
     }
 
-    if let view = responder as? NSView,
-       let ghosttyView = cmuxOwningGhosttyView(
-           for: view,
-           includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
-       ) {
-        return ghosttyView
+    /// Terminal focus lookup for AppKit responders hosted below
+    /// GhosttySurfaceScrollView, where keyboard focus still belongs to Ghostty.
+    static func terminalFocusOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
+        owningGhosttyView(for: responder, includingHostedSurfaceDescendants: true)
     }
 
-    if let textView = responder as? NSTextView {
-        if textView.isFieldEditor,
-           let ownerView = cmuxFieldEditorOwnerView(textView),
-           let ghosttyView = cmuxOwningGhosttyView(
-               for: ownerView,
-               includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
-           ) {
+    /// Terminal key-equivalent routing lookup; hosted surface descendants should
+    /// count as terminal-owned so app shortcuts can be repaired or forwarded.
+    static func terminalKeyEquivalentOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
+        terminalFocusOwningGhosttyView(for: responder)
+    }
+
+    private static func owningGhosttyView(
+        for responder: NSResponder?,
+        includingHostedSurfaceDescendants: Bool
+    ) -> GhosttyNSView? {
+        guard let responder else { return nil }
+        if let ghosttyView = responder as? GhosttyNSView {
             return ghosttyView
         }
-    }
 
-    var current = responder.nextResponder
-    while let next = current {
-        if let ghosttyView = next as? GhosttyNSView {
-            return ghosttyView
-        }
-        if let view = next as? NSView,
-           let ghosttyView = cmuxOwningGhosttyView(
+        if let view = responder as? NSView,
+           let ghosttyView = owningGhosttyView(
                for: view,
                includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
            ) {
             return ghosttyView
         }
-        current = next.nextResponder
+
+        if let textView = responder as? NSTextView {
+            if textView.isFieldEditor,
+               let ownerView = cmuxFieldEditorOwnerView(textView),
+               let ghosttyView = owningGhosttyView(
+                   for: ownerView,
+                   includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
+               ) {
+                return ghosttyView
+            }
+        }
+
+        var current = responder.nextResponder
+        while let next = current {
+            if let ghosttyView = next as? GhosttyNSView {
+                return ghosttyView
+            }
+            if let view = next as? NSView,
+               let ghosttyView = owningGhosttyView(
+                   for: view,
+                   includingHostedSurfaceDescendants: includingHostedSurfaceDescendants
+               ) {
+                return ghosttyView
+            }
+            current = next.nextResponder
+        }
+
+        return nil
     }
 
-    return nil
+    private static func owningGhosttyView(
+        for view: NSView,
+        includingHostedSurfaceDescendants: Bool
+    ) -> GhosttyNSView? {
+        if let ghosttyView = view as? GhosttyNSView {
+            return ghosttyView
+        }
+
+        var current: NSView? = view.superview
+        while let candidate = current {
+            if let ghosttyView = candidate as? GhosttyNSView {
+                return ghosttyView
+            }
+            if includingHostedSurfaceDescendants,
+               let hostedView = candidate as? GhosttySurfaceScrollView {
+                return hostedView.surfaceView
+            }
+            current = candidate.superview
+        }
+
+        return nil
+    }
 }
 
 func cmuxFieldEditorOwnerView(_ editor: NSTextView) -> NSView? {
@@ -831,29 +866,6 @@ func cmuxFieldEditorOwnerView(_ editor: NSTextView) -> NSView? {
     }
 
     return editor.superview
-}
-
-private func cmuxOwningGhosttyView(
-    for view: NSView,
-    includingHostedSurfaceDescendants: Bool
-) -> GhosttyNSView? {
-    if let ghosttyView = view as? GhosttyNSView {
-        return ghosttyView
-    }
-
-    var current: NSView? = view.superview
-    while let candidate = current {
-        if let ghosttyView = candidate as? GhosttyNSView {
-            return ghosttyView
-        }
-        if includingHostedSurfaceDescendants,
-           let hostedView = candidate as? GhosttySurfaceScrollView {
-            return hostedView.surfaceView
-        }
-        current = candidate.superview
-    }
-
-    return nil
 }
 
 #if DEBUG

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -761,10 +761,6 @@ func shouldRouteInlineVSCodeCommandPaletteShortcutThroughWebContentFirst(
     return shortcutForAction(.commandPalette).matches(event: event)
 }
 
-func cmuxOwningGhosttyView(for responder: NSResponder?) -> GhosttyNSView? {
-    CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder)
-}
-
 enum CmuxGhosttyResponderResolution {
     /// Strict owner lookup for direct Ghostty responder chains, sidebar ownership,
     /// and call sites that must not treat hosted surface descendants as Ghostty.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6760,7 +6760,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     fileprivate func terminalKeyboardFocusRequest(for responder: NSResponder?) -> TerminalKeyboardFocusRequest? {
-        guard let ghosttyView = cmuxTerminalFocusOwningGhosttyView(for: responder),
+        guard let ghosttyView = CmuxGhosttyResponderResolution.terminalFocusOwningGhosttyView(for: responder),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id else {
             return nil
@@ -16935,7 +16935,8 @@ private extension NSWindow {
         // When a terminal owns first responder, bypass SwiftUI's hosting view:
         // after browser focus churn it can claim key equivalents without firing.
         // Non-Command keys go to Ghostty; Command keys go to the main menu.
-        let firstResponderGhosttyView = cmuxTerminalKeyEquivalentOwningGhosttyView(for: self.firstResponder)
+        let firstResponderGhosttyView = CmuxGhosttyResponderResolution
+            .terminalKeyEquivalentOwningGhosttyView(for: self.firstResponder)
         let firstResponderWebView = self.firstResponder.flatMap {
             Self.cmuxOwningWebView(for: $0, in: self, event: event)
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6728,12 +6728,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let sidebarIntentActive = keyboardFocusCoordinator(for: window)?.activeRightSidebarMode != nil
         guard let responder = window.firstResponder else { return sidebarIntentActive }
         if isRightSidebarFocusResponder(responder, in: window) { return true }
-        if sidebarIntentActive {
-            if responder is NSWindow { return true }
-            if cmuxTerminalKeyEquivalentOwningGhosttyView(for: responder) != nil {
-                return true
-            }
-        }
+        if sidebarIntentActive, responder is NSWindow { return true }
         if terminalKeyboardFocusRequest(for: responder) != nil { return false }
         guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
               let panelId = ghosttyView.terminalSurface?.id else { return false }
@@ -6765,7 +6760,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     fileprivate func terminalKeyboardFocusRequest(for responder: NSResponder?) -> TerminalKeyboardFocusRequest? {
-        guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
+        guard let ghosttyView = cmuxTerminalFocusOwningGhosttyView(for: responder),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id else {
             return nil

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5365,7 +5365,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         _ responder: NSResponder,
         in window: NSWindow
     ) -> Bool {
-        if let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) {
+        if let ghosttyView = responder.cmuxStrictOwningGhosttyView() {
             if ghosttyView.window !== window {
                 return false
             }
@@ -6428,7 +6428,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func focusedTerminalShortcutContext(preferredWindow: NSWindow? = nil) -> FocusedTerminalShortcutContext? {
         let targetWindow = preferredWindow ?? shortcutRoutingActiveWindow
         let responder = shortcutRoutingFirstResponder(preferredWindow: targetWindow)
-        guard let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder),
+        guard let ghosttyView = responder.cmuxStrictOwningGhosttyView(),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id,
               let manager = resolveShortcutTabManager(for: workspaceId, preferredWindow: targetWindow) else {
@@ -6730,7 +6730,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if isRightSidebarFocusResponder(responder, in: window) { return true }
         if sidebarIntentActive, responder is NSWindow { return true }
         if terminalKeyboardFocusRequest(for: responder) != nil { return false }
-        guard let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder),
+        guard let ghosttyView = responder.cmuxStrictOwningGhosttyView(),
               let panelId = ghosttyView.terminalSurface?.id else { return false }
         return GhosttyApp.terminalSurfaceRegistry.isRightSidebarDockSurface(id: panelId)
     }
@@ -6760,7 +6760,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     fileprivate func terminalKeyboardFocusRequest(for responder: NSResponder?) -> TerminalKeyboardFocusRequest? {
-        guard let ghosttyView = CmuxGhosttyResponderResolution.terminalFocusOwningGhosttyView(for: responder),
+        guard let ghosttyView = responder.cmuxTerminalFocusOwningGhosttyView(),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id else {
             return nil
@@ -10843,8 +10843,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let currentResponder = (NSApp.keyWindow ?? NSApp.mainWindow)?.firstResponder
         updates["firstResponderTerminalPanelId"] =
-            CmuxGhosttyResponderResolution
-                .strictOwningGhosttyView(for: currentResponder)?
+            currentResponder
+                .cmuxStrictOwningGhosttyView()?
                 .terminalSurface?.id.uuidString ?? ""
 
         updates.merge(cmuxFindResponderSnapshot()) { _, new in new }
@@ -13089,8 +13089,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // (e.g., split that doesn't properly blur the address bar). If the first responder
         // is a terminal surface, the address bar can't be focused.
         if browserAddressBarFocusedPanelId != nil,
-           CmuxGhosttyResponderResolution
-               .strictOwningGhosttyView(for: shortcutRoutingKeyWindow?.firstResponder) != nil {
+           (shortcutRoutingKeyWindow?.firstResponder).cmuxStrictOwningGhosttyView() != nil {
 #if DEBUG
             let stalePanelToken = browserAddressBarFocusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
             let firstResponderType = shortcutRoutingKeyWindow?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
@@ -13166,8 +13165,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // input method. Cmd-based shortcuts (Cmd+T, Cmd+Shift+L, etc.) should still
         // work during composition since Cmd is never part of IME input sequences.
         if !normalizedFlags.contains(.command),
-           let ghosttyView = CmuxGhosttyResponderResolution
-               .strictOwningGhosttyView(for: shortcutRoutingKeyWindow?.firstResponder),
+           let ghosttyView = (shortcutRoutingKeyWindow?.firstResponder).cmuxStrictOwningGhosttyView(),
            ghosttyView.hasMarkedText() {
             return false
         }
@@ -14492,7 +14490,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if browserOmnibarPanelId(for: responder) == panel.id {
             return true
         }
-        if CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) != nil {
+        if responder.cmuxStrictOwningGhosttyView() != nil {
             return false
         }
         if responder is NSTextView || responder is NSTextField {
@@ -16489,7 +16487,7 @@ private extension NSApplication {
             let responder = event.window?.firstResponder
                 ?? AppDelegate.shared?.shortcutRoutingKeyWindow?.firstResponder
                 ?? mainWindow?.firstResponder
-            if let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) {
+            if let ghosttyView = responder.cmuxStrictOwningGhosttyView() {
                 ghosttyView.keyDown(with: event)
 #if DEBUG
                 cmuxDebugLog("app.sendEvent suppressed stale cmux menu shortcut and forwarded to terminal")
@@ -16939,8 +16937,8 @@ private extension NSWindow {
         // When a terminal owns first responder, bypass SwiftUI's hosting view:
         // after browser focus churn it can claim key equivalents without firing.
         // Non-Command keys go to Ghostty; Command keys go to the main menu.
-        let firstResponderGhosttyView = CmuxGhosttyResponderResolution
-            .terminalKeyEquivalentOwningGhosttyView(for: self.firstResponder)
+        let firstResponderGhosttyView = self.firstResponder
+            .cmuxTerminalKeyEquivalentOwningGhosttyView()
         let firstResponderWebView = self.firstResponder.flatMap {
             Self.cmuxOwningWebView(for: $0, in: self, event: event)
         }
@@ -17601,7 +17599,7 @@ private extension NSWindow {
         guard let hitView = cmuxHitViewForCurrentEvent(in: window, event: event) else {
             return nil
         }
-        return CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: hitView)
+        return hitView.cmuxTerminalFocusOwningGhosttyView()
     }
 
     private static func cmuxShouldAllowPointerInitiatedTerminalFocus(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6728,6 +6728,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let sidebarIntentActive = keyboardFocusCoordinator(for: window)?.activeRightSidebarMode != nil
         guard let responder = window.firstResponder else { return sidebarIntentActive }
         if isRightSidebarFocusResponder(responder, in: window) { return true }
+        if sidebarIntentActive {
+            if responder is NSWindow { return true }
+            if cmuxTerminalKeyEquivalentOwningGhosttyView(for: responder) != nil {
+                return true
+            }
+        }
         if terminalKeyboardFocusRequest(for: responder) != nil { return false }
         guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
               let panelId = ghosttyView.terminalSurface?.id else { return false }
@@ -16934,7 +16940,7 @@ private extension NSWindow {
         // When a terminal owns first responder, bypass SwiftUI's hosting view:
         // after browser focus churn it can claim key equivalents without firing.
         // Non-Command keys go to Ghostty; Command keys go to the main menu.
-        let firstResponderGhosttyView = cmuxOwningGhosttyView(for: self.firstResponder)
+        let firstResponderGhosttyView = cmuxTerminalKeyEquivalentOwningGhosttyView(for: self.firstResponder)
         let firstResponderWebView = self.firstResponder.flatMap {
             Self.cmuxOwningWebView(for: $0, in: self, event: event)
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5365,7 +5365,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         _ responder: NSResponder,
         in window: NSWindow
     ) -> Bool {
-        if let ghosttyView = cmuxOwningGhosttyView(for: responder) {
+        if let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) {
             if ghosttyView.window !== window {
                 return false
             }
@@ -6428,7 +6428,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func focusedTerminalShortcutContext(preferredWindow: NSWindow? = nil) -> FocusedTerminalShortcutContext? {
         let targetWindow = preferredWindow ?? shortcutRoutingActiveWindow
         let responder = shortcutRoutingFirstResponder(preferredWindow: targetWindow)
-        guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
+        guard let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id,
               let manager = resolveShortcutTabManager(for: workspaceId, preferredWindow: targetWindow) else {
@@ -6730,7 +6730,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if isRightSidebarFocusResponder(responder, in: window) { return true }
         if sidebarIntentActive, responder is NSWindow { return true }
         if terminalKeyboardFocusRequest(for: responder) != nil { return false }
-        guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
+        guard let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder),
               let panelId = ghosttyView.terminalSurface?.id else { return false }
         return GhosttyApp.terminalSurfaceRegistry.isRightSidebarDockSurface(id: panelId)
     }
@@ -10843,7 +10843,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let currentResponder = (NSApp.keyWindow ?? NSApp.mainWindow)?.firstResponder
         updates["firstResponderTerminalPanelId"] =
-            cmuxOwningGhosttyView(for: currentResponder)?.terminalSurface?.id.uuidString ?? ""
+            CmuxGhosttyResponderResolution
+                .strictOwningGhosttyView(for: currentResponder)?
+                .terminalSurface?.id.uuidString ?? ""
 
         updates.merge(cmuxFindResponderSnapshot()) { _, new in new }
         return updates
@@ -13087,7 +13089,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // (e.g., split that doesn't properly blur the address bar). If the first responder
         // is a terminal surface, the address bar can't be focused.
         if browserAddressBarFocusedPanelId != nil,
-           cmuxOwningGhosttyView(for: shortcutRoutingKeyWindow?.firstResponder) != nil {
+           CmuxGhosttyResponderResolution
+               .strictOwningGhosttyView(for: shortcutRoutingKeyWindow?.firstResponder) != nil {
 #if DEBUG
             let stalePanelToken = browserAddressBarFocusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
             let firstResponderType = shortcutRoutingKeyWindow?.firstResponder.map { String(describing: type(of: $0)) } ?? "nil"
@@ -13163,7 +13166,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // input method. Cmd-based shortcuts (Cmd+T, Cmd+Shift+L, etc.) should still
         // work during composition since Cmd is never part of IME input sequences.
         if !normalizedFlags.contains(.command),
-           let ghosttyView = cmuxOwningGhosttyView(for: shortcutRoutingKeyWindow?.firstResponder),
+           let ghosttyView = CmuxGhosttyResponderResolution
+               .strictOwningGhosttyView(for: shortcutRoutingKeyWindow?.firstResponder),
            ghosttyView.hasMarkedText() {
             return false
         }
@@ -14488,7 +14492,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if browserOmnibarPanelId(for: responder) == panel.id {
             return true
         }
-        if cmuxOwningGhosttyView(for: responder) != nil {
+        if CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) != nil {
             return false
         }
         if responder is NSTextView || responder is NSTextField {
@@ -16485,7 +16489,7 @@ private extension NSApplication {
             let responder = event.window?.firstResponder
                 ?? AppDelegate.shared?.shortcutRoutingKeyWindow?.firstResponder
                 ?? mainWindow?.firstResponder
-            if let ghosttyView = cmuxOwningGhosttyView(for: responder) {
+            if let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) {
                 ghosttyView.keyDown(with: event)
 #if DEBUG
                 cmuxDebugLog("app.sendEvent suppressed stale cmux menu shortcut and forwarded to terminal")
@@ -17597,7 +17601,7 @@ private extension NSWindow {
         guard let hitView = cmuxHitViewForCurrentEvent(in: window, event: event) else {
             return nil
         }
-        return cmuxOwningGhosttyView(for: hitView)
+        return CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: hitView)
     }
 
     private static func cmuxShouldAllowPointerInitiatedTerminalFocus(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -16487,7 +16487,7 @@ private extension NSApplication {
             let responder = event.window?.firstResponder
                 ?? AppDelegate.shared?.shortcutRoutingKeyWindow?.firstResponder
                 ?? mainWindow?.firstResponder
-            if let ghosttyView = responder.cmuxStrictOwningGhosttyView() {
+            if let ghosttyView = responder.cmuxTerminalKeyEquivalentOwningGhosttyView() {
                 ghosttyView.keyDown(with: event)
 #if DEBUG
                 cmuxDebugLog("app.sendEvent suppressed stale cmux menu shortcut and forwarded to terminal")

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -280,7 +280,7 @@ final class DockKeyboardFocusView: NSView {
     func ownsKeyboardFocus(_ responder: NSResponder) -> Bool {
         if responder === self { return true }
         if let window, ownsDockBrowserFocus?(responder, window) == true { return true }
-        guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
+        guard let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder),
               let surfaceId = ghosttyView.terminalSurface?.id else {
             return false
         }

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -280,7 +280,7 @@ final class DockKeyboardFocusView: NSView {
     func ownsKeyboardFocus(_ responder: NSResponder) -> Bool {
         if responder === self { return true }
         if let window, ownsDockBrowserFocus?(responder, window) == true { return true }
-        guard let ghosttyView = CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder),
+        guard let ghosttyView = responder.cmuxStrictOwningGhosttyView(),
               let surfaceId = ghosttyView.terminalSurface?.id else {
             return false
         }

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -235,7 +235,7 @@ extension AppDelegate {
         }
 
         let responder = shortcutWindow.firstResponder
-        if CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) != nil {
+        if responder.cmuxStrictOwningGhosttyView() != nil {
             return nil
         }
 

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -235,7 +235,7 @@ extension AppDelegate {
         }
 
         let responder = shortcutWindow.firstResponder
-        if cmuxOwningGhosttyView(for: responder) != nil {
+        if CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: responder) != nil {
             return nil
         }
 

--- a/Sources/MainWindowFocusController.swift
+++ b/Sources/MainWindowFocusController.swift
@@ -821,7 +821,7 @@ final class MainWindowFocusController {
     }
 
     private func terminalFocusRequest(for responder: NSResponder?) -> TerminalFocusRequest? {
-        guard let ghosttyView = CmuxGhosttyResponderResolution.terminalFocusOwningGhosttyView(for: responder),
+        guard let ghosttyView = responder.cmuxTerminalFocusOwningGhosttyView(),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id else {
             return nil

--- a/Sources/MainWindowFocusController.swift
+++ b/Sources/MainWindowFocusController.swift
@@ -821,7 +821,7 @@ final class MainWindowFocusController {
     }
 
     private func terminalFocusRequest(for responder: NSResponder?) -> TerminalFocusRequest? {
-        guard let ghosttyView = cmuxOwningGhosttyView(for: responder),
+        guard let ghosttyView = cmuxTerminalFocusOwningGhosttyView(for: responder),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id else {
             return nil

--- a/Sources/MainWindowFocusController.swift
+++ b/Sources/MainWindowFocusController.swift
@@ -821,7 +821,7 @@ final class MainWindowFocusController {
     }
 
     private func terminalFocusRequest(for responder: NSResponder?) -> TerminalFocusRequest? {
-        guard let ghosttyView = cmuxTerminalFocusOwningGhosttyView(for: responder),
+        guard let ghosttyView = CmuxGhosttyResponderResolution.terminalFocusOwningGhosttyView(for: responder),
               let workspaceId = ghosttyView.tabId,
               let panelId = ghosttyView.terminalSurface?.id else {
             return nil

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8504,7 +8504,7 @@ final class Workspace: Identifiable, ObservableObject {
         // Mapping can transiently drift during split-tree mutations. If the target panel is
         // currently focused (or is the active terminal first responder), close whichever tab
         // bonsplit marks selected in that focused pane.
-        let firstResponderPanelId = cmuxOwningGhosttyView(
+        let firstResponderPanelId = CmuxGhosttyResponderResolution.strictOwningGhosttyView(
             for: NSApp.keyWindow?.firstResponder ?? NSApp.mainWindow?.firstResponder
         )?.terminalSurface?.id
         let targetIsActive = focusedPanelId == panelId || firstResponderPanelId == panelId

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8504,9 +8504,8 @@ final class Workspace: Identifiable, ObservableObject {
         // Mapping can transiently drift during split-tree mutations. If the target panel is
         // currently focused (or is the active terminal first responder), close whichever tab
         // bonsplit marks selected in that focused pane.
-        let firstResponderPanelId = CmuxGhosttyResponderResolution.strictOwningGhosttyView(
-            for: NSApp.keyWindow?.firstResponder ?? NSApp.mainWindow?.firstResponder
-        )?.terminalSurface?.id
+        let firstResponderPanelId = (NSApp.keyWindow?.firstResponder ?? NSApp.mainWindow?.firstResponder)
+            .cmuxStrictOwningGhosttyView()?.terminalSurface?.id
         let targetIsActive = focusedPanelId == panelId || firstResponderPanelId == panelId
         guard targetIsActive,
               let focusedPane = bonsplitController.focusedPaneId,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -6416,6 +6416,69 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(probeView.lastKeyDownCharactersIgnoringModifiers, "d")
     }
 
+    func testWindowPerformKeyEquivalentResolvesHostedSurfaceDescendantAsTerminalOwner() {
+        let previousMainMenu = NSApp.mainMenu
+        let probeWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: probeWindow.contentRect(forFrameRect: probeWindow.frame))
+        let probeView = GhosttyCommandEquivalentProbeView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let hostedView = GhosttySurfaceScrollView(surfaceView: probeView)
+        hostedView.frame = contentView.bounds
+        let descendantResponder = FocusableTestView(frame: NSRect(x: 8, y: 8, width: 40, height: 40))
+        let menuProbe = MenuActionProbe()
+
+        defer {
+            NSApp.mainMenu = previousMainMenu
+            probeWindow.orderOut(nil)
+        }
+
+        let staleMenu = NSMenu(title: "Test")
+        let staleSplitItem = NSMenuItem(
+            title: "Split Right",
+            action: #selector(MenuActionProbe.perform(_:)),
+            keyEquivalent: "d"
+        )
+        staleSplitItem.keyEquivalentModifierMask = [.command]
+        staleSplitItem.target = menuProbe
+        staleMenu.addItem(staleSplitItem)
+        NSApp.mainMenu = staleMenu
+
+        probeWindow.contentView = contentView
+        contentView.addSubview(hostedView)
+        hostedView.addSubview(descendantResponder)
+        probeWindow.makeKeyAndOrderFront(nil)
+        probeWindow.displayIfNeeded()
+        XCTAssertTrue(
+            probeWindow.makeFirstResponder(descendantResponder),
+            "Expected hosted surface descendant to own first responder"
+        )
+
+        guard let event = makeKeyDownEvent(
+            key: "d",
+            modifiers: [.command],
+            keyCode: 2,
+            windowNumber: probeWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+D event")
+            return
+        }
+
+        withTemporaryShortcut(action: .splitRight, shortcut: .unbound) {
+            XCTAssertTrue(
+                probeWindow.performKeyEquivalent(with: event),
+                "Command equivalents from hosted surface descendants should route as terminal-owned"
+            )
+        }
+
+        XCTAssertEqual(menuProbe.callCount, 0, "A stale menu equivalent must not consume cleared Cmd+D")
+        XCTAssertEqual(probeView.keyDownCallCount, 1, "Cmd+D should be forwarded into the hosted terminal surface")
+        XCTAssertEqual(probeView.lastKeyDownCharactersIgnoringModifiers, "d")
+    }
+
     func testWindowPerformKeyEquivalentSuppressesRemappedCmdDStaleMenuShortcut() {
         let previousMainMenu = NSApp.mainMenu
         let probeWindow = NSWindow(

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -1,6 +1,7 @@
 import CmuxCommandPalette
 import CmuxCore
 import CmuxFoundation
+import CmuxTerminal
 import XCTest
 import AppKit
 import SwiftUI
@@ -1381,6 +1382,10 @@ final class MainWindowFocusControllerRightSidebarHideTests: XCTestCase {
         override var acceptsFirstResponder: Bool { true }
     }
 
+    private final class TestHostedTerminalDescendantResponder: NSView {
+        override var acceptsFirstResponder: Bool { true }
+    }
+
     @MainActor
     func testHiddenRightSidebarClearsFocusIntentWhenNoTerminalCanRestore() {
         let controller = MainWindowFocusController(
@@ -1533,6 +1538,36 @@ final class MainWindowFocusControllerRightSidebarHideTests: XCTestCase {
 
         XCTAssertFalse(controller.toggleRightSidebarOrTerminalFocus())
         XCTAssertTrue(controller.allowsTerminalFocus(workspaceId: workspaceId, panelId: panelId))
+    }
+
+    @MainActor
+    func testHostedTerminalDescendantClearsRightSidebarIntentOnFocusSync() {
+        let workspaceId = UUID()
+        let surface = TerminalSurface(
+            tabId: workspaceId,
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        let descendant = TestHostedTerminalDescendantResponder(frame: NSRect(x: 0, y: 0, width: 24, height: 24))
+        hostedView.addSubview(descendant)
+
+        let controller = MainWindowFocusController(
+            windowId: UUID(),
+            window: nil,
+            tabManager: TabManager(),
+            fileExplorerState: FileExplorerState()
+        )
+        let panelId = surface.id
+
+        controller.noteRightSidebarInteraction(mode: .sessions)
+        XCTAssertFalse(controller.allowsTerminalFocus(workspaceId: workspaceId, panelId: panelId))
+
+        controller.debugSyncAfterResponderChange(responder: descendant)
+
+        XCTAssertTrue(controller.allowsTerminalFocus(workspaceId: workspaceId, panelId: panelId))
+        XCTAssertEqual(controller.focusToggleDestination(currentResponder: descendant), .rightSidebar)
     }
 }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2755,7 +2755,9 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         hostedView.addSubview(descendant)
 
-        XCTAssertTrue(cmuxTerminalKeyEquivalentOwningGhosttyView(for: descendant) === ghosttyView)
+        XCTAssertTrue(
+            CmuxGhosttyResponderResolution.terminalKeyEquivalentOwningGhosttyView(for: descendant) === ghosttyView
+        )
     }
 
     func testResolvesTerminalFocusGhosttyViewFromHostedSurfaceDescendantResponder() {
@@ -2764,7 +2766,9 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         hostedView.addSubview(descendant)
 
-        XCTAssertTrue(cmuxTerminalFocusOwningGhosttyView(for: descendant) === ghosttyView)
+        XCTAssertTrue(
+            CmuxGhosttyResponderResolution.terminalFocusOwningGhosttyView(for: descendant) === ghosttyView
+        )
     }
 
     func testReturnsNilForUnrelatedResponder() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2725,19 +2725,19 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         ghosttyView.addSubview(descendant)
 
-        XCTAssertTrue(cmuxOwningGhosttyView(for: descendant) === ghosttyView)
+        XCTAssertTrue(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: descendant) === ghosttyView)
     }
 
     func testResolvesGhosttyViewFromGhosttyResponder() {
         let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
-        XCTAssertTrue(cmuxOwningGhosttyView(for: ghosttyView) === ghosttyView)
+        XCTAssertTrue(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: ghosttyView) === ghosttyView)
     }
 
     func testDoesNotResolveGhosttyViewFromHostedSurfaceContainerResponder() {
         let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
         let hostedView = GhosttySurfaceScrollView(surfaceView: ghosttyView)
 
-        XCTAssertNil(cmuxOwningGhosttyView(for: hostedView))
+        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: hostedView))
     }
 
     func testDoesNotResolveGhosttyViewFromHostedSurfaceDescendantResponderByDefault() {
@@ -2746,7 +2746,7 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         hostedView.addSubview(descendant)
 
-        XCTAssertNil(cmuxOwningGhosttyView(for: descendant))
+        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: descendant))
     }
 
     func testResolvesTerminalKeyEquivalentGhosttyViewFromHostedSurfaceDescendantResponder() {
@@ -2773,13 +2773,13 @@ final class GhosttyResponderResolutionTests: XCTestCase {
 
     func testReturnsNilForUnrelatedResponder() {
         let view = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
-        XCTAssertNil(cmuxOwningGhosttyView(for: view))
+        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: view))
     }
 
     func testDoesNotReadTextViewDelegateForGhosttyResponderResolution() {
         let textView = DelegateTrackingTextView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
 
-        XCTAssertNil(cmuxOwningGhosttyView(for: textView))
+        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: textView))
         XCTAssertEqual(
             textView.delegateReadCount,
             0,

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2725,19 +2725,19 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         ghosttyView.addSubview(descendant)
 
-        XCTAssertTrue(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: descendant) === ghosttyView)
+        XCTAssertTrue(descendant.cmuxStrictOwningGhosttyView() === ghosttyView)
     }
 
     func testResolvesGhosttyViewFromGhosttyResponder() {
         let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
-        XCTAssertTrue(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: ghosttyView) === ghosttyView)
+        XCTAssertTrue(ghosttyView.cmuxStrictOwningGhosttyView() === ghosttyView)
     }
 
     func testDoesNotResolveGhosttyViewFromHostedSurfaceContainerResponder() {
         let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
         let hostedView = GhosttySurfaceScrollView(surfaceView: ghosttyView)
 
-        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: hostedView))
+        XCTAssertNil(hostedView.cmuxStrictOwningGhosttyView())
     }
 
     func testDoesNotResolveGhosttyViewFromHostedSurfaceDescendantResponderByDefault() {
@@ -2746,7 +2746,7 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         hostedView.addSubview(descendant)
 
-        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: descendant))
+        XCTAssertNil(descendant.cmuxStrictOwningGhosttyView())
     }
 
     func testResolvesTerminalKeyEquivalentGhosttyViewFromHostedSurfaceDescendantResponder() {
@@ -2756,7 +2756,7 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         hostedView.addSubview(descendant)
 
         XCTAssertTrue(
-            CmuxGhosttyResponderResolution.terminalKeyEquivalentOwningGhosttyView(for: descendant) === ghosttyView
+            descendant.cmuxTerminalKeyEquivalentOwningGhosttyView() === ghosttyView
         )
     }
 
@@ -2767,19 +2767,19 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         hostedView.addSubview(descendant)
 
         XCTAssertTrue(
-            CmuxGhosttyResponderResolution.terminalFocusOwningGhosttyView(for: descendant) === ghosttyView
+            descendant.cmuxTerminalFocusOwningGhosttyView() === ghosttyView
         )
     }
 
     func testReturnsNilForUnrelatedResponder() {
         let view = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
-        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: view))
+        XCTAssertNil(view.cmuxStrictOwningGhosttyView())
     }
 
     func testDoesNotReadTextViewDelegateForGhosttyResponderResolution() {
         let textView = DelegateTrackingTextView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
 
-        XCTAssertNil(CmuxGhosttyResponderResolution.strictOwningGhosttyView(for: textView))
+        XCTAssertNil(textView.cmuxStrictOwningGhosttyView())
         XCTAssertEqual(
             textView.delegateReadCount,
             0,

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2758,6 +2758,15 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         XCTAssertTrue(cmuxTerminalKeyEquivalentOwningGhosttyView(for: descendant) === ghosttyView)
     }
 
+    func testResolvesTerminalFocusGhosttyViewFromHostedSurfaceDescendantResponder() {
+        let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let hostedView = GhosttySurfaceScrollView(surfaceView: ghosttyView)
+        let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
+        hostedView.addSubview(descendant)
+
+        XCTAssertTrue(cmuxTerminalFocusOwningGhosttyView(for: descendant) === ghosttyView)
+    }
+
     func testReturnsNilForUnrelatedResponder() {
         let view = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         XCTAssertNil(cmuxOwningGhosttyView(for: view))

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2733,6 +2733,31 @@ final class GhosttyResponderResolutionTests: XCTestCase {
         XCTAssertTrue(cmuxOwningGhosttyView(for: ghosttyView) === ghosttyView)
     }
 
+    func testDoesNotResolveGhosttyViewFromHostedSurfaceContainerResponder() {
+        let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let hostedView = GhosttySurfaceScrollView(surfaceView: ghosttyView)
+
+        XCTAssertNil(cmuxOwningGhosttyView(for: hostedView))
+    }
+
+    func testDoesNotResolveGhosttyViewFromHostedSurfaceDescendantResponderByDefault() {
+        let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let hostedView = GhosttySurfaceScrollView(surfaceView: ghosttyView)
+        let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
+        hostedView.addSubview(descendant)
+
+        XCTAssertNil(cmuxOwningGhosttyView(for: descendant))
+    }
+
+    func testResolvesTerminalKeyEquivalentGhosttyViewFromHostedSurfaceDescendantResponder() {
+        let ghosttyView = GhosttyNSView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+        let hostedView = GhosttySurfaceScrollView(surfaceView: ghosttyView)
+        let descendant = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
+        hostedView.addSubview(descendant)
+
+        XCTAssertTrue(cmuxTerminalKeyEquivalentOwningGhosttyView(for: descendant) === ghosttyView)
+    }
+
     func testReturnsNilForUnrelatedResponder() {
         let view = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
         XCTAssertNil(cmuxOwningGhosttyView(for: view))


### PR DESCRIPTION
## Summary
- recognize responders hosted by `GhosttySurfaceScrollView` as terminal owners for command-equivalent routing
- keep the stricter generic Ghostty owner resolver for focus/sidebar logic, and use the broader resolver only where terminal key equivalents need it
- add regression coverage for hosted-surface descendants and terminal command-equivalent forwarding

## Root cause
Remote tmux-server panes can leave AppKit first responder on a hosted view beneath `GhosttySurfaceScrollView` instead of directly under `GhosttyNSView`. The app-level command-equivalent path only recognized responders whose superview chain contained `GhosttyNSView`, so workspace shortcuts could fall through differently for those hosted terminal surfaces. Cmd+P still worked because it uses a separate global/menu path.

## Verification
- `xcodebuild test -quiet -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /Users/austinwang/Library/Developer/Xcode/DerivedData/cmux-issue-8592-tests -parallel-testing-enabled NO -only-testing:cmuxTests/GhosttyResponderResolutionTests -only-testing:cmuxTests/CommandEquivalentTransientFocusRepairTests -only-testing:cmuxTests/AppDelegateSurfaceShortcutRoutingTests -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testWindowPerformKeyEquivalentDefersTerminalPasteMenuMissToGhosttyBindingResolution -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testWindowPerformKeyEquivalentForwardsClearedCmdDPastStaleMenuShortcut -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testWindowPerformKeyEquivalentResolvesHostedSurfaceDescendantAsTerminalOwner`
- `./scripts/reload.sh --tag issue-8592 --launch`
- manual tagged-app verification with real `mosh-tmux`/ssh-backed tmux pane, raw `tmuxStartCommand` pane, and local shell pane: Ctrl+Cmd+] / Ctrl+Cmd+[ / Cmd+number switch to expected workspaces; Cmd+P takes palette focus without leaking typed probe text into the terminal

Fixes #8592

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787276447&installation_model_id=21920&pr_number=8621&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8621&signature=65859f1e79830589f902d7d3890fa3283fb43f58e9ff2687b6ad875a83a52314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workspace shortcuts and focus from hosted tmux terminals by recognizing `GhosttySurfaceScrollView` descendants as terminal owners. Terminal shortcuts (Cmd+number, Ctrl+Cmd+[ / ]) and focus toggles now work from remote panes, and stale menu shortcuts no longer steal cleared terminal commands. Fixes #8592.

- **Bug Fixes**
  - Added `NSResponder` resolvers: `cmuxStrictOwningGhosttyView`, `cmuxTerminalFocusOwningGhosttyView`, `cmuxTerminalKeyEquivalentOwningGhosttyView`; use strict for sidebar/non-terminal logic, terminal-aware for key equivalents and focus.
  - Updated `NSWindow.performKeyEquivalent`, `NSApplication.sendEvent`, `AppDelegate`, and `MainWindowFocusController` to route via terminal-aware resolvers; pointer hit testing now uses terminal-focus resolution.
  - Treat `NSWindow` as right-sidebar intent when active; clear that intent when a hosted terminal descendant gains focus to restore terminal eligibility.
  - Applied strict resolution in non-terminal contexts (IME composition, address bar gating, dock focus, shortcut context, workspace panel resolution); added tests for hosted-descendant key equivalents, menu suppression, and right-sidebar focus sync.

<sup>Written for commit 2f9feac6125aef689b0920d267028096bf04f449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut and key-equivalent handling so terminal routing correctly identifies Ghostty ownership for responders inside hosted terminal surface descendants.
  * Tightened focus and panel-context resolution to use stricter Ghostty ownership checks, preventing stale menu items from intercepting key events and ensuring correct sidebar-intent behavior.
* **Tests**
  * Added/expanded coverage for hosted-surface descendant cases, including `performKeyEquivalent` routing and responder ownership resolution.
  * Added a focus-sync regression test to verify right-sidebar intent behavior for hosted terminal descendants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->