### PR TITLE
Fix agent session WebView reentrant layout

### DIFF
--- a/Sources/Panels/AgentSessionWebHostView.swift
+++ b/Sources/Panels/AgentSessionWebHostView.swift
@@ -159,6 +159,8 @@ final class AgentSessionWebHostView: NSView {
         onGeometryChanged?()
     }
 
+    // This can run from NSViewRepresentable.updateNSView. Do not force a
+    // synchronous layout here; it reenters the surrounding NSHostingView.
     func attachWebView(_ webView: WKWebView) {
         if hostedWebView !== webView {
             resetPendingScroll()
@@ -172,7 +174,6 @@ final class AgentSessionWebHostView: NSView {
         webView.autoresizingMask = []
         webView.frame = sessionContentWidthPresentation.contentFrame(in: bounds)
         needsLayout = true
-        layoutSubtreeIfNeeded()
     }
 
     func setSessionContentWidthPresentation(_ presentation: SessionContentWidthPresentation) {

--- a/cmuxTests/AgentSessionWebRendererTests.swift
+++ b/cmuxTests/AgentSessionWebRendererTests.swift
@@ -1,5 +1,7 @@
+import AppKit
 import Foundation
 import Testing
+import WebKit
 
 #if canImport(cmux_DEV)
     @testable import cmux_DEV
@@ -9,6 +11,19 @@ import Testing
 
 @Suite(.serialized)
 struct AgentSessionWebRendererTests {
+    @Test @MainActor
+    func attachingWebViewDefersHostLayout() {
+        let host = AgentSessionWebHostView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
+        )
+        let webView = WKWebView(frame: .zero)
+
+        host.attachWebView(webView)
+
+        #expect(host.geometryRevision == 0)
+        #expect(webView.frame == host.bounds)
+    }
+
     @Test
     func testTrustedShellURLAcceptsOnlyMatchingFileURL() {
         let resources = URL(fileURLWithPath: "/tmp/cmux DEV test.app/Contents/Resources", isDirectory: true)


### PR DESCRIPTION
## Summary

- defer `AgentSessionWebHostView` layout to the normal AppKit pass
- keep the hosted WebView frame correct immediately without flushing the surrounding `NSHostingView`
- add behavior-level regression coverage for the synchronous layout

## Root cause

`AgentSessionWebRenderer.updateNSView` calls `attachWebView` on every SwiftUI update. `attachWebView` then called `layoutSubtreeIfNeeded()` synchronously, which reentered the surrounding `NSHostingView` while SwiftUI was rendering. On the affected 0.64.20 process this produced a sustained reentrant-layout loop and a macOS CPU resource report.

## Validation

- test-only commit `ed025d72d`: focused suite fails with `geometryRevision` changing synchronously from 0 to 1
- fix commit `6d6d85264`: focused suite passes (2 tests)
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag agent-loop-high-cpu` succeeds

No user-facing strings changed; localization catalogs are unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787279695&installation_model_id=21920&pr_number=8623&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8623&signature=2403c1d93a52031d2efb6afdf49a2cda4d5e0bd719cbbb6de97bd25e17d89623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a reentrant layout loop in the agent session WebView by deferring layout to the normal AppKit pass. Prevents high CPU usage while keeping the WebView frame correct.

- **Bug Fixes**
  - Removed synchronous `layoutSubtreeIfNeeded()` from `AgentSessionWebHostView.attachWebView` and set `needsLayout` instead.
  - Added a test to confirm host layout is deferred and `WKWebView` frame matches the host bounds.

<sup>Written for commit 6d6d8526401abaf9c271c32929472bfa45bc75e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web view attachment and layout handling to prevent reentrancy-related issues.
  * Ensured attached web views correctly match their host view’s bounds.

* **Tests**
  * Added coverage verifying layout is deferred appropriately when attaching a web view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->