### PR TITLE
Fix WebAuthn capability crash

### DIFF
--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -3,7 +3,6 @@ import AuthenticationServices
 import Bonsplit
 import CoreBluetooth
 import Foundation
-import ObjectiveC.runtime
 import WebKit
 
 /// Native WebAuthn bridge for `WKWebView`.
@@ -637,20 +636,8 @@ enum BrowserWebAuthnBridgeContract {
     }()
 }
 
-func browserWebAuthnAdvertisedPlatformPasskeyAvailability(
-    authorizationState: ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState,
-    deviceConfiguredForPasskeys: Bool?,
-    callerMayPromptForPlatformAuthorization: Bool
-) -> Bool? {
-    if authorizationState == .denied {
-        return false
-    }
-
-    if authorizationState == .notDetermined && !callerMayPromptForPlatformAuthorization {
-        return false
-    }
-
-    return deviceConfiguredForPasskeys
+func browserWebAuthnNativeCapabilityPayload() -> [String: Bool] {
+    [:]
 }
 
 @MainActor
@@ -1073,12 +1060,7 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
                 switch envelope.kind {
                 case .capabilities:
                     _ = try BrowserWebAuthnClientDataContext.resolvePermitted(for: message)
-                    let callerMayPrompt = callerMayPromptForPlatformAuthorization(message)
-                    let capReply = capabilityReply(
-                        for: BrowserPasskeyAuthorizationGate.shared.currentAuthorizationState(),
-                        bluetoothState: BrowserBluetoothAuthorizationGate.shared.currentState(),
-                        callerMayPromptForPlatformAuthorization: callerMayPrompt
-                    )
+                    let capReply = capabilityReply()
                     #if DEBUG
                     cmuxDebugLog("webauthn.capabilities reply=\(capReply)")
                     #endif
@@ -1768,79 +1750,11 @@ private extension BrowserWebAuthnCoordinator {
         }
     }
 
-    func capabilityReply(
-        for state: ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState,
-        bluetoothState: BrowserBluetoothAuthorizationState,
-        callerMayPromptForPlatformAuthorization: Bool
-    ) -> [String: Any] {
+    func capabilityReply() -> [String: Any] {
         [
             "ok": true,
-            "capabilities": capabilityPayload(
-                for: state,
-                bluetoothState: bluetoothState,
-                callerMayPromptForPlatformAuthorization: callerMayPromptForPlatformAuthorization
-            ),
+            "capabilities": browserWebAuthnNativeCapabilityPayload(),
         ]
-    }
-
-    func capabilityPayload(
-        for state: ASAuthorizationWebBrowserPublicKeyCredentialManager.AuthorizationState,
-        bluetoothState: BrowserBluetoothAuthorizationState,
-        callerMayPromptForPlatformAuthorization: Bool
-    ) -> [String: Any] {
-        let denied = state == .denied
-        let platformRequestSupport = supportsPlatformCredentialRequests
-        let deviceConfiguredForPasskeys = denied ? nil : self.deviceConfiguredForPasskeys()
-        let platformPasskeyAvailability = browserWebAuthnAdvertisedPlatformPasskeyAvailability(
-            authorizationState: state,
-            deviceConfiguredForPasskeys: deviceConfiguredForPasskeys,
-            callerMayPromptForPlatformAuthorization: callerMayPromptForPlatformAuthorization
-        )
-        #if DEBUG
-        let authorized = state == .authorized
-        let canPromptForAccess = state == .notDetermined && callerMayPromptForPlatformAuthorization
-        let securityKeySupport = supportsSecurityKeyCredentialRequests
-        cmuxDebugLog("webauthn.capability state=\(state.rawValue) authorized=\(authorized) denied=\(denied) canPrompt=\(canPromptForAccess) callerMayPrompt=\(callerMayPromptForPlatformAuthorization) platformSupport=\(platformRequestSupport) securityKeySupport=\(securityKeySupport) deviceConfigured=\(deviceConfiguredForPasskeys as Any) advertisedPlatform=\(platformPasskeyAvailability as Any) btAuth=\(bluetoothState.isAuthorized) btHybrid=\(bluetoothState.canUseHybridTransport)")
-        #endif
-
-        var payload: [String: Any] = [:]
-        if platformRequestSupport,
-           let platformPasskeyAvailability {
-            payload["userVerifyingPlatformAuthenticatorAvailable"] = platformPasskeyAvailability
-            payload["conditionalMediationAvailable"] = platformPasskeyAvailability
-        }
-
-        return payload
-    }
-
-    var supportsPlatformCredentialRequests: Bool {
-        if #available(macOS 13.5, *) {
-            return true
-        }
-        return false
-    }
-
-    var supportsSecurityKeyCredentialRequests: Bool {
-        if #available(macOS 14.4, *) {
-            return true
-        }
-        return false
-    }
-
-    func deviceConfiguredForPasskeys() -> Bool? {
-        let selector = NSSelectorFromString("isDeviceConfiguredForPasskeys")
-        let managerClass: AnyClass = ASAuthorizationWebBrowserPublicKeyCredentialManager.self
-
-        guard let metaClass = object_getClass(managerClass),
-              class_respondsToSelector(metaClass, selector),
-              let method = class_getClassMethod(managerClass, selector) else {
-            return nil
-        }
-
-        typealias Getter = @convention(c) (AnyClass, Selector) -> Bool
-        let implementation = method_getImplementation(method)
-        let getter = unsafeBitCast(implementation, to: Getter.self)
-        return getter(managerClass, selector)
     }
 
     func fallbackReply() -> [String: Any] {

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -1112,6 +1112,13 @@ final class BrowserWebAuthnCoordinator: NSObject, WKScriptMessageHandlerWithRepl
             }
         }
     }
+
+    func capabilityReply() -> [String: Any] {
+        [
+            "ok": true,
+            "capabilities": [String: Bool](),
+        ]
+    }
 }
 
 @MainActor
@@ -1747,12 +1754,6 @@ private extension BrowserWebAuthnCoordinator {
         }
     }
 
-    func capabilityReply() -> [String: Any] {
-        [
-            "ok": true,
-            "capabilities": [String: Bool](),
-        ]
-    }
 
     func fallbackReply() -> [String: Any] {
         [

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -636,9 +636,6 @@ enum BrowserWebAuthnBridgeContract {
     }()
 }
 
-func browserWebAuthnNativeCapabilityPayload() -> [String: Bool] {
-    [:]
-}
 
 @MainActor
 private struct BrowserWebAuthnClientDataContext {
@@ -1753,7 +1750,7 @@ private extension BrowserWebAuthnCoordinator {
     func capabilityReply() -> [String: Any] {
         [
             "ok": true,
-            "capabilities": browserWebAuthnNativeCapabilityPayload(),
+            "capabilities": [String: Bool](),
         ]
     }
 

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -192,6 +192,14 @@ struct BrowserWebContentProcessTests {
     }
 
     @Test
+    func webAuthnNativeCapabilitiesOmitUnavailablePlatformSignals() {
+        let capabilities = browserWebAuthnNativeCapabilityPayload()
+
+        #expect(capabilities["userVerifyingPlatformAuthenticatorAvailable"] == nil)
+        #expect(capabilities["conditionalMediationAvailable"] == nil)
+    }
+
+    @Test
     func webAuthnNativeBridgeScopesParentDomainRelyingPartyIDs() throws {
         let googleOrigin = try #require(
             BrowserWebAuthnSecurityOrigin(url: URL(string: "https://accounts.google.com")!)

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -192,9 +192,11 @@ struct BrowserWebContentProcessTests {
     }
 
     @Test
-    func webAuthnNativeCapabilitiesOmitUnavailablePlatformSignals() {
-        let capabilities = browserWebAuthnNativeCapabilityPayload()
+    func webAuthnNativeCapabilitiesOmitUnavailablePlatformSignals() throws {
+        let reply = BrowserWebAuthnCoordinator().capabilityReply()
+        let capabilities = try #require(reply["capabilities"] as? [String: Bool])
 
+        #expect(reply["ok"] as? Bool == true)
         #expect(capabilities["userVerifyingPlatformAuthenticatorAvailable"] == nil)
         #expect(capabilities["conditionalMediationAvailable"] == nil)
     }

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -197,8 +197,7 @@ struct BrowserWebContentProcessTests {
         let capabilities = try #require(reply["capabilities"] as? [String: Bool])
 
         #expect(reply["ok"] as? Bool == true)
-        #expect(capabilities["userVerifyingPlatformAuthenticatorAvailable"] == nil)
-        #expect(capabilities["conditionalMediationAvailable"] == nil)
+        #expect(capabilities.isEmpty)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- remove the undocumented `isDeviceConfiguredForPasskeys` runtime probe from WebAuthn capability reporting
- return no synthetic platform capability values so the existing page bridge delegates to WebKit's original `PublicKeyCredential` methods
- preserve native WebAuthn create/get ceremonies and documented browser passkey authorization handling

## Why

On cmux 0.64.20 / macOS 26.1, six browser crashes correlated exactly with six `NSInvalidArgumentException` faults. The unredacted fault enters `ASCAgentProxy isDeviceConfiguredForPasskeysWithTestOptions:` through the private selector invoked by `BrowserWebAuthnCoordinator.deviceConfiguredForPasskeys()`.

The selector is undocumented, called through Objective-C runtime lookup plus an unsafe function-pointer cast, and rejected by `NSXPCConnection`. Omitting those native capability keys is already supported: the page bridge falls back to WebKit's captured original capability methods.

## Testing

- added `webAuthnNativeCapabilitiesOmitUnavailablePlatformSignals`, which exercises the production capability reply and asserts its native capability payload is empty
- hosted macOS/Xcode run: https://github.com/usr-bin-roygbiv/cmux/actions/runs/29891951125
  - `webAuthnNativeCapabilitiesOmitUnavailablePlatformSignals` passed in 0.001s
  - the enclosing 18-test suite reported two unrelated WebKit/window-lifecycle failures: `webAuthnPageBridgeRelaysCredentialGetThroughContentWorldHandler` returned WKErrorDomain code 5, and `floatingPopupClosesWhenWebContentProcessTerminates` observed a retained popup window
  - run head `6c4f7bb` contains production code through `e96fff0`; the later PR commit `ce3399f` only strengthens the passing assertion from two missing keys to `capabilities.isEmpty`
- `xcrun swiftc -frontend -parse Sources/Panels/BrowserWebAuthnSupport.swift cmuxTests/BrowserWebContentProcessTests.swift`
- `git diff --check`
- full local `xcodebuild` is unavailable because this host only has Command Line Tools

## Demo Video

- Not applicable: no visible UI change; this removes a crashing native capability probe.

## Checklist

- [ ] I tested the change locally (full Xcode unavailable; hosted Xcode proof linked above)
- [x] I added or updated tests for behavior changes
- [x] Docs/changelog are not needed for this internal crash fix
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [x] No human review comments are outstanding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming WebAuthn capability checks complete successfully when queried from browser content.
  * Verifies platform authenticator and conditional mediation availability results are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->