### PR TITLE
Restoring a remote workspace terminal hands it this machine's working directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,7 @@ jobs:
             -disableAutomaticPackageResolution \
             -destination "platform=macOS" \
             CMUX_SKIP_ZIG_BUILD=1 \
-            -only-testing:cmuxTests/AgentSessionAutoResumeSwiftTests \
+            -only-testing:cmuxTests/RemoteAgentRestoreWorkingDirectoryTests \
             test
 
       - name: Run agent chat transcript lifecycle regressions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,6 +625,26 @@ jobs:
             echo "::warning::Passwordless sudo unavailable; XCTest will use its default automation-mode setup"
           fi
 
+      - name: Run remote agent restore cwd regressions
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        run: |
+          # Swift Testing assertion failures are tolerated in the full sharded
+          # app-host suite. Keep remote restore's trusted-cwd boundary on a
+          # non-tolerant focused invocation so a local path cannot leak into a
+          # remote resume command while the broad shard still reports success.
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          scripts/ci/run-in-console-session.sh \
+            scripts/ci/run-app-host-xcodebuild.sh \
+            -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
+            -derivedDataPath "$CMUX_DERIVED_DATA_PATH" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            CMUX_SKIP_ZIG_BUILD=1 \
+            -only-testing:cmuxTests/AgentSessionAutoResumeSwiftTests \
+            test
+
       - name: Run agent chat transcript lifecycle regressions
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -261,6 +261,7 @@ public enum AgentLaunchSanitizer {
         }
         let valueOptions: Set<String> = ["--cd", "-C", "--cwd", "--work-dir", "--workspace", "-w"]
         let optionPrefixes = valueOptions.map { "\($0)=" }
+        let attachedShortValueOptions: Set<String> = ["-C", "-w"]
         var result: [String] = []
         var index = 0
         while index < args.count {
@@ -277,6 +278,15 @@ public enum AgentLaunchSanitizer {
             }
             if let prefix = optionPrefixes.first(where: { arg.hasPrefix($0) }) {
                 let value = String(arg.dropFirst(prefix.count))
+                if shouldRemoveValue(value) {
+                    index += 1
+                    continue
+                }
+            }
+            if let option = attachedShortValueOptions.first(where: {
+                arg.count > $0.count && arg.hasPrefix($0)
+            }) {
+                let value = String(arg.dropFirst(option.count))
                 if shouldRemoveValue(value) {
                     index += 1
                     continue

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -237,14 +237,28 @@ public enum AgentLaunchSanitizer {
         }
         return false
     }
+
+    /// Removes captured cwd options before an argument boundary.
+    ///
+    /// - Parameters:
+    ///   - args: The captured command arguments to sanitize.
+    ///   - workingDirectory: The saved cwd whose matching options should be removed.
+    ///   - removeAllWorkingDirectoryOptions: Whether to remove every cwd option regardless of value.
+    /// - Returns: Sanitized arguments while preserving content after `--`.
     public static func removingSavedWorkingDirectoryOptions(
         from args: [String],
-        workingDirectory: String?
+        workingDirectory: String?,
+        removeAllWorkingDirectoryOptions: Bool = false
     ) -> [String] {
-        guard let workingDirectory = normalizedWorkingDirectory(workingDirectory) else {
+        let savedWorkingDirectory = normalizedWorkingDirectory(workingDirectory)
+        guard removeAllWorkingDirectoryOptions || savedWorkingDirectory != nil else {
             return args
         }
-
+        let shouldRemoveValue: (String) -> Bool = { value in
+            removeAllWorkingDirectoryOptions || savedWorkingDirectory.map {
+                workingDirectoryValue(value, matches: $0)
+            } == true
+        }
         let valueOptions: Set<String> = ["--cd", "-C", "--cwd", "--work-dir", "--workspace", "-w"]
         let optionPrefixes = valueOptions.map { "\($0)=" }
         var result: [String] = []
@@ -257,13 +271,13 @@ public enum AgentLaunchSanitizer {
             }
             if valueOptions.contains(arg),
                index + 1 < args.count,
-               workingDirectoryValue(args[index + 1], matches: workingDirectory) {
+               shouldRemoveValue(args[index + 1]) {
                 index += 2
                 continue
             }
             if let prefix = optionPrefixes.first(where: { arg.hasPrefix($0) }) {
                 let value = String(arg.dropFirst(prefix.count))
-                if workingDirectoryValue(value, matches: workingDirectory) {
+                if shouldRemoveValue(value) {
                     index += 1
                     continue
                 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -245,7 +245,7 @@ public enum AgentLaunchSanitizer {
             return args
         }
 
-        let valueOptions: Set<String> = ["--cd", "-C", "--cwd", "--workspace", "-w"]
+        let valueOptions: Set<String> = ["--cd", "-C", "--cwd", "--work-dir", "--workspace", "-w"]
         let optionPrefixes = valueOptions.map { "\($0)=" }
         var result: [String] = []
         var index = 0

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -647,4 +647,22 @@ struct AgentLaunchSanitizerTests {
             ) == ["kimi", "--resume", "session", "--model", "kimi-k2"]
         )
     }
+
+    @Test("Removes every cwd option while preserving arguments after the boundary")
+    func removesWorkingDirectoryOptions() {
+        #expect(
+            AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
+                from: ["kimi", "--resume", "session", "--work-dir", "/local/repo", "--model", "kimi-k2"],
+                workingDirectory: nil,
+                removeAllWorkingDirectoryOptions: true
+            ) == ["kimi", "--resume", "session", "--model", "kimi-k2"]
+        )
+        #expect(
+            AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
+                from: ["grok", "-r", "session", "--cwd=/local/repo", "--", "--cwd", "prompt text"],
+                workingDirectory: nil,
+                removeAllWorkingDirectoryOptions: true
+            ) == ["grok", "-r", "session", "--", "--cwd", "prompt text"]
+        )
+    }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -664,5 +664,19 @@ struct AgentLaunchSanitizerTests {
                 removeAllWorkingDirectoryOptions: true
             ) == ["grok", "-r", "session", "--", "--cwd", "prompt text"]
         )
+        #expect(
+            AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
+                from: ["codex", "resume", "session", "-C/local/repo", "--model", "gpt-5.4"],
+                workingDirectory: nil,
+                removeAllWorkingDirectoryOptions: true
+            ) == ["codex", "resume", "session", "--model", "gpt-5.4"]
+        )
+        #expect(
+            AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
+                from: ["kimi", "--resume", "session", "-w/local/repo", "--model", "kimi-k2"],
+                workingDirectory: nil,
+                removeAllWorkingDirectoryOptions: true
+            ) == ["kimi", "--resume", "session", "--model", "kimi-k2"]
+        )
     }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -640,5 +640,11 @@ struct AgentLaunchSanitizerTests {
                 workingDirectory: "/tmp/project"
             ) == ["qoder", "--model", "best"]
         )
+        #expect(
+            AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
+                from: ["kimi", "--resume", "session", "--work-dir=/tmp/project", "--model", "kimi-k2"],
+                workingDirectory: "/tmp/project"
+            ) == ["kimi", "--resume", "session", "--model", "kimi-k2"]
+        )
     }
 }

--- a/Sources/AgentRelaunchCommandBuilder.swift
+++ b/Sources/AgentRelaunchCommandBuilder.swift
@@ -13,6 +13,21 @@ struct AgentRelaunchCommandBuilder {
         workingDirectory: String?,
         includeWorkingDirectoryPrefix: Bool = true
     ) -> String? {
+        shellCommand(
+            kind: kind,
+            launchCommand: launchCommand,
+            resolvedWorkingDirectory: workingDirectory ?? launchCommand?.workingDirectory,
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
+        )
+    }
+
+    /// Builds a relaunch command after the caller has applied its cwd fallback policy.
+    func shellCommand(
+        kind: RestorableAgentKind,
+        launchCommand: AgentLaunchCommandSnapshot?,
+        resolvedWorkingDirectory: String?,
+        includeWorkingDirectoryPrefix: Bool = true
+    ) -> String? {
         guard kind.restoreMode == .relaunchCommand,
               let launchCommand,
               let argv = AgentResumeArgv().builtInRelaunchKind(
@@ -43,7 +58,7 @@ struct AgentRelaunchCommandBuilder {
         guard includeWorkingDirectoryPrefix else { return command }
         return TerminalStartupWorkingDirectoryPrefix.prefix(
             command,
-            workingDirectory: workingDirectory ?? launchCommand.workingDirectory
+            workingDirectory: resolvedWorkingDirectory
         )
     }
 }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -227,7 +227,7 @@ enum TerminalStartupWorkingDirectoryPrefix {
         in words: [ShellWordRange],
         workingDirectory: String
     ) -> [Range<String.Index>] {
-        let valueOptions: Set<String> = ["--cd", "-C", "--cwd", "--workspace", "-w"]
+        let valueOptions: Set<String> = ["--cd", "-C", "--cwd", "--work-dir", "--workspace", "-w"]
         let optionPrefixes = valueOptions.map { "\($0)=" }
         var ranges: [Range<String.Index>] = []
         var index = 0
@@ -431,7 +431,11 @@ enum AgentResumeCommandBuilder {
             cwd,
             normalized(launchCommand?.workingDirectory),
         ].compactMap { $0 }
-        let sanitizedCommandParts = customRegistration == nil
+        // Exact built-in registrations delegate to AgentResumeArgv just like
+        // non-Vault kinds; only user-authored templates own their cwd flags.
+        let usesStructuredResumeArguments = customRegistration == nil ||
+            customRegistration?.registeredResumeKind != nil
+        let sanitizedCommandParts = usesStructuredResumeArguments
             ? workingDirectoriesToRemove.reduce(commandParts) { parts, directory in
                 AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
                     from: parts,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -334,6 +334,7 @@ enum AgentResumeCommandBuilder {
             sessionId: sessionId,
             launchCommand: launchCommand,
             resolvedWorkingDirectory: workingDirectory ?? launchCommand?.workingDirectory,
+            discardRecordedCwdOptions: false,
             registrationOverride: registrationOverride,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
             observedPermissionMode: observedPermissionMode
@@ -346,6 +347,7 @@ enum AgentResumeCommandBuilder {
         sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?,
         resolvedWorkingDirectory: String?,
+        discardRecordedCwdOptions: Bool,
         registrationOverride: CmuxVaultAgentRegistration? = nil,
         includeWorkingDirectoryPrefix: Bool = true,
         observedPermissionMode: String? = nil
@@ -370,7 +372,8 @@ enum AgentResumeCommandBuilder {
             launchCommand: launchCommand,
             workingDirectory: resolvedWorkingDirectory,
             customRegistration: customRegistration,
-            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
+            discardRecordedCwdOptions: discardRecordedCwdOptions
         )
     }
 
@@ -404,7 +407,8 @@ enum AgentResumeCommandBuilder {
             launchCommand: launchCommand,
             workingDirectory: resolvedWorkingDirectory,
             customRegistration: customRegistration,
-            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
+            discardRecordedCwdOptions: false
         )
     }
 
@@ -414,7 +418,8 @@ enum AgentResumeCommandBuilder {
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
         customRegistration: CmuxVaultAgentRegistration?,
-        includeWorkingDirectoryPrefix: Bool
+        includeWorkingDirectoryPrefix: Bool,
+        discardRecordedCwdOptions: Bool
     ) -> String {
         var commandParts: [String] = []
         let environmentParts = launchEnvironmentParts(kind: kind, environment: launchCommand?.environment)
@@ -435,14 +440,25 @@ enum AgentResumeCommandBuilder {
         // non-Vault kinds; only user-authored templates own their cwd flags.
         let usesStructuredResumeArguments = customRegistration == nil ||
             customRegistration?.registeredResumeKind != nil
-        let sanitizedCommandParts = usesStructuredResumeArguments
-            ? workingDirectoriesToRemove.reduce(commandParts) { parts, directory in
+        let sanitizedCommandParts: [String]
+        if !usesStructuredResumeArguments {
+            sanitizedCommandParts = commandParts
+        } else if discardRecordedCwdOptions {
+            // Exact remote selections trust no captured cwd value, including one
+            // that differs from the process working directory saved at launch.
+            sanitizedCommandParts = AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
+                from: commandParts,
+                workingDirectory: nil,
+                removeAllWorkingDirectoryOptions: true
+            )
+        } else {
+            sanitizedCommandParts = workingDirectoriesToRemove.reduce(commandParts) { parts, directory in
                 AgentLaunchSanitizer.removingSavedWorkingDirectoryOptions(
                     from: parts,
                     workingDirectory: directory
                 )
             }
-            : commandParts
+        }
         // Render the claude/codex executable as the wrapper shim token so the
         // executed command routes through cmux's `claude`/`codex` wrapper
         // (re-injecting the agent hooks) even when an `env`-prefixed invocation

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -329,13 +329,34 @@ enum AgentResumeCommandBuilder {
         includeWorkingDirectoryPrefix: Bool = true,
         observedPermissionMode: String? = nil
     ) -> String? {
+        resumeShellCommand(
+            kind: kind,
+            sessionId: sessionId,
+            launchCommand: launchCommand,
+            resolvedWorkingDirectory: workingDirectory ?? launchCommand?.workingDirectory,
+            registrationOverride: registrationOverride,
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
+            observedPermissionMode: observedPermissionMode
+        )
+    }
+
+    /// Builds a resume command after the caller has applied its cwd fallback policy.
+    static func resumeShellCommand(
+        kind: RestorableAgentKind,
+        sessionId: String,
+        launchCommand: AgentLaunchCommandSnapshot?,
+        resolvedWorkingDirectory: String?,
+        registrationOverride: CmuxVaultAgentRegistration? = nil,
+        includeWorkingDirectoryPrefix: Bool = true,
+        observedPermissionMode: String? = nil
+    ) -> String? {
         let customRegistration = registrationOverride
         guard !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               let argv = resumeArguments(
                   kind: kind,
                   sessionId: sessionId,
                   launchCommand: launchCommand,
-                  workingDirectory: workingDirectory,
+                  workingDirectory: resolvedWorkingDirectory,
                   customRegistration: customRegistration,
                   observedPermissionMode: observedPermissionMode
               ),
@@ -347,7 +368,7 @@ enum AgentResumeCommandBuilder {
             argv: argv,
             kind: kind,
             launchCommand: launchCommand,
-            workingDirectory: workingDirectory,
+            workingDirectory: resolvedWorkingDirectory,
             customRegistration: customRegistration,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
         )
@@ -363,12 +384,13 @@ enum AgentResumeCommandBuilder {
         observedPermissionMode: String? = nil
     ) -> String? {
         let customRegistration = registrationOverride
+        let resolvedWorkingDirectory = workingDirectory ?? launchCommand?.workingDirectory
         guard !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               let argv = forkArguments(
                   kind: kind,
                   sessionId: sessionId,
                   launchCommand: launchCommand,
-                  workingDirectory: workingDirectory,
+                  workingDirectory: resolvedWorkingDirectory,
                   customRegistration: customRegistration,
                   observedPermissionMode: observedPermissionMode
               ),
@@ -380,7 +402,7 @@ enum AgentResumeCommandBuilder {
             argv: argv,
             kind: kind,
             launchCommand: launchCommand,
-            workingDirectory: workingDirectory,
+            workingDirectory: resolvedWorkingDirectory,
             customRegistration: customRegistration,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
         )
@@ -404,7 +426,7 @@ enum AgentResumeCommandBuilder {
 
         let cwd = customRegistration?.cwd == .ignore
             ? nil
-            : normalized(workingDirectory ?? launchCommand?.workingDirectory)
+            : normalized(workingDirectory)
         let workingDirectoriesToRemove = [
             cwd,
             normalized(launchCommand?.workingDirectory),
@@ -650,7 +672,7 @@ enum AgentResumeCommandBuilder {
             "sessionId": sessionId,
             "sessionPath": sessionId,
             "executable": original.executable,
-            "cwd": normalized(workingDirectory ?? launchCommand?.workingDirectory) ?? "",
+            "cwd": normalized(workingDirectory) ?? "",
             "sessionDir": sessionDirectory ?? "",
         ]
         var resolved: [String] = []
@@ -793,7 +815,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             kind: kind,
             sessionId: sessionId,
             launchCommand: launchCommand,
-            workingDirectory: workingDirectory,
+            workingDirectory: workingDirectory ?? launchCommand?.workingDirectory,
             customRegistration: registration,
             observedPermissionMode: observedPermissionMode
         )
@@ -803,6 +825,16 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         useLocalRestoreVerb: Bool = true,
         restoringWorkingDirectory: String? = nil
     ) -> String? {
+        resumeStartupInput(
+            useLocalRestoreVerb: useLocalRestoreVerb,
+            workingDirectorySelection: .recordedFallback(preferred: restoringWorkingDirectory)
+        )
+    }
+
+    func resumeStartupInput(
+        useLocalRestoreVerb: Bool,
+        workingDirectorySelection: RestorableAgentWorkingDirectorySelection
+    ) -> String? {
         if useLocalRestoreVerb {
             let executable = AgentRestoreLaunch.cliStartupExecutableToken
             guard AgentRestoreCLIArgument(rawValue: kind.rawValue) != nil,
@@ -811,12 +843,12 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             }
             return " \(executable) restore \(kind.rawValue) \(sessionId)\n"
         }
-        let effectiveWorkingDirectory = resumeWorkingDirectory(
-            preferred: restoringWorkingDirectory
-        )
+        let effectiveWorkingDirectorySelection = registration?.cwd == .ignore
+            ? RestorableAgentWorkingDirectorySelection.exact(nil)
+            : workingDirectorySelection
         let restoreCommand = resumeCommand(
             includeWorkingDirectoryPrefix: true,
-            restoringWorkingDirectory: effectiveWorkingDirectory
+            workingDirectorySelection: effectiveWorkingDirectorySelection
         ).map { command in
             AgentRestoreLaunch(kind: kind.rawValue, sessionID: sessionId)?
                 .applying(toStoredCommand: command) ?? command
@@ -861,18 +893,6 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             return nil
         }
         return scriptInput.utf8.count <= Self.maxInlineForkInputBytes ? scriptInput : nil
-    }
-
-    private func resumeWorkingDirectory(preferred: String?) -> String? {
-        guard registration?.cwd != .ignore else { return nil }
-        for candidate in [preferred, workingDirectory, launchCommand?.workingDirectory] {
-            guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !trimmed.isEmpty else {
-                continue
-            }
-            return trimmed
-        }
-        return nil
     }
 }
 

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -218,6 +218,16 @@ enum RestorableAgentWorkingDirectorySelection: Sendable {
     /// Use only the supplied cwd; an explicit `nil` must remain `nil`.
     case exact(String?)
 
+    /// Whether captured argv cwd options must be discarded instead of value-matched.
+    var discardsRecordedCwdOptions: Bool {
+        switch self {
+        case .recordedFallback:
+            false
+        case .exact:
+            true
+        }
+    }
+
     func resolved(
         snapshotWorkingDirectory: String?,
         launchWorkingDirectory: String?

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -210,3 +210,31 @@ enum RestorableAgentKind: Codable, Hashable, Sendable {
 }
 
 typealias AgentLaunchCommandSnapshot = AgentLaunchCommand
+
+/// Selects whether agent restore may consult cwd values recorded with the agent process.
+enum RestorableAgentWorkingDirectorySelection: Sendable {
+    /// Prefer the supplied cwd, then fall back through the agent and launch snapshots.
+    case recordedFallback(preferred: String?)
+    /// Use only the supplied cwd; an explicit `nil` must remain `nil`.
+    case exact(String?)
+
+    func resolved(
+        snapshotWorkingDirectory: String?,
+        launchWorkingDirectory: String?
+    ) -> String? {
+        let candidates: [String?] = switch self {
+        case .recordedFallback(let preferred):
+            [preferred, snapshotWorkingDirectory, launchWorkingDirectory]
+        case .exact(let workingDirectory):
+            [workingDirectory]
+        }
+        for candidate in candidates {
+            guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty else {
+                continue
+            }
+            return trimmed
+        }
+        return nil
+    }
+}

--- a/Sources/SessionRestorableAgentSnapshot+Commands.swift
+++ b/Sources/SessionRestorableAgentSnapshot+Commands.swift
@@ -49,12 +49,25 @@ extension SessionRestorableAgentSnapshot {
         includeWorkingDirectoryPrefix: Bool,
         restoringWorkingDirectory: String? = nil
     ) -> String? {
-        let effectiveWorkingDirectory = restoringWorkingDirectory ?? workingDirectory
+        resumeCommand(
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
+            workingDirectorySelection: .recordedFallback(preferred: restoringWorkingDirectory)
+        )
+    }
+
+    func resumeCommand(
+        includeWorkingDirectoryPrefix: Bool,
+        workingDirectorySelection: RestorableAgentWorkingDirectorySelection
+    ) -> String? {
+        let effectiveWorkingDirectory = workingDirectorySelection.resolved(
+            snapshotWorkingDirectory: workingDirectory,
+            launchWorkingDirectory: launchCommand?.workingDirectory
+        )
         if kind.restoreMode == .relaunchCommand {
             return AgentRelaunchCommandBuilder().shellCommand(
                 kind: kind,
                 launchCommand: launchCommand,
-                workingDirectory: effectiveWorkingDirectory,
+                resolvedWorkingDirectory: effectiveWorkingDirectory,
                 includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
             )
         }
@@ -62,7 +75,7 @@ extension SessionRestorableAgentSnapshot {
             kind: kind,
             sessionId: sessionId,
             launchCommand: launchCommand,
-            workingDirectory: effectiveWorkingDirectory,
+            resolvedWorkingDirectory: effectiveWorkingDirectory,
             registrationOverride: registration,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
             observedPermissionMode: permissionMode

--- a/Sources/SessionRestorableAgentSnapshot+Commands.swift
+++ b/Sources/SessionRestorableAgentSnapshot+Commands.swift
@@ -76,6 +76,7 @@ extension SessionRestorableAgentSnapshot {
             sessionId: sessionId,
             launchCommand: launchCommand,
             resolvedWorkingDirectory: effectiveWorkingDirectory,
+            discardRecordedCwdOptions: workingDirectorySelection.discardsRecordedCwdOptions,
             registrationOverride: registration,
             includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix,
             observedPermissionMode: permissionMode

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1428,10 +1428,23 @@ extension Workspace {
                     return nil
                 }
                 if restoresRemoteWorkspaceTerminalSnapshot {
-                    // Only remote-report provenance is safe to send to the far
-                    // host. `savedWorkingDirectory` is nil when the snapshot's
-                    // directory still requires remote trust.
-                    return savedWorkingDirectory
+                    // Keep directory-keyed agents in the launch namespace while
+                    // id-keyed agents may follow the latest remote runtime cwd.
+                    // Snapshot agent paths are eligible only when the panel's
+                    // remote-directory provenance says they are trusted.
+                    let hasTrustedRemoteDirectory = snapshot.directoryIsTrustedRemoteReport == true
+                    let trustedRuntimeWorkingDirectory = hasTrustedRemoteDirectory
+                        ? savedWorkingDirectory
+                        : nil
+                    let trustedAgentWorkingDirectory = hasTrustedRemoteDirectory
+                        ? (restorableAgent.workingDirectory
+                            ?? restorableAgent.launchCommand?.workingDirectory)
+                        : nil
+                    return AgentResumeWorkingDirectory().resolve(
+                        kind: restorableAgent.kind.rawValue,
+                        runtimeCwd: trustedRuntimeWorkingDirectory,
+                        launchWorkingDirectory: trustedAgentWorkingDirectory
+                    )
                 }
                 return restorableAgent.workingDirectory
                     ?? restorableAgent.launchCommand?.workingDirectory

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1428,14 +1428,10 @@ extension Workspace {
                     return nil
                 }
                 if restoresRemoteWorkspaceTerminalSnapshot {
-                    // The resume command runs on the remote host, so the panel's
-                    // recorded directory is the right cd target even while remote
-                    // trust rules keep it out of savedWorkingDirectory. Falling
-                    // back to workingDirectory would hand the far host this
-                    // machine's cwd.
+                    // Only remote-report provenance is safe to send to the far
+                    // host. `savedWorkingDirectory` is nil when the snapshot's
+                    // directory still requires remote trust.
                     return savedWorkingDirectory
-                        ?? snapshot.terminal?.workingDirectory
-                        ?? snapshot.directory
                 }
                 return restorableAgent.workingDirectory
                     ?? restorableAgent.launchCommand?.workingDirectory
@@ -1487,7 +1483,7 @@ extension Workspace {
                     if restoresRemoteWorkspaceTerminalSnapshot {
                         restorableAgent?.resumeStartupInput(
                             useLocalRestoreVerb: false,
-                            restoringWorkingDirectory: resumeSessionWorkingDirectory
+                            workingDirectorySelection: .exact(resumeSessionWorkingDirectory)
                         )
                             .map(SurfaceResumeStartupLaunch.input)
                     } else {
@@ -4988,17 +4984,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
         let previousPresentedDirectory = presentedCurrentDirectory
         let isRemoteTerminalReport = isRemoteTerminalSurface(panelId)
-        // A generic live report must not overwrite a directory that remote trust
-        // rules own, but it may fill an empty slot: on a remote-workspace terminal
-        // the pty stream is the remote session, and dropping its first report
-        // leaves the panel with no recorded directory at all, so a later session
-        // restore can only fall back to this machine's cwd. The recorded value
-        // stays trust-required — it gains no remote-report provenance and never
-        // feeds local consumers.
-        if source == .liveReport, remoteDirectoryTrustRequiredPanelIds.contains(panelId) {
-            let existingDirectory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard existingDirectory.isEmpty else { return false }
-        }
+        if source == .liveReport, remoteDirectoryTrustRequiredPanelIds.contains(panelId) { return false }
         let routedRemoteReport = source == .remoteReport && !allowsLocalDirectoryFallback(panelId: panelId)
         let establishesRemoteProvenance = source == .trustedRestoredRemoteSnapshotMetadata ||
             (source.establishesRemoteProvenance &&

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1428,7 +1428,14 @@ extension Workspace {
                     return nil
                 }
                 if restoresRemoteWorkspaceTerminalSnapshot {
-                    return workingDirectory
+                    // The resume command runs on the remote host, so the panel's
+                    // recorded directory is the right cd target even while remote
+                    // trust rules keep it out of savedWorkingDirectory. Falling
+                    // back to workingDirectory would hand the far host this
+                    // machine's cwd.
+                    return savedWorkingDirectory
+                        ?? snapshot.terminal?.workingDirectory
+                        ?? snapshot.directory
                 }
                 return restorableAgent.workingDirectory
                     ?? restorableAgent.launchCommand?.workingDirectory
@@ -4981,7 +4988,17 @@ final class Workspace: Identifiable, ObservableObject {
         }
         let previousPresentedDirectory = presentedCurrentDirectory
         let isRemoteTerminalReport = isRemoteTerminalSurface(panelId)
-        if source == .liveReport, remoteDirectoryTrustRequiredPanelIds.contains(panelId) { return false }
+        // A generic live report must not overwrite a directory that remote trust
+        // rules own, but it may fill an empty slot: on a remote-workspace terminal
+        // the pty stream is the remote session, and dropping its first report
+        // leaves the panel with no recorded directory at all, so a later session
+        // restore can only fall back to this machine's cwd. The recorded value
+        // stays trust-required — it gains no remote-report provenance and never
+        // feeds local consumers.
+        if source == .liveReport, remoteDirectoryTrustRequiredPanelIds.contains(panelId) {
+            let existingDirectory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard existingDirectory.isEmpty else { return false }
+        }
         let routedRemoteReport = source == .remoteReport && !allowsLocalDirectoryFallback(panelId: panelId)
         let establishesRemoteProvenance = source == .trustedRestoredRemoteSnapshotMetadata ||
             (source.establishesRemoteProvenance &&

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -227,7 +227,7 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
             )
             let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
             let remoteWorkingDirectory = "/home/dev/cmux-remote-running"
-            source.updatePanelDirectory(
+            source.updateRemotePanelDirectory(
                 panelId: sourcePanelId,
                 directory: remoteWorkingDirectory
             )

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -1762,6 +1762,50 @@ struct RemoteAgentRestoreWorkingDirectoryTests {
         }
     }
 
+    @Test func exactSelectionStripsAttachedShortCwdArguments() throws {
+        let trustedRemoteDirectory = "/repo-b"
+        let cases: [(
+            kind: RestorableAgentKind,
+            registration: CmuxVaultAgentRegistration?,
+            executable: String,
+            attachedCwdOption: String
+        )] = [
+            (.codex, nil, "codex", "-C/Users/alice/codex-explicit-cwd"),
+            (.kimi, .builtInKimi, "kimi", "-w/Users/alice/kimi-explicit-cwd"),
+        ]
+
+        for testCase in cases {
+            let sessionId = "remote-\(testCase.executable)-attached-cwd"
+            let snapshot = SessionRestorableAgentSnapshot(
+                kind: testCase.kind,
+                sessionId: sessionId,
+                workingDirectory: "/Users/alice/recorded-agent-cwd",
+                launchCommand: AgentLaunchCommandSnapshot(
+                    launcher: testCase.executable,
+                    executablePath: testCase.executable,
+                    arguments: [testCase.executable, testCase.attachedCwdOption],
+                    workingDirectory: "/tmp/process-cwd",
+                    environment: [:],
+                    capturedAt: 1_777_777_777,
+                    source: "process"
+                ),
+                registration: testCase.registration
+            )
+
+            for exactDirectory in [trustedRemoteDirectory, nil] as [String?] {
+                let input = try #require(snapshot.resumeStartupInput(
+                    useLocalRestoreVerb: false,
+                    workingDirectorySelection: .exact(exactDirectory)
+                ))
+                #expect(input.contains(sessionId), Comment(rawValue: input))
+                #expect(!input.contains(testCase.attachedCwdOption), Comment(rawValue: input))
+                if let exactDirectory {
+                    #expect(input.contains(exactDirectory), Comment(rawValue: input))
+                }
+            }
+        }
+    }
+
     @MainActor
     @Test func genericDirectoryReportCannotSeedEmptyTrustRequiredRemotePanel() throws {
         let localDirectory = "/Users/alice/development"
@@ -1831,6 +1875,69 @@ struct RemoteAgentRestoreWorkingDirectoryTests {
         #expect(!startupInput.contains(firstRemoteDirectory), Comment(rawValue: startupInput))
         #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
         #expect(restoredPanel.requestedWorkingDirectory == latestRemoteDirectory)
+    }
+
+    @MainActor
+    @Test func remoteDirectoryNamespacedAutoResumeKeepsLaunchDirectory() throws {
+        let defaultsName = "cmux-remote-launch-cwd-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let localDirectory = "/Users/alice/development"
+        let launchRemoteDirectory = "/repo-a"
+        let latestRemoteDirectory = "/repo-b"
+        let remoteCommand = "ssh cmux-remote"
+        let sessionId = "grok-remote-launch-cwd-\(UUID().uuidString)"
+        let source = Workspace(
+            workingDirectory: localDirectory,
+            initialTerminalCommand: remoteCommand,
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { source.teardownAllPanels() }
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.configureRemoteConnection(
+            remoteWorkspaceConfiguration(command: remoteCommand),
+            autoConnect: false
+        )
+        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: launchRemoteDirectory))
+        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: latestRemoteDirectory))
+        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+        source.setRestoredAgentSnapshotForTesting(
+            SessionRestorableAgentSnapshot(
+                kind: .grok,
+                sessionId: sessionId,
+                workingDirectory: launchRemoteDirectory,
+                launchCommand: AgentLaunchCommandSnapshot(
+                    launcher: "grok",
+                    executablePath: "grok",
+                    arguments: ["grok", "--cwd", launchRemoteDirectory],
+                    workingDirectory: launchRemoteDirectory,
+                    environment: [:],
+                    capturedAt: 1_777_777_777,
+                    source: "process"
+                ),
+                registration: .builtInGrok
+            ),
+            panelId: sourcePanelId
+        )
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        #expect(snapshot.panels.first?.directoryIsTrustedRemoteReport == true)
+        #expect(snapshot.panels.first?.terminal?.workingDirectory == latestRemoteDirectory)
+        #expect(snapshot.panels.first?.terminal?.agent?.workingDirectory == launchRemoteDirectory)
+
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelId))
+        let startupInput = try #require(restoredPanel.surface.initialInput)
+
+        #expect(startupInput.contains(launchRemoteDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(latestRemoteDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
+        #expect(restoredPanel.requestedWorkingDirectory == launchRemoteDirectory)
     }
 
     @MainActor

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -1699,6 +1699,52 @@ struct AgentSessionAutoResumeSwiftTests {
 
 @Suite(.serialized)
 struct RemoteAgentRestoreWorkingDirectoryTests {
+    @Test func exactSelectionStripsRegisteredBuiltInRecordedCwdArguments() throws {
+        let recordedLocalDirectory = "/Users/alice/recorded-agent-cwd"
+        let trustedRemoteDirectory = "/repo-b"
+        let cases: [(
+            kind: RestorableAgentKind,
+            registration: CmuxVaultAgentRegistration,
+            executable: String,
+            cwdOption: String
+        )] = [
+            (.grok, .builtInGrok, "grok", "--cwd"),
+            (.kimi, .builtInKimi, "kimi", "--work-dir"),
+        ]
+
+        for testCase in cases {
+            let sessionId = "remote-\(testCase.executable)-session"
+            let snapshot = SessionRestorableAgentSnapshot(
+                kind: testCase.kind,
+                sessionId: sessionId,
+                workingDirectory: recordedLocalDirectory,
+                launchCommand: AgentLaunchCommandSnapshot(
+                    launcher: testCase.executable,
+                    executablePath: testCase.executable,
+                    arguments: [testCase.executable, testCase.cwdOption, recordedLocalDirectory],
+                    workingDirectory: recordedLocalDirectory,
+                    environment: [:],
+                    capturedAt: 1_777_777_777,
+                    source: "process"
+                ),
+                registration: testCase.registration
+            )
+
+            for exactDirectory in [trustedRemoteDirectory, nil] as [String?] {
+                let input = try #require(snapshot.resumeStartupInput(
+                    useLocalRestoreVerb: false,
+                    workingDirectorySelection: .exact(exactDirectory)
+                ))
+                #expect(input.contains(sessionId), Comment(rawValue: input))
+                #expect(!input.contains(recordedLocalDirectory), Comment(rawValue: input))
+                #expect(!input.contains(testCase.cwdOption), Comment(rawValue: input))
+                if let exactDirectory {
+                    #expect(input.contains(exactDirectory), Comment(rawValue: input))
+                }
+            }
+        }
+    }
+
     @MainActor
     @Test func genericDirectoryReportCannotSeedEmptyTrustRequiredRemotePanel() throws {
         let localDirectory = "/Users/alice/development"

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -1706,10 +1706,26 @@ struct RemoteAgentRestoreWorkingDirectoryTests {
             kind: RestorableAgentKind,
             registration: CmuxVaultAgentRegistration,
             executable: String,
-            cwdOption: String
+            cwdOption: String,
+            cwdArgument: String,
+            launchWorkingDirectory: String?
         )] = [
-            (.grok, .builtInGrok, "grok", "--cwd"),
-            (.kimi, .builtInKimi, "kimi", "--work-dir"),
+            (
+                .grok,
+                .builtInGrok,
+                "grok",
+                "--cwd",
+                "/Users/alice/grok-explicit-cwd",
+                "/tmp/grok-process-cwd"
+            ),
+            (
+                .kimi,
+                .builtInKimi,
+                "kimi",
+                "--work-dir",
+                "/Users/alice/kimi-explicit-cwd",
+                nil
+            ),
         ]
 
         for testCase in cases {
@@ -1721,8 +1737,8 @@ struct RemoteAgentRestoreWorkingDirectoryTests {
                 launchCommand: AgentLaunchCommandSnapshot(
                     launcher: testCase.executable,
                     executablePath: testCase.executable,
-                    arguments: [testCase.executable, testCase.cwdOption, recordedLocalDirectory],
-                    workingDirectory: recordedLocalDirectory,
+                    arguments: [testCase.executable, testCase.cwdOption, testCase.cwdArgument],
+                    workingDirectory: testCase.launchWorkingDirectory,
                     environment: [:],
                     capturedAt: 1_777_777_777,
                     source: "process"
@@ -1737,6 +1753,7 @@ struct RemoteAgentRestoreWorkingDirectoryTests {
                 ))
                 #expect(input.contains(sessionId), Comment(rawValue: input))
                 #expect(!input.contains(recordedLocalDirectory), Comment(rawValue: input))
+                #expect(!input.contains(testCase.cwdArgument), Comment(rawValue: input))
                 #expect(!input.contains(testCase.cwdOption), Comment(rawValue: input))
                 if let exactDirectory {
                     #expect(input.contains(exactDirectory), Comment(rawValue: input))

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -396,130 +396,6 @@ struct AgentSessionAutoResumeSwiftTests {
         }
     }
 
-    @MainActor
-    @Test func genericDirectoryReportCannotSeedEmptyTrustRequiredRemotePanel() throws {
-        let localDirectory = "/Users/alice/development"
-        let genericDirectory = "/repo-a"
-        let remoteCommand = "ssh cmux-remote"
-        let workspace = Workspace(
-            workingDirectory: localDirectory,
-            initialTerminalCommand: remoteCommand
-        )
-        defer { workspace.teardownAllPanels() }
-        let panelId = try #require(workspace.focusedPanelId)
-        workspace.configureRemoteConnection(
-            remoteWorkspaceConfiguration(command: remoteCommand),
-            autoConnect: false
-        )
-        workspace.panelDirectories.removeValue(forKey: panelId)
-
-        #expect(workspace.remoteDirectoryTrustRequiredPanelIds.contains(panelId))
-        #expect(!workspace.updatePanelDirectory(panelId: panelId, directory: genericDirectory))
-        #expect(workspace.panelDirectories[panelId] == nil)
-        #expect(workspace.reportedPanelDirectory(panelId: panelId) == nil)
-    }
-
-    @MainActor
-    @Test func remoteAutoResumeUsesLatestAuthoritativeDirectoryReport() throws {
-        let defaultsName = "cmux-remote-latest-cwd-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: defaultsName))
-        defer { defaults.removePersistentDomain(forName: defaultsName) }
-        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
-
-        let localDirectory = "/Users/alice/development"
-        let firstRemoteDirectory = "/repo-a"
-        let latestRemoteDirectory = "/repo-b"
-        let remoteCommand = "ssh cmux-remote"
-        let sessionId = "codex-remote-latest-cwd-\(UUID().uuidString)"
-        let source = Workspace(
-            workingDirectory: localDirectory,
-            initialTerminalCommand: remoteCommand,
-            agentSessionAutoResumeDefaults: defaults
-        )
-        defer { source.teardownAllPanels() }
-        let sourcePanelId = try #require(source.focusedPanelId)
-        source.configureRemoteConnection(
-            remoteWorkspaceConfiguration(command: remoteCommand),
-            autoConnect: false
-        )
-        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: firstRemoteDirectory))
-        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: latestRemoteDirectory))
-        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
-        source.setRestoredAgentSnapshotForTesting(
-            restorableCodexAgent(sessionId: sessionId, workingDirectory: firstRemoteDirectory),
-            panelId: sourcePanelId
-        )
-
-        let snapshot = source.sessionSnapshot(includeScrollback: false)
-        #expect(snapshot.panels.first?.directoryIsTrustedRemoteReport == true)
-        #expect(snapshot.panels.first?.terminal?.workingDirectory == latestRemoteDirectory)
-
-        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
-        defer { restored.teardownAllPanels() }
-        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
-        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
-        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelId))
-        let startupInput = try #require(restoredPanel.surface.initialInput)
-
-        #expect(startupInput.contains(latestRemoteDirectory), Comment(rawValue: startupInput))
-        #expect(!startupInput.contains(firstRemoteDirectory), Comment(rawValue: startupInput))
-        #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
-        #expect(restoredPanel.requestedWorkingDirectory == latestRemoteDirectory)
-    }
-
-    @MainActor
-    @Test func remoteAutoResumeWithoutTrustedDirectoryRejectsRecordedLocalCwd() throws {
-        let defaultsName = "cmux-remote-untrusted-cwd-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: defaultsName))
-        defer { defaults.removePersistentDomain(forName: defaultsName) }
-        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
-
-        let localDirectory = "/Users/alice/development"
-        let untrustedRecordedDirectory = "/Users/alice/recorded-agent-cwd"
-        let remoteCommand = "ssh cmux-remote"
-        let sessionId = "codex-remote-untrusted-cwd-\(UUID().uuidString)"
-        let source = Workspace(
-            workingDirectory: localDirectory,
-            initialTerminalCommand: remoteCommand,
-            agentSessionAutoResumeDefaults: defaults
-        )
-        defer { source.teardownAllPanels() }
-        let sourcePanelId = try #require(source.focusedPanelId)
-        source.configureRemoteConnection(
-            remoteWorkspaceConfiguration(command: remoteCommand),
-            autoConnect: false
-        )
-        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
-        source.setRestoredAgentSnapshotForTesting(
-            restorableCodexAgent(sessionId: sessionId, workingDirectory: untrustedRecordedDirectory),
-            panelId: sourcePanelId
-        )
-
-        var snapshot = source.sessionSnapshot(includeScrollback: false)
-        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == sourcePanelId })
-        snapshot.panels[panelIndex].directory = untrustedRecordedDirectory
-        snapshot.panels[panelIndex].directoryIsTrustedRemoteReport = false
-        snapshot.panels[panelIndex].directoryRequiresRemoteTrust = true
-        var terminalSnapshot = try #require(snapshot.panels[panelIndex].terminal)
-        terminalSnapshot.workingDirectory = untrustedRecordedDirectory
-        terminalSnapshot.isRemoteTerminal = true
-        terminalSnapshot.wasAgentRunning = true
-        snapshot.panels[panelIndex].terminal = terminalSnapshot
-
-        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
-        defer { restored.teardownAllPanels() }
-        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
-        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
-        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelId))
-        let startupInput = try #require(restoredPanel.surface.initialInput)
-
-        #expect(startupInput.contains(sessionId), Comment(rawValue: startupInput))
-        #expect(!startupInput.contains(untrustedRecordedDirectory), Comment(rawValue: startupInput))
-        #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
-        #expect(restoredPanel.requestedWorkingDirectory == nil)
-        #expect(restored.remoteDirectoryTrustRequiredPanelIds.contains(restoredPanelId))
-    }
-
     /// Regression for #6617: after Cmd+Q/restore of a workspace whose focused
     /// terminal is running an auto-resumed agent in a project directory, the
     /// resumed shell spawns in its default directory and shell integration
@@ -1778,41 +1654,6 @@ struct AgentSessionAutoResumeSwiftTests {
         return record
     }
 
-    private func remoteWorkspaceConfiguration(command: String) -> WorkspaceRemoteConfiguration {
-        WorkspaceRemoteConfiguration(
-            destination: "cmux-remote",
-            port: nil,
-            identityFile: nil,
-            sshOptions: [],
-            localProxyPort: nil,
-            relayPort: 64_000,
-            relayID: "relay-remote-cwd-\(UUID().uuidString)",
-            relayToken: String(repeating: "a", count: 64),
-            localSocketPath: "/tmp/cmux-remote-cwd-\(UUID().uuidString).sock",
-            terminalStartupCommand: command
-        )
-    }
-
-    private func restorableCodexAgent(
-        sessionId: String,
-        workingDirectory: String
-    ) -> SessionRestorableAgentSnapshot {
-        SessionRestorableAgentSnapshot(
-            kind: .codex,
-            sessionId: sessionId,
-            workingDirectory: workingDirectory,
-            launchCommand: AgentLaunchCommandSnapshot(
-                launcher: "codex",
-                executablePath: "/usr/local/bin/codex",
-                arguments: ["/usr/local/bin/codex"],
-                workingDirectory: workingDirectory,
-                environment: [:],
-                capturedAt: 1_777_777_777,
-                source: "process"
-            )
-        )
-    }
-
     private func withRestoredDefaults<T>(
         key: String,
         defaults: UserDefaults = .standard,
@@ -1853,5 +1694,167 @@ struct AgentSessionAutoResumeSwiftTests {
         }
         #expect(script.contains("rm -f -- \"$0\""), Comment(rawValue: script))
         #expect(!script.contains("exec -l"), Comment(rawValue: script))
+    }
+}
+
+@Suite(.serialized)
+struct RemoteAgentRestoreWorkingDirectoryTests {
+    @MainActor
+    @Test func genericDirectoryReportCannotSeedEmptyTrustRequiredRemotePanel() throws {
+        let localDirectory = "/Users/alice/development"
+        let genericDirectory = "/repo-a"
+        let remoteCommand = "ssh cmux-remote"
+        let workspace = Workspace(
+            workingDirectory: localDirectory,
+            initialTerminalCommand: remoteCommand
+        )
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        workspace.configureRemoteConnection(
+            remoteWorkspaceConfiguration(command: remoteCommand),
+            autoConnect: false
+        )
+        workspace.panelDirectories.removeValue(forKey: panelId)
+
+        #expect(workspace.remoteDirectoryTrustRequiredPanelIds.contains(panelId))
+        #expect(!workspace.updatePanelDirectory(panelId: panelId, directory: genericDirectory))
+        #expect(workspace.panelDirectories[panelId] == nil)
+        #expect(workspace.reportedPanelDirectory(panelId: panelId) == nil)
+    }
+
+    @MainActor
+    @Test func remoteAutoResumeUsesLatestAuthoritativeDirectoryReport() throws {
+        let defaultsName = "cmux-remote-latest-cwd-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let localDirectory = "/Users/alice/development"
+        let firstRemoteDirectory = "/repo-a"
+        let latestRemoteDirectory = "/repo-b"
+        let remoteCommand = "ssh cmux-remote"
+        let sessionId = "codex-remote-latest-cwd-\(UUID().uuidString)"
+        let source = Workspace(
+            workingDirectory: localDirectory,
+            initialTerminalCommand: remoteCommand,
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { source.teardownAllPanels() }
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.configureRemoteConnection(
+            remoteWorkspaceConfiguration(command: remoteCommand),
+            autoConnect: false
+        )
+        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: firstRemoteDirectory))
+        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: latestRemoteDirectory))
+        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+        source.setRestoredAgentSnapshotForTesting(
+            restorableCodexAgent(sessionId: sessionId, workingDirectory: firstRemoteDirectory),
+            panelId: sourcePanelId
+        )
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        #expect(snapshot.panels.first?.directoryIsTrustedRemoteReport == true)
+        #expect(snapshot.panels.first?.terminal?.workingDirectory == latestRemoteDirectory)
+
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelId))
+        let startupInput = try #require(restoredPanel.surface.initialInput)
+
+        #expect(startupInput.contains(latestRemoteDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(firstRemoteDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
+        #expect(restoredPanel.requestedWorkingDirectory == latestRemoteDirectory)
+    }
+
+    @MainActor
+    @Test func remoteAutoResumeWithoutTrustedDirectoryRejectsRecordedLocalCwd() throws {
+        let defaultsName = "cmux-remote-untrusted-cwd-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let localDirectory = "/Users/alice/development"
+        let untrustedRecordedDirectory = "/Users/alice/recorded-agent-cwd"
+        let remoteCommand = "ssh cmux-remote"
+        let sessionId = "codex-remote-untrusted-cwd-\(UUID().uuidString)"
+        let source = Workspace(
+            workingDirectory: localDirectory,
+            initialTerminalCommand: remoteCommand,
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { source.teardownAllPanels() }
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.configureRemoteConnection(
+            remoteWorkspaceConfiguration(command: remoteCommand),
+            autoConnect: false
+        )
+        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+        source.setRestoredAgentSnapshotForTesting(
+            restorableCodexAgent(sessionId: sessionId, workingDirectory: untrustedRecordedDirectory),
+            panelId: sourcePanelId
+        )
+
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == sourcePanelId })
+        snapshot.panels[panelIndex].directory = untrustedRecordedDirectory
+        snapshot.panels[panelIndex].directoryIsTrustedRemoteReport = false
+        snapshot.panels[panelIndex].directoryRequiresRemoteTrust = true
+        var terminalSnapshot = try #require(snapshot.panels[panelIndex].terminal)
+        terminalSnapshot.workingDirectory = untrustedRecordedDirectory
+        terminalSnapshot.isRemoteTerminal = true
+        terminalSnapshot.wasAgentRunning = true
+        snapshot.panels[panelIndex].terminal = terminalSnapshot
+
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelId))
+        let startupInput = try #require(restoredPanel.surface.initialInput)
+
+        #expect(startupInput.contains(sessionId), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(untrustedRecordedDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
+        #expect(restoredPanel.requestedWorkingDirectory == nil)
+        #expect(restored.remoteDirectoryTrustRequiredPanelIds.contains(restoredPanelId))
+    }
+
+    private func remoteWorkspaceConfiguration(command: String) -> WorkspaceRemoteConfiguration {
+        WorkspaceRemoteConfiguration(
+            destination: "cmux-remote",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_000,
+            relayID: "relay-remote-cwd-\(UUID().uuidString)",
+            relayToken: String(repeating: "a", count: 64),
+            localSocketPath: "/tmp/cmux-remote-cwd-\(UUID().uuidString).sock",
+            terminalStartupCommand: command
+        )
+    }
+
+    private func restorableCodexAgent(
+        sessionId: String,
+        workingDirectory: String
+    ) -> SessionRestorableAgentSnapshot {
+        SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: sessionId,
+            workingDirectory: workingDirectory,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/usr/local/bin/codex",
+                arguments: ["/usr/local/bin/codex"],
+                workingDirectory: workingDirectory,
+                environment: [:],
+                capturedAt: 1_777_777_777,
+                source: "process"
+            )
+        )
     }
 }

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -396,6 +396,130 @@ struct AgentSessionAutoResumeSwiftTests {
         }
     }
 
+    @MainActor
+    @Test func genericDirectoryReportCannotSeedEmptyTrustRequiredRemotePanel() throws {
+        let localDirectory = "/Users/alice/development"
+        let genericDirectory = "/repo-a"
+        let remoteCommand = "ssh cmux-remote"
+        let workspace = Workspace(
+            workingDirectory: localDirectory,
+            initialTerminalCommand: remoteCommand
+        )
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        workspace.configureRemoteConnection(
+            remoteWorkspaceConfiguration(command: remoteCommand),
+            autoConnect: false
+        )
+        workspace.panelDirectories.removeValue(forKey: panelId)
+
+        #expect(workspace.remoteDirectoryTrustRequiredPanelIds.contains(panelId))
+        #expect(!workspace.updatePanelDirectory(panelId: panelId, directory: genericDirectory))
+        #expect(workspace.panelDirectories[panelId] == nil)
+        #expect(workspace.reportedPanelDirectory(panelId: panelId) == nil)
+    }
+
+    @MainActor
+    @Test func remoteAutoResumeUsesLatestAuthoritativeDirectoryReport() throws {
+        let defaultsName = "cmux-remote-latest-cwd-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let localDirectory = "/Users/alice/development"
+        let firstRemoteDirectory = "/repo-a"
+        let latestRemoteDirectory = "/repo-b"
+        let remoteCommand = "ssh cmux-remote"
+        let sessionId = "codex-remote-latest-cwd-\(UUID().uuidString)"
+        let source = Workspace(
+            workingDirectory: localDirectory,
+            initialTerminalCommand: remoteCommand,
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { source.teardownAllPanels() }
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.configureRemoteConnection(
+            remoteWorkspaceConfiguration(command: remoteCommand),
+            autoConnect: false
+        )
+        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: firstRemoteDirectory))
+        #expect(source.updateRemotePanelDirectory(panelId: sourcePanelId, directory: latestRemoteDirectory))
+        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+        source.setRestoredAgentSnapshotForTesting(
+            restorableCodexAgent(sessionId: sessionId, workingDirectory: firstRemoteDirectory),
+            panelId: sourcePanelId
+        )
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        #expect(snapshot.panels.first?.directoryIsTrustedRemoteReport == true)
+        #expect(snapshot.panels.first?.terminal?.workingDirectory == latestRemoteDirectory)
+
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelId))
+        let startupInput = try #require(restoredPanel.surface.initialInput)
+
+        #expect(startupInput.contains(latestRemoteDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(firstRemoteDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
+        #expect(restoredPanel.requestedWorkingDirectory == latestRemoteDirectory)
+    }
+
+    @MainActor
+    @Test func remoteAutoResumeWithoutTrustedDirectoryRejectsRecordedLocalCwd() throws {
+        let defaultsName = "cmux-remote-untrusted-cwd-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsName))
+        defer { defaults.removePersistentDomain(forName: defaultsName) }
+        defaults.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+        let localDirectory = "/Users/alice/development"
+        let untrustedRecordedDirectory = "/Users/alice/recorded-agent-cwd"
+        let remoteCommand = "ssh cmux-remote"
+        let sessionId = "codex-remote-untrusted-cwd-\(UUID().uuidString)"
+        let source = Workspace(
+            workingDirectory: localDirectory,
+            initialTerminalCommand: remoteCommand,
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { source.teardownAllPanels() }
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.configureRemoteConnection(
+            remoteWorkspaceConfiguration(command: remoteCommand),
+            autoConnect: false
+        )
+        source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+        source.setRestoredAgentSnapshotForTesting(
+            restorableCodexAgent(sessionId: sessionId, workingDirectory: untrustedRecordedDirectory),
+            panelId: sourcePanelId
+        )
+
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == sourcePanelId })
+        snapshot.panels[panelIndex].directory = untrustedRecordedDirectory
+        snapshot.panels[panelIndex].directoryIsTrustedRemoteReport = false
+        snapshot.panels[panelIndex].directoryRequiresRemoteTrust = true
+        var terminalSnapshot = try #require(snapshot.panels[panelIndex].terminal)
+        terminalSnapshot.workingDirectory = untrustedRecordedDirectory
+        terminalSnapshot.isRemoteTerminal = true
+        terminalSnapshot.wasAgentRunning = true
+        snapshot.panels[panelIndex].terminal = terminalSnapshot
+
+        let restored = Workspace(agentSessionAutoResumeDefaults: defaults)
+        defer { restored.teardownAllPanels() }
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+        let restoredPanel = try #require(restored.terminalPanel(for: restoredPanelId))
+        let startupInput = try #require(restoredPanel.surface.initialInput)
+
+        #expect(startupInput.contains(sessionId), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(untrustedRecordedDirectory), Comment(rawValue: startupInput))
+        #expect(!startupInput.contains(localDirectory), Comment(rawValue: startupInput))
+        #expect(restoredPanel.requestedWorkingDirectory == nil)
+        #expect(restored.remoteDirectoryTrustRequiredPanelIds.contains(restoredPanelId))
+    }
+
     /// Regression for #6617: after Cmd+Q/restore of a workspace whose focused
     /// terminal is running an auto-resumed agent in a project directory, the
     /// resumed shell spawns in its default directory and shell integration
@@ -1652,6 +1776,41 @@ struct AgentSessionAutoResumeSwiftTests {
             record["transcriptPath"] = transcriptPath
         }
         return record
+    }
+
+    private func remoteWorkspaceConfiguration(command: String) -> WorkspaceRemoteConfiguration {
+        WorkspaceRemoteConfiguration(
+            destination: "cmux-remote",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64_000,
+            relayID: "relay-remote-cwd-\(UUID().uuidString)",
+            relayToken: String(repeating: "a", count: 64),
+            localSocketPath: "/tmp/cmux-remote-cwd-\(UUID().uuidString).sock",
+            terminalStartupCommand: command
+        )
+    }
+
+    private func restorableCodexAgent(
+        sessionId: String,
+        workingDirectory: String
+    ) -> SessionRestorableAgentSnapshot {
+        SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: sessionId,
+            workingDirectory: workingDirectory,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "/usr/local/bin/codex",
+                arguments: ["/usr/local/bin/codex"],
+                workingDirectory: workingDirectory,
+                environment: [:],
+                capturedAt: 1_777_777_777,
+                source: "process"
+            )
+        )
     }
 
     private func withRestoredDefaults<T>(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -4371,6 +4371,23 @@ extension SessionPersistenceTests {
         )
     }
 
+    func testAgentHookSurfaceResumeBindingDropsDuplicateKimiWorkingDirectoryOption() {
+        let binding = SurfaceResumeBindingSnapshot(
+            command: "cd '/tmp/project' && kimi --resume session --work-dir '/tmp/project' --model kimi-k2",
+            cwd: "/tmp/project",
+            source: "agent-hook",
+            updatedAt: 1
+        )
+
+        XCTAssertEqual(
+            binding.command,
+            TerminalStartupWorkingDirectoryPrefix.prefix(
+                "kimi --resume session --model kimi-k2",
+                workingDirectory: "/tmp/project"
+            )
+        )
+    }
+
     func testAgentHookSurfaceResumeBindingPreservesShellOperatorsWhenDroppingDuplicateWorkingDirectoryOption() {
         let binding = SurfaceResumeBindingSnapshot(
             command: "cd '/tmp/project' && codex resume session --cd '/tmp/project' && echo done",


### PR DESCRIPTION
## Summary

- Fail closed when a remote-workspace agent restore has no trusted remote cwd: only authoritative restored remote provenance may select the far-host directory.
- Preserve an exact nil cwd through built-in, custom-agent, and relaunch command construction instead of silently consulting the agent or launch snapshot again.
- Keep generic directory reports rejected for trust-required remote panels, while allowing repeated authoritative remote reports to update the restored cwd.
- Add behavior regressions and a non-tolerant focused CI invocation so Swift Testing assertion failures in this security boundary cannot be masked by the broad sharded wrapper.

## Testing

- Red regression proof: GitHub Actions run 31136545880 failed the focused app-host shard on the test-only commit ff0f3cff19.
- Swift parser validation passed for every touched Swift and test file.
- ./scripts/lint-pbxproj-test-wiring.sh
- python3 tests/test_swift_testing_suite_timeout.py
- python3 scripts/ci/cmux_unit_test_shard.py --validate
- python3 tests/test_ci_cmux_unit_test_shard.py
- ./tests/test_ci_self_hosted_guard.sh
- ./tests/test_ci_app_host_xcodebuild_retry.sh
- ./tests/test_ci_app_host_xcodebuild_attempts.sh
- Local Xcode tests and builds were intentionally not run; required GitHub CI is the authoritative compilation and behavior gate.

## Demo Video

- Not applicable: this is a non-visual session-restore correctness fix, and no build was requested.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally — intentionally not run; required GitHub CI is the verification gate.
- [x] Regression coverage exercises the exact remote restore paths.
- [x] No user-facing strings were added; localization catalogs require no changes.
- [x] Docs and changelog changes are not needed for this internal correctness fix.
- [ ] All required CI checks are green.
- [ ] All review comments are resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes session-restore and remote auto-resume cwd trust boundaries and command construction; incorrect behavior could run agents in the wrong directory on a remote host or drop cwd when it should apply.
> 
> **Overview**
> Fixes **remote workspace terminal restore** leaking the local machine's cwd into remote agent resume commands.
> 
> **Working directory policy:** Introduces `RestorableAgentWorkingDirectorySelection` with `recordedFallback` vs `exact` modes. **Exact** selection stops silent fallback to agent/launch snapshot cwd and forces stripping **all** captured cwd argv flags (`--work-dir`, attached `-C`/`w`, etc.) via `AgentLaunchSanitizer.removeAllWorkingDirectoryOptions`.
> 
> **Remote restore path:** When restoring a remote workspace terminal snapshot, resume cwd is chosen only from **trusted** remote directory provenance (`directoryIsTrustedRemoteReport`), then `AgentResumeWorkingDirectory` resolves per agent kind (runtime vs launch namespace). Remote auto-resume uses `.exact(...)` so untrusted or missing remote cwd cannot reapply recorded local paths.
> 
> **CI:** Adds a **non-tolerant** focused app-host run for `RemoteAgentRestoreWorkingDirectoryTests` so assertion failures on this boundary are not masked by the broad sharded suite's tolerance.
> 
> **Tests:** Broad regressions for exact cwd stripping, remote authoritative directory updates, directory-keyed vs id-keyed agents, and untrusted remote panels; hook binding duplicate Kimi `--work-dir` drop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146a3489b9247b44488c44cc569b0e5d9e85e27c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent session resuming to select the correct working directory, including remote sessions.
  * Prevented stale, untrusted, or duplicate working-directory arguments from affecting resumed sessions.
  * Added support for recognizing and removing working-directory options across supported command formats.
  * Preserved custom agent working-directory settings and template substitutions during relaunches.

* **Tests**
  * Added regression coverage for remote restores, Kimi resume commands, and working-directory argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->