### PR TITLE
CMUXProjectModel: find the worktree root instead of counting directories

### DIFF
--- a/Packages/macOS/CMUXProjectModel/Tests/CMUXProjectModelTests/XcodeProjectAdapterTests.swift
+++ b/Packages/macOS/CMUXProjectModel/Tests/CMUXProjectModelTests/XcodeProjectAdapterTests.swift
@@ -7,22 +7,57 @@ struct XcodeProjectAdapterTests {
     private let workspaceURL: URL
     private let projectURL: URL
 
-    init() {
+    /// How many directories the search below looks at, counting the one holding
+    /// this file. This file sits five levels below the worktree root today, so
+    /// six candidates cover the current layout and eight leaves a little room.
+    private static let searchedDirectoryCount = 8
+
+    init() throws {
         let env = ProcessInfo.processInfo.environment
         if let override = env["CMUX_PROJECT_FIXTURE"] {
             let base = URL(fileURLWithPath: override)
             self.workspaceURL = base.pathExtension.lowercased() == "xcworkspace" ? base : base.appendingPathComponent("cmux.xcworkspace")
             self.projectURL = base.pathExtension.lowercased() == "xcodeproj" ? base : base.appendingPathComponent("cmux.xcodeproj")
         } else {
-            let here = URL(fileURLWithPath: #filePath)
-            let worktreeRoot = here
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
+            let start = URL(fileURLWithPath: #filePath).resolvingSymlinksInPath().deletingLastPathComponent()
+            guard let worktreeRoot = Self.worktreeRootContainingProject(startingAt: start) else {
+                throw ProjectNotFoundError(searchStart: start, searchedDirectoryCount: Self.searchedDirectoryCount)
+            }
             self.workspaceURL = worktreeRoot.appendingPathComponent("cmux.xcworkspace")
             self.projectURL = worktreeRoot.appendingPathComponent("cmux.xcodeproj")
+        }
+    }
+
+    /// Returns the nearest directory at or above `start` that holds cmux.xcodeproj,
+    /// or nil when none of the `searchedDirectoryCount` directories it looks at has one.
+    ///
+    /// Packages move between the Packages/Shared, Packages/iOS and Packages/macOS
+    /// group folders, which changes how deep this file sits, and counting parent
+    /// directories silently points at the wrong root when that happens. The search
+    /// stops after a fixed number of levels so that a checkout nested inside another
+    /// checkout cannot bind these tests to the outer checkout's project.
+    private static func worktreeRootContainingProject(startingAt start: URL) -> URL? {
+        var directory = start
+        for _ in 0..<searchedDirectoryCount {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("cmux.xcodeproj").path) {
+                return directory
+            }
+            directory.deleteLastPathComponent()
+        }
+        return nil
+    }
+
+    private struct ProjectNotFoundError: Error, CustomStringConvertible {
+        let searchStart: URL
+        let searchedDirectoryCount: Int
+
+        var description: String {
+            """
+            cmux.xcodeproj is not in \(searchStart.path) or in any of the \
+            \(searchedDirectoryCount - 1) directories above it, so these tests have no \
+            project to load. Run them from a cmux checkout, or point \
+            CMUX_PROJECT_FIXTURE at a directory that contains cmux.xcodeproj.
+            """
         }
     }
 

--- a/Packages/macOS/CMUXProjectModel/Tests/CMUXProjectModelTests/XcodeProjectAdapterTests.swift
+++ b/Packages/macOS/CMUXProjectModel/Tests/CMUXProjectModelTests/XcodeProjectAdapterTests.swift
@@ -16,8 +16,14 @@ struct XcodeProjectAdapterTests {
         let env = ProcessInfo.processInfo.environment
         if let override = env["CMUX_PROJECT_FIXTURE"] {
             let base = URL(fileURLWithPath: override)
-            self.workspaceURL = base.pathExtension.lowercased() == "xcworkspace" ? base : base.appendingPathComponent("cmux.xcworkspace")
-            self.projectURL = base.pathExtension.lowercased() == "xcodeproj" ? base : base.appendingPathComponent("cmux.xcodeproj")
+            // The override may name the directory, the workspace bundle, or the project
+            // bundle. Siblings are derived from the containing directory, or a workspace
+            // override would nest projectURL inside the .xcworkspace bundle (and the
+            // symmetric bug for a .xcodeproj override).
+            let ext = base.pathExtension.lowercased()
+            let root = ["xcworkspace", "xcodeproj"].contains(ext) ? base.deletingLastPathComponent() : base
+            self.workspaceURL = ext == "xcworkspace" ? base : root.appendingPathComponent("cmux.xcworkspace")
+            self.projectURL = ext == "xcodeproj" ? base : root.appendingPathComponent("cmux.xcodeproj")
         } else {
             let start = URL(fileURLWithPath: #filePath).resolvingSymlinksInPath().deletingLastPathComponent()
             guard let worktreeRoot = Self.worktreeRootContainingProject(startingAt: start) else {


### PR DESCRIPTION
`swift test` in `Packages/macOS/CMUXProjectModel` fails 7 of 15 tests on current main:

```
✘ Test loadsCmuxXcodeprojIntoOneModule() recorded an issue: Caught error:
  unreadable(file:///.../Packages/cmux.xcodeproj)
```

`XcodeProjectAdapterTests.init` finds `cmux.xcodeproj` by walking five parent directories up from its own `#filePath`. That was the right depth when packages sat directly in `Packages/`. They now live in a group folder — this one is `Packages/macOS/CMUXProjectModel` — so five steps stop at `Packages/`, and every test that loads the project or workspace is handed a path that isn't there.

This searches upward for the directory that actually holds `cmux.xcodeproj`. CLAUDE.md describes packages moving between the `Shared`, `iOS` and `macOS` group folders, so a hardcoded depth breaks again on the next move while a search does not.

The search looks at eight directories and stops, rather than running to the filesystem root the way an unbounded walk would. A checkout nested inside another checkout has a `cmux.xcodeproj` above it that belongs to the outer checkout, and walking that far would quietly load the wrong project and pass. `CustomSidebarValidationTests` bounds its own upward search to eight levels for the same reason, so this matches it. `#filePath` also goes through `resolvingSymlinksInPath()` first, so a symlinked package path lands on a directory the walk can compare against instead of falling out the bottom.

When the search comes up empty the initializer throws and says so, rather than returning a path it made up:

```
cmux.xcodeproj is not in /.../Tests/CMUXProjectModelTests or in any of the 7
directories above it, so these tests have no project to load. Run them from a
cmux checkout, or point CMUX_PROJECT_FIXTURE at a directory that contains
cmux.xcodeproj.
```

In the repo, `swift test --disable-sandbox` reports `Test run with 15 tests in 2 suites passed after 0.131 seconds`. The count is 15 before and after, so the assertions run rather than being skipped. Copying the package to a directory with no `cmux.xcodeproj` anywhere above it produces the message quoted above and fails all nine tests in the suite. Two of those nine used to pass against the missing path without loading anything, because `canLoad` only inspects the path extension and the workspace test returns early when the file is absent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787292293&installation_model_id=21920&pr_number=8641&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8641&signature=aa28994c809740d54bf5e53af6afb61248d460e20e0aa685ea3b617c8ed595e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test project discovery by searching parent directories reliably.
  * Added clear error reporting when the project cannot be located.
  * Preserved support for custom project fixtures through `CMUX_PROJECT_FIXTURE`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->