### PR TITLE
CmuxNotifications: unbreak the test target so its 66 tests run

### DIFF
--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
@@ -43,7 +43,7 @@ private final class FakeHost: NotificationDismissalHosting {
 
     func panelId(forSurfaceOrPanelId surfaceId: UUID, in workspaceId: UUID) -> UUID? {
         detailedLookupCount += 1
-        panelIdsBySurface[surfaceId] ?? surfaceId
+        return panelIdsBySurface[surfaceId] ?? surfaceId
     }
 
     func storeHasDismissibleState(workspaceId: UUID) -> Bool {


### PR DESCRIPTION
`swift test` in `Packages/macOS/CmuxNotifications` fails to compile on current main:

```
NotificationDismissalModelTests.swift:47:5: error: missing return in instance
method expected to return 'UUID?'
```

The `panelId(forSurfaceOrPanelId:in:)` stub on a test double increments a counter and then leaves its dictionary lookup as a bare trailing expression. A body with two statements gets no implicit return, so the target has never built — which means all 66 tests across its 5 suites have never run.

Adding the `return` is the whole change. With it, the target builds and reports `Test run with 66 tests in 5 suites passed`.

Worth noting for anyone reviewing coverage here: this file is a package test target, so `xcodebuild`'s app-host suites never touch it and its failure is invisible unless someone runs `swift test` on the package directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787292363&installation_model_id=21920&pr_number=8642&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8642&signature=9e9f44028421f4aaa882fde5c7ab32fe5e4853d91644e50b6177f0087f726f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in the `CmuxNotifications` package test target so `swift test` builds and runs all 66 tests across 5 suites.

- **Bug Fixes**
  - Add an explicit `return` in `FakeHost.panelId(forSurfaceOrPanelId:in:)` in `NotificationDismissalModelTests.swift` to satisfy the `UUID?` return type and restore the test target build.

<sup>Written for commit 08dbedc91e6cf57da8e4d9ec6a2662ab3dacb115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test instrumentation for tracking detailed panel ID lookups during notification dismissal testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->