### PR TITLE
remote-daemon: tear a PTY session down once

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -193,6 +193,7 @@ type wsPTYSession struct {
 	ptyFileMu      sync.Mutex
 	closeTTYOnce   sync.Once
 	closePTYOnce   sync.Once
+	terminateOnce  sync.Once
 }
 
 type wsPTYHub struct {
@@ -1370,22 +1371,33 @@ func (session *wsPTYSession) terminateProcesses() {
 }
 
 func (session *wsPTYSession) terminateProcessesWithForegroundGroupLookup(lookup func(*os.File) int) {
-	foregroundGroup := 0
-	session.withPTYFileLocked(func(ptyFile *os.File) {
-		foregroundGroup = lookup(ptyFile)
+	// Two independent paths tear the same session down. waitSessionProcess runs
+	// after the session leader exits, and the hub runs when a client closes the
+	// session, when a non-persistent attachment goes away, on closeAll, and on
+	// an idle reap. A session that outlives its leader and is then closed goes
+	// through both. The hub paths run while the leader is still alive and
+	// unreaped, which is why they signal it at all, but a second pass can only
+	// happen once cmd.Wait has returned, and by then the leader's pid is not
+	// ours to signal. Repeating the member scan is not free either, since it
+	// reads every entry in /proc on Linux and forks ps on macOS.
+	session.terminateOnce.Do(func() {
+		foregroundGroup := 0
+		session.withPTYFileLocked(func(ptyFile *os.File) {
+			foregroundGroup = lookup(ptyFile)
+		})
+		sessionLeader := 0
+		if session.cmd != nil && session.cmd.Process != nil {
+			sessionLeader = session.cmd.Process.Pid
+			terminatePTYSessionMembers(sessionLeader)
+		}
+		if foregroundGroup > 0 {
+			_ = syscall.Kill(-foregroundGroup, syscall.SIGKILL)
+		}
+		if sessionLeader > 0 {
+			_ = syscall.Kill(-sessionLeader, syscall.SIGKILL)
+			_ = session.cmd.Process.Kill()
+		}
 	})
-	sessionLeader := 0
-	if session.cmd != nil && session.cmd.Process != nil {
-		sessionLeader = session.cmd.Process.Pid
-		terminatePTYSessionMembers(sessionLeader)
-	}
-	if foregroundGroup > 0 {
-		_ = syscall.Kill(-foregroundGroup, syscall.SIGKILL)
-	}
-	if sessionLeader > 0 {
-		_ = syscall.Kill(-sessionLeader, syscall.SIGKILL)
-		_ = session.cmd.Process.Kill()
-	}
 }
 
 func terminatePTYSessionMembers(sessionID int) {


### PR DESCRIPTION
`TestTerminateProcessesRunsOnlyOnce` has failed on main since it was added in #8438:

```
--- FAIL: TestTerminateProcessesRunsOnlyOnce
    ws_pty_test.go:809: process teardown ran 2 times, want exactly once
FAIL github.com/manaflow-ai/cmux/daemon/remote/cmd/cmuxd-remote
```

The test asserts that a PTY session is torn down once, but the guard it was written against never landed, so `terminateProcessesWithForegroundGroupLookup` redoes the foreground-group ioctl and re-sends both SIGKILLs on every call.

Two paths reach teardown for the same session. `waitSessionProcess` runs it after the session leader exits. The hub runs it when a client sends a close frame, when a non-persistent attachment's connection ends, on `closeAll`, and on an idle reap. Those four hub paths cannot collide with each other, because each one removes the session from the hub map under `h.mu` before it signals anything, but `waitSessionProcess` is outside that bookkeeping. A session that outlives its leader and is then closed runs teardown twice.

This wraps the body in a `sync.Once`, matching `closeTTYOnce` and `closePTYOnce` already on the struct. A `wsPTYSession` owns one `exec.Cmd` for its whole life and nothing reassigns it, and reconnecting to a live session only adds an attachment, so the guard covers exactly the one process group it is meant to. Once a session is closed the attach path builds a fresh `wsPTYSession` with its own `sync.Once`.

What a duplicate pass actually costs is a second pair of SIGKILLs and a second walk of the process table. `terminatePTYSessionMembers` reads every `/proc/<pid>/stat` on Linux and forks `ps` on macOS, and it rescans until the discovered member set stops growing. A second pass can also only run after `cmd.Wait` has returned, so the leader pid it signals has already been reaped and no longer belongs to the daemon.

The guard does change one thing. When a hub path tears the session down first, the sweep `waitSessionProcess` does after `cmd.Wait` becomes a no-op, and that sweep's own comment says it is there to catch a SIGHUP-shielded background job still holding the PTY slave. I do not believe anything is lost in practice. The hub pass runs the same rescanning member sweep, the leader is a member of its own session so it gets killed inside that sweep, and a process cannot fork once SIGKILL has been delivered to it, which is what makes the scan converge. `TestWebSocketPTYCleanupTerminatesEverySessionProcessGroup` already drives that exact case from all three hub paths with `set -m; trap '' HUP; sleep 300 &`, and with this guard in place it is the hub pass alone that has to clean up. I could not construct a member that the hub pass misses and the skipped pass would have caught, but it is one fewer sweep than before, so please check that reasoning rather than take it from me.

I left the stale-pid signalling alone. Signalling a pid the daemon has already reaped is wrong on the first pass too: `waitSessionProcess` calls `terminateProcesses` after `cmd.Wait`, so the leader is gone by then, and a `sync.Once` cannot suppress a first call. The window is narrow, because Linux keeps a pid allocated while any process still has it as a session id, so recycling requires the session to be empty and then `Kill(-pid, SIGKILL)` just returns ESRCH. Fixing it properly means capturing the member set before `cmd.Wait` instead of rederiving it from the leader pid afterwards, which is a bigger change than this test fix and belongs in its own PR.

I could not compile or run any of this locally, since the machine I wrote it on has no Go toolchain. The linux `remote-daemon-tests` job is the gate. An earlier `workflow_dispatch` run of this branch on my fork reported `ok github.com/manaflow-ai/cmux/daemon/remote/cmd/cmuxd-remote 1.783s`.

This failure also blocked CI that has nothing to do with the daemon. `linux-preflight` fails when a routed linux job with a true route fails, the macOS jobs gate on `linux-preflight` succeeding, and any non-`pull_request` event marks every route true. So while this test was red, every manually dispatched `ci.yml` run skipped the entire macOS matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PTY session shutdown reliability by ensuring termination actions run only once.
  * Prevented repeated shutdown attempts from causing duplicate process termination or inconsistent session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->