### PR TITLE
CmuxAuthRuntime: wake the sign-in test waits on an event

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorStaleRevalidationTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorStaleRevalidationTests.swift
@@ -206,17 +206,16 @@ import Testing
         }
         await client.storedAccessDidPark()
 
+        // The late exchange's write is what sign-out's credential capture has to
+        // race, so wait for the store to hold exchange 2's tokens (or to have
+        // been cleared) before releasing the capture. The client resumes this
+        // from the write, so the wait does not compete with it for CPU.
         await client.releaseParkedCredential()
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
-        while true {
-            let refresh = await client.refreshToken()
-            if refresh == "refresh-2" || refresh == nil { break }
-            if clock.now >= deadline {
-                preconditionFailure("Timed out waiting for late exchange cleanup to reach the token store")
-            }
-            await Task.yield()
+        let cleanupWatchdog = failAfterDeadline(.seconds(30)) {
+            "Timed out waiting for late exchange cleanup to reach the token store"
         }
+        await client.tokensDidSettle(afterExchange: 2)
+        cleanupWatchdog.cancel()
 
         await client.releaseParkedStoredAccess()
         await signOut.value

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/GateableValidationAuthClient.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/GateableValidationAuthClient.swift
@@ -28,6 +28,8 @@ actor GateableValidationAuthClient: AuthClient {
     /// so tests can tell WHICH exchange's write the store currently holds:
     /// exchange N stores `"access-N"` / `"refresh-N"` in write order.
     private var exchangeCounter = 0
+    /// Tests awaiting a settled token store after a late exchange.
+    private var tokenWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var currentUserStartCount = 0
     private let validationGate = Gate()
     private let teamsGate = Gate()
@@ -53,6 +55,29 @@ actor GateableValidationAuthClient: AuthClient {
     private func release(_ gate: Gate) {
         guard !gate.parked.isEmpty else { return }
         gate.parked.removeFirst().resume()
+    }
+
+    // MARK: - Token-store settling
+
+    /// Suspends until exchange `count` has written its tokens, or until a clear
+    /// emptied the store. Those are the two outcomes a late exchange racing
+    /// sign-out can produce, and both are written inside this actor, so the
+    /// waiter is resumed by the write instead of polling for it.
+    func tokensDidSettle(afterExchange count: Int) async {
+        if tokensSettled(afterExchange: count) { return }
+        await withCheckedContinuation { tokenWaiters.append((count, $0)) }
+    }
+
+    private func tokensSettled(afterExchange count: Int) -> Bool {
+        exchangeCounter >= count || refresh == nil
+    }
+
+    private func resumeSettledTokenWaiters() {
+        tokenWaiters.removeAll { waiter in
+            guard tokensSettled(afterExchange: waiter.count) else { return false }
+            waiter.continuation.resume()
+            return true
+        }
     }
 
     private func parkIfArmed(_ gate: Gate) async {
@@ -138,6 +163,7 @@ actor GateableValidationAuthClient: AuthClient {
         exchangeCounter += 1
         access = "access-\(exchangeCounter)"
         refresh = "refresh-\(exchangeCounter)"
+        resumeSettledTokenWaiters()
     }
 
     func accessToken() async -> String? { access }
@@ -151,6 +177,7 @@ actor GateableValidationAuthClient: AuthClient {
         exchangeCounter += 1
         access = "access-\(exchangeCounter)"
         refresh = "refresh-\(exchangeCounter)"
+        resumeSettledTokenWaiters()
     }
     func signInWithOAuth(provider: String, anchor: any AuthPresentationAnchoring) async throws {}
 
@@ -163,6 +190,7 @@ actor GateableValidationAuthClient: AuthClient {
         await parkIfArmed(clearGate)
         access = nil
         refresh = nil
+        resumeSettledTokenWaiters()
     }
 
     func clearLocalSession(ifRefreshTokenMatches refreshToken: String) async {
@@ -173,6 +201,7 @@ actor GateableValidationAuthClient: AuthClient {
         guard refresh == refreshToken else { return }
         access = nil
         refresh = nil
+        resumeSettledTokenWaiters()
     }
 
     func revokeSession(accessToken: String?, refreshToken: String?) async throws {}

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowFakes.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowFakes.swift
@@ -17,6 +17,7 @@ actor FlowFakeAuthClient: AuthClient {
     private var currentUserError: (any Error)?
     private var userGateClosed = false
     private var userGateWaiters: [CheckedContinuation<Void, Never>] = []
+    private var pendingUserRequestWaiters: [CheckedContinuation<Void, Never>] = []
     private var storedAccessGateArmed = false
     private var storedAccessParked: [CheckedContinuation<Void, Never>] = []
     private var storedAccessParkWaiters: [CheckedContinuation<Void, Never>] = []
@@ -36,6 +37,12 @@ actor FlowFakeAuthClient: AuthClient {
         let waiters = userGateWaiters
         userGateWaiters = []
         for waiter in waiters { waiter.resume() }
+    }
+
+    /// Suspends until a `currentUser` read is parked on the closed user gate.
+    func pendingUserRequestDidPark() async {
+        if pendingUserRequests > 0 { return }
+        await withCheckedContinuation { pendingUserRequestWaiters.append($0) }
     }
 
     func armStoredAccessTokenGate() { storedAccessGateArmed = true }
@@ -59,7 +66,12 @@ actor FlowFakeAuthClient: AuthClient {
     func currentUser(throwOnMissing: Bool) async throws -> CMUXAuthUser? {
         if userGateClosed {
             pendingUserRequests += 1
-            await withCheckedContinuation { userGateWaiters.append($0) }
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                userGateWaiters.append(continuation)
+                let waiters = pendingUserRequestWaiters
+                pendingUserRequestWaiters = []
+                for waiter in waiters { waiter.resume() }
+            }
             pendingUserRequests -= 1
         }
         if let currentUserError {
@@ -140,6 +152,14 @@ actor FlowInMemoryTokenStore: StackAuthTokenStoreProtocol {
 final class FakeBrowserAuthSessionFactory: HostBrowserAuthSessionFactory {
     private(set) var sessions: [FakeBrowserAuthSession] = []
     var nextStartResult = true
+    private var sessionWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    /// Suspends until the attempt has created at least `count` sessions, so a
+    /// test acts on a session that exists rather than polling for one.
+    func sessionsDidReach(_ count: Int) async {
+        if sessions.count >= count { return }
+        await withCheckedContinuation { sessionWaiters.append((count, $0)) }
+    }
 
     func makeSession(
         signInURL: URL,
@@ -153,7 +173,18 @@ final class FakeBrowserAuthSessionFactory: HostBrowserAuthSessionFactory {
         )
         sessions.append(session)
         nextStartResult = true
+        for waiter in takeSatisfiedSessionWaiters() { waiter.resume() }
         return session
+    }
+
+    private func takeSatisfiedSessionWaiters() -> [CheckedContinuation<Void, Never>] {
+        var satisfied: [CheckedContinuation<Void, Never>] = []
+        sessionWaiters.removeAll { waiter in
+            guard sessions.count >= waiter.count else { return false }
+            satisfied.append(waiter.continuation)
+            return true
+        }
+        return satisfied
     }
 }
 

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTestSupport.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTestSupport.swift
@@ -1,5 +1,6 @@
 import CMUXAuthCore
 import Foundation
+import Observation
 @testable import CmuxAuthRuntime
 
 @MainActor
@@ -92,40 +93,48 @@ struct HostBrowserSignInFlowHarness {
             .value ?? ""
     }
 
-    func waitForSession(count: Int = 1, timeout: Duration = .seconds(2)) async {
-        // The attempt task runs on the same main actor; yielding lets it reach
-        // the browser-session continuation deterministically.
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while factory.sessions.count < count {
-            if clock.now >= deadline {
-                preconditionFailure(
-                    "Timed out waiting for \(count) host-browser session(s); got \(factory.sessions.count)"
-                )
-            }
-            await Task.yield()
+    /// Waits for the attempt to create `count` browser sessions. The factory
+    /// resumes this from the session it creates, so the wait costs no CPU while
+    /// the attempt runs.
+    func waitForSession(count: Int = 1, timeout: Duration = .seconds(30)) async {
+        let watchdog = failAfterDeadline(timeout) { [factory] in
+            "Timed out waiting for \(count) host-browser session(s); got \(factory.sessions.count)"
         }
+        await factory.sessionsDidReach(count)
+        watchdog.cancel()
     }
 
-    func waitForCondition(timeout: Duration = .seconds(2), until condition: @MainActor () -> Bool) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
+    /// Waits until `condition` holds.
+    ///
+    /// `condition` has to read observable state on the flow or the coordinator
+    /// (both are `@Observable` and main-actor isolated). The wait registers with
+    /// the observation system and suspends until one of the properties the
+    /// condition read is written, then re-checks; a condition over unobserved
+    /// state would never be woken and would hit the deadline below.
+    func waitForCondition(timeout: Duration = .seconds(30), until condition: @MainActor () -> Bool) async {
+        let watchdog = failAfterDeadline(timeout) {
+            "Timed out waiting for host-browser condition; it must read observable flow or coordinator state"
+        }
         while !condition() {
-            if clock.now >= deadline {
-                preconditionFailure("Timed out waiting for host-browser condition")
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                withObservationTracking {
+                    _ = condition()
+                } onChange: {
+                    // Fires from the write itself, before the new value lands.
+                    // Resuming here queues the re-check as a separate main-actor
+                    // job, which cannot run until the write has finished.
+                    continuation.resume()
+                }
             }
-            await Task.yield()
         }
+        watchdog.cancel()
     }
 
-    func waitForPendingUserRequest(timeout: Duration = .seconds(2)) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while await client.pendingUserRequests == 0 {
-            if clock.now >= deadline {
-                preconditionFailure("Timed out waiting for a pending user request")
-            }
-            await Task.yield()
-        }
+    /// Waits for a `currentUser` read to park on the closed user gate. The fake
+    /// client resumes this as it parks.
+    func waitForPendingUserRequest(timeout: Duration = .seconds(30)) async {
+        let watchdog = failAfterDeadline(timeout) { "Timed out waiting for a pending user request" }
+        await client.pendingUserRequestDidPark()
+        watchdog.cancel()
     }
 }

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/TestDeadlineWatchdog.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/TestDeadlineWatchdog.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Aborts the run with `message` unless the caller cancels the returned task
+/// first.
+///
+/// The waits this guards are event-driven: they suspend until the fake they
+/// wait on resumes them, so a run that reaches this deadline is one where the
+/// awaited edge never arrived. Reporting that by name beats leaving the run
+/// suspended forever. The deadline is generous on purpose — it never bounds a
+/// passing run, so machine load cannot push a healthy wait past it.
+@MainActor
+func failAfterDeadline(
+    _ timeout: Duration,
+    _ message: @escaping @MainActor () -> String
+) -> Task<Void, Never> {
+    Task { @MainActor in
+        try? await Task.sleep(for: timeout)
+        guard !Task.isCancelled else { return }
+        preconditionFailure(message())
+    }
+}


### PR DESCRIPTION
Running a few package suites at once was enough to lose the whole `CmuxAuthRuntime` target:

```
HostBrowserSignInFlowTestSupport.swift:102: Fatal error: Timed out waiting for
1 host-browser session(s); got 0
```

**My first attempt at this was wrong, and measurement is what showed it.** It only raised the three `waitFor…` deadlines from 2 s to 10 s. Under a load precondition the 10 s version still died three runs out of three with that same fatal, and a loaded pass cost 120–147 s instead of about 7. The reason is the mechanism: the waits spun on `Task.yield()` from the MainActor, so a larger budget means *more* spinning by the waiting test, which further delays the very task it is waiting for. Raising the number moves the cliff and buys nothing.

Worth noting why the original verification was worthless too: unloaded, both the 2 s and the 10 s versions pass 167/167, so an unloaded run cannot tell them apart. "The tests still pass" was never evidence for that change.

So the waits are now event-driven and the deadline is only a backstop:

- `FakeBrowserAuthSessionFactory.makeSession` resumes any satisfied waiters right after `sessions.append(session)`, so `waitForSession` suspends until the session it is waiting for actually exists and costs no CPU meanwhile. This follows the shape the same file already used for `FlowFakeAuthClient.storedAccessTokenDidPark()`.
- `waitForCondition` registers with `withObservationTracking` and re-checks when one of the properties the condition read is written. That constrains callers — the condition has to read observable flow or coordinator state — and the deadline message says so, because a condition over unobserved state would never be woken.
- `GateableValidationAuthClient` already counted exchanges, so the inline deadline loop in `AuthCoordinatorStaleRevalidationTests` now waits on that signal instead of polling the token store.
- The remaining `.seconds(30)` values are watchdogs. On a passing run they never fire; when they do fire the message names what was being waited for.

Five files, +126/−37, all under `Packages/Shared/CmuxAuthRuntime/Tests`. No product code changes.

**Verified:** `swift test --disable-sandbox` reports `Test run with 167 tests in 24 suites passed`, the same count as before, so nothing was dropped or skipped.

**Not verified, deliberately:** I have not re-run the load-precondition comparison. Generating that load meant pinning a developer workstation with dozens of busy processes, which is not something to do on a machine someone is using — the earlier run of it was stopped for exactly that reason. The argument for this change does not rest on a load measurement anyway: the pass path no longer contains a wall-clock wait, so there is no budget left to be starved. If someone wants the load number, it belongs on a CI runner or a dedicated builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved authentication flow test reliability by replacing polling with event-driven waits.
  * Added clearer timeout reporting for stalled sign-in, sign-out, session, and token-state transitions.
  * Enhanced test coverage for late credential exchanges and session coordination.
  * Added synchronization helpers for tracking token settlement, browser sessions, and pending user requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->