### PR TITLE
cmuxTests: pass the liveness the Entry initializer requires

### DIFF
--- a/cmuxTests/AgentResumeLivenessTests.swift
+++ b/cmuxTests/AgentResumeLivenessTests.swift
@@ -23,6 +23,10 @@ struct AgentResumeLivenessTests {
             snapshot: SessionRestorableAgentSnapshot(kind: kind, sessionId: sessionId),
             lifecycle: nil,
             updatedAt: 0,
+            // `hasLiveProcess` decides from the PID set alone, so keep the recorded
+            // liveness consistent with the PIDs each case asks for instead of pinning
+            // one value that would contradict the empty-PID case.
+            processLiveness: processIDs.isEmpty ? .exited : .running,
             processIDs: processIDs,
             agentProcessIDs: processIDs,
             agentProcessIdentities: [:]


### PR DESCRIPTION
The `cmux-unit` test target does not compile on current main:

```
cmuxTests/AgentResumeLivenessTests.swift:25:25: error: missing argument for
parameter 'processLiveness' in call
** TEST BUILD FAILED **
```

`RestorableAgentSessionIndex.Entry` gained a `processLiveness` field with no default in #8547 (`Sources/RestorableAgentSession.swift:936`), which makes it required in the memberwise initializer. #8619 then added `cmuxTests/AgentResumeLivenessTests.swift`, whose `entry(...)` helper constructs an `Entry` without it. The file is wired into the pbxproj, so this is not a skipped file: the target fails to build, and **no suite in `cmuxTests` can run at all** until it is fixed.

`AgentResumeLiveness.hasLiveProcess` decides from the PID set alone (`guard let entry, !entry.processIDs.isEmpty`), so the value is not load-bearing — it only has to be honest. Deriving it from the PIDs each case asks for keeps the empty-PID test from claiming a running process.

Verified with the same command both ways on a pristine checkout of `main`:

```
before:  ** TEST BUILD FAILED **    (1 compile error, the one above)
after:   ** TEST BUILD SUCCEEDED ** (0 compile errors)
```

Two things that corroborate the timeline. A full 674-suite headless sweep completed on a base that is four commits behind main, and it produced verdicts for 671 suites; that base predates #8619, so the test file is simply absent there and the target builds. And the last commit to touch this test file is #8619 itself.

Worth noting how this reached main: no GitHub Actions workflow builds or tests pull requests in this repo — the only PR checks are third-party review bots — so a change that breaks the unit-test target still shows an all-green PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved agent resume liveness test coverage by deriving process liveness from the provided process ID set.
  * Added guidance to keep test data consistent for empty and non-empty process ID scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->