### PR TITLE
Add cross-harness conversation fork variants

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Vault/Providers/HermesAgent/HermesAgentIndex.swift
@@ -130,6 +130,7 @@ public enum HermesAgentIndex {
     public static func loadTranscript(
         sessionId: String,
         limit: Int,
+        latest: Bool = false,
         stateDBPath: String = Self.defaultStateDBPath()
     ) throws -> [HermesAgentTranscriptTurn] {
         guard limit > 0 else { return [] }
@@ -139,7 +140,7 @@ public enum HermesAgentIndex {
         defer { snapshot.remove() }
 
         return try withDatabase(snapshot.databaseURL.path) { db in
-            try loadTranscript(db: db, sessionId: sessionId, limit: limit)
+            try loadTranscript(db: db, sessionId: sessionId, limit: limit, latest: latest)
         }
     }
 
@@ -247,15 +248,31 @@ public enum HermesAgentIndex {
     private static func loadTranscript(
         db: OpaquePointer,
         sessionId: String,
-        limit: Int
+        limit: Int,
+        latest: Bool
     ) throws -> [HermesAgentTranscriptTurn] {
-        let sql = """
-            SELECT role, content, tool_name, tool_calls
-            FROM messages
-            WHERE session_id = ?
-            ORDER BY timestamp, id
-            LIMIT \(limit)
-            """
+        let sql: String
+        if latest {
+            sql = """
+                SELECT role, content, tool_name, tool_calls
+                FROM (
+                  SELECT role, content, tool_name, tool_calls, timestamp, id
+                  FROM messages
+                  WHERE session_id = ?
+                  ORDER BY timestamp DESC, id DESC
+                  LIMIT \(limit)
+                )
+                ORDER BY timestamp, id
+                """
+        } else {
+            sql = """
+                SELECT role, content, tool_name, tool_calls
+                FROM messages
+                WHERE session_id = ?
+                ORDER BY timestamp, id
+                LIMIT \(limit)
+                """
+        }
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else {
             sqlite3_finalize(stmt)

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Vault/Providers/HermesAgent/HermesAgentIndexTests.swift
@@ -102,6 +102,32 @@ struct HermesAgentIndexTests {
         #expect(turns[1].content.contains("pwd"))
     }
 
+    @Test("Loads the latest transcript turns in chronological order")
+    func loadsLatestTranscriptTurns() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dbURL = root.appendingPathComponent("state.db", isDirectory: false)
+        try makeHermesStateDB(at: dbURL)
+        try exec(dbURL, """
+        INSERT INTO sessions (id, source, model, started_at, title)
+        VALUES ('session-a', 'cli', 'model-a', 10, 'General');
+        INSERT INTO messages (session_id, role, content, timestamp)
+        VALUES
+          ('session-a', 'user', 'first', 11),
+          ('session-a', 'assistant', 'middle', 12),
+          ('session-a', 'user', 'latest', 13);
+        """)
+
+        let turns = try HermesAgentIndex.loadTranscript(
+            sessionId: "session-a",
+            limit: 2,
+            latest: true,
+            stateDBPath: dbURL.path
+        )
+
+        #expect(turns.map(\.content) == ["middle", "latest"])
+    }
+
     private func temporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-hermes-index-\(UUID().uuidString)", isDirectory: true)

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Actions/CmuxAction.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Actions/CmuxAction.swift
@@ -2,6 +2,26 @@ import Foundation
 
 /// A stable argument contract shared by every presentation of a cmux action.
 public struct CmuxActionArgumentDefinition: Sendable, Equatable {
+    /// One finite value offered by an interactive action adapter.
+    public struct Choice: Sendable, Equatable, Identifiable {
+        /// Stable value supplied to the action handler and automation callers.
+        public let value: String
+        /// Localized label shown by interactive adapters.
+        public let title: String
+
+        /// Uses the stable wire value as this choice's identity.
+        public var id: String { value }
+
+        /// Creates one finite action-argument choice.
+        /// - Parameters:
+        ///   - value: Stable value supplied to the action handler.
+        ///   - title: Localized label shown to the user.
+        public init(value: String, title: String) {
+            self.value = value
+            self.title = title
+        }
+    }
+
     /// The value representation accepted on the wire and in configuration.
     public enum ValueType: String, Sendable {
         case string
@@ -11,24 +31,32 @@ public struct CmuxActionArgumentDefinition: Sendable, Equatable {
 
     /// Stable argument name.
     public let name: String
+    /// Localized argument label shown by interactive adapters.
+    public let title: String
     /// Expected value representation.
     public let valueType: ValueType
     /// Whether automation callers must supply this argument.
     public let required: Bool
     /// Whether an explicitly supplied empty string is valid.
     public let allowsEmpty: Bool
+    /// Finite accepted values, or an empty array when the value is free-form.
+    public let choices: [Choice]
 
     /// Creates a static action argument contract.
     public init(
         name: String,
+        title: String? = nil,
         valueType: ValueType = .string,
         required: Bool = true,
-        allowsEmpty: Bool = false
+        allowsEmpty: Bool = false,
+        choices: [Choice] = []
     ) {
         self.name = name
+        self.title = title ?? name
         self.valueType = valueType
         self.required = required
         self.allowsEmpty = allowsEmpty
+        self.choices = choices
     }
 }
 

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteArgumentCollection.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteArgumentCollection.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// The in-progress finite-choice arguments for one command-palette action.
+public struct CommandPaletteArgumentCollection: Sendable, Equatable {
+    /// The result of selecting one value for the current argument.
+    public enum SelectionResult: Sendable, Equatable {
+        /// The value was rejected because it is not a declared choice.
+        case invalid
+        /// The value was accepted and another choice argument remains.
+        case advanced
+        /// The value was accepted and every choice argument is now populated.
+        case completed
+    }
+
+    /// Stable identifier of the action being configured.
+    public let commandID: String
+    /// Static argument contract declared by the action.
+    public let arguments: [CmuxActionArgumentDefinition]
+    /// Values collected so far, keyed by stable argument name.
+    public private(set) var values: [String: String]
+    /// Index of the argument currently presented by the palette.
+    public private(set) var currentArgumentIndex: Int
+
+    /// The argument currently presented by the palette.
+    public var currentArgument: CmuxActionArgumentDefinition {
+        arguments[currentArgumentIndex]
+    }
+
+    /// One-based position of the current finite-choice argument.
+    public var currentStep: Int {
+        choiceArgumentIndices.firstIndex(of: currentArgumentIndex).map { $0 + 1 } ?? 1
+    }
+
+    /// Total number of finite-choice arguments in this collection.
+    public var stepCount: Int { choiceArgumentIndices.count }
+
+    /// Creates a collection positioned at the first missing finite-choice argument.
+    ///
+    /// Returns `nil` when no finite-choice argument needs interactive collection.
+    /// - Parameters:
+    ///   - commandID: Stable identifier of the action being configured.
+    ///   - arguments: Static arguments declared by the action.
+    ///   - initialValues: Values already supplied by the caller.
+    public init?(
+        commandID: String,
+        arguments: [CmuxActionArgumentDefinition],
+        initialValues: [String: String] = [:]
+    ) {
+        guard let firstMissingIndex = arguments.indices.first(where: { index in
+            !arguments[index].choices.isEmpty && initialValues[arguments[index].name] == nil
+        }) else {
+            return nil
+        }
+        self.commandID = commandID
+        self.arguments = arguments
+        self.values = initialValues
+        self.currentArgumentIndex = firstMissingIndex
+    }
+
+    /// Selects a declared value for the current argument and advances the collection.
+    /// - Parameter value: Stable choice value to supply to the action.
+    /// - Returns: Whether the selection was invalid, advanced, or completed.
+    @discardableResult
+    public mutating func selectCurrentChoice(value: String) -> SelectionResult {
+        let argument = currentArgument
+        guard argument.choices.contains(where: { $0.value == value }) else {
+            return .invalid
+        }
+        values[argument.name] = value
+        guard let nextIndex = arguments.indices.dropFirst(currentArgumentIndex + 1).first(where: { index in
+            !arguments[index].choices.isEmpty && values[arguments[index].name] == nil
+        }) else {
+            return .completed
+        }
+        currentArgumentIndex = nextIndex
+        return .advanced
+    }
+
+    private var choiceArgumentIndices: [Int] {
+        arguments.indices.filter { !arguments[$0].choices.isEmpty }
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteCommand.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteCommand.swift
@@ -104,10 +104,16 @@ public struct CommandPaletteCommand: Identifiable {
             }
             switch argument.valueType {
             case .string, .path:
-                return nil
+                break
             case .boolean:
-                return invocation.bool(argument.name) == nil ? argument.name : nil
+                guard invocation.bool(argument.name) != nil else {
+                    return argument.name
+                }
             }
+            guard argument.choices.isEmpty || argument.choices.contains(where: { $0.value == value }) else {
+                return argument.name
+            }
+            return nil
         }.sorted()
         if !invalidValueArguments.isEmpty {
             return .invalidArgumentValues(invalidValueArguments)

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteMode.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Values/CommandPaletteMode.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 /// The palette's input mode: the regular command/switcher list, one of the
-/// two rename phases, or the workspace-description editor.
+/// two rename phases, finite action-argument collection, or the
+/// workspace-description editor.
 public enum CommandPaletteMode {
     /// Regular command/switcher list.
     case commands
@@ -9,6 +10,8 @@ public enum CommandPaletteMode {
     case renameInput(CommandPaletteRenameTarget)
     /// Rename confirmation for `target` with the user's `proposedName`.
     case renameConfirm(CommandPaletteRenameTarget, proposedName: String)
+    /// Finite-choice arguments are being collected for one action.
+    case actionArguments(CommandPaletteArgumentCollection)
     /// Workspace-description editor is open for the target workspace.
     case workspaceDescriptionInput(CommandPaletteWorkspaceDescriptionTarget)
 }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CmuxActionRegistryTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CmuxActionRegistryTests.swift
@@ -106,6 +106,70 @@ struct CmuxActionRegistryTests {
         )) == .invalidArgumentValues(["overwrite"]))
     }
 
+    @Test func finiteChoiceArgumentsRejectUndeclaredValues() {
+        var receivedHarness: String?
+        let command = makeCommand(arguments: [
+            CmuxActionArgumentDefinition(
+                name: "harness",
+                title: "Harness",
+                choices: [
+                    .init(value: "claude", title: "Claude Code"),
+                    .init(value: "codex", title: "Codex"),
+                ]
+            ),
+        ]) { invocation in
+            receivedHarness = invocation.string("harness")
+            return .completed
+        }
+
+        #expect(command.execute(CmuxActionInvocation(
+            source: .automation,
+            arguments: ["harness": "unknown"]
+        )) == .invalidArgumentValues(["harness"]))
+        #expect(receivedHarness == nil)
+        #expect(command.execute(CmuxActionInvocation(
+            source: .automation,
+            arguments: ["harness": "claude"]
+        )) == .completed)
+        #expect(receivedHarness == "claude")
+    }
+
+    @Test func finiteChoiceCollectionAdvancesInDeclarationOrder() throws {
+        let arguments = [
+            CmuxActionArgumentDefinition(
+                name: "harness",
+                title: "Harness",
+                choices: [
+                    .init(value: "current", title: "Current Harness"),
+                    .init(value: "claude", title: "Claude Code"),
+                ]
+            ),
+            CmuxActionArgumentDefinition(
+                name: "destination",
+                title: "Destination",
+                choices: [
+                    .init(value: "right", title: "Right Split"),
+                    .init(value: "newTab", title: "New Tab"),
+                ]
+            ),
+        ]
+        var collection = try #require(CommandPaletteArgumentCollection(
+            commandID: "palette.forkAgentConversation",
+            arguments: arguments
+        ))
+
+        #expect(collection.currentArgument.name == "harness")
+        #expect(collection.currentStep == 1)
+        #expect(collection.stepCount == 2)
+        #expect(collection.selectCurrentChoice(value: "invalid") == .invalid)
+        #expect(collection.values.isEmpty)
+        #expect(collection.selectCurrentChoice(value: "claude") == .advanced)
+        #expect(collection.currentArgument.name == "destination")
+        #expect(collection.currentStep == 2)
+        #expect(collection.selectCurrentChoice(value: "right") == .completed)
+        #expect(collection.values == ["harness": "claude", "destination": "right"])
+    }
+
     @Test func registryUsesStableStringIDsAndRejectsDuplicates() {
         let first = makeCommand(id: "custom.deploy") { _ in .completed }
         let duplicate = makeCommand(id: "custom.deploy") { _ in .presented }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/CommandPalette/ControlCommandCoordinator+CommandPalette.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/CommandPalette/ControlCommandCoordinator+CommandPalette.swift
@@ -211,9 +211,16 @@ extension ControlCommandCoordinator {
     ) -> JSONValue {
         .object([
             "name": .string(argument.name),
+            "title": .string(argument.title),
             "type": .string(argument.type),
             "required": .bool(argument.required),
             "allows_empty": .bool(argument.allowsEmpty),
+            "choices": .array(argument.choices.map { choice in
+                .object([
+                    "value": .string(choice.value),
+                    "title": .string(choice.title),
+                ])
+            }),
         ])
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/CommandPalette/ControlCommandPaletteItem.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/CommandPalette/ControlCommandPaletteItem.swift
@@ -1,20 +1,47 @@
 /// One statically declared argument accepted by a command-palette action.
 public struct ControlCommandPaletteArgument: Sendable, Equatable {
+    /// One finite argument value exposed to control-socket clients.
+    public struct Choice: Sendable, Equatable {
+        /// Stable value accepted by `palette.run`.
+        public let value: String
+        /// Localized label shown by interactive clients.
+        public let title: String
+
+        /// Creates one finite command-palette argument choice.
+        public init(value: String, title: String) {
+            self.value = value
+            self.title = title
+        }
+    }
+
     /// Stable argument name used on the wire.
     public let name: String
+    /// Localized argument label shown by interactive clients.
+    public let title: String
     /// Wire value type, currently `string`, `path`, or `boolean`.
     public let type: String
     /// Whether automation callers must supply the argument.
     public let required: Bool
     /// Whether an explicitly supplied empty string is valid.
     public let allowsEmpty: Bool
+    /// Finite accepted values, or an empty array for a free-form argument.
+    public let choices: [Choice]
 
     /// Creates an action argument description.
-    public init(name: String, type: String, required: Bool, allowsEmpty: Bool) {
+    public init(
+        name: String,
+        title: String? = nil,
+        type: String,
+        required: Bool,
+        allowsEmpty: Bool,
+        choices: [Choice] = []
+    ) {
         self.name = name
+        self.title = title ?? name
         self.type = type
         self.required = required
         self.allowsEmpty = allowsEmpty
+        self.choices = choices
     }
 }
 

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorCommandPaletteTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorCommandPaletteTests.swift
@@ -18,9 +18,16 @@ struct ControlCommandCoordinatorCommandPaletteTests {
             dismissOnRun: true,
             arguments: [ControlCommandPaletteArgument(
                 name: "path",
+                title: "Project Path",
                 type: "path",
                 required: true,
-                allowsEmpty: false
+                allowsEmpty: false,
+                choices: [
+                    ControlCommandPaletteArgument.Choice(
+                        value: "Sources",
+                        title: "Sources"
+                    ),
+                ]
             )]
         )
         context.listResolution = .listed(windowID: windowID, commands: [command])
@@ -47,9 +54,14 @@ struct ControlCommandCoordinatorCommandPaletteTests {
             "dismiss_on_run": .bool(true),
             "arguments": .array([.object([
                 "name": .string("path"),
+                "title": .string("Project Path"),
                 "type": .string("path"),
                 "required": .bool(true),
                 "allows_empty": .bool(false),
+                "choices": .array([.object([
+                    "value": .string("Sources"),
+                    "title": .string("Sources"),
+                ])]),
             ])]),
         ])]))
     }
@@ -123,10 +135,15 @@ struct ControlCommandCoordinatorCommandPaletteTests {
         let context = FakeCommandPaletteControlCommandContext()
         let windowID = UUID()
         let argument = ControlCommandPaletteArgument(
-            name: "name",
+            name: "harness",
+            title: "Harness",
             type: "string",
             required: true,
-            allowsEmpty: true
+            allowsEmpty: false,
+            choices: [
+                ControlCommandPaletteArgument.Choice(value: "claude", title: "Claude Code"),
+                ControlCommandPaletteArgument.Choice(value: "codex", title: "Codex"),
+            ]
         )
         let command = ControlCommandPaletteItem(
             id: "palette.renameWorkspace",
@@ -155,10 +172,21 @@ struct ControlCommandCoordinatorCommandPaletteTests {
         }
         #expect(code == "invalid_params")
         #expect(data["required_arguments"] == .array([.object([
-            "name": .string("name"),
+            "name": .string("harness"),
+            "title": .string("Harness"),
             "type": .string("string"),
             "required": .bool(true),
-            "allows_empty": .bool(true),
+            "allows_empty": .bool(false),
+            "choices": .array([
+                .object([
+                    "value": .string("claude"),
+                    "title": .string("Claude Code"),
+                ]),
+                .object([
+                    "value": .string("codex"),
+                    "title": .string("Codex"),
+                ]),
+            ]),
         ])]))
     }
 

--- a/Sources/AgentConversationExportService.swift
+++ b/Sources/AgentConversationExportService.swift
@@ -1,0 +1,438 @@
+import Foundation
+import os
+
+nonisolated private let agentConversationExportLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
+    category: "AgentConversationExport"
+)
+
+nonisolated private let agentConversationTransferRetention =
+    SessionTranscriptLoader.Retention.openingUserAndLatest(1_000)
+
+/// Storage-independent identity for one source conversation.
+nonisolated struct AgentConversationSource: Sendable {
+    let kind: RestorableAgentKind
+    let sessionId: String
+    let workingDirectory: String?
+    let transcriptPath: String?
+    let registration: CmuxVaultAgentRegistration?
+
+    init(snapshot: SessionRestorableAgentSnapshot) {
+        kind = snapshot.kind
+        sessionId = snapshot.sessionId
+        workingDirectory = snapshot.workingDirectory
+        transcriptPath = snapshot.transcriptPath
+        registration = snapshot.registration
+    }
+
+    var sessionAgent: SessionAgent {
+        switch kind {
+        case .claude:
+            return .claude
+        case .codex:
+            return .codex
+        case .grok:
+            return .grok
+        case .opencode:
+            return .opencode
+        case .rovodev:
+            return .rovodev
+        case .hermesAgent:
+            return .hermesAgent
+        default:
+            let registered = RegisteredSessionAgent(
+                id: kind.rawValue,
+                name: registration?.name,
+                iconAssetName: registration?.iconAssetName
+            )
+            return .registered(registered)
+        }
+    }
+
+    var transcriptURL: URL? {
+        guard let path = transcriptPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+    }
+
+    var usesGrokTranscriptLayout: Bool {
+        if kind == .grok {
+            return true
+        }
+        guard let registration else { return false }
+        if case .grokSessionDirectory = registration.sessionIdSource {
+            return true
+        }
+        return false
+    }
+}
+
+/// One pluggable storage adapter. Returning nil lets the registry try the next adapter.
+nonisolated protocol AgentConversationSourceAdapter: Sendable {
+    func supports(_ source: AgentConversationSource) -> Bool
+    func read(_ source: AgentConversationSource) async throws -> [SessionTranscriptTurn]?
+}
+
+nonisolated enum AgentConversationExportError: Error, Equatable {
+    case sourceUnavailable(String)
+    case emptyConversation
+}
+
+/// Ordered adapter registry. Specific database readers precede file and indexed fallbacks.
+nonisolated struct AgentConversationReaderRegistry: Sendable {
+    static let live = AgentConversationReaderRegistry(adapters: [
+        OpenCodeAgentConversationSourceAdapter(),
+        HermesAgentConversationSourceAdapter(),
+        DirectTranscriptAgentConversationSourceAdapter(),
+        IndexedAgentConversationSourceAdapter(),
+    ])
+
+    let adapters: [any AgentConversationSourceAdapter]
+
+    func read(_ source: AgentConversationSource) async throws -> [SessionTranscriptTurn] {
+        var lastError: Error?
+        for adapter in adapters where adapter.supports(source) {
+            do {
+                if let turns = try await adapter.read(source), !turns.isEmpty {
+                    return turns
+                }
+            } catch {
+                lastError = error
+            }
+        }
+        if let lastError {
+            agentConversationExportLogger.error(
+                "Conversation reader failed kind=\(source.kind.rawValue, privacy: .public): \(lastError.localizedDescription, privacy: .public)"
+            )
+        }
+        throw AgentConversationExportError.sourceUnavailable(source.kind.rawValue)
+    }
+}
+
+nonisolated struct OpenCodeAgentConversationSourceAdapter: AgentConversationSourceAdapter {
+    let databasePath: String?
+
+    init(databasePath: String? = nil) {
+        self.databasePath = databasePath
+    }
+
+    func supports(_ source: AgentConversationSource) -> Bool {
+        source.kind == .opencode
+    }
+
+    func read(_ source: AgentConversationSource) async throws -> [SessionTranscriptTurn]? {
+        try await SessionTranscriptLoader.load(source: .init(
+            agent: .opencode,
+            sessionId: source.sessionId,
+            fileURL: nil,
+            openCodeDatabasePath: databasePath,
+            retention: agentConversationTransferRetention
+        ))
+    }
+}
+
+nonisolated struct HermesAgentConversationSourceAdapter: AgentConversationSourceAdapter {
+    func supports(_ source: AgentConversationSource) -> Bool {
+        source.kind == .hermesAgent
+    }
+
+    func read(_ source: AgentConversationSource) async throws -> [SessionTranscriptTurn]? {
+        try await SessionTranscriptLoader.load(source: .init(
+            agent: .hermesAgent,
+            sessionId: source.sessionId,
+            fileURL: nil,
+            retention: agentConversationTransferRetention
+        ))
+    }
+}
+
+nonisolated struct DirectTranscriptAgentConversationSourceAdapter: AgentConversationSourceAdapter {
+    func supports(_ source: AgentConversationSource) -> Bool {
+        guard let url = source.transcriptURL else { return false }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+
+    func read(_ source: AgentConversationSource) async throws -> [SessionTranscriptTurn]? {
+        guard let url = source.transcriptURL else { return nil }
+        return try await SessionTranscriptLoader.load(source: .init(
+            agent: source.sessionAgent,
+            sessionId: source.sessionId,
+            fileURL: url,
+            usesGrokTranscriptLayout: source.usesGrokTranscriptLayout,
+            retention: agentConversationTransferRetention
+        ))
+    }
+}
+
+nonisolated struct IndexedAgentConversationSourceAdapter: AgentConversationSourceAdapter {
+    func supports(_ source: AgentConversationSource) -> Bool {
+        source.kind != .opencode && source.kind != .hermesAgent
+    }
+
+    func read(_ source: AgentConversationSource) async throws -> [SessionTranscriptTurn]? {
+        guard let entry = await SessionIndexStore.resolveConversationEntry(source: source) else {
+            return nil
+        }
+        return try await SessionTranscriptLoader.load(
+            entry: entry,
+            retention: agentConversationTransferRetention
+        )
+    }
+}
+
+nonisolated struct AgentConversationExportPolicy: Equatable, Sendable {
+    var maximumCharacters: Int
+    var initialUserCharacterLimit: Int
+    var includesSystemTurns: Bool
+    var includesToolTurns: Bool
+
+    init(
+        maximumCharacters: Int = 24_000,
+        initialUserCharacterLimit: Int = 4_000,
+        includesSystemTurns: Bool = false,
+        includesToolTurns: Bool = false
+    ) {
+        self.maximumCharacters = max(1_024, maximumCharacters)
+        self.initialUserCharacterLimit = max(0, initialUserCharacterLimit)
+        self.includesSystemTurns = includesSystemTurns
+        self.includesToolTurns = includesToolTurns
+    }
+
+    func includes(_ role: SessionTranscriptRole) -> Bool {
+        switch role {
+        case .user, .assistant:
+            return true
+        case .system:
+            return includesSystemTurns
+        case .tool:
+            return includesToolTurns
+        case .event:
+            return false
+        }
+    }
+}
+
+nonisolated struct AgentConversationCompaction: Equatable, Sendable {
+    let turns: [SessionTranscriptTurn]
+    let omittedTurnCount: Int
+    let shortenedTurnCount: Int
+}
+
+nonisolated protocol AgentConversationCompacting: Sendable {
+    func compact(
+        _ turns: [SessionTranscriptTurn],
+        policy: AgentConversationExportPolicy
+    ) -> AgentConversationCompaction
+}
+
+/// Keeps the opening request and the most recent dialogue, shortening only when required.
+nonisolated struct TailPreservingAgentConversationCompactor: AgentConversationCompacting {
+    private static let framingReserve = 512
+    private static let turnFramingCharacters = 16
+
+    func compact(
+        _ turns: [SessionTranscriptTurn],
+        policy: AgentConversationExportPolicy
+    ) -> AgentConversationCompaction {
+        let eligible = turns.filter { policy.includes($0.role) && !$0.text.isEmpty }
+        guard !eligible.isEmpty else {
+            return AgentConversationCompaction(turns: [], omittedTurnCount: 0, shortenedTurnCount: 0)
+        }
+
+        let bodyBudget = max(256, policy.maximumCharacters - Self.framingReserve)
+        if estimatedLength(of: eligible) <= bodyBudget {
+            return AgentConversationCompaction(
+                turns: renumbered(eligible),
+                omittedTurnCount: 0,
+                shortenedTurnCount: 0
+            )
+        }
+
+        let firstUserIndex = eligible.firstIndex { $0.role == .user }
+        let reservedHead = firstUserIndex.map { _ in
+            min(policy.initialUserCharacterLimit, max(256, bodyBudget / 4))
+        } ?? 0
+        let tailBudget = max(128, bodyBudget - reservedHead - 96)
+
+        var tail: [(index: Int, turn: SessionTranscriptTurn)] = []
+        var remaining = tailBudget
+        var shortenedCount = 0
+        for index in eligible.indices.reversed() where index != firstUserIndex {
+            let turn = eligible[index]
+            let cost = estimatedLength(of: turn)
+            if cost <= remaining {
+                tail.append((index, turn))
+                remaining -= cost
+                continue
+            }
+            if tail.isEmpty, remaining > Self.turnFramingCharacters {
+                tail.append((index, clipped(turn, characterLimit: remaining - Self.turnFramingCharacters)))
+                shortenedCount += 1
+            }
+            break
+        }
+        tail.reverse()
+
+        var kept: [(index: Int, turn: SessionTranscriptTurn)] = []
+        if let firstUserIndex {
+            let firstUser = eligible[firstUserIndex]
+            let limit = max(1, reservedHead - Self.turnFramingCharacters)
+            let clippedFirst = clipped(firstUser, characterLimit: limit)
+            if clippedFirst.text != firstUser.text {
+                shortenedCount += 1
+            }
+            kept.append((firstUserIndex, clippedFirst))
+        }
+        kept.append(contentsOf: tail)
+        kept.sort { $0.index < $1.index }
+
+        if kept.isEmpty, let last = eligible.last {
+            kept = [(eligible.count - 1, clipped(last, characterLimit: bodyBudget - Self.turnFramingCharacters))]
+            shortenedCount = 1
+        }
+
+        let uniqueIndices = Set(kept.map(\.index))
+        return AgentConversationCompaction(
+            turns: renumbered(kept.map(\.turn)),
+            omittedTurnCount: max(0, eligible.count - uniqueIndices.count),
+            shortenedTurnCount: shortenedCount
+        )
+    }
+
+    private func estimatedLength(of turns: [SessionTranscriptTurn]) -> Int {
+        turns.reduce(0) { $0 + estimatedLength(of: $1) }
+    }
+
+    private func estimatedLength(of turn: SessionTranscriptTurn) -> Int {
+        turn.text.count + Self.turnFramingCharacters
+    }
+
+    private func clipped(_ turn: SessionTranscriptTurn, characterLimit: Int) -> SessionTranscriptTurn {
+        guard characterLimit > 0, turn.text.count > characterLimit else { return turn }
+        let marker = "\n…\n"
+        let available = max(1, characterLimit - marker.count)
+        let headCount = available / 2
+        let tailCount = available - headCount
+        let headEnd = turn.text.index(turn.text.startIndex, offsetBy: headCount)
+        let tailStart = turn.text.index(turn.text.endIndex, offsetBy: -tailCount)
+        return SessionTranscriptTurn(
+            id: turn.id,
+            role: turn.role,
+            text: String(turn.text[..<headEnd]) + marker + String(turn.text[tailStart...])
+        )
+    }
+
+    private func renumbered(_ turns: [SessionTranscriptTurn]) -> [SessionTranscriptTurn] {
+        turns.enumerated().map { index, turn in
+            SessionTranscriptTurn(id: index, role: turn.role, text: turn.text)
+        }
+    }
+}
+
+nonisolated protocol AgentConversationFormatting: Sendable {
+    func format(
+        _ compaction: AgentConversationCompaction,
+        sourceDisplayName: String,
+        maximumCharacters: Int
+    ) -> String
+}
+
+/// Harness-neutral, human-readable transfer format suitable for one prompt argument.
+nonisolated struct RoleLabeledAgentConversationFormatter: AgentConversationFormatting {
+    func format(
+        _ compaction: AgentConversationCompaction,
+        sourceDisplayName: String,
+        maximumCharacters: Int
+    ) -> String {
+        let introductionFormat = String(
+            localized: "forkConversation.handoff.introduction",
+            defaultValue: "The following conversation was transferred from %@. Continue the latest unfinished request using this context."
+        )
+        var sections = [String(format: introductionFormat, promptSafe(sourceDisplayName))]
+
+        if compaction.omittedTurnCount > 0 || compaction.shortenedTurnCount > 0 {
+            let compactionFormat = String(
+                localized: "forkConversation.handoff.compacted",
+                defaultValue: "Conversation compacted: %1$lld earlier turns omitted, %2$lld long turns shortened."
+            )
+            sections.append(String(
+                format: compactionFormat,
+                Int64(compaction.omittedTurnCount),
+                Int64(compaction.shortenedTurnCount)
+            ))
+        }
+
+        sections.append(contentsOf: compaction.turns.map { turn in
+            "\(roleLabel(turn.role)):\n\(promptSafe(turn.text))"
+        })
+        let output = sections.joined(separator: "\n\n")
+        guard output.count > maximumCharacters else { return output }
+        let end = output.index(output.startIndex, offsetBy: maximumCharacters)
+        return String(output[..<end])
+    }
+
+    private func roleLabel(_ role: SessionTranscriptRole) -> String {
+        switch role {
+        case .user:
+            return String(localized: "forkConversation.handoff.role.user", defaultValue: "User")
+        case .assistant:
+            return String(localized: "forkConversation.handoff.role.assistant", defaultValue: "Assistant")
+        case .system:
+            return String(localized: "forkConversation.handoff.role.system", defaultValue: "System")
+        case .tool:
+            return String(localized: "forkConversation.handoff.role.tool", defaultValue: "Tool")
+        case .event:
+            return String(localized: "forkConversation.handoff.role.event", defaultValue: "Event")
+        }
+    }
+
+    /// Removes terminal control bytes while preserving tabs, newlines, and Unicode text.
+    private func promptSafe(_ text: String) -> String {
+        let scalars = text.unicodeScalars.filter { scalar in
+            scalar.value == 9 || scalar.value == 10 || (scalar.value >= 32 && scalar.value != 127)
+        }
+        return String(String.UnicodeScalarView(scalars))
+    }
+}
+
+/// Converts any supported source harness into one target-ready message.
+nonisolated struct AgentConversationExportService: Sendable {
+    static let live = AgentConversationExportService()
+
+    let readerRegistry: AgentConversationReaderRegistry
+    let compactor: any AgentConversationCompacting
+    let formatter: any AgentConversationFormatting
+    let policy: AgentConversationExportPolicy
+
+    init(
+        readerRegistry: AgentConversationReaderRegistry = .live,
+        compactor: any AgentConversationCompacting = TailPreservingAgentConversationCompactor(),
+        formatter: any AgentConversationFormatting = RoleLabeledAgentConversationFormatter(),
+        policy: AgentConversationExportPolicy = AgentConversationExportPolicy()
+    ) {
+        self.readerRegistry = readerRegistry
+        self.compactor = compactor
+        self.formatter = formatter
+        self.policy = policy
+    }
+
+    #if compiler(>=6.2)
+    @concurrent
+    #else
+    @Sendable
+    #endif
+    func message(for snapshot: SessionRestorableAgentSnapshot) async throws -> String {
+        let turns = try await readerRegistry.read(AgentConversationSource(snapshot: snapshot))
+        let compaction = compactor.compact(turns, policy: policy)
+        guard !compaction.turns.isEmpty else {
+            throw AgentConversationExportError.emptyConversation
+        }
+        return formatter.format(
+            compaction,
+            sourceDisplayName: snapshot.agentDisplayName,
+            maximumCharacters: policy.maximumCharacters
+        )
+    }
+}

--- a/Sources/AgentConversationForkRequest.swift
+++ b/Sources/AgentConversationForkRequest.swift
@@ -1,0 +1,117 @@
+import CmuxCommandPalette
+import Foundation
+
+/// One requested agent-conversation fork, including its target harness and layout destination.
+struct AgentConversationForkRequest: Equatable, Sendable {
+    /// The harness that should own the forked conversation.
+    enum TargetHarness: String, CaseIterable, Identifiable, Sendable {
+        case current
+        case claude
+        case codex
+        case opencode
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .current:
+                return String(localized: "forkConversation.harness.current", defaultValue: "Current Harness")
+            case .claude:
+                return String(localized: "forkConversation.harness.claude", defaultValue: "Claude Code")
+            case .codex:
+                return String(localized: "forkConversation.harness.codex", defaultValue: "Codex")
+            case .opencode:
+                return String(localized: "forkConversation.harness.opencode", defaultValue: "OpenCode")
+            }
+        }
+
+        fileprivate func usesNativeFork(for sourceKind: RestorableAgentKind) -> Bool {
+            self == .current || rawValue == sourceKind.rawValue
+        }
+
+        fileprivate func startupCommand(
+            sourceSnapshot: SessionRestorableAgentSnapshot
+        ) -> String? {
+            guard !usesNativeFork(for: sourceSnapshot.kind) else { return nil }
+
+            let lookupCommand = [
+                "cmux sessions list --agent",
+                Self.shellSingleQuoted(sourceSnapshot.kind.rawValue),
+                "--session",
+                Self.shellSingleQuoted(sourceSnapshot.sessionId),
+                "--json",
+            ].joined(separator: " ")
+            let prompt = String(
+                localized: "forkConversation.crossHarness.prompt",
+                defaultValue: "Continue the latest unfinished request from the \(sourceSnapshot.agentDisplayName) session \(sourceSnapshot.sessionId). Before acting, run `\(lookupCommand)` and read the transcript path it returns. If no transcript is readable, use the source harness's export command. Explain any missing context before changing files."
+            )
+
+            switch self {
+            case .current:
+                return nil
+            case .claude:
+                return "claude \(Self.shellSingleQuoted(prompt))"
+            case .codex:
+                return "codex \(Self.shellSingleQuoted(prompt))"
+            case .opencode:
+                return "opencode --prompt \(Self.shellSingleQuoted(prompt))"
+            }
+        }
+
+        private static func shellSingleQuoted(_ value: String) -> String {
+            "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        }
+    }
+
+    static let harnessArgumentName = "harness"
+    static let destinationArgumentName = "destination"
+
+    static var commandPaletteArguments: [CmuxActionArgumentDefinition] {
+        [
+            CmuxActionArgumentDefinition(
+                name: harnessArgumentName,
+                title: String(localized: "forkConversation.argument.harness", defaultValue: "Harness"),
+                choices: TargetHarness.allCases.map {
+                    CmuxActionArgumentDefinition.Choice(value: $0.rawValue, title: $0.title)
+                }
+            ),
+            CmuxActionArgumentDefinition(
+                name: destinationArgumentName,
+                title: String(localized: "forkConversation.argument.destination", defaultValue: "Destination"),
+                choices: AgentConversationForkDestination.allCases.map {
+                    CmuxActionArgumentDefinition.Choice(value: $0.rawValue, title: $0.settingsTitle)
+                }
+            ),
+        ]
+    }
+
+    let targetHarness: TargetHarness
+    let destination: AgentConversationForkDestination
+
+    init(
+        targetHarness: TargetHarness,
+        destination: AgentConversationForkDestination
+    ) {
+        self.targetHarness = targetHarness
+        self.destination = destination
+    }
+
+    init?(invocation: CmuxActionInvocation) {
+        guard let harnessValue = invocation.string(Self.harnessArgumentName),
+              let targetHarness = TargetHarness(rawValue: harnessValue),
+              let destinationValue = invocation.string(Self.destinationArgumentName),
+              let destination = AgentConversationForkDestination(rawValue: destinationValue) else {
+            return nil
+        }
+        self.init(targetHarness: targetHarness, destination: destination)
+    }
+
+    /// Returns a startup-input override for a cross-harness handoff.
+    ///
+    /// `nil` means the request should use the source harness's native fork command.
+    func startupInputOverride(
+        sourceSnapshot: SessionRestorableAgentSnapshot
+    ) -> String? {
+        targetHarness.startupCommand(sourceSnapshot: sourceSnapshot).map { $0 + "\n" }
+    }
+}

--- a/Sources/AgentConversationForkRequest.swift
+++ b/Sources/AgentConversationForkRequest.swift
@@ -29,37 +29,17 @@ struct AgentConversationForkRequest: Equatable, Sendable {
             self == .current || rawValue == sourceKind.rawValue
         }
 
-        fileprivate func startupCommand(
-            sourceSnapshot: SessionRestorableAgentSnapshot
-        ) -> String? {
-            guard !usesNativeFork(for: sourceSnapshot.kind) else { return nil }
-
-            let lookupCommand = [
-                "cmux sessions list --agent",
-                Self.shellSingleQuoted(sourceSnapshot.kind.rawValue),
-                "--session",
-                Self.shellSingleQuoted(sourceSnapshot.sessionId),
-                "--json",
-            ].joined(separator: " ")
-            let prompt = String(
-                localized: "forkConversation.crossHarness.prompt",
-                defaultValue: "Continue the latest unfinished request from the \(sourceSnapshot.agentDisplayName) session \(sourceSnapshot.sessionId). Before acting, run `\(lookupCommand)` and read the transcript path it returns. If no transcript is readable, use the source harness's export command. Explain any missing context before changing files."
-            )
-
+        fileprivate func startupCommand(handoffMessage: String) -> String? {
             switch self {
             case .current:
                 return nil
             case .claude:
-                return "claude \(Self.shellSingleQuoted(prompt))"
+                return "claude \(TerminalStartupShellQuoting.singleQuoted(handoffMessage))"
             case .codex:
-                return "codex \(Self.shellSingleQuoted(prompt))"
+                return "codex \(TerminalStartupShellQuoting.singleQuoted(handoffMessage))"
             case .opencode:
-                return "opencode --prompt \(Self.shellSingleQuoted(prompt))"
+                return "opencode --prompt \(TerminalStartupShellQuoting.singleQuoted(handoffMessage))"
             }
-        }
-
-        private static func shellSingleQuoted(_ value: String) -> String {
-            "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
         }
     }
 
@@ -106,12 +86,17 @@ struct AgentConversationForkRequest: Equatable, Sendable {
         self.init(targetHarness: targetHarness, destination: destination)
     }
 
-    /// Returns a startup-input override for a cross-harness handoff.
+    /// Returns a startup command for a cross-harness handoff.
     ///
     /// `nil` means the request should use the source harness's native fork command.
-    func startupInputOverride(
-        sourceSnapshot: SessionRestorableAgentSnapshot
-    ) -> String? {
-        targetHarness.startupCommand(sourceSnapshot: sourceSnapshot).map { $0 + "\n" }
+    func startupCommandOverride(
+        sourceSnapshot: SessionRestorableAgentSnapshot,
+        exportService: AgentConversationExportService = .live
+    ) async throws -> String? {
+        guard !targetHarness.usesNativeFork(for: sourceSnapshot.kind) else {
+            return nil
+        }
+        let handoffMessage = try await exportService.message(for: sourceSnapshot)
+        return targetHarness.startupCommand(handoffMessage: handoffMessage)
     }
 }

--- a/Sources/CommandPalette/CommandPaletteArgumentChoiceView.swift
+++ b/Sources/CommandPalette/CommandPaletteArgumentChoiceView.swift
@@ -1,0 +1,72 @@
+import CmuxCommandPalette
+import SwiftUI
+
+/// The floating command-palette step that presents one finite action argument.
+struct CommandPaletteArgumentChoiceView: View {
+    let actionTitle: String
+    let instruction: String
+    let commandID: String
+    let argument: CmuxActionArgumentDefinition
+    let selectedIndex: Int
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Header(actionTitle: actionTitle, instruction: instruction)
+
+            Divider()
+
+            CommandPaletteCommandListRowsView(
+                state: renderState,
+                onRunResult: onSelect
+            )
+        }
+    }
+
+    private var renderState: CommandPaletteCommandListRenderState {
+        let resolvedIndex = argument.choices.isEmpty
+            ? 0
+            : min(max(selectedIndex, 0), argument.choices.count - 1)
+        let rows = argument.choices.map { choice in
+            CommandPaletteRenderResultRow(
+                id: choice.value,
+                title: choice.title,
+                matchedIndices: [],
+                trailingLabel: nil
+            )
+        }
+        return CommandPaletteCommandListRenderState(
+            resultsVersion: 0,
+            emptyStateText: "",
+            listIdentity: "arguments.\(commandID).\(argument.name)",
+            rows: rows,
+            selectedIndex: resolvedIndex,
+            shouldShowEmptyState: false,
+            scrollTargetID: rows.indices.contains(resolvedIndex) ? rows[resolvedIndex].id : nil,
+            scrollTargetAnchor: ContentView.commandPaletteScrollPositionAnchor(
+                selectedIndex: resolvedIndex,
+                resultCount: rows.count
+            )
+        )
+    }
+
+    private struct Header: View {
+        let actionTitle: String
+        let instruction: String
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(actionTitle)
+                    .cmuxFont(size: 13, weight: .medium)
+                    .lineLimit(1)
+                Text(instruction)
+                    .cmuxFont(size: 11)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+        }
+    }
+}

--- a/Sources/ContentView+ForkAgentConversation.swift
+++ b/Sources/ContentView+ForkAgentConversation.swift
@@ -5,43 +5,37 @@ import Foundation
 
 extension ContentView {
     func forkFocusedAgentConversationRight() {
-        Task { @MainActor in
-            await forkFocusedAgentConversation(.right)
-        }
+        forkFocusedAgentConversation(.init(targetHarness: .current, destination: .right))
     }
 
     func forkFocusedAgentConversationLeft() {
-        Task { @MainActor in
-            await forkFocusedAgentConversation(.left)
-        }
+        forkFocusedAgentConversation(.init(targetHarness: .current, destination: .left))
     }
 
     func forkFocusedAgentConversationTop() {
-        Task { @MainActor in
-            await forkFocusedAgentConversation(.top)
-        }
+        forkFocusedAgentConversation(.init(targetHarness: .current, destination: .top))
     }
 
     func forkFocusedAgentConversationBottom() {
-        Task { @MainActor in
-            await forkFocusedAgentConversation(.bottom)
-        }
+        forkFocusedAgentConversation(.init(targetHarness: .current, destination: .bottom))
     }
 
     func forkFocusedAgentConversationToNewTab() {
-        Task { @MainActor in
-            await forkFocusedAgentConversation(.newTab)
-        }
+        forkFocusedAgentConversation(.init(targetHarness: .current, destination: .newTab))
     }
 
     func forkFocusedAgentConversationToNewWorkspace() {
+        forkFocusedAgentConversation(.init(targetHarness: .current, destination: .newWorkspace))
+    }
+
+    func forkFocusedAgentConversation(_ request: AgentConversationForkRequest) {
         Task { @MainActor in
-            await forkFocusedAgentConversation(.newWorkspace)
+            await performForkFocusedAgentConversation(request)
         }
     }
 
     @MainActor
-    private func forkFocusedAgentConversation(_ destination: AgentConversationForkDestination) async {
+    private func performForkFocusedAgentConversation(_ request: AgentConversationForkRequest) async {
         guard var currentContext = focusedPanelContext,
               currentContext.panel.panelType == .terminal else {
             NSSound.beep()
@@ -247,61 +241,19 @@ extension ContentView {
         commandPaletteForkableAgentRemoteContextsByPanelKey[panelKey] = isRemoteContext
         commandPaletteForkableAgentResultHadFallbackByPanelKey[panelKey] = selection.usedFallbackSnapshot
 
-        let didFork: Bool
-        if let direction = destination.splitDirection {
-            didFork = currentContext.workspace.forkAgentConversation(
-                fromPanelId: panelId,
-                snapshot: snapshot,
-                direction: direction
-            ) != nil
-        } else {
-            switch destination {
-            case .newTab:
-                guard let anchorTabId = currentContext.workspace.surfaceIdFromPanelId(panelId),
-                      let paneId = currentContext.workspace.paneId(forPanelId: panelId) else {
-                    clearCommandPaletteForkableAgentCache(panelKey: panelKey)
-                    NSSound.beep()
-                    return
-                }
-                didFork = currentContext.workspace.forkAgentConversationToNewTab(
-                    fromPanelId: panelId,
-                    snapshot: snapshot,
-                    anchorTabId: anchorTabId,
-                    paneId: paneId
-                ) != nil
-            case .newWorkspace:
-                guard let launch = currentContext.workspace.forkAgentWorkspaceLaunch(
-                    fromPanelId: panelId,
-                    snapshot: snapshot
-                ) else {
-                    clearCommandPaletteForkableAgentCache(panelKey: panelKey)
-                    NSSound.beep()
-                    return
-                }
-                let forkWorkspace = tabManager.addWorkspace(
-                    workingDirectory: launch.terminalWorkingDirectory,
-                    initialTerminalCommand: launch.initialTerminalCommand,
-                    initialTerminalInput: launch.initialTerminalInput,
-                    initialTerminalEnvironment: launch.initialTerminalEnvironment,
-                    inheritWorkingDirectory: launch.terminalWorkingDirectory != nil,
-                    autoWelcomeIfNeeded: false
-                )
-                if let remoteConfiguration = launch.remoteConfiguration {
-                    forkWorkspace.configureRemoteConnection(
-                        remoteConfiguration,
-                        autoConnect: launch.autoConnectRemoteConfiguration
-                    )
-                }
-                if let workingDirectory = launch.workingDirectory,
-                   launch.terminalWorkingDirectory == nil,
-                   let forkPanelId = forkWorkspace.focusedPanelId {
-                    forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
-                }
-                didFork = true
-            case .right, .left, .top, .bottom:
-                didFork = false
-            }
+        guard let anchorTabId = currentContext.workspace.surfaceIdFromPanelId(panelId),
+              let paneId = currentContext.workspace.paneId(forPanelId: panelId) else {
+            clearCommandPaletteForkableAgentCache(panelKey: panelKey)
+            NSSound.beep()
+            return
         }
+        let didFork = currentContext.workspace.forkAgentConversation(
+            fromPanelId: panelId,
+            snapshot: snapshot,
+            request: request,
+            anchorTabId: anchorTabId,
+            paneId: paneId
+        )
 
         guard didFork else {
             clearCommandPaletteForkableAgentCache(panelKey: panelKey)

--- a/Sources/ContentView+ForkAgentConversation.swift
+++ b/Sources/ContentView+ForkAgentConversation.swift
@@ -247,7 +247,7 @@ extension ContentView {
             NSSound.beep()
             return
         }
-        let didFork = currentContext.workspace.forkAgentConversation(
+        let didFork = await currentContext.workspace.forkAgentConversation(
             fromPanelId: panelId,
             snapshot: snapshot,
             request: request,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -885,6 +885,8 @@ struct ContentView: View {
     @State private var isCommandPalettePresented = false
     @State private var commandPaletteQuery: String = ""
     @State private var commandPaletteMode: CommandPaletteMode = .commands
+    @State private var commandPaletteArgumentCommand: CommandPaletteCommand?
+    @State private var commandPaletteArgumentSelectedIndex: Int = 0
     @State private var commandPaletteRenameDraft: String = ""
     @State private var commandPaletteWorkspaceDescriptionDraft: String = ""
     @State private var commandPaletteWorkspaceDescriptionHeight: CGFloat = CommandPaletteMultilineTextEditorRepresentable.defaultMinimumHeight
@@ -3016,7 +3018,6 @@ struct ContentView: View {
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteMoveSelection)) { notification in
             guard isCommandPalettePresented else { return }
-            guard case .commands = commandPaletteMode else { return }
             let requestedWindow = notification.object as? NSWindow
             guard Self.shouldHandleCommandPaletteRequest(
                 observedWindow: observedWindow,
@@ -3025,7 +3026,14 @@ struct ContentView: View {
                 mainWindow: NSApp.mainWindow
             ) else { return }
             guard let delta = notification.userInfo?["delta"] as? Int, delta != 0 else { return }
-            moveCommandPaletteSelection(by: delta)
+            switch commandPaletteMode {
+            case .commands:
+                moveCommandPaletteSelection(by: delta)
+            case .actionArguments:
+                moveCommandPaletteArgumentSelection(by: delta)
+            case .renameInput, .renameConfirm, .workspaceDescriptionInput:
+                break
+            }
         })
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .commandPaletteRenameInputInteractionRequested)) { notification in
@@ -3529,6 +3537,15 @@ struct ContentView: View {
                         commandPaletteRenameInputView(target: target)
                     case let .renameConfirm(target, proposedName):
                         commandPaletteRenameConfirmView(target: target, proposedName: proposedName)
+                    case .actionArguments(let collection):
+                        CommandPaletteArgumentChoiceView(
+                            actionTitle: commandPaletteArgumentCommand?.title ?? "",
+                            instruction: commandPaletteArgumentInstruction(collection),
+                            commandID: collection.commandID,
+                            argument: collection.currentArgument,
+                            selectedIndex: commandPaletteArgumentSelectedIndex,
+                            onSelect: selectCommandPaletteArgumentChoice(value:)
+                        )
                     case .workspaceDescriptionInput(let target):
                         commandPaletteWorkspaceDescriptionInputView(
                             target: target,
@@ -4919,7 +4936,7 @@ struct ContentView: View {
 
     nonisolated static func commandPaletteForkPriorityBoost(commandId: String, query: String) -> Int {
         guard CommandPaletteFuzzyMatcher.normalizeForSearch(query) == "fork",
-              commandId == "palette.forkAgentConversationRight" else {
+              commandId == "palette.forkAgentConversation" else {
             return 0
         }
         return 10_000
@@ -7929,6 +7946,25 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.forkAgentConversation",
+                title: constant(String(
+                    localized: "command.forkAgentConversation.title",
+                    defaultValue: "Fork Conversation…"
+                )),
+                subtitle: terminalPanelSubtitle,
+                keywords: [
+                    "terminal", "agent", "fork", "conversation", "session",
+                    "harness", "claude", "codex", "opencode", "direction", "destination",
+                ],
+                arguments: AgentConversationForkRequest.commandPaletteArguments,
+                when: {
+                    $0.bool(CommandPaletteContextKeys.panelIsTerminal) &&
+                    $0.bool(CommandPaletteContextKeys.panelHasForkableAgent)
+                }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.forkAgentConversationRight",
                 title: constant(String(localized: "command.forkAgentConversationRight.title", defaultValue: "Fork Conversation to the Right")),
                 subtitle: terminalPanelSubtitle,
@@ -8771,6 +8807,19 @@ struct ContentView: View {
                 tabManager.createSplit(direction: .right)
             }
         }
+        registry.register(commandId: "palette.forkAgentConversation") { invocation in
+            guard let request = AgentConversationForkRequest(invocation: invocation) else {
+                return .failed(
+                    code: "invalid_fork_request",
+                    message: String(
+                        localized: "action.error.invalidForkRequest",
+                        defaultValue: "Choose a harness and destination for the conversation fork."
+                    )
+                )
+            }
+            forkFocusedAgentConversation(request)
+            return .completed
+        }
         registry.register(commandId: "palette.forkAgentConversationRight") {
             forkFocusedAgentConversationRight()
         }
@@ -9079,6 +9128,18 @@ struct ContentView: View {
         syncCommandPaletteDebugStateForObservedWindow()
     }
 
+    private func moveCommandPaletteArgumentSelection(by delta: Int) {
+        guard case .actionArguments(let collection) = commandPaletteMode else { return }
+        let count = collection.currentArgument.choices.count
+        guard count > 0 else {
+            NSSound.beep()
+            return
+        }
+        let current = min(max(commandPaletteArgumentSelectedIndex, 0), count - 1)
+        commandPaletteArgumentSelectedIndex = min(max(current + delta, 0), count - 1)
+        syncCommandPaletteDebugStateForObservedWindow()
+    }
+
     private func forwardCommandPaletteUnhandledNavigationKeyToFocusedTerminal(_ event: NSEvent) -> Bool {
         guard let target = commandPaletteRestoreFocusTarget,
               target.intent == .terminal(.surface),
@@ -9200,6 +9261,14 @@ struct ContentView: View {
         switch commandPaletteMode {
         case .commands:
             runSelectedCommandPaletteResult()
+        case .actionArguments(let collection):
+            let choices = collection.currentArgument.choices
+            guard !choices.isEmpty else {
+                NSSound.beep()
+                return
+            }
+            let index = min(max(commandPaletteArgumentSelectedIndex, 0), choices.count - 1)
+            selectCommandPaletteArgumentChoice(value: choices[index].value)
         case .renameInput(let target):
             continueRenameFlow(target: target)
         case .renameConfirm(let target, let proposedName):
@@ -9230,6 +9299,16 @@ struct ContentView: View {
 #if DEBUG
         cmuxDebugLog("palette.run commandId=\(command.id) dismissOnRun=\(command.dismissOnRun ? 1 : 0)")
 #endif
+        if invocation.source == .commandPalette,
+           isCommandPalettePresented,
+           let collection = CommandPaletteArgumentCollection(
+               commandID: command.id,
+               arguments: command.arguments,
+               initialValues: invocation.arguments
+           ) {
+            beginCommandPaletteArgumentCollection(command: command, collection: collection)
+            return .presented
+        }
         let postRunFocusTarget = commandPalettePostRunFocusTarget(for: command)
         recordCommandPaletteUsage(command.id)
         if invocation.source == .automation {
@@ -9256,6 +9335,61 @@ struct ContentView: View {
             }
         }
         return result
+    }
+
+    private func beginCommandPaletteArgumentCollection(
+        command: CommandPaletteCommand,
+        collection: CommandPaletteArgumentCollection
+    ) {
+        commandPaletteArgumentCommand = command
+        commandPaletteArgumentSelectedIndex = 0
+        commandPaletteMode = .actionArguments(collection)
+        isCommandPaletteSearchFocused = false
+        isCommandPaletteRenameFocused = false
+        commandPaletteShouldFocusWorkspaceDescriptionEditor = false
+        commandPalettePendingTextSelectionBehavior = nil
+        if let window = observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow {
+            _ = window.makeFirstResponder(nil)
+        }
+        syncCommandPaletteDebugStateForObservedWindow()
+    }
+
+    private func selectCommandPaletteArgumentChoice(value: String) {
+        guard case .actionArguments(var collection) = commandPaletteMode,
+              let command = commandPaletteArgumentCommand,
+              command.id == collection.commandID else {
+            NSSound.beep()
+            return
+        }
+
+        switch collection.selectCurrentChoice(value: value) {
+        case .invalid:
+            NSSound.beep()
+        case .advanced:
+            commandPaletteArgumentSelectedIndex = 0
+            commandPaletteMode = .actionArguments(collection)
+            syncCommandPaletteDebugStateForObservedWindow()
+        case .completed:
+            commandPaletteArgumentCommand = nil
+            commandPaletteArgumentSelectedIndex = 0
+            commandPaletteMode = .commands
+            _ = runCommandPaletteCommand(
+                command,
+                invocation: CmuxActionInvocation(
+                    source: .commandPalette,
+                    arguments: collection.values
+                )
+            )
+        }
+    }
+
+    private func commandPaletteArgumentInstruction(
+        _ collection: CommandPaletteArgumentCollection
+    ) -> String {
+        String(
+            localized: "commandPalette.argument.instruction",
+            defaultValue: "Choose \(collection.currentArgument.title) (\(collection.currentStep) of \(collection.stepCount))"
+        )
     }
 
     private func commandPalettePostRunFocusTarget(for command: CommandPaletteCommand) -> CommandPaletteRestoreFocusTarget? {
@@ -9372,7 +9506,8 @@ struct ContentView: View {
 
     static func commandPaletteShouldDismissBeforeRun(forCommandId commandId: String) -> Bool {
         switch commandId {
-        case "palette.forkAgentConversationRight",
+        case "palette.forkAgentConversation",
+             "palette.forkAgentConversationRight",
              "palette.forkAgentConversationLeft",
              "palette.forkAgentConversationTop",
              "palette.forkAgentConversationBottom",
@@ -9402,8 +9537,18 @@ struct ContentView: View {
     private func syncCommandPaletteDebugStateForObservedWindow() {
         guard let window = observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow else { return }
         AppDelegate.shared?.setCommandPaletteVisible(isCommandPalettePresented, for: window)
-        let visibleResultCount = commandPaletteVisibleResults.count
-        let selectedIndex = isCommandPalettePresented ? commandPaletteSelectedIndex(resultCount: visibleResultCount) : 0
+        let selectedIndex: Int
+        if isCommandPalettePresented,
+           case .actionArguments(let collection) = commandPaletteMode {
+            selectedIndex = min(
+                max(commandPaletteArgumentSelectedIndex, 0),
+                max(collection.currentArgument.choices.count - 1, 0)
+            )
+        } else {
+            selectedIndex = isCommandPalettePresented
+                ? commandPaletteSelectedIndex(resultCount: commandPaletteVisibleResults.count)
+                : 0
+        }
         AppDelegate.shared?.setCommandPaletteSelectionIndex(selectedIndex, for: window)
         AppDelegate.shared?.setCommandPaletteSnapshot(commandPaletteDebugSnapshot(), for: window)
     }
@@ -9419,11 +9564,25 @@ struct ContentView: View {
             mode = "rename_input"
         case .renameConfirm:
             mode = "rename_confirm"
+        case .actionArguments(let collection):
+            mode = "action_arguments.\(collection.currentArgument.name)"
         case .workspaceDescriptionInput:
             mode = "workspace_description_input"
         }
 
-        let rows = Array(commandPaletteVisibleResults.prefix(20)).map { result in
+        let rows: [CommandPaletteDebugResultRow]
+        if case .actionArguments(let collection) = commandPaletteMode {
+            rows = Array(collection.currentArgument.choices.prefix(20)).map { choice in
+                CommandPaletteDebugResultRow(
+                    commandId: choice.value,
+                    title: choice.title,
+                    shortcutHint: nil,
+                    trailingLabel: nil,
+                    score: 0
+                )
+            }
+        } else {
+            rows = Array(commandPaletteVisibleResults.prefix(20)).map { result in
                 CommandPaletteDebugResultRow(
                     commandId: result.command.id,
                     title: result.command.title,
@@ -9431,6 +9590,7 @@ struct ContentView: View {
                     trailingLabel: commandPaletteRenderTrailingLabel(for: result.command)?.text,
                     score: result.score
                 )
+            }
         }
 
         return CommandPaletteDebugSnapshot(
@@ -9461,6 +9621,8 @@ struct ContentView: View {
 
     private func resetCommandPaletteListState(initialQuery: String) {
         commandPaletteMode = .commands
+        commandPaletteArgumentCommand = nil
+        commandPaletteArgumentSelectedIndex = 0
         commandPaletteQuery = initialQuery
         commandPaletteRenameDraft = ""
         commandPaletteWorkspaceDescriptionDraft = ""
@@ -9572,6 +9734,8 @@ struct ContentView: View {
         commandPaletteSearchRequestID &+= 1
         isCommandPalettePresented = false
         commandPaletteMode = .commands
+        commandPaletteArgumentCommand = nil
+        commandPaletteArgumentSelectedIndex = 0
         commandPaletteQuery = ""
         commandPaletteRenameDraft = ""
         commandPaletteWorkspaceDescriptionDraft = ""
@@ -9702,6 +9866,8 @@ struct ContentView: View {
             return "renameInput"
         case .renameConfirm:
             return "renameConfirm"
+        case .actionArguments(let collection):
+            return "actionArguments.\(collection.currentArgument.name)"
         case .workspaceDescriptionInput:
             return "workspaceDescriptionInput"
         }
@@ -9799,7 +9965,7 @@ struct ContentView: View {
             switch commandPaletteMode {
             case .commands, .renameInput:
                 break
-            case .renameConfirm:
+            case .renameConfirm, .actionArguments:
                 return
             case .workspaceDescriptionInput:
                 return

--- a/Sources/GhosttyNSView+ForkConversationContextMenu.swift
+++ b/Sources/GhosttyNSView+ForkConversationContextMenu.swift
@@ -56,7 +56,98 @@ extension GhosttyNSView {
         submenuItem.submenu = submenu
         menu.addItem(submenuItem)
 
+        menu.addItem(
+            forkConversationHarnessFirstMenuItem(defaultDestination: defaultDestination)
+        )
+        menu.addItem(
+            forkConversationDestinationFirstMenuItem(defaultDestination: defaultDestination)
+        )
+
         return true
+    }
+
+    private func forkConversationHarnessFirstMenuItem(
+        defaultDestination: AgentConversationForkDestination
+    ) -> NSMenuItem {
+        let rootItem = NSMenuItem(
+            title: String(
+                localized: "terminalContextMenu.forkConversationByHarness",
+                defaultValue: "Fork by Harness"
+            ),
+            action: nil,
+            keyEquivalent: ""
+        )
+        rootItem.image = NSImage(systemSymbolName: "arrow.triangle.branch", accessibilityDescription: nil)
+        let rootMenu = NSMenu()
+        for harness in AgentConversationForkRequest.TargetHarness.allCases {
+            let harnessItem = NSMenuItem(title: harness.title, action: nil, keyEquivalent: "")
+            let destinationMenu = NSMenu()
+            for destination in AgentConversationForkDestination.allCases {
+                destinationMenu.addItem(forkConversationLeafMenuItem(
+                    request: AgentConversationForkRequest(
+                        targetHarness: harness,
+                        destination: destination
+                    ),
+                    defaultDestination: defaultDestination,
+                    title: destination.settingsTitle
+                ))
+            }
+            harnessItem.submenu = destinationMenu
+            rootMenu.addItem(harnessItem)
+        }
+        rootItem.submenu = rootMenu
+        return rootItem
+    }
+
+    private func forkConversationDestinationFirstMenuItem(
+        defaultDestination: AgentConversationForkDestination
+    ) -> NSMenuItem {
+        let rootItem = NSMenuItem(
+            title: String(
+                localized: "terminalContextMenu.forkConversationByDestination",
+                defaultValue: "Fork by Destination"
+            ),
+            action: nil,
+            keyEquivalent: ""
+        )
+        rootItem.image = NSImage(systemSymbolName: "arrow.triangle.branch", accessibilityDescription: nil)
+        let rootMenu = NSMenu()
+        for destination in AgentConversationForkDestination.allCases {
+            let destinationItem = NSMenuItem(title: destination.settingsTitle, action: nil, keyEquivalent: "")
+            let harnessMenu = NSMenu()
+            for harness in AgentConversationForkRequest.TargetHarness.allCases {
+                harnessMenu.addItem(forkConversationLeafMenuItem(
+                    request: AgentConversationForkRequest(
+                        targetHarness: harness,
+                        destination: destination
+                    ),
+                    defaultDestination: defaultDestination,
+                    title: harness.title
+                ))
+            }
+            destinationItem.submenu = harnessMenu
+            rootMenu.addItem(destinationItem)
+        }
+        rootItem.submenu = rootMenu
+        return rootItem
+    }
+
+    private func forkConversationLeafMenuItem(
+        request: AgentConversationForkRequest,
+        defaultDestination: AgentConversationForkDestination,
+        title: String
+    ) -> NSMenuItem {
+        let item = NSMenuItem(
+            title: title,
+            action: #selector(forkCurrentAgentConversation(_:)),
+            keyEquivalent: ""
+        )
+        item.target = self
+        item.representedObject = request
+        item.state = request.targetHarness == .current && request.destination == defaultDestination
+            ? .on
+            : .off
+        return item
     }
 
     private func currentAgentConversationForkAvailability() -> WorkspaceForkAgentConversationAvailability {
@@ -97,19 +188,26 @@ extension GhosttyNSView {
         }
         let workspace = located.workspace
 
-        let destination: AgentConversationForkDestination
-        if let item = sender as? NSMenuItem,
-           let rawDestination = item.representedObject as? String,
-           let representedDestination = AgentConversationForkDestination(rawValue: rawDestination) {
-            destination = representedDestination
+        let request: AgentConversationForkRequest
+        if let representedRequest = (sender as? NSMenuItem)?.representedObject as? AgentConversationForkRequest {
+            request = representedRequest
+        } else if let rawDestination = (sender as? NSMenuItem)?.representedObject as? String,
+                  let representedDestination = AgentConversationForkDestination(rawValue: rawDestination) {
+            request = AgentConversationForkRequest(
+                targetHarness: .current,
+                destination: representedDestination
+            )
         } else {
-            destination = AgentConversationForkDefaultSettings.current()
+            request = AgentConversationForkRequest(
+                targetHarness: .current,
+                destination: AgentConversationForkDefaultSettings.current()
+            )
         }
 
         Task { @MainActor in
             guard await workspace.forkAgentConversationFromContextMenu(
                 fromPanelId: panelId,
-                destination: destination
+                request: request
             ) else {
                 NSSound.beep()
                 return

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -766,6 +766,9 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
     var workingDirectory: String?
     var launchCommand: AgentLaunchCommandSnapshot?
     var registration: CmuxVaultAgentRegistration? = nil
+    /// Source-owned transcript path when the harness exposes one. Database-backed
+    /// harnesses leave this nil and resolve through a conversation reader adapter.
+    var transcriptPath: String? = nil
     /// Last hook-observed permission mode; re-applied as `--permission-mode` on
     /// user-owned claude resume/fork when no explicit launch flag covers it.
     var permissionMode: String? = nil
@@ -818,6 +821,24 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
             fileManager: fileManager,
             temporaryDirectory: temporaryDirectory,
             allowLauncherScript: allowLauncherScript
+        )
+    }
+
+    /// Applies the same inline-size and launcher-script policy to a command
+    /// supplied by another continuation strategy, such as cross-harness export.
+    func customStartupInput(
+        command: String,
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory,
+        allowLauncherScript: Bool = true,
+        allowOversizedInlineInput: Bool = false
+    ) -> String? {
+        startupInput(
+            command: command,
+            fileManager: fileManager,
+            temporaryDirectory: temporaryDirectory,
+            allowLauncherScript: allowLauncherScript,
+            allowOversizedInlineInput: allowOversizedInlineInput
         )
     }
 
@@ -1180,6 +1201,7 @@ struct RestorableAgentSessionIndex: Sendable {
                     ),
                     launchCommand: effectiveRecord.launchCommand,
                     registration: registration,
+                    transcriptPath: normalizedNonEmptyValue(effectiveRecord.transcriptPath),
                     permissionMode: effectiveRecord.lastPermissionMode
                 )
                 let key = PanelKey(workspaceId: workspaceId, panelId: panelId)

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -149,11 +149,12 @@ enum OpenCodeDatabaseSnapshot {
         }
     }
 
-    private static let sourcePath = ("~/.local/share/opencode/opencode.db" as NSString).expandingTildeInPath
+    private static let defaultSourcePath = ("~/.local/share/opencode/opencode.db" as NSString).expandingTildeInPath
 
-    static func make(prefix: String) throws -> Snapshot? {
+    static func make(prefix: String, sourcePath: String? = nil) throws -> Snapshot? {
         let fileManager = FileManager.default
-        guard fileManager.fileExists(atPath: sourcePath) else { return nil }
+        let resolvedSourcePath = sourcePath ?? defaultSourcePath
+        guard fileManager.fileExists(atPath: resolvedSourcePath) else { return nil }
 
         let snapshotDir = fileManager.temporaryDirectory.appendingPathComponent(
             "\(prefix)-\(UUID().uuidString)",
@@ -163,7 +164,7 @@ enum OpenCodeDatabaseSnapshot {
 
         let snapshotDB = snapshotDir.appendingPathComponent("opencode.db")
         do {
-            try fileManager.copyItem(atPath: sourcePath, toPath: snapshotDB.path)
+            try fileManager.copyItem(atPath: resolvedSourcePath, toPath: snapshotDB.path)
         } catch {
             try? fileManager.removeItem(at: snapshotDir)
             throw error
@@ -171,7 +172,7 @@ enum OpenCodeDatabaseSnapshot {
 
         do {
             for sidecar in ["-wal", "-shm"] {
-                let source = sourcePath + sidecar
+                let source = resolvedSourcePath + sidecar
                 let destination = snapshotDB.path + sidecar
                 if fileManager.fileExists(atPath: source) {
                     try fileManager.copyItem(atPath: source, toPath: destination)

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1273,6 +1273,89 @@ final class SessionIndexStore: ObservableObject {
         #endif
     }
 
+    /// Resolves one exact conversation through the same provider-specific index
+    /// used by the Sessions UI. Database-backed providers use dedicated readers
+    /// before this fallback, so this path primarily resolves file-backed sessions.
+    #if compiler(>=6.2)
+    @concurrent
+    #else
+    @Sendable
+    #endif
+    nonisolated static func resolveConversationEntry(
+        source: AgentConversationSource
+    ) async -> SessionEntry? {
+        let registry = await Task.detached(priority: .utility) {
+            var registrations = CmuxVaultAgentRegistry.load(
+                workingDirectory: source.workingDirectory
+            ).registrations
+            if let registration = source.registration {
+                registrations.append(registration)
+            }
+            return CmuxVaultAgentRegistry(registrations: registrations)
+        }.value
+        let errorBag = ErrorBag()
+
+        func exactMatch(in entries: [SessionEntry]) -> SessionEntry? {
+            entries.first { $0.sessionId == source.sessionId }
+        }
+
+        let scopedMatches = await searchAgent(
+            needle: source.sessionId,
+            agent: source.sessionAgent,
+            cwdFilter: source.workingDirectory,
+            offset: 0,
+            limit: 64,
+            errorBag: errorBag,
+            registry: registry
+        )
+        if let match = exactMatch(in: scopedMatches) {
+            return match
+        }
+
+        if source.workingDirectory != nil {
+            let unscopedMatches = await searchAgent(
+                needle: source.sessionId,
+                agent: source.sessionAgent,
+                cwdFilter: nil,
+                offset: 0,
+                limit: 64,
+                errorBag: errorBag,
+                registry: registry
+            )
+            if let match = exactMatch(in: unscopedMatches) {
+                return match
+            }
+        }
+
+        // Some provider indexes search transcript text rather than IDs. Their
+        // empty-query path enumerates metadata, which lets us match the ID after
+        // indexing without teaching the export layer provider internals.
+        let scopedEntries = await searchAgent(
+            needle: "",
+            agent: source.sessionAgent,
+            cwdFilter: source.workingDirectory,
+            offset: 0,
+            limit: 2_000,
+            errorBag: errorBag,
+            registry: registry
+        )
+        if let match = exactMatch(in: scopedEntries) {
+            return match
+        }
+
+        guard source.workingDirectory != nil else { return nil }
+        let unscopedEntries = await searchAgent(
+            needle: "",
+            agent: source.sessionAgent,
+            cwdFilter: nil,
+            offset: 0,
+            limit: 2_000,
+            errorBag: errorBag,
+            registry: registry
+        )
+        return exactMatch(in: unscopedEntries)
+    }
+
     nonisolated private static func searchAgent(
         needle: String, agent: SessionAgent, cwdFilter: String?,
         offset: Int, limit: Int, errorBag: ErrorBag,

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -1060,7 +1060,87 @@ private extension SessionEntry {
     }
 }
 
-private enum SessionTranscriptLoader {
+enum SessionTranscriptLoader {
+    enum Retention: Equatable, Sendable {
+        case prefix(Int)
+        case openingUserAndLatest(Int)
+
+        var limit: Int {
+            switch self {
+            case .prefix(let limit), .openingUserAndLatest(let limit):
+                return max(1, limit)
+            }
+        }
+
+        var keepsLatestTurns: Bool {
+            if case .openingUserAndLatest = self { return true }
+            return false
+        }
+    }
+
+    struct Source: Sendable {
+        let agent: SessionAgent
+        let sessionId: String
+        let fileURL: URL?
+        let usesGrokTranscriptLayout: Bool
+        let openCodeDatabasePath: String?
+        let retention: Retention
+
+        init(
+            agent: SessionAgent,
+            sessionId: String,
+            fileURL: URL?,
+            usesGrokTranscriptLayout: Bool = false,
+            openCodeDatabasePath: String? = nil,
+            retention: Retention = .prefix(500)
+        ) {
+            self.agent = agent
+            self.sessionId = sessionId
+            self.fileURL = fileURL
+            self.usesGrokTranscriptLayout = usesGrokTranscriptLayout
+            self.openCodeDatabasePath = openCodeDatabasePath
+            self.retention = retention
+        }
+    }
+
+    private struct LatestTurnCollector {
+        let capacity: Int
+        private(set) var openingUser: SessionTranscriptTurn?
+        private var storage: [SessionTranscriptTurn] = []
+        private var replacementIndex = 0
+
+        init(capacity: Int) {
+            self.capacity = max(1, capacity)
+            storage.reserveCapacity(self.capacity)
+        }
+
+        mutating func append(_ turn: SessionTranscriptTurn) {
+            if openingUser == nil, turn.role == .user {
+                openingUser = turn
+            }
+            if storage.count < capacity {
+                storage.append(turn)
+                return
+            }
+            storage[replacementIndex] = turn
+            replacementIndex = (replacementIndex + 1) % capacity
+        }
+
+        var turns: [SessionTranscriptTurn] {
+            let ordered: [SessionTranscriptTurn]
+            if storage.count < capacity || replacementIndex == 0 {
+                ordered = storage
+            } else {
+                ordered = Array(storage[replacementIndex...]) + Array(storage[..<replacementIndex])
+            }
+            guard let openingUser,
+                  !ordered.contains(where: { $0.id == openingUser.id }) else {
+                return ordered
+            }
+            return [openingUser] + Array(ordered.suffix(max(0, capacity - 1)))
+        }
+    }
+
     private static let streamChunkSize = 256 * 1024
     private static let maxPreviewRecordBytes = 2 * 1024 * 1024
     private static let maxPreviewTurns = 500
@@ -1150,37 +1230,63 @@ private enum SessionTranscriptLoader {
         + grokSystemRoleNeedles
         + grokToolRoleNeedles
 
-    static func load(entry: SessionEntry) async throws -> [SessionTranscriptTurn] {
-        if entry.agent == .opencode {
-            let sessionId = entry.sessionId
+    static func load(
+        entry: SessionEntry,
+        retention: Retention = .prefix(maxPreviewTurns)
+    ) async throws -> [SessionTranscriptTurn] {
+        try await load(source: Source(
+            agent: entry.agent,
+            sessionId: entry.sessionId,
+            fileURL: entry.fileURL,
+            usesGrokTranscriptLayout: entry.usesGrokTranscriptLayout,
+            retention: retention
+        ))
+    }
+
+    static func load(source: Source) async throws -> [SessionTranscriptTurn] {
+        if source.agent == .opencode {
+            let sessionId = source.sessionId
+            let databasePath = source.openCodeDatabasePath
             // OpenCode is SQLite-backed. Keep its synchronous query work off
             // the main actor so presenting the popover only flips UI state.
             return try await Task.detached(priority: .userInitiated) {
-                try loadOpenCodeSynchronously(sessionId: sessionId)
+                try loadOpenCodeSynchronously(
+                    sessionId: sessionId,
+                    databasePath: databasePath,
+                    retention: source.retention
+                )
             }.value
         }
-        if entry.agent == .hermesAgent {
-            let sessionId = entry.sessionId
+        if source.agent == .hermesAgent {
+            let sessionId = source.sessionId
             return try await Task.detached(priority: .userInitiated) {
-                try loadHermesAgentSynchronously(sessionId: sessionId)
+                try loadHermesAgentSynchronously(
+                    sessionId: sessionId,
+                    retention: source.retention
+                )
             }.value
         }
-        guard let url = entry.fileURL else {
+        guard let url = source.fileURL else {
             throw SessionTranscriptLoadError.missingFile
         }
-        let agent = entry.agent
-        let sessionId = entry.sessionId
+        let agent = source.agent
+        let sessionId = source.sessionId
         if agent.id == "antigravity" {
             return try await Task.detached(priority: .userInitiated) {
-                try loadAntigravityHistorySynchronously(from: url, sessionId: sessionId)
+                try loadAntigravityHistorySynchronously(
+                    from: url,
+                    sessionId: sessionId,
+                    retention: source.retention
+                )
             }.value
         }
-        let usesGrokTranscriptLayout = entry.usesGrokTranscriptLayout
+        let usesGrokTranscriptLayout = source.usesGrokTranscriptLayout
         return try await Task.detached(priority: .userInitiated) {
             try loadSynchronously(
                 from: url,
                 agent: agent,
-                usesGrokTranscriptLayout: usesGrokTranscriptLayout
+                usesGrokTranscriptLayout: usesGrokTranscriptLayout,
+                retention: source.retention
             )
         }.value
     }
@@ -1188,29 +1294,46 @@ private enum SessionTranscriptLoader {
     private static func loadSynchronously(
         from url: URL,
         agent: SessionAgent,
-        usesGrokTranscriptLayout: Bool
+        usesGrokTranscriptLayout: Bool,
+        retention: Retention
     ) throws -> [SessionTranscriptTurn] {
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw SessionTranscriptLoadError.missingFile
         }
         if agent == .rovodev {
-            guard let preview = try RovoDevTranscriptPreview.load(from: url, limit: maxPreviewTurns) else { throw SessionTranscriptLoadError.missingFile }
-            return coalesce(preview.enumerated().map { index, turn in
+            let loadLimit = retention.keepsLatestTurns ? Int.max : retention.limit
+            guard let preview = try RovoDevTranscriptPreview.load(from: url, limit: loadLimit) else { throw SessionTranscriptLoadError.missingFile }
+            let mapped = preview.enumerated().map { index, turn in
                 let role = transcriptRole(from: turn.role) ?? .event
                 return SessionTranscriptTurn(id: index, role: role, text: truncatedText(turn.text, role: role))
-            })
+            }
+            if retention.keepsLatestTurns {
+                var collector = LatestTurnCollector(capacity: retention.limit)
+                mapped.forEach { collector.append($0) }
+                return coalesce(collector.turns)
+            }
+            return coalesce(mapped)
         }
 
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
 
         var turns: [SessionTranscriptTurn] = []
+        var latestTurns = LatestTurnCollector(capacity: retention.limit)
         var lineData = Data()
         lineData.reserveCapacity(64 * 1024)
         var lineIndex = 0
         var isSkippingOversizedLine = false
         var oversizedPreviewRole: SessionTranscriptRole?
         var didHitTurnLimit = false
+
+        func appendTurn(_ turn: SessionTranscriptTurn) {
+            if retention.keepsLatestTurns {
+                latestTurns.append(turn)
+            } else {
+                turns.append(turn)
+            }
+        }
 
         func finishLine() {
             defer {
@@ -1219,15 +1342,15 @@ private enum SessionTranscriptLoader {
                 isSkippingOversizedLine = false
                 oversizedPreviewRole = nil
             }
-            guard turns.count < maxPreviewTurns else {
+            guard retention.keepsLatestTurns || turns.count < retention.limit else {
                 didHitTurnLimit = true
                 return
             }
             guard !isSkippingOversizedLine else {
                 if let oversizedPreviewRole {
-                    turns.append(largeRecordTurn(id: lineIndex, role: oversizedPreviewRole))
+                    appendTurn(largeRecordTurn(id: lineIndex, role: oversizedPreviewRole))
                 }
-                didHitTurnLimit = turns.count >= maxPreviewTurns
+                didHitTurnLimit = !retention.keepsLatestTurns && turns.count >= retention.limit
                 return
             }
             guard let parsed = parseLineData(
@@ -1238,8 +1361,8 @@ private enum SessionTranscriptLoader {
             ) else {
                 return
             }
-            turns.append(parsed)
-            didHitTurnLimit = turns.count >= maxPreviewTurns
+            appendTurn(parsed)
+            didHitTurnLimit = !retention.keepsLatestTurns && turns.count >= retention.limit
         }
 
         func appendSegment(_ segment: Data.SubSequence) {
@@ -1292,6 +1415,9 @@ private enum SessionTranscriptLoader {
         if !didHitTurnLimit, !lineData.isEmpty || isSkippingOversizedLine {
             finishLine()
         }
+        if retention.keepsLatestTurns {
+            return coalesce(latestTurns.turns)
+        }
         if didHitTurnLimit {
             appendTurnLimitMarker(to: &turns, id: lineIndex)
         }
@@ -1301,13 +1427,15 @@ private enum SessionTranscriptLoader {
 
     private static func loadAntigravityHistorySynchronously(
         from url: URL,
-        sessionId: String
+        sessionId: String,
+        retention: Retention
     ) throws -> [SessionTranscriptTurn] {
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw SessionTranscriptLoadError.missingFile
         }
 
         var turns: [SessionTranscriptTurn] = []
+        var latestTurns = LatestTurnCollector(capacity: retention.limit)
         var lineIndex = 0
         var didHitTurnLimit = false
         let agent = SessionAgent.registered(RegisteredSessionAgent(id: "antigravity"))
@@ -1315,7 +1443,7 @@ private enum SessionTranscriptLoader {
         SessionIndexStore.forEachJSONLine(url: url, maxBytes: Int.max) { object in
             defer { lineIndex += 1 }
             if Task.isCancelled { return true }
-            guard turns.count < maxPreviewTurns else {
+            guard retention.keepsLatestTurns || turns.count < retention.limit else {
                 didHitTurnLimit = true
                 return true
             }
@@ -1326,8 +1454,16 @@ private enum SessionTranscriptLoader {
             guard let text = normalizedText(from: content, role: .user, agent: agent) else {
                 return false
             }
-            turns.append(SessionTranscriptTurn(id: lineIndex, role: .user, text: text))
+            let turn = SessionTranscriptTurn(id: lineIndex, role: .user, text: text)
+            if retention.keepsLatestTurns {
+                latestTurns.append(turn)
+            } else {
+                turns.append(turn)
+            }
             return false
+        }
+        if retention.keepsLatestTurns {
+            return coalesce(latestTurns.turns)
         }
         if didHitTurnLimit {
             appendTurnLimitMarker(to: &turns, id: lineIndex)
@@ -1344,10 +1480,17 @@ private enum SessionTranscriptLoader {
         return nil
     }
 
-    private static func loadOpenCodeSynchronously(sessionId: String) throws -> [SessionTranscriptTurn] {
+    private static func loadOpenCodeSynchronously(
+        sessionId: String,
+        databasePath: String? = nil,
+        retention: Retention = .prefix(maxPreviewTurns)
+    ) throws -> [SessionTranscriptTurn] {
         let snapshot: OpenCodeDatabaseSnapshot.Snapshot
         do {
-            guard let madeSnapshot = try OpenCodeDatabaseSnapshot.make(prefix: "cmux-opencode-preview") else {
+            guard let madeSnapshot = try OpenCodeDatabaseSnapshot.make(
+                prefix: "cmux-opencode-preview",
+                sourcePath: databasePath
+            ) else {
                 throw SessionTranscriptLoadError.missingFile
             }
             snapshot = madeSnapshot
@@ -1392,6 +1535,7 @@ private enum SessionTranscriptLoader {
         }
 
         var turns: [SessionTranscriptTurn] = []
+        var latestTurns = LatestTurnCollector(capacity: retention.limit)
         var turnId = 0
         var currentMessageId: String?
         var currentMessageRole: SessionTranscriptRole = .event
@@ -1407,9 +1551,13 @@ private enum SessionTranscriptLoader {
             }
             if let partJSON = sqliteText(stmt, 2),
                let turn = parseOpenCodePart(partJSON, messageRole: currentMessageRole, id: turnId) {
-                turns.append(turn)
+                if retention.keepsLatestTurns {
+                    latestTurns.append(turn)
+                } else {
+                    turns.append(turn)
+                }
                 turnId += 1
-                if turns.count >= maxPreviewTurns {
+                if !retention.keepsLatestTurns, turns.count >= retention.limit {
                     didHitTurnLimit = true
                     break
                 }
@@ -1422,6 +1570,9 @@ private enum SessionTranscriptLoader {
             throw SessionTranscriptLoadError.databaseError(message)
         }
 
+        if retention.keepsLatestTurns {
+            return coalesce(latestTurns.turns)
+        }
         if didHitTurnLimit {
             appendTurnLimitMarker(to: &turns, id: turnId)
         }
@@ -1429,11 +1580,19 @@ private enum SessionTranscriptLoader {
         return coalesce(turns)
     }
 
-    private static func loadHermesAgentSynchronously(sessionId: String) throws -> [SessionTranscriptTurn] {
+    private static func loadHermesAgentSynchronously(
+        sessionId: String,
+        retention: Retention = .prefix(maxPreviewTurns)
+    ) throws -> [SessionTranscriptTurn] {
         do {
-            let turns = try HermesAgentIndex.loadTranscript(sessionId: sessionId, limit: maxPreviewTurns + 1)
-            let didHitTurnLimit = turns.count > maxPreviewTurns
-            var previewTurns: [SessionTranscriptTurn] = turns.prefix(maxPreviewTurns).enumerated().compactMap { index, turn -> SessionTranscriptTurn? in
+            let queryLimit = retention.keepsLatestTurns ? retention.limit : retention.limit + 1
+            let turns = try HermesAgentIndex.loadTranscript(
+                sessionId: sessionId,
+                limit: queryLimit,
+                latest: retention.keepsLatestTurns
+            )
+            let didHitTurnLimit = !retention.keepsLatestTurns && turns.count > retention.limit
+            var previewTurns: [SessionTranscriptTurn] = turns.prefix(retention.limit).enumerated().compactMap { index, turn -> SessionTranscriptTurn? in
                 let role: SessionTranscriptRole = (turn.toolName?.isEmpty == false) ? .tool : (transcriptRole(from: turn.role) ?? .event)
                 let text: String
                 if role == .tool, let toolName = turn.toolName, !toolName.isEmpty {

--- a/Sources/SessionRestorableAgentSnapshot+Commands.swift
+++ b/Sources/SessionRestorableAgentSnapshot+Commands.swift
@@ -7,6 +7,7 @@ extension SessionRestorableAgentSnapshot {
         case workingDirectory
         case launchCommand
         case registration
+        case transcriptPath
         case permissionMode
     }
 
@@ -37,6 +38,7 @@ extension SessionRestorableAgentSnapshot {
                 forKey: .launchCommand
             ),
             registration: registration,
+            transcriptPath: try container.decodeIfPresent(String.self, forKey: .transcriptPath),
             // Optional so snapshots persisted before the field decode unchanged.
             permissionMode: try container.decodeIfPresent(String.self, forKey: .permissionMode)
         )

--- a/Sources/TerminalController+ControlCommandPaletteContext.swift
+++ b/Sources/TerminalController+ControlCommandPaletteContext.swift
@@ -138,9 +138,13 @@ extension TerminalController: ControlCommandPaletteContext, ControlInlineVSCodeC
     ) -> ControlCommandPaletteArgument {
         ControlCommandPaletteArgument(
             name: argument.name,
+            title: argument.title,
             type: argument.valueType.rawValue,
             required: argument.required,
-            allowsEmpty: argument.allowsEmpty
+            allowsEmpty: argument.allowsEmpty,
+            choices: argument.choices.map {
+                ControlCommandPaletteArgument.Choice(value: $0.value, title: $0.title)
+            }
         )
     }
 

--- a/Sources/Workspace+AgentConversationForkRequest.swift
+++ b/Sources/Workspace+AgentConversationForkRequest.swift
@@ -1,5 +1,11 @@
 import Bonsplit
 import Foundation
+import os
+
+nonisolated private let agentConversationForkRequestLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
+    category: "AgentConversationForkRequest"
+)
 
 extension Workspace {
     /// Executes one validated fork request after the caller resolves the source snapshot.
@@ -9,8 +15,29 @@ extension Workspace {
         request: AgentConversationForkRequest,
         anchorTabId: TabID,
         paneId: PaneID
-    ) -> Bool {
-        let startupInputOverride = request.startupInputOverride(sourceSnapshot: snapshot)
+    ) async -> Bool {
+        let startupCommandOverride: String?
+        do {
+            startupCommandOverride = try await request.startupCommandOverride(
+                sourceSnapshot: snapshot
+            )
+        } catch {
+            agentConversationForkRequestLogger.error(
+                "Conversation export failed kind=\(snapshot.kind.rawValue, privacy: .public): \(error.localizedDescription, privacy: .public)"
+            )
+            return false
+        }
+        let isRemoteFork = isRemoteTerminalSurface(panelId)
+        let startupInputOverride = startupCommandOverride.flatMap {
+            snapshot.customStartupInput(
+                command: $0,
+                allowLauncherScript: !isRemoteFork,
+                allowOversizedInlineInput: isRemoteFork
+            )
+        }
+        if startupCommandOverride != nil, startupInputOverride == nil {
+            return false
+        }
 
         if let direction = request.destination.splitDirection {
             return forkAgentConversation(

--- a/Sources/Workspace+AgentConversationForkRequest.swift
+++ b/Sources/Workspace+AgentConversationForkRequest.swift
@@ -1,0 +1,67 @@
+import Bonsplit
+import Foundation
+
+extension Workspace {
+    /// Executes one validated fork request after the caller resolves the source snapshot.
+    func forkAgentConversation(
+        fromPanelId panelId: UUID,
+        snapshot: SessionRestorableAgentSnapshot,
+        request: AgentConversationForkRequest,
+        anchorTabId: TabID,
+        paneId: PaneID
+    ) -> Bool {
+        let startupInputOverride = request.startupInputOverride(sourceSnapshot: snapshot)
+
+        if let direction = request.destination.splitDirection {
+            return forkAgentConversation(
+                fromPanelId: panelId,
+                snapshot: snapshot,
+                direction: direction,
+                startupInputOverride: startupInputOverride
+            ) != nil
+        }
+
+        switch request.destination {
+        case .newTab:
+            return forkAgentConversationToNewTab(
+                fromPanelId: panelId,
+                snapshot: snapshot,
+                anchorTabId: anchorTabId,
+                paneId: paneId,
+                startupInputOverride: startupInputOverride
+            ) != nil
+        case .newWorkspace:
+            guard let owningTabManager,
+                  let launch = forkAgentWorkspaceLaunch(
+                      fromPanelId: panelId,
+                      snapshot: snapshot,
+                      startupInputOverride: startupInputOverride
+                  ) else {
+                return false
+            }
+
+            let forkWorkspace = owningTabManager.addWorkspace(
+                workingDirectory: launch.terminalWorkingDirectory,
+                initialTerminalCommand: launch.initialTerminalCommand,
+                initialTerminalInput: launch.initialTerminalInput,
+                initialTerminalEnvironment: launch.initialTerminalEnvironment,
+                inheritWorkingDirectory: launch.terminalWorkingDirectory != nil,
+                autoWelcomeIfNeeded: false
+            )
+            if let remoteConfiguration = launch.remoteConfiguration {
+                forkWorkspace.configureRemoteConnection(
+                    remoteConfiguration,
+                    autoConnect: launch.autoConnectRemoteConfiguration
+                )
+            }
+            if let workingDirectory = launch.workingDirectory,
+               launch.terminalWorkingDirectory == nil,
+               let forkPanelId = forkWorkspace.focusedPanelId {
+                forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
+            }
+            return true
+        case .right, .left, .top, .bottom:
+            return false
+        }
+    }
+}

--- a/Sources/Workspace+ForkConversationContextMenu.swift
+++ b/Sources/Workspace+ForkConversationContextMenu.swift
@@ -8,6 +8,20 @@ extension Workspace {
         fromPanelId panelId: UUID,
         destination: AgentConversationForkDestination
     ) async -> Bool {
+        await forkAgentConversationFromContextMenu(
+            fromPanelId: panelId,
+            request: AgentConversationForkRequest(
+                targetHarness: .current,
+                destination: destination
+            )
+        )
+    }
+
+    @discardableResult
+    func forkAgentConversationFromContextMenu(
+        fromPanelId panelId: UUID,
+        request: AgentConversationForkRequest
+    ) async -> Bool {
         guard beginForkAgentConversationAction(panelId: panelId) else {
             return false
         }
@@ -83,76 +97,9 @@ extension Workspace {
         return forkAgentConversation(
             fromPanelId: panelId,
             snapshot: snapshot,
-            destination: destination,
+            request: request,
             anchorTabId: anchorTabId,
             paneId: paneId
         )
-    }
-
-    private func forkAgentConversation(
-        fromPanelId panelId: UUID,
-        snapshot: SessionRestorableAgentSnapshot,
-        destination: AgentConversationForkDestination,
-        anchorTabId: TabID,
-        paneId: PaneID
-    ) -> Bool {
-        if let direction = destination.splitDirection {
-            return forkAgentConversation(
-                fromPanelId: panelId,
-                snapshot: snapshot,
-                direction: direction
-            ) != nil
-        }
-
-        switch destination {
-        case .newTab:
-            return forkAgentConversationToNewTab(
-                fromPanelId: panelId,
-                snapshot: snapshot,
-                anchorTabId: anchorTabId,
-                paneId: paneId
-            ) != nil
-        case .newWorkspace:
-            return forkAgentConversationToNewWorkspace(
-                fromPanelId: panelId,
-                snapshot: snapshot
-            )
-        case .right, .left, .top, .bottom:
-            return false
-        }
-    }
-
-    private func forkAgentConversationToNewWorkspace(
-        fromPanelId panelId: UUID,
-        snapshot: SessionRestorableAgentSnapshot
-    ) -> Bool {
-        guard let owningTabManager,
-              let launch = forkAgentWorkspaceLaunch(
-                  fromPanelId: panelId,
-                  snapshot: snapshot
-              ) else {
-            return false
-        }
-
-        let forkWorkspace = owningTabManager.addWorkspace(
-            workingDirectory: launch.terminalWorkingDirectory,
-            initialTerminalCommand: launch.initialTerminalCommand,
-            initialTerminalInput: launch.initialTerminalInput,
-            initialTerminalEnvironment: launch.initialTerminalEnvironment,
-            inheritWorkingDirectory: launch.terminalWorkingDirectory != nil,
-            autoWelcomeIfNeeded: false
-        )
-        if let remoteConfiguration = launch.remoteConfiguration {
-            forkWorkspace.configureRemoteConnection(
-                remoteConfiguration,
-                autoConnect: launch.autoConnectRemoteConfiguration
-            )
-        }
-        if let workingDirectory = launch.workingDirectory,
-           launch.terminalWorkingDirectory == nil,
-           let forkPanelId = forkWorkspace.focusedPanelId {
-            forkWorkspace.updatePanelDirectory(panelId: forkPanelId, directory: workingDirectory)
-        }
-        return true
     }
 }

--- a/Sources/Workspace+ForkConversationContextMenu.swift
+++ b/Sources/Workspace+ForkConversationContextMenu.swift
@@ -94,7 +94,7 @@ extension Workspace {
             }
         }
 
-        return forkAgentConversation(
+        return await forkAgentConversation(
             fromPanelId: panelId,
             snapshot: snapshot,
             request: request,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10925,9 +10925,8 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     /// Fork the panel's agent conversation into a brand-new sibling tab placed immediately
-    /// to the right of `anchorTabId` in `paneId`. Uses the same `claude --resume --fork-session`
-    /// startup input the existing split/new-workspace forks rely on, so divergence is owned by
-    /// the agent itself (Claude / Codex / OpenCode) instead of any cmux-side history copy.
+    /// to the right of `anchorTabId` in `paneId`. Native forks use the source harness's resume
+    /// command; cross-harness forks pass the normalized conversation as startup input.
     @discardableResult
     func forkAgentConversationToNewTab(
         fromPanelId panelId: UUID,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10828,6 +10828,7 @@ final class Workspace: Identifiable, ObservableObject {
     func forkAgentWorkspaceLaunch(
         fromPanelId panelId: UUID,
         snapshot: SessionRestorableAgentSnapshot,
+        startupInputOverride: String? = nil,
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory
     ) -> AgentConversationForkWorkspaceLaunch? {
@@ -10837,12 +10838,13 @@ final class Workspace: Identifiable, ObservableObject {
         let remoteStartupCommand = forkAgentRemoteStartupCommand(fromPanelId: panelId)
         let remoteConfiguration = forkAgentRemoteConfigurationForNewWorkspace(fromPanelId: panelId)
         let isRemoteFork = remoteConfiguration?.terminalStartupCommand?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-        guard panels[panelId] is TerminalPanel,
-              let startupInput = launchSnapshot.forkStartupInput(
+        let startupInput = startupInputOverride ?? launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: !isRemoteFork
-              ) else {
+              )
+        guard panels[panelId] is TerminalPanel,
+              let startupInput else {
             return nil
         }
 
@@ -10862,6 +10864,7 @@ final class Workspace: Identifiable, ObservableObject {
         fromPanelId panelId: UUID,
         snapshot: SessionRestorableAgentSnapshot,
         direction: SplitDirection,
+        startupInputOverride: String? = nil,
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory
     ) -> TerminalPanel? {
@@ -10869,13 +10872,14 @@ final class Workspace: Identifiable, ObservableObject {
         let workingDirectory = forkAgentWorkingDirectory(fromPanelId: panelId, snapshot: snapshot)
         launchSnapshot.workingDirectory = workingDirectory
         let remoteStartupCommand = forkAgentRemoteStartupCommand(fromPanelId: panelId)
-        guard panels[panelId] is TerminalPanel,
-              let paneId = paneId(forPanelId: panelId),
-              let startupInput = launchSnapshot.forkStartupInput(
+        let startupInput = startupInputOverride ?? launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: remoteStartupCommand == nil
-              ) else {
+              )
+        guard panels[panelId] is TerminalPanel,
+              let paneId = paneId(forPanelId: panelId),
+              let startupInput else {
             return nil
         }
 
@@ -10930,6 +10934,7 @@ final class Workspace: Identifiable, ObservableObject {
         snapshot: SessionRestorableAgentSnapshot,
         anchorTabId: TabID,
         paneId: PaneID,
+        startupInputOverride: String? = nil,
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory
     ) -> TerminalPanel? {
@@ -10937,12 +10942,13 @@ final class Workspace: Identifiable, ObservableObject {
         let workingDirectory = forkAgentWorkingDirectory(fromPanelId: panelId, snapshot: snapshot)
         launchSnapshot.workingDirectory = workingDirectory
         let remoteStartupCommand = forkAgentRemoteStartupCommand(fromPanelId: panelId)
-        guard panels[panelId] is TerminalPanel,
-              let startupInput = launchSnapshot.forkStartupInput(
+        let startupInput = startupInputOverride ?? launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: remoteStartupCommand == nil
-              ) else {
+              )
+        guard panels[panelId] is TerminalPanel,
+              let startupInput else {
             return nil
         }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		C7A52F000000000000000002 /* AgentChatTranscriptService+Wire.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A52F000000000000000001 /* AgentChatTranscriptService+Wire.swift */; };
 		ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */; };
 		ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */; };
+		348651ABCE54D0BDADFF9534 /* AgentConversationForkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7473F51829DA22035773E9C7 /* AgentConversationForkRequest.swift */; };
 		79390005AA11BB22CC33DD05 /* AgentDeliveryTargetResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79390006AA11BB22CC33DD06 /* AgentDeliveryTargetResolution.swift */; };
 		A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000001 /* AgentExecutableResolver.swift */; };
 		A9F200000000000000000002 /* AgentExecutableResolverError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000002 /* AgentExecutableResolverError.swift */; };
@@ -718,6 +719,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */; };
 		C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4041001000000000000001A /* CommandClickFileOpenRouter.swift */; };
+		627B40F54877DC01004CDB45 /* CommandPaletteArgumentChoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0599BEA05CC5F116F5180AF8 /* CommandPaletteArgumentChoiceView.swift */; };
 		C0DEB0A10000000000000001 /* CommandPaletteControlRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEB0A10000000000000002 /* CommandPaletteControlRequest.swift */; };
 		C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */; };
 		C0DE32470000000000000005 /* CommandPaletteIdentifierClipboardUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000006 /* CommandPaletteIdentifierClipboardUITests.swift */; };
@@ -2046,6 +2048,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		805600000000000000000003 /* WKWebView+BrowserViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805600000000000000000004 /* WKWebView+BrowserViewport.swift */; };
 		D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */; };
 		C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE43000000000000000008 /* Workspace+AgentChat.swift */; };
+		3441094E32F545951DCEDF38 /* Workspace+AgentConversationForkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1C28F5181918DA6D27B0C6 /* Workspace+AgentConversationForkRequest.swift */; };
 		A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
@@ -2271,6 +2274,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C7A52F000000000000000001 /* AgentChatTranscriptService+Wire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService+Wire.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptTailer.swift"; sourceTree = "<group>"; };
+		7473F51829DA22035773E9C7 /* AgentConversationForkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentConversationForkRequest.swift; sourceTree = "<group>"; };
 		79390006AA11BB22CC33DD06 /* AgentDeliveryTargetResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDeliveryTargetResolution.swift; sourceTree = "<group>"; };
 		A9F100000000000000000001 /* AgentExecutableResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolver.swift; sourceTree = "<group>"; };
 		A9F100000000000000000002 /* AgentExecutableResolverError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolverError.swift; sourceTree = "<group>"; };
@@ -2887,6 +2891,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsApprovalBridge.swift; sourceTree = "<group>"; };
 		C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTerminalErrorNotificationTests.swift; sourceTree = "<group>"; };
 		C4041001000000000000001A /* CommandClickFileOpenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandClickFileOpenRouter.swift; sourceTree = "<group>"; };
+		0599BEA05CC5F116F5180AF8 /* CommandPaletteArgumentChoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalette/CommandPaletteArgumentChoiceView.swift; sourceTree = "<group>"; };
 		C0DEB0A10000000000000002 /* CommandPaletteControlRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteControlRequest.swift; sourceTree = "<group>"; };
 		C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteEmojiTitleSearchTests.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000006 /* CommandPaletteIdentifierClipboardUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteIdentifierClipboardUITests.swift; sourceTree = "<group>"; };
@@ -4195,6 +4200,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		805600000000000000000004 /* WKWebView+BrowserViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/WKWebView+BrowserViewport.swift"; sourceTree = "<group>"; };
 		D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/WKWebView+CmuxPrintOperation.swift"; sourceTree = "<group>"; };
 		C0DE43000000000000000008 /* Workspace+AgentChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentChat.swift"; sourceTree = "<group>"; };
+		EF1C28F5181918DA6D27B0C6 /* Workspace+AgentConversationForkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentConversationForkRequest.swift"; sourceTree = "<group>"; };
 		A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentLifecycle.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
@@ -4645,6 +4651,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001041 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				7473F51829DA22035773E9C7 /* AgentConversationForkRequest.swift */,
+				0599BEA05CC5F116F5180AF8 /* CommandPaletteArgumentChoiceView.swift */,
+				EF1C28F5181918DA6D27B0C6 /* Workspace+AgentConversationForkRequest.swift */,
 				A11CE0030000000000000001 /* AboutLicenseContent.swift */,
 				3023B1003023B1003023B100 /* ConfigSource.swift */,
 				3023B1013023B1013023B101 /* ConfigSettingsView.swift */,
@@ -7096,6 +7105,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A52F000000000000000002 /* AgentChatTranscriptService+Wire.swift in Sources */,
 				ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */,
 				ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */,
+				348651ABCE54D0BDADFF9534 /* AgentConversationForkRequest.swift in Sources */,
 				79390005AA11BB22CC33DD05 /* AgentDeliveryTargetResolution.swift in Sources */,
 				A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */,
 				A9F200000000000000000002 /* AgentExecutableResolverError.swift in Sources */,
@@ -7438,6 +7448,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */,
 				A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */,
 				C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */,
+				627B40F54877DC01004CDB45 /* CommandPaletteArgumentChoiceView.swift in Sources */,
 				C0DEB0A10000000000000001 /* CommandPaletteControlRequest.swift in Sources */,
 				C0DEFF200000000000000001 /* CommandPaletteOverlay.swift in Sources */,
 				C0DEF4110000000000000001 /* CommandPaletteSettingsToggle.swift in Sources */,
@@ -8351,6 +8362,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				805600000000000000000003 /* WKWebView+BrowserViewport.swift in Sources */,
 				D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */,
 				C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */,
+				3441094E32F545951DCEDF38 /* Workspace+AgentConversationForkRequest.swift in Sources */,
 				A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		C7A52F000000000000000002 /* AgentChatTranscriptService+Wire.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A52F000000000000000001 /* AgentChatTranscriptService+Wire.swift */; };
 		ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */; };
 		ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */; };
+		4E79A02DC6024048853C3B05 /* AgentConversationExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C498E73D1D246B7B92287C2 /* AgentConversationExportService.swift */; };
 		348651ABCE54D0BDADFF9534 /* AgentConversationForkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7473F51829DA22035773E9C7 /* AgentConversationForkRequest.swift */; };
 		79390005AA11BB22CC33DD05 /* AgentDeliveryTargetResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79390006AA11BB22CC33DD06 /* AgentDeliveryTargetResolution.swift */; };
 		A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000001 /* AgentExecutableResolver.swift */; };
@@ -2274,6 +2275,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C7A52F000000000000000001 /* AgentChatTranscriptService+Wire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService+Wire.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptTailer.swift"; sourceTree = "<group>"; };
+		9C498E73D1D246B7B92287C2 /* AgentConversationExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentConversationExportService.swift; sourceTree = "<group>"; };
 		7473F51829DA22035773E9C7 /* AgentConversationForkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentConversationForkRequest.swift; sourceTree = "<group>"; };
 		79390006AA11BB22CC33DD06 /* AgentDeliveryTargetResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDeliveryTargetResolution.swift; sourceTree = "<group>"; };
 		A9F100000000000000000001 /* AgentExecutableResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentExecutableResolver.swift; sourceTree = "<group>"; };
@@ -4651,6 +4653,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001041 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				9C498E73D1D246B7B92287C2 /* AgentConversationExportService.swift */,
 				7473F51829DA22035773E9C7 /* AgentConversationForkRequest.swift */,
 				0599BEA05CC5F116F5180AF8 /* CommandPaletteArgumentChoiceView.swift */,
 				EF1C28F5181918DA6D27B0C6 /* Workspace+AgentConversationForkRequest.swift */,
@@ -7105,6 +7108,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A52F000000000000000002 /* AgentChatTranscriptService+Wire.swift in Sources */,
 				ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */,
 				ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */,
+				4E79A02DC6024048853C3B05 /* AgentConversationExportService.swift in Sources */,
 				348651ABCE54D0BDADFF9534 /* AgentConversationForkRequest.swift in Sources */,
 				79390005AA11BB22CC33DD05 /* AgentDeliveryTargetResolution.swift in Sources */,
 				A9F200000000000000000001 /* AgentExecutableResolver.swift in Sources */,

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -1093,6 +1093,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
 
     func testForkCommandsDismissPaletteBeforeRunning() {
         let forkCommandIds = [
+            "palette.forkAgentConversation",
             "palette.forkAgentConversationRight",
             "palette.forkAgentConversationLeft",
             "palette.forkAgentConversationTop",

--- a/cmuxTests/WorkspaceForkConversationContextMenuTests.swift
+++ b/cmuxTests/WorkspaceForkConversationContextMenuTests.swift
@@ -2,6 +2,7 @@ import Darwin
 import CmuxCommandPalette
 import Foundation
 import os
+import SQLite3
 import Testing
 
 #if canImport(cmux_DEV)
@@ -33,48 +34,298 @@ private actor AsyncTestBarrier {
     }
 }
 
+private struct StubAgentConversationSourceAdapter: AgentConversationSourceAdapter {
+    let turns: [SessionTranscriptTurn]?
+
+    func supports(_: AgentConversationSource) -> Bool { true }
+
+    func read(_: AgentConversationSource) async throws -> [SessionTranscriptTurn]? {
+        turns
+    }
+}
+
 @MainActor
 @Suite(.serialized)
 struct WorkspaceForkConversationContextMenuTests {
     @Test
-    func crossHarnessForkBuildsTranscriptHandoffCommand() throws {
+    func crossHarnessForkBuildsConversationMessage() async throws {
         let source = makeForkableSnapshot(kind: .codex, sessionId: "codex-session")
         let request = AgentConversationForkRequest(
             targetHarness: .claude,
             destination: .right
         )
+        let service = makeExportService(turns: [
+            SessionTranscriptTurn(id: 0, role: .user, text: "Fix the quoted 'value'."),
+            SessionTranscriptTurn(id: 1, role: .assistant, text: "I found the failing parser."),
+        ])
 
-        let startupInput = try #require(request.startupInputOverride(sourceSnapshot: source))
-        #expect(startupInput.hasPrefix("claude '"))
-        #expect(startupInput.contains("cmux sessions list --agent"))
-        #expect(startupInput.contains("codex-session"))
-        #expect(startupInput.hasSuffix("\n"))
+        let startupCommand = try #require(await request.startupCommandOverride(
+            sourceSnapshot: source,
+            exportService: service
+        ))
+        #expect(startupCommand.hasPrefix("claude '"))
+        #expect(startupCommand.contains("User:\nFix the quoted"))
+        #expect(startupCommand.contains("Assistant:\nI found the failing parser."))
+        #expect(startupCommand.contains("'\\''value'\\''"))
+        #expect(!startupCommand.contains("cmux sessions"))
+        #expect(!startupCommand.contains("transcript path"))
+        #expect(!startupCommand.contains("codex-session"))
     }
 
     @Test
-    func sameHarnessForkKeepsNativeForkCommand() {
+    func sameHarnessForkKeepsNativeForkCommand() async throws {
         let source = makeForkableClaudeSnapshot()
 
-        #expect(AgentConversationForkRequest(
+        #expect(try await AgentConversationForkRequest(
             targetHarness: .current,
             destination: .newTab
-        ).startupInputOverride(sourceSnapshot: source) == nil)
-        #expect(AgentConversationForkRequest(
+        ).startupCommandOverride(sourceSnapshot: source) == nil)
+        #expect(try await AgentConversationForkRequest(
             targetHarness: .claude,
             destination: .newTab
-        ).startupInputOverride(sourceSnapshot: source) == nil)
+        ).startupCommandOverride(sourceSnapshot: source) == nil)
     }
 
     @Test
-    func openCodeForkUsesPromptFlag() throws {
+    func openCodeForkUsesPromptFlag() async throws {
         let source = makeForkableSnapshot(kind: .codex, sessionId: "codex-session")
         let request = AgentConversationForkRequest(
             targetHarness: .opencode,
             destination: .newWorkspace
         )
 
-        let startupInput = try #require(request.startupInputOverride(sourceSnapshot: source))
-        #expect(startupInput.hasPrefix("opencode --prompt '"))
+        let startupCommand = try #require(await request.startupCommandOverride(
+            sourceSnapshot: source,
+            exportService: makeExportService(turns: [
+                SessionTranscriptTurn(id: 0, role: .user, text: "Continue this work."),
+            ])
+        ))
+        #expect(startupCommand.hasPrefix("opencode --prompt '"))
+    }
+
+    @Test
+    func longConversationHandoffUsesLauncherScript() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-handoff-launcher-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let source = makeForkableSnapshot(kind: .codex, sessionId: "long-handoff-session")
+        let request = AgentConversationForkRequest(targetHarness: .claude, destination: .right)
+        let startupCommand = try #require(await request.startupCommandOverride(
+            sourceSnapshot: source,
+            exportService: makeExportService(turns: [
+                SessionTranscriptTurn(
+                    id: 0,
+                    role: .user,
+                    text: "LONG HANDOFF " + String(repeating: "context ", count: 500)
+                ),
+            ])
+        ))
+        #expect(startupCommand.utf8.count > SessionRestorableAgentSnapshot.maxInlineStartupInputBytes)
+
+        let startupInput = try #require(source.customStartupInput(
+            command: startupCommand,
+            temporaryDirectory: root
+        ))
+        #expect(startupInput.hasPrefix("/bin/zsh '"))
+        #expect(startupInput.utf8.count <= SessionRestorableAgentSnapshot.maxInlineStartupInputBytes)
+        let components = startupInput.split(separator: "'", omittingEmptySubsequences: false)
+        let scriptPath = try #require(components.count >= 2 ? String(components[1]) : nil)
+        let script = try String(contentsOfFile: scriptPath, encoding: .utf8)
+        #expect(script.contains("User:\nLONG HANDOFF"))
+    }
+
+    @Test
+    func codexFileConversationIsConvertedToRoleLabeledMessage() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-export-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let transcript = root.appendingPathComponent("rollout.jsonl")
+        let lines = [
+            #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Inspect the parser."}]}}"#,
+            #"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"The parser drops one field."}]}}"#,
+        ]
+        try (lines.joined(separator: "\n") + "\n").write(to: transcript, atomically: true, encoding: .utf8)
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "codex-file-session",
+            workingDirectory: root.path,
+            launchCommand: nil,
+            transcriptPath: transcript.path
+        )
+        let service = AgentConversationExportService(
+            readerRegistry: AgentConversationReaderRegistry(adapters: [
+                DirectTranscriptAgentConversationSourceAdapter(),
+            ])
+        )
+
+        let message = try await service.message(for: snapshot)
+
+        #expect(message.contains("User:\nInspect the parser."))
+        #expect(message.contains("Assistant:\nThe parser drops one field."))
+    }
+
+    @Test
+    func longFileConversationKeepsOpeningRequestAndLatestTurns() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-long-export-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let transcript = root.appendingPathComponent("rollout.jsonl")
+        var lines = [
+            #"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"OPENING REQUEST"}]}}"#,
+            #"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"EARLY ONLY"}]}}"#,
+        ]
+        lines.append(contentsOf: (0..<1_005).map { index in
+            let text = index == 1_004 ? "LATEST ONLY" : "reply \(index)"
+            return #"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"\#(text)"}]}}"#
+        })
+        try (lines.joined(separator: "\n") + "\n").write(to: transcript, atomically: true, encoding: .utf8)
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "long-file-session",
+            workingDirectory: root.path,
+            launchCommand: nil,
+            transcriptPath: transcript.path
+        )
+        let service = AgentConversationExportService(
+            readerRegistry: AgentConversationReaderRegistry(adapters: [
+                DirectTranscriptAgentConversationSourceAdapter(),
+            ])
+        )
+
+        let message = try await service.message(for: snapshot)
+
+        #expect(message.contains("OPENING REQUEST"))
+        #expect(message.contains("LATEST ONLY"))
+        #expect(!message.contains("EARLY ONLY"))
+    }
+
+    @Test
+    func claudeFileConversationIsConvertedToRoleLabeledMessage() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-claude-export-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let transcript = root.appendingPathComponent("conversation.jsonl")
+        let lines = [
+            #"{"type":"user","message":{"role":"user","content":"Refactor the reader."}}"#,
+            #"{"type":"assistant","message":{"role":"assistant","content":"I mapped the storage boundary."}}"#,
+        ]
+        try (lines.joined(separator: "\n") + "\n").write(to: transcript, atomically: true, encoding: .utf8)
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "claude-file-session",
+            workingDirectory: root.path,
+            launchCommand: nil,
+            transcriptPath: transcript.path
+        )
+        let service = AgentConversationExportService(
+            readerRegistry: AgentConversationReaderRegistry(adapters: [
+                DirectTranscriptAgentConversationSourceAdapter(),
+            ])
+        )
+
+        let message = try await service.message(for: snapshot)
+
+        #expect(message.contains("User:\nRefactor the reader."))
+        #expect(message.contains("Assistant:\nI mapped the storage boundary."))
+    }
+
+    @Test
+    func openCodeSQLiteConversationIsConvertedToRoleLabeledMessage() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-opencode-export-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let database = root.appendingPathComponent("opencode.db")
+        try makeOpenCodeDatabase(at: database, sessionId: "opencode-sqlite-session")
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .opencode,
+            sessionId: "opencode-sqlite-session",
+            workingDirectory: root.path,
+            launchCommand: nil
+        )
+        let service = AgentConversationExportService(
+            readerRegistry: AgentConversationReaderRegistry(adapters: [
+                OpenCodeAgentConversationSourceAdapter(databasePath: database.path),
+            ])
+        )
+
+        let message = try await service.message(for: snapshot)
+
+        #expect(message.contains("User:\nPlan the migration."))
+        #expect(message.contains("Assistant:\nThe adapter reads SQLite."))
+    }
+
+    @Test
+    func conversationCompactionKeepsOpeningRequestAndLatestReply() {
+        let turns = [
+            SessionTranscriptTurn(id: 0, role: .user, text: "OPENING " + String(repeating: "request ", count: 80)),
+            SessionTranscriptTurn(id: 1, role: .assistant, text: String(repeating: "old response ", count: 80)),
+            SessionTranscriptTurn(id: 2, role: .user, text: String(repeating: "follow-up ", count: 80)),
+            SessionTranscriptTurn(id: 3, role: .assistant, text: "LATEST answer"),
+        ]
+        let policy = AgentConversationExportPolicy(
+            maximumCharacters: 1_024,
+            initialUserCharacterLimit: 300
+        )
+
+        let compaction = TailPreservingAgentConversationCompactor().compact(turns, policy: policy)
+        let message = RoleLabeledAgentConversationFormatter().format(
+            compaction,
+            sourceDisplayName: "Codex",
+            maximumCharacters: policy.maximumCharacters
+        )
+
+        #expect(compaction.omittedTurnCount > 0 || compaction.shortenedTurnCount > 0)
+        #expect(message.contains("OPENING"))
+        #expect(message.contains("LATEST answer"))
+        #expect(message.count <= policy.maximumCharacters)
+    }
+
+    @Test
+    func conversationFormatterRemovesTerminalControlSequences() {
+        let compaction = AgentConversationCompaction(
+            turns: [
+                SessionTranscriptTurn(
+                    id: 0,
+                    role: .user,
+                    text: "safe\u{1B}]0;renamed\u{7}\u{0}\nnext"
+                ),
+            ],
+            omittedTurnCount: 0,
+            shortenedTurnCount: 0
+        )
+
+        let message = RoleLabeledAgentConversationFormatter().format(
+            compaction,
+            sourceDisplayName: "Codex\u{1B}",
+            maximumCharacters: 2_000
+        )
+
+        #expect(message.contains("safe]0;renamed\nnext"))
+        #expect(!message.unicodeScalars.contains(where: { $0.value == 0 || $0.value == 7 || $0.value == 27 }))
+    }
+
+    @Test
+    func everyRestorableHarnessMapsToAConversationProvider() {
+        let kinds: [RestorableAgentKind] = [
+            .claude, .codex, .grok, .pi, .amp, .cursor, .gemini, .kiro,
+            .antigravity, .opencode, .rovodev, .hermesAgent, .copilot,
+            .codebuddy, .factory, .qoder, .kimi, .ollama, .custom("team-agent"),
+        ]
+
+        for kind in kinds {
+            let snapshot = SessionRestorableAgentSnapshot(
+                kind: kind,
+                sessionId: "session",
+                workingDirectory: nil,
+                launchCommand: nil
+            )
+            #expect(AgentConversationSource(snapshot: snapshot).sessionAgent.rawValue == kind.rawValue)
+        }
     }
 
     @Test
@@ -4920,6 +5171,50 @@ struct WorkspaceForkConversationContextMenuTests {
             result == -1 && processError == ESRCH,
             "The timed-out fork probe must terminate descendant process \(pid)."
         )
+    }
+
+    private func makeExportService(
+        turns: [SessionTranscriptTurn]
+    ) -> AgentConversationExportService {
+        AgentConversationExportService(
+            readerRegistry: AgentConversationReaderRegistry(adapters: [
+                StubAgentConversationSourceAdapter(turns: turns),
+            ])
+        )
+    }
+
+    private func makeOpenCodeDatabase(at url: URL, sessionId: String) throws {
+        var database: OpaquePointer?
+        guard sqlite3_open(url.path, &database) == SQLITE_OK, let database else {
+            sqlite3_close(database)
+            throw NSError(
+                domain: "WorkspaceForkConversationContextMenuTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not create OpenCode test database"]
+            )
+        }
+        defer { sqlite3_close(database) }
+
+        let statements = [
+            "CREATE TABLE message (id TEXT PRIMARY KEY, data TEXT, session_id TEXT, time_created INTEGER)",
+            "CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, data TEXT, time_created INTEGER)",
+            "INSERT INTO message VALUES ('user-message', '{\"role\":\"user\"}', '\(sessionId)', 1)",
+            "INSERT INTO part VALUES ('user-part', 'user-message', '{\"type\":\"text\",\"text\":\"Plan the migration.\"}', 1)",
+            "INSERT INTO message VALUES ('assistant-message', '{\"role\":\"assistant\"}', '\(sessionId)', 2)",
+            "INSERT INTO part VALUES ('assistant-part', 'assistant-message', '{\"type\":\"text\",\"text\":\"The adapter reads SQLite.\"}', 2)",
+        ]
+        for statement in statements {
+            var errorMessage: UnsafeMutablePointer<CChar>?
+            guard sqlite3_exec(database, statement, nil, nil, &errorMessage) == SQLITE_OK else {
+                let description = errorMessage.map(String.init(cString:)) ?? "SQLite execution failed"
+                sqlite3_free(errorMessage)
+                throw NSError(
+                    domain: "WorkspaceForkConversationContextMenuTests",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: description]
+                )
+            }
+        }
     }
 
     private func makeForkableClaudeSnapshot(

--- a/cmuxTests/WorkspaceForkConversationContextMenuTests.swift
+++ b/cmuxTests/WorkspaceForkConversationContextMenuTests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import CmuxCommandPalette
 import Foundation
 import os
 import Testing
@@ -35,6 +36,62 @@ private actor AsyncTestBarrier {
 @MainActor
 @Suite(.serialized)
 struct WorkspaceForkConversationContextMenuTests {
+    @Test
+    func crossHarnessForkBuildsTranscriptHandoffCommand() throws {
+        let source = makeForkableSnapshot(kind: .codex, sessionId: "codex-session")
+        let request = AgentConversationForkRequest(
+            targetHarness: .claude,
+            destination: .right
+        )
+
+        let startupInput = try #require(request.startupInputOverride(sourceSnapshot: source))
+        #expect(startupInput.hasPrefix("claude '"))
+        #expect(startupInput.contains("cmux sessions list --agent"))
+        #expect(startupInput.contains("codex-session"))
+        #expect(startupInput.hasSuffix("\n"))
+    }
+
+    @Test
+    func sameHarnessForkKeepsNativeForkCommand() {
+        let source = makeForkableClaudeSnapshot()
+
+        #expect(AgentConversationForkRequest(
+            targetHarness: .current,
+            destination: .newTab
+        ).startupInputOverride(sourceSnapshot: source) == nil)
+        #expect(AgentConversationForkRequest(
+            targetHarness: .claude,
+            destination: .newTab
+        ).startupInputOverride(sourceSnapshot: source) == nil)
+    }
+
+    @Test
+    func openCodeForkUsesPromptFlag() throws {
+        let source = makeForkableSnapshot(kind: .codex, sessionId: "codex-session")
+        let request = AgentConversationForkRequest(
+            targetHarness: .opencode,
+            destination: .newWorkspace
+        )
+
+        let startupInput = try #require(request.startupInputOverride(sourceSnapshot: source))
+        #expect(startupInput.hasPrefix("opencode --prompt '"))
+    }
+
+    @Test
+    func paletteForkRequestParsesHarnessAndDestination() throws {
+        let request = try #require(AgentConversationForkRequest(invocation: CmuxActionInvocation(
+            source: .commandPalette,
+            arguments: [
+                AgentConversationForkRequest.harnessArgumentName: "opencode",
+                AgentConversationForkRequest.destinationArgumentName: "bottom",
+            ]
+        )))
+
+        #expect(request.targetHarness == .opencode)
+        #expect(request.destination == .bottom)
+        #expect(AgentConversationForkRequest.commandPaletteArguments.map(\.name) == ["harness", "destination"])
+    }
+
     @Test
     func panelContextMenuActionUsesClickedPanel() async throws {
         let workspace = Workspace()
@@ -4869,14 +4926,27 @@ struct WorkspaceForkConversationContextMenuTests {
         sessionId: String = "019dad34-d218-7943-b81a-eddac5c87951",
         workingDirectory: String = "/tmp/fork repo"
     ) -> SessionRestorableAgentSnapshot {
-        SessionRestorableAgentSnapshot(
+        makeForkableSnapshot(
             kind: .claude,
+            sessionId: sessionId,
+            workingDirectory: workingDirectory
+        )
+    }
+
+    private func makeForkableSnapshot(
+        kind: RestorableAgentKind,
+        sessionId: String,
+        workingDirectory: String = "/tmp/fork repo"
+    ) -> SessionRestorableAgentSnapshot {
+        let launcher = kind.rawValue
+        return SessionRestorableAgentSnapshot(
+            kind: kind,
             sessionId: sessionId,
             workingDirectory: workingDirectory,
             launchCommand: AgentLaunchCommandSnapshot(
-                launcher: "claude",
-                executablePath: "/opt/homebrew/bin/claude",
-                arguments: ["/opt/homebrew/bin/claude"],
+                launcher: launcher,
+                executablePath: "/opt/homebrew/bin/\(launcher)",
+                arguments: ["/opt/homebrew/bin/\(launcher)"],
                 workingDirectory: workingDirectory,
                 environment: nil,
                 capturedAt: 123,


### PR DESCRIPTION
Summary

- Add a two-step command palette flow for target harness and destination, plus harness-first and destination-first terminal context menus.
- Convert cross-harness source history into one role-labeled message before launching Claude Code, Codex, or OpenCode.
- Read file-backed and SQLite-backed stores through pluggable adapters, including OpenCode and Hermes database readers plus registered-agent fallback.
- Preserve the opening request and latest 1,000 turns, then compact to a 24,000-character prompt when needed.
- Keep native same-harness forks and route palette and context-menu actions through one executor.
- Localize transfer text and controls in English and Japanese.

Verification

- CMUXAgentLaunch HermesAgentIndex: 4 tests passed.
- CmuxCommandPalette: 91 tests passed in the first UI pass.
- CmuxControlSocket: 284 tests passed in the first UI pass.
- Swift parser, project-file validation, localization validation, and diff checks passed.
- Tagged cloud build xfork passed: https://github.com/manaflow-ai/cmux/actions/runs/29971942471
- GUI preflight passed for Cmd+Shift+P, Claude Code to Codex bottom split. Codex received one User/Assistant message with no session lookup.
- GUI preflight passed for right-click, Fork by Harness, Claude Code to OpenCode new tab. OpenCode received the same normalized message.
- The focused app-host test invocation was blocked before test execution by remote fleet setup; PR CI remains the app-test gate.

Based on https://github.com/manaflow-ai/cmux/pull/8639.