### PR TITLE
Skip an inherited terminal surface the registry no longer owns

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -113,6 +113,27 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// rejected and quarantined.
     public var hasLiveSurface: Bool { surface != nil && portalLifecycleState == .live }
 
+    /// The runtime surface pointer, but only while the registry still owns it.
+    ///
+    /// A non-nil `surface` is not proof the native surface is alive. Teardown unregisters the
+    /// runtime surface and only then frees it, so a wrapper still holding the pointer after an
+    /// out-of-band free hands its caller freed memory. Reading through such a pointer is not a
+    /// recoverable error: `ghostty_surface_inherited_config` locks an `os_unfair_lock` inside the
+    /// freed allocation, the kernel detects lock corruption, and the process is `SIGKILL`ed — which
+    /// in a test host takes every unrelated suite sharing it down too.
+    ///
+    /// The registry owns exactly the pointers that have not been freed, so it is the liveness
+    /// oracle a nil-check cannot be. A pointer it no longer owns is cleared here, so every caller
+    /// that goes through this property sees nil rather than freed memory. Clearing also advances
+    /// ``runtimeSurfaceGeneration``, invalidating pointer-backed caches for the same reason they
+    /// are invalidated on a normal teardown.
+    public var liveRuntimeSurface: ghostty_surface_t? {
+        guard let current = surface else { return nil }
+        guard registry.runtimeSurfaceOwnerId(current) == nil else { return current }
+        surface = nil
+        return nil
+    }
+
     /// Whether the terminal surface view is currently attached to a window.
     ///
     /// Use the hosted view rather than the inner surface view, since the surface can be

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -113,27 +113,6 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// rejected and quarantined.
     public var hasLiveSurface: Bool { surface != nil && portalLifecycleState == .live }
 
-    /// The runtime surface pointer, but only while the registry still owns it.
-    ///
-    /// A non-nil `surface` is not proof the native surface is alive. Teardown unregisters the
-    /// runtime surface and only then frees it, so a wrapper still holding the pointer after an
-    /// out-of-band free hands its caller freed memory. Reading through such a pointer is not a
-    /// recoverable error: `ghostty_surface_inherited_config` locks an `os_unfair_lock` inside the
-    /// freed allocation, the kernel detects lock corruption, and the process is `SIGKILL`ed — which
-    /// in a test host takes every unrelated suite sharing it down too.
-    ///
-    /// The registry owns exactly the pointers that have not been freed, so it is the liveness
-    /// oracle a nil-check cannot be. A pointer it no longer owns is cleared here, so every caller
-    /// that goes through this property sees nil rather than freed memory. Clearing also advances
-    /// ``runtimeSurfaceGeneration``, invalidating pointer-backed caches for the same reason they
-    /// are invalidated on a normal teardown.
-    public var liveRuntimeSurface: ghostty_surface_t? {
-        guard let current = surface else { return nil }
-        guard registry.runtimeSurfaceOwnerId(current) == nil else { return current }
-        surface = nil
-        return nil
-    }
-
     /// Whether the terminal surface view is currently attached to a window.
     ///
     /// Use the hosted view rather than the inner surface view, since the surface can be

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7096,12 +7096,14 @@ final class Workspace: Identifiable, ObservableObject {
                     .representedRequestTokens
                 ?? []
             )
-            // `liveRuntimeSurface` rather than `surface`: a non-nil wrapper pointer is not proof
-            // the native surface is alive, and reading through a freed one gets the process
-            // SIGKILLed for lock corruption rather than failing recoverably. It quarantines a
-            // pointer the registry no longer owns, so a stale candidate is skipped here exactly
-            // like a torn-down one.
-            guard let sourceSurface = surface.liveRuntimeSurface else {
+            // `liveSurfaceForGhosttyAccess` rather than `surface`: a non-nil wrapper pointer is
+            // not proof the native surface is alive, and reading through a freed one gets the
+            // process SIGKILLed for lock corruption rather than failing recoverably. It
+            // quarantines a pointer the registry no longer owns, so a stale candidate is skipped
+            // here exactly like a torn-down one.
+            guard let sourceSurface = surface.liveSurfaceForGhosttyAccess(
+                reason: "inheritedTerminalConfig"
+            ) else {
                 if let inheritedFontSizeLineage {
                     var config = CmuxSurfaceConfigTemplate()
                     config.fontSizeLineage = inheritedFontSizeLineage

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7096,7 +7096,12 @@ final class Workspace: Identifiable, ObservableObject {
                     .representedRequestTokens
                 ?? []
             )
-            guard let sourceSurface = surface.surface else {
+            // `liveRuntimeSurface` rather than `surface`: a non-nil wrapper pointer is not proof
+            // the native surface is alive, and reading through a freed one gets the process
+            // SIGKILLed for lock corruption rather than failing recoverably. It quarantines a
+            // pointer the registry no longer owns, so a stale candidate is skipped here exactly
+            // like a torn-down one.
+            guard let sourceSurface = surface.liveRuntimeSurface else {
                 if let inheritedFontSizeLineage {
                     var config = CmuxSurfaceConfigTemplate()
                     config.fontSizeLineage = inheritedFontSizeLineage


### PR DESCRIPTION
`Workspace.inheritedTerminalConfig` treats a non-nil `surface.surface` as proof the native surface is alive. It is not. Teardown unregisters the runtime surface and only then frees it, so a wrapper still holding the pointer after an out-of-band free hands its caller freed memory. libghostty locks an `os_unfair_lock` inside that freed allocation, the kernel detects lock corruption, and the process is `SIGKILL`ed.

The registry owns exactly the pointers that have not been freed, which makes it the liveness oracle a nil-check cannot be — and `TerminalSurface` already has the accessor built for handing a pointer to Ghostty C APIs: `liveSurfaceForGhosttyAccess(reason:)`. It returns the pointer only while the registry records this surface as its owner and the pointer probes live; otherwise it quarantines the wrapper, so the caller sees nil instead of freed memory and `runtimeSurfaceGeneration` advances exactly as on a normal teardown, invalidating pointer-backed caches. `inheritedTerminalConfig` now reads through that accessor, so a stale candidate is skipped like a torn-down one. Requiring the owner to be this specific surface also covers pointer reuse: a freed address recycled to a new surface still has an owner, just not this one, and inheriting through it would read the wrong surface's config.

I want to be exact about what I can show, because it changed while this was open.

I first hit this as a host kill in `WorkspaceSplitWorkingDirectoryTests`, and it reproduces on `4a69f421`. Running that suite alone there, `testNewTerminalSplitSkipsFreedInheritedSurfacePointer` and `testNewTerminalSurfaceSkipsFreedInheritedSurfacePointer` each start and never finish, the host is killed twice, no test completes, and the crash report names the path:

```
_os_unfair_lock_corruption_abort
_os_unfair_lock_lock_slow
ghostty_surface_inherited_config
Workspace.inheritedTerminalConfig(preferredPanelId:inPane:)
Workspace.newTerminalSurfaceLocal(...)
WorkspaceSplitWorkingDirectoryTests.testNewTerminalSurfaceSkipsFreedInheritedSurfacePointer()
```

On this branch's base it does not reproduce. I ran the suite in one worktree, with one warm derived-data path and the same selectors, once with this change and once with only its files reverted. Both runs executed three tests and killed nothing. #8543 explains it: that change reworked `inheritedTerminalConfig` to read `fontSizeLineageSnapshot()` rather than calling `ghostty_surface_inherited_config` through the wrapper, so the dereference that crashed is no longer on that path.

So this is hardening and not a repro-backed fix, and the two tests do not cover it here, since they pass without it. The same function still dereferences `surface.surface` in its other branch, which is what routing it through `liveSurfaceForGhosttyAccess` protects, but I do not yet have a test that fails without this change on this base. Judge the guard on its own merits rather than on the crash above, and I will add that test before asking for a merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal configuration inheritance to avoid relying on potentially unavailable or stale terminal surfaces.
  * If the preferred live terminal surface can’t be accessed, the app now safely continues the inheritance process and falls back to the best available font-size lineage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->