### PR TITLE
Name workspaces after the first prompt

### DIFF
--- a/CLI/CMUXCLI+AutoNaming.swift
+++ b/CLI/CMUXCLI+AutoNaming.swift
@@ -335,7 +335,8 @@ struct AutoNamingEngine: Sendable {
         totalMessageCount: Int? = nil
     ) -> Int {
         let count = max(messages.count, totalMessageCount ?? 0)
-        return count * config.minLineGrowth
+        // A single initial prompt qualifies; later turns retain monotonic growth units.
+        return max(config.minTranscriptLines, count * config.minLineGrowth)
     }
 
     // MARK: - Prompt and response

--- a/CLI/CMUXCLI+AutoNaming.swift
+++ b/CLI/CMUXCLI+AutoNaming.swift
@@ -335,7 +335,8 @@ struct AutoNamingEngine: Sendable {
         totalMessageCount: Int? = nil
     ) -> Int {
         let count = max(messages.count, totalMessageCount ?? 0)
-        // A single initial prompt qualifies; later turns retain monotonic growth units.
+        // Empty caches stay ineligible; one initial prompt reaches the naming floor.
+        guard count > 0 else { return 0 }
         return max(config.minTranscriptLines, count * config.minLineGrowth)
     }
 

--- a/CLI/CMUXCLI+AutoNamingGenericHooks.swift
+++ b/CLI/CMUXCLI+AutoNamingGenericHooks.swift
@@ -45,6 +45,39 @@ extension CMUXCLI {
         return engine.extractHookMessages(fromPayloadObjects: [object])
     }
 
+    /// Starts a detached naming pass when the live workspace still permits generated titles.
+    func spawnDetachedAgentAutoNameIfEnabled(
+        def: AgentHookDef,
+        sessionId: String,
+        workspaceId: String,
+        surfaceId: String,
+        transcriptPath: String?,
+        cwd: String?,
+        env: [String: String],
+        client: SocketClient,
+        telemetry: CLISocketSentryTelemetry
+    ) {
+        guard autoNamingSource(for: def) != nil, !sessionId.isEmpty,
+              let probe = try? client.sendV2(
+                  method: "workspace.set_auto_title",
+                  params: ["probe": true, "workspace_id": workspaceId]
+              ),
+              probe["enabled"] as? Bool == true,
+              probe["workspace_user_owned"] as? Bool != true else {
+            return
+        }
+        spawnDetachedAgentAutoName(
+            def: def,
+            sessionId: sessionId,
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            transcriptPath: transcriptPath,
+            cwd: cwd,
+            env: env,
+            telemetry: telemetry
+        )
+    }
+
     /// Detached naming pass for non-Codex generic agents.
     func runGenericAgentAutoNameHook(
         def: AgentHookDef,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30922,6 +30922,21 @@ export default CMUXSessionRestore;
                 )
             }
 
+            // Message-backed agents can name the workspace from the first prompt while work continues.
+            if usesHookMessageCacheForAutoNaming(def), !suppressVisibleMutations {
+                spawnDetachedAgentAutoNameIfEnabled(
+                    def: def,
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    transcriptPath: normalizedHookValue(input.transcriptPath ?? mapped?.transcriptPath),
+                    cwd: hookCwd ?? mapped?.cwd,
+                    env: env,
+                    client: client,
+                    telemetry: telemetry
+                )
+            }
+
         case .stop:
             if def.name == "codex", !sessionId.isEmpty {
                 let stopTurnId = input.turnId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -31243,19 +31258,9 @@ export default CMUXSessionRestore;
                 }
             }
 
-            // Opt-in auto-naming for generic-agent sessions: a detached pass so the
-            // summarization subprocess never blocks this short sync hook.
-            // Gate the fork on the live setting (one cheap socket probe) so a
-            // disabled feature spawns nothing extra on turn end; the detached
-            // process re-probes to honor a toggle that lands mid-pass.
-            if autoNamingSource(for: def) != nil, !suppressVisibleMutations, !sessionId.isEmpty,
-               let autoNameProbe = try? client.sendV2(
-                   method: "workspace.set_auto_title",
-                   params: ["probe": true, "workspace_id": workspaceId]
-               ),
-               autoNameProbe["enabled"] as? Bool == true,
-               autoNameProbe["workspace_user_owned"] as? Bool != true {
-                spawnDetachedAgentAutoName(
+            // Turn-end naming refreshes file-backed agents and incorporates the completed response.
+            if !suppressVisibleMutations {
+                spawnDetachedAgentAutoNameIfEnabled(
                     def: def,
                     sessionId: sessionId,
                     workspaceId: workspaceId,
@@ -31263,6 +31268,7 @@ export default CMUXSessionRestore;
                     transcriptPath: normalizedHookValue(input.transcriptPath ?? mapped?.transcriptPath),
                     cwd: cwd,
                     env: env,
+                    client: client,
                     telemetry: telemetry
                 )
             }

--- a/cmuxTests/AutoNamingHookPayloadAdapterTests.swift
+++ b/cmuxTests/AutoNamingHookPayloadAdapterTests.swift
@@ -41,11 +41,9 @@ import Testing
         ])
     }
 
-    @Test func hookMessageLineEquivalentsReachSharedThrottleFloor() {
-        let messages = [
-            AutoNamingTranscriptMessage(role: "user", text: "Name this workspace"),
-            AutoNamingTranscriptMessage(role: "assistant", text: "I can summarize it.")
-        ]
+    @Test func initialPromptReachesSharedThrottleFloor() {
+        // The first submitted prompt must be sufficient to start workspace naming.
+        let messages = [AutoNamingTranscriptMessage(role: "user", text: "Name this workspace")]
 
         let lineCount = engine.hookMessageLineEquivalentCount(messages)
         #expect(lineCount == engine.config.minTranscriptLines)

--- a/cmuxTests/AutoNamingHookPayloadAdapterTests.swift
+++ b/cmuxTests/AutoNamingHookPayloadAdapterTests.swift
@@ -47,6 +47,7 @@ import Testing
 
         let lineCount = engine.hookMessageLineEquivalentCount(messages)
         #expect(lineCount == engine.config.minTranscriptLines)
+        #expect(engine.hookMessageLineEquivalentCount([]) == 0)
 
         let decision = engine.throttleDecision(
             snapshot: AutoNamingSessionSnapshot(),


### PR DESCRIPTION
## Context
Pi workspaces keep generic directory titles while the first turn runs because auto-naming waits for a completed assistant response. Naming should begin from the submitted prompt.

## Summary
- Trigger message-backed auto-naming when the first prompt is submitted
- Preserve manual-title and disabled-setting guards through a shared spawn path
- Qualify one prompt for naming while keeping empty caches ineligible
- Add first-prompt throttle regression coverage

## Dependencies
None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787324890&installation_model_id=21920&pr_number=8658&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8658&signature=a96b54acaf55137738382541541a31329bf93303e3ea97bbfd5af8024c2e01d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start auto-naming workspaces as soon as the first prompt is submitted, so sessions get meaningful titles without waiting for an assistant response. Naming runs in a detached process to avoid blocking.

- New Features
  - Trigger detached auto-naming on the first prompt for message-backed agents.
  - Update throttle: a single prompt meets `minTranscriptLines`; empty caches stay ineligible.

- Refactors
  - Centralized spawn and guard checks in `spawnDetachedAgentAutoNameIfEnabled`, used on first-prompt and turn-end paths; honors `workspace.set_auto_title` probe and user-owned workspaces.
  - Added regression coverage for the first-prompt naming floor.

<sup>Written for commit 973f42de92e0e80cb168a582fa7d9e0f9b6f6d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

