### PR TITLE
Fix: exclude .attrib from watched filesystem events

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/FileWatcher.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/FileWatcher.swift
@@ -76,8 +76,16 @@ public actor FileWatcher {
 
     // OptionSet masks. Inlined (not stored as statics) because
     // `DispatchSource.FileSystemEvent` is not `Sendable`.
+    //
+    // `.attrib` is deliberately excluded. Reading the watched file (e.g. via
+    // `NSData(contentsOfFile:)`) can update its `com.apple.lastuseddate#PS`
+    // extended attribute, which is itself an attribute change on the same
+    // inode this source watches — a self-sustaining loop with no external
+    // trigger: read -> touches the xattr -> fires `.attrib` -> another read.
+    // `.write`/`.delete`/`.rename`/`.extend` already cover real content
+    // changes, which is what callers actually need to react to.
     private static var fileEventMask: DispatchSource.FileSystemEvent {
-        [.write, .delete, .rename, .extend, .attrib]
+        [.write, .delete, .rename, .extend]
     }
     private static var directoryEventMask: DispatchSource.FileSystemEvent {
         [.write, .rename, .delete]


### PR DESCRIPTION
## Summary

Excludes .attrib from the DispatchSource.FileSystemEvent mask used to watch a file, keeping only .write, .delete, .rename, .extend.
.attrib was causing an infinite loop: reading the watched file (e.g. via NSData(contentsOfFile:)) updates its com.apple.lastuseddate#PS extended attribute, which itself fires another .attrib event on the same inode, triggering another read, and so on indefinitely with no external trigger. The remaining event types already cover all real content changes callers need to react to.

## Testing

- How did you test this change?
- What did you verify manually?
  - Built the version locally and tested several UI and terminal actions.
   - Checked that CPU usage was no longer at 100% via monitor
   - Let the app run for more than 15 minutes -> no crash

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787325928&installation_model_id=21920&pr_number=8659&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8659&signature=397f1fb89bd27112767b395075fc9acfe240ec6a3191027263f3ecd08eab9159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops runaway file-watcher loops by excluding `.attrib` events, fixing high CPU usage and crashes while keeping real content-change notifications.

- **Bug Fixes**
  - Removed `.attrib` from `fileEventMask` in `FileWatcher` (`Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/FileWatch/FileWatcher.swift`) to prevent loops from `com.apple.lastuseddate#PS` xattr updates triggered by reads.
  - Still listens to `.write`, `.delete`, `.rename`, `.extend` to detect actual changes.
  - Manually verified: CPU back to normal; no crash after 15+ minutes across UI and terminal actions.

<sup>Written for commit bd03c7de76c2fd7c4da64e1a2e0fd251cc8cc8d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary file-watching event loops caused by changes to file attributes.
  * File monitoring now responds to relevant file changes without repeatedly retriggering after a file is read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->