### PR TITLE
Support respawn-pane in Go relay __tmux-compat for SSH sessions

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1663,7 +1663,10 @@ func tmuxRespawnPane(rc *rpcContext, args []string) error {
 	}
 	commandText := strings.TrimSpace(strings.Join(p.positional, " "))
 	if commandText == "" {
-		commandText = tmuxStoredStartCommand(rc, wsId, surfId)
+		commandText, err = tmuxStoredStartCommand(rc, wsId, surfId)
+		if err != nil {
+			return err
+		}
 	}
 	if commandText == "" {
 		commandText = "exec ${SHELL:-/bin/sh} -l"
@@ -1687,11 +1690,14 @@ func tmuxRespawnPane(rc *rpcContext, args []string) error {
 
 // tmuxStoredStartCommand returns the surface's recorded start command, used
 // when respawn-pane is called without an explicit command (tmux semantics:
-// reuse the command the pane was started with).
-func tmuxStoredStartCommand(rc *rpcContext, workspaceId, surfaceId string) string {
+// reuse the command the pane was started with). A lookup failure is
+// propagated rather than treated as "no stored command", so a transient
+// RPC error cannot silently replace the pane's intended command with the
+// login-shell fallback (matching the Swift path, where the lookup throws).
+func tmuxStoredStartCommand(rc *rpcContext, workspaceId, surfaceId string) (string, error) {
 	payload, err := rc.call("surface.list", map[string]any{"workspace_id": workspaceId})
 	if err != nil {
-		return ""
+		return "", err
 	}
 	surfaces, _ := payload["surfaces"].([]any)
 	for _, s := range surfaces {
@@ -1701,12 +1707,12 @@ func tmuxStoredStartCommand(rc *rpcContext, workspaceId, surfaceId string) strin
 		}
 		for _, key := range []string{"tmux_start_command", "pane_start_command", "initial_command"} {
 			if v := stringFromAnyGo(surface[key]); v != "" {
-				return v
+				return v, nil
 			}
 		}
-		return ""
+		return "", nil
 	}
-	return ""
+	return "", nil
 }
 
 // tmuxShellInvokedStartCommand wraps a tmux shell-command in `/bin/sh -c`

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1389,6 +1389,8 @@ func dispatchTmuxCommand(rc *rpcContext, command string, args []string) error {
 		return tmuxKillWindow(rc, args)
 	case "kill-pane", "killp":
 		return tmuxKillPane(rc, args)
+	case "respawn-pane", "respawnp":
+		return tmuxRespawnPane(rc, args)
 	case "send-keys", "send":
 		return tmuxSendKeys(rc, args)
 	case "capture-pane", "capturep":
@@ -1645,6 +1647,118 @@ func tmuxKillPane(rc *rpcContext, args []string) error {
 	// Re-equalize after removal
 	rc.call("workspace.equalize_splits", map[string]any{"workspace_id": wsId, "orientation": "vertical"})
 	return nil
+}
+
+// tmuxRespawnPane mirrors the Swift __tmux-compat respawn-pane handler
+// (CLI/cmux.swift), which Claude Code agent teams use to start teammate
+// panes. Both paths dispatch to the same surface.respawn socket method.
+func tmuxRespawnPane(rc *rpcContext, args []string) error {
+	p := parseTmuxArgs(args, []string{"-c", "-t"}, []string{"-k"})
+	if !p.hasFlag("-k") {
+		return fmt.Errorf("respawn-pane requires -k in cmux tmux compatibility mode")
+	}
+	wsId, _, surfId, err := tmuxResolveSurfaceTarget(rc, p.value("-t"))
+	if err != nil {
+		return err
+	}
+	commandText := strings.TrimSpace(strings.Join(p.positional, " "))
+	if commandText == "" {
+		commandText = tmuxStoredStartCommand(rc, wsId, surfId)
+	}
+	if commandText == "" {
+		commandText = "exec ${SHELL:-/bin/sh} -l"
+	}
+	params := map[string]any{
+		"workspace_id": wsId,
+		"surface_id":   surfId,
+		"command":      tmuxRespawnStartCommand(commandText, tmuxClaudeTeamsRespawnEnvironment()),
+		// Kept raw (unwrapped) for display and session persistence, matching
+		// the Swift path.
+		"tmux_start_command": commandText,
+	}
+	if cwd := strings.TrimSpace(p.value("-c")); cwd != "" {
+		if resolved := tmuxNormalizePath(cwd); resolved != "" {
+			params["working_directory"] = resolved
+		}
+	}
+	_, err = rc.call("surface.respawn", params)
+	return err
+}
+
+// tmuxStoredStartCommand returns the surface's recorded start command, used
+// when respawn-pane is called without an explicit command (tmux semantics:
+// reuse the command the pane was started with).
+func tmuxStoredStartCommand(rc *rpcContext, workspaceId, surfaceId string) string {
+	payload, err := rc.call("surface.list", map[string]any{"workspace_id": workspaceId})
+	if err != nil {
+		return ""
+	}
+	surfaces, _ := payload["surfaces"].([]any)
+	for _, s := range surfaces {
+		surface, _ := s.(map[string]any)
+		if surface == nil || stringFromAnyGo(surface["id"]) != surfaceId {
+			continue
+		}
+		for _, key := range []string{"tmux_start_command", "pane_start_command", "initial_command"} {
+			if v := stringFromAnyGo(surface[key]); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+	return ""
+}
+
+// tmuxShellInvokedStartCommand wraps a tmux shell-command in `/bin/sh -c`
+// so the surface can exec it. Ghostty execs the pane start command as a
+// single executable, but tmux shell-commands are arbitrary shell
+// expressions (Claude Code teammates respawn with `cd <dir> && env …`),
+// so a bare exec of `cd` fails and the pane dies before the real command
+// runs. Mirrors the Swift tmuxShellInvokedStartCommand.
+func tmuxShellInvokedStartCommand(command string) string {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return command
+	}
+	return "/bin/sh -c " + tmuxShellQuote(trimmed)
+}
+
+type tmuxEnvPair struct {
+	key   string
+	value string
+}
+
+// tmuxRespawnStartCommand is tmuxShellInvokedStartCommand with prependEnv
+// exported inside the wrapping shell, so the respawned process inherits
+// those variables. With an empty prependEnv it is byte-for-byte identical
+// to tmuxShellInvokedStartCommand. Mirrors the Swift tmuxRespawnStartCommand.
+func tmuxRespawnStartCommand(command string, prependEnv []tmuxEnvPair) string {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return command
+	}
+	if len(prependEnv) == 0 {
+		return tmuxShellInvokedStartCommand(trimmed)
+	}
+	exports := make([]string, len(prependEnv))
+	for i, kv := range prependEnv {
+		exports[i] = "export " + kv.key + "=" + tmuxShellQuote(kv.value)
+	}
+	return tmuxShellInvokedStartCommand(strings.Join(exports, "; ") + "; " + trimmed)
+}
+
+// tmuxClaudeTeamsRespawnEnvironment re-supplies the environment a
+// claude-teams teammate pane must start with. CLAUDE_CODE_SANDBOXED
+// short-circuits Claude Code's interactive trust prompt, which a teammate
+// pane can never answer. It is only set when the claude-teams launcher
+// recorded the user's explicit opt-in (CMUX_CLAUDE_TEAMS_SANDBOXED=1),
+// propagated to this process by the tmux shim. Mirrors the Swift
+// tmuxClaudeTeamsRespawnEnvironment; see that for the full rationale.
+func tmuxClaudeTeamsRespawnEnvironment() []tmuxEnvPair {
+	if strings.TrimSpace(os.Getenv("CMUX_CLAUDE_TEAMS_SANDBOXED")) != "1" {
+		return nil
+	}
+	return []tmuxEnvPair{{key: "CLAUDE_CODE_SANDBOXED", value: "1"}}
 }
 
 func tmuxSendKeys(rc *rpcContext, args []string) error {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
@@ -23,6 +23,7 @@ type tmuxCorpusRPCRecorder struct {
 	workspaces            []map[string]any
 	readText              string
 	surfaceListExtras     map[string]any
+	failMethods           map[string]bool
 	includePaneMetrics    bool
 	includePointMetrics   bool
 	includeContainerFrame bool
@@ -103,6 +104,15 @@ func (r *tmuxCorpusRPCRecorder) serveConn(conn net.Conn) {
 	resp := map[string]any{
 		"id": req["id"],
 		"ok": true,
+	}
+
+	if r.failMethods[method] {
+		resp["ok"] = false
+		resp["error"] = map[string]any{"code": "unavailable", "message": method + " unavailable"}
+		r.mu.Unlock()
+		payload, _ := json.Marshal(resp)
+		_, _ = conn.Write(append(payload, '\n'))
+		return
 	}
 
 	switch method {
@@ -237,6 +247,15 @@ func (r *tmuxCorpusRPCRecorder) setSurfaceListExtras(extras map[string]any) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.surfaceListExtras = cloneMap(extras)
+}
+
+func (r *tmuxCorpusRPCRecorder) setMethodFails(method string, fails bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.failMethods == nil {
+		r.failMethods = make(map[string]bool)
+	}
+	r.failMethods[method] = fails
 }
 
 func cloneMap(input map[string]any) map[string]any {
@@ -425,6 +444,20 @@ func TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn(t *testing.T) {
 		}
 		if got := requests[0].Params["working_directory"]; got != "/tmp/teammate-cwd" {
 			t.Errorf("working_directory = %v, want /tmp/teammate-cwd", got)
+		}
+	})
+
+	t.Run("stored command lookup failure propagates instead of respawning a login shell", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		recorder.setMethodFails("surface.list", true)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{"-k", "-t", paneTarget})
+		if err == nil {
+			t.Fatal("respawn-pane should fail when the stored-command lookup fails")
+		}
+		if len(recorder.requestsFor("surface.respawn")) != 0 {
+			t.Error("surface.respawn must not be called when the stored-command lookup fails")
 		}
 	})
 

--- a/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
@@ -185,6 +185,8 @@ func (r *tmuxCorpusRPCRecorder) serveConn(conn net.Conn) {
 		}}}
 	case "pane.resize":
 		resp["result"] = map[string]any{"ok": true}
+	case "surface.respawn":
+		resp["result"] = map[string]any{"ok": true}
 	default:
 		resp["ok"] = false
 		resp["error"] = map[string]any{"code": "unsupported", "message": method}
@@ -292,6 +294,128 @@ func TestTmuxCorpusNewSessionAndNewWindowCommandsDispatchShellText(t *testing.T)
 			t.Fatalf("tmux detached/no-client creation should use focus=false, got %v in %+v", got, req.Params)
 		}
 	}
+}
+
+// Regression: Claude Code agent-team teammate panes respawn with
+// `respawn-pane -k -t %<paneID> <command>`. The Swift/local `__tmux-compat`
+// path supports this, but the Go relay path used for SSH sessions did not,
+// so the first teammate spawn failed with "unsupported tmux command:
+// respawn-pane" and Claude Code fell back to headless for the session.
+func TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	defer os.Setenv("HOME", origHome)
+
+	const paneTarget = "%33333333-3333-4333-8333-333333333333"
+	const wantSurface = "44444444-4444-4444-8444-444444444444"
+
+	t.Run("explicit command wraps in sh and keeps raw start command", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+			"-k", "-t", paneTarget, "cd /tmp && env FOO=1 claude",
+		})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		params := requests[0].Params
+		if got := params["surface_id"]; got != wantSurface {
+			t.Errorf("surface_id = %v, want %v", got, wantSurface)
+		}
+		if got := params["tmux_start_command"]; got != "cd /tmp && env FOO=1 claude" {
+			t.Errorf("tmux_start_command = %q", got)
+		}
+		if got := params["command"]; got != "/bin/sh -c 'cd /tmp && env FOO=1 claude'" {
+			t.Errorf("command = %q", got)
+		}
+	})
+
+	t.Run("respawnp alias with terminator", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawnp", []string{
+			"-k", "-t", paneTarget, "--", "echo hi",
+		})
+		if err != nil {
+			t.Fatalf("respawnp: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		if got := requests[0].Params["command"]; got != "/bin/sh -c 'echo hi'" {
+			t.Errorf("command = %q", got)
+		}
+	})
+
+	t.Run("no command falls back to login shell", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{"-k", "-t", paneTarget})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		params := requests[0].Params
+		if got := params["tmux_start_command"]; got != "exec ${SHELL:-/bin/sh} -l" {
+			t.Errorf("tmux_start_command = %q", got)
+		}
+		if got := params["command"]; got != "/bin/sh -c 'exec ${SHELL:-/bin/sh} -l'" {
+			t.Errorf("command = %q", got)
+		}
+	})
+
+	t.Run("claude-teams sandbox opt-in prepends env export", func(t *testing.T) {
+		t.Setenv("CMUX_CLAUDE_TEAMS_SANDBOXED", "1")
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+			"-k", "-t", paneTarget, "claude --resume",
+		})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		params := requests[0].Params
+		want := `/bin/sh -c 'export CLAUDE_CODE_SANDBOXED='"'"'1'"'"'; claude --resume'`
+		if got := params["command"]; got != want {
+			t.Errorf("command = %q, want %q", got, want)
+		}
+		if got := params["tmux_start_command"]; got != "claude --resume" {
+			t.Errorf("tmux_start_command = %q (must stay raw for persistence)", got)
+		}
+	})
+
+	t.Run("missing -k is rejected", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{"-t", paneTarget})
+		if err == nil {
+			t.Fatal("respawn-pane without -k should fail")
+		}
+		if !strings.Contains(err.Error(), "-k") {
+			t.Errorf("error = %q, want mention of -k", err.Error())
+		}
+		if len(recorder.requestsFor("surface.respawn")) != 0 {
+			t.Error("surface.respawn should not be called without -k")
+		}
+	})
 }
 
 func TestTmuxCorpusHasSessionReturnSemantics(t *testing.T) {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_corpus_behavior_test.go
@@ -22,6 +22,7 @@ type tmuxCorpusRPCRecorder struct {
 	requests              []tmuxCorpusRPCRequest
 	workspaces            []map[string]any
 	readText              string
+	surfaceListExtras     map[string]any
 	includePaneMetrics    bool
 	includePointMetrics   bool
 	includeContainerFrame bool
@@ -131,13 +132,17 @@ func (r *tmuxCorpusRPCRecorder) serveConn(conn net.Conn) {
 	case "workspace.list":
 		resp["result"] = map[string]any{"workspaces": cloneSliceOfMaps(r.workspaces)}
 	case "surface.list":
-		resp["result"] = map[string]any{"surfaces": []map[string]any{{
+		surface := map[string]any{
 			"id":      "44444444-4444-4444-8444-444444444444",
 			"ref":     "surface:1",
 			"focused": true,
 			"pane_id": "33333333-3333-4333-8333-333333333333",
 			"title":   "shell",
-		}}}
+		}
+		for k, v := range r.surfaceListExtras {
+			surface[k] = v
+		}
+		resp["result"] = map[string]any{"surfaces": []map[string]any{surface}}
 	case "surface.current":
 		resp["result"] = map[string]any{
 			"workspace_id": r.workspaces[0]["id"],
@@ -228,6 +233,12 @@ func (r *tmuxCorpusRPCRecorder) setReadText(text string) {
 	r.readText = text
 }
 
+func (r *tmuxCorpusRPCRecorder) setSurfaceListExtras(extras map[string]any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.surfaceListExtras = cloneMap(extras)
+}
+
 func cloneMap(input map[string]any) map[string]any {
 	out := make(map[string]any, len(input))
 	for k, v := range input {
@@ -302,9 +313,7 @@ func TestTmuxCorpusNewSessionAndNewWindowCommandsDispatchShellText(t *testing.T)
 // so the first teammate spawn failed with "unsupported tmux command:
 // respawn-pane" and Claude Code fell back to headless for the session.
 func TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn(t *testing.T) {
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", t.TempDir())
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", t.TempDir())
 
 	const paneTarget = "%33333333-3333-4333-8333-333333333333"
 	const wantSurface = "44444444-4444-4444-8444-444444444444"
@@ -352,6 +361,70 @@ func TestTmuxCorpusRespawnPaneDispatchesSurfaceRespawn(t *testing.T) {
 		}
 		if got := requests[0].Params["command"]; got != "/bin/sh -c 'echo hi'" {
 			t.Errorf("command = %q", got)
+		}
+	})
+
+	t.Run("no command reuses stored start command", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		recorder.setSurfaceListExtras(map[string]any{
+			"tmux_start_command": "claude --resume abc",
+			"initial_command":    "should-not-win",
+		})
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{"-k", "-t", paneTarget})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		params := requests[0].Params
+		if got := params["tmux_start_command"]; got != "claude --resume abc" {
+			t.Errorf("tmux_start_command = %q, want stored tmux_start_command to win", got)
+		}
+		if got := params["command"]; got != "/bin/sh -c 'claude --resume abc'" {
+			t.Errorf("command = %q", got)
+		}
+	})
+
+	t.Run("no command falls back to pane_start_command", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		recorder.setSurfaceListExtras(map[string]any{
+			"pane_start_command": "htop",
+		})
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{"-k", "-t", paneTarget})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		if got := requests[0].Params["tmux_start_command"]; got != "htop" {
+			t.Errorf("tmux_start_command = %q, want pane_start_command fallback", got)
+		}
+	})
+
+	t.Run("-c sets working_directory", func(t *testing.T) {
+		recorder := startTmuxCorpusRPCRecorder(t)
+		rc := &rpcContext{socketPath: recorder.socketPath}
+
+		err := dispatchTmuxCommand(rc, "respawn-pane", []string{
+			"-k", "-t", paneTarget, "-c", "/tmp/teammate-cwd", "echo hi",
+		})
+		if err != nil {
+			t.Fatalf("respawn-pane: %v", err)
+		}
+		requests := recorder.requestsFor("surface.respawn")
+		if len(requests) != 1 {
+			t.Fatalf("surface.respawn requests = %d, want 1", len(requests))
+		}
+		if got := requests[0].Params["working_directory"]; got != "/tmp/teammate-cwd" {
+			t.Errorf("working_directory = %v, want /tmp/teammate-cwd", got)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Claude Code's agent-teams feature never renders teammate panes when cmux is driven over a **remote/SSH session**. The first teammate spawn fails with:

```
cmux __tmux-compat: unsupported tmux command: respawn-pane
```

after which Claude Code latches to headless mode for the rest of the session (agents still run, but no panes appear). Local (non-SSH) sessions work fine.

**Root cause:** parity gap between the two `__tmux-compat` implementations. The Swift/local path implements `respawn-pane` (`CLI/cmux.swift`, `tmuxRespawnStartCommand` in `CLI/CMUXCLI+TmuxCompatSupport.swift`), but the verb was never included when `__tmux-compat` was ported to the Go relay in #2238, so `dispatchTmuxCommand` in `daemon/remote/cmd/cmuxd-remote/tmux_compat.go` hits the default unsupported-command error. Related prior fix on the Swift side: #5465.

## Fix

Add `respawn-pane`/`respawnp` routing to a new `tmuxRespawnPane` that mirrors the Swift handler and dispatches to the same `surface.respawn` socket method:

- requires `-k` (matching the Swift compat restriction)
- resolves the surface target with the existing `tmuxResolveSurfaceTarget` (caller-surface preference included)
- no explicit command → falls back to the surface's stored start command (`tmux_start_command` → `pane_start_command` → `initial_command`), then `exec ${SHELL:-/bin/sh} -l`
- wraps the command in `/bin/sh -c '<quoted>'` so Ghostty can exec shell expressions like `cd <dir> && env …` (same rationale as #6447 on the Swift side)
- re-supplies `CLAUDE_CODE_SANDBOXED=1` only when the claude-teams launcher recorded the explicit opt-in (`CMUX_CLAUDE_TEAMS_SANDBOXED=1`)
- keeps the raw command in `tmux_start_command` for display/persistence
- `-c <cwd>` → normalized `working_directory` param

## Testing

Two-commit red/green structure per the regression test policy: the first commit adds the failing test only, the second adds the fix.

- 8 behavioral sub-tests in `tmux_corpus_behavior_test.go` drive `dispatchTmuxCommand` against the corpus RPC recorder and assert the exact `surface.respawn` params (command wrapping, alias, `--` terminator, stored-start-command fallback chain, `-c` passthrough, sandbox env export, `-k` rejection)
- `go vet` + full `TestTmux*` suite pass

**Not verified end-to-end over a live SSH session** — I don't have a second machine pair I can safely deploy a patched `cmuxd-remote` to right now. Verification on your remote-session infra would be appreciated.

## Repro (v0.64.20)

1. From the cmux GUI, open a remote (SSH) workspace (`CMUX_REMOTE_TRANSPORT=ws`).
2. Run Claude Code in that pane and trigger agent teams (spawn a teammate).
3. First spawn errors with `unsupported tmux command: respawn-pane`; Claude Code falls back to headless and no teammate panes appear for the rest of the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787326435&installation_model_id=21920&pr_number=8660&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8660&signature=982bd1a6b2fd74fedc8b5df9f90df726a1613e8c34926ee41a7118a7f1ac2d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `respawn-pane`/`respawnp` in the Go remote `__tmux-compat`, fixing Claude Code agent-teams panes not appearing in SSH sessions. Mirrors the Swift/local behavior, dispatches to `surface.respawn`, and now fails the respawn if the stored start-command lookup errors.

- **Bug Fixes**
  - Route `respawn-pane`/`respawnp` to a new handler that calls `surface.respawn`.
  - Require `-k`; resolve the `-t` surface target; support `-c <cwd>` via `working_directory`.
  - If no command is given, reuse the stored start command (`tmux_start_command` → `pane_start_command` → `initial_command`), else default to `exec ${SHELL:-/bin/sh} -l`. Keep the raw command in `tmux_start_command` and execute via `/bin/sh -c`.
  - Set `CLAUDE_CODE_SANDBOXED=1` only when `CMUX_CLAUDE_TEAMS_SANDBOXED=1`.
  - Propagate stored-command lookup failures (`surface.list`) instead of falling back to a login shell; tests cover routing, wrapping, fallbacks, cwd, sandbox env, `-k` rejection, and error propagation.

<sup>Written for commit c43bc02a54df43b317cf9c199e35927e302e8fa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the tmux `respawn-pane` and `respawnp` commands.
  - Respawn can use an explicit command, a previously stored start command, or a safe default login-shell command.
  - Added support for selecting the target pane and setting its working directory via `-c`, with appropriate command wrapping and environment handling.

- **Bug Fixes**
  - Previously unsupported respawn commands now correctly dispatch the underlying respawn action and return clear errors when required options (such as `-k`) are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->