### PR TITLE
Render sidebar metadata Markdown links in AppKit

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -40,6 +40,181 @@ struct SidebarRowPalette {
     }
 }
 
+/// One-line attributed metadata label whose individual Markdown links route
+/// through the sidebar's existing workspace-selection and URL action path.
+/// The delegate consumes link clicks so AppKit never opens a destination on
+/// its own.
+@MainActor
+final class SidebarRowMarkdownTextView: NSTextView, NSTextViewDelegate {
+    private var onOpenURL: ((URL) -> Void)?
+    private var lineHeight: CGFloat = 0
+
+    init() {
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        )
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+        super.init(frame: .zero, textContainer: textContainer)
+
+        drawsBackground = false
+        isEditable = false
+        isSelectable = true
+        isRichText = true
+        importsGraphics = false
+        textContainerInset = .zero
+        textContainer.lineFragmentPadding = 0
+        textContainer.maximumNumberOfLines = 1
+        textContainer.lineBreakMode = .byTruncatingTail
+        textContainer.widthTracksTextView = true
+        textContainer.heightTracksTextView = false
+        isHorizontallyResizable = false
+        isVerticallyResizable = false
+        setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        markdown: String,
+        font: NSFont,
+        color: NSColor,
+        explicitURL: URL? = nil,
+        onOpenURL: @escaping (URL) -> Void
+    ) {
+        reset()
+        self.onOpenURL = onOpenURL
+        delegate = self
+        lineHeight = ceil(layoutManager?.defaultLineHeight(for: font) ?? font.pointSize)
+        linkTextAttributes = [
+            .foregroundColor: color,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+
+        let mutable: NSMutableAttributedString
+        if let rendered = SidebarMarkdownRenderer(markdown: markdown).workspaceDescription {
+            mutable = NSMutableAttributedString(attributedString: NSAttributedString(rendered))
+        } else {
+            mutable = NSMutableAttributedString(string: markdown)
+        }
+        let fullRange = NSRange(location: 0, length: mutable.length)
+        mutable.addAttributes(
+            [
+                .font: font,
+                .foregroundColor: color,
+            ],
+            range: fullRange
+        )
+        if let explicitURL {
+            mutable.removeAttribute(.link, range: fullRange)
+            mutable.removeAttribute(.underlineStyle, range: fullRange)
+            if Self.isAllowedMetadataURL(explicitURL), fullRange.length > 0 {
+                mutable.addAttribute(.link, value: explicitURL, range: fullRange)
+                mutable.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: fullRange)
+                toolTip = explicitURL.absoluteString
+            }
+            textStorage?.setAttributedString(mutable)
+            return
+        }
+        var links: [(value: Any?, range: NSRange)] = []
+        mutable.enumerateAttribute(.link, in: fullRange) { value, range, _ in
+            guard value != nil else { return }
+            links.append((value, range))
+        }
+        for link in links {
+            guard let url = Self.url(from: link.value), Self.isAllowedMetadataURL(url) else {
+                mutable.removeAttribute(.link, range: link.range)
+                mutable.removeAttribute(.underlineStyle, range: link.range)
+                continue
+            }
+            mutable.addAttribute(.link, value: url, range: link.range)
+            mutable.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: link.range)
+        }
+        textStorage?.setAttributedString(mutable)
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard !isHidden, frame.contains(point) else { return nil }
+        let localPoint = convert(point, from: superview)
+        return link(at: localPoint) == nil ? nil : self
+    }
+
+    func reset() {
+        delegate = nil
+        onOpenURL = nil
+        lineHeight = 0
+        toolTip = nil
+        textStorage?.setAttributedString(NSAttributedString(string: ""))
+    }
+
+    func measuredHeight(width _: CGFloat) -> CGFloat {
+        guard !isHidden else { return 0 }
+        return lineHeight
+    }
+
+    func textView(
+        _ textView: NSTextView,
+        clickedOnLink link: Any,
+        at charIndex: Int
+    ) -> Bool {
+        guard textView === self,
+              let url = Self.url(from: link),
+              Self.isAllowedMetadataURL(url),
+              charIndex >= 0,
+              charIndex < (textStorage?.length ?? 0),
+              textStorage?.attribute(.link, at: charIndex, effectiveRange: nil) != nil,
+              let onOpenURL else {
+            return false
+        }
+        onOpenURL(url)
+        return true
+    }
+
+    private func link(at localPoint: NSPoint) -> URL? {
+        guard let layoutManager, let textContainer, let textStorage else { return nil }
+        layoutManager.ensureLayout(for: textContainer)
+        let containerPoint = NSPoint(
+            x: localPoint.x - textContainerOrigin.x,
+            y: localPoint.y - textContainerOrigin.y
+        )
+        guard containerPoint.x >= 0, containerPoint.y >= 0 else { return nil }
+        let glyphIndex = layoutManager.glyphIndex(for: containerPoint, in: textContainer)
+        guard glyphIndex < layoutManager.numberOfGlyphs else { return nil }
+        let glyphRange = NSRange(location: glyphIndex, length: 1)
+        guard layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer).contains(containerPoint) else {
+            return nil
+        }
+        let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+        guard characterIndex < textStorage.length,
+              let url = Self.url(from: textStorage.attribute(.link, at: characterIndex, effectiveRange: nil)),
+              Self.isAllowedMetadataURL(url) else {
+            return nil
+        }
+        return url
+    }
+
+    private static func url(from value: Any?) -> URL? {
+        if let url = value as? URL {
+            return url
+        }
+        if let value = value as? String {
+            return URL(string: value)
+        }
+        return nil
+    }
+
+    /// Matches the control-socket metadata URL contract in
+    /// `upsertSidebarMetadata`: only HTTP(S) metadata destinations are accepted.
+    private static func isAllowedMetadataURL(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return scheme == "http" || scheme == "https"
+    }
+}
+
 /// One "small icon + text" line (metadata entry, log line, branch/dir line).
 @MainActor
 final class SidebarRowIconTextLine: NSView {
@@ -53,6 +228,7 @@ final class SidebarRowIconTextLine: NSView {
     private let iconLabel = NSTextField(labelWithString: "")
     private let textView = SidebarRowTextView(lines: 1)
     private let metadataButton = SidebarRowLinkButton()
+    private let markdownTextView = SidebarRowMarkdownTextView()
     private let secondTextView = SidebarRowTextView(lines: 1)
     private var iconSize: CGFloat = 0
     private var stacked = false
@@ -68,6 +244,8 @@ final class SidebarRowIconTextLine: NSView {
         metadataButton.alignment = .left
         metadataButton.isHidden = true
         addSubview(metadataButton)
+        markdownTextView.isHidden = true
+        addSubview(markdownTextView)
         secondTextView.isHidden = true
         addSubview(secondTextView)
     }
@@ -82,6 +260,7 @@ final class SidebarRowIconTextLine: NSView {
         color: NSColor,
         onOpenURL: @escaping (URL) -> Void
     ) {
+        resetPrimaryContent()
         stacked = false
         secondTextView.isHidden = true
         iconLabel.isHidden = true
@@ -112,7 +291,16 @@ final class SidebarRowIconTextLine: NSView {
             }
         }
         let font = NSFont.systemFont(ofSize: model.scaled(10))
-        if let url = entry.url {
+        if entry.format == .markdown {
+            markdownTextView.isHidden = false
+            markdownTextView.configure(
+                markdown: entry.sidebarDisplayText,
+                font: font,
+                color: color,
+                explicitURL: entry.url,
+                onOpenURL: onOpenURL
+            )
+        } else if let url = entry.url {
             textView.isHidden = true
             metadataButton.isHidden = false
             metadataButton.configure(
@@ -138,8 +326,8 @@ final class SidebarRowIconTextLine: NSView {
         model: SidebarWorkspaceRowModel,
         palette: SidebarRowPalette
     ) {
+        resetPrimaryContent()
         stacked = false
-        metadataButton.isHidden = true
         textView.isHidden = false
         secondTextView.isHidden = true
         iconLabel.isHidden = true
@@ -186,7 +374,7 @@ final class SidebarRowIconTextLine: NSView {
         model: SidebarWorkspaceRowModel,
         palette: SidebarRowPalette
     ) {
-        metadataButton.isHidden = true
+        resetPrimaryContent()
         textView.isHidden = false
         iconView.isHidden = true
         iconLabel.isHidden = true
@@ -232,11 +420,36 @@ final class SidebarRowIconTextLine: NSView {
 
     func measuredHeight(width: CGFloat) -> CGFloat {
         resolveCandidates(width: width)
-        let first = metadataButton.isHidden
-            ? textView.measuredHeight(width: max(10, width - iconSize))
-            : ceil(metadataButton.intrinsicContentSize.height)
+        let first = primaryMeasuredHeight(width: max(10, width - iconSize))
         let second = secondTextView.isHidden ? 0 : secondTextView.measuredHeight(width: max(10, width - iconSize)) + 1
         return first + second
+    }
+
+    private func resetPrimaryContent() {
+        textView.isHidden = true
+        textView.stringValue = ""
+        textView.attributedStringValue = NSAttributedString(string: "")
+        metadataButton.isHidden = true
+        metadataButton.reset()
+        markdownTextView.isHidden = true
+        markdownTextView.reset()
+    }
+
+    private func primaryMeasuredHeight(width: CGFloat) -> CGFloat {
+        if !markdownTextView.isHidden {
+            return markdownTextView.measuredHeight(width: width)
+        }
+        if !metadataButton.isHidden {
+            return ceil(metadataButton.intrinsicContentSize.height)
+        }
+        return textView.measuredHeight(width: width)
+    }
+
+    private var primaryView: NSView {
+        if !markdownTextView.isHidden {
+            return markdownTextView
+        }
+        return metadataButton.isHidden ? textView : metadataButton
     }
 
     private func resolveCandidates(width: CGFloat) {
@@ -268,11 +481,9 @@ final class SidebarRowIconTextLine: NSView {
             x = side + 4
         }
         let availableWidth = max(10, bounds.width - x)
-        let firstHeight = metadataButton.isHidden
-            ? textView.measuredHeight(width: availableWidth)
-            : ceil(metadataButton.intrinsicContentSize.height)
-        let primaryView: NSView = metadataButton.isHidden ? textView : metadataButton
-        primaryView.frame = NSRect(x: x, y: 0, width: availableWidth, height: firstHeight)
+        let firstHeight = primaryMeasuredHeight(width: availableWidth)
+        let activePrimaryView = primaryView
+        activePrimaryView.frame = NSRect(x: x, y: 0, width: availableWidth, height: firstHeight)
         if !secondTextView.isHidden {
             let secondHeight = secondTextView.measuredHeight(width: max(10, bounds.width - x))
             secondTextView.frame = NSRect(x: x, y: firstHeight + 1, width: max(10, bounds.width - x), height: secondHeight)
@@ -413,8 +624,13 @@ final class SidebarRowLinkButton: NSButton {
         self.onClick = onClick
     }
 
+    func reset() {
+        attributedTitle = NSAttributedString(string: "")
+        toolTip = nil
+        onClick = nil
+    }
+
     @objc private func execute() {
         onClick?()
     }
 }
-

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -151,11 +151,14 @@ struct SidebarAppKitRowCellTests {
 
     private static func makeActions(
         model: SidebarWorkspaceRowModel,
+        tab: Workspace? = nil,
+        tabManager: TabManager? = nil,
         onOpenStatusURL: @escaping (URL) -> Void = { _ in }
     ) -> SidebarAppKitRowActions {
+        let resolvedTab = tab ?? Workspace()
         let commands = SidebarWorkspaceRowCommands(
-            tab: Workspace(),
-            tabManager: nil,
+            tab: resolvedTab,
+            tabManager: tabManager,
             notificationStore: nil,
             index: model.index,
             contextMenuWorkspaceIds: [model.workspaceId],
@@ -201,12 +204,19 @@ struct SidebarAppKitRowCellTests {
 
     private static func configuredCell(
         model: SidebarWorkspaceRowModel,
+        tab: Workspace? = nil,
+        tabManager: TabManager? = nil,
         onOpenStatusURL: @escaping (URL) -> Void = { _ in }
     ) -> SidebarWorkspaceRowTableCellView {
         let cell = SidebarWorkspaceRowTableCellView()
         cell.configure(
             model: model,
-            actions: makeActions(model: model, onOpenStatusURL: onOpenStatusURL),
+            actions: makeActions(
+                model: model,
+                tab: tab,
+                tabManager: tabManager,
+                onOpenStatusURL: onOpenStatusURL
+            ),
             isPointerHovering: false,
             contextMenuDidOpen: {},
             contextMenuDidClose: {}
@@ -216,6 +226,67 @@ struct SidebarAppKitRowCellTests {
 
     private static func descendants(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { descendants(of: $0) }
+    }
+
+    private static let linkedMetadataMarkdown =
+        "[acme/widgets](https://github.com/acme/widgets/tree/branch) • " +
+        "[PR#123](https://github.com/acme/widgets/pull/123) • " +
+        "[dev-7](http://127.0.0.1:53000/workspaces/7)"
+
+    private static let linkedMetadataURLs = [
+        URL(string: "https://github.com/acme/widgets/tree/branch")!,
+        URL(string: "https://github.com/acme/widgets/pull/123")!,
+        URL(string: "http://127.0.0.1:53000/workspaces/7")!,
+    ]
+
+    private static func links(in textView: NSTextView) -> [(range: NSRange, url: URL)] {
+        var links: [(range: NSRange, url: URL)] = []
+        let fullRange = NSRange(location: 0, length: textView.textStorage?.length ?? 0)
+        textView.textStorage?.enumerateAttribute(.link, in: fullRange) { value, range, _ in
+            let url: URL?
+            if let value = value as? URL {
+                url = value
+            } else if let value = value as? String {
+                url = URL(string: value)
+            } else {
+                url = nil
+            }
+            if let url {
+                links.append((range, url))
+            }
+        }
+        return links
+    }
+
+    @discardableResult
+    private static func activateLink(
+        _ link: (range: NSRange, url: URL),
+        in textView: NSTextView
+    ) -> Bool {
+        textView.delegate?.textView?(
+            textView,
+            clickedOnLink: link.url,
+            at: link.range.location
+        ) ?? false
+    }
+
+    private static func hitTestPoint(
+        forCharacterAt characterIndex: Int,
+        in textView: NSTextView
+    ) throws -> NSPoint {
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+        let glyphRange = layoutManager.glyphRange(
+            forCharacterRange: NSRange(location: characterIndex, length: 1),
+            actualCharacterRange: nil
+        )
+        let glyphBounds = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+        let localPoint = NSPoint(
+            x: textView.textContainerOrigin.x + glyphBounds.midX,
+            y: textView.textContainerOrigin.y + glyphBounds.midY
+        )
+        return textView.convert(localPoint, to: textView.superview)
     }
 
     @Test(arguments: zip(["codex", "claude_code"], ["Running", "Needs input"]))
@@ -251,6 +322,269 @@ struct SidebarAppKitRowCellTests {
         #expect(link.isEnabled)
         link.performClick(nil)
         #expect(openedURL == url)
+    }
+
+    @Test
+    func markdownMetadataRendersLabelsAndIndependentLinks() throws {
+        let model = Self.makeModel(
+            metadataEntries: [
+                SidebarStatusEntry(
+                    key: "repo_workspace",
+                    value: Self.linkedMetadataMarkdown,
+                    format: .markdown
+                ),
+            ]
+        )
+        let cell = Self.configuredCell(model: model)
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.string == "acme/widgets • PR#123 • dev-7")
+        #expect(!textView.string.contains("["))
+        #expect(Self.links(in: textView).map(\.url) == Self.linkedMetadataURLs)
+    }
+
+    @Test
+    func markdownMetadataExplicitURLPreservesFormattedRowAction() throws {
+        let explicitURL = try #require(URL(string: "https://example.com/explicit"))
+        let model = Self.makeModel(
+            metadataEntries: [
+                SidebarStatusEntry(
+                    key: "repo_workspace",
+                    value: Self.linkedMetadataMarkdown,
+                    url: explicitURL,
+                    format: .markdown
+                ),
+            ]
+        )
+        var openedURL: URL?
+        let cell = Self.configuredCell(model: model) { openedURL = $0 }
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.string == "acme/widgets • PR#123 • dev-7")
+        let links = Self.links(in: textView)
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.range == NSRange(location: 0, length: textView.string.utf16.count))
+        #expect(link.url == explicitURL)
+        #expect(Self.activateLink(link, in: textView))
+        #expect(openedURL == explicitURL)
+    }
+
+    @Test
+    func markdownMetadataOnlyCapturesClicksOnLinkGlyphs() throws {
+        let row = SidebarRowIconTextLine()
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "links",
+                value: "plain [link](https://example.com)",
+                format: .markdown
+            ),
+            model: Self.makeModel(),
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+
+        let height = row.measuredHeight(width: 220)
+        row.frame = NSRect(x: 0, y: 0, width: 220, height: height)
+        row.layoutSubtreeIfNeeded()
+        let textView = try #require(
+            Self.descendants(of: row)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+        let links = Self.links(in: textView)
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        let plainPoint = try Self.hitTestPoint(forCharacterAt: 0, in: textView)
+        let linkPoint = try Self.hitTestPoint(forCharacterAt: link.range.location, in: textView)
+
+        #expect(textView.hitTest(plainPoint) == nil)
+        #expect(textView.hitTest(linkPoint) === textView)
+    }
+
+    @Test
+    func markdownMetadataLinkSelectionPrecedesEachOpen() throws {
+        let manager = TabManager()
+        let originalWorkspaceId = try #require(manager.selectedTabId)
+        let targetWorkspace = manager.addWorkspace(select: false)
+        let model = Self.makeModel(
+            workspaceId: targetWorkspace.id,
+            metadataEntries: [
+                SidebarStatusEntry(
+                    key: "repo_workspace",
+                    value: Self.linkedMetadataMarkdown,
+                    format: .markdown
+                ),
+            ]
+        )
+        var opened: [URL] = []
+        var wasSelectedBeforeOpen: [Bool] = []
+        let cell = Self.configuredCell(
+            model: model,
+            tab: targetWorkspace,
+            tabManager: manager
+        ) { url in
+            wasSelectedBeforeOpen.append(manager.selectedTabId == targetWorkspace.id)
+            opened.append(url)
+        }
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(manager.selectedTabId == originalWorkspaceId)
+        for link in Self.links(in: textView) {
+            #expect(Self.activateLink(link, in: textView))
+        }
+        #expect(opened == Self.linkedMetadataURLs)
+        #expect(wasSelectedBeforeOpen == [true, true, true])
+    }
+
+    @Test
+    func markdownMetadataLeavesUnsafeSchemeLabelInert() throws {
+        let markdown = "[safe](https://example.com) • [unsafe](javascript:alert(1))"
+        let model = Self.makeModel(
+            metadataEntries: [
+                SidebarStatusEntry(key: "links", value: markdown, format: .markdown),
+            ]
+        )
+        let cell = Self.configuredCell(model: model)
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.string == "safe • unsafe")
+        #expect(Self.links(in: textView).map(\.url) == [URL(string: "https://example.com")!])
+    }
+
+    @Test
+    func markdownMetadataStaysSingleLineAndHeightStable() throws {
+        let markdown = (1...20)
+            .map { "[workspace-\($0)](https://example.com/workspaces/\($0))" }
+            .joined(separator: " • ")
+        let row = SidebarRowIconTextLine()
+        row.configureMetadataEntry(
+            SidebarStatusEntry(key: "links", value: markdown, format: .markdown),
+            model: Self.makeModel(),
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+
+        let beforeLayout = row.measuredHeight(width: 120)
+        row.frame = NSRect(x: 0, y: 0, width: 120, height: beforeLayout)
+        row.layoutSubtreeIfNeeded()
+        let afterLayout = row.measuredHeight(width: 120)
+        let textView = try #require(
+            Self.descendants(of: row)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.textContainer?.maximumNumberOfLines == 1)
+        #expect(textView.textContainer?.lineBreakMode == .byTruncatingTail)
+        #expect(afterLayout == beforeLayout)
+    }
+
+    @Test
+    func markdownMetadataTextContainerHasDrawableHeight() throws {
+        let row = SidebarRowIconTextLine()
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "repo_workspace",
+                value: Self.linkedMetadataMarkdown,
+                format: .markdown
+            ),
+            model: Self.makeModel(),
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+
+        let height = row.measuredHeight(width: 220)
+        row.frame = NSRect(x: 0, y: 0, width: 220, height: height)
+        row.layoutSubtreeIfNeeded()
+        let textView = try #require(
+            Self.descendants(of: row)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+        let textContainer = try #require(textView.textContainer)
+        let layoutManager = try #require(textView.layoutManager)
+
+        layoutManager.ensureLayout(for: textContainer)
+        #expect(textContainer.containerSize.height > 0)
+        #expect(layoutManager.usedRect(for: textContainer).height > 0)
+    }
+
+    @Test
+    func metadataRowReconfigurationClearsMutuallyExclusiveState() throws {
+        let row = SidebarRowIconTextLine()
+        let model = Self.makeModel()
+        var firstOpened = 0
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "repo_workspace",
+                value: Self.linkedMetadataMarkdown,
+                format: .markdown
+            ),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in firstOpened += 1 }
+        )
+        let markdownView = try #require(
+            Self.descendants(of: row).compactMap { $0 as? NSTextView }.first
+        )
+        let staleLink = try #require(Self.links(in: markdownView).first)
+
+        row.configureMetadataEntry(
+            SidebarStatusEntry(key: "plain", value: "plain value"),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+        #expect(markdownView.isHidden)
+        #expect(markdownView.string.isEmpty)
+        #expect(Self.links(in: markdownView).isEmpty)
+        #expect(!Self.activateLink(staleLink, in: markdownView))
+        #expect(firstOpened == 0)
+
+        let explicitURL = try #require(URL(string: "https://example.com/plain"))
+        row.configureMetadataEntry(
+            SidebarStatusEntry(key: "plain-link", value: "plain link", url: explicitURL),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+        #expect(markdownView.isHidden)
+        #expect(markdownView.string.isEmpty)
+
+        var secondOpened: URL?
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "markdown-again",
+                value: "[again](https://example.com/again)",
+                format: .markdown
+            ),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { secondOpened = $0 }
+        )
+        let currentLink = try #require(Self.links(in: markdownView).first)
+        #expect(!markdownView.isHidden)
+        #expect(markdownView.string == "again")
+        #expect(Self.activateLink(currentLink, in: markdownView))
+        #expect(secondOpened == URL(string: "https://example.com/again"))
+        #expect(firstOpened == 0)
     }
 
     @Test


### PR DESCRIPTION
## Motivation

We maintain a custom app that creates and attaches remote development workspaces, then uses cmux's CLI/control-socket `report_meta` command to publish pane-scoped sidebar metadata. One `format=markdown` entry combines repository, optional pull-request, and workspace-page links into a compact line.

After the AppKit sidebar became the default renderer, cmux retained that metadata but displayed its literal Markdown source. The labels no longer acted as independent links.

## Changes

### 1. Render inline metadata links in AppKit sidebar rows

#### Base Behavior

The AppKit metadata row in [SidebarWorkspaceRowSupportViews.swift](https://github.com/manaflow-ai/cmux/blob/f616cecf3b9e564e49bcd4ac39e2722c1553e6e6/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift) treats entries as plain text unless they have one explicit URL. Multi-link `format=markdown` values therefore expose their source syntax and lose their independent destinations.

#### Change

[SidebarWorkspaceRowSupportViews.swift](https://github.com/djova/cmux/blob/a7fc4c607/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift) adds a one-line AppKit attributed-text view for Markdown metadata. It:

- parses inline-only Markdown while preserving whitespace;
- retains independent `http` and `https` link ranges while rendering unsupported schemes as inert labels;
- preserves an explicit entry URL as the formatted row's authoritative action;
- uses the existing active/inactive sidebar colors and underlines clickable ranges;
- lets non-link text clicks fall through to normal workspace selection;
- routes link activation through the existing selection and `onOpenStatusURL` path;
- truncates at the trailing edge and clears text, delegates, callbacks, and links during reuse.

Plain metadata and the existing single-URL control remain unchanged. The CLI/control-socket metadata contract does not change.

#### Justification

A native TextKit view is the smallest AppKit control that provides multiple independently accessible link ranges in one measured line. Keeping parsing and hit testing inside that view gives the behavior a single owner without global cache state.

#### Risk

The behavior change is limited to visible AppKit metadata entries whose format is Markdown. The main risks are stale actions during cell reuse, unsafe URL activation, intercepted row clicks, and row-height drift. Explicit reset logic, an `http`/`https` allowlist, link-glyph hit testing, delegate-owned activation, single-line layout, and focused behavioral coverage bound those risks.

## Testing

Using the custom integration against an isolated tagged cmux development build:

- attached an existing remote tmux session;
- confirmed `sidebar-state` retained the multi-link Markdown metadata;
- observed compact repository and workspace labels with no Markdown delimiters;
- verified selected and unselected rows use readable adaptive colors;
- confirmed Accessibility exposes the destinations as distinct links;
- confirmed non-link text still selects the workspace row.

### Before

<img width="316" height="141" alt="Sidebar displaying literal Markdown metadata" src="https://github.com/user-attachments/assets/d6ebad94-f6d9-4076-936f-c84dd251e520" />

### After

<img width="238" height="138" alt="Sidebar displaying compact linked metadata labels" src="https://github.com/user-attachments/assets/16b1d84e-0a03-40e6-91c4-dc28f8259639" />

## Demo Video

The before/after screenshots cover this static rendering change.

## Documentation and localization

No user-facing strings, commands, configuration, or metadata contracts changed, so product documentation, changelog, and localization catalogs do not require updates.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787326457&installation_model_id=21920&pr_number=8661&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8661&signature=b964a9d899cb791839392bd1d92ee1141cccdad18be9d5a82f34a572962d2c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render inline Markdown metadata links in the AppKit sidebar so multi‑link metadata shows as compact, clickable labels instead of raw Markdown. Plain text and single‑URL entries continue to work the same.

- **New Features**
  - Add a one‑line TextKit view that parses inline‑only Markdown and preserves independent http/https link ranges using sidebar colors and underlines.
  - If an explicit `entry.url` exists, it overrides Markdown links while keeping the formatted label.
  - Capture clicks only on link glyphs; non‑link text keeps row selection, and links open via workspace selection + `onOpenStatusURL`.
  - Allow only http/https links; unsupported schemes (e.g., `javascript:`) render as plain text.
  - Single‑line with tail truncation and stable measured height; reset on reuse to avoid stale links or actions.

<sup>Written for commit 5ca447c0185fb5f45c7f37b62590e1f42eead0ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline, single-line Markdown metadata rendering for workspace sidebar rows.
  * Sidebar Markdown links can be activated directly, opening destinations while keeping sidebar selection behavior consistent.
  * Supports safe HTTP(S) links, including multiple links within the same metadata entry.

* **Bug Fixes**
  * Prevents unsafe `javascript:` links from being clickable or producing navigation.
  * Improves row layout/sizing stability when switching between Markdown, plain text, and link-based metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
