### PR TITLE
Render sidebar metadata Markdown links in AppKit

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -40,6 +40,181 @@ struct SidebarRowPalette {
     }
 }
 
+/// One-line attributed metadata label whose individual Markdown links route
+/// through the sidebar's existing workspace-selection and URL action path.
+/// The delegate consumes link clicks so AppKit never opens a destination on
+/// its own.
+@MainActor
+final class SidebarRowMarkdownTextView: NSTextView, NSTextViewDelegate {
+    private var onOpenURL: ((URL) -> Void)?
+    private var lineHeight: CGFloat = 0
+
+    init() {
+        let textStorage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        )
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+        super.init(frame: .zero, textContainer: textContainer)
+
+        drawsBackground = false
+        isEditable = false
+        isSelectable = true
+        isRichText = true
+        importsGraphics = false
+        textContainerInset = .zero
+        textContainer.lineFragmentPadding = 0
+        textContainer.maximumNumberOfLines = 1
+        textContainer.lineBreakMode = .byTruncatingTail
+        textContainer.widthTracksTextView = true
+        textContainer.heightTracksTextView = false
+        isHorizontallyResizable = false
+        isVerticallyResizable = false
+        setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        markdown: String,
+        font: NSFont,
+        color: NSColor,
+        explicitURL: URL? = nil,
+        onOpenURL: @escaping (URL) -> Void
+    ) {
+        reset()
+        self.onOpenURL = onOpenURL
+        delegate = self
+        lineHeight = ceil(layoutManager?.defaultLineHeight(for: font) ?? font.pointSize)
+        linkTextAttributes = [
+            .foregroundColor: color,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+
+        let mutable: NSMutableAttributedString
+        if let rendered = SidebarMarkdownRenderer(markdown: markdown).workspaceDescription {
+            mutable = NSMutableAttributedString(attributedString: NSAttributedString(rendered))
+        } else {
+            mutable = NSMutableAttributedString(string: markdown)
+        }
+        let fullRange = NSRange(location: 0, length: mutable.length)
+        mutable.addAttributes(
+            [
+                .font: font,
+                .foregroundColor: color,
+            ],
+            range: fullRange
+        )
+        if let explicitURL {
+            mutable.removeAttribute(.link, range: fullRange)
+            mutable.removeAttribute(.underlineStyle, range: fullRange)
+            if Self.isAllowedMetadataURL(explicitURL), fullRange.length > 0 {
+                mutable.addAttribute(.link, value: explicitURL, range: fullRange)
+                mutable.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: fullRange)
+                toolTip = explicitURL.absoluteString
+            }
+            textStorage?.setAttributedString(mutable)
+            return
+        }
+        var links: [(value: Any?, range: NSRange)] = []
+        mutable.enumerateAttribute(.link, in: fullRange) { value, range, _ in
+            guard value != nil else { return }
+            links.append((value, range))
+        }
+        for link in links {
+            guard let url = Self.url(from: link.value), Self.isAllowedMetadataURL(url) else {
+                mutable.removeAttribute(.link, range: link.range)
+                mutable.removeAttribute(.underlineStyle, range: link.range)
+                continue
+            }
+            mutable.addAttribute(.link, value: url, range: link.range)
+            mutable.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: link.range)
+        }
+        textStorage?.setAttributedString(mutable)
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard !isHidden, frame.contains(point) else { return nil }
+        let localPoint = convert(point, from: superview)
+        return link(at: localPoint) == nil ? nil : self
+    }
+
+    func reset() {
+        delegate = nil
+        onOpenURL = nil
+        lineHeight = 0
+        toolTip = nil
+        textStorage?.setAttributedString(NSAttributedString(string: ""))
+    }
+
+    func measuredHeight(width _: CGFloat) -> CGFloat {
+        guard !isHidden else { return 0 }
+        return lineHeight
+    }
+
+    func textView(
+        _ textView: NSTextView,
+        clickedOnLink link: Any,
+        at charIndex: Int
+    ) -> Bool {
+        guard textView === self,
+              let url = Self.url(from: link),
+              Self.isAllowedMetadataURL(url),
+              charIndex >= 0,
+              charIndex < (textStorage?.length ?? 0),
+              textStorage?.attribute(.link, at: charIndex, effectiveRange: nil) != nil,
+              let onOpenURL else {
+            return false
+        }
+        onOpenURL(url)
+        return true
+    }
+
+    private func link(at localPoint: NSPoint) -> URL? {
+        guard let layoutManager, let textContainer, let textStorage else { return nil }
+        layoutManager.ensureLayout(for: textContainer)
+        let containerPoint = NSPoint(
+            x: localPoint.x - textContainerOrigin.x,
+            y: localPoint.y - textContainerOrigin.y
+        )
+        guard containerPoint.x >= 0, containerPoint.y >= 0 else { return nil }
+        let glyphIndex = layoutManager.glyphIndex(for: containerPoint, in: textContainer)
+        guard glyphIndex < layoutManager.numberOfGlyphs else { return nil }
+        let glyphRange = NSRange(location: glyphIndex, length: 1)
+        guard layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer).contains(containerPoint) else {
+            return nil
+        }
+        let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+        guard characterIndex < textStorage.length,
+              let url = Self.url(from: textStorage.attribute(.link, at: characterIndex, effectiveRange: nil)),
+              Self.isAllowedMetadataURL(url) else {
+            return nil
+        }
+        return url
+    }
+
+    private static func url(from value: Any?) -> URL? {
+        if let url = value as? URL {
+            return url
+        }
+        if let value = value as? String {
+            return URL(string: value)
+        }
+        return nil
+    }
+
+    /// Matches the control-socket metadata URL contract in
+    /// `upsertSidebarMetadata`: only HTTP(S) metadata destinations are accepted.
+    private static func isAllowedMetadataURL(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return scheme == "http" || scheme == "https"
+    }
+}
+
 /// One "small icon + text" line (metadata entry, log line, branch/dir line).
 @MainActor
 final class SidebarRowIconTextLine: NSView {
@@ -53,6 +228,7 @@ final class SidebarRowIconTextLine: NSView {
     private let iconLabel = NSTextField(labelWithString: "")
     private let textView = SidebarRowTextView(lines: 1)
     private let metadataButton = SidebarRowLinkButton()
+    private let markdownTextView = SidebarRowMarkdownTextView()
     private let secondTextView = SidebarRowTextView(lines: 1)
     private var iconSize: CGFloat = 0
     private var stacked = false
@@ -68,6 +244,8 @@ final class SidebarRowIconTextLine: NSView {
         metadataButton.alignment = .left
         metadataButton.isHidden = true
         addSubview(metadataButton)
+        markdownTextView.isHidden = true
+        addSubview(markdownTextView)
         secondTextView.isHidden = true
         addSubview(secondTextView)
     }
@@ -82,6 +260,7 @@ final class SidebarRowIconTextLine: NSView {
         color: NSColor,
         onOpenURL: @escaping (URL) -> Void
     ) {
+        resetPrimaryContent()
         stacked = false
         secondTextView.isHidden = true
         iconLabel.isHidden = true
@@ -112,7 +291,16 @@ final class SidebarRowIconTextLine: NSView {
             }
         }
         let font = NSFont.systemFont(ofSize: model.scaled(10))
-        if let url = entry.url {
+        if entry.format == .markdown {
+            markdownTextView.isHidden = false
+            markdownTextView.configure(
+                markdown: entry.sidebarDisplayText,
+                font: font,
+                color: color,
+                explicitURL: entry.url,
+                onOpenURL: onOpenURL
+            )
+        } else if let url = entry.url {
             textView.isHidden = true
             metadataButton.isHidden = false
             metadataButton.configure(
@@ -138,8 +326,8 @@ final class SidebarRowIconTextLine: NSView {
         model: SidebarWorkspaceRowModel,
         palette: SidebarRowPalette
     ) {
+        resetPrimaryContent()
         stacked = false
-        metadataButton.isHidden = true
         textView.isHidden = false
         secondTextView.isHidden = true
         iconLabel.isHidden = true
@@ -186,7 +374,7 @@ final class SidebarRowIconTextLine: NSView {
         model: SidebarWorkspaceRowModel,
         palette: SidebarRowPalette
     ) {
-        metadataButton.isHidden = true
+        resetPrimaryContent()
         textView.isHidden = false
         iconView.isHidden = true
         iconLabel.isHidden = true
@@ -232,11 +420,36 @@ final class SidebarRowIconTextLine: NSView {
 
     func measuredHeight(width: CGFloat) -> CGFloat {
         resolveCandidates(width: width)
-        let first = metadataButton.isHidden
-            ? textView.measuredHeight(width: max(10, width - iconSize))
-            : ceil(metadataButton.intrinsicContentSize.height)
+        let first = primaryMeasuredHeight(width: max(10, width - iconSize))
         let second = secondTextView.isHidden ? 0 : secondTextView.measuredHeight(width: max(10, width - iconSize)) + 1
         return first + second
+    }
+
+    private func resetPrimaryContent() {
+        textView.isHidden = true
+        textView.stringValue = ""
+        textView.attributedStringValue = NSAttributedString(string: "")
+        metadataButton.isHidden = true
+        metadataButton.reset()
+        markdownTextView.isHidden = true
+        markdownTextView.reset()
+    }
+
+    private func primaryMeasuredHeight(width: CGFloat) -> CGFloat {
+        if !markdownTextView.isHidden {
+            return markdownTextView.measuredHeight(width: width)
+        }
+        if !metadataButton.isHidden {
+            return ceil(metadataButton.intrinsicContentSize.height)
+        }
+        return textView.measuredHeight(width: width)
+    }
+
+    private var primaryView: NSView {
+        if !markdownTextView.isHidden {
+            return markdownTextView
+        }
+        return metadataButton.isHidden ? textView : metadataButton
     }
 
     private func resolveCandidates(width: CGFloat) {
@@ -268,11 +481,9 @@ final class SidebarRowIconTextLine: NSView {
             x = side + 4
         }
         let availableWidth = max(10, bounds.width - x)
-        let firstHeight = metadataButton.isHidden
-            ? textView.measuredHeight(width: availableWidth)
-            : ceil(metadataButton.intrinsicContentSize.height)
-        let primaryView: NSView = metadataButton.isHidden ? textView : metadataButton
-        primaryView.frame = NSRect(x: x, y: 0, width: availableWidth, height: firstHeight)
+        let firstHeight = primaryMeasuredHeight(width: availableWidth)
+        let activePrimaryView = primaryView
+        activePrimaryView.frame = NSRect(x: x, y: 0, width: availableWidth, height: firstHeight)
         if !secondTextView.isHidden {
             let secondHeight = secondTextView.measuredHeight(width: max(10, bounds.width - x))
             secondTextView.frame = NSRect(x: x, y: firstHeight + 1, width: max(10, bounds.width - x), height: secondHeight)
@@ -413,8 +624,13 @@ final class SidebarRowLinkButton: NSButton {
         self.onClick = onClick
     }
 
+    func reset() {
+        attributedTitle = NSAttributedString(string: "")
+        toolTip = nil
+        onClick = nil
+    }
+
     @objc private func execute() {
         onClick?()
     }
 }
-

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -49,6 +49,8 @@ final class SidebarRowMarkdownTextView: NSTextView, NSTextViewDelegate {
     private var onOpenURL: ((URL) -> Void)?
     private var lineHeight: CGFloat = 0
 
+    override var acceptsFirstResponder: Bool { false }
+
     init() {
         let textStorage = NSTextStorage()
         let layoutManager = NSLayoutManager()

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -348,6 +348,27 @@ struct SidebarAppKitRowCellTests {
     }
 
     @Test
+    func markdownMetadataDoesNotCaptureKeyboardFocus() throws {
+        let model = Self.makeModel(
+            metadataEntries: [
+                SidebarStatusEntry(
+                    key: "repo_workspace",
+                    value: Self.linkedMetadataMarkdown,
+                    format: .markdown
+                ),
+            ]
+        )
+        let cell = Self.configuredCell(model: model)
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(!textView.acceptsFirstResponder)
+    }
+
+    @Test
     func markdownMetadataExplicitURLPreservesFormattedRowAction() throws {
         let explicitURL = try #require(URL(string: "https://example.com/explicit"))
         let model = Self.makeModel(

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -151,11 +151,14 @@ struct SidebarAppKitRowCellTests {
 
     private static func makeActions(
         model: SidebarWorkspaceRowModel,
+        tab: Workspace? = nil,
+        tabManager: TabManager? = nil,
         onOpenStatusURL: @escaping (URL) -> Void = { _ in }
     ) -> SidebarAppKitRowActions {
+        let resolvedTab = tab ?? Workspace()
         let commands = SidebarWorkspaceRowCommands(
-            tab: Workspace(),
-            tabManager: nil,
+            tab: resolvedTab,
+            tabManager: tabManager,
             notificationStore: nil,
             index: model.index,
             contextMenuWorkspaceIds: [model.workspaceId],
@@ -201,12 +204,19 @@ struct SidebarAppKitRowCellTests {
 
     private static func configuredCell(
         model: SidebarWorkspaceRowModel,
+        tab: Workspace? = nil,
+        tabManager: TabManager? = nil,
         onOpenStatusURL: @escaping (URL) -> Void = { _ in }
     ) -> SidebarWorkspaceRowTableCellView {
         let cell = SidebarWorkspaceRowTableCellView()
         cell.configure(
             model: model,
-            actions: makeActions(model: model, onOpenStatusURL: onOpenStatusURL),
+            actions: makeActions(
+                model: model,
+                tab: tab,
+                tabManager: tabManager,
+                onOpenStatusURL: onOpenStatusURL
+            ),
             isPointerHovering: false,
             contextMenuDidOpen: {},
             contextMenuDidClose: {}
@@ -216,6 +226,67 @@ struct SidebarAppKitRowCellTests {
 
     private static func descendants(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { descendants(of: $0) }
+    }
+
+    private static let linkedMetadataMarkdown =
+        "[acme/widgets](https://github.com/acme/widgets/tree/branch) • " +
+        "[PR#123](https://github.com/acme/widgets/pull/123) • " +
+        "[dev-7](http://127.0.0.1:53000/workspaces/7)"
+
+    private static let linkedMetadataURLs = [
+        URL(string: "https://github.com/acme/widgets/tree/branch")!,
+        URL(string: "https://github.com/acme/widgets/pull/123")!,
+        URL(string: "http://127.0.0.1:53000/workspaces/7")!,
+    ]
+
+    private static func links(in textView: NSTextView) -> [(range: NSRange, url: URL)] {
+        var links: [(range: NSRange, url: URL)] = []
+        let fullRange = NSRange(location: 0, length: textView.textStorage?.length ?? 0)
+        textView.textStorage?.enumerateAttribute(.link, in: fullRange) { value, range, _ in
+            let url: URL?
+            if let value = value as? URL {
+                url = value
+            } else if let value = value as? String {
+                url = URL(string: value)
+            } else {
+                url = nil
+            }
+            if let url {
+                links.append((range, url))
+            }
+        }
+        return links
+    }
+
+    @discardableResult
+    private static func activateLink(
+        _ link: (range: NSRange, url: URL),
+        in textView: NSTextView
+    ) -> Bool {
+        textView.delegate?.textView?(
+            textView,
+            clickedOnLink: link.url,
+            at: link.range.location
+        ) ?? false
+    }
+
+    private static func hitTestPoint(
+        forCharacterAt characterIndex: Int,
+        in textView: NSTextView
+    ) throws -> NSPoint {
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+        let glyphRange = layoutManager.glyphRange(
+            forCharacterRange: NSRange(location: characterIndex, length: 1),
+            actualCharacterRange: nil
+        )
+        let glyphBounds = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+        let localPoint = NSPoint(
+            x: textView.textContainerOrigin.x + glyphBounds.midX,
+            y: textView.textContainerOrigin.y + glyphBounds.midY
+        )
+        return textView.convert(localPoint, to: textView.superview)
     }
 
     @Test(arguments: zip(["codex", "claude_code"], ["Running", "Needs input"]))
@@ -251,6 +322,269 @@ struct SidebarAppKitRowCellTests {
         #expect(link.isEnabled)
         link.performClick(nil)
         #expect(openedURL == url)
+    }
+
+    @Test
+    func markdownMetadataRendersLabelsAndIndependentLinks() throws {
+        let model = Self.makeModel(
+            metadataEntries: [
+                SidebarStatusEntry(
+                    key: "repo_workspace",
+                    value: Self.linkedMetadataMarkdown,
+                    format: .markdown
+                ),
+            ]
+        )
+        let cell = Self.configuredCell(model: model)
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.string == "acme/widgets • PR#123 • dev-7")
+        #expect(!textView.string.contains("["))
+        #expect(Self.links(in: textView).map(\.url) == Self.linkedMetadataURLs)
+    }
+
+    @Test
+    func markdownMetadataExplicitURLPreservesFormattedRowAction() throws {
+        let explicitURL = try #require(URL(string: "https://example.com/explicit"))
+        let model = Self.makeModel(
+            metadataEntries: [
+                SidebarStatusEntry(
+                    key: "repo_workspace",
+                    value: Self.linkedMetadataMarkdown,
+                    url: explicitURL,
+                    format: .markdown
+                ),
+            ]
+        )
+        var openedURL: URL?
+        let cell = Self.configuredCell(model: model) { openedURL = $0 }
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.string == "acme/widgets • PR#123 • dev-7")
+        let links = Self.links(in: textView)
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.range == NSRange(location: 0, length: textView.string.utf16.count))
+        #expect(link.url == explicitURL)
+        #expect(Self.activateLink(link, in: textView))
+        #expect(openedURL == explicitURL)
+    }
+
+    @Test
+    func markdownMetadataOnlyCapturesClicksOnLinkGlyphs() throws {
+        let row = SidebarRowIconTextLine()
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "links",
+                value: "plain [link](https://example.com)",
+                format: .markdown
+            ),
+            model: Self.makeModel(),
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+
+        let height = row.measuredHeight(width: 220)
+        row.frame = NSRect(x: 0, y: 0, width: 220, height: height)
+        row.layoutSubtreeIfNeeded()
+        let textView = try #require(
+            Self.descendants(of: row)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+        let links = Self.links(in: textView)
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        let plainPoint = try Self.hitTestPoint(forCharacterAt: 0, in: textView)
+        let linkPoint = try Self.hitTestPoint(forCharacterAt: link.range.location, in: textView)
+
+        #expect(textView.hitTest(plainPoint) == nil)
+        #expect(textView.hitTest(linkPoint) === textView)
+    }
+
+    @Test
+    func markdownMetadataLinkSelectionPrecedesEachOpen() throws {
+        let manager = TabManager()
+        let originalWorkspaceId = try #require(manager.selectedTabId)
+        let targetWorkspace = manager.addWorkspace(select: false)
+        let model = Self.makeModel(
+            workspaceId: targetWorkspace.id,
+            metadataEntries: [
+                SidebarStatusEntry(
+                    key: "repo_workspace",
+                    value: Self.linkedMetadataMarkdown,
+                    format: .markdown
+                ),
+            ]
+        )
+        var opened: [URL] = []
+        var wasSelectedBeforeOpen: [Bool] = []
+        let cell = Self.configuredCell(
+            model: model,
+            tab: targetWorkspace,
+            tabManager: manager
+        ) { url in
+            wasSelectedBeforeOpen.append(manager.selectedTabId == targetWorkspace.id)
+            opened.append(url)
+        }
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(manager.selectedTabId == originalWorkspaceId)
+        for link in Self.links(in: textView) {
+            #expect(Self.activateLink(link, in: textView))
+        }
+        #expect(opened == Self.linkedMetadataURLs)
+        #expect(wasSelectedBeforeOpen == [true, true, true])
+    }
+
+    @Test
+    func markdownMetadataLeavesUnsafeSchemeLabelInert() throws {
+        let markdown = "[safe](https://example.com) • [unsafe](javascript:alert(1))"
+        let model = Self.makeModel(
+            metadataEntries: [
+                SidebarStatusEntry(key: "links", value: markdown, format: .markdown),
+            ]
+        )
+        let cell = Self.configuredCell(model: model)
+        let textView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.string == "safe • unsafe")
+        #expect(Self.links(in: textView).map(\.url) == [URL(string: "https://example.com")!])
+    }
+
+    @Test
+    func markdownMetadataStaysSingleLineAndHeightStable() throws {
+        let markdown = (1...20)
+            .map { "[workspace-\($0)](https://example.com/workspaces/\($0))" }
+            .joined(separator: " • ")
+        let row = SidebarRowIconTextLine()
+        row.configureMetadataEntry(
+            SidebarStatusEntry(key: "links", value: markdown, format: .markdown),
+            model: Self.makeModel(),
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+
+        let beforeLayout = row.measuredHeight(width: 120)
+        row.frame = NSRect(x: 0, y: 0, width: 120, height: beforeLayout)
+        row.layoutSubtreeIfNeeded()
+        let afterLayout = row.measuredHeight(width: 120)
+        let textView = try #require(
+            Self.descendants(of: row)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+
+        #expect(textView.textContainer?.maximumNumberOfLines == 1)
+        #expect(textView.textContainer?.lineBreakMode == .byTruncatingTail)
+        #expect(afterLayout == beforeLayout)
+    }
+
+    @Test
+    func markdownMetadataTextContainerHasDrawableHeight() throws {
+        let row = SidebarRowIconTextLine()
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "repo_workspace",
+                value: Self.linkedMetadataMarkdown,
+                format: .markdown
+            ),
+            model: Self.makeModel(),
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+
+        let height = row.measuredHeight(width: 220)
+        row.frame = NSRect(x: 0, y: 0, width: 220, height: height)
+        row.layoutSubtreeIfNeeded()
+        let textView = try #require(
+            Self.descendants(of: row)
+                .compactMap { $0 as? NSTextView }
+                .first { !$0.isHidden }
+        )
+        let textContainer = try #require(textView.textContainer)
+        let layoutManager = try #require(textView.layoutManager)
+
+        layoutManager.ensureLayout(for: textContainer)
+        #expect(textContainer.containerSize.height > 0)
+        #expect(layoutManager.usedRect(for: textContainer).height > 0)
+    }
+
+    @Test
+    func metadataRowReconfigurationClearsMutuallyExclusiveState() throws {
+        let row = SidebarRowIconTextLine()
+        let model = Self.makeModel()
+        var firstOpened = 0
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "repo_workspace",
+                value: Self.linkedMetadataMarkdown,
+                format: .markdown
+            ),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in firstOpened += 1 }
+        )
+        let markdownView = try #require(
+            Self.descendants(of: row).compactMap { $0 as? NSTextView }.first
+        )
+        let staleLink = try #require(Self.links(in: markdownView).first)
+
+        row.configureMetadataEntry(
+            SidebarStatusEntry(key: "plain", value: "plain value"),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+        #expect(markdownView.isHidden)
+        #expect(markdownView.string.isEmpty)
+        #expect(Self.links(in: markdownView).isEmpty)
+        #expect(!Self.activateLink(staleLink, in: markdownView))
+        #expect(firstOpened == 0)
+
+        let explicitURL = try #require(URL(string: "https://example.com/plain"))
+        row.configureMetadataEntry(
+            SidebarStatusEntry(key: "plain-link", value: "plain link", url: explicitURL),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { _ in }
+        )
+        #expect(markdownView.isHidden)
+        #expect(markdownView.string.isEmpty)
+
+        var secondOpened: URL?
+        row.configureMetadataEntry(
+            SidebarStatusEntry(
+                key: "markdown-again",
+                value: "[again](https://example.com/again)",
+                format: .markdown
+            ),
+            model: model,
+            color: .secondaryLabelColor,
+            onOpenURL: { secondOpened = $0 }
+        )
+        let currentLink = try #require(Self.links(in: markdownView).first)
+        #expect(!markdownView.isHidden)
+        #expect(markdownView.string == "again")
+        #expect(Self.activateLink(currentLink, in: markdownView))
+        #expect(secondOpened == URL(string: "https://example.com/again"))
+        #expect(firstOpened == 0)
     }
 
     @Test


### PR DESCRIPTION
## Summary

A custom workspace client uses the cmux CLI to create or attach remote development workspaces, then reports one `format=markdown` metadata row containing repository, pull-request, and workspace destinations. In the default sidebar, this feature is broken: cmux displays the Markdown source instead of readable, independently clickable labels.

Git history points to the AppKit transition as the cause. [`b7bd90103`](https://github.com/manaflow-ai/cmux/commit/b7bd90103cca37614355aa0e6fdc6f6d7ec3d7d3) introduced a sidebar row that omitted the SwiftUI Markdown branch and assigned metadata to plain text; [`e35b74407`](https://github.com/manaflow-ai/cmux/commit/e35b74407ad726a6cf04f744b9d63bddf0e2d029) then made that incomplete path the default.

This PR restores the documented format distinction in the default sidebar without changing the control API, plain metadata rows, or workspace-level URL behavior.

## Changes

### 1. Restore Markdown metadata parity in the AppKit sidebar

#### Base Behavior

The legacy row parses `format=markdown` values as inline Markdown in [ContentView.swift](https://github.com/manaflow-ai/cmux/blob/f616cecf3b9e564e49bcd4ac39e2722c1553e6e6/Sources/ContentView.swift#L16020-L16035). At the PR base, the default AppKit row instead checks only `entry.url`; without that single explicit destination, [SidebarWorkspaceRowSupportViews.swift](https://github.com/manaflow-ai/cmux/blob/f616cecf3b9e564e49bcd4ac39e2722c1553e6e6/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift#L79-L132) assigns `sidebarDisplayText` to a plain text field. The [`12798dc4f`](https://github.com/manaflow-ai/cmux/commit/12798dc4fa425b636876ce025b57933322ce3f73) follow-up restored clicks for one explicit whole-row URL but could not represent several destinations embedded in Markdown.

#### Change

Markdown rows now use cmux's existing `SidebarMarkdownRenderer` inside a one-line AppKit text view in [SidebarWorkspaceRowSupportViews.swift](https://github.com/djova/cmux/blob/bd48fa7f31062a213cdbb57f11ee2f6886721260/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift#L43-L215). Each HTTP(S) destination remains an independent link; an explicit `entry.url` replaces embedded destinations across the row, matching the existing control-API precedence. Link activation selects the owning workspace before using its established open callback, while clicks outside link glyphs continue to the table row.

#### Justification

`NSTextField` cannot provide several independently actionable ranges, while `NSTextView` exposes the attributed links already produced by cmux's renderer. Keeping the view single-line, tail-truncated, outside the focus chain, and reset during cell reuse preserves the table's height, keyboard navigation, selection, and recycled-row behavior.

#### Risk

The production change is limited to metadata entries whose format is Markdown in the default AppKit sidebar. Plain rows and explicit whole-row links retain their existing paths; only HTTP(S) link attributes remain active; non-link pixels do not capture row clicks. The main failure modes are stale recycled state or changed focus and hit-testing, bounded by per-configuration reset, link-glyph hit testing, and refusal to become first responder.

## Testing

I compared isolated tagged builds of the exact PR base and this branch after injecting identical `format=markdown` metadata through the cmux CLI. The base displayed literal Markdown; the patched app displayed three readable, underlined labels, and its accessibility tree exposed three independent links with the expected destinations. The patched build remains launched under the isolated `cmux-test` tag.

## Demo Video

This is a static sidebar-state change, so before-and-after screenshots show the relevant behavior more directly than a video.

### Before

<img width="383" height="89" alt="cmux-sidebar-links-before" src="https://github.com/user-attachments/assets/ef28f9a7-94bd-402f-97bb-356802fe6627" />

The default AppKit row displays the Markdown source and exposes no independent link labels.

### After

<img width="390" height="94" alt="cmux-sidebar-links-after" src="https://github.com/user-attachments/assets/32e296ab-5215-4cfd-97e5-bfdc68dfeda2" />

The same metadata payload renders three distinct, underlined destinations.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787334239&installation_model_id=21920&pr_number=8663&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8663&signature=57d6505296d50b137db1e55e5bb9186f44c94fab685a222da5c30301291c879d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render Markdown metadata in the AppKit sidebar as safe, clickable links without stealing keyboard focus. Each label renders as its own link using `SidebarMarkdownRenderer` and opens via the existing row-selection/open handler.

- **New Features**
  - Added single-line `SidebarRowMarkdownTextView` to render metadata Markdown with independent links, tail truncation, and accessibility.
  - Preserved explicit `entry.url` by applying it to the whole row; only `http`/`https` links are allowed; non-link clicks still select the workspace.
  - Updated layout, measurement, and hit testing so only link glyphs capture clicks; stable height; proper cell reuse with state reset.

- **Bug Fixes**
  - Kept Markdown links out of the focus chain to preserve keyboard focus and selection behavior.

<sup>Written for commit bd48fa7f31062a213cdbb57f11ee2f6886721260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar metadata now supports inline Markdown rendering with clickable HTTP(S) links.
  * Metadata can preserve an explicit URL for consistent link behavior.
* **Bug Fixes**
  * Unsafe URL schemes are ignored so links become inert.
  * Link activation is limited to the link text (non-link text is not clickable).
  * Switching between metadata formats clears prior state and prevents stale link activation.
  * Markdown metadata stays single-line with stable measured height and reliable layout.
* **Tests**
  * Expanded coverage for Markdown/link rendering and link-click behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->