### PR TITLE
Show progress while verifying sign-in code

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -202,6 +202,7 @@ struct SignInView: View {
                         .fontWeight(.semibold)
                         .frame(maxWidth: .infinity)
                         .contentShape(.capsule)
+                        .mobileButtonLoading(authManager.isLoading, tint: .white)
                 }
                 .disabled(code.count != 6 || isAuthInProgress)
                 .mobileGlassProminentButton()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -207,6 +207,7 @@ struct SignInView: View {
                 .disabled(code.count != 6 || isAuthInProgress)
                 .mobileGlassProminentButton()
                 .accessibilityIdentifier("signin.verifyCode")
+                .accessibilityLabel(L10n.string("mobile.signIn.verifyCode", defaultValue: "Verify code"))
 
                 Button {
                     let autofocusEmailOnReturn = isCodeFocused

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SignInView.swift
@@ -202,7 +202,7 @@ struct SignInView: View {
                         .fontWeight(.semibold)
                         .frame(maxWidth: .infinity)
                         .contentShape(.capsule)
-                        .mobileButtonLoading(authManager.isLoading, tint: .white)
+                        .mobileButtonLoading(authManager.isLoading, tint: .primary)
                 }
                 .disabled(code.count != 6 || isAuthInProgress)
                 .mobileGlassProminentButton()


### PR DESCRIPTION
## Summary
- replace the Verify code label with the existing stable-height progress indicator while verification is active
- preserve the button size and use the shared AuthCoordinator loading state

## Testing
- tagged macOS build: vspin
- isolated iOS simulator build, install, and launch: cmux-vspin-20260722
- light and dark UI preflight: dummy six-character codes replace the label with an appearance-adaptive spinner, preserve button size, then restore the button
- localization catalog JSON audit: English and Japanese Verify code values present

## Task
- User-requested verification code loading UX improvement

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787339830&installation_model_id=21920&pr_number=8666&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8666&signature=18dfac6fe2291da6665f5dafa95b9e8b958ae0a57ddea0deba58aacc0ac97306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show inline loading on the Verify code button during code verification to improve feedback and avoid flicker. Uses the shared auth loading state with a stable-height spinner that preserves button size, adapts to appearance, and keeps the button’s accessibility label.

<sup>Written for commit 8f4e3bbf923dd06cb61404d82fcd882039c4d89c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The “Verify code” button now shows an active loading-state indication while authentication is in progress, improving feedback during code verification (not just disabling).
  * Added an accessibility label for the “Verify code” button to improve screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
