### PR TITLE
Fix CmuxTerminal hibernation test hang

### DIFF
--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
@@ -45,7 +45,7 @@ final class TeardownOrderRecorder: @unchecked Sendable {
 
     /// Suspends until at least `count` events have been recorded, or returns
     /// false after a bounded wait so a failed teardown cannot hang the suite.
-    func waitForEventCount(_ count: Int, timeout: TimeInterval = 1) async -> Bool {
+    func waitForEventCount(_ count: Int, timeout: TimeInterval = 5) async -> Bool {
         let waiterID = UUID()
         return await withCheckedContinuation { continuation in
             lock.lock()

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
@@ -19,6 +19,7 @@ final class TeardownOrderRecorder: @unchecked Sendable {
         let id: UUID
         let count: Int
         let continuation: CheckedContinuation<Bool, Never>
+        let timeoutTask: Task<Void, Never>
     }
 
     private var waiters: [Waiter] = []
@@ -35,31 +36,54 @@ final class TeardownOrderRecorder: @unchecked Sendable {
         lock.lock()
         storedEvents.append(event)
         let count = storedEvents.count
-        let resumable = waiters.filter { $0.count <= count }.map(\.continuation)
+        let resumable = waiters.filter { $0.count <= count }
         waiters.removeAll { $0.count <= count }
         lock.unlock()
-        for continuation in resumable {
-            continuation.resume(returning: true)
+        for waiter in resumable {
+            waiter.timeoutTask.cancel()
+            waiter.continuation.resume(returning: true)
         }
     }
 
     /// Suspends until at least `count` events have been recorded, or returns
     /// false after a bounded wait so a failed teardown cannot hang the suite.
-    func waitForEventCount(_ count: Int, timeout: TimeInterval = 5) async -> Bool {
+    func waitForEventCount(_ count: Int, timeout: Duration = .seconds(5)) async -> Bool {
         let waiterID = UUID()
-        return await withCheckedContinuation { continuation in
-            lock.lock()
-            if storedEvents.count >= count {
-                lock.unlock()
-                continuation.resume(returning: true)
-                return
-            }
-            waiters.append(Waiter(id: waiterID, count: count, continuation: continuation))
-            lock.unlock()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                if Task.isCancelled {
+                    lock.unlock()
+                    continuation.resume(returning: false)
+                    return
+                }
+                if storedEvents.count >= count {
+                    lock.unlock()
+                    continuation.resume(returning: true)
+                    return
+                }
 
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) { [weak self] in
-                self?.expireWaiter(id: waiterID)
+                let timeoutTask = Task { [weak self] in
+                    do {
+                        // Genuine test deadline; event delivery or parent cancellation cancels this task.
+                        try await Task.sleep(for: timeout)
+                    } catch {
+                        return
+                    }
+                    self?.expireWaiter(id: waiterID)
+                }
+                waiters.append(
+                    Waiter(
+                        id: waiterID,
+                        count: count,
+                        continuation: continuation,
+                        timeoutTask: timeoutTask
+                    )
+                )
+                lock.unlock()
             }
+        } onCancel: {
+            cancelWaiter(id: waiterID)
         }
     }
 
@@ -72,5 +96,17 @@ final class TeardownOrderRecorder: @unchecked Sendable {
         let continuation = waiters.remove(at: index).continuation
         lock.unlock()
         continuation.resume(returning: false)
+    }
+
+    private func cancelWaiter(id: UUID) {
+        lock.lock()
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+            lock.unlock()
+            return
+        }
+        let waiter = waiters.remove(at: index)
+        lock.unlock()
+        waiter.timeoutTask.cancel()
+        waiter.continuation.resume(returning: false)
     }
 }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
@@ -15,7 +15,13 @@ final class TeardownOrderRecorder: @unchecked Sendable {
 
     private let lock = NSLock()
     private var storedEvents: [Event] = []
-    private var waiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private struct Waiter {
+        let id: UUID
+        let count: Int
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var waiters: [Waiter] = []
 
     /// The events recorded so far, in order.
     var events: [Event] {
@@ -33,21 +39,38 @@ final class TeardownOrderRecorder: @unchecked Sendable {
         waiters.removeAll { $0.count <= count }
         lock.unlock()
         for continuation in resumable {
-            continuation.resume()
+            continuation.resume(returning: true)
         }
     }
 
-    /// Suspends until at least `count` events have been recorded.
-    func waitForEventCount(_ count: Int) async {
-        await withCheckedContinuation { continuation in
+    /// Suspends until at least `count` events have been recorded, or returns
+    /// false after a bounded wait so a failed teardown cannot hang the suite.
+    func waitForEventCount(_ count: Int, timeout: TimeInterval = 1) async -> Bool {
+        let waiterID = UUID()
+        return await withCheckedContinuation { continuation in
             lock.lock()
             if storedEvents.count >= count {
                 lock.unlock()
-                continuation.resume()
+                continuation.resume(returning: true)
                 return
             }
-            waiters.append((count, continuation))
+            waiters.append(Waiter(id: waiterID, count: count, continuation: continuation))
             lock.unlock()
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout) { [weak self] in
+                self?.expireWaiter(id: waiterID)
+            }
         }
+    }
+
+    private func expireWaiter(id: UUID) {
+        lock.lock()
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+            lock.unlock()
+            return
+        }
+        let continuation = waiters.remove(at: index).continuation
+        lock.unlock()
+        continuation.resume(returning: false)
     }
 }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TeardownOrderRecorder.swift
@@ -23,6 +23,7 @@ final class TeardownOrderRecorder: @unchecked Sendable {
     }
 
     private var waiters: [Waiter] = []
+    private var waiterRegistrationSignals: [CheckedContinuation<Void, Never>] = []
 
     /// The events recorded so far, in order.
     var events: [Event] {
@@ -80,10 +81,28 @@ final class TeardownOrderRecorder: @unchecked Sendable {
                         timeoutTask: timeoutTask
                     )
                 )
+                let registrationSignals = waiterRegistrationSignals
+                waiterRegistrationSignals.removeAll()
                 lock.unlock()
+                for signal in registrationSignals { signal.resume() }
             }
         } onCancel: {
             cancelWaiter(id: waiterID)
+        }
+    }
+
+    /// Suspends until an event-count waiter is installed. Tests use this to
+    /// cancel the registered waiter instead of racing its setup task.
+    func waitUntilEventWaiterIsRegistered() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if waiters.isEmpty {
+                waiterRegistrationSignals.append(continuation)
+                lock.unlock()
+            } else {
+                lock.unlock()
+                continuation.resume()
+            }
         }
     }
 

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
@@ -15,6 +15,18 @@ import Testing
 /// native free to the runtime teardown coordinator.
 @MainActor
 @Suite(.serialized) struct TerminalSurfaceTeardownCallbackLifetimeTests {
+    @Test func cancellingEventWaitReturnsWithoutWaitingForDeadline() async {
+        let recorder = TeardownOrderRecorder()
+        let wait = Task {
+            await recorder.waitForEventCount(1, timeout: .seconds(60))
+        }
+
+        await Task.yield()
+        wait.cancel()
+
+        #expect(await wait.value == false)
+    }
+
     @Test func teardownSurfaceKeepsTeeLeaseUntilNativeFree() async {
         let recorder = TeardownOrderRecorder()
         let surface = makeSurface()

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxTerminalCore
 import Foundation
 import GhosttyKit
 import Testing
@@ -40,8 +41,12 @@ import Testing
 
     @Test func agentHibernationSuspendKeepsTeeLeaseUntilNativeFree() async {
         let recorder = TeardownOrderRecorder()
-        let surface = makeSurface()
-        surface.installRuntimeSurfaceForTesting(fakeRuntimeSurface())
+        let registry = TerminalSurfaceRegistry()
+        let surface = makeSurface(registry: registry)
+        let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
+        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+        defer { runtimeSurface.deallocate() }
         surface.mobileByteTeeLease = RecordingTerminalByteTeeLease(recorder: recorder)
         TerminalSurface.runtimeSurfaceFreeOverrideForTesting = { _ in
             recorder.record(.nativeFree)
@@ -143,7 +148,9 @@ import Testing
         #expect(recorder.events == [.nativeFree, .teeLeaseRelease])
     }
 
-    private func makeSurface() -> TerminalSurface {
+    private func makeSurface(
+        registry: any TerminalSurfaceRegistering = FakeSurfaceRegistry()
+    ) -> TerminalSurface {
         let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
         let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
         return TerminalSurface(
@@ -151,7 +158,7 @@ import Testing
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: nil,
             dependencies: TerminalSurfaceRuntimeDependencies(
-                registry: FakeSurfaceRegistry(),
+                registry: registry,
                 engine: FakeTerminalEngine(),
                 viewProvider: FakeTerminalSurfaceViewProvider(surfaceView: nativeView, paneHost: paneHost),
                 spawnPolicy: FakeSpawnPolicyProvider(),

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
@@ -21,7 +21,7 @@ import Testing
             await recorder.waitForEventCount(1, timeout: .seconds(60))
         }
 
-        await Task.yield()
+        await recorder.waitUntilEventWaiterIsRegistered()
         wait.cancel()
 
         #expect(await wait.value == false)

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceTeardownCallbackLifetimeTests.swift
@@ -33,7 +33,8 @@ import Testing
             "tee lease was released before the native free; the IO reader thread can still fire the tee callback"
         )
 
-        await recorder.waitForEventCount(2)
+        let completed = await recorder.waitForEventCount(2)
+        #expect(completed, "timed out waiting for native free and tee-lease release")
         #expect(recorder.events == [.nativeFree, .teeLeaseRelease])
     }
 
@@ -54,7 +55,8 @@ import Testing
             "tee lease was released before the native free; the IO reader thread can still fire the tee callback"
         )
 
-        await recorder.waitForEventCount(2)
+        let completed = await recorder.waitForEventCount(2)
+        #expect(completed, "timed out waiting for native free and tee-lease release")
         #expect(recorder.events == [.nativeFree, .teeLeaseRelease])
     }
 
@@ -77,7 +79,8 @@ import Testing
             "deinit released the tee lease inline instead of handing it to the teardown coordinator"
         )
 
-        await recorder.waitForEventCount(2)
+        let completed = await recorder.waitForEventCount(2)
+        #expect(completed, "timed out waiting for native free and tee-lease release")
         // The native free must land before the tee-lease release: ghostty's IO
         // reader thread can fire the tee callback until the free joins it.
         #expect(recorder.events == [.nativeFree, .teeLeaseRelease])
@@ -110,7 +113,8 @@ import Testing
 
         // The coordinator releases the manual IO context before the tee
         // lease, so the lease event doubles as the completion beacon.
-        await recorder.waitForEventCount(2)
+        let completed = await recorder.waitForEventCount(2)
+        #expect(completed, "timed out waiting for native free and tee-lease release")
         #expect(recorder.events == [.nativeFree, .teeLeaseRelease])
         #expect(weakBox == nil, "manual IO write box must still be released after the native free")
     }
@@ -134,7 +138,8 @@ import Testing
             }
         )
 
-        await recorder.waitForEventCount(2)
+        let completed = await recorder.waitForEventCount(2)
+        #expect(completed, "timed out waiting for native free and tee-lease release")
         #expect(recorder.events == [.nativeFree, .teeLeaseRelease])
     }
 


### PR DESCRIPTION
The hibernation teardown lifetime test injected an unregistered sentinel pointer. The new font-lineage snapshot correctly quarantined it before teardown, released the lease, and left the test waiting forever for a native-free event.

The fixture now allocates and registers a live runtime pointer before exercising hibernation. Teardown waits are bounded so future lifecycle regressions fail instead of consuming the full CI timeout.

Red commit: 17647d6068 makes the existing regression terminate with the early-release and timeout failures.
Green commit: 9f472fdbe8 registers the runtime pointer and passes all 108 CmuxTerminal package tests locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787346400&installation_model_id=21920&pr_number=8674&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8674&signature=91bdfd9b3a5acce095f174ad3a11e69f24e3c501f8416d3f06dcca254bb27970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang in the `CmuxTerminal` hibernation teardown tests by registering a real runtime surface, bounding teardown waits, and adding waiter-registration signaling so cancellations return immediately. The suite now fails fast with clear assertions instead of stalling in CI.

- **Bug Fixes**
  - Register a live runtime surface: allocate, register via `TerminalSurfaceRegistry`, install, then deallocate.
  - Bound waits: `TeardownOrderRecorder.waitForEventCount` times out (5s) and returns a Bool; tests assert completion.
  - Cancellation with waiter registration: tests wait for the waiter to register, cancel, and get `false` immediately; deadline tasks cancel on event delivery or parent cancellation.

<sup>Written for commit 8622ddf6063e86cf281416dd8dcfb49eea5b9704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated teardown event waiting to use bounded timeouts and explicit cancellation handling; `waitForEventCount` now returns a success/failure result (`Bool`) and won’t hang indefinitely.
* **Tests**
  * Added a cancellation scenario to verify waiting returns `false` when cancelled.
  * Strengthened teardown-order assertions to confirm the exact expected event sequence and completion status.
* **Test Coverage**
  * Improved hibernation-related teardown validation to ensure runtime surface cleanup and lease release occur in the correct order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->