### PR TITLE
Fit same-display restored windows to visible bounds

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -301,10 +301,10 @@ final class CmuxMainWindow: NSWindow {
     /// is what stops the sleep/wake drift (#6305).
     ///
     /// Delegates to the shared ``isTitlebarReachable(frame:visibleFrame:)``
-    /// predicate, which the startup/restore-path clamp
-    /// (`AppDelegate.shouldPreserveAccessibleFrame`) also uses, so the runtime
-    /// constrain pass and the restore-time clamp can never disagree on what
-    /// counts as reachable.
+    /// predicate used by the reactive titlebar-stranding safety net. Persisted
+    /// frames and display-topology changes use the stricter visible-frame fit
+    /// policy instead: restored windows must be fully covered by current
+    /// displays even when this lenient drag-reachability test passes.
     nonisolated static func shouldPreserveFrameDuringConstrain(
         _ proposedFrame: NSRect,
         visibleFrames: [NSRect]
@@ -315,8 +315,8 @@ final class CmuxMainWindow: NSWindow {
     /// Whether a grabbable slice of `frame`'s titlebar — its top strip — is
     /// visible on `visibleFrame`. This is the single source of truth for "can
     /// the user still grab this window", shared by the runtime constrain veto
-    /// (``shouldPreserveFrameDuringConstrain``) and the reactive/restore-time
-    /// clamp (`AppDelegate`).
+    /// (``shouldPreserveFrameDuringConstrain``) and AppDelegate's reactive
+    /// titlebar-stranding safety net.
     ///
     /// The window is non-movable (``configureCmuxMainWindowDragBehavior`` sets
     /// `isMovable = false`) and can only be dragged by ``WindowDragHandleView``

--- a/Sources/AppDelegate+WindowFramePolicy.swift
+++ b/Sources/AppDelegate+WindowFramePolicy.swift
@@ -1,30 +1,6 @@
 import AppKit
 
 extension AppDelegate {
-    /// Exact restoration is safe only while the saved size still fits its
-    /// display. Interactive sizing cannot create an oversized frame, so one
-    /// indicates programmatic growth and must not be resurrected at launch.
-    nonisolated static func preservingOrClampingExactFrame(
-        _ frame: CGRect,
-        targetDisplay: SessionDisplayGeometry,
-        availableDisplays: [SessionDisplayGeometry],
-        minWidth: CGFloat,
-        minHeight: CGFloat
-    ) -> CGRect {
-        let displayUnion = availableDisplays.map(\.frame).reduce(CGRect.null) { $0.union($1) }
-        let maximumFrame = displayUnion.isNull ? targetDisplay.frame : displayUnion
-        guard frame.width > maximumFrame.width + 1
-                || frame.height > maximumFrame.height + 1 else {
-            return frame
-        }
-        return clampFrame(
-            frame,
-            within: targetDisplay.visibleFrame,
-            minWidth: minWidth,
-            minHeight: minHeight
-        )
-    }
-
     nonisolated static func shouldPreserveAccessibleFrame(
         frame: CGRect,
         targetDisplay: SessionDisplayGeometry

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3560,6 +3560,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     minHeight: minHeight
                 )
             }
+        } else if availableDisplays.contains(where: { $0.visibleFrame.intersects(frame) }) {
+            resolvedFrame = frame
         } else if let fallbackDisplay,
                   let sourceReference = displaySnapshot?.visibleFrame?.cgRect ?? displaySnapshot?.frame?.cgRect {
             resolvedFrame = remappedFrame(
@@ -3581,10 +3583,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             resolvedFrame = frame
         }
 
-        // Display identity decides whether the saved coordinates can be reused
-        // or must first be remapped. Visibility is a separate invariant: every
-        // restored candidate passes through the same fit core used after live
-        // display-topology changes.
+        // Display identity and overlap with current displays decide whether the
+        // saved coordinates can be reused or must first be remapped. Visibility
+        // is a separate invariant: every restored candidate passes through the
+        // same fit core used after live display-topology changes.
         return MainWindowVisibleFrameFitCore().fittedFrame(
             for: resolvedFrame,
             displays: availableDisplays,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3543,63 +3543,65 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         guard !availableDisplays.isEmpty else { return frame }
 
+        let resolvedFrame: CGRect
         if let targetDisplay = display(for: displaySnapshot, in: availableDisplays) {
-            if shouldPreserveExactFrame(
+            if canReuseSavedDisplayCoordinates(
                 frame: frame,
                 displaySnapshot: displaySnapshot,
                 targetDisplay: targetDisplay
             ) {
-                return preservingOrClampingExactFrame(frame, targetDisplay: targetDisplay, availableDisplays: availableDisplays, minWidth: minWidth, minHeight: minHeight)
+                resolvedFrame = frame
+            } else {
+                resolvedFrame = resolvedWindowFrame(
+                    frame: frame,
+                    displaySnapshot: displaySnapshot,
+                    targetDisplay: targetDisplay,
+                    minWidth: minWidth,
+                    minHeight: minHeight
+                )
             }
-            return resolvedWindowFrame(
-                frame: frame,
-                displaySnapshot: displaySnapshot,
-                availableDisplays: availableDisplays,
-                targetDisplay: targetDisplay,
-                minWidth: minWidth,
-                minHeight: minHeight
-            )
-        }
-
-        if let intersectingDisplay = availableDisplays.first(where: { $0.visibleFrame.intersects(frame) }) {
-            return clampFrame(
-                frame,
-                within: intersectingDisplay.visibleFrame,
-                minWidth: minWidth,
-                minHeight: minHeight
-            )
-        }
-
-        guard let fallbackDisplay else { return frame }
-        if let sourceReference = displaySnapshot?.visibleFrame?.cgRect ?? displaySnapshot?.frame?.cgRect {
-            return remappedFrame(
+        } else if let fallbackDisplay,
+                  let sourceReference = displaySnapshot?.visibleFrame?.cgRect ?? displaySnapshot?.frame?.cgRect {
+            resolvedFrame = remappedFrame(
                 frame,
                 from: sourceReference,
                 to: fallbackDisplay.visibleFrame,
                 minWidth: minWidth,
                 minHeight: minHeight
             )
+        } else if let fallbackDisplay,
+                  !availableDisplays.contains(where: { $0.visibleFrame.intersects(frame) }) {
+            resolvedFrame = centeredFrame(
+                frame,
+                in: fallbackDisplay.visibleFrame,
+                minWidth: minWidth,
+                minHeight: minHeight
+            )
+        } else {
+            resolvedFrame = frame
         }
 
-        return centeredFrame(
-            frame,
-            in: fallbackDisplay.visibleFrame,
-            minWidth: minWidth,
-            minHeight: minHeight
-        )
+        // Display identity decides whether the saved coordinates can be reused
+        // or must first be remapped. Visibility is a separate invariant: every
+        // restored candidate passes through the same fit core used after live
+        // display-topology changes.
+        return MainWindowVisibleFrameFitCore().fittedFrame(
+            for: resolvedFrame,
+            displays: availableDisplays,
+            minimumWidth: minWidth,
+            minimumHeight: minHeight
+        ) ?? resolvedFrame
     }
 
     private nonisolated static func resolvedWindowFrame(
         frame: CGRect,
         displaySnapshot: SessionDisplaySnapshot?,
-        availableDisplays: [SessionDisplayGeometry],
         targetDisplay: SessionDisplayGeometry,
         minWidth: CGFloat,
         minHeight: CGFloat
     ) -> CGRect {
-        let fitCore = MainWindowVisibleFrameFitCore()
         if targetDisplay.visibleFrame.intersects(frame) {
-            return fitCore.fittedFrame(for: frame, displays: availableDisplays, minimumWidth: minWidth, minimumHeight: minHeight) ?? frame
+            return frame
         }
 
         if let sourceReference = displaySnapshot?.visibleFrame?.cgRect ?? displaySnapshot?.frame?.cgRect {
@@ -3690,7 +3692,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return clampFrame(centered, within: visibleFrame, minWidth: minWidth, minHeight: minHeight)
     }
 
-    private nonisolated static func shouldPreserveExactFrame(
+    private nonisolated static func canReuseSavedDisplayCoordinates(
         frame: CGRect,
         displaySnapshot: SessionDisplaySnapshot?,
         targetDisplay: SessionDisplayGeometry

--- a/cmuxTests/AppDelegateOversizedFrameRestoreTests.swift
+++ b/cmuxTests/AppDelegateOversizedFrameRestoreTests.swift
@@ -36,6 +36,37 @@ struct AppDelegateOversizedFrameRestoreTests {
     }
 
     @Test
+    func replacementDisplayPreservesAlreadyVisibleSavedFrameCoordinates() throws {
+        let builtInDisplay = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            stableID: "uuid:BUILTIN",
+            frame: CGRect(x: 0, y: 0, width: 1_512, height: 982),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_512, height: 944)
+        )
+        let replacementDisplay = AppDelegate.SessionDisplayGeometry(
+            displayID: 3,
+            stableID: "uuid:NEW-EXTERNAL",
+            frame: CGRect(x: 1_512, y: 0, width: 2_560, height: 1_440),
+            visibleFrame: CGRect(x: 1_512, y: 0, width: 2_560, height: 1_415)
+        )
+        let savedFrame = CGRect(x: 1_700, y: 100, width: 900, height: 700)
+        let restored = try #require(AppDelegate.resolvedWindowFrame(
+            from: SessionRectSnapshot(savedFrame),
+            display: SessionDisplaySnapshot(
+                displayID: 2,
+                stableID: "uuid:OLD-EXTERNAL",
+                frame: SessionRectSnapshot(replacementDisplay.frame),
+                visibleFrame: SessionRectSnapshot(replacementDisplay.visibleFrame)
+            ),
+            availableDisplays: [builtInDisplay, replacementDisplay],
+            fallbackDisplay: builtInDisplay
+        ))
+
+        #expect(restored == savedFrame)
+        #expect(replacementDisplay.visibleFrame.contains(restored))
+    }
+
+    @Test
     func oversizedSavedFrameClampsToItsDisplay() throws {
         let visible = CGRect(x: 0, y: 0, width: 1_512, height: 944)
         let display = AppDelegate.SessionDisplayGeometry(

--- a/cmuxTests/AppDelegateOversizedFrameRestoreTests.swift
+++ b/cmuxTests/AppDelegateOversizedFrameRestoreTests.swift
@@ -90,7 +90,7 @@ struct AppDelegateOversizedFrameRestoreTests {
     }
 
     @Test
-    func fullPhysicalDisplayHeightIsPreserved() {
+    func fullPhysicalDisplayHeightIsFittedToVisibleFrame() throws {
         let display = AppDelegate.SessionDisplayGeometry(
             displayID: 1,
             stableID: "uuid:BUILTIN",
@@ -99,15 +99,66 @@ struct AppDelegateOversizedFrameRestoreTests {
         )
         let saved = CGRect(x: 0, y: 0, width: 1_200, height: 982)
 
-        let restored = AppDelegate.preservingOrClampingExactFrame(
-            saved,
-            targetDisplay: display,
+        let restored = try #require(AppDelegate.resolvedWindowFrame(
+            from: SessionRectSnapshot(saved),
+            display: SessionDisplaySnapshot(
+                displayID: 1,
+                stableID: "uuid:BUILTIN",
+                frame: SessionRectSnapshot(display.frame),
+                visibleFrame: SessionRectSnapshot(display.visibleFrame)
+            ),
             availableDisplays: [display],
-            minWidth: 400,
-            minHeight: 300
-        )
+            fallbackDisplay: display
+        ))
 
-        #expect(restored == saved)
+        #expect(restored == CGRect(x: 0, y: 0, width: 1_200, height: 944))
+        #expect(display.visibleFrame.contains(restored))
+    }
+
+    @Test
+    func unchangedDisplayStillFitsSavedFrameToItsVisibleFrame() throws {
+        let visible = CGRect(x: 0, y: 0, width: 2_560, height: 1_410)
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 2,
+            frame: CGRect(x: 0, y: 0, width: 2_560, height: 1_440),
+            visibleFrame: visible
+        )
+        let restored = try #require(AppDelegate.resolvedWindowFrame(
+            from: SessionRectSnapshot(x: 1_303, y: -90, width: 1_280, height: 1_410),
+            display: SessionDisplaySnapshot(
+                displayID: 2,
+                frame: SessionRectSnapshot(display.frame),
+                visibleFrame: SessionRectSnapshot(visible)
+            ),
+            availableDisplays: [display],
+            fallbackDisplay: display
+        ))
+
+        #expect(restored == CGRect(x: 1_280, y: 0, width: 1_280, height: 1_410))
+        #expect(visible.contains(restored))
+    }
+
+    @Test
+    func changedVisibleFrameFitsOtherwiseAccessibleSavedFrame() throws {
+        let visible = CGRect(x: 0, y: 40, width: 2_560, height: 1_360)
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 2,
+            frame: CGRect(x: 0, y: 0, width: 2_560, height: 1_440),
+            visibleFrame: visible
+        )
+        let restored = try #require(AppDelegate.resolvedWindowFrame(
+            from: SessionRectSnapshot(x: 1_100, y: -20, width: 1_280, height: 1_000),
+            display: SessionDisplaySnapshot(
+                displayID: 2,
+                frame: SessionRectSnapshot(display.frame),
+                visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 2_560, height: 1_410)
+            ),
+            availableDisplays: [display],
+            fallbackDisplay: display
+        ))
+
+        #expect(restored == CGRect(x: 1_100, y: 40, width: 1_280, height: 1_000))
+        #expect(visible.contains(restored))
     }
 
     @Test

--- a/cmuxTests/AppDelegateOversizedFrameRestoreTests.swift
+++ b/cmuxTests/AppDelegateOversizedFrameRestoreTests.swift
@@ -11,6 +11,31 @@ import Testing
 @MainActor
 struct AppDelegateOversizedFrameRestoreTests {
     @Test
+    func sameDisplaySavedFrameCutOffPastLeftEdgeIsFittedToVisibleFrame() throws {
+        let visible = CGRect(x: 0, y: 0, width: 1_512, height: 944)
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            stableID: "uuid:BUILTIN",
+            frame: CGRect(x: 0, y: 0, width: 1_512, height: 982),
+            visibleFrame: visible
+        )
+        let restored = try #require(AppDelegate.resolvedWindowFrame(
+            from: SessionRectSnapshot(CGRect(x: -240, y: 120, width: 900, height: 700)),
+            display: SessionDisplaySnapshot(
+                displayID: 1,
+                stableID: "uuid:BUILTIN",
+                frame: SessionRectSnapshot(display.frame),
+                visibleFrame: SessionRectSnapshot(visible)
+            ),
+            availableDisplays: [display],
+            fallbackDisplay: display
+        ))
+
+        #expect(restored == CGRect(x: 0, y: 120, width: 900, height: 700))
+        #expect(visible.contains(restored))
+    }
+
+    @Test
     func oversizedSavedFrameClampsToItsDisplay() throws {
         let visible = CGRect(x: 0, y: 0, width: 1_512, height: 944)
         let display = AppDelegate.SessionDisplayGeometry(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1188,62 +1188,6 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertEqual(restored.height, 700, accuracy: 0.001)
     }
 
-    func testResolvedWindowFramePreservesExactGeometryWhenDisplayIsUnchanged() {
-        let savedFrame = SessionRectSnapshot(x: 1_303, y: -90, width: 1_280, height: 1_410)
-        let savedDisplay = SessionDisplaySnapshot(
-            displayID: 2,
-            frame: SessionRectSnapshot(x: 0, y: 0, width: 2_560, height: 1_440),
-            visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 2_560, height: 1_410)
-        )
-        let display = AppDelegate.SessionDisplayGeometry(
-            displayID: 2,
-            frame: CGRect(x: 0, y: 0, width: 2_560, height: 1_440),
-            visibleFrame: CGRect(x: 0, y: 0, width: 2_560, height: 1_410)
-        )
-
-        let restored = AppDelegate.resolvedWindowFrame(
-            from: savedFrame,
-            display: savedDisplay,
-            availableDisplays: [display],
-            fallbackDisplay: display
-        )
-
-        XCTAssertNotNil(restored)
-        guard let restored else { return }
-        XCTAssertEqual(restored.minX, 1_303, accuracy: 0.001)
-        XCTAssertEqual(restored.minY, -90, accuracy: 0.001)
-        XCTAssertEqual(restored.width, 1_280, accuracy: 0.001)
-        XCTAssertEqual(restored.height, 1_410, accuracy: 0.001)
-    }
-
-    func testResolvedWindowFramePreservesExactGeometryWhenDisplayChangesButWindowRemainsAccessible() {
-        let savedFrame = SessionRectSnapshot(x: 1_100, y: -20, width: 1_280, height: 1_000)
-        let savedDisplay = SessionDisplaySnapshot(
-            displayID: 2,
-            frame: SessionRectSnapshot(x: 0, y: 0, width: 2_560, height: 1_440),
-            visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 2_560, height: 1_410)
-        )
-        let adjustedDisplay = AppDelegate.SessionDisplayGeometry(
-            displayID: 2,
-            frame: CGRect(x: 0, y: 0, width: 2_560, height: 1_440),
-            visibleFrame: CGRect(x: 0, y: 40, width: 2_560, height: 1_360)
-        )
-
-        let restored = AppDelegate.resolvedWindowFrame(
-            from: savedFrame,
-            display: savedDisplay,
-            availableDisplays: [adjustedDisplay],
-            fallbackDisplay: adjustedDisplay
-        )
-
-        XCTAssertNotNil(restored)
-        guard let restored else { return }
-        XCTAssertEqual(restored.minX, 1_100, accuracy: 0.001)
-        XCTAssertEqual(restored.minY, -20, accuracy: 0.001)
-        XCTAssertEqual(restored.width, 1_280, accuracy: 0.001)
-        XCTAssertEqual(restored.height, 1_000, accuracy: 0.001)
-    }
-
     func testResolvedWindowFrameClampsWhenDisplayGeometryChangesEvenWithSameDisplayID() {
         let savedFrame = SessionRectSnapshot(x: 1_303, y: -90, width: 1_280, height: 1_410)
         let savedDisplay = SessionDisplaySnapshot(


### PR DESCRIPTION
## Summary

- make `MainWindowVisibleFrameFitCore` the final invariant gate for every restored main-window frame, including snapshots whose display identity and geometry still match
- preserve exact saved coordinates only as the pre-fit candidate; remap changed displays first, then clamp or shrink against the union of current `visibleFrame`s
- keep ordinary interactive placement governed by the existing lenient titlebar-reachability policy, so this does not clamp every live drag or break adjacent-display spanning
- migrate contradictory restore expectations into Swift Testing and cover left-edge cutoff plus menu-bar/Dock visible-frame insets

## Root cause

#7308 already added the correct pure visible-frame fit core and live topology integration, but the launch resolver bypassed it when the saved display snapshot matched the current display. That path returned any finite, normal-sized frame verbatim, even when part of the window lay outside the current visible frame. A separate oversized-frame safeguard later preserved the same bypass for every frame smaller than the full display union.

This left two competing restore invariants: titlebar reachability allowed clipped frames, while visible-frame coverage repaired them only on changed-display paths. The resolver now uses display identity only to choose whether coordinates need remapping; all resolved candidates then pass through the shared visible-frame fit core.

## Regression proof

Commit `f1c5003b68` adds the failing test only. It restores a same-display 900x700 window from `x = -240` and expects it at `x = 0`; current `main` returns the clipped frame unchanged. The following commit applies the fix and updates the conflicting legacy expectations.

## Validation

- Not run locally per task instruction: app build, `xcodebuild`, unit test target, or XCUITests
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `git diff --check origin/main...HEAD`
- `scripts/swift_file_length_budget.py` is not present on current `origin/main`; all touched production files are net-shrunk or line-count neutral, and the existing Swift Testing file remains under 500 lines

## Cloud Mac

A cloud macOS runner reached the GUI-ready hold step, but this workstation could not resolve or enumerate the runner on the tailnet, so SSH/CUA and the required full-screen recording were unavailable. The unreachable lease was cancelled: https://github.com/manaflow-ai/cmux-loader/actions/runs/29957345415

## Localization

No user-facing strings or localized surfaces changed.

Closes #8669

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787346843&installation_model_id=21920&pr_number=8675&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8675&signature=5f8cfb240894d515734a239fc3f02867f99d18b1920b7e1a511bda263ef88ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fit every restored main-window frame to the current visible display bounds to prevent off-screen placement, even when the saved display is unchanged. Preserve coordinates when the saved frame is already fully visible on a replacement display; add Swift Testing for left-edge cutoff (x = -240 → 0), unchanged/inset-adjusted displays, and replacement-display preservation, addressing #8669.

<sup>Written for commit 82c7d88d86c7ea1f5a961c28c9a60d56a38cd3dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window restoration when a saved window extends beyond the left edge (or other visibility bounds) of the current display.
  * Restored windows are now consistently fitted to the display’s visible area, including updated behavior when display geometry changes.
* **Tests**
  * Updated and added regression coverage to verify the restored frame is correctly resized/remapped and remains within the visible frame constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->