### PR TITLE
Make sidebar scheduler test deterministic

### DIFF
--- a/Sources/Sidebar/SidebarResizerOcclusionResolver.swift
+++ b/Sources/Sidebar/SidebarResizerOcclusionResolver.swift
@@ -2,8 +2,13 @@ import AppKit
 
 @MainActor
 final class SidebarResizerCursorReleaseScheduler {
+    private let clock: any Clock<Duration>
     private var pendingTask: Task<Void, Never>?
     private var generation: UInt64 = 0
+
+    init(clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
+    }
 
     func cancelPendingRelease() {
         generation &+= 1
@@ -19,10 +24,11 @@ final class SidebarResizerCursorReleaseScheduler {
         cancelPendingRelease()
 
         let scheduledGeneration = generation
-        pendingTask = Task { @MainActor [weak self] in
+        pendingTask = Task { @MainActor [weak self, clock] in
             if delay > .zero {
                 do {
-                    try await Task.sleep(for: delay)
+                    // Genuine cursor-release delay; replacing or cancelling the request cancels this task.
+                    try await clock.sleep(for: delay)
                 } catch {
                     return
                 }

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -48,7 +48,9 @@ private actor SidebarTestSleeperRegistrationGate {
     }
 }
 
-/// Deterministic clock: sleeps suspend until the test advances time.
+/// Deterministic clock: sleeps suspend until the test advances time. Every
+/// mutable field is protected by `lock`; `Clock` requires synchronous `now`
+/// and sleep registration, so actor isolation cannot provide the same API.
 final class SidebarTestManualClock: Clock, @unchecked Sendable {
     struct Instant: InstantProtocol, Sendable {
         var offset: Duration
@@ -104,6 +106,18 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         return waiters
     }
 
+    private func takeSleepWaitersLocked(
+        matching deadline: Instant
+    ) -> [CheckedContinuation<Void, Never>] {
+        var matchedWaiters: [CheckedContinuation<Void, Never>] = []
+        sleepWaiters.removeAll { waiter in
+            let matches = waiter.deadline == nil || waiter.deadline == deadline
+            if matches { matchedWaiters.append(waiter.continuation) }
+            return matches
+        }
+        return matchedWaiters
+    }
+
     var now: Instant {
         lock.lock()
         defer { lock.unlock() }
@@ -136,19 +150,16 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
                     return
                 }
                 if deadline <= _now {
-                    let waiters = takeIdleWaitersIfIdleLocked()
+                    let sleepWaiters = takeSleepWaitersLocked(matching: deadline)
+                    let idleWaiters = takeIdleWaitersIfIdleLocked()
                     lock.unlock()
                     continuation.resume()
-                    for waiter in waiters { waiter.resume() }
+                    for waiter in sleepWaiters { waiter.resume() }
+                    for waiter in idleWaiters { waiter.resume() }
                     return
                 }
                 sleepers[id] = Sleeper(deadline: deadline, continuation: continuation)
-                var matchedWaiters: [CheckedContinuation<Void, Never>] = []
-                sleepWaiters.removeAll { waiter in
-                    let matches = waiter.deadline == nil || waiter.deadline == deadline
-                    if matches { matchedWaiters.append(waiter.continuation) }
-                    return matches
-                }
+                let matchedWaiters = takeSleepWaitersLocked(matching: deadline)
                 lock.unlock()
                 for waiter in matchedWaiters { waiter.resume() }
             }

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -82,6 +82,8 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     private var pendingSleeperRegistrationIDs: Set<UUID> = []
     private var cancelledSleeperIDs: Set<UUID> = []
     private var sleepWaiters: [SleepWaiter] = []
+    private var sleepWaiterRegistrationCount = 0
+    private var sleepWaiterRegistrationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private var idleWaiters: [CheckedContinuation<Void, Never>] = []
     private var idleWaiterRegistrationCount = 0
     private var idleWaiterRegistrationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
@@ -175,9 +177,46 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
                 continuation.resume()
             } else {
                 sleepWaiters.append(SleepWaiter(deadline: deadline, continuation: continuation))
+                sleepWaiterRegistrationCount += 1
+                var registrationWaiters: [CheckedContinuation<Void, Never>] = []
+                sleepWaiterRegistrationWaiters.removeAll { waiter in
+                    if sleepWaiterRegistrationCount >= waiter.count {
+                        registrationWaiters.append(waiter.continuation)
+                        return true
+                    }
+                    return false
+                }
+                lock.unlock()
+                for waiter in registrationWaiters { waiter.resume() }
+            }
+        }
+    }
+
+    func waitUntilSleepWaiterRegistered(_ count: Int = 1) async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if sleepWaiterRegistrationCount >= count {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                sleepWaiterRegistrationWaiters.append((count, continuation))
                 lock.unlock()
             }
         }
+    }
+
+    var pendingSleepWaiterCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return sleepWaiters.count
+    }
+
+    func releasePendingSleepWaitersForTesting() {
+        lock.lock()
+        let waiters = sleepWaiters.map(\.continuation)
+        sleepWaiters.removeAll()
+        lock.unlock()
+        for waiter in waiters { waiter.resume() }
     }
 
     func advance(by duration: Duration, beforeResuming: () -> Void = {}) {
@@ -337,6 +376,30 @@ struct SidebarSelectionCoalescerTests {
         _ = await sleep.result
 
         #expect(clock.retainedCancellationMarkerCount == 0)
+    }
+
+    @Test
+    func overdueRegistrationReleasesMatchingSleepWaiters() async {
+        let registrationGate = SidebarTestSleeperRegistrationGate(isOpen: false)
+        let clock = SidebarTestManualClock {
+            await registrationGate.wait()
+        }
+        let sleep = Task {
+            try await clock.sleep(for: .milliseconds(100))
+        }
+        await registrationGate.waitUntilArrival(1)
+
+        let sleeping = Task {
+            await clock.waitUntilSleeping(for: .milliseconds(100))
+        }
+        await clock.waitUntilSleepWaiterRegistered()
+        clock.advance(by: .milliseconds(100))
+        await registrationGate.open()
+        _ = await sleep.result
+
+        #expect(clock.pendingSleepWaiterCount == 0)
+        clock.releasePendingSleepWaitersForTesting()
+        await sleeping.value
     }
 
     @Test

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -83,6 +83,8 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     private var cancelledSleeperIDs: Set<UUID> = []
     private var sleepWaiters: [SleepWaiter] = []
     private var idleWaiters: [CheckedContinuation<Void, Never>] = []
+    private var idleWaiterRegistrationCount = 0
+    private var idleWaiterRegistrationWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
     private let beforeRegisteringSleeper: @Sendable () async -> Void
 
     init(beforeRegisteringSleeper: @escaping @Sendable () async -> Void = {}) {
@@ -202,6 +204,29 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
                 continuation.resume()
             } else {
                 idleWaiters.append(continuation)
+                idleWaiterRegistrationCount += 1
+                var registrationWaiters: [CheckedContinuation<Void, Never>] = []
+                idleWaiterRegistrationWaiters.removeAll { waiter in
+                    if idleWaiterRegistrationCount >= waiter.count {
+                        registrationWaiters.append(waiter.continuation)
+                        return true
+                    }
+                    return false
+                }
+                lock.unlock()
+                for waiter in registrationWaiters { waiter.resume() }
+            }
+        }
+    }
+
+    func waitUntilIdleWaiterRegistered(_ count: Int = 1) async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if idleWaiterRegistrationCount >= count {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                idleWaiterRegistrationWaiters.append((count, continuation))
                 lock.unlock()
             }
         }
@@ -330,7 +355,7 @@ struct SidebarSelectionCoalescerTests {
             await clock.waitUntilIdle()
             idleReturned = true
         }
-        await drain()
+        await clock.waitUntilIdleWaiterRegistered()
         #expect(!idleReturned)
 
         sleep.cancel()
@@ -365,7 +390,7 @@ struct SidebarSelectionCoalescerTests {
             await clock.waitUntilIdle()
             idleReturned = true
         }
-        await drain()
+        await clock.waitUntilIdleWaiterRegistered()
         #expect(!idleReturned)
 
         clock.advance(by: .milliseconds(100))

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -25,9 +25,17 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         let continuation: CheckedContinuation<Void, any Error>
     }
 
+    private struct SleepWaiter {
+        let deadline: Instant?
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
     private let lock = NSLock()
     private var _now = Instant(offset: .zero)
-    private var sleepers: [Sleeper] = []
+    private var sleepers: [UUID: Sleeper] = [:]
+    private var cancelledSleeperIDs: Set<UUID> = []
+    private var sleepWaiters: [SleepWaiter] = []
+    private var idleWaiters: [CheckedContinuation<Void, Never>] = []
 
     var now: Instant {
         lock.lock()
@@ -38,33 +46,86 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     var minimumResolution: Duration { .zero }
 
     func sleep(until deadline: Instant, tolerance: Duration?) async throws {
-        try Task.checkCancellation()
-        let readyNow: Bool = {
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if cancelledSleeperIDs.remove(id) != nil {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if deadline <= _now {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                sleepers[id] = Sleeper(deadline: deadline, continuation: continuation)
+                var matchedWaiters: [CheckedContinuation<Void, Never>] = []
+                sleepWaiters.removeAll { waiter in
+                    let matches = waiter.deadline == nil || waiter.deadline == deadline
+                    if matches { matchedWaiters.append(waiter.continuation) }
+                    return matches
+                }
+                lock.unlock()
+                for waiter in matchedWaiters { waiter.resume() }
+            }
+        } onCancel: {
             lock.lock()
-            defer { lock.unlock() }
-            return deadline <= _now
-        }()
-        if readyNow { return }
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            let sleeper = sleepers.removeValue(forKey: id)
+            if sleeper == nil { cancelledSleeperIDs.insert(id) }
+            let waiters = sleepers.isEmpty ? idleWaiters : []
+            if sleepers.isEmpty { idleWaiters.removeAll() }
+            lock.unlock()
+            sleeper?.continuation.resume(throwing: CancellationError())
+            for waiter in waiters { waiter.resume() }
+        }
+    }
+
+    func waitUntilSleeping(for duration: Duration? = nil) async {
+        let deadline = duration.map { now.advanced(by: $0) }
+        await withCheckedContinuation { continuation in
             lock.lock()
-            if deadline <= _now {
+            let alreadySleeping = sleepers.values.contains { sleeper in
+                deadline == nil || sleeper.deadline == deadline
+            }
+            if alreadySleeping {
                 lock.unlock()
                 continuation.resume()
-                return
+            } else {
+                sleepWaiters.append(SleepWaiter(deadline: deadline, continuation: continuation))
+                lock.unlock()
             }
-            sleepers.append(Sleeper(deadline: deadline, continuation: continuation))
-            lock.unlock()
         }
     }
 
     func advance(by duration: Duration) {
         lock.lock()
         _now = _now.advanced(by: duration)
-        let due = sleepers.filter { $0.deadline <= _now }
-        sleepers.removeAll { $0.deadline <= _now }
+        var due: [Sleeper] = []
+        for (id, sleeper) in sleepers where sleeper.deadline <= _now {
+            sleepers[id] = nil
+            due.append(sleeper)
+        }
+        let waiters = sleepers.isEmpty ? idleWaiters : []
+        if sleepers.isEmpty { idleWaiters.removeAll() }
         lock.unlock()
         for sleeper in due {
             sleeper.continuation.resume()
+        }
+        for waiter in waiters { waiter.resume() }
+    }
+
+    func waitUntilIdle() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if sleepers.isEmpty {
+                lock.unlock()
+                continuation.resume()
+            } else {
+                idleWaiters.append(continuation)
+                lock.unlock()
+            }
         }
     }
 }

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -33,6 +33,7 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     private let lock = NSLock()
     private var _now = Instant(offset: .zero)
     private var sleepers: [UUID: Sleeper] = [:]
+    private var pendingSleeperRegistrationIDs: Set<UUID> = []
     private var cancelledSleeperIDs: Set<UUID> = []
     private var sleepWaiters: [SleepWaiter] = []
     private var idleWaiters: [CheckedContinuation<Void, Never>] = []
@@ -53,9 +54,13 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
 
     func sleep(until deadline: Instant, tolerance: Duration?) async throws {
         let id = UUID()
+        lock.lock()
+        pendingSleeperRegistrationIDs.insert(id)
+        lock.unlock()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                 lock.lock()
+                pendingSleeperRegistrationIDs.remove(id)
                 if cancelledSleeperIDs.remove(id) != nil {
                     lock.unlock()
                     continuation.resume(throwing: CancellationError())
@@ -79,7 +84,9 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         } onCancel: {
             lock.lock()
             let sleeper = sleepers.removeValue(forKey: id)
-            if sleeper == nil { cancelledSleeperIDs.insert(id) }
+            if sleeper == nil, pendingSleeperRegistrationIDs.contains(id) {
+                cancelledSleeperIDs.insert(id)
+            }
             let waiters = sleepers.isEmpty ? idleWaiters : []
             if sleepers.isEmpty { idleWaiters.removeAll() }
             lock.unlock()

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -83,9 +83,9 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     }
 
     func waitUntilSleeping(for duration: Duration? = nil) async {
-        let deadline = duration.map { now.advanced(by: $0) }
         await withCheckedContinuation { continuation in
             lock.lock()
+            let deadline = duration.map { _now.advanced(by: $0) }
             let alreadySleeping = sleepers.values.contains { sleeper in
                 deadline == nil || sleeper.deadline == deadline
             }
@@ -102,11 +102,10 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     func advance(by duration: Duration) {
         lock.lock()
         _now = _now.advanced(by: duration)
-        var due: [Sleeper] = []
-        for (id, sleeper) in sleepers where sleeper.deadline <= _now {
-            sleepers[id] = nil
-            due.append(sleeper)
+        let dueIDs = sleepers.compactMap { id, sleeper in
+            sleeper.deadline <= _now ? id : nil
         }
+        let due = dueIDs.compactMap { sleepers.removeValue(forKey: $0) }
         let waiters = sleepers.isEmpty ? idleWaiters : []
         if sleepers.isEmpty { idleWaiters.removeAll() }
         lock.unlock()

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -89,6 +89,17 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         self.beforeRegisteringSleeper = beforeRegisteringSleeper
     }
 
+    private var isIdleLocked: Bool {
+        sleepers.isEmpty && pendingSleeperRegistrationIDs.isEmpty
+    }
+
+    private func takeIdleWaitersIfIdleLocked() -> [CheckedContinuation<Void, Never>] {
+        guard isIdleLocked else { return [] }
+        let waiters = idleWaiters
+        idleWaiters.removeAll()
+        return waiters
+    }
+
     var now: Instant {
         lock.lock()
         defer { lock.unlock() }
@@ -114,13 +125,17 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
                 lock.lock()
                 pendingSleeperRegistrationIDs.remove(id)
                 if cancelledSleeperIDs.remove(id) != nil {
+                    let waiters = takeIdleWaitersIfIdleLocked()
                     lock.unlock()
                     continuation.resume(throwing: CancellationError())
+                    for waiter in waiters { waiter.resume() }
                     return
                 }
                 if deadline <= _now {
+                    let waiters = takeIdleWaitersIfIdleLocked()
                     lock.unlock()
                     continuation.resume()
+                    for waiter in waiters { waiter.resume() }
                     return
                 }
                 sleepers[id] = Sleeper(deadline: deadline, continuation: continuation)
@@ -139,8 +154,7 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
             if sleeper == nil, pendingSleeperRegistrationIDs.contains(id) {
                 cancelledSleeperIDs.insert(id)
             }
-            let waiters = sleepers.isEmpty ? idleWaiters : []
-            if sleepers.isEmpty { idleWaiters.removeAll() }
+            let waiters = takeIdleWaitersIfIdleLocked()
             lock.unlock()
             sleeper?.continuation.resume(throwing: CancellationError())
             for waiter in waiters { waiter.resume() }
@@ -171,8 +185,7 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
             sleeper.deadline <= _now ? id : nil
         }
         let due = dueIDs.compactMap { sleepers.removeValue(forKey: $0) }
-        let waiters = sleepers.isEmpty ? idleWaiters : []
-        if sleepers.isEmpty { idleWaiters.removeAll() }
+        let waiters = takeIdleWaitersIfIdleLocked()
         lock.unlock()
         beforeResuming()
         for sleeper in due {
@@ -184,7 +197,7 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     func waitUntilIdle() async {
         await withCheckedContinuation { continuation in
             lock.lock()
-            if sleepers.isEmpty {
+            if isIdleLocked {
                 lock.unlock()
                 continuation.resume()
             } else {

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -2,6 +2,52 @@ import Foundation
 import Testing
 @testable import cmux_DEV
 
+private actor SidebarTestSleeperRegistrationGate {
+    private var isOpen: Bool
+    private var arrivalCount = 0
+    private var blocked: [CheckedContinuation<Void, Never>] = []
+    private var arrivalWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    init(isOpen: Bool) {
+        self.isOpen = isOpen
+    }
+
+    func wait() async {
+        arrivalCount += 1
+        var reached: [CheckedContinuation<Void, Never>] = []
+        arrivalWaiters.removeAll { waiter in
+            if arrivalCount >= waiter.count {
+                reached.append(waiter.continuation)
+                return true
+            }
+            return false
+        }
+        for continuation in reached { continuation.resume() }
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            blocked.append(continuation)
+        }
+    }
+
+    func waitUntilArrival(_ count: Int) async {
+        guard arrivalCount < count else { return }
+        await withCheckedContinuation { continuation in
+            arrivalWaiters.append((count, continuation))
+        }
+    }
+
+    func close() {
+        isOpen = false
+    }
+
+    func open() {
+        isOpen = true
+        let continuations = blocked
+        blocked.removeAll()
+        for continuation in continuations { continuation.resume() }
+    }
+}
+
 /// Deterministic clock: sleeps suspend until the test advances time.
 final class SidebarTestManualClock: Clock, @unchecked Sendable {
     struct Instant: InstantProtocol, Sendable {
@@ -37,6 +83,11 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
     private var cancelledSleeperIDs: Set<UUID> = []
     private var sleepWaiters: [SleepWaiter] = []
     private var idleWaiters: [CheckedContinuation<Void, Never>] = []
+    private let beforeRegisteringSleeper: @Sendable () async -> Void
+
+    init(beforeRegisteringSleeper: @escaping @Sendable () async -> Void = {}) {
+        self.beforeRegisteringSleeper = beforeRegisteringSleeper
+    }
 
     var now: Instant {
         lock.lock()
@@ -57,6 +108,7 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         lock.lock()
         pendingSleeperRegistrationIDs.insert(id)
         lock.unlock()
+        await beforeRegisteringSleeper()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                 lock.lock()
@@ -247,5 +299,74 @@ struct SidebarSelectionCoalescerTests {
         _ = await sleep.result
 
         #expect(clock.retainedCancellationMarkerCount == 0)
+    }
+
+    @Test
+    func pendingRegistrationIsNotIdleUntilCancellationCleanupFinishes() async {
+        let registrationGate = SidebarTestSleeperRegistrationGate(isOpen: false)
+        let clock = SidebarTestManualClock {
+            await registrationGate.wait()
+        }
+        let sleep = Task {
+            try await clock.sleep(for: .milliseconds(100))
+        }
+        await registrationGate.waitUntilArrival(1)
+
+        var idleReturned = false
+        let idle = Task {
+            await clock.waitUntilIdle()
+            idleReturned = true
+        }
+        await drain()
+        #expect(!idleReturned)
+
+        sleep.cancel()
+        await drain()
+        #expect(!idleReturned)
+
+        await registrationGate.open()
+        _ = await sleep.result
+        await idle.value
+        #expect(idleReturned)
+    }
+
+    @Test
+    func advancingLastSleeperDoesNotBecomeIdleDuringAnotherRegistration() async {
+        let registrationGate = SidebarTestSleeperRegistrationGate(isOpen: true)
+        let clock = SidebarTestManualClock {
+            await registrationGate.wait()
+        }
+        let firstSleep = Task {
+            try await clock.sleep(for: .milliseconds(100))
+        }
+        await registrationGate.waitUntilArrival(1)
+        await clock.waitUntilSleeping(for: .milliseconds(100))
+        await registrationGate.close()
+        let pendingSleep = Task {
+            try await clock.sleep(for: .milliseconds(200))
+        }
+        await registrationGate.waitUntilArrival(2)
+
+        var idleReturned = false
+        let idle = Task {
+            await clock.waitUntilIdle()
+            idleReturned = true
+        }
+        await drain()
+        #expect(!idleReturned)
+
+        clock.advance(by: .milliseconds(100))
+        _ = await firstSleep.result
+        await drain()
+        #expect(!idleReturned)
+
+        pendingSleep.cancel()
+        await drain()
+        #expect(!idleReturned)
+
+        await registrationGate.open()
+        _ = await pendingSleep.result
+        await idle.value
+        #expect(idleReturned)
     }
 }

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -119,8 +119,8 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         lock.lock()
         pendingSleeperRegistrationIDs.insert(id)
         lock.unlock()
-        await beforeRegisteringSleeper()
         try await withTaskCancellationHandler {
+            await beforeRegisteringSleeper()
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                 lock.lock()
                 pendingSleeperRegistrationIDs.remove(id)

--- a/cmuxTests/SidebarSelectionCoalescerTests.swift
+++ b/cmuxTests/SidebarSelectionCoalescerTests.swift
@@ -45,6 +45,12 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
 
     var minimumResolution: Duration { .zero }
 
+    var retainedCancellationMarkerCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelledSleeperIDs.count
+    }
+
     func sleep(until deadline: Instant, tolerance: Duration?) async throws {
         let id = UUID()
         try await withTaskCancellationHandler {
@@ -99,7 +105,7 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         }
     }
 
-    func advance(by duration: Duration) {
+    func advance(by duration: Duration, beforeResuming: () -> Void = {}) {
         lock.lock()
         _now = _now.advanced(by: duration)
         let dueIDs = sleepers.compactMap { id, sleeper in
@@ -109,6 +115,7 @@ final class SidebarTestManualClock: Clock, @unchecked Sendable {
         let waiters = sleepers.isEmpty ? idleWaiters : []
         if sleepers.isEmpty { idleWaiters.removeAll() }
         lock.unlock()
+        beforeResuming()
         for sleeper in due {
             sleeper.continuation.resume()
         }
@@ -217,5 +224,21 @@ struct SidebarSelectionCoalescerTests {
         coalescer.request { applied.append("a") }
         coalescer.flushNow()
         #expect(applied == ["a"])
+    }
+
+    @Test
+    func cancellationAfterDeadlineDoesNotRetainMarker() async {
+        let clock = SidebarTestManualClock()
+        let sleep = Task {
+            try await clock.sleep(for: .milliseconds(100))
+        }
+
+        await clock.waitUntilSleeping(for: .milliseconds(100))
+        clock.advance(by: .milliseconds(100)) {
+            sleep.cancel()
+        }
+        _ = await sleep.result
+
+        #expect(clock.retainedCancellationMarkerCount == 0)
     }
 }

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -77,31 +77,49 @@ final class WorkspaceContentViewVisibilityTests {
 
     @Test
     @MainActor
-    func sidebarResizerCursorReleaseSchedulerCancelsReplacedDelayedRelease() async throws {
-        let scheduler = SidebarResizerCursorReleaseScheduler()
+    func sidebarResizerCursorReleaseSchedulerCancelsReplacedDelayedRelease() async {
+        let clock = SidebarTestManualClock()
+        let scheduler = SidebarResizerCursorReleaseScheduler(clock: clock)
+        let releaseEvents = AsyncStream<Bool>.makeStream()
+        defer { releaseEvents.continuation.finish() }
+        var releaseIterator = releaseEvents.stream.makeAsyncIterator()
         var releases: [Bool] = []
 
         scheduler.schedule(force: false, delay: .zero) { force in
             releases.append(force)
+            releaseEvents.continuation.yield(force)
         }
         #expect(releases.isEmpty)
-        try await Task.sleep(for: .milliseconds(10))
+        let immediateRelease = await releaseIterator.next()
+        #expect(immediateRelease == false)
         #expect(releases == [false])
         releases.removeAll()
 
         scheduler.schedule(force: false, delay: .milliseconds(200)) { force in
             releases.append(force)
+            releaseEvents.continuation.yield(force)
         }
+        await clock.waitUntilSleeping(for: .milliseconds(200))
         scheduler.schedule(force: true, delay: .milliseconds(10)) { force in
             releases.append(force)
+            releaseEvents.continuation.yield(force)
         }
+        await clock.waitUntilSleeping(for: .milliseconds(10))
 
-        try await Task.sleep(for: .milliseconds(80))
+        clock.advance(by: .milliseconds(10))
+        let replacementRelease = await releaseIterator.next()
+        #expect(replacementRelease == true)
         #expect(releases == [true])
 
-        scheduler.cancelPendingRelease()
-        try await Task.sleep(for: .milliseconds(160))
-        #expect(releases == [true])
+        await clock.waitUntilIdle()
+        clock.advance(by: .milliseconds(190))
+        scheduler.schedule(force: true, delay: .zero) { force in
+            releases.append(force)
+            releaseEvents.continuation.yield(force)
+        }
+        let sentinelRelease = await releaseIterator.next()
+        #expect(sentinelRelease == true)
+        #expect(releases == [true, true])
     }
 
     @Test


### PR DESCRIPTION
Inject a Clock into SidebarResizerCursorReleaseScheduler while preserving ContinuousClock in production.

Upgrade the shared sidebar manual clock with cancellation-aware sleepers and causal wait signals. Replace wall-clock sleeps in WorkspaceContentViewVisibilityTests with manual advancement and release events.

Validation:
- `python3 scripts/check-test-determinism.py --strict` (0 findings)
- `git diff --check`
- Exact stack CI will exercise the app-host tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787347662&installation_model_id=21920&pr_number=8676&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8676&signature=3c08d065267c0b010deb64a98aac68dac10222d89dab6fd07f0eb5c2bf298344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes sidebar cursor-release scheduling tests deterministic by injecting a `Clock` and running them on a manual test clock. Adds pending-registration–aware idle tracking, sleep-waiter registration signaling, and cancellation gating to prevent flakiness while production stays on `ContinuousClock`.

- **Refactors**
  - Inject `clock` into `SidebarResizerCursorReleaseScheduler` (default `ContinuousClock`) and use `clock.sleep` for delays.
  - Expand `SidebarTestManualClock` with UUID-keyed sleepers, `beforeRegisteringSleeper`, pending-registration inclusion in `waitUntilIdle`, sleep-waiter sync APIs (`waitUntilSleeping(for:)`, `waitUntilSleepWaiterRegistered`, `pendingSleepWaiterCount`, `releasePendingSleepWaitersForTesting`), idle-waiter registration signaling (`waitUntilIdleWaiterRegistered`), and bounded cancellation markers (`retainedCancellationMarkerCount`).
  - Update tests to deterministically assert immediate, delayed, replaced, and cancelled releases using `AsyncStream`; add a sleeper registration gate to avoid races; replace wall-clock sleeps with manual advancement; cover overdue sleep-waiter registration and cleanup (no retained cancellation markers, idle waits include pending registrations).

<sup>Written for commit 2d88b04d7c32594312c7f24189c24ae82816f200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar resizer cursor-release scheduling by using an injected, controllable timing source for delayed releases, while preserving correct cancellation, replacement, and forced-release behavior.

- **Tests**
  - Updated workspace/sidebar visibility and resizer tests to deterministically observe delayed and replaced release actions using a controllable manual clock and event-driven assertions.
  - Enhanced the test manual clock (idle detection, deadline/idle wait handling, cancellation cleanup tracking) and added new concurrency coverage for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->