### PR TITLE
Fix remote PTY PATH inherited from cmuxd

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -107,6 +107,7 @@ const (
 	defaultPTYInputChunkBytes        = 16 * 1024
 	defaultWebSocketWriteTimeout     = 10 * time.Second
 	defaultWebSocketSessionIdleTTL   = 24 * time.Hour
+	standardExecutablePath           = "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 )
 
 type wsPTYOutgoingFrame struct {
@@ -680,6 +681,7 @@ func defaultWebSocketPTYEnv(shellPath string) []string {
 		}
 	}
 
+	set("PATH", pathWithStandardExecutableDirectories(env["PATH"]))
 	set("TERM", "xterm-256color")
 	setIfMissing("COLORTERM", "truecolor")
 	setIfMissing("TERM_PROGRAM", "ghostty")
@@ -701,6 +703,22 @@ func defaultWebSocketPTYEnv(shellPath string) []string {
 		out = append(out, key+"="+env[key])
 	}
 	return out
+}
+
+func pathWithStandardExecutableDirectories(inheritedPath string) string {
+	entries := filepath.SplitList(inheritedPath)
+	present := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		present[entry] = struct{}{}
+	}
+	for _, standardDirectory := range filepath.SplitList(standardExecutablePath) {
+		if _, ok := present[standardDirectory]; ok {
+			continue
+		}
+		entries = append(entries, standardDirectory)
+		present[standardDirectory] = struct{}{}
+	}
+	return strings.Join(entries, string(os.PathListSeparator))
 }
 
 func envMapWithOrder(values []string) (map[string]string, []string) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -17,7 +17,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1725,6 +1724,7 @@ func TestDefaultWebSocketPTYEnvAddsStandardExecutableDirectories(t *testing.T) {
 	}{
 		{name: "restricted daemon PATH", inheritedPath: "/opt/cmux/bin"},
 		{name: "empty daemon PATH", inheritedPath: ""},
+		{name: "partially complete daemon PATH", inheritedPath: "/opt/cmux/bin:/usr/bin"},
 	}
 
 	for _, test := range tests {
@@ -1733,7 +1733,8 @@ func TestDefaultWebSocketPTYEnvAddsStandardExecutableDirectories(t *testing.T) {
 
 			env, _ := envMapWithOrder(defaultWebSocketPTYEnv("/bin/sh"))
 			pathEntries := strings.Split(env["PATH"], string(os.PathListSeparator))
-			if test.inheritedPath != "" && pathEntries[0] != test.inheritedPath {
+			inheritedPrefix := test.inheritedPath + string(os.PathListSeparator)
+			if test.inheritedPath != "" && env["PATH"] != test.inheritedPath && !strings.HasPrefix(env["PATH"], inheritedPrefix) {
 				t.Fatalf("PATH should preserve inherited entries first, got %q", env["PATH"])
 			}
 			for _, standardDirectory := range []string{
@@ -1744,12 +1745,22 @@ func TestDefaultWebSocketPTYEnvAddsStandardExecutableDirectories(t *testing.T) {
 				"/usr/sbin",
 				"/sbin",
 			} {
-				if !slices.Contains(pathEntries, standardDirectory) {
-					t.Errorf("PATH %q is missing standard directory %q", env["PATH"], standardDirectory)
+				if count := countStrings(pathEntries, standardDirectory); count != 1 {
+					t.Errorf("PATH %q contains standard directory %q %d times, want once", env["PATH"], standardDirectory, count)
 				}
 			}
 		})
 	}
+}
+
+func countStrings(values []string, target string) int {
+	count := 0
+	for _, value := range values {
+		if value == target {
+			count++
+		}
+	}
+	return count
 }
 
 func TestWebSocketPTYSeedsUTF8LocaleAndTerminalEnv(t *testing.T) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -17,6 +17,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1714,6 +1715,40 @@ func TestWebSocketPTYScrollbackDoesNotRetainOversizedChunks(t *testing.T) {
 	}
 	if !strings.HasSuffix(string(session.scrollback), "tail") {
 		t.Fatalf("scrollback should retain newest output, got suffix %q", string(session.scrollback[len(session.scrollback)-16:]))
+	}
+}
+
+func TestDefaultWebSocketPTYEnvAddsStandardExecutableDirectories(t *testing.T) {
+	tests := []struct {
+		name          string
+		inheritedPath string
+	}{
+		{name: "restricted daemon PATH", inheritedPath: "/opt/cmux/bin"},
+		{name: "empty daemon PATH", inheritedPath: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("PATH", test.inheritedPath)
+
+			env, _ := envMapWithOrder(defaultWebSocketPTYEnv("/bin/sh"))
+			pathEntries := strings.Split(env["PATH"], string(os.PathListSeparator))
+			if test.inheritedPath != "" && pathEntries[0] != test.inheritedPath {
+				t.Fatalf("PATH should preserve inherited entries first, got %q", env["PATH"])
+			}
+			for _, standardDirectory := range []string{
+				"/usr/local/bin",
+				"/usr/bin",
+				"/bin",
+				"/usr/local/sbin",
+				"/usr/sbin",
+				"/sbin",
+			} {
+				if !slices.Contains(pathEntries, standardDirectory) {
+					t.Errorf("PATH %q is missing standard directory %q", env["PATH"], standardDirectory)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- establish a single PATH invariant at the shared cmuxd-remote PTY environment boundary
- preserve inherited PATH precedence while appending each missing standard executable directory
- provide the same sane baseline when the daemon PATH is empty
- cover restricted, empty, and partially complete daemon PATH values with a red/green regression sequence

Both persistent SSH PTYs and cloud WebSocket PTYs use this environment builder. The audit found no non-PTY user-command execution path in cmuxd-remote; the other exec paths are daemon self-spawn or explicit CLI agent launch and intentionally retain their existing semantics.

## Verification

- `go test ./... -skip ^TestTerminateProcessesRunsOnlyOnce$`
- `go test -race ./cmd/cmuxd-remote -run ^TestDefaultWebSocketPTYEnvAddsStandardExecutableDirectories$ -count=1`
- `go vet ./...`
- no Swift files or Swift warning budgets changed

A bare local `go test ./...` also runs the new regression successfully, but origin/main currently fails the unrelated `TestTerminateProcessesRunsOnlyOnce` test deterministically on this Mac (2 teardown calls, expected 1). This branch does not alter that lifecycle code.

Closes #8618

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787347843&installation_model_id=21920&pr_number=8677&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8677&signature=22f4ab6aa5d3ee585e6e3a512fae2fd0a2dbbc9cf617d7791c39d5dcffd57d77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PATH handling for remote PTYs in `cmuxd-remote` by appending standard executable directories while preserving inherited order. Ensures SSH and WebSocket PTYs get a consistent PATH even when the daemon PATH is restricted or empty. Addresses #8618.

- **Bug Fixes**
  - Preserve inherited PATH precedence and append missing standard dirs: /usr/local/bin, /usr/bin, /bin, /usr/local/sbin, /usr/sbin, /sbin.
  - Ensure each standard directory appears once and provide a sane default when PATH is empty.
  - Apply via the shared PTY environment builder used by both SSH and WebSocket PTYs.
  - Add regression tests for restricted, empty, and partially complete daemon PATH values.

<sup>Written for commit 8cfa15a1103a435e9720b95540b1117a6a089e23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote terminal sessions by ensuring standard executable directories are included in the command search path.
  * Preserved existing path entries and prevented duplicate directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->