### PR TITLE
Allow internal TestFlight bundle id for APNs device-token registration

### DIFF
--- a/web/services/apns/routePolicy.ts
+++ b/web/services/apns/routePolicy.ts
@@ -65,7 +65,15 @@ export type JsonObjectResult =
   | { readonly ok: false; readonly error: "invalid_json" | "request_too_large" };
 
 const DEV_TAGGED_BUNDLE_ID = /^dev\.cmux\.ios\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
-const PROD_BUNDLE_IDS = new Set(["com.cmux.app", "com.cmuxterm.app", "dev.cmux.app.beta"]);
+// Every TestFlight lane (beta AND internal) uses the production APNs
+// environment; the internal lane's bundle id is set in
+// .github/workflows/ios-testflight.yml (IOS_BETA_BUNDLE_ID).
+const PROD_BUNDLE_IDS = new Set([
+  "com.cmux.app",
+  "com.cmuxterm.app",
+  "dev.cmux.app.beta",
+  "dev.cmux.app.internal",
+]);
 
 function stringValue(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -190,6 +190,17 @@ describe("apns route policy", () => {
     expect(normalizeApnsBundle("dev.cmux.ios.-bad")).toBeNull();
   });
 
+  test("allows the internal TestFlight bundle id as a production APNs topic", () => {
+    // The scheduled internal TestFlight lane ships dev.cmux.app.internal
+    // (.github/workflows/ios-testflight.yml); TestFlight uses the production
+    // APNs environment. Rejecting it here makes every internal-beta phone fail
+    // device-token registration with invalid_bundle_id, so pushes never arrive.
+    expect(normalizeApnsBundle("dev.cmux.app.internal")).toEqual({
+      bundleId: "dev.cmux.app.internal",
+      environment: "production",
+    });
+  });
+
   test("bounds and trims push payloads before sending to APNs", () => {
     const parsed = parsePushPayload({
       title: " agent ",


### PR DESCRIPTION
Since https://github.com/manaflow-ai/cmux/pull/8183 the scheduled internal TestFlight lane ships bundle id `dev.cmux.app.internal` (https://github.com/manaflow-ai/cmux/blob/main/.github/workflows/ios-testflight.yml), but `normalizeApnsBundle` in `web/services/apns/routePolicy.ts` only accepted `com.cmux.app`, `com.cmuxterm.app`, `dev.cmux.app.beta`, and `dev.cmux.ios.<tag>`. Every phone running the internal TestFlight app fails `POST /api/device-tokens` with `invalid_bundle_id` 400, so it never gets a `device_tokens` row and `POST /api/notifications/push` silently no-ops with `devices=0` for that user. Found while auditing why a teammate's phone receives no pushes.

The fix maps `dev.cmux.app.internal` to the production APNs environment, matching the beta lane (TestFlight builds always use production APNs; CI already gates the internal profile on `aps-environment=production`).

Two-commit structure: the first commit adds the failing regression test, the second adds the fix.

Verification: `bun test tests/apns.test.ts` (29 pass, new test red before fix), `bun run typecheck` clean.

After deploy, affected internal-beta users re-register automatically on next app launch or sign-in (the client re-POSTs its cached token when the push toggle is enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787348103&installation_model_id=21920&pr_number=8679&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8679&signature=c8989b403ee37f1bbe9814a422f8d7a8bb74d0e816c785a3b10831463545d7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes APNs device-token registration for internal TestFlight builds so those users receive push notifications again.

- **Bug Fixes**
  - Accept `dev.cmux.app.internal` in `normalizeApnsBundle` and map it to the production APNs environment.
  - Added a regression test to cover the internal TestFlight bundle ID.

- **Migration**
  - No action needed. Affected devices re-register on next app launch or sign-in.

<sup>Written for commit a9eafcd2c972460a563ebde7c4c180250aa12909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification routing for internal and beta TestFlight builds.
  * These builds now consistently use the production APNs environment, helping ensure notifications are delivered correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->