### PR TITLE
Fix Vault sidebar beachball at large session counts

### DIFF
--- a/Sources/SessionIndexEntryProjection.swift
+++ b/Sources/SessionIndexEntryProjection.swift
@@ -1,0 +1,41 @@
+/// Off-main projection of merged Vault entries into bounded UI snapshots.
+struct SessionIndexEntryProjection: Sendable {
+#if compiler(>=6.2)
+    @concurrent
+#else
+    @Sendable
+#endif
+    nonisolated func directorySnapshot(
+        cwd: String,
+        entries: [SessionEntry],
+        noFolderScope: Bool,
+        errors: [String]
+    ) async -> DirectorySnapshot {
+        let scoped = noFolderScope
+            ? entries.filter { ($0.cwd ?? "").isEmpty }
+            : entries
+        return DirectorySnapshot(
+            cwd: cwd,
+            entries: scoped.sorted { $0.modified > $1.modified },
+            errors: errors
+        )
+    }
+
+#if compiler(>=6.2)
+    @concurrent
+#else
+    @Sendable
+#endif
+    nonisolated func page(
+        entries: [SessionEntry],
+        noFolderScope: Bool,
+        offset: Int,
+        limit: Int
+    ) async -> [SessionEntry] {
+        let scoped = noFolderScope
+            ? entries.filter { ($0.cwd ?? "").isEmpty }
+            : entries
+        let sorted = scoped.sorted { $0.modified > $1.modified }
+        return Array(sorted.dropFirst(offset).prefix(limit))
+    }
+}

--- a/Sources/SessionIndexJSONLReadMetrics.swift
+++ b/Sources/SessionIndexJSONLReadMetrics.swift
@@ -1,0 +1,5 @@
+/// Bounded-work accounting returned by the shared Vault JSONL reader.
+struct SessionIndexJSONLReadMetrics: Equatable, Sendable {
+    let bytesRead: Int
+    let recordsVisited: Int
+}

--- a/Sources/SessionIndexJSONLReadMetrics.swift
+++ b/Sources/SessionIndexJSONLReadMetrics.swift
@@ -2,4 +2,18 @@
 struct SessionIndexJSONLReadMetrics: Equatable, Sendable {
     let bytesRead: Int
     let recordsVisited: Int
+    let didReachStart: Bool
+    let nextEndOffset: UInt64?
+
+    init(
+        bytesRead: Int,
+        recordsVisited: Int,
+        didReachStart: Bool = true,
+        nextEndOffset: UInt64? = nil
+    ) {
+        self.bytesRead = bytesRead
+        self.recordsVisited = recordsVisited
+        self.didReachStart = didReachStart
+        self.nextEndOffset = nextEndOffset
+    }
 }

--- a/Sources/SessionIndexJSONLReader.swift
+++ b/Sources/SessionIndexJSONLReader.swift
@@ -131,6 +131,8 @@ struct SessionIndexJSONLReader: Sendable {
             }
         }
 
+        // `nextEndOffset` is the next older page's exclusive `endingBeforeOffset`.
+        // `nil` means no earlier bytes remain; `didReachStart` reports that same terminal state.
         let nextEndOffset: UInt64?
         if !includesBoundaryContext {
             nextEndOffset = nil

--- a/Sources/SessionIndexJSONLReader.swift
+++ b/Sources/SessionIndexJSONLReader.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Streaming, byte-bounded JSONL reader shared by Vault index and preview paths.
+struct SessionIndexJSONLReader: Sendable {
+    private let chunkSize: Int
+
+    init(chunkSize: Int = 64 * 1024) {
+        self.chunkSize = max(1, chunkSize)
+    }
+
+    func fromStart(
+        url: URL,
+        maxBytes: Int,
+        body: ([String: Any]) -> Bool
+    ) -> SessionIndexJSONLReadMetrics {
+        guard maxBytes > 0, let handle = try? FileHandle(forReadingFrom: url) else {
+            return SessionIndexJSONLReadMetrics(bytesRead: 0, recordsVisited: 0)
+        }
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        var lineStart = buffer.startIndex
+        var bytesRead = 0
+        var recordsVisited = 0
+        var reachedEnd = false
+
+        while bytesRead < maxBytes {
+            let readCount = min(chunkSize, maxBytes - bytesRead)
+            let chunk = (try? handle.read(upToCount: readCount)) ?? Data()
+            if chunk.isEmpty {
+                reachedEnd = true
+                break
+            }
+            bytesRead += chunk.count
+            buffer.append(chunk)
+
+            while let newline = buffer[lineStart...].firstIndex(of: 0x0a) {
+                let line = Data(buffer[lineStart..<newline])
+                lineStart = buffer.index(after: newline)
+                guard !line.isEmpty else { continue }
+                recordsVisited += 1
+                if Self.visit(line: line, body: body) {
+                    return SessionIndexJSONLReadMetrics(
+                        bytesRead: bytesRead,
+                        recordsVisited: recordsVisited
+                    )
+                }
+            }
+
+            if lineStart > buffer.startIndex,
+               buffer.distance(from: buffer.startIndex, to: lineStart) >= chunkSize {
+                buffer.removeSubrange(buffer.startIndex..<lineStart)
+                lineStart = buffer.startIndex
+            }
+        }
+
+        if reachedEnd, lineStart < buffer.endIndex {
+            let line = Data(buffer[lineStart..<buffer.endIndex])
+            if !line.isEmpty {
+                recordsVisited += 1
+                _ = Self.visit(line: line, body: body)
+            }
+        }
+        return SessionIndexJSONLReadMetrics(
+            bytesRead: bytesRead,
+            recordsVisited: recordsVisited
+        )
+    }
+
+    func fromTail(
+        url: URL,
+        maxBytes: Int,
+        body: ([String: Any]) -> Bool
+    ) -> SessionIndexJSONLReadMetrics {
+        guard maxBytes > 0, let handle = try? FileHandle(forReadingFrom: url) else {
+            return SessionIndexJSONLReadMetrics(bytesRead: 0, recordsVisited: 0)
+        }
+        defer { try? handle.close() }
+
+        let endOffset = (try? handle.seekToEnd()) ?? 0
+        let requestedBytes = min(UInt64(maxBytes), endOffset)
+        let startOffset = endOffset - requestedBytes
+        try? handle.seek(toOffset: startOffset)
+        let data = (try? handle.read(upToCount: Int(requestedBytes))) ?? Data()
+        var lines = data.split(separator: 0x0a, omittingEmptySubsequences: true)
+        if startOffset > 0, !lines.isEmpty {
+            lines.removeFirst()
+        }
+
+        var recordsVisited = 0
+        for line in lines.reversed() {
+            recordsVisited += 1
+            if Self.visit(line: Data(line), body: body) {
+                break
+            }
+        }
+        return SessionIndexJSONLReadMetrics(
+            bytesRead: data.count,
+            recordsVisited: recordsVisited
+        )
+    }
+
+    private static func visit(
+        line: Data,
+        body: ([String: Any]) -> Bool
+    ) -> Bool {
+        autoreleasepool {
+            guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any] else {
+                return false
+            }
+            return body(object)
+        }
+    }
+}

--- a/Sources/SessionIndexJSONLReader.swift
+++ b/Sources/SessionIndexJSONLReader.swift
@@ -70,6 +70,7 @@ struct SessionIndexJSONLReader: Sendable {
     func fromTail(
         url: URL,
         maxBytes: Int,
+        endingBeforeOffset: UInt64? = nil,
         body: ([String: Any]) -> Bool
     ) -> SessionIndexJSONLReadMetrics {
         guard maxBytes > 0, let handle = try? FileHandle(forReadingFrom: url) else {
@@ -77,13 +78,34 @@ struct SessionIndexJSONLReader: Sendable {
         }
         defer { try? handle.close() }
 
-        let endOffset = (try? handle.seekToEnd()) ?? 0
-        let requestedBytes = min(UInt64(maxBytes), endOffset)
-        let startOffset = endOffset - requestedBytes
-        try? handle.seek(toOffset: startOffset)
-        let data = (try? handle.read(upToCount: Int(requestedBytes))) ?? Data()
-        var lines = data.split(separator: 0x0a, omittingEmptySubsequences: true)
-        if startOffset > 0, !lines.isEmpty {
+        let fileEndOffset = (try? handle.seekToEnd()) ?? 0
+        let pageEndOffset = min(endingBeforeOffset ?? fileEndOffset, fileEndOffset)
+        guard pageEndOffset > 0 else {
+            return SessionIndexJSONLReadMetrics(bytesRead: 0, recordsVisited: 0)
+        }
+
+        let includesBoundaryContext = pageEndOffset > UInt64(maxBytes)
+        let candidateStartOffset: UInt64
+        let readStartOffset: UInt64
+        if includesBoundaryContext {
+            candidateStartOffset = pageEndOffset - UInt64(maxBytes - 1)
+            readStartOffset = candidateStartOffset - 1
+        } else {
+            candidateStartOffset = 0
+            readStartOffset = 0
+        }
+
+        try? handle.seek(toOffset: readStartOffset)
+        let readCount = Int(pageEndOffset - readStartOffset)
+        let data = (try? handle.read(upToCount: readCount)) ?? Data()
+        let payload = includesBoundaryContext ? data.dropFirst() : data[...]
+        let startsOnNewline = payload.first == 0x0a
+        let startsWithinRecord = includesBoundaryContext
+            && data.first != 0x0a
+            && !startsOnNewline
+        let firstNewline = payload.firstIndex(of: 0x0a)
+        var lines = payload.split(separator: 0x0a, omittingEmptySubsequences: true)
+        if startsWithinRecord, !lines.isEmpty {
             lines.removeFirst()
         }
 
@@ -94,9 +116,71 @@ struct SessionIndexJSONLReader: Sendable {
                 break
             }
         }
+
+        let nextEndOffset: UInt64?
+        if !includesBoundaryContext {
+            nextEndOffset = nil
+        } else if maxBytes == 1 {
+            nextEndOffset = readStartOffset
+        } else if data.first == 0x0a {
+            nextEndOffset = candidateStartOffset
+        } else if startsOnNewline {
+            nextEndOffset = candidateStartOffset + 1
+        } else if let firstNewline {
+            let distance = payload.distance(from: payload.startIndex, to: firstNewline)
+            let boundary = candidateStartOffset + UInt64(distance + 1)
+            nextEndOffset = boundary < pageEndOffset ? boundary : candidateStartOffset
+        } else {
+            nextEndOffset = candidateStartOffset
+        }
         return SessionIndexJSONLReadMetrics(
             bytesRead: data.count,
-            recordsVisited: recordsVisited
+            recordsVisited: recordsVisited,
+            didReachStart: !includesBoundaryContext,
+            nextEndOffset: nextEndOffset
+        )
+    }
+
+    /// Visits fixed-size tail pages until the callback stops or the file start is reached.
+    @discardableResult
+    func fromTailPages(
+        url: URL,
+        maxBytesPerPage: Int,
+        maximumPageCount: Int? = nil,
+        body: ([String: Any]) -> Bool
+    ) -> SessionIndexJSONLReadMetrics {
+        var endOffset: UInt64?
+        var bytesRead = 0
+        var recordsVisited = 0
+        var didReachStart = false
+        var stoppedEarly = false
+        var pagesRead = 0
+
+        repeat {
+            let page = fromTail(
+                url: url,
+                maxBytes: maxBytesPerPage,
+                endingBeforeOffset: endOffset
+            ) { object in
+                stoppedEarly = body(object)
+                return stoppedEarly
+            }
+            bytesRead += page.bytesRead
+            recordsVisited += page.recordsVisited
+            didReachStart = page.didReachStart
+            endOffset = page.nextEndOffset
+            pagesRead += 1
+        } while !stoppedEarly
+            && !didReachStart
+            && endOffset != nil
+            && maximumPageCount.map({ pagesRead < $0 }) != false
+            && !Task.isCancelled
+
+        return SessionIndexJSONLReadMetrics(
+            bytesRead: bytesRead,
+            recordsVisited: recordsVisited,
+            didReachStart: didReachStart,
+            nextEndOffset: endOffset
         )
     }
 

--- a/Sources/SessionIndexJSONLReader.swift
+++ b/Sources/SessionIndexJSONLReader.swift
@@ -22,13 +22,11 @@ struct SessionIndexJSONLReader: Sendable {
         var lineStart = buffer.startIndex
         var bytesRead = 0
         var recordsVisited = 0
-        var reachedEnd = false
 
         while bytesRead < maxBytes {
             let readCount = min(chunkSize, maxBytes - bytesRead)
             let chunk = (try? handle.read(upToCount: readCount)) ?? Data()
             if chunk.isEmpty {
-                reachedEnd = true
                 break
             }
             bytesRead += chunk.count
@@ -54,7 +52,7 @@ struct SessionIndexJSONLReader: Sendable {
             }
         }
 
-        if reachedEnd, lineStart < buffer.endIndex {
+        if lineStart < buffer.endIndex {
             let line = Data(buffer[lineStart..<buffer.endIndex])
             if !line.isEmpty {
                 recordsVisited += 1

--- a/Sources/SessionIndexJSONLReader.swift
+++ b/Sources/SessionIndexJSONLReader.swift
@@ -104,15 +104,31 @@ struct SessionIndexJSONLReader: Sendable {
             && data.first != 0x0a
             && !startsOnNewline
         let firstNewline = payload.firstIndex(of: 0x0a)
-        var lines = payload.split(separator: 0x0a, omittingEmptySubsequences: true)
-        if startsWithinRecord, !lines.isEmpty {
-            lines.removeFirst()
-        }
+        let completeRecordsStart = startsWithinRecord
+            ? firstNewline.map { payload.index(after: $0) } ?? payload.endIndex
+            : payload.startIndex
 
         var recordsVisited = 0
-        for line in lines.reversed() {
+        var lineEnd = payload.endIndex
+        while lineEnd > completeRecordsStart {
+            while lineEnd > completeRecordsStart,
+                  payload[payload.index(before: lineEnd)] == 0x0a {
+                lineEnd = payload.index(before: lineEnd)
+            }
+            guard lineEnd > completeRecordsStart else { break }
+
+            let currentLineEnd = lineEnd
+            let lineStart: Data.SubSequence.Index
+            if let newline = payload[completeRecordsStart..<lineEnd].lastIndex(of: 0x0a) {
+                lineStart = payload.index(after: newline)
+                lineEnd = newline
+            } else {
+                lineStart = completeRecordsStart
+                lineEnd = completeRecordsStart
+            }
+            guard lineStart < currentLineEnd else { continue }
             recordsVisited += 1
-            if Self.visit(line: Data(line), body: body) {
+            if Self.visit(line: Data(payload[lineStart..<currentLineEnd]), body: body) {
                 break
             }
         }

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -188,14 +188,14 @@ enum OpenCodeDatabaseSnapshot {
 
 // MARK: - Session entry
 
-struct PullRequestLink: Hashable {
+struct PullRequestLink: Hashable, Sendable {
     let number: Int
     let url: String
     let repository: String?
 }
 
 /// Agent-specific fields used to build the resume command with appropriate flags.
-enum AgentSpecifics: Hashable {
+enum AgentSpecifics: Hashable, Sendable {
     case claude(model: String?, permissionMode: String?, configDirectoryForResume: String?)
     case codex(model: String?, approvalPolicy: String?, sandboxMode: String?, effort: String?)
     case grok(model: String?, permissionMode: String?, sandboxMode: String?, grokHome: String?)
@@ -252,7 +252,7 @@ enum ClaudeConfigurationRoot {
     }
 }
 
-struct SessionEntry: Identifiable, Hashable {
+struct SessionEntry: Identifiable, Hashable, Sendable {
     let id: String
     let agent: SessionAgent
     /// Native session identifier for the agent's CLI (used to build the resume command).

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -488,7 +488,8 @@ extension SessionIndexStore {
             let fallbackModified = ((try? fm.attributesOfItem(atPath: historyURL.path))?[.modificationDate] as? Date)
                 ?? Date.distantPast
 
-            forEachJSONLineFromTail(url: historyURL, maxBytes: antigravityHistoryByteCap) { object in
+            let pageLimit = needle.isEmpty && cwdFilter == nil && offset == 0 && limit == perAgentLimit ? 1 : nil
+            SessionIndexJSONLReader().fromTailPages(url: historyURL, maxBytesPerPage: antigravityHistoryByteCap, maximumPageCount: pageLimit) { object in
                 if Task.isCancelled { return true }
                 guard let sessionId = firstString(in: object, keys: antigravitySessionIDKeys()) else {
                     return false
@@ -524,7 +525,6 @@ extension SessionIndexStore {
                 return target > 0 && latestBySessionID.count >= target
             }
         }
-
         let entries = latestBySessionID.values
             .sorted {
                 if $0.modified == $1.modified {

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -470,57 +470,54 @@ extension SessionIndexStore {
         offset: Int,
         limit: Int
     ) -> [SessionEntry] {
-        let roots = registeredSessionRoots(registration: registration, cwdFilter: cwdFilter)
-        guard !roots.isEmpty else { return [] }
+        guard limit > 0, let configuredRoot = registration.sessionDirectory else { return [] }
 
         let fm = FileManager.default
         var seenSessionIDs = Set<String>()
         var entriesInReverseAppendOrder: [AntigravityHistoryMetadata] = []
         let target = max(0, offset) + max(0, limit)
-        for root in roots {
-            if Task.isCancelled { break }
-            let historyURL = URL(fileURLWithPath: root, isDirectory: true)
-                .appendingPathComponent("history.jsonl", isDirectory: false)
-            var isDirectory: ObjCBool = false
-            guard fm.fileExists(atPath: historyURL.path, isDirectory: &isDirectory),
-                  !isDirectory.boolValue else {
-                continue
+        let root = (configuredRoot as NSString).expandingTildeInPath
+        let historyURL = URL(fileURLWithPath: root, isDirectory: true)
+            .appendingPathComponent("history.jsonl", isDirectory: false)
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: historyURL.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue else {
+            return []
+        }
+        let fallbackModified = ((try? fm.attributesOfItem(atPath: historyURL.path))?[.modificationDate] as? Date)
+            ?? Date.distantPast
+
+        let pageLimit = needle.isEmpty && cwdFilter == nil && offset == 0 && limit == perAgentLimit
+            ? 1
+            : antigravityHistoryExplicitPageLimit
+        SessionIndexJSONLReader().fromTailPages(url: historyURL, maxBytesPerPage: antigravityHistoryByteCap, maximumPageCount: pageLimit) { object in
+            if Task.isCancelled { return true }
+            guard let sessionId = firstString(in: object, keys: antigravitySessionIDKeys()) else {
+                return false
             }
-            let fallbackModified = ((try? fm.attributesOfItem(atPath: historyURL.path))?[.modificationDate] as? Date)
-                ?? Date.distantPast
+            let cwd = firstString(in: object, keys: registeredJSONLCWDKeys())
+            if let cwdFilter, cwd != cwdFilter { return false }
 
-            let pageLimit = needle.isEmpty && cwdFilter == nil && offset == 0 && limit == perAgentLimit
-                ? 1
-                : antigravityHistoryExplicitPageLimit
-            SessionIndexJSONLReader().fromTailPages(url: historyURL, maxBytesPerPage: antigravityHistoryByteCap, maximumPageCount: pageLimit) { object in
-                if Task.isCancelled { return true }
-                guard let sessionId = firstString(in: object, keys: antigravitySessionIDKeys()) else {
-                    return false
-                }
-                let cwd = firstString(in: object, keys: registeredJSONLCWDKeys())
-                if let cwdFilter, cwd != cwdFilter { return false }
-
-                let title = antigravityHistoryTitle(in: object) ?? ""
-                guard antigravityHistoryMatchesNeedle(
-                    needle: needle,
-                    sessionId: sessionId,
-                    title: title,
-                    cwd: cwd
-                ) else {
-                    return false
-                }
-                guard seenSessionIDs.insert(sessionId).inserted else { return false }
-
-                let modified = antigravityHistoryModifiedDate(in: object, fallback: fallbackModified)
-                entriesInReverseAppendOrder.append(AntigravityHistoryMetadata(
-                    sessionId: sessionId,
-                    title: title,
-                    cwd: cwd,
-                    modified: modified,
-                    fileURL: historyURL
-                ))
-                return target > 0 && entriesInReverseAppendOrder.count >= target
+            let title = antigravityHistoryTitle(in: object) ?? ""
+            guard antigravityHistoryMatchesNeedle(
+                needle: needle,
+                sessionId: sessionId,
+                title: title,
+                cwd: cwd
+            ) else {
+                return false
             }
+            guard seenSessionIDs.insert(sessionId).inserted else { return false }
+
+            let modified = antigravityHistoryModifiedDate(in: object, fallback: fallbackModified)
+            entriesInReverseAppendOrder.append(AntigravityHistoryMetadata(
+                sessionId: sessionId,
+                title: title,
+                cwd: cwd,
+                modified: modified,
+                fileURL: historyURL
+            ))
+            return entriesInReverseAppendOrder.count >= target
         }
         let entries = entriesInReverseAppendOrder.map { metadata in
             SessionEntry(

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -475,7 +475,7 @@ extension SessionIndexStore {
 
         let fm = FileManager.default
         var latestBySessionID: [String: AntigravityHistoryMetadata] = [:]
-
+        let target = max(0, offset) + max(0, limit)
         for root in roots {
             if Task.isCancelled { break }
             let historyURL = URL(fileURLWithPath: root, isDirectory: true)
@@ -488,7 +488,7 @@ extension SessionIndexStore {
             let fallbackModified = ((try? fm.attributesOfItem(atPath: historyURL.path))?[.modificationDate] as? Date)
                 ?? Date.distantPast
 
-            forEachJSONLine(url: historyURL, maxBytes: Int.max) { object in
+            forEachJSONLineFromTail(url: historyURL, maxBytes: antigravityHistoryByteCap) { object in
                 if Task.isCancelled { return true }
                 guard let sessionId = firstString(in: object, keys: antigravitySessionIDKeys()) else {
                     return false
@@ -521,7 +521,7 @@ extension SessionIndexStore {
                 } else {
                     latestBySessionID[sessionId] = metadata
                 }
-                return false
+                return target > 0 && latestBySessionID.count >= target
             }
         }
 

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -474,7 +474,8 @@ extension SessionIndexStore {
         guard !roots.isEmpty else { return [] }
 
         let fm = FileManager.default
-        var latestBySessionID: [String: AntigravityHistoryMetadata] = [:]
+        var seenSessionIDs = Set<String>()
+        var entriesInReverseAppendOrder: [AntigravityHistoryMetadata] = []
         let target = max(0, offset) + max(0, limit)
         for root in roots {
             if Task.isCancelled { break }
@@ -488,7 +489,9 @@ extension SessionIndexStore {
             let fallbackModified = ((try? fm.attributesOfItem(atPath: historyURL.path))?[.modificationDate] as? Date)
                 ?? Date.distantPast
 
-            let pageLimit = needle.isEmpty && cwdFilter == nil && offset == 0 && limit == perAgentLimit ? 1 : nil
+            let pageLimit = needle.isEmpty && cwdFilter == nil && offset == 0 && limit == perAgentLimit
+                ? 1
+                : antigravityHistoryExplicitPageLimit
             SessionIndexJSONLReader().fromTailPages(url: historyURL, maxBytesPerPage: antigravityHistoryByteCap, maximumPageCount: pageLimit) { object in
                 if Task.isCancelled { return true }
                 guard let sessionId = firstString(in: object, keys: antigravitySessionIDKeys()) else {
@@ -506,46 +509,33 @@ extension SessionIndexStore {
                 ) else {
                     return false
                 }
+                guard seenSessionIDs.insert(sessionId).inserted else { return false }
 
                 let modified = antigravityHistoryModifiedDate(in: object, fallback: fallbackModified)
-                let metadata = AntigravityHistoryMetadata(
+                entriesInReverseAppendOrder.append(AntigravityHistoryMetadata(
                     sessionId: sessionId,
                     title: title,
                     cwd: cwd,
                     modified: modified,
                     fileURL: historyURL
-                )
-                if let existing = latestBySessionID[sessionId] {
-                    if metadata.modified > existing.modified {
-                        latestBySessionID[sessionId] = metadata
-                    }
-                } else {
-                    latestBySessionID[sessionId] = metadata
-                }
-                return target > 0 && latestBySessionID.count >= target
+                ))
+                return target > 0 && entriesInReverseAppendOrder.count >= target
             }
         }
-        let entries = latestBySessionID.values
-            .sorted {
-                if $0.modified == $1.modified {
-                    return $0.sessionId < $1.sessionId
-                }
-                return $0.modified > $1.modified
-            }
-            .map { metadata in
-                SessionEntry(
-                    id: "\(registration.id):\(metadata.sessionId)",
-                    agent: .registered(RegisteredSessionAgent(registration: registration)),
-                    sessionId: metadata.sessionId,
-                    title: metadata.title,
-                    cwd: metadata.cwd,
-                    gitBranch: nil,
-                    pullRequest: nil,
-                    modified: metadata.modified,
-                    fileURL: metadata.fileURL,
-                    specifics: .registered(registration)
-                )
-            }
+        let entries = entriesInReverseAppendOrder.map { metadata in
+            SessionEntry(
+                id: "\(registration.id):\(metadata.sessionId)",
+                agent: .registered(RegisteredSessionAgent(registration: registration)),
+                sessionId: metadata.sessionId,
+                title: metadata.title,
+                cwd: metadata.cwd,
+                gitBranch: nil,
+                pullRequest: nil,
+                modified: metadata.modified,
+                fileURL: metadata.fileURL,
+                specifics: .registered(registration)
+            )
+        }
         return Array(entries.dropFirst(offset).prefix(limit))
     }
 

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -516,7 +516,7 @@ extension SessionIndexStore {
                     fileURL: historyURL
                 )
                 if let existing = latestBySessionID[sessionId] {
-                    if metadata.modified >= existing.modified {
+                    if metadata.modified > existing.modified {
                         latestBySessionID[sessionId] = metadata
                     }
                 } else {

--- a/Sources/SessionIndexSnapshotLoader.swift
+++ b/Sources/SessionIndexSnapshotLoader.swift
@@ -4,7 +4,13 @@ struct SessionIndexSnapshotLoader: Sendable {
 
     private let loadOperation: LoadOperation
 
-    init(loadOperation: @escaping LoadOperation = SessionIndexStore.loadInitialEntries) {
+    init() {
+        self.loadOperation = {
+            await SessionIndexStore.loadInitialEntries()
+        }
+    }
+
+    init(loadOperation: @escaping LoadOperation) {
         self.loadOperation = loadOperation
     }
 

--- a/Sources/SessionIndexSnapshotLoader.swift
+++ b/Sources/SessionIndexSnapshotLoader.swift
@@ -1,0 +1,19 @@
+/// Explicit executor boundary for the Vault's initial filesystem snapshot.
+struct SessionIndexSnapshotLoader: Sendable {
+    typealias LoadOperation = @Sendable () async -> [SessionEntry]
+
+    private let loadOperation: LoadOperation
+
+    init(loadOperation: @escaping LoadOperation = SessionIndexStore.loadInitialEntries) {
+        self.loadOperation = loadOperation
+    }
+
+#if compiler(>=6.2)
+    @concurrent
+#else
+    @Sendable
+#endif
+    nonisolated func load() async -> [SessionEntry] {
+        await loadOperation()
+    }
+}

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -164,16 +164,13 @@ struct IndexSection: Identifiable, Equatable {
 
     /// Whether to render the "Show more" affordance for this section.
     ///
-    /// Directory sections are derived from `loadInitialEntries()`'s global, per-agent-capped
-    /// pool, so their in-memory `entries` are only a preview that can under-report
-    /// a folder's true on-disk session count (issue #6302). "Show more" is the
-    /// only trigger for the complete folder-scoped query (`loadDirectorySnapshot`),
-    /// so always offer it for directory sections; otherwise a folder that
-    /// contributed ≤ `rowLimit` sessions to the capped pool would have the rest of
-    /// its sessions permanently unreachable from the UI. Agent sections aren't
-    /// folder-truncated this way, so they keep the simple count threshold.
+    /// Directory sections can under-report sessions because the initial pool is capped
+    /// per agent (issue #6302). Antigravity's initial history read is also deliberately
+    /// capped to one tail page. Keep "Show more" available for both so the explicit,
+    /// off-main query can page beyond either bounded snapshot.
     func shouldOfferShowMore(rowLimit: Int) -> Bool {
-        key.isDirectory || entries.count > rowLimit
+        let isAntigravity = entries.first?.agent.rawValue == "antigravity"
+        return key.isDirectory || isAntigravity || entries.count > rowLimit
     }
 }
 

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -664,9 +664,9 @@ final class SessionIndexStore: ObservableObject {
     nonisolated static let perAgentLimit = 30
     nonisolated static let headByteCap = 64 * 1024
     nonisolated static let tailByteCap = 32 * 1024
-    /// Antigravity keeps every prompt in one append-only history file. Read only
-    /// the newest bounded window for initial rows and previews.
     nonisolated static let antigravityHistoryByteCap = 16 * 1024 * 1024
+    nonisolated static let antigravityHistoryExplicitPageLimit = 16
+    nonisolated static let antigravityHistoryPreviewPageLimit = 8
     /// Hard cap on candidate files inspected per call to keep deep-page searches bounded.
     nonisolated static let searchMaxFiles = 1500
 

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -164,7 +164,7 @@ struct IndexSection: Identifiable, Equatable {
 
     /// Whether to render the "Show more" affordance for this section.
     ///
-    /// Directory sections are derived from `scanAll()`'s global, per-agent-capped
+    /// Directory sections are derived from `loadInitialEntries()`'s global, per-agent-capped
     /// pool, so their in-memory `entries` are only a preview that can under-report
     /// a folder's true on-disk session count (issue #6302). "Show more" is the
     /// only trigger for the complete folder-scoped query (`loadDirectorySnapshot`),
@@ -203,6 +203,8 @@ struct DirectorySnapshot: Sendable {
 
 @MainActor
 final class SessionIndexStore: ObservableObject {
+    private let snapshotLoader: SessionIndexSnapshotLoader
+
     @Published private(set) var entries: [SessionEntry] = [] {
         didSet {
             guard entries != oldValue else { return }
@@ -268,7 +270,8 @@ final class SessionIndexStore: ObservableObject {
     private var cachedSectionsRevision: UInt64?
     private var cachedSections: [IndexSection] = []
 
-    init() {
+    init(snapshotLoader: SessionIndexSnapshotLoader = SessionIndexSnapshotLoader()) {
+        self.snapshotLoader = snapshotLoader
         self.agentOrder = Self.loadAgentOrder()
         self.directoryOrder = Self.loadDirectoryOrder()
         let storedGrouping = UserDefaults.standard.string(forKey: Self.groupingKey)
@@ -539,16 +542,14 @@ final class SessionIndexStore: ObservableObject {
         isLoading = true
         directorySnapshotGeneration += 1
         invalidateDirectorySnapshots()
-        loadTask = Task.detached(priority: .userInitiated) { [weak self] in
-            let scanned = await Self.scanAll()
-            await MainActor.run {
-                guard let self else { return }
-                if Task.isCancelled { return }
-                self.entries = scanned
-                self.isLoading = false
-                self.backfillAgentOrderFromEntries()
-                self.backfillDirectoryOrderFromEntries()
-            }
+        let snapshotLoader = self.snapshotLoader
+        loadTask = Task { @MainActor [weak self] in
+            let scanned = await snapshotLoader.load()
+            guard let self, !Task.isCancelled else { return }
+            self.entries = scanned
+            self.isLoading = false
+            self.backfillAgentOrderFromEntries()
+            self.backfillDirectoryOrderFromEntries()
         }
     }
 
@@ -597,7 +598,7 @@ final class SessionIndexStore: ObservableObject {
         // anyone has more Claude sessions in a single cwd we'll bump it.
         let bigLimit = 10_000
         let order = await Self.defaultAgentOrder(workingDirectory: cwdFilter)
-        var merged = await Self.loadAgents(
+        let merged = await Self.loadAgents(
             order.agents,
             registry: order.registry,
             needle: "",
@@ -609,11 +610,12 @@ final class SessionIndexStore: ObservableObject {
         if Task.isCancelled {
             return DirectorySnapshot(cwd: key, entries: [], errors: [])
         }
-        if noFolderScope {
-            merged = merged.filter { ($0.cwd ?? "").isEmpty }
-        }
-        let sorted = merged.sorted { $0.modified > $1.modified }
-        let snapshot = DirectorySnapshot(cwd: key, entries: sorted, errors: bag.snapshot())
+        let snapshot = await SessionIndexEntryProjection().directorySnapshot(
+            cwd: key,
+            entries: merged,
+            noFolderScope: noFolderScope,
+            errors: bag.snapshot()
+        )
         // Only cache this result if no `reload()` raced in while the
         // build was running. Otherwise the caller gets a fresh snapshot
         // but the cache stays invalidated; the next open will rebuild.
@@ -665,10 +667,18 @@ final class SessionIndexStore: ObservableObject {
     private static let perAgentLimit = 30
     nonisolated static let headByteCap = 64 * 1024
     nonisolated static let tailByteCap = 32 * 1024
+    /// Antigravity keeps every prompt in one append-only history file. Read only
+    /// the newest bounded window for initial rows and previews.
+    nonisolated static let antigravityHistoryByteCap = 16 * 1024 * 1024
     /// Hard cap on candidate files inspected per call to keep deep-page searches bounded.
     nonisolated static let searchMaxFiles = 1500
 
-    private static func scanAll() async -> [SessionEntry] {
+#if compiler(>=6.2)
+    @concurrent
+#else
+    @Sendable
+#endif
+    nonisolated static func loadInitialEntries() async -> [SessionEntry] {
         // Initial scan errors are silently ignored — UI just shows the cached
         // entries we did get. Errors get surfaced when the user actively
         // searches via the popover.
@@ -1042,40 +1052,22 @@ final class SessionIndexStore: ObservableObject {
 
     /// Stream JSON-lines from the start of `url`. `body` returns true to stop early.
     /// Caps total bytes read at `maxBytes`.
+    @discardableResult
     nonisolated static func forEachJSONLine(
         url: URL,
         maxBytes: Int,
         body: ([String: Any]) -> Bool
-    ) {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return }
-        defer { try? handle.close() }
-        var leftover = Data()
-        var totalRead = 0
-        let chunkSize = 64 * 1024
-        while totalRead < maxBytes {
-            let chunk: Data
-            if #available(macOS 10.15.4, *) {
-                chunk = (try? handle.read(upToCount: chunkSize)) ?? Data()
-            } else {
-                chunk = handle.readData(ofLength: chunkSize)
-            }
-            if chunk.isEmpty { break }
-            totalRead += chunk.count
-            leftover.append(chunk)
-            while let nl = leftover.firstIndex(of: 0x0a) {
-                let lineData = leftover.subdata(in: 0..<nl)
-                leftover.removeSubrange(0..<(nl + 1))
-                if lineData.isEmpty { continue }
-                if let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] {
-                    if body(obj) { return }
-                }
-            }
-        }
-        // Flush trailing line if no newline at EOF.
-        if !leftover.isEmpty,
-           let obj = try? JSONSerialization.jsonObject(with: leftover) as? [String: Any] {
-            _ = body(obj)
-        }
+    ) -> SessionIndexJSONLReadMetrics {
+        SessionIndexJSONLReader().fromStart(url: url, maxBytes: maxBytes, body: body)
+    }
+
+    @discardableResult
+    nonisolated static func forEachJSONLineFromTail(
+        url: URL,
+        maxBytes: Int,
+        body: ([String: Any]) -> Bool
+    ) -> SessionIndexJSONLReadMetrics {
+        SessionIndexJSONLReader().fromTail(url: url, maxBytes: maxBytes, body: body)
     }
 
     // MARK: OpenCode
@@ -1192,7 +1184,7 @@ final class SessionIndexStore: ObservableObject {
             // merge-sort can produce a stable global ordering, then slice.
             let target = offset + limit
             let order = await Self.defaultAgentOrder(workingDirectory: cwdFilter)
-            var merged = await Self.loadAgents(
+            let merged = await Self.loadAgents(
                 order.agents,
                 registry: order.registry,
                 needle: needle,
@@ -1201,11 +1193,12 @@ final class SessionIndexStore: ObservableObject {
                 limit: target,
                 errorBag: bag
             )
-            if noFolderScope {
-                merged = merged.filter { ($0.cwd ?? "").isEmpty }
-            }
-            let sorted = merged.sorted { $0.modified > $1.modified }
-            entries = Array(sorted.dropFirst(offset).prefix(limit))
+            entries = await SessionIndexEntryProjection().page(
+                entries: merged,
+                noFolderScope: noFolderScope,
+                offset: offset,
+                limit: limit
+            )
         }
         return SearchOutcome(entries: entries, errors: bag.snapshot())
     }
@@ -1273,6 +1266,11 @@ final class SessionIndexStore: ObservableObject {
         #endif
     }
 
+#if compiler(>=6.2)
+    @concurrent
+#else
+    @Sendable
+#endif
     nonisolated private static func searchAgent(
         needle: String, agent: SessionAgent, cwdFilter: String?,
         offset: Int, limit: Int, errorBag: ErrorBag,
@@ -1676,7 +1674,7 @@ final class SessionIndexStore: ObservableObject {
     /// Returns OpenCode session entries paginated by `time_updated` desc.
     /// Empty needle skips the `LIKE` clause entirely so it's just `ORDER BY … LIMIT/OFFSET`.
     /// Sync because the SQL pass is fast and SQLite's API is sync; the caller
-    /// awaits the wrapping `searchSessions`/`scanAll` boundaries.
+    /// awaits the wrapping `searchSessions`/`loadInitialEntries` boundaries.
     nonisolated private static func loadOpenCodeEntries(
         needle: String, cwdFilter: String?, offset: Int, limit: Int,
         errorBag: ErrorBag

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -664,7 +664,7 @@ final class SessionIndexStore: ObservableObject {
 
     // MARK: - Scanning
 
-    private static let perAgentLimit = 30
+    nonisolated static let perAgentLimit = 30
     nonisolated static let headByteCap = 64 * 1024
     nonisolated static let tailByteCap = 32 * 1024
     /// Antigravity keeps every prompt in one append-only history file. Read only

--- a/Sources/SessionIndexTableApplyInput.swift
+++ b/Sources/SessionIndexTableApplyInput.swift
@@ -1,0 +1,6 @@
+/// Latest immutable input delivered by the SwiftUI Vault table bridge.
+@MainActor
+struct SessionIndexTableApplyInput {
+    let rows: [SessionIndexTableRow]
+    let environment: SessionIndexTableEnvironmentSnapshot
+}

--- a/Sources/SessionIndexTableCellRootView.swift
+++ b/Sources/SessionIndexTableCellRootView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Isolated SwiftUI graph hosted by one recycled Vault table cell.
+struct SessionIndexTableCellRootView: View {
+    let row: SessionIndexTableRow
+    let environment: SessionIndexTableEnvironmentSnapshot
+
+    var body: some View {
+        environment.apply(to: rowContent)
+    }
+
+    @ViewBuilder
+    private var rowContent: some View {
+        Group {
+            switch row {
+            case let .section(
+                section,
+                rowLimit,
+                isDragged,
+                previewEntryId,
+                isCollapsed,
+                isPopoverOpen,
+                actions,
+                setCollapsed,
+                setPopoverOpen
+            ):
+                IndexSectionView(
+                    section: section,
+                    rowLimit: rowLimit,
+                    isDragged: isDragged,
+                    previewEntryId: previewEntryId,
+                    isCollapsed: Binding(
+                        get: { isCollapsed },
+                        set: setCollapsed
+                    ),
+                    isPopoverOpen: Binding(
+                        get: { isPopoverOpen },
+                        set: setPopoverOpen
+                    ),
+                    actions: actions
+                )
+                .equatable()
+            case let .gap(beforeKey, isValidDrop, actions):
+                SectionReorderGap(
+                    beforeKey: beforeKey,
+                    isValidDrop: isValidDrop,
+                    actions: actions
+                )
+                .equatable()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Sources/SessionIndexTableCellView.swift
+++ b/Sources/SessionIndexTableCellView.swift
@@ -1,0 +1,59 @@
+import AppKit
+import SwiftUI
+
+/// Recycled AppKit cell containing one stable Vault row hosting view.
+@MainActor
+final class SessionIndexTableCellView: NSTableCellView {
+    private let hostingView = NSHostingView(
+        rootView: SessionIndexTableCellRootView(
+            row: .gap(beforeKey: nil, isValidDrop: true, actions: SectionGapActions(
+                currentDraggedKey: { nil },
+                moveSection: { _, _ in },
+                clearDraggedKey: {}
+            )),
+            environment: .fallback
+        )
+    )
+    private var configuredRow: SessionIndexTableRow?
+    private var configuredEnvironment: SessionIndexTableEnvironmentSnapshot?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        hostingView.wantsLayer = true
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        // The controller owns row heights, so visible cells never negotiate
+        // intrinsic SwiftUI size during an AppKit table layout pass.
+        hostingView.sizingOptions = []
+        addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hostingView.topAnchor.constraint(equalTo: topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        row: SessionIndexTableRow,
+        environment: SessionIndexTableEnvironmentSnapshot
+    ) {
+        if let configuredRow,
+           let configuredEnvironment,
+           configuredRow.hasEquivalentContent(to: row),
+           configuredEnvironment.hasEquivalentPresentation(to: environment) {
+            return
+        }
+        configuredRow = row
+        configuredEnvironment = environment
+        hostingView.rootView = SessionIndexTableCellRootView(
+            row: row,
+            environment: environment
+        )
+    }
+}

--- a/Sources/SessionIndexTableContainerView.swift
+++ b/Sources/SessionIndexTableContainerView.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+/// AppKit scroll and table container for the right-sidebar Vault.
+@MainActor
+final class SessionIndexTableContainerView: NSView {
+    let scrollView = NSScrollView()
+    let tableView = NSTableView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/SessionIndexTableController.swift
+++ b/Sources/SessionIndexTableController.swift
@@ -11,6 +11,9 @@ final class SessionIndexTableController: NSObject, NSTableViewDataSource, NSTabl
     private var rows: [SessionIndexTableRow] = []
     private var environment: SessionIndexTableEnvironmentSnapshot?
     private let rowHeightCalculator = SessionIndexTableRowHeightCalculator()
+    private lazy var mutationScheduler = SessionIndexTableMutationScheduler(
+        applyFlush: { [weak self] in self?.flushApply($0) }
+    )
 
     func makeContainerView() -> SessionIndexTableContainerView {
         let container = SessionIndexTableContainerView()
@@ -55,7 +58,15 @@ final class SessionIndexTableController: NSObject, NSTableViewDataSource, NSTabl
         rows nextRows: [SessionIndexTableRow],
         environment nextEnvironment: SessionIndexTableEnvironmentSnapshot
     ) {
+        mutationScheduler.stageApply(
+            SessionIndexTableApplyInput(rows: nextRows, environment: nextEnvironment)
+        )
+    }
+
+    private func flushApply(_ input: SessionIndexTableApplyInput) {
         guard let table = containerView?.tableView else { return }
+        let nextRows = input.rows
+        let nextEnvironment = input.environment
         let previousRows = rows
         let hasStructuralChanges = previousRows.map(\.id) != nextRows.map(\.id)
         let hasEnvironmentChanges = environment?.hasEquivalentPresentation(

--- a/Sources/SessionIndexTableController.swift
+++ b/Sources/SessionIndexTableController.swift
@@ -43,6 +43,8 @@ final class SessionIndexTableController: NSObject, NSTableViewDataSource, NSTabl
 
         let scrollView = container.scrollView
         scrollView.documentView = table
+        table.frame = scrollView.contentView.bounds
+        table.autoresizingMask = [.width]
         scrollView.drawsBackground = false
         scrollView.backgroundColor = .clear
         scrollView.hasHorizontalScroller = false

--- a/Sources/SessionIndexTableController.swift
+++ b/Sources/SessionIndexTableController.swift
@@ -1,0 +1,107 @@
+import AppKit
+import CmuxAppKitSupportUI
+
+/// Main-actor owner of the Vault table lifecycle and its immutable row snapshot.
+@MainActor
+final class SessionIndexTableController: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+    private static let columnIdentifier = NSUserInterfaceItemIdentifier("vault-session")
+    private static let cellIdentifier = NSUserInterfaceItemIdentifier("vault-session-cell")
+
+    private weak var containerView: SessionIndexTableContainerView?
+    private var rows: [SessionIndexTableRow] = []
+    private var environment: SessionIndexTableEnvironmentSnapshot?
+    private let rowHeightCalculator = SessionIndexTableRowHeightCalculator()
+
+    func makeContainerView() -> SessionIndexTableContainerView {
+        let container = SessionIndexTableContainerView()
+        containerView = container
+
+        let table = container.tableView
+        table.dataSource = self
+        table.delegate = self
+        table.headerView = nil
+        table.style = .plain
+        table.backgroundColor = .clear
+        table.focusRingType = .none
+        table.gridStyleMask = []
+        table.usesAlternatingRowBackgroundColors = false
+        table.selectionHighlightStyle = .none
+        table.allowsEmptySelection = true
+        table.allowsMultipleSelection = false
+        table.allowsTypeSelect = false
+        table.intercellSpacing = .zero
+        table.usesAutomaticRowHeights = false
+        table.rowHeight = 24
+        table.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+
+        let column = NSTableColumn(identifier: Self.columnIdentifier)
+        column.resizingMask = .autoresizingMask
+        table.addTableColumn(column)
+
+        let scrollView = container.scrollView
+        scrollView.documentView = table
+        scrollView.drawsBackground = false
+        scrollView.backgroundColor = .clear
+        scrollView.hasHorizontalScroller = false
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentView.drawsBackground = false
+        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
+        scrollView.applySidebarOverlayScrollerConfiguration()
+
+        return container
+    }
+
+    func apply(
+        rows nextRows: [SessionIndexTableRow],
+        environment nextEnvironment: SessionIndexTableEnvironmentSnapshot
+    ) {
+        guard let table = containerView?.tableView else { return }
+        let previousRows = rows
+        let hasStructuralChanges = previousRows.map(\.id) != nextRows.map(\.id)
+        let hasEnvironmentChanges = environment?.hasEquivalentPresentation(
+            to: nextEnvironment
+        ) != true
+        rows = nextRows
+        environment = nextEnvironment
+
+        if hasStructuralChanges || hasEnvironmentChanges {
+            table.reloadData()
+            return
+        }
+
+        let changedRows = IndexSet(nextRows.indices.filter { index in
+            !previousRows[index].hasEquivalentContent(to: nextRows[index])
+        })
+        guard !changedRows.isEmpty else { return }
+        table.reloadData(forRowIndexes: changedRows, columnIndexes: IndexSet(integer: 0))
+        table.noteHeightOfRows(withIndexesChanged: changedRows)
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        rows.count
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        guard rows.indices.contains(row) else { return tableView.rowHeight }
+        return rowHeightCalculator.height(
+            for: rows[row],
+            environment: environment ?? .fallback
+        )
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        viewFor tableColumn: NSTableColumn?,
+        row: Int
+    ) -> NSView? {
+        guard rows.indices.contains(row) else { return nil }
+        let cell = (tableView.makeView(withIdentifier: Self.cellIdentifier, owner: self)
+            as? SessionIndexTableCellView) ?? SessionIndexTableCellView()
+        cell.identifier = Self.cellIdentifier
+        cell.configure(
+            row: rows[row],
+            environment: environment ?? .fallback
+        )
+        return cell
+    }
+}

--- a/Sources/SessionIndexTableEnvironmentSnapshot.swift
+++ b/Sources/SessionIndexTableEnvironmentSnapshot.swift
@@ -1,0 +1,25 @@
+import CmuxFoundation
+import SwiftUI
+
+/// Value-only SwiftUI environment forwarded into each independently hosted Vault row.
+struct SessionIndexTableEnvironmentSnapshot {
+    static let fallback = SessionIndexTableEnvironmentSnapshot(
+        colorScheme: .light,
+        globalFontMagnificationPercent: GlobalFontMagnification.defaultPercent
+    )
+
+    let colorScheme: ColorScheme
+    let globalFontMagnificationPercent: Int
+
+    func hasEquivalentPresentation(to other: Self) -> Bool {
+        colorScheme == other.colorScheme
+            && globalFontMagnificationPercent == other.globalFontMagnificationPercent
+    }
+
+    @ViewBuilder
+    func apply<Content: View>(to content: Content) -> some View {
+        content
+            .environment(\.colorScheme, colorScheme)
+            .environment(\.cmuxGlobalFontMagnificationPercent, globalFontMagnificationPercent)
+    }
+}

--- a/Sources/SessionIndexTableMutationScheduler.swift
+++ b/Sources/SessionIndexTableMutationScheduler.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Defers and coalesces Vault table mutations past the originating layout callback.
+@MainActor
+final class SessionIndexTableMutationScheduler {
+    private var pendingApply: SessionIndexTableApplyInput?
+    private var isFlushScheduled = false
+    private let applyFlush: @MainActor (SessionIndexTableApplyInput) -> Void
+
+    init(applyFlush: @escaping @MainActor (SessionIndexTableApplyInput) -> Void) {
+        self.applyFlush = applyFlush
+    }
+
+    func stageApply(_ input: SessionIndexTableApplyInput) {
+        pendingApply = input
+        guard !isFlushScheduled else { return }
+        isFlushScheduled = true
+        RunLoop.main.perform(inModes: [.common]) { [weak self] in
+            // RunLoop guarantees main-thread delivery, but Foundation does
+            // not annotate this callback with MainActor.
+            MainActor.assumeIsolated {
+                self?.flushPendingApply()
+            }
+        }
+    }
+
+    private func flushPendingApply() {
+        let input = pendingApply
+        pendingApply = nil
+        isFlushScheduled = false
+        if let input {
+            applyFlush(input)
+        }
+    }
+}

--- a/Sources/SessionIndexTableRow.swift
+++ b/Sources/SessionIndexTableRow.swift
@@ -28,16 +28,26 @@ enum SessionIndexTableRow {
         }
     }
 
+    static func containedPreviewEntryID(
+        _ candidate: SessionEntry.ID?,
+        in section: IndexSection
+    ) -> SessionEntry.ID? {
+        guard let candidate, section.entries.contains(where: { $0.id == candidate }) else { return nil }
+        return candidate
+    }
+
     func hasEquivalentContent(to other: SessionIndexTableRow) -> Bool {
         switch (self, other) {
         case let (
             .section(lhsSection, lhsLimit, lhsDragged, lhsPreview, lhsCollapsed, lhsPopover, _, _, _),
             .section(rhsSection, rhsLimit, rhsDragged, rhsPreview, rhsCollapsed, rhsPopover, _, _, _)
         ):
+            let lhsContainedPreview = Self.containedPreviewEntryID(lhsPreview, in: lhsSection)
+            let rhsContainedPreview = Self.containedPreviewEntryID(rhsPreview, in: rhsSection)
             return lhsSection == rhsSection
                 && lhsLimit == rhsLimit
                 && lhsDragged == rhsDragged
-                && lhsPreview == rhsPreview
+                && lhsContainedPreview == rhsContainedPreview
                 && lhsCollapsed == rhsCollapsed
                 && lhsPopover == rhsPopover
         case let (.gap(lhsKey, lhsValid, _), .gap(rhsKey, rhsValid, _)):

--- a/Sources/SessionIndexTableRow.swift
+++ b/Sources/SessionIndexTableRow.swift
@@ -1,0 +1,49 @@
+/// Immutable row configuration consumed by the AppKit-owned Vault table.
+enum SessionIndexTableRow {
+    case section(
+        section: IndexSection,
+        rowLimit: Int,
+        isDragged: Bool,
+        previewEntryId: SessionEntry.ID?,
+        isCollapsed: Bool,
+        isPopoverOpen: Bool,
+        actions: IndexSectionActions,
+        setCollapsed: @MainActor (Bool) -> Void,
+        setPopoverOpen: @MainActor (Bool) -> Void
+    )
+    case gap(
+        beforeKey: SectionKey?,
+        isValidDrop: Bool,
+        actions: SectionGapActions
+    )
+
+    var id: SessionIndexTableRowID {
+        switch self {
+        case .section(let section, _, _, _, _, _, _, _, _):
+            return .section(section.key)
+        case .gap(let beforeKey?, _, _):
+            return .gapBefore(beforeKey)
+        case .gap(nil, _, _):
+            return .trailingGap
+        }
+    }
+
+    func hasEquivalentContent(to other: SessionIndexTableRow) -> Bool {
+        switch (self, other) {
+        case let (
+            .section(lhsSection, lhsLimit, lhsDragged, lhsPreview, lhsCollapsed, lhsPopover, _, _, _),
+            .section(rhsSection, rhsLimit, rhsDragged, rhsPreview, rhsCollapsed, rhsPopover, _, _, _)
+        ):
+            return lhsSection == rhsSection
+                && lhsLimit == rhsLimit
+                && lhsDragged == rhsDragged
+                && lhsPreview == rhsPreview
+                && lhsCollapsed == rhsCollapsed
+                && lhsPopover == rhsPopover
+        case let (.gap(lhsKey, lhsValid, _), .gap(rhsKey, rhsValid, _)):
+            return lhsKey == rhsKey && lhsValid == rhsValid
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/SessionIndexTableRowHeightCalculator.swift
+++ b/Sources/SessionIndexTableRowHeightCalculator.swift
@@ -1,0 +1,58 @@
+import AppKit
+import CmuxFoundation
+
+/// Computes Vault table heights without instantiating offscreen SwiftUI rows.
+@MainActor
+struct SessionIndexTableRowHeightCalculator {
+    func height(
+        for row: SessionIndexTableRow,
+        environment: SessionIndexTableEnvironmentSnapshot
+    ) -> CGFloat {
+        switch row {
+        case .gap:
+            return 4
+        case .section(let section, let rowLimit, _, _, let isCollapsed, _, _, _, _):
+            let headerHeight = lineHeight(
+                baseFontSize: 13,
+                minimumContentHeight: 14,
+                verticalPadding: 6,
+                environment: environment
+            )
+            guard !isCollapsed else { return headerHeight }
+
+            let entryHeight = lineHeight(
+                baseFontSize: 13,
+                minimumContentHeight: 12,
+                verticalPadding: 8,
+                environment: environment
+            )
+            let visibleEntryHeight = CGFloat(min(section.entries.count, rowLimit)) * entryHeight
+            let showMoreHeight: CGFloat
+            if section.shouldOfferShowMore(rowLimit: rowLimit) {
+                showMoreHeight = lineHeight(
+                    baseFontSize: 12,
+                    minimumContentHeight: 0,
+                    verticalPadding: 8,
+                    environment: environment
+                )
+            } else {
+                showMoreHeight = 0
+            }
+            return headerHeight + visibleEntryHeight + showMoreHeight + 2
+        }
+    }
+
+    private func lineHeight(
+        baseFontSize: CGFloat,
+        minimumContentHeight: CGFloat,
+        verticalPadding: CGFloat,
+        environment: SessionIndexTableEnvironmentSnapshot
+    ) -> CGFloat {
+        let pointSize = GlobalFontMagnification.scaledSize(
+            baseFontSize,
+            percent: environment.globalFontMagnificationPercent
+        )
+        let fontHeight = NSFont.systemFont(ofSize: pointSize).boundingRectForFont.height
+        return ceil(max(fontHeight, minimumContentHeight) + verticalPadding)
+    }
+}

--- a/Sources/SessionIndexTableRowHeightCalculator.swift
+++ b/Sources/SessionIndexTableRowHeightCalculator.swift
@@ -3,7 +3,9 @@ import CmuxFoundation
 
 /// Computes Vault table heights without instantiating offscreen SwiftUI rows.
 @MainActor
-struct SessionIndexTableRowHeightCalculator {
+final class SessionIndexTableRowHeightCalculator {
+    private var fontHeightByPointSize: [CGFloat: CGFloat] = [:]
+
     func height(
         for row: SessionIndexTableRow,
         environment: SessionIndexTableEnvironmentSnapshot
@@ -52,7 +54,13 @@ struct SessionIndexTableRowHeightCalculator {
             baseFontSize,
             percent: environment.globalFontMagnificationPercent
         )
-        let fontHeight = NSFont.systemFont(ofSize: pointSize).boundingRectForFont.height
+        let fontHeight: CGFloat
+        if let cachedFontHeight = fontHeightByPointSize[pointSize] {
+            fontHeight = cachedFontHeight
+        } else {
+            fontHeight = NSFont.systemFont(ofSize: pointSize).boundingRectForFont.height
+            fontHeightByPointSize[pointSize] = fontHeight
+        }
         return ceil(max(fontHeight, minimumContentHeight) + verticalPadding)
     }
 }

--- a/Sources/SessionIndexTableRowID.swift
+++ b/Sources/SessionIndexTableRowID.swift
@@ -1,0 +1,5 @@
+enum SessionIndexTableRowID: Hashable {
+    case section(SectionKey)
+    case gapBefore(SectionKey)
+    case trailingGap
+}

--- a/Sources/SessionIndexTableView.swift
+++ b/Sources/SessionIndexTableView.swift
@@ -1,0 +1,27 @@
+import CmuxFoundation
+import SwiftUI
+
+/// SwiftUI bridge for the AppKit-virtualized Vault session list.
+struct SessionIndexTableView: NSViewRepresentable {
+    let rows: [SessionIndexTableRow]
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.cmuxGlobalFontMagnificationPercent) private var globalFontMagnificationPercent
+
+    func makeCoordinator() -> SessionIndexTableController {
+        SessionIndexTableController()
+    }
+
+    func makeNSView(context: Context) -> SessionIndexTableContainerView {
+        context.coordinator.makeContainerView()
+    }
+
+    func updateNSView(_ nsView: SessionIndexTableContainerView, context: Context) {
+        context.coordinator.apply(
+            rows: rows,
+            environment: SessionIndexTableEnvironmentSnapshot(
+                colorScheme: colorScheme,
+                globalFontMagnificationPercent: globalFontMagnificationPercent
+            )
+        )
+    }
+}

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -1054,7 +1054,7 @@ private extension SessionEntry {
     }
 }
 
-private enum SessionTranscriptLoader {
+enum SessionTranscriptLoader {
     private static let streamChunkSize = 256 * 1024
     private static let maxPreviewRecordBytes = 2 * 1024 * 1024
     private static let maxPreviewTurns = 500
@@ -1326,10 +1326,10 @@ private enum SessionTranscriptLoader {
             turns.append(SessionTranscriptTurn(id: lineIndex, role: .user, text: text))
             return false
         }
-        turns.reverse()
         if didHitTurnLimit {
             appendTurnLimitMarker(to: &turns, id: lineIndex)
         }
+        turns.reverse()
         return coalesce(turns)
     }
 

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -192,63 +192,56 @@ struct SessionIndexView: View {
             await store.loadDirectorySnapshot(cwd: cwd)
         }
 
-        return ScrollView(.vertical) {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(Array(sections.enumerated()), id: \.element.key) { index, section in
-                    // Drop above this row -> insert dragged section BEFORE this section's key.
-                    SectionReorderGap(
-                        beforeKey: section.key,
-                        isValidDrop: draggedKey == nil || draggedKey != section.key,
-                        actions: gapActions
-                    ).equatable()
-                    IndexSectionView(
-                        section: section,
-                        rowLimit: Self.collapsedRowLimit,
-                        isDragged: draggedKey == section.key,
-                        previewEntryId: previewEntry?.id,
-                        isCollapsed: Binding(
-                            get: { collapsedSections.contains(section.key) },
-                            set: { newValue in
-                                if newValue {
-                                    collapsedSections.insert(section.key)
-                                } else {
-                                    collapsedSections.remove(section.key)
-                                }
-                            }
-                        ),
-                        isPopoverOpen: Binding(
-                            get: { openPopoverSection == section.key },
-                            set: { newValue in
-                                openPopoverSection = newValue ? section.key : nil
-                            }
-                        ),
-                        actions: IndexSectionActions(
-                            onBeginDrag: { dragCoordinator.draggedKey = section.key },
-                            onPreviewEntry: { entry in
-                                previewEntry = entry
-                            },
-                            onDismissPreview: { id in
-                                if previewEntry?.id == id {
-                                    previewEntry = nil
-                                }
-                            },
-                            onResume: onResumeClosure,
-                            search: searchFn,
-                            loadSnapshot: loadSnapshotFn
-                        )
-                    ).equatable()
-                    let _ = index
-                }
-                // Trailing gap -> append.
-                SectionReorderGap(
-                    beforeKey: nil,
-                    isValidDrop: true,
+        let rows = sections.flatMap { section in
+            let sectionActions = IndexSectionActions(
+                onBeginDrag: { dragCoordinator.draggedKey = section.key },
+                onPreviewEntry: { entry in
+                    previewEntry = entry
+                },
+                onDismissPreview: { id in
+                    if previewEntry?.id == id {
+                        previewEntry = nil
+                    }
+                },
+                onResume: onResumeClosure,
+                search: searchFn,
+                loadSnapshot: loadSnapshotFn
+            )
+            return [
+                SessionIndexTableRow.gap(
+                    beforeKey: section.key,
+                    isValidDrop: draggedKey == nil || draggedKey != section.key,
                     actions: gapActions
-                ).equatable()
-            }
-            .padding(.bottom, 8)
-        }
-        .modifier(ClearScrollBackground())
+                ),
+                SessionIndexTableRow.section(
+                    section: section,
+                    rowLimit: Self.collapsedRowLimit,
+                    isDragged: draggedKey == section.key,
+                    previewEntryId: previewEntry?.id,
+                    isCollapsed: collapsedSections.contains(section.key),
+                    isPopoverOpen: openPopoverSection == section.key,
+                    actions: sectionActions,
+                    setCollapsed: { newValue in
+                        if newValue {
+                            collapsedSections.insert(section.key)
+                        } else {
+                            collapsedSections.remove(section.key)
+                        }
+                    },
+                    setPopoverOpen: { newValue in
+                        openPopoverSection = newValue ? section.key : nil
+                    }
+                ),
+            ]
+        } + [
+            SessionIndexTableRow.gap(
+                beforeKey: nil,
+                isValidDrop: true,
+                actions: gapActions
+            ),
+        ]
+
+        return SessionIndexTableView(rows: rows)
         .background(
             DragCancelMonitor(dragCoordinator: dragCoordinator)
         )
@@ -342,7 +335,7 @@ struct SectionGapActions {
     let clearDraggedKey: @MainActor () -> Void
 }
 
-private struct IndexSectionView: View, Equatable {
+struct IndexSectionView: View, Equatable {
     let section: IndexSection
     let rowLimit: Int
     /// True iff this section is the one currently being dragged. Precomputed
@@ -478,7 +471,7 @@ private struct IndexSectionView: View, Equatable {
     }
 }
 
-private struct SectionReorderGap: View, Equatable {
+struct SectionReorderGap: View, Equatable {
     /// Section the dragged item should land BEFORE if dropped here. `nil` for
     /// the trailing gap (drop appends to the end of persisted order).
     let beforeKey: SectionKey?
@@ -1312,7 +1305,10 @@ private enum SessionTranscriptLoader {
         var didHitTurnLimit = false
         let agent = SessionAgent.registered(RegisteredSessionAgent(id: "antigravity"))
 
-        SessionIndexStore.forEachJSONLine(url: url, maxBytes: Int.max) { object in
+        SessionIndexStore.forEachJSONLineFromTail(
+            url: url,
+            maxBytes: SessionIndexStore.antigravityHistoryByteCap
+        ) { object in
             defer { lineIndex += 1 }
             if Task.isCancelled { return true }
             guard turns.count < maxPreviewTurns else {
@@ -1329,6 +1325,7 @@ private enum SessionTranscriptLoader {
             turns.append(SessionTranscriptTurn(id: lineIndex, role: .user, text: text))
             return false
         }
+        turns.reverse()
         if didHitTurnLimit {
             appendTurnLimitMarker(to: &turns, id: lineIndex)
         }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -217,7 +217,7 @@ struct SessionIndexView: View {
                     section: section,
                     rowLimit: Self.collapsedRowLimit,
                     isDragged: draggedKey == section.key,
-                    previewEntryId: previewEntry?.id,
+                    previewEntryId: SessionIndexTableRow.containedPreviewEntryID(previewEntry?.id, in: section),
                     isCollapsed: collapsedSections.contains(section.key),
                     isPopoverOpen: openPopoverSection == section.key,
                     actions: sectionActions,
@@ -1305,10 +1305,10 @@ enum SessionTranscriptLoader {
         var lineIndex = 0
         var didHitTurnLimit = false
         let agent = SessionAgent.registered(RegisteredSessionAgent(id: "antigravity"))
-
-        let metrics = SessionIndexStore.forEachJSONLineFromTail(
+        let metrics = SessionIndexJSONLReader().fromTailPages(
             url: url,
-            maxBytes: SessionIndexStore.antigravityHistoryByteCap
+            maxBytesPerPage: SessionIndexStore.antigravityHistoryByteCap,
+            maximumPageCount: SessionIndexStore.antigravityHistoryPreviewPageLimit
         ) { object in
             defer { lineIndex += 1 }
             if Task.isCancelled { return true }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -242,9 +242,10 @@ struct SessionIndexView: View {
         ]
 
         return SessionIndexTableView(rows: rows)
-        .background(
-            DragCancelMonitor(dragCoordinator: dragCoordinator)
-        )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(
+                DragCancelMonitor(dragCoordinator: dragCoordinator)
+            )
     }
 }
 
@@ -352,9 +353,9 @@ struct IndexSectionView: View, Equatable {
 
     /// Skip body re-eval when this view's inputs are unchanged. `actions` is
     /// not comparable (closures) but is expected to be stable (closures
-    /// capture stable object references above the list boundary). Excluding
-    /// it from `==` is the core optimization that keeps LazyVStack's layout
-    /// cache from thrashing when unrelated store fields change.
+    /// capture stable object references above the table boundary). Excluding
+    /// it from `==` keeps a recycled cell's hosted graph stable when unrelated
+    /// store fields change.
     static func == (lhs: IndexSectionView, rhs: IndexSectionView) -> Bool {
         lhs.section == rhs.section
             && lhs.rowLimit == rhs.rowLimit

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -1306,7 +1306,7 @@ enum SessionTranscriptLoader {
         var didHitTurnLimit = false
         let agent = SessionAgent.registered(RegisteredSessionAgent(id: "antigravity"))
 
-        SessionIndexStore.forEachJSONLineFromTail(
+        let metrics = SessionIndexStore.forEachJSONLineFromTail(
             url: url,
             maxBytes: SessionIndexStore.antigravityHistoryByteCap
         ) { object in
@@ -1326,7 +1326,7 @@ enum SessionTranscriptLoader {
             turns.append(SessionTranscriptTurn(id: lineIndex, role: .user, text: text))
             return false
         }
-        if didHitTurnLimit {
+        if didHitTurnLimit || !metrics.didReachStart {
             appendTurnLimitMarker(to: &turns, id: lineIndex)
         }
         turns.reverse()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1475,11 +1475,27 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C71500040000000000000001 /* SessionContentWidthPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71500030000000000000001 /* SessionContentWidthPresentation.swift */; };
 		C71510010000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71510020000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift */; };
 		A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74770010000000000000004 /* SessionDisplaySnapshot.swift */; };
+		85000000000000000000002A /* SessionIndexEntryProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85000000000000000000001A /* SessionIndexEntryProjection.swift */; };
+		850000000000000000000028 /* SessionIndexJSONLReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000018 /* SessionIndexJSONLReader.swift */; };
+		850000000000000000000004 /* SessionIndexJSONLReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000003 /* SessionIndexJSONLReaderTests.swift */; };
+		850000000000000000000029 /* SessionIndexJSONLReadMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000019 /* SessionIndexJSONLReadMetrics.swift */; };
 		B3575000000000000000000C /* SessionIndexModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3575000000000000000000B /* SessionIndexModels.swift */; };
 		B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */; };
 		FE003108 /* SessionIndexSectionPopoverHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003008 /* SessionIndexSectionPopoverHost.swift */; };
+		850000000000000000000027 /* SessionIndexSnapshotLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000017 /* SessionIndexSnapshotLoader.swift */; };
+		850000000000000000000006 /* SessionIndexSnapshotLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000005 /* SessionIndexSnapshotLoaderTests.swift */; };
 		FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003004 /* SessionIndexStore+CodexSQL.swift */; };
 		FE003101 /* SessionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003001 /* SessionIndexStore.swift */; };
+		850000000000000000000008 /* SessionIndexSyntheticCorpus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000007 /* SessionIndexSyntheticCorpus.swift */; };
+		850000000000000000000020 /* SessionIndexTableCellRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000010 /* SessionIndexTableCellRootView.swift */; };
+		850000000000000000000021 /* SessionIndexTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000011 /* SessionIndexTableCellView.swift */; };
+		850000000000000000000022 /* SessionIndexTableContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000012 /* SessionIndexTableContainerView.swift */; };
+		850000000000000000000023 /* SessionIndexTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000013 /* SessionIndexTableController.swift */; };
+		85000000000000000000002B /* SessionIndexTableEnvironmentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85000000000000000000001B /* SessionIndexTableEnvironmentSnapshot.swift */; };
+		850000000000000000000024 /* SessionIndexTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000014 /* SessionIndexTableRow.swift */; };
+		85000000000000000000002C /* SessionIndexTableRowHeightCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85000000000000000000001C /* SessionIndexTableRowHeightCalculator.swift */; };
+		850000000000000000000025 /* SessionIndexTableRowID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000015 /* SessionIndexTableRowID.swift */; };
+		850000000000000000000026 /* SessionIndexTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000016 /* SessionIndexTableView.swift */; };
 		850000000000000000000002 /* SessionIndexTableViewportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000001 /* SessionIndexTableViewportTests.swift */; };
 		FE003102 /* SessionIndexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003002 /* SessionIndexView.swift */; };
 		8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */; };
@@ -3638,11 +3654,27 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C71500030000000000000001 /* SessionContentWidthPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/SessionContentWidthPresentation.swift; sourceTree = "<group>"; };
 		C71510020000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContentWidthSettingsFileStoreTests.swift; sourceTree = "<group>"; };
 		A74770010000000000000004 /* SessionDisplaySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplaySnapshot.swift; sourceTree = "<group>"; };
+		85000000000000000000001A /* SessionIndexEntryProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexEntryProjection.swift; sourceTree = "<group>"; };
+		850000000000000000000018 /* SessionIndexJSONLReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexJSONLReader.swift; sourceTree = "<group>"; };
+		850000000000000000000003 /* SessionIndexJSONLReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexJSONLReaderTests.swift; sourceTree = "<group>"; };
+		850000000000000000000019 /* SessionIndexJSONLReadMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexJSONLReadMetrics.swift; sourceTree = "<group>"; };
 		B3575000000000000000000B /* SessionIndexModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexModels.swift; sourceTree = "<group>"; };
 		B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexRegisteredAgents.swift; sourceTree = "<group>"; };
 		FE003008 /* SessionIndexSectionPopoverHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSectionPopoverHost.swift; sourceTree = "<group>"; };
+		850000000000000000000017 /* SessionIndexSnapshotLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSnapshotLoader.swift; sourceTree = "<group>"; };
+		850000000000000000000005 /* SessionIndexSnapshotLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSnapshotLoaderTests.swift; sourceTree = "<group>"; };
 		FE003004 /* SessionIndexStore+CodexSQL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionIndexStore+CodexSQL.swift"; sourceTree = "<group>"; };
 		FE003001 /* SessionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexStore.swift; sourceTree = "<group>"; };
+		850000000000000000000007 /* SessionIndexSyntheticCorpus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSyntheticCorpus.swift; sourceTree = "<group>"; };
+		850000000000000000000010 /* SessionIndexTableCellRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableCellRootView.swift; sourceTree = "<group>"; };
+		850000000000000000000011 /* SessionIndexTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableCellView.swift; sourceTree = "<group>"; };
+		850000000000000000000012 /* SessionIndexTableContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableContainerView.swift; sourceTree = "<group>"; };
+		850000000000000000000013 /* SessionIndexTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableController.swift; sourceTree = "<group>"; };
+		85000000000000000000001B /* SessionIndexTableEnvironmentSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableEnvironmentSnapshot.swift; sourceTree = "<group>"; };
+		850000000000000000000014 /* SessionIndexTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableRow.swift; sourceTree = "<group>"; };
+		85000000000000000000001C /* SessionIndexTableRowHeightCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableRowHeightCalculator.swift; sourceTree = "<group>"; };
+		850000000000000000000015 /* SessionIndexTableRowID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableRowID.swift; sourceTree = "<group>"; };
+		850000000000000000000016 /* SessionIndexTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableView.swift; sourceTree = "<group>"; };
 		850000000000000000000001 /* SessionIndexTableViewportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableViewportTests.swift; sourceTree = "<group>"; };
 		FE003002 /* SessionIndexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexView.swift; sourceTree = "<group>"; };
 		42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexViewTests.swift; sourceTree = "<group>"; };
@@ -5860,6 +5892,19 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE001007 /* GitFileStatus.swift */,
 				FE001006 /* GitStatusProvider.swift */,
 				FE003001 /* SessionIndexStore.swift */,
+				850000000000000000000010 /* SessionIndexTableCellRootView.swift */,
+				850000000000000000000011 /* SessionIndexTableCellView.swift */,
+				850000000000000000000012 /* SessionIndexTableContainerView.swift */,
+				850000000000000000000013 /* SessionIndexTableController.swift */,
+				850000000000000000000014 /* SessionIndexTableRow.swift */,
+				850000000000000000000015 /* SessionIndexTableRowID.swift */,
+				850000000000000000000016 /* SessionIndexTableView.swift */,
+				850000000000000000000017 /* SessionIndexSnapshotLoader.swift */,
+				850000000000000000000018 /* SessionIndexJSONLReader.swift */,
+				850000000000000000000019 /* SessionIndexJSONLReadMetrics.swift */,
+				85000000000000000000001A /* SessionIndexEntryProjection.swift */,
+				85000000000000000000001B /* SessionIndexTableEnvironmentSnapshot.swift */,
+				85000000000000000000001C /* SessionIndexTableRowHeightCalculator.swift */,
 				B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */,
 				CAFE58130000000000000002 /* CampfireLaunchArgumentNormalizer.swift */,
 				B35750000000000000000005 /* VaultAgentProcessScanner.swift */,
@@ -6481,6 +6526,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */,
 				C9A57402C9A57402C9A57402 /* WorkspaceGroupMoveToMenuStateTests.swift */,
 				FEED49850000000000000002 /* FeedEventClassificationTests.swift */,
+				850000000000000000000003 /* SessionIndexJSONLReaderTests.swift */,
+				850000000000000000000005 /* SessionIndexSnapshotLoaderTests.swift */,
+				850000000000000000000007 /* SessionIndexSyntheticCorpus.swift */,
 				850000000000000000000001 /* SessionIndexTableViewportTests.swift */,
 				42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */,
 				F1C3F1DBF6BF5D7223C4A30C /* SidebarMarkdownRendererTests.swift */,
@@ -7952,11 +8000,24 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C71500020000000000000001 /* SessionContentWidthModifier.swift in Sources */,
 				C71500040000000000000001 /* SessionContentWidthPresentation.swift in Sources */,
 				A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */,
+				85000000000000000000002A /* SessionIndexEntryProjection.swift in Sources */,
+				850000000000000000000028 /* SessionIndexJSONLReader.swift in Sources */,
+				850000000000000000000029 /* SessionIndexJSONLReadMetrics.swift in Sources */,
 				B3575000000000000000000C /* SessionIndexModels.swift in Sources */,
 				B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */,
 				FE003108 /* SessionIndexSectionPopoverHost.swift in Sources */,
+				850000000000000000000027 /* SessionIndexSnapshotLoader.swift in Sources */,
 				FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */,
 				FE003101 /* SessionIndexStore.swift in Sources */,
+				850000000000000000000020 /* SessionIndexTableCellRootView.swift in Sources */,
+				850000000000000000000021 /* SessionIndexTableCellView.swift in Sources */,
+				850000000000000000000022 /* SessionIndexTableContainerView.swift in Sources */,
+				850000000000000000000023 /* SessionIndexTableController.swift in Sources */,
+				85000000000000000000002B /* SessionIndexTableEnvironmentSnapshot.swift in Sources */,
+				850000000000000000000024 /* SessionIndexTableRow.swift in Sources */,
+				85000000000000000000002C /* SessionIndexTableRowHeightCalculator.swift in Sources */,
+				850000000000000000000025 /* SessionIndexTableRowID.swift in Sources */,
+				850000000000000000000026 /* SessionIndexTableView.swift in Sources */,
 				FE003102 /* SessionIndexView.swift in Sources */,
 		A5F10000000000000000000F /* SessionNotificationSnapshot.swift in Sources */,
 				481D7BF878AB38DA5642D1C9 /* SessionPersistence+Todos.swift in Sources */,
@@ -9027,6 +9088,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				3865A0043865A0043865A004 /* SearchIndexTests.swift in Sources */,
 				5E2701030000000000000001 /* SentryEventScrubberTests.swift in Sources */,
 				C71510010000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift in Sources */,
+				850000000000000000000004 /* SessionIndexJSONLReaderTests.swift in Sources */,
+				850000000000000000000006 /* SessionIndexSnapshotLoaderTests.swift in Sources */,
+				850000000000000000000008 /* SessionIndexSyntheticCorpus.swift in Sources */,
 				850000000000000000000002 /* SessionIndexTableViewportTests.swift in Sources */,
 				8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */,
 				F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1480,6 +1480,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		FE003108 /* SessionIndexSectionPopoverHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003008 /* SessionIndexSectionPopoverHost.swift */; };
 		FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003004 /* SessionIndexStore+CodexSQL.swift */; };
 		FE003101 /* SessionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003001 /* SessionIndexStore.swift */; };
+		850000000000000000000002 /* SessionIndexTableViewportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000001 /* SessionIndexTableViewportTests.swift */; };
 		FE003102 /* SessionIndexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003002 /* SessionIndexView.swift */; };
 		8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */; };
 		A5F10000000000000000000F /* SessionNotificationSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F100000000000000000010 /* SessionNotificationSnapshot.swift */; };
@@ -3642,6 +3643,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		FE003008 /* SessionIndexSectionPopoverHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSectionPopoverHost.swift; sourceTree = "<group>"; };
 		FE003004 /* SessionIndexStore+CodexSQL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionIndexStore+CodexSQL.swift"; sourceTree = "<group>"; };
 		FE003001 /* SessionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexStore.swift; sourceTree = "<group>"; };
+		850000000000000000000001 /* SessionIndexTableViewportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableViewportTests.swift; sourceTree = "<group>"; };
 		FE003002 /* SessionIndexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexView.swift; sourceTree = "<group>"; };
 		42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexViewTests.swift; sourceTree = "<group>"; };
 		A5F100000000000000000010 /* SessionNotificationSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNotificationSnapshot.swift; sourceTree = "<group>"; };
@@ -6479,6 +6481,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */,
 				C9A57402C9A57402C9A57402 /* WorkspaceGroupMoveToMenuStateTests.swift */,
 				FEED49850000000000000002 /* FeedEventClassificationTests.swift */,
+				850000000000000000000001 /* SessionIndexTableViewportTests.swift */,
 				42D69572C8D276745E502B94 /* SessionIndexViewTests.swift */,
 				F1C3F1DBF6BF5D7223C4A30C /* SidebarMarkdownRendererTests.swift */,
 				14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */,
@@ -9024,6 +9027,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				3865A0043865A0043865A004 /* SearchIndexTests.swift in Sources */,
 				5E2701030000000000000001 /* SentryEventScrubberTests.swift in Sources */,
 				C71510010000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift in Sources */,
+				850000000000000000000002 /* SessionIndexTableViewportTests.swift in Sources */,
 				8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */,
 				F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */,
 				F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1487,11 +1487,13 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003004 /* SessionIndexStore+CodexSQL.swift */; };
 		FE003101 /* SessionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003001 /* SessionIndexStore.swift */; };
 		850000000000000000000008 /* SessionIndexSyntheticCorpus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000007 /* SessionIndexSyntheticCorpus.swift */; };
+		85000000000000000000002D /* SessionIndexTableApplyInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85000000000000000000001D /* SessionIndexTableApplyInput.swift */; };
 		850000000000000000000020 /* SessionIndexTableCellRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000010 /* SessionIndexTableCellRootView.swift */; };
 		850000000000000000000021 /* SessionIndexTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000011 /* SessionIndexTableCellView.swift */; };
 		850000000000000000000022 /* SessionIndexTableContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000012 /* SessionIndexTableContainerView.swift */; };
 		850000000000000000000023 /* SessionIndexTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000013 /* SessionIndexTableController.swift */; };
 		85000000000000000000002B /* SessionIndexTableEnvironmentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85000000000000000000001B /* SessionIndexTableEnvironmentSnapshot.swift */; };
+		85000000000000000000002E /* SessionIndexTableMutationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85000000000000000000001E /* SessionIndexTableMutationScheduler.swift */; };
 		850000000000000000000024 /* SessionIndexTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000014 /* SessionIndexTableRow.swift */; };
 		85000000000000000000002C /* SessionIndexTableRowHeightCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85000000000000000000001C /* SessionIndexTableRowHeightCalculator.swift */; };
 		850000000000000000000025 /* SessionIndexTableRowID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850000000000000000000015 /* SessionIndexTableRowID.swift */; };
@@ -3666,11 +3668,13 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		FE003004 /* SessionIndexStore+CodexSQL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionIndexStore+CodexSQL.swift"; sourceTree = "<group>"; };
 		FE003001 /* SessionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexStore.swift; sourceTree = "<group>"; };
 		850000000000000000000007 /* SessionIndexSyntheticCorpus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSyntheticCorpus.swift; sourceTree = "<group>"; };
+		85000000000000000000001D /* SessionIndexTableApplyInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableApplyInput.swift; sourceTree = "<group>"; };
 		850000000000000000000010 /* SessionIndexTableCellRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableCellRootView.swift; sourceTree = "<group>"; };
 		850000000000000000000011 /* SessionIndexTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableCellView.swift; sourceTree = "<group>"; };
 		850000000000000000000012 /* SessionIndexTableContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableContainerView.swift; sourceTree = "<group>"; };
 		850000000000000000000013 /* SessionIndexTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableController.swift; sourceTree = "<group>"; };
 		85000000000000000000001B /* SessionIndexTableEnvironmentSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableEnvironmentSnapshot.swift; sourceTree = "<group>"; };
+		85000000000000000000001E /* SessionIndexTableMutationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableMutationScheduler.swift; sourceTree = "<group>"; };
 		850000000000000000000014 /* SessionIndexTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableRow.swift; sourceTree = "<group>"; };
 		85000000000000000000001C /* SessionIndexTableRowHeightCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableRowHeightCalculator.swift; sourceTree = "<group>"; };
 		850000000000000000000015 /* SessionIndexTableRowID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexTableRowID.swift; sourceTree = "<group>"; };
@@ -5892,6 +5896,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE001007 /* GitFileStatus.swift */,
 				FE001006 /* GitStatusProvider.swift */,
 				FE003001 /* SessionIndexStore.swift */,
+				85000000000000000000001D /* SessionIndexTableApplyInput.swift */,
 				850000000000000000000010 /* SessionIndexTableCellRootView.swift */,
 				850000000000000000000011 /* SessionIndexTableCellView.swift */,
 				850000000000000000000012 /* SessionIndexTableContainerView.swift */,
@@ -5904,6 +5909,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				850000000000000000000019 /* SessionIndexJSONLReadMetrics.swift */,
 				85000000000000000000001A /* SessionIndexEntryProjection.swift */,
 				85000000000000000000001B /* SessionIndexTableEnvironmentSnapshot.swift */,
+				85000000000000000000001E /* SessionIndexTableMutationScheduler.swift */,
 				85000000000000000000001C /* SessionIndexTableRowHeightCalculator.swift */,
 				B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */,
 				CAFE58130000000000000002 /* CampfireLaunchArgumentNormalizer.swift */,
@@ -8009,11 +8015,13 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				850000000000000000000027 /* SessionIndexSnapshotLoader.swift in Sources */,
 				FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */,
 				FE003101 /* SessionIndexStore.swift in Sources */,
+				85000000000000000000002D /* SessionIndexTableApplyInput.swift in Sources */,
 				850000000000000000000020 /* SessionIndexTableCellRootView.swift in Sources */,
 				850000000000000000000021 /* SessionIndexTableCellView.swift in Sources */,
 				850000000000000000000022 /* SessionIndexTableContainerView.swift in Sources */,
 				850000000000000000000023 /* SessionIndexTableController.swift in Sources */,
 				85000000000000000000002B /* SessionIndexTableEnvironmentSnapshot.swift in Sources */,
+				85000000000000000000002E /* SessionIndexTableMutationScheduler.swift in Sources */,
 				850000000000000000000024 /* SessionIndexTableRow.swift in Sources */,
 				85000000000000000000002C /* SessionIndexTableRowHeightCalculator.swift in Sources */,
 				850000000000000000000025 /* SessionIndexTableRowID.swift in Sources */,

--- a/cmuxTests/SessionIndexJSONLReaderTests.swift
+++ b/cmuxTests/SessionIndexJSONLReaderTests.swift
@@ -156,6 +156,19 @@ struct SessionIndexJSONLReaderTests {
             specifics: .registered(registration)
         )
         let turns = try await SessionTranscriptLoader.load(entry: previewEntry)
+        let oldPreviewEntry = SessionEntry(
+            id: "antigravity:old-session",
+            agent: .registered(RegisteredSessionAgent(registration: registration)),
+            sessionId: "old-session",
+            title: "Old",
+            cwd: nil,
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: .distantPast,
+            fileURL: url,
+            specifics: .registered(registration)
+        )
+        let oldTurns = try await SessionTranscriptLoader.load(entry: oldPreviewEntry)
 
         #expect(initialEntries.map(\.sessionId) == ["active-session"])
         #expect(Set(expandedEntries.map(\.sessionId)) == ["active-session", "old-session"])
@@ -169,6 +182,7 @@ struct SessionIndexJSONLReaderTests {
         #expect(entries.map(\.sessionId) == ["old-session"])
         #expect(turns.first?.role == .event)
         #expect(turns.last?.text == "latest prompt")
+        #expect(oldTurns.contains { $0.text == "needle-old" })
     }
 
     @Test
@@ -198,5 +212,43 @@ struct SessionIndexJSONLReaderTests {
         #expect(entries.count == 1)
         #expect(entries.first?.title == "newest title")
         #expect(entries.first?.cwd == "/tmp/newest")
+    }
+
+    @Test
+    func antigravityPaginationIsStableWhenTimestampsAreMissing() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vault-antigravity-stable-pages-\(UUID().uuidString)", isDirectory: true)
+        let url = root.appendingPathComponent("history.jsonl")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let olderSessionIDs = (0..<100).map { String(format: "a-%03d", $0) }
+        let newerSessionIDs = (0..<100).map { String(format: "z-%03d", $0) }
+        let history = (olderSessionIDs + newerSessionIDs).map { sessionID in
+            #"{"conversationId":"\#(sessionID)","display":"\#(sessionID)"}"#
+        }.joined(separator: "\n") + "\n"
+        try Data(history.utf8).write(to: url)
+
+        var registration = CmuxVaultAgentRegistration.builtInAntigravity
+        registration.sessionDirectory = root.path
+        let firstPage = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: nil,
+            offset: 0,
+            limit: 100
+        )
+        let secondPage = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: nil,
+            offset: 100,
+            limit: 100
+        )
+        let combinedSessionIDs = (firstPage + secondPage).map(\.sessionId)
+
+        #expect(firstPage.count == 100)
+        #expect(secondPage.count == 100)
+        #expect(Set(combinedSessionIDs).count == 200)
     }
 }

--- a/cmuxTests/SessionIndexJSONLReaderTests.swift
+++ b/cmuxTests/SessionIndexJSONLReaderTests.swift
@@ -103,7 +103,7 @@ struct SessionIndexJSONLReaderTests {
     }
 
     @Test
-    func antigravitySearchPagesPastTailCapAndPreviewDisclosesOmittedHistory() async throws {
+    func antigravityShowMoreAndSearchPagePastTailCap() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-vault-antigravity-pages-\(UUID().uuidString)", isDirectory: true)
         let url = root.appendingPathComponent("history.jsonl")
@@ -129,6 +129,13 @@ struct SessionIndexJSONLReaderTests {
             offset: 0,
             limit: SessionIndexStore.perAgentLimit
         )
+        let expandedEntries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: nil,
+            offset: 0,
+            limit: 100
+        )
         let entries = await SessionIndexStore.loadRegisteredAgentEntries(
             registration: registration,
             needle: "needle-old",
@@ -151,8 +158,45 @@ struct SessionIndexJSONLReaderTests {
         let turns = try await SessionTranscriptLoader.load(entry: previewEntry)
 
         #expect(initialEntries.map(\.sessionId) == ["active-session"])
+        #expect(Set(expandedEntries.map(\.sessionId)) == ["active-session", "old-session"])
+        let initialSection = IndexSection(
+            key: .agent(.registered(RegisteredSessionAgent(registration: registration))),
+            title: "Antigravity",
+            icon: .agent(.registered(RegisteredSessionAgent(registration: registration))),
+            entries: initialEntries
+        )
+        #expect(initialSection.shouldOfferShowMore(rowLimit: 5))
         #expect(entries.map(\.sessionId) == ["old-session"])
         #expect(turns.first?.role == .event)
         #expect(turns.last?.text == "latest prompt")
+    }
+
+    @Test
+    func antigravityReverseScanKeepsNewestMetadataWhenTimestampsAreMissing() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vault-antigravity-equal-dates-\(UUID().uuidString)", isDirectory: true)
+        let url = root.appendingPathComponent("history.jsonl")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let history = """
+        {"conversationId":"same-session","display":"older title","cwd":"/tmp/older"}
+        {"conversationId":"same-session","display":"newest title","cwd":"/tmp/newest"}
+
+        """
+        try Data(history.utf8).write(to: url)
+
+        var registration = CmuxVaultAgentRegistration.builtInAntigravity
+        registration.sessionDirectory = root.path
+        let entries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: nil,
+            offset: 0,
+            limit: SessionIndexStore.perAgentLimit
+        )
+
+        #expect(entries.count == 1)
+        #expect(entries.first?.title == "newest title")
+        #expect(entries.first?.cwd == "/tmp/newest")
     }
 }

--- a/cmuxTests/SessionIndexJSONLReaderTests.swift
+++ b/cmuxTests/SessionIndexJSONLReaderTests.swift
@@ -38,4 +38,41 @@ struct SessionIndexJSONLReaderTests {
         #expect(metrics.bytesRead <= byteLimit)
         #expect(metrics.recordsVisited < 2_000)
     }
+
+    @Test
+    func antigravityTailPreviewPlacesTruncationBeforeVisibleTurns() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vault-antigravity-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let sessionID = "antigravity-session"
+        let history = (0...500).map { index in
+            "{\"conversationId\":\"\(sessionID)\",\"display\":\"prompt-\(index)\"}"
+        }.joined(separator: "\n") + "\n"
+        try Data(history.utf8).write(to: url)
+
+        let entry = SessionEntry(
+            id: "antigravity:\(url.path)",
+            agent: .registered(RegisteredSessionAgent(id: "antigravity")),
+            sessionId: sessionID,
+            title: "Antigravity",
+            cwd: nil,
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: .distantPast,
+            fileURL: url,
+            specifics: .rovodev
+        )
+
+        let turns = try await SessionTranscriptLoader.load(entry: entry)
+
+        #expect(turns.first?.role == .event)
+        #expect(
+            turns.first?.text == String(
+                localized: "sessionIndex.preview.truncated",
+                defaultValue: "Preview truncated"
+            )
+        )
+        #expect(turns.last?.text.contains("prompt-500") == true)
+    }
 }

--- a/cmuxTests/SessionIndexJSONLReaderTests.swift
+++ b/cmuxTests/SessionIndexJSONLReaderTests.swift
@@ -10,6 +10,31 @@ import Testing
 @Suite
 struct SessionIndexJSONLReaderTests {
     @Test
+    func startReaderParsesCompleteRecordEndingAtByteCap() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vault-start-boundary-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let record = #"{"sessionId":"exact-cap"}"#
+        try Data(record.utf8).write(to: url)
+
+        var visitedSessionIDs: [String] = []
+        let metrics = SessionIndexJSONLReader().fromStart(
+            url: url,
+            maxBytes: Data(record.utf8).count
+        ) { object in
+            if let sessionID = object["sessionId"] as? String {
+                visitedSessionIDs.append(sessionID)
+            }
+            return false
+        }
+
+        #expect(visitedSessionIDs == ["exact-cap"])
+        #expect(metrics.bytesRead == Data(record.utf8).count)
+        #expect(metrics.recordsVisited == 1)
+    }
+
+    @Test
     func tailReaderReturnsNewestRecordsWithoutReadingTheWholeHistory() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-vault-history-\(UUID().uuidString).jsonl")

--- a/cmuxTests/SessionIndexJSONLReaderTests.swift
+++ b/cmuxTests/SessionIndexJSONLReaderTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct SessionIndexJSONLReaderTests {
+    @Test
+    func tailReaderReturnsNewestRecordsWithoutReadingTheWholeHistory() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vault-history-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let padding = String(repeating: "x", count: 512)
+        let history = (0..<2_000).map { index in
+            "{\"sessionId\":\"session-\(index)\",\"display\":\"\(padding)\"}"
+        }.joined(separator: "\n") + "\n"
+        try Data(history.utf8).write(to: url)
+
+        var visitedSessionIDs: [String] = []
+        let byteLimit = 64 * 1024
+        let metrics = SessionIndexJSONLReader().fromTail(
+            url: url,
+            maxBytes: byteLimit
+        ) { object in
+            if let sessionID = object["sessionId"] as? String {
+                visitedSessionIDs.append(sessionID)
+            }
+            return visitedSessionIDs.count == 30
+        }
+
+        #expect(visitedSessionIDs.first == "session-1999")
+        #expect(visitedSessionIDs.count == 30)
+        #expect(metrics.bytesRead <= byteLimit)
+        #expect(metrics.recordsVisited < 2_000)
+    }
+}

--- a/cmuxTests/SessionIndexJSONLReaderTests.swift
+++ b/cmuxTests/SessionIndexJSONLReaderTests.swift
@@ -37,6 +37,32 @@ struct SessionIndexJSONLReaderTests {
         #expect(visitedSessionIDs.count == 30)
         #expect(metrics.bytesRead <= byteLimit)
         #expect(metrics.recordsVisited < 2_000)
+        #expect(!metrics.didReachStart)
+    }
+
+    @Test
+    func tailReaderPreservesRecordAtExactNewlineBoundary() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vault-boundary-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let older = "{\"sessionId\":\"older\"}\n"
+        let newer = "{\"sessionId\":\"newer\"}\n"
+        try Data((older + newer).utf8).write(to: url)
+
+        var visitedSessionIDs: [String] = []
+        let metrics = SessionIndexJSONLReader().fromTail(
+            url: url,
+            maxBytes: Data(newer.utf8).count + 1
+        ) { object in
+            if let sessionID = object["sessionId"] as? String {
+                visitedSessionIDs.append(sessionID)
+            }
+            return false
+        }
+
+        #expect(visitedSessionIDs == ["newer"])
+        #expect(!metrics.didReachStart)
     }
 
     @Test
@@ -74,5 +100,59 @@ struct SessionIndexJSONLReaderTests {
             )
         )
         #expect(turns.last?.text.contains("prompt-500") == true)
+    }
+
+    @Test
+    func antigravitySearchPagesPastTailCapAndPreviewDisclosesOmittedHistory() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vault-antigravity-pages-\(UUID().uuidString)", isDirectory: true)
+        let url = root.appendingPathComponent("history.jsonl")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        var history = Data(#"{"conversationId":"old-session","display":"needle-old","timestamp":1}"#.utf8)
+        history.append(0x0a)
+        history.append(Data(#"{"conversationId":"padding","display":""#.utf8))
+        history.append(Data(repeating: 0x78, count: SessionIndexStore.antigravityHistoryByteCap + 1_024))
+        history.append(Data(#"","timestamp":2}"#.utf8))
+        history.append(0x0a)
+        history.append(Data(#"{"conversationId":"active-session","display":"latest prompt","timestamp":3}"#.utf8))
+        history.append(0x0a)
+        try history.write(to: url)
+
+        var registration = CmuxVaultAgentRegistration.builtInAntigravity
+        registration.sessionDirectory = root.path
+        let initialEntries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: nil,
+            offset: 0,
+            limit: SessionIndexStore.perAgentLimit
+        )
+        let entries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "needle-old",
+            cwdFilter: nil,
+            offset: 0,
+            limit: 1
+        )
+        let previewEntry = SessionEntry(
+            id: "antigravity:active-session",
+            agent: .registered(RegisteredSessionAgent(registration: registration)),
+            sessionId: "active-session",
+            title: "Active",
+            cwd: nil,
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: .distantPast,
+            fileURL: url,
+            specifics: .registered(registration)
+        )
+        let turns = try await SessionTranscriptLoader.load(entry: previewEntry)
+
+        #expect(initialEntries.map(\.sessionId) == ["active-session"])
+        #expect(entries.map(\.sessionId) == ["old-session"])
+        #expect(turns.first?.role == .event)
+        #expect(turns.last?.text == "latest prompt")
     }
 }

--- a/cmuxTests/SessionIndexSnapshotLoaderTests.swift
+++ b/cmuxTests/SessionIndexSnapshotLoaderTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct SessionIndexSnapshotLoaderTests {
+    @MainActor
+    @Test
+    func twoThousandTranscriptCorpusScansOffMainActorWithinBudget() async throws {
+        let corpus = try await SessionIndexSyntheticCorpus.create(
+            projectCount: 20,
+            transcriptsPerProject: 100
+        )
+        let loader = SessionIndexSnapshotLoader {
+            corpus.loadEntries()
+        }
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        let entries = await loader.load()
+        let elapsed = start.duration(to: clock.now)
+        await corpus.remove()
+
+        #expect(entries.count == 2_000)
+        #expect(entries.allSatisfy { $0.title == "off-main" })
+        #expect(
+            elapsed < .seconds(10),
+            "A 2,000-transcript filesystem snapshot should complete within the bounded CI budget"
+        )
+    }
+}

--- a/cmuxTests/SessionIndexSnapshotLoaderTests.swift
+++ b/cmuxTests/SessionIndexSnapshotLoaderTests.swift
@@ -11,7 +11,7 @@ import Testing
 struct SessionIndexSnapshotLoaderTests {
     @MainActor
     @Test
-    func twoThousandTranscriptCorpusScansOffMainActorWithinBudget() async throws {
+    func twoThousandTranscriptCorpusScansOffMainActor() async throws {
         let corpus = try await SessionIndexSyntheticCorpus.create(
             projectCount: 20,
             transcriptsPerProject: 100
@@ -19,18 +19,10 @@ struct SessionIndexSnapshotLoaderTests {
         let loader = SessionIndexSnapshotLoader {
             corpus.loadEntries()
         }
-        let clock = ContinuousClock()
-        let start = clock.now
-
         let entries = await loader.load()
-        let elapsed = start.duration(to: clock.now)
         await corpus.remove()
 
         #expect(entries.count == 2_000)
         #expect(entries.allSatisfy { $0.title == "off-main" })
-        #expect(
-            elapsed < .seconds(10),
-            "A 2,000-transcript filesystem snapshot should complete within the bounded CI budget"
-        )
     }
 }

--- a/cmuxTests/SessionIndexSyntheticCorpus.swift
+++ b/cmuxTests/SessionIndexSyntheticCorpus.swift
@@ -1,6 +1,12 @@
 import Foundation
 import Darwin
 
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
 struct SessionIndexSyntheticCorpus: Sendable {
     let homeDirectory: URL
     let projectsDirectory: URL

--- a/cmuxTests/SessionIndexSyntheticCorpus.swift
+++ b/cmuxTests/SessionIndexSyntheticCorpus.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Darwin
+
+struct SessionIndexSyntheticCorpus: Sendable {
+    let homeDirectory: URL
+    let projectsDirectory: URL
+    let transcriptCount: Int
+
+    @concurrent
+    static func create(projectCount: Int, transcriptsPerProject: Int) async throws -> Self {
+        let fileManager = FileManager.default
+        let homeDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-vault-corpus-\(UUID().uuidString)", isDirectory: true)
+        let projectsDirectory = homeDirectory
+            .appendingPathComponent(".claude/projects", isDirectory: true)
+
+        for projectIndex in 0..<projectCount {
+            let projectDirectory = projectsDirectory
+                .appendingPathComponent("-tmp-project-\(projectIndex)", isDirectory: true)
+            try fileManager.createDirectory(
+                at: projectDirectory,
+                withIntermediateDirectories: true
+            )
+            for transcriptIndex in 0..<transcriptsPerProject {
+                let sessionID = "session-\(projectIndex)-\(transcriptIndex)"
+                let line = """
+                {"type":"user","sessionId":"\(sessionID)","cwd":"/tmp/project-\(projectIndex)","message":{"role":"user","content":"Synthetic transcript \(transcriptIndex)"}}
+
+                """
+                try Data(line.utf8).write(
+                    to: projectDirectory.appendingPathComponent("\(sessionID).jsonl")
+                )
+            }
+        }
+
+        return Self(
+            homeDirectory: homeDirectory,
+            projectsDirectory: projectsDirectory,
+            transcriptCount: projectCount * transcriptsPerProject
+        )
+    }
+
+    func loadEntries() -> [SessionEntry] {
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: projectsDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        let executorLabel = pthread_main_np() == 0 ? "off-main" : "main"
+        var entries: [SessionEntry] = []
+        entries.reserveCapacity(transcriptCount)
+        for case let url as URL in enumerator where url.pathExtension == "jsonl" {
+            guard let values = try? url.resourceValues(
+                forKeys: [.contentModificationDateKey, .isRegularFileKey]
+            ), values.isRegularFile == true,
+                  let data = try? Data(contentsOf: url),
+                  !data.isEmpty else {
+                continue
+            }
+            let sessionID = url.deletingPathExtension().lastPathComponent
+            entries.append(SessionEntry(
+                id: "claude:\(url.path)",
+                agent: .claude,
+                sessionId: sessionID,
+                title: executorLabel,
+                cwd: url.deletingLastPathComponent().lastPathComponent,
+                gitBranch: nil,
+                pullRequest: nil,
+                modified: values.contentModificationDate ?? .distantPast,
+                fileURL: url,
+                specifics: .claude(
+                    model: nil,
+                    permissionMode: nil,
+                    configDirectoryForResume: nil
+                )
+            ))
+        }
+        return entries
+    }
+
+    @concurrent
+    func remove() async {
+        try? FileManager.default.removeItem(at: homeDirectory)
+    }
+}

--- a/cmuxTests/SessionIndexTableViewportTests.swift
+++ b/cmuxTests/SessionIndexTableViewportTests.swift
@@ -12,6 +12,46 @@ import Testing
 struct SessionIndexTableViewportTests {
     @MainActor
     @Test
+    func tableHeightsTrackFontMagnificationWithoutMeasuringOffscreenViews() {
+        let section = IndexSection(
+            key: .directory("/tmp/vault-scale"),
+            title: "vault-scale",
+            icon: .folder,
+            entries: [Self.makeEntry(index: 0)]
+        )
+        let row = SessionIndexTableRow.section(
+            section: section,
+            rowLimit: 5,
+            isDragged: false,
+            previewEntryId: nil,
+            isCollapsed: false,
+            isPopoverOpen: false,
+            actions: IndexSectionActions(
+                onBeginDrag: {},
+                onPreviewEntry: { _ in },
+                onDismissPreview: { _ in },
+                onResume: nil,
+                search: { _, _, _, _ in .init(entries: [], errors: []) },
+                loadSnapshot: { cwd in .init(cwd: cwd ?? "", entries: [], errors: []) }
+            ),
+            setCollapsed: { _ in },
+            setPopoverOpen: { _ in }
+        )
+        let calculator = SessionIndexTableRowHeightCalculator()
+        let standardHeight = calculator.height(
+            for: row,
+            environment: .init(colorScheme: .light, globalFontMagnificationPercent: 100)
+        )
+        let magnifiedHeight = calculator.height(
+            for: row,
+            environment: .init(colorScheme: .light, globalFontMagnificationPercent: 200)
+        )
+
+        #expect(magnifiedHeight > standardHeight)
+    }
+
+    @MainActor
+    @Test
     func vaultUsesViewportBoundedAppKitRowsAtScale() throws {
         let defaults = SessionIndexDefaultsSnapshot()
         defer { defaults.restore() }
@@ -20,24 +60,7 @@ struct SessionIndexTableViewportTests {
         store.grouping = .directory
         store.directoryOrder = []
         store.replaceEntriesForTesting(
-            (0..<46).map { index in
-                SessionEntry(
-                    id: "claude:/tmp/vault-scale/session-\(index).jsonl",
-                    agent: .claude,
-                    sessionId: "session-\(index)",
-                    title: "Synthetic session \(index)",
-                    cwd: "/tmp/vault-scale/project-\(index)",
-                    gitBranch: nil,
-                    pullRequest: nil,
-                    modified: Date(timeIntervalSince1970: TimeInterval(10_000 - index)),
-                    fileURL: nil,
-                    specifics: .claude(
-                        model: nil,
-                        permissionMode: nil,
-                        configDirectoryForResume: nil
-                    )
-                )
-            }
+            (0..<46).map(Self.makeEntry)
         )
 
         let host = NSHostingView(
@@ -65,6 +88,25 @@ struct SessionIndexTableViewportTests {
         #expect(visibleRows.length > 0)
         #expect(table.numberOfRows > visibleRows.length)
         #expect(realizedRows.count <= visibleRows.length + 2)
+    }
+
+    private static func makeEntry(index: Int) -> SessionEntry {
+        SessionEntry(
+            id: "claude:/tmp/vault-scale/session-\(index).jsonl",
+            agent: .claude,
+            sessionId: "session-\(index)",
+            title: "Synthetic session \(index)",
+            cwd: "/tmp/vault-scale/project-\(index)",
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: Date(timeIntervalSince1970: TimeInterval(10_000 - index)),
+            fileURL: nil,
+            specifics: .claude(
+                model: nil,
+                permissionMode: nil,
+                configDirectoryForResume: nil
+            )
+        )
     }
 }
 

--- a/cmuxTests/SessionIndexTableViewportTests.swift
+++ b/cmuxTests/SessionIndexTableViewportTests.swift
@@ -85,6 +85,25 @@ struct SessionIndexTableViewportTests {
 
     @MainActor
     @Test
+    func tableDocumentViewTracksSidebarViewportWidth() throws {
+        let controller = SessionIndexTableController()
+        let container = controller.makeContainerView()
+        container.frame = NSRect(x: 0, y: 0, width: 320, height: 300)
+        container.layoutSubtreeIfNeeded()
+
+        let table = container.tableView
+        let clipView = try #require(table.superview as? NSClipView)
+        let column = try #require(table.tableColumns.first)
+        #expect(abs(table.frame.width - clipView.bounds.width) < 0.5)
+
+        container.frame.size.width = 480
+        container.layoutSubtreeIfNeeded()
+        #expect(abs(table.frame.width - clipView.bounds.width) < 0.5)
+        #expect(abs(column.width - table.bounds.width) < 0.5)
+    }
+
+    @MainActor
+    @Test
     func unrelatedPreviewDoesNotInvalidateASectionRow() {
         let section = IndexSection(
             key: .directory("/tmp/vault-scale"),

--- a/cmuxTests/SessionIndexTableViewportTests.swift
+++ b/cmuxTests/SessionIndexTableViewportTests.swift
@@ -85,6 +85,49 @@ struct SessionIndexTableViewportTests {
 
     @MainActor
     @Test
+    func unrelatedPreviewDoesNotInvalidateASectionRow() {
+        let section = IndexSection(
+            key: .directory("/tmp/vault-scale"),
+            title: "vault-scale",
+            icon: .folder,
+            entries: [Self.makeEntry(index: 0)]
+        )
+        let actions = IndexSectionActions(
+            onBeginDrag: {},
+            onPreviewEntry: { _ in },
+            onDismissPreview: { _ in },
+            onResume: nil,
+            search: { _, _, _, _ in .init(entries: [], errors: []) },
+            loadSnapshot: { cwd in .init(cwd: cwd ?? "", entries: [], errors: []) }
+        )
+        let withoutPreview = SessionIndexTableRow.section(
+            section: section,
+            rowLimit: 5,
+            isDragged: false,
+            previewEntryId: nil,
+            isCollapsed: false,
+            isPopoverOpen: false,
+            actions: actions,
+            setCollapsed: { _ in },
+            setPopoverOpen: { _ in }
+        )
+        let unrelatedPreview = SessionIndexTableRow.section(
+            section: section,
+            rowLimit: 5,
+            isDragged: false,
+            previewEntryId: "claude:/tmp/another-section/session.jsonl",
+            isCollapsed: false,
+            isPopoverOpen: false,
+            actions: actions,
+            setCollapsed: { _ in },
+            setPopoverOpen: { _ in }
+        )
+
+        #expect(withoutPreview.hasEquivalentContent(to: unrelatedPreview))
+    }
+
+    @MainActor
+    @Test
     func vaultUsesViewportBoundedAppKitRowsAtScale() async throws {
         let defaults = SessionIndexDefaultsSnapshot()
         defer { defaults.restore() }

--- a/cmuxTests/SessionIndexTableViewportTests.swift
+++ b/cmuxTests/SessionIndexTableViewportTests.swift
@@ -52,7 +52,40 @@ struct SessionIndexTableViewportTests {
 
     @MainActor
     @Test
-    func vaultUsesViewportBoundedAppKitRowsAtScale() throws {
+    func tableApplyDefersAndCoalescesUntilAfterTheCurrentCallback() async {
+        let controller = SessionIndexTableController()
+        let container = controller.makeContainerView()
+        let actions = SectionGapActions(
+            currentDraggedKey: { nil },
+            moveSection: { _, _ in },
+            clearDraggedKey: {}
+        )
+        let environment = SessionIndexTableEnvironmentSnapshot(
+            colorScheme: .light,
+            globalFontMagnificationPercent: 100
+        )
+        let first = SessionIndexTableRow.gap(
+            beforeKey: .directory("/tmp/first"),
+            isValidDrop: true,
+            actions: actions
+        )
+        let second = SessionIndexTableRow.gap(
+            beforeKey: .directory("/tmp/second"),
+            isValidDrop: true,
+            actions: actions
+        )
+
+        controller.apply(rows: [first], environment: environment)
+        controller.apply(rows: [first, second], environment: environment)
+
+        #expect(container.tableView.numberOfRows == 0)
+        await flushStagedTableMutations()
+        #expect(container.tableView.numberOfRows == 2)
+    }
+
+    @MainActor
+    @Test
+    func vaultUsesViewportBoundedAppKitRowsAtScale() async throws {
         let defaults = SessionIndexDefaultsSnapshot()
         defer { defaults.restore() }
 
@@ -77,6 +110,9 @@ struct SessionIndexTableViewportTests {
         host.frame = window.contentView?.bounds ?? .zero
         host.layoutSubtreeIfNeeded()
         window.contentView?.layoutSubtreeIfNeeded()
+        await flushStagedTableMutations()
+        host.layoutSubtreeIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
 
         let table = try #require(host.firstDescendant(of: NSTableView.self))
         let visibleRows = table.rows(in: table.visibleRect)
@@ -88,6 +124,15 @@ struct SessionIndexTableViewportTests {
         #expect(visibleRows.length > 0)
         #expect(table.numberOfRows > visibleRows.length)
         #expect(realizedRows.count <= visibleRows.length + 2)
+    }
+
+    @MainActor
+    private func flushStagedTableMutations() async {
+        await withCheckedContinuation { continuation in
+            RunLoop.main.perform(inModes: [.common]) {
+                continuation.resume()
+            }
+        }
     }
 
     private static func makeEntry(index: Int) -> SessionEntry {

--- a/cmuxTests/SessionIndexTableViewportTests.swift
+++ b/cmuxTests/SessionIndexTableViewportTests.swift
@@ -1,0 +1,107 @@
+import AppKit
+import SwiftUI
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct SessionIndexTableViewportTests {
+    @MainActor
+    @Test
+    func vaultUsesViewportBoundedAppKitRowsAtScale() throws {
+        let defaults = SessionIndexDefaultsSnapshot()
+        defer { defaults.restore() }
+
+        let store = SessionIndexStore()
+        store.grouping = .directory
+        store.directoryOrder = []
+        store.replaceEntriesForTesting(
+            (0..<46).map { index in
+                SessionEntry(
+                    id: "claude:/tmp/vault-scale/session-\(index).jsonl",
+                    agent: .claude,
+                    sessionId: "session-\(index)",
+                    title: "Synthetic session \(index)",
+                    cwd: "/tmp/vault-scale/project-\(index)",
+                    gitBranch: nil,
+                    pullRequest: nil,
+                    modified: Date(timeIntervalSince1970: TimeInterval(10_000 - index)),
+                    fileURL: nil,
+                    specifics: .claude(
+                        model: nil,
+                        permissionMode: nil,
+                        configDirectoryForResume: nil
+                    )
+                )
+            }
+        )
+
+        let host = NSHostingView(
+            rootView: SessionIndexView(store: store, onResume: nil)
+                .frame(width: 320, height: 300)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.frame = window.contentView?.bounds ?? .zero
+        host.layoutSubtreeIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+
+        let table = try #require(host.firstDescendant(of: NSTableView.self))
+        let visibleRows = table.rows(in: table.visibleRect)
+        let realizedRows = (0..<table.numberOfRows).filter { row in
+            table.view(atColumn: 0, row: row, makeIfNecessary: false) != nil
+        }
+
+        #expect(table.numberOfRows >= 46)
+        #expect(visibleRows.length > 0)
+        #expect(table.numberOfRows > visibleRows.length)
+        #expect(realizedRows.count <= visibleRows.length + 2)
+    }
+}
+
+private struct SessionIndexDefaultsSnapshot {
+    private let values: [(key: String, value: Any?)]
+
+    init(defaults: UserDefaults = .standard) {
+        values = Self.keys.map { key in (key, defaults.object(forKey: key)) }
+    }
+
+    func restore(defaults: UserDefaults = .standard) {
+        for item in values {
+            if let value = item.value {
+                defaults.set(value, forKey: item.key)
+            } else {
+                defaults.removeObject(forKey: item.key)
+            }
+        }
+    }
+
+    private static let keys = [
+        "sessionIndex.agentOrder",
+        "sessionIndex.directoryOrder",
+        "sessionIndex.grouping",
+    ]
+}
+
+private extension NSView {
+    func firstDescendant<ViewType: NSView>(of type: ViewType.Type) -> ViewType? {
+        if let match = self as? ViewType {
+            return match
+        }
+        for subview in subviews {
+            if let match = subview.firstDescendant(of: type) {
+                return match
+            }
+        }
+        return nil
+    }
+}

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -369,7 +369,7 @@ final class SessionIndexViewTests: XCTestCase {
     }
 
     // Regression for https://github.com/manaflow-ai/cmux/issues/6302.
-    // The always-visible sidebar list is built from `scanAll()`, which loads
+    // The always-visible sidebar list is built from `loadInitialEntries()`, which loads
     // only each agent's 30 most-recent sessions across ALL folders and then
     // groups that already-capped pool by folder. A folder can therefore
     // contribute ≤ collapsedRowLimit sessions to the in-memory list even

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -369,7 +369,7 @@ final class SessionIndexViewTests: XCTestCase {
     }
 
     // Regression for https://github.com/manaflow-ai/cmux/issues/6302.
-    // The always-visible sidebar list is built from `loadInitialEntries()`, which loads
+    // The always-visible sidebar list is built from `scanAll()`, which loads
     // only each agent's 30 most-recent sessions across ALL folders and then
     // groups that already-capped pool by folder. A folder can therefore
     // contribute ≤ collapsedRowLimit sessions to the in-memory list even


### PR DESCRIPTION
Fixes #8500

## Summary
- replace the Vault SwiftUI `LazyVStack` with an AppKit-owned `NSTableView` that realizes only viewport rows, with one isolated SwiftUI hosting graph per recycled section cell
- keep initial scans, demand searches, filesystem enumeration, metadata parsing, record construction, and merge/sort projection behind explicit off-main executor boundaries
- share byte-bounded JSONL head/tail reading, cap Antigravity history work at 16 MiB, preserve parsed Claude metadata and per-directory snapshot caches, and retain paginated “Show more” rendering
- forward immutable color/font environment snapshots into hosted rows and calculate row heights without measuring offscreen SwiftUI views

## Regression coverage
- commit `270b256ab6` adds the behavior-level red test first: 46 directory sections in a 300-point viewport must use an `NSTableView` and realize only viewport-bounded cells
- a synthetic 20-directory / 2,000-transcript corpus asserts that the provider performs stat/read/session construction off the main thread and completes within a bounded CI budget
- a 2,000-record JSONL history test asserts tail reads return newest records without reading the full file
- font magnification coverage verifies table heights grow from immutable environment snapshots without offscreen view measurement

## Concurrency justification
`SessionIndexStore` remains the main-actor UI-state owner. `SessionIndexSnapshotLoader`, agent search, filesystem scanning, JSON parsing, and entry projection return `Sendable` value snapshots across explicit `@concurrent` boundaries. AppKit layout and SwiftUI row bodies consume those snapshots and perform no transcript I/O.

## Validation
- `python3 scripts/normalize-pbxproj.py`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `swiftc -frontend -parse` on every touched/new Swift file
- `swiftc -typecheck Sources/SessionIndexJSONLReadMetrics.swift Sources/SessionIndexJSONLReader.swift`
- `git diff --check`

Local `xcodebuild`, XCUITests, and app builds were intentionally not run per the issue request; macOS test execution is delegated to GitHub Actions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787349493&installation_model_id=21920&pr_number=8680&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8680&signature=3b67d246513733fa7bdc827179389f08b56cb259ab5982342837f2f90657b41f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8500 by replacing the Vault sidebar with an AppKit-virtualized `NSTableView` that renders only visible rows and defers/coalesces updates to remove beachballs. Antigravity history and previews now use bounded, tail-first JSONL paging with strict byte/page caps and stable page offsets, with reliable “Show more” and search beyond the initial cap.

- **Bug Fixes**
  - Filled the sidebar viewport; autoresizing column; tuned scrollers/insets.
  - Deferred/coalesced mutations past layout; reload only changed rows/heights.
  - Tail-page reader preserves record boundaries and stable page offsets; truncation appears before visible turns; always offer “Show more” for Antigravity and directories.
  - Read Antigravity history from a single `history.jsonl`; reverse-scan deduplicates by session ID and keeps newest metadata even without timestamps; heavy work stays off the main thread.

- **Refactors**
  - Centralized JSONL streaming in `SessionIndexJSONLReader` with `fromStart`, `fromTail`, `fromTailPages`, and `SessionIndexJSONLReadMetrics`; added `forEachJSONLineFromTail`.
  - Introduced `SessionIndexSnapshotLoader` and off-main entry projection (`SessionIndexEntryProjection`); renamed the scan entrypoint to `loadInitialEntries`.
  - Added the `SessionIndexTableView` stack (container, controller, rows) with immutable environment snapshots and a row-height calculator.
  - Added tests for byte/page boundaries, stable Antigravity pagination and truncation placement, off-main initial scans over a 2k corpus, viewport-bounded row realization with deferred applies, and table width tracking.

<sup>Written for commit ba671a75916fe97029d4f01ed2fd9e5d51931dc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a faster, virtualized session index table with smoother scrolling and dynamic row sizing.
  * Added stable pagination for large session histories and directory searches.
  * Improved session preview loading, including newest-first history and truncated-preview indicators.
  * Added support for preserving appearance settings such as color scheme and font magnification.

* **Bug Fixes**
  * Improved handling of missing timestamps, folder scopes, and large history files.
  * Prevented duplicate sessions and improved pagination consistency.

* **Tests**
  * Added coverage for table rendering, pagination, history boundaries, and session previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->