### PR TITLE
Resolve executable login shell before terminal spawn

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Lifecycle/TerminalChildExitPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Lifecycle/TerminalChildExitPolicy.swift
@@ -1,0 +1,20 @@
+/// Decides whether a child exit is a startup failure that must remain visible.
+public struct TerminalChildExitPolicy: Sendable {
+    private let abnormalRuntimeMilliseconds: UInt64
+
+    /// Creates a policy matching Ghostty's configured abnormal-exit threshold.
+    ///
+    /// - Parameter abnormalRuntimeMilliseconds: The maximum runtime Ghostty
+    ///   classifies as an abnormal command exit.
+    public init(abnormalRuntimeMilliseconds: UInt32) {
+        self.abnormalRuntimeMilliseconds = UInt64(abnormalRuntimeMilliseconds)
+    }
+
+    /// Returns whether Ghostty should retain the surface and render its error state.
+    ///
+    /// - Parameter runtimeMilliseconds: How long the child process survived.
+    /// - Returns: `true` for startup failures; `false` for established-process exits.
+    public func shouldKeepSurfaceVisible(runtimeMilliseconds: UInt64) -> Bool {
+        runtimeMilliseconds <= abnormalRuntimeMilliseconds
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Runtime/TerminalEngineHosting.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Runtime/TerminalEngineHosting.swift
@@ -16,4 +16,7 @@ public protocol TerminalEngineHosting: AnyObject {
     /// The user's effective `shell-integration` Ghostty config value
     /// (`"detect"`, `"none"`, or an explicit shell).
     var userGhosttyShellIntegrationMode: String { get }
+
+    /// The executable user shell resolved before Ghostty config finalization.
+    var resolvedUserShell: String? { get }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Runtime/TerminalEngineHosting.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Runtime/TerminalEngineHosting.swift
@@ -17,6 +17,9 @@ public protocol TerminalEngineHosting: AnyObject {
     /// (`"detect"`, `"none"`, or an explicit shell).
     var userGhosttyShellIntegrationMode: String { get }
 
+    /// Whether Ghostty's app configuration supplies the default surface command.
+    var hasUserGhosttyCommand: Bool { get }
+
     /// The executable user shell resolved before Ghostty config finalization.
     var resolvedUserShell: String? { get }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalLaunchCommandPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalLaunchCommandPolicy.swift
@@ -1,0 +1,40 @@
+/// Selects the command passed to Ghostty when creating a terminal surface.
+public struct TerminalLaunchCommandPolicy: Sendable {
+    /// Creates a launch-command policy.
+    public init() {}
+
+    /// Resolves the first non-empty command in launch-precedence order.
+    ///
+    /// Explicit per-surface commands win first. When Ghostty's app config owns
+    /// the default command, this returns `nil` so Ghostty preserves its parsed
+    /// direct-versus-shell execution semantics. Otherwise cmux supplies its
+    /// shell-integration wrapper or resolved user-shell fallback.
+    ///
+    /// - Parameters:
+    ///   - initialCommand: The command requested for this surface.
+    ///   - surfaceCommand: A command inherited from cmux surface state.
+    ///   - hasUserGhosttyCommand: Whether Ghostty's app config owns the default command.
+    ///   - managedShellCommand: cmux's shell-integration launch command.
+    ///   - resolvedShell: The executable user-shell fallback.
+    /// - Returns: A per-surface command override, or `nil` to inherit Ghostty's command.
+    public func resolve(
+        initialCommand: String?,
+        surfaceCommand: String?,
+        hasUserGhosttyCommand: Bool,
+        managedShellCommand: String?,
+        resolvedShell: String?
+    ) -> String? {
+        for candidate in [initialCommand, surfaceCommand] {
+            if let candidate, !candidate.isEmpty {
+                return candidate
+            }
+        }
+        if hasUserGhosttyCommand { return nil }
+        for candidate in [managedShellCommand, resolvedShell] {
+            if let candidate, !candidate.isEmpty {
+                return candidate
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalShellResolver.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalShellResolver.swift
@@ -1,0 +1,71 @@
+internal import Foundation
+
+/// Selects an executable login shell from macOS user and shell declarations.
+///
+/// The resolver is pure apart from the injected executable check. Production
+/// supplies values from the user database, `$SHELL`, and `/etc/shells`; tests
+/// can model relocated package-manager paths without changing the host Mac.
+public struct TerminalShellResolver: Sendable {
+    private let isExecutable: @Sendable (String) -> Bool
+
+    /// Creates a shell resolver with an injected executable check.
+    ///
+    /// - Parameter isExecutable: Returns whether an absolute path names an
+    ///   executable file.
+    public init(isExecutable: @escaping @Sendable (String) -> Bool) {
+        self.isExecutable = isExecutable
+    }
+
+    /// Resolves the first executable shell while preserving the user's shell family.
+    ///
+    /// User-database and environment values are authoritative when executable.
+    /// If both point at stale installations, a declared shell with the same
+    /// basename is preferred before the system fallback chain. A non-executable
+    /// candidate is never returned.
+    ///
+    /// - Parameters:
+    ///   - loginShell: The current user's shell from the macOS user database.
+    ///   - environmentShell: The process's inherited `$SHELL` value.
+    ///   - declaredShells: Shell paths declared by `/etc/shells`.
+    ///   - fallbackShells: Known-safe system fallback candidates.
+    /// - Returns: An executable absolute shell path, or `nil` when none exists.
+    public func resolve(
+        loginShell: String?,
+        environmentShell: String?,
+        declaredShells: [String],
+        fallbackShells: [String] = ["/bin/zsh", "/bin/sh"]
+    ) -> String? {
+        let loginCandidate = normalizedAbsolutePath(loginShell)
+        let environmentCandidate = normalizedAbsolutePath(environmentShell)
+        let declaredCandidates = declaredShells.compactMap(normalizedAbsolutePath)
+        let preferredShellNames = [loginCandidate, environmentCandidate]
+            .compactMap { $0 }
+            .map(lastPathComponent)
+        let relocatedPreferredShells = declaredCandidates.filter {
+            preferredShellNames.contains(lastPathComponent($0))
+        }
+        let candidates = [loginCandidate, environmentCandidate].compactMap { $0 }
+            + relocatedPreferredShells
+            + fallbackShells.compactMap(normalizedAbsolutePath)
+            + declaredCandidates
+
+        var visited: Set<String> = []
+        for candidate in candidates where visited.insert(candidate).inserted {
+            if isExecutable(candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private func normalizedAbsolutePath(_ candidate: String?) -> String? {
+        guard let candidate else { return nil }
+        let path = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard path.hasPrefix("/"), path != "/" else { return nil }
+        return path
+    }
+
+    private func lastPathComponent(_ path: String) -> String {
+        URL(fileURLWithPath: path).lastPathComponent
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
@@ -88,6 +88,10 @@ extension TerminalSurface {
             protectedStartupEnvironmentKeys.insert(key)
         }
 
+        if let resolvedUserShell = engine.resolvedUserShell {
+            setManagedEnvironmentValue("SHELL", resolvedUserShell)
+        }
+
         let socketPath = spawnPolicyProvider.controlSocketPath()
         Self.applyManagedCmuxContextEnvironment(
             Self.cmuxContextEnvironment(
@@ -210,11 +214,8 @@ extension TerminalSurface {
                 protectedKeys: &protectedStartupEnvironmentKeys
             )
 
-            let shell = (env["SHELL"]?.isEmpty == false ? env["SHELL"] : nil)
-                ?? getenv("SHELL").map { String(cString: $0) }
-                ?? ProcessInfo.processInfo.environment["SHELL"]
-                ?? "/bin/zsh"
-            if let command = Self.applyManagedShellSpecificStartupEnvironment(
+            if let shell = engine.resolvedUserShell,
+               let command = Self.applyManagedShellSpecificStartupEnvironment(
                 shell: shell,
                 integrationDir: integrationDir,
                 userGhosttyShellIntegrationMode: engine.userGhosttyShellIntegrationMode,

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeSurfaceCreation.swift
@@ -18,7 +18,7 @@ extension TerminalSurface {
         scaleFactors: (x: CGFloat, y: CGFloat, layer: CGFloat),
         claudeShim: ClaudeCommandShim?
     ) -> (createdSurface: ghostty_surface_t?, runtimeInitialInput: String?) {
-        var baseConfig = runtimeCreationConfigTemplate()
+        let baseConfig = runtimeCreationConfigTemplate()
         var surfaceConfig = ghostty_surface_config_new()
         let magnificationPercent = globalFontMagnificationPercent()
         surfaceConfig.font_size = CmuxSurfaceConfigTemplate.runtimeFontSize(
@@ -202,6 +202,7 @@ extension TerminalSurface {
             )
         }
 
+        var managedShellCommand: String?
         if spawnPolicy.shellIntegrationEnabled,
            let integrationDir = Bundle.main.resourceURL?.appendingPathComponent("shell-integration").path,
            Self.shellIntegrationDirectoryExists(integrationDir) {
@@ -214,15 +215,14 @@ extension TerminalSurface {
                 protectedKeys: &protectedStartupEnvironmentKeys
             )
 
-            if let shell = engine.resolvedUserShell,
-               let command = Self.applyManagedShellSpecificStartupEnvironment(
-                shell: shell,
-                integrationDir: integrationDir,
-                userGhosttyShellIntegrationMode: engine.userGhosttyShellIntegrationMode,
-                to: &env,
-                protectedKeys: &protectedStartupEnvironmentKeys
-            ) {
-                if baseConfig.command?.isEmpty != false { baseConfig.command = command }
+            if let shell = engine.resolvedUserShell {
+                managedShellCommand = Self.applyManagedShellSpecificStartupEnvironment(
+                    shell: shell,
+                    integrationDir: integrationDir,
+                    userGhosttyShellIntegrationMode: engine.userGhosttyShellIntegrationMode,
+                    to: &env,
+                    protectedKeys: &protectedStartupEnvironmentKeys
+                )
             }
         }
         env = Self.mergedStartupEnvironment(
@@ -253,12 +253,13 @@ extension TerminalSurface {
             }
             return baseConfig.workingDirectory
         }()
-        let resolvedCommand: String? = {
-            if let initialCommand, !initialCommand.isEmpty {
-                return initialCommand
-            }
-            return baseConfig.command
-        }()
+        let resolvedCommand = TerminalLaunchCommandPolicy().resolve(
+            initialCommand: initialCommand,
+            surfaceCommand: baseConfig.command,
+            hasUserGhosttyCommand: engine.hasUserGhosttyCommand,
+            managedShellCommand: managedShellCommand,
+            resolvedShell: engine.resolvedUserShell
+        )
         let runtimeInitialInput = nextRuntimeInitialInput
         let resolvedInitialInput: String? = {
             if let runtimeInitialInput, !runtimeInitialInput.isEmpty {

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeTerminalEngine.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeTerminalEngine.swift
@@ -6,4 +6,5 @@ final class FakeTerminalEngine: TerminalEngineHosting {
     var runtimeApp: ghostty_app_t? { nil }
     var runtimeConfig: ghostty_config_t? { nil }
     var userGhosttyShellIntegrationMode: String { "none" }
+    var resolvedUserShell: String? { nil }
 }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeTerminalEngine.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/FakeTerminalEngine.swift
@@ -6,5 +6,6 @@ final class FakeTerminalEngine: TerminalEngineHosting {
     var runtimeApp: ghostty_app_t? { nil }
     var runtimeConfig: ghostty_config_t? { nil }
     var userGhosttyShellIntegrationMode: String { "none" }
+    var hasUserGhosttyCommand: Bool { false }
     var resolvedUserShell: String? { nil }
 }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalChildExitPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalChildExitPolicyTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import CmuxTerminal
+
+@Suite
+struct TerminalChildExitPolicyTests {
+    @Test
+    func instantSpawnFailureKeepsSurfaceVisible() {
+        let policy = TerminalChildExitPolicy(abnormalRuntimeMilliseconds: 250)
+
+        #expect(policy.shouldKeepSurfaceVisible(runtimeMilliseconds: 3))
+    }
+
+    @Test
+    func establishedShellExitContinuesThroughNormalClose() {
+        let policy = TerminalChildExitPolicy(abnormalRuntimeMilliseconds: 250)
+
+        #expect(!policy.shouldKeepSurfaceVisible(runtimeMilliseconds: 251))
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
@@ -1,0 +1,62 @@
+import Testing
+@testable import CmuxTerminal
+
+@Suite
+struct TerminalShellResolverTests {
+    @Test
+    func validLoginShellWinsOverStaleEnvironmentShell() {
+        let nixFish = "/run/current-system/sw/bin/fish"
+        let staleHomebrewFish = "/opt/homebrew/bin/fish"
+        let resolver = TerminalShellResolver(isExecutable: { $0 == nixFish })
+
+        let resolved = resolver.resolve(
+            loginShell: nixFish,
+            environmentShell: staleHomebrewFish,
+            declaredShells: [nixFish]
+        )
+
+        #expect(resolved == nixFish)
+    }
+
+    @Test
+    func declaredRelocationPreservesPreferredShellFamily() {
+        let staleNixFish = "/run/old-system/sw/bin/fish"
+        let staleHomebrewFish = "/opt/homebrew/bin/fish"
+        let currentNixFish = "/nix/store/current-system/bin/fish"
+        let resolver = TerminalShellResolver(isExecutable: { $0 == currentNixFish })
+
+        let resolved = resolver.resolve(
+            loginShell: staleNixFish,
+            environmentShell: staleHomebrewFish,
+            declaredShells: ["/bin/bash", currentNixFish]
+        )
+
+        #expect(resolved == currentNixFish)
+    }
+
+    @Test
+    func invalidCandidatesFallBackToExecutableZsh() {
+        let resolver = TerminalShellResolver(isExecutable: { $0 == "/bin/zsh" })
+
+        let resolved = resolver.resolve(
+            loginShell: "/missing/fish",
+            environmentShell: "/also/missing/fish",
+            declaredShells: ["/missing/fish"]
+        )
+
+        #expect(resolved == "/bin/zsh")
+    }
+
+    @Test
+    func resolverNeverReturnsANonExecutableCandidate() {
+        let resolver = TerminalShellResolver(isExecutable: { _ in false })
+
+        let resolved = resolver.resolve(
+            loginShell: "/missing/fish",
+            environmentShell: "/missing/zsh",
+            declaredShells: ["/missing/bash"]
+        )
+
+        #expect(resolved == nil)
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalShellResolverTests.swift
@@ -59,4 +59,43 @@ struct TerminalShellResolverTests {
 
         #expect(resolved == nil)
     }
+
+    @Test
+    func resolvedShellBecomesTheDefaultSurfaceCommand() {
+        let command = TerminalLaunchCommandPolicy().resolve(
+            initialCommand: nil,
+            surfaceCommand: nil,
+            hasUserGhosttyCommand: false,
+            managedShellCommand: nil,
+            resolvedShell: "/run/current-system/sw/bin/fish"
+        )
+
+        #expect(command == "/run/current-system/sw/bin/fish")
+    }
+
+    @Test
+    func explicitGhosttyCommandIsInheritedWithoutSurfaceOverride() {
+        let command = TerminalLaunchCommandPolicy().resolve(
+            initialCommand: nil,
+            surfaceCommand: nil,
+            hasUserGhosttyCommand: true,
+            managedShellCommand: "/run/current-system/sw/bin/fish --init-command source",
+            resolvedShell: "/run/current-system/sw/bin/fish"
+        )
+
+        #expect(command == nil)
+    }
+
+    @Test
+    func managedFishCommandWinsOverPlainResolvedShell() {
+        let command = TerminalLaunchCommandPolicy().resolve(
+            initialCommand: nil,
+            surfaceCommand: nil,
+            hasUserGhosttyCommand: false,
+            managedShellCommand: "/run/current-system/sw/bin/fish --init-command source",
+            resolvedShell: "/run/current-system/sw/bin/fish"
+        )
+
+        #expect(command == "/run/current-system/sw/bin/fish --init-command source")
+    }
 }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyConfig.swift
@@ -55,6 +55,8 @@ public struct GhosttyConfig {
     public var theme: String?
     /// The configured `working-directory`, or `nil` when unset.
     public var workingDirectory: String?
+    /// The explicit `command` directive, or `nil` when Ghostty should resolve the login shell.
+    public var command: String?
     /// The scrollback limit. Ghostty measures this in bytes, not lines.
     public var scrollbackLimit: Int = 50_000_000
     /// The opacity (0...1) applied to unfocused split panes.
@@ -543,6 +545,10 @@ public struct GhosttyConfig {
                     }
                 case "working-directory":
                     workingDirectory = value
+                case "command":
+                    if !value.isEmpty {
+                        command = value
+                    }
                 case "scrollback-limit":
                     if let limit = Self.parseIntegerLiteral(value) {
                         scrollbackLimit = limit

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigCommandTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyConfigCommandTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import CmuxTerminalCore
+
+@Suite
+struct GhosttyConfigCommandTests {
+    @Test
+    func parsesExplicitCommandDirective() {
+        var config = GhosttyConfig()
+
+        config.parse("command = direct:/usr/local/bin/custom-shell --login")
+
+        #expect(config.command == "direct:/usr/local/bin/custom-shell --login")
+    }
+
+    @Test
+    func emptyCommandDoesNotReplaceLastValidDirective() {
+        var config = GhosttyConfig()
+
+        config.parse(
+            """
+            command = /usr/local/bin/custom-shell
+            command =
+            """
+        )
+
+        #expect(config.command == "/usr/local/bin/custom-shell")
+    }
+
+    @Test
+    func includedConfigCommandUsesResolvedFilePrecedence() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-shell-command-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let included = directory.appendingPathComponent("shell.conf")
+        try "command = direct:/opt/custom/bin/fish\n".write(to: included, atomically: true, encoding: .utf8)
+        let main = directory.appendingPathComponent("config")
+        try "command = /bin/zsh\nconfig-file = shell.conf\n".write(to: main, atomically: true, encoding: .utf8)
+
+        var config = GhosttyConfig()
+        config.loadResolvedUserConfig(configPaths: [main.path], preferredColorScheme: .dark)
+
+        #expect(config.command == "direct:/opt/custom/bin/fish")
+    }
+}

--- a/Sources/GhosttyApp+ChildExitPolicy.swift
+++ b/Sources/GhosttyApp+ChildExitPolicy.swift
@@ -32,28 +32,31 @@ extension GhosttyApp {
         )
 #endif
 
-        // Returning false lets Ghostty render its detailed abnormal-exit text
-        // and, by Ghostty's contract, retain the dead surface for inspection.
-        if keepSurfaceVisible {
-            return false
-        }
-
-        guard let runtimeSurface else { return true }
-        // Avoid re-entrant close/deinit while Ghostty dispatches this callback.
-        DispatchQueue.main.async {
-            guard let app = AppDelegate.shared else { return }
-            guard GhosttyApp.terminalSurfaceRegistry.surface(id: runtimeSurface.id) === runtimeSurface else { return }
-            if let surfaceId, app.closeWindowDockRuntimeSurface(surfaceId: surfaceId, force: true) { return }
-            if let tabId, let surfaceId,
-               let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager {
-                manager.closePanelAfterChildExited(
-                    tabId: tabId,
-                    surfaceId: surfaceId,
-                    runtimeSurface: runtimeSurface
-                )
+        if let runtimeSurface {
+            // Avoid re-entrant close/deinit while Ghostty dispatches this callback.
+            DispatchQueue.main.async {
+                guard let app = AppDelegate.shared else { return }
+                guard GhosttyApp.terminalSurfaceRegistry.surface(id: runtimeSurface.id) === runtimeSurface else { return }
+                if !keepSurfaceVisible,
+                   let surfaceId,
+                   app.closeWindowDockRuntimeSurface(surfaceId: surfaceId, force: true) {
+                    return
+                }
+                if let tabId, let surfaceId,
+                   let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager {
+                    manager.closePanelAfterChildExited(
+                        tabId: tabId,
+                        surfaceId: surfaceId,
+                        runtimeSurface: runtimeSurface,
+                        keepSurfaceVisible: keepSurfaceVisible
+                    )
+                }
             }
         }
-        return true
+
+        // Returning false lets Ghostty render its detailed abnormal-exit text
+        // and, by Ghostty's contract, retain the dead surface for inspection.
+        return !keepSurfaceVisible
     }
 
     private func abnormalCommandExitRuntimeMilliseconds() -> UInt32 {

--- a/Sources/GhosttyApp+ChildExitPolicy.swift
+++ b/Sources/GhosttyApp+ChildExitPolicy.swift
@@ -1,0 +1,74 @@
+import CMUXDebugLog
+import CmuxTerminal
+import CmuxTerminalCore
+import Foundation
+import GhosttyKit
+
+extension GhosttyApp {
+    func handleChildExitedAction(
+        runtimeSurface: TerminalSurface?,
+        tabId: UUID?,
+        surfaceId: UUID?,
+        message: ghostty_surface_message_childexited_s
+    ) -> Bool {
+        let keepSurfaceVisible = TerminalChildExitPolicy(
+            abnormalRuntimeMilliseconds: abnormalCommandExitRuntimeMilliseconds()
+        ).shouldKeepSurfaceVisible(runtimeMilliseconds: message.timetime_ms)
+
+#if DEBUG
+        cmuxDebugLog(
+            "surface.action.showChildExited tab=\(tabId?.uuidString.prefix(5) ?? "nil") " +
+            "surface=\(surfaceId?.uuidString.prefix(5) ?? "nil") " +
+            "runtimeMs=\(message.timetime_ms) keepVisible=\(keepSurfaceVisible ? 1 : 0)"
+        )
+        TerminalChildExitProbe().write(
+            [
+                "probeShowChildExitedTabId": tabId?.uuidString ?? "",
+                "probeShowChildExitedSurfaceId": surfaceId?.uuidString ?? "",
+                "probeShowChildExitedRuntimeMs": String(message.timetime_ms),
+                "probeShowChildExitedKeptVisible": keepSurfaceVisible ? "1" : "0",
+            ],
+            increments: ["probeShowChildExitedCount": 1]
+        )
+#endif
+
+        // Returning false lets Ghostty render its detailed abnormal-exit text
+        // and, by Ghostty's contract, retain the dead surface for inspection.
+        if keepSurfaceVisible {
+            return false
+        }
+
+        guard let runtimeSurface else { return true }
+        // Avoid re-entrant close/deinit while Ghostty dispatches this callback.
+        DispatchQueue.main.async {
+            guard let app = AppDelegate.shared else { return }
+            guard GhosttyApp.terminalSurfaceRegistry.surface(id: runtimeSurface.id) === runtimeSurface else { return }
+            if let surfaceId, app.closeWindowDockRuntimeSurface(surfaceId: surfaceId, force: true) { return }
+            if let tabId, let surfaceId,
+               let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager {
+                manager.closePanelAfterChildExited(
+                    tabId: tabId,
+                    surfaceId: surfaceId,
+                    runtimeSurface: runtimeSurface
+                )
+            }
+        }
+        return true
+    }
+
+    private func abnormalCommandExitRuntimeMilliseconds() -> UInt32 {
+        let defaultValue: UInt32 = 250
+        guard let config else { return defaultValue }
+        var value = defaultValue
+        let key = "abnormal-command-exit-runtime"
+        guard ghostty_config_get(
+            config,
+            &value,
+            key,
+            UInt(key.lengthOfBytes(using: .utf8))
+        ) else {
+            return defaultValue
+        }
+        return value
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -449,6 +449,7 @@ class GhosttyApp {
     private var reloadConfigurationDepth = 0
     private(set) var usesHostLayerBackground = false
     private(set) var userGhosttyShellIntegrationMode: String = "detect"
+    private(set) var hasUserGhosttyCommand = false
     private(set) var resolvedUserShell: String?
 
     static func retainTickNotifications() -> () -> Void {
@@ -973,6 +974,7 @@ class GhosttyApp {
             // If the user config is invalid, prefer a minimal fallback configuration so
             // cmux still launches with working terminals.
             ghostty_config_free(primaryConfig)
+            hasUserGhosttyCommand = false
 
             guard let fallbackConfig = ghostty_config_new() else {
                 #if DEBUG
@@ -1195,6 +1197,10 @@ class GhosttyApp {
         if appearanceSummary.shouldApplyDefaultAppearance, !appearanceSummary.hasExplicitTerminalColorDirective {
             loadCmuxDefaultAppearanceConfig(config, preferredColorScheme: preferredColorScheme)
         }
+        hasUserGhosttyCommand = GhosttyConfig.load(
+            preferredColorScheme: preferredColorScheme,
+            useCache: false
+        ).command != nil
     }
 
     func loadDefaultConfigFilesWithLegacyFallback(
@@ -1202,6 +1208,7 @@ class GhosttyApp {
         preferredColorScheme: GhosttyConfig.ColorSchemePreference = GhosttyConfig.currentColorSchemePreference(),
         conditionalThemeColorScheme: GhosttyConfig.ColorSchemePreference? = nil
     ) -> Bool {
+        hasUserGhosttyCommand = false
         // Surface-only reloads may use a terminal-derived scheme for background
         // handling, while Ghostty split-theme pairs follow app appearance.
         let themeColorScheme = conditionalThemeColorScheme ?? preferredColorScheme

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -449,6 +449,7 @@ class GhosttyApp {
     private var reloadConfigurationDepth = 0
     private(set) var usesHostLayerBackground = false
     private(set) var userGhosttyShellIntegrationMode: String = "detect"
+    private(set) var resolvedUserShell: String?
 
     static func retainTickNotifications() -> () -> Void {
         // The legacy release closure decremented on every call; a retention
@@ -806,6 +807,11 @@ class GhosttyApp {
                 data: ["result": Int(result)]
             )
             return
+        }
+
+        resolvedUserShell = TerminalShellResolver.resolveCurrentUserShell()
+        if let resolvedUserShell {
+            setenv("SHELL", resolvedUserShell, 1)
         }
 
         // Load config
@@ -2631,35 +2637,12 @@ class GhosttyApp {
         let callbackSurfaceId = callbackContext?.surfaceId
 
         if action.tag == GHOSTTY_ACTION_SHOW_CHILD_EXITED {
-            // Ghostty otherwise prints "Process exited. Press any key..."; cmux closes the panel.
-            guard let callbackRuntimeSurface = callbackContext?.terminalSurface else { return true }
-#if DEBUG
-            cmuxDebugLog(
-                "surface.action.showChildExited tab=\(callbackTabId?.uuidString.prefix(5) ?? "nil") " +
-                "surface=\(callbackSurfaceId?.uuidString.prefix(5) ?? "nil")"
+            return handleChildExitedAction(
+                runtimeSurface: callbackContext?.terminalSurface,
+                tabId: callbackTabId,
+                surfaceId: callbackSurfaceId,
+                message: action.action.child_exited
             )
-#endif
-#if DEBUG
-            TerminalChildExitProbe().write(
-                [
-                    "probeShowChildExitedTabId": callbackTabId?.uuidString ?? "",
-                    "probeShowChildExitedSurfaceId": callbackSurfaceId?.uuidString ?? "",
-                ],
-                increments: ["probeShowChildExitedCount": 1]
-            )
-#endif
-            // Avoid re-entrant close/deinit while Ghostty dispatches this callback.
-            DispatchQueue.main.async {
-                guard let app = AppDelegate.shared else { return }
-                guard GhosttyApp.terminalSurfaceRegistry.surface(id: callbackRuntimeSurface.id) === callbackRuntimeSurface else { return }
-                if let callbackSurfaceId, app.closeWindowDockRuntimeSurface(surfaceId: callbackSurfaceId, force: true) { return }
-                if let callbackTabId, let callbackSurfaceId,
-                   let manager = app.tabManagerFor(tabId: callbackTabId) ?? app.tabManager {
-                    manager.closePanelAfterChildExited(tabId: callbackTabId, surfaceId: callbackSurfaceId, runtimeSurface: callbackRuntimeSurface)
-                }
-            }
-            // Always report handled so Ghostty doesn't print the fallback prompt.
-            return true
         }
 
         guard let surfaceView = callbackContext?.surfaceView else { return false }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2862,10 +2862,14 @@ class TabManager: ObservableObject {
         AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: tab.id, surfaceId: surfaceId)
     }
 
-    /// Close a panel because its child process exited (e.g. the user hit Ctrl+D).
-    /// This should never prompt: the process is already gone, and Ghostty emits the
-    /// `SHOW_CHILD_EXITED` action specifically so the host app can decide what to do.
-    func closePanelAfterChildExited(tabId: UUID, surfaceId: UUID, runtimeSurface: TerminalSurface? = nil) {
+    /// Handles Ghostty's `SHOW_CHILD_EXITED` action without prompting because the
+    /// process is already gone; startup failures may keep the addressed surface visible.
+    func closePanelAfterChildExited(
+        tabId: UUID,
+        surfaceId: UUID,
+        runtimeSurface: TerminalSurface? = nil,
+        keepSurfaceVisible: Bool = false
+    ) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         if tab.panels[surfaceId] == nil { tab.closeDockPanelAndClearNotifications(surfaceId, force: true); return }
         if let runtimeSurface, tab.terminalPanel(for: surfaceId)?.surface !== runtimeSurface { return }
@@ -2896,16 +2900,16 @@ class TabManager: ObservableObject {
         )
 #endif
 
-        // A persistent SSH workspace must never silently replace a failed remote attach with
-        // a local login shell. Keep the exited surface visible so the user can see the error
-        // and retry instead of making a detached remote workspace look local after relaunch.
+        // A persistent SSH workspace must keep the exited surface visible so the user can
+        // inspect the failure and retry instead of silently falling back to a local shell.
         if keepsPersistentRemoteSurfaceOpen {
             tab.markPersistentRemotePTYAttachFailed(surfaceId: surfaceId)
             return
         }
 
-        // Workspace owns the remote terminal's active -> disconnected transition so the
-        // logical pane and its rendered history survive the runtime replacement.
+        if keepSurfaceVisible { return }
+
+        // Workspace owns remote active -> disconnected transitions and preserves pane history.
         if handlesRemoteExitThroughWorkspace {
             guard !tab.transitionRemoteTerminalToDisconnectedPlaceholder(surfaceId: surfaceId) else { return }
             closeRuntimeSurface(tabId: tabId, surfaceId: surfaceId)

--- a/Sources/TerminalShellResolver+CurrentUser.swift
+++ b/Sources/TerminalShellResolver+CurrentUser.swift
@@ -1,0 +1,37 @@
+import CmuxTerminal
+import Darwin
+import Foundation
+
+extension TerminalShellResolver {
+    static func resolveCurrentUserShell(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        shellsFileURL: URL = URL(fileURLWithPath: "/etc/shells")
+    ) -> String? {
+        TerminalShellResolver(isExecutable: FileManager.default.isExecutableFile(atPath:))
+            .resolve(
+                loginShell: currentUserDatabaseShell(),
+                environmentShell: environment["SHELL"],
+                declaredShells: declaredShells(at: shellsFileURL)
+            )
+    }
+
+    private static func currentUserDatabaseShell() -> String? {
+        guard let record = getpwuid(getuid()),
+              let shell = record.pointee.pw_shell else {
+            return nil
+        }
+        return String(cString: shell)
+    }
+
+    private static func declaredShells(at url: URL) -> [String] {
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            return []
+        }
+        return contents.split(whereSeparator: \.isNewline).compactMap { rawLine in
+            let path = rawLine
+                .split(separator: "#", maxSplits: 1, omittingEmptySubsequences: false)[0]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return path.isEmpty ? nil : path
+        }
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -898,6 +898,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F0F0CF0D0000000000000001 /* ForkParentFallbackSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0CF0D0000000000000002 /* ForkParentFallbackSessionIndexTests.swift */; };
 		F17F00000000000000000003 /* FullWidthTabCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000004 /* FullWidthTabCommandTests.swift */; };
 		F17F00000000000000000001 /* FullWidthTabPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000002 /* FullWidthTabPersistenceTests.swift */; };
+		85510001A1B2C3D4E5F60001 /* GhosttyApp+ChildExitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85510002A1B2C3D4E5F60001 /* GhosttyApp+ChildExitPolicy.swift */; };
 		D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */; };
 		EC010D01 /* GhosttyApp+TerminalCustomUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010D02 /* GhosttyApp+TerminalCustomUpload.swift */; };
 		1718C0DE1718C0DE17180002 /* GhosttyCommandShiftForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */; };
@@ -1933,6 +1934,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A11E5E1E0000000000000003 /* TerminalSelectionAccessibilityNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E5E1E0000000000000002 /* TerminalSelectionAccessibilityNotifier.swift */; };
 		C75100020000000000000001 /* TerminalSelectionTranslation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75100020000000000000002 /* TerminalSelectionTranslation.swift */; };
 		C75100030000000000000001 /* TerminalSelectionTranslationAnchorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75100030000000000000002 /* TerminalSelectionTranslationAnchorView.swift */; };
+		85510003A1B2C3D4E5F60001 /* TerminalShellResolver+CurrentUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85510004A1B2C3D4E5F60001 /* TerminalShellResolver+CurrentUser.swift */; };
 		A5001543 /* TerminalSSHSessionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* TerminalSSHSessionDetector.swift */; };
 		D3052001000000000000001 /* TerminalSurfaceResizePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */; };
 		C750500000000000000000B1 /* TerminalSurfaceRuntimeWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */; };
@@ -3072,6 +3074,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F17F00000000000000000004 /* FullWidthTabCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthTabCommandTests.swift; sourceTree = "<group>"; };
 		F17F00000000000000000002 /* FullWidthTabPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthTabPersistenceTests.swift; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
+		85510002A1B2C3D4E5F60001 /* GhosttyApp+ChildExitPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyApp+ChildExitPolicy.swift"; sourceTree = "<group>"; };
 		D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyApp+SurfaceConfigurationReload.swift"; sourceTree = "<group>"; };
 		EC010D02 /* GhosttyApp+TerminalCustomUpload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyApp+TerminalCustomUpload.swift"; sourceTree = "<group>"; };
 		1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyCommandShiftForwardingTests.swift; sourceTree = "<group>"; };
@@ -4086,6 +4089,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A11E5E1E0000000000000002 /* TerminalSelectionAccessibilityNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSelectionAccessibilityNotifier.swift; sourceTree = "<group>"; };
 		C75100020000000000000002 /* TerminalSelectionTranslation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSelectionTranslation.swift; sourceTree = "<group>"; };
 		C75100030000000000000002 /* TerminalSelectionTranslationAnchorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSelectionTranslationAnchorView.swift; sourceTree = "<group>"; };
+		85510004A1B2C3D4E5F60001 /* TerminalShellResolver+CurrentUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalShellResolver+CurrentUser.swift"; sourceTree = "<group>"; };
 		A5001545 /* TerminalSSHSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSSHSessionDetector.swift; sourceTree = "<group>"; };
 		D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceResizePolicyTests.swift; sourceTree = "<group>"; };
 		C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceRuntimeWiring.swift; sourceTree = "<group>"; };
@@ -5127,6 +5131,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C40410010000000000000020 /* FileExplorerDoubleClickActionSettings.swift */,
 				C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
+				85510002A1B2C3D4E5F60001 /* GhosttyApp+ChildExitPolicy.swift */,
 				816400000000000000000002 /* GhosttyScrollView.swift */,
 				A11E5E1E0000000000000002 /* TerminalSelectionAccessibilityNotifier.swift */,
 				A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */,
@@ -5176,6 +5181,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */,
 				D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */,
 				EC010D02 /* GhosttyApp+TerminalCustomUpload.swift */,
+				85510004A1B2C3D4E5F60001 /* TerminalShellResolver+CurrentUser.swift */,
 				EC010E02 /* GhosttyNSView+TerminalCustomUpload.swift */,
 				D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */,
 				D0B752900000000000000001 /* PaneDropRoutingRegistration.swift */,
@@ -7574,6 +7580,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E55400000000000000000D1 /* FocusStealingResponderConformances.swift in Sources */,
 					C0DEFB100000000000000001 /* FocusSurfaceBroadcaster.swift in Sources */,
 				AA5269A0C0DE0002FACE0002 /* ForeignFirstResponderPolicy.swift in Sources */,
+				85510001A1B2C3D4E5F60001 /* GhosttyApp+ChildExitPolicy.swift in Sources */,
 				D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */,
 				EC010D01 /* GhosttyApp+TerminalCustomUpload.swift in Sources */,
 				A7206D010000000000000001 /* GhosttyConfig+AppearanceSync.swift in Sources */,
@@ -8281,6 +8288,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A11E5E1E0000000000000001 /* TerminalSelectionAccessibilityNotifier.swift in Sources */,
 				C75100020000000000000001 /* TerminalSelectionTranslation.swift in Sources */,
 				C75100030000000000000001 /* TerminalSelectionTranslationAnchorView.swift in Sources */,
+				85510003A1B2C3D4E5F60001 /* TerminalShellResolver+CurrentUser.swift in Sources */,
 				A5001543 /* TerminalSSHSessionDetector.swift in Sources */,
 				C750500000000000000000B1 /* TerminalSurfaceRuntimeWiring.swift in Sources */,
 				F83620020000000000000001 /* TerminalTTYSessionIdentity.swift in Sources */,

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -270,7 +270,7 @@ final class TabManagerChildExitCloseTests: XCTestCase {
         )
     }
 
-    func testChildExitOnLastRemotePanelKeepsWorkspaceDisconnected() async throws {
+    func testFastChildExitOnLastRemotePanelKeepsWorkspaceDisconnected() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace,
               let remotePanelId = workspace.focusedPanelId,
@@ -298,15 +298,15 @@ final class TabManagerChildExitCloseTests: XCTestCase {
         XCTAssertTrue(workspace.isRemoteWorkspace)
         XCTAssertTrue(workspace.isRemoteTerminalSurface(remotePanelId))
 
-        manager.closePanelAfterChildExited(tabId: workspace.id, surfaceId: remotePanelId)
-        await workspace.waitForRemoteDisconnectTransition(surfaceId: remotePanelId)
+        manager.closePanelAfterChildExited(tabId: workspace.id, surfaceId: remotePanelId, keepSurfaceVisible: true)
 
         XCTAssertEqual(manager.tabs.count, 1)
         XCTAssertEqual(workspace.remoteConnectionState, .disconnected)
         XCTAssertNotNil(workspace.panels[remotePanelId])
         XCTAssertEqual(workspace.focusedPanelId, remotePanelId)
-        XCTAssertFalse(workspace.terminalPanel(for: remotePanelId)?.surface === remotePanel.surface)
-        XCTAssertTrue(workspace.remoteDisconnectPlaceholderPanelIds.contains(remotePanelId))
+        XCTAssertTrue(workspace.terminalPanel(for: remotePanelId)?.surface === remotePanel.surface)
+        XCTAssertTrue(workspace.pendingRemoteTerminalChildExitSurfaceIds.contains(remotePanelId))
+        XCTAssertFalse(workspace.remoteDisconnectPlaceholderPanelIds.contains(remotePanelId))
         XCTAssertEqual(workspace.activeRemoteTerminalSessionCount, 0)
     }
 


### PR DESCRIPTION
## Summary

- resolve the current user's executable shell from the macOS user database, inherited `SHELL`, declared `/etc/shells` paths, then `/bin/zsh` and `/bin/sh` fallbacks
- pass that resolved shell as the actual default surface command instead of relying on Ghostty's desktop/passwd lookup, while leaving explicit Ghostty `command` config inherited so `direct:` semantics remain intact
- retain instant abnormal child exits so Ghostty renders its existing launch-failure state, while still completing remote-session bookkeeping and preserving normal-exit teardown

## Regression coverage

- test-only red commit: `b241f02ce6`
  - from a clean pre-fix package build, launch-policy tests failed because `TerminalLaunchCommandPolicy` was absent
  - from a clean pre-fix Core package build, config-command tests failed because `GhosttyConfig.command` was absent
- green implementation commit: `964d12b226`
- deterministic fake-path coverage for the nix-darwin fish / stale Homebrew fish repro, relocated shell declarations, zsh fallback, and no non-executable return
- launch-command precedence coverage, including inheriting explicit Ghostty config rather than copying raw `direct:` commands into the shell-only embedded override
- recursive Ghostty `config-file` command precedence coverage
- abnormal remote-exit behavior coverage verifies the original error surface remains visible while remote lifecycle state becomes disconnected

## Validation

- `swift test --package-path Packages/macOS/CmuxTerminal --filter 'TerminalShellResolverTests|TerminalChildExitPolicyTests'` — 9 tests passed
- `swift test --package-path Packages/macOS/CmuxTerminalCore --filter GhosttyConfigCommandTests` — 3 tests passed
- `xcrun swiftc -parse Sources/GhosttyApp+ChildExitPolicy.swift Sources/GhosttyTerminalView.swift Sources/TabManager.swift cmuxTests/TabManagerUnitTests.swift`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- `scripts/check-pbxproj.sh`
- `git diff --check origin/main...HEAD`

The local SwiftPM runner process exits 1 after Swift Testing completes because this Intel process cannot load the arm64 test bundle; the Swift Testing output itself executed and passed all 12 focused tests. The requested `scripts/swift_file_length_budget.py` and `.github/swift-file-length-budget.tsv` are absent from this checkout; `.github/swift-warning-budget.tsv` was not touched. No local `xcodebuild`, XCUITest, app reload, or app build was run.

Fixes #8551
