### PR TITLE
iOS: preserve terminal input ordering under fast typing

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -169,6 +169,12 @@ jobs:
           # terminal mirror behavior without relying on local-only SwiftPM runs.
           swift test --package-path Packages/iOS/CmuxMobileShell
 
+      - name: Run CmuxMobileShellModel package tests
+        run: |
+          # Pure shell-model queue and ordering regressions live in this package.
+          # Keep them beside the shell package gate so input framing stays covered.
+          swift test --package-path Packages/iOS/CmuxMobileShellModel
+
   ios-simulator:
     needs: detect-ios-changes
     if: ${{ needs.detect-ios-changes.outputs.should_run == 'true' }}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -911,6 +911,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var terminalLiveFontTokensBySurfaceID: [String: UUID]
     private var rawTerminalInputBuffer: MobileTerminalInputSendBuffer
     private var rawTerminalInputDrainWaiters: [CheckedContinuation<Void, Never>]
+    private var isRawTerminalInputDrainLoopRunning: Bool
     private var pairingAttemptID: UUID
 
     /// High-level shell phase derived from sign-in and connection state.
@@ -1135,6 +1136,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.terminalLiveFontTokensBySurfaceID = [:]
         self.rawTerminalInputBuffer = MobileTerminalInputSendBuffer()
         self.rawTerminalInputDrainWaiters = []
+        self.isRawTerminalInputDrainLoopRunning = false
         self.pairingAttemptID = UUID()
     }
 
@@ -5016,13 +5018,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let text = String(data: data, encoding: .utf8), !text.isEmpty else {
             return
         }
-        let workspaceCandidate = workspaces.first(where: { workspace in
-            workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
-        })
-        guard let workspace = workspaceCandidate else { return }
+        guard let workspaceID = workspaceID(containingSurfaceID: surfaceID) else { return }
         let enqueueResult = rawTerminalInputBuffer.enqueue(
             text,
-            workspaceID: workspace.id,
+            workspaceID: workspaceID,
             terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
         )
         handleSynchronousRawTerminalInputEnqueueResult(enqueueResult)
@@ -5069,15 +5068,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let text = String(data: data, encoding: .utf8) else {
             return
         }
-        let workspaceCandidate = workspaces.first(where: { workspace in
-            workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
-        })
-        guard let workspace = workspaceCandidate else { return }
-        let terminalID = MobileTerminalPreview.ID(rawValue: surfaceID)
+        guard let workspaceID = workspaceID(containingSurfaceID: surfaceID) else { return }
         await enqueueTerminalRawInputAwaitingDrain(
             text,
-            workspaceID: workspace.id,
-            terminalID: terminalID
+            workspaceID: workspaceID,
+            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
         )
     }
 
@@ -5095,6 +5090,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         ) {
         case .startDraining:
             await drainRawTerminalInputBuffer()
+            // A stale drain loop may still own the buffer (the runner guard
+            // made our call a no-op); wait for it so awaited submitters only
+            // return once their input has actually been handed to the sender.
+            await awaitRawTerminalInputDrainCompletion()
         case .queued:
             await awaitRawTerminalInputDrainCompletion()
         case .rejected:
@@ -5103,6 +5102,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     private func drainRawTerminalInputBuffer() async {
+        // A drain Task can outlive rawTerminalInputBuffer.clear(): the buffer's
+        // isDraining flag resets synchronously, so a new enqueue can start a
+        // second loop while the old one is still awaiting a send. Two loops
+        // interleaving sends is exactly the input reorder this pipeline exists
+        // to prevent, so an instance-level runner flag keeps at most one loop
+        // alive; late starters return and the active loop drains their chunks.
+        guard !isRawTerminalInputDrainLoopRunning else { return }
+        isRawTerminalInputDrainLoopRunning = true
+        defer {
+            isRawTerminalInputDrainLoopRunning = false
+            resumeRawTerminalInputDrainWaiters()
+        }
         // Matches MobileIrohTerminalLane.maximumInputByteCount and the Mac lane
         // router's maximumInputFrameByteCount.
         while let chunk = rawTerminalInputBuffer.nextBatch(maximumByteCount: 16 * 1_024) {
@@ -5112,7 +5123,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 terminalID: chunk.terminalID
             )
         }
-        resumeRawTerminalInputDrainWaiters()
     }
 
     private func awaitRawTerminalInputDrainCompletion() async {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -910,6 +910,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// stream's continuation.
     private var terminalLiveFontTokensBySurfaceID: [String: UUID]
     private var rawTerminalInputBuffer: MobileTerminalInputSendBuffer
+    private var rawTerminalInputDrainWaiters: [CheckedContinuation<Void, Never>]
     private var pairingAttemptID: UUID
 
     /// High-level shell phase derived from sign-in and connection state.
@@ -1133,6 +1134,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.terminalLiveFontContinuationsBySurfaceID = [:]
         self.terminalLiveFontTokensBySurfaceID = [:]
         self.rawTerminalInputBuffer = MobileTerminalInputSendBuffer()
+        self.rawTerminalInputDrainWaiters = []
         self.pairingAttemptID = UUID()
     }
 
@@ -1292,6 +1294,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             Task { await refresher.cancelInFlightRestores() }
         }
         rawTerminalInputBuffer.clear()
+        resumeRawTerminalInputDrainWaiters()
         reportedViewportSizesByTerminalKey = [:]
         terminalPreBarrierDeliveredEndSeqBySurfaceID = [:]
         terminalRenderGridBaselineReplayRequestCountsBySurfaceID = [:]
@@ -4455,7 +4458,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             "line_count": .int(text.split(separator: "\n", omittingEmptySubsequences: false).count),
             "had_attachment": .bool(false),
         ])
-        await sendRemoteTerminalInput(text + "\r")
+        await submitTerminalRawInput(text + "\r")
     }
 
     /// Show or hide the iMessage-style composer from the input accessory bar.
@@ -5000,11 +5003,35 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             #endif
             return
         }
-        switch rawTerminalInputBuffer.enqueue(
+        let enqueueResult = rawTerminalInputBuffer.enqueue(
             text,
             workspaceID: workspaceID,
             terminalID: terminalID
-        ) {
+        )
+        handleSynchronousRawTerminalInputEnqueueResult(enqueueResult)
+    }
+
+    /// Enqueue raw UTF-8 input for the terminal identified by `surfaceID`.
+    public func sendTerminalRawInput(_ data: Data, surfaceID: String) {
+        guard let text = String(data: data, encoding: .utf8), !text.isEmpty else {
+            return
+        }
+        let workspaceCandidate = workspaces.first(where: { workspace in
+            workspace.terminals.contains(where: { $0.id.rawValue == surfaceID })
+        })
+        guard let workspace = workspaceCandidate else { return }
+        let enqueueResult = rawTerminalInputBuffer.enqueue(
+            text,
+            workspaceID: workspace.id,
+            terminalID: MobileTerminalPreview.ID(rawValue: surfaceID)
+        )
+        handleSynchronousRawTerminalInputEnqueueResult(enqueueResult)
+    }
+
+    private func handleSynchronousRawTerminalInputEnqueueResult(
+        _ enqueueResult: MobileTerminalInputEnqueueResult
+    ) {
+        switch enqueueResult {
         case .startDraining:
             Task { @MainActor [weak self] in
                 await self?.drainRawTerminalInputBuffer()
@@ -5012,21 +5039,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         case .queued:
             return
         case .rejected:
-            mobileShellLog.error("disconnecting mobile terminal input because pending byte count exceeded limit")
-            // Real error-rate signal: the core input loop silently broke because
-            // the send buffer filled. Distinct from an RPC timeout.
-            analytics.capture("ios_terminal_input_dropped", [
-                "pending_byte_count": .int(rawTerminalInputBuffer.pendingByteCount),
-                "reason": .string("queue_full"),
-            ])
-            connectionError = L10n.string(
-                "mobile.terminal.inputQueueFull",
-                defaultValue: "The terminal can't accept more input right now. Wait a moment and retry, or reopen the terminal if it stays unavailable."
-            )
-            connectionErrorGuidance = nil
-            connectionState = .disconnected
-            macConnectionStatus = .unavailable
-            clearRemoteConnectionContext()
+            handleRawTerminalInputOverflow()
         }
     }
 
@@ -5037,7 +5050,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
               let terminalID = selectedTerminalID else {
             return
         }
-        await submitTerminalRawInput(text, workspaceID: workspaceID, terminalID: terminalID)
+        await enqueueTerminalRawInputAwaitingDrain(
+            text,
+            workspaceID: workspaceID,
+            terminalID: terminalID
+        )
     }
 
     /// Raw-bytes overload. The libghostty render path on iOS uses this
@@ -5057,27 +5074,78 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         })
         guard let workspace = workspaceCandidate else { return }
         let terminalID = MobileTerminalPreview.ID(rawValue: surfaceID)
-        await submitTerminalRawInput(text, workspaceID: workspace.id, terminalID: terminalID)
+        await enqueueTerminalRawInputAwaitingDrain(
+            text,
+            workspaceID: workspace.id,
+            terminalID: terminalID
+        )
     }
 
-    private func submitTerminalRawInput(
+    private func enqueueTerminalRawInputAwaitingDrain(
         _ text: String,
         workspaceID: MobileWorkspacePreview.ID,
         terminalID: MobileTerminalPreview.ID
     ) async {
         guard !text.isEmpty else { return }
         guard remoteClient != nil else { return }
-        await sendRemoteTerminalInput(text, workspaceID: workspaceID, terminalID: terminalID)
+        switch rawTerminalInputBuffer.enqueue(
+            text,
+            workspaceID: workspaceID,
+            terminalID: terminalID
+        ) {
+        case .startDraining:
+            await drainRawTerminalInputBuffer()
+        case .queued:
+            await awaitRawTerminalInputDrainCompletion()
+        case .rejected:
+            handleRawTerminalInputOverflow()
+        }
     }
 
     private func drainRawTerminalInputBuffer() async {
-        while let chunk = rawTerminalInputBuffer.nextBatch() {
-            await submitTerminalRawInput(
+        // Matches MobileIrohTerminalLane.maximumInputByteCount and the Mac lane
+        // router's maximumInputFrameByteCount.
+        while let chunk = rawTerminalInputBuffer.nextBatch(maximumByteCount: 16 * 1_024) {
+            await sendRemoteTerminalInput(
                 chunk.text,
                 workspaceID: chunk.workspaceID,
                 terminalID: chunk.terminalID
             )
         }
+        resumeRawTerminalInputDrainWaiters()
+    }
+
+    private func awaitRawTerminalInputDrainCompletion() async {
+        guard rawTerminalInputBuffer.isDraining else { return }
+        await withCheckedContinuation { continuation in
+            rawTerminalInputDrainWaiters.append(continuation)
+        }
+    }
+
+    private func resumeRawTerminalInputDrainWaiters() {
+        let waiters = rawTerminalInputDrainWaiters
+        rawTerminalInputDrainWaiters = []
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func handleRawTerminalInputOverflow() {
+        mobileShellLog.error("disconnecting mobile terminal input because pending byte count exceeded limit")
+        // Real error-rate signal: the core input loop silently broke because
+        // the send buffer filled. Distinct from an RPC timeout.
+        analytics.capture("ios_terminal_input_dropped", [
+            "pending_byte_count": .int(rawTerminalInputBuffer.pendingByteCount),
+            "reason": .string("queue_full"),
+        ])
+        connectionError = L10n.string(
+            "mobile.terminal.inputQueueFull",
+            defaultValue: "The terminal can't accept more input right now. Wait a moment and retry, or reopen the terminal if it stays unavailable."
+        )
+        connectionErrorGuidance = nil
+        connectionState = .disconnected
+        macConnectionStatus = .unavailable
+        clearRemoteConnectionContext()
     }
 
     /// Establishes the live connection for `ticket`. Returns `nil` on success
@@ -5102,6 +5170,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         diagnosticLog?.record(DiagnosticEvent(.connect))
         cancelRemoteOperationTasks()
         rawTerminalInputBuffer.clear()
+        resumeRawTerminalInputDrainWaiters()
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         let supportedRoutes = Self.supportedRoutes(for: ticket, supportedKinds: supportedKinds)
         guard let firstRoute = supportedRoutes.first else {
@@ -5637,6 +5706,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             workspacesByMac[offlineForegroundKey] = offline
         }
         rawTerminalInputBuffer.clear()
+        resumeRawTerminalInputDrainWaiters()
     }
 
     /// Set `remoteClient` to a new value (possibly nil) and disconnect the
@@ -5741,6 +5811,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectionAttemptGeneration = UUID()
         cancelRemoteOperationTasks()
         rawTerminalInputBuffer.clear()
+        resumeRawTerminalInputDrainWaiters()
         clearPairingError()
         clearPairingVersionWarning()
         return attemptID

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
@@ -40,10 +40,6 @@ actor RoutingHostRouter {
         var surfaceID: String
         var text: String
     }
-    struct TerminalInputRecord: Sendable {
-        var surfaceID: String
-        var text: String
-    }
     struct WorkspaceCreateRecord: Sendable, Equatable {
         var groupID: String?
         var title: String?
@@ -54,13 +50,7 @@ actor RoutingHostRouter {
     }
     private(set) var pasteImages: [PasteImageRecord] = []
     private(set) var pastes: [PasteRecord] = []
-    private(set) var terminalInputs: [TerminalInputRecord] = []
-    private var terminalInputInFlightCount = 0
-    private var terminalInputMaximumInFlightCount = 0
-    private var holdFirstTerminalInput = false
-    private var firstTerminalInputHeld = false
-    private var firstTerminalInputContinuation: CheckedContinuation<Void, Never>?
-    private var firstTerminalInputReachedWaiters: [CheckedContinuation<Void, Never>] = []
+    let terminalInputRecorder = RoutingTerminalInputRecorder()
     private(set) var directorySearchQueries: [String] = []
     private(set) var dismisses: [(notificationIDs: [String], clientID: String?)] = []
     private var workspaceCreates: [WorkspaceCreateRecord] = []
@@ -121,21 +111,6 @@ actor RoutingHostRouter {
         continuation?.resume()
     }
 
-    func setHoldFirstTerminalInput(_ hold: Bool) {
-        holdFirstTerminalInput = hold
-    }
-
-    func awaitFirstTerminalInputReached() async {
-        if firstTerminalInputHeld { return }
-        await withCheckedContinuation { firstTerminalInputReachedWaiters.append($0) }
-    }
-
-    func releaseFirstTerminalInput() {
-        let continuation = firstTerminalInputContinuation
-        firstTerminalInputContinuation = nil
-        continuation?.resume()
-    }
-
     func setRejectWorkspaceCreate(_ reject: Bool) {
         rejectWorkspaceCreate = reject
     }
@@ -185,9 +160,6 @@ actor RoutingHostRouter {
 
     func recordedPasteImages() -> [PasteImageRecord] { pasteImages }
     func recordedPastes() -> [PasteRecord] { pastes }
-    func recordedTerminalInputs() -> [TerminalInputRecord] { terminalInputs }
-    func recordedTerminalInputInFlightCount() -> Int { terminalInputInFlightCount }
-    func recordedTerminalInputMaximumInFlightCount() -> Int { terminalInputMaximumInFlightCount }
     func recordedDirectorySearchQueries() -> [String] { directorySearchQueries }
     func recordedDirectoryListRequests() -> [(path: String, offset: Int, limit: Int)] {
         directoryListRequests
@@ -395,28 +367,7 @@ actor RoutingHostRouter {
             pastes.append(PasteRecord(surfaceID: surfaceID, text: text))
             return try? Self.resultFrame(id: id, result: [:])
         case "terminal.input":
-            let surfaceID = info.surfaceID ?? ""
-            let text = info.text ?? ""
-            let index = terminalInputs.count
-            terminalInputs.append(TerminalInputRecord(surfaceID: surfaceID, text: text))
-            terminalInputInFlightCount += 1
-            terminalInputMaximumInFlightCount = max(
-                terminalInputMaximumInFlightCount,
-                terminalInputInFlightCount
-            )
-            if index == 0 && holdFirstTerminalInput {
-                firstTerminalInputHeld = true
-                let reachedWaiters = firstTerminalInputReachedWaiters
-                firstTerminalInputReachedWaiters = []
-                for waiter in reachedWaiters { waiter.resume() }
-                await withCheckedContinuation { firstTerminalInputContinuation = $0 }
-            }
-            terminalInputInFlightCount -= 1
-            return try? Self.resultFrame(id: id, result: [
-                "workspace_id": Self.workspaceID,
-                "surface_id": surfaceID,
-                "queued": false,
-            ])
+            return await terminalInputResponse(info)
         case "notification.dismiss":
             dismisses.append((
                 notificationIDs: info.notificationIDs ?? [],
@@ -430,7 +381,7 @@ actor RoutingHostRouter {
         }
     }
 
-    private static func resultFrame(id: String?, result: [String: Any]) throws -> Data {
+    static func resultFrame(id: String?, result: [String: Any]) throws -> Data {
         let envelope: [String: Any] = [
             "id": id ?? UUID().uuidString,
             "ok": true,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ComposerSubmitRoutingTestSupport.swift
@@ -40,6 +40,10 @@ actor RoutingHostRouter {
         var surfaceID: String
         var text: String
     }
+    struct TerminalInputRecord: Sendable {
+        var surfaceID: String
+        var text: String
+    }
     struct WorkspaceCreateRecord: Sendable, Equatable {
         var groupID: String?
         var title: String?
@@ -50,6 +54,13 @@ actor RoutingHostRouter {
     }
     private(set) var pasteImages: [PasteImageRecord] = []
     private(set) var pastes: [PasteRecord] = []
+    private(set) var terminalInputs: [TerminalInputRecord] = []
+    private var terminalInputInFlightCount = 0
+    private var terminalInputMaximumInFlightCount = 0
+    private var holdFirstTerminalInput = false
+    private var firstTerminalInputHeld = false
+    private var firstTerminalInputContinuation: CheckedContinuation<Void, Never>?
+    private var firstTerminalInputReachedWaiters: [CheckedContinuation<Void, Never>] = []
     private(set) var directorySearchQueries: [String] = []
     private(set) var dismisses: [(notificationIDs: [String], clientID: String?)] = []
     private var workspaceCreates: [WorkspaceCreateRecord] = []
@@ -110,6 +121,21 @@ actor RoutingHostRouter {
         continuation?.resume()
     }
 
+    func setHoldFirstTerminalInput(_ hold: Bool) {
+        holdFirstTerminalInput = hold
+    }
+
+    func awaitFirstTerminalInputReached() async {
+        if firstTerminalInputHeld { return }
+        await withCheckedContinuation { firstTerminalInputReachedWaiters.append($0) }
+    }
+
+    func releaseFirstTerminalInput() {
+        let continuation = firstTerminalInputContinuation
+        firstTerminalInputContinuation = nil
+        continuation?.resume()
+    }
+
     func setRejectWorkspaceCreate(_ reject: Bool) {
         rejectWorkspaceCreate = reject
     }
@@ -159,6 +185,9 @@ actor RoutingHostRouter {
 
     func recordedPasteImages() -> [PasteImageRecord] { pasteImages }
     func recordedPastes() -> [PasteRecord] { pastes }
+    func recordedTerminalInputs() -> [TerminalInputRecord] { terminalInputs }
+    func recordedTerminalInputInFlightCount() -> Int { terminalInputInFlightCount }
+    func recordedTerminalInputMaximumInFlightCount() -> Int { terminalInputMaximumInFlightCount }
     func recordedDirectorySearchQueries() -> [String] { directorySearchQueries }
     func recordedDirectoryListRequests() -> [(path: String, offset: Int, limit: Int)] {
         directoryListRequests
@@ -365,6 +394,29 @@ actor RoutingHostRouter {
             let text = info.text ?? ""
             pastes.append(PasteRecord(surfaceID: surfaceID, text: text))
             return try? Self.resultFrame(id: id, result: [:])
+        case "terminal.input":
+            let surfaceID = info.surfaceID ?? ""
+            let text = info.text ?? ""
+            let index = terminalInputs.count
+            terminalInputs.append(TerminalInputRecord(surfaceID: surfaceID, text: text))
+            terminalInputInFlightCount += 1
+            terminalInputMaximumInFlightCount = max(
+                terminalInputMaximumInFlightCount,
+                terminalInputInFlightCount
+            )
+            if index == 0 && holdFirstTerminalInput {
+                firstTerminalInputHeld = true
+                let reachedWaiters = firstTerminalInputReachedWaiters
+                firstTerminalInputReachedWaiters = []
+                for waiter in reachedWaiters { waiter.resume() }
+                await withCheckedContinuation { firstTerminalInputContinuation = $0 }
+            }
+            terminalInputInFlightCount -= 1
+            return try? Self.resultFrame(id: id, result: [
+                "workspace_id": Self.workspaceID,
+                "surface_id": surfaceID,
+                "queued": false,
+            ])
         case "notification.dismiss":
             dismisses.append((
                 notificationIDs: info.notificationIDs ?? [],

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTestSupport.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct RoutingTerminalInputRecord: Sendable {
+    var surfaceID: String
+    var text: String
+}
+
+actor TerminalRawInputTaskCompletionTracker {
+    private var completionCount = 0
+
+    func recordCompletion() {
+        completionCount += 1
+    }
+
+    func recordedCompletionCount() -> Int { completionCount }
+}
+
+actor RoutingTerminalInputRecorder {
+    private var inputs: [RoutingTerminalInputRecord] = []
+    private var inFlightCount = 0
+    private var maximumInFlightCount = 0
+    private var holdFirstInput = false
+    private var firstInputHeld = false
+    private var firstInputContinuation: CheckedContinuation<Void, Never>?
+    private var firstInputReachedWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func setHoldFirstInput(_ hold: Bool) {
+        holdFirstInput = hold
+    }
+
+    func awaitFirstInputReached() async {
+        if firstInputHeld { return }
+        await withCheckedContinuation { firstInputReachedWaiters.append($0) }
+    }
+
+    func releaseFirstInput() {
+        let continuation = firstInputContinuation
+        firstInputContinuation = nil
+        continuation?.resume()
+    }
+
+    func record(surfaceID: String, text: String) async {
+        let index = inputs.count
+        inputs.append(RoutingTerminalInputRecord(surfaceID: surfaceID, text: text))
+        inFlightCount += 1
+        maximumInFlightCount = max(maximumInFlightCount, inFlightCount)
+        if index == 0 && holdFirstInput {
+            firstInputHeld = true
+            let reachedWaiters = firstInputReachedWaiters
+            firstInputReachedWaiters = []
+            for waiter in reachedWaiters { waiter.resume() }
+            await withCheckedContinuation { firstInputContinuation = $0 }
+        }
+        inFlightCount -= 1
+    }
+
+    func recordedInputs() -> [RoutingTerminalInputRecord] { inputs }
+    func recordedInFlightCount() -> Int { inFlightCount }
+    func recordedMaximumInFlightCount() -> Int { maximumInFlightCount }
+}
+
+extension RoutingHostRouter {
+    func setHoldFirstTerminalInput(_ hold: Bool) async {
+        await terminalInputRecorder.setHoldFirstInput(hold)
+    }
+
+    func awaitFirstTerminalInputReached() async {
+        await terminalInputRecorder.awaitFirstInputReached()
+    }
+
+    func releaseFirstTerminalInput() async {
+        await terminalInputRecorder.releaseFirstInput()
+    }
+
+    func recordedTerminalInputs() async -> [RoutingTerminalInputRecord] {
+        await terminalInputRecorder.recordedInputs()
+    }
+
+    func recordedTerminalInputInFlightCount() async -> Int {
+        await terminalInputRecorder.recordedInFlightCount()
+    }
+
+    func recordedTerminalInputMaximumInFlightCount() async -> Int {
+        await terminalInputRecorder.recordedMaximumInFlightCount()
+    }
+
+    func terminalInputResponse(_ info: RequestInfo) async -> Data? {
+        let surfaceID = info.surfaceID ?? ""
+        await terminalInputRecorder.record(surfaceID: surfaceID, text: info.text ?? "")
+        return try? Self.resultFrame(id: info.id, result: [
+            "workspace_id": Self.workspaceID,
+            "surface_id": surfaceID,
+            "queued": false,
+        ])
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
@@ -8,6 +8,7 @@ import Testing
     @Test func fastTypingPreservesKeystrokeOrder() async throws {
         let router = RoutingHostRouter()
         let store = try await makeRoutingConnectedStore(router: router)
+        let completionTracker = TerminalRawInputTaskCompletionTracker()
         await router.setHoldFirstTerminalInput(true)
 
         for character in ["a", "z", "i", "z"] {
@@ -16,12 +17,17 @@ import Testing
                     Data(character.utf8),
                     surfaceID: RoutingHostRouter.terminalA
                 )
+                await completionTracker.recordCompletion()
             }
         }
 
         await router.awaitFirstTerminalInputReached()
         _ = await waitForTerminalInputCount(4, router: router)
         await router.releaseFirstTerminalInput()
+        let producersCompleted = await waitForProducerCompletion(
+            expectedCount: 4,
+            tracker: completionTracker
+        )
         let reachedQuiescence = await waitForTerminalInputQuiescence(router: router)
 
         let inputs = await router.recordedTerminalInputs()
@@ -31,6 +37,7 @@ import Testing
             .joined()
         let maximumInFlightCount = await router.recordedTerminalInputMaximumInFlightCount()
 
+        #expect(producersCompleted)
         #expect(reachedQuiescence)
         #expect(terminalAText == "aziz")
         #expect(maximumInFlightCount == 1)
@@ -63,6 +70,21 @@ import Testing
                 lastArrivalCount = arrivalCount
                 stableSince = clock.now
             } else if stableSince.duration(to: clock.now) >= .milliseconds(20) {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+
+    private func waitForProducerCompletion(
+        expectedCount: Int,
+        tracker: TerminalRawInputTaskCompletionTracker
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while clock.now < deadline {
+            if await tracker.recordedCompletionCount() >= expectedCount {
                 return true
             }
             await Task.yield()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalRawInputOrderingTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+@Suite struct TerminalRawInputOrderingTests {
+    @MainActor
+    @Test func fastTypingPreservesKeystrokeOrder() async throws {
+        let router = RoutingHostRouter()
+        let store = try await makeRoutingConnectedStore(router: router)
+        await router.setHoldFirstTerminalInput(true)
+
+        for character in ["a", "z", "i", "z"] {
+            Task { @MainActor in
+                await store.submitTerminalRawInput(
+                    Data(character.utf8),
+                    surfaceID: RoutingHostRouter.terminalA
+                )
+            }
+        }
+
+        await router.awaitFirstTerminalInputReached()
+        _ = await waitForTerminalInputCount(4, router: router)
+        await router.releaseFirstTerminalInput()
+        let reachedQuiescence = await waitForTerminalInputQuiescence(router: router)
+
+        let inputs = await router.recordedTerminalInputs()
+        let terminalAText = inputs
+            .filter { $0.surfaceID == RoutingHostRouter.terminalA }
+            .map(\.text)
+            .joined()
+        let maximumInFlightCount = await router.recordedTerminalInputMaximumInFlightCount()
+
+        #expect(reachedQuiescence)
+        #expect(terminalAText == "aziz")
+        #expect(maximumInFlightCount == 1)
+    }
+
+    private func waitForTerminalInputCount(
+        _ expectedCount: Int,
+        router: RoutingHostRouter
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .milliseconds(500))
+        while clock.now < deadline {
+            if await router.recordedTerminalInputs().count >= expectedCount {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+
+    private func waitForTerminalInputQuiescence(router: RoutingHostRouter) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .milliseconds(500))
+        var stableSince = clock.now
+        var lastArrivalCount = -1
+        while clock.now < deadline {
+            let arrivalCount = await router.recordedTerminalInputs().count
+            let inFlightCount = await router.recordedTerminalInputInFlightCount()
+            if arrivalCount != lastArrivalCount || inFlightCount != 0 {
+                lastArrivalCount = arrivalCount
+                stableSince = clock.now
+            } else if stableSince.duration(to: clock.now) >= .milliseconds(20) {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+}

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
@@ -83,13 +83,39 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
         return .startDraining
     }
 
-    /// Removes and returns the next pending chunk, or clears the draining flag
-    /// and returns `nil` when the buffer is empty.
+    /// Removes and returns the next pending chunk, optionally splitting an
+    /// oversized head chunk at a Unicode-scalar boundary.
+    /// - Parameter maximumByteCount: The maximum UTF-8 bytes to return, or `nil` for no cap.
     /// - Returns: The next chunk to deliver, or `nil` when nothing is pending.
-    public mutating func nextBatch() -> Chunk? {
+    public mutating func nextBatch(maximumByteCount: Int? = nil) -> Chunk? {
         guard !pendingChunks.isEmpty else {
             isDraining = false
             return nil
+        }
+        if let maximumByteCount,
+           pendingChunks[0].text.utf8.count > maximumByteCount {
+            precondition(maximumByteCount > 0)
+            let text = pendingChunks[0].text
+            var prefixByteCount = 0
+            var splitIndex = text.unicodeScalars.startIndex
+            while splitIndex < text.unicodeScalars.endIndex {
+                let scalar = text.unicodeScalars[splitIndex]
+                let scalarByteCount = String(scalar).utf8.count
+                guard prefixByteCount + scalarByteCount <= maximumByteCount else {
+                    break
+                }
+                prefixByteCount += scalarByteCount
+                splitIndex = text.unicodeScalars.index(after: splitIndex)
+            }
+            precondition(splitIndex != text.unicodeScalars.startIndex)
+            let prefix = String(text.unicodeScalars[..<splitIndex])
+            pendingChunks[0].text = String(text.unicodeScalars[splitIndex...])
+            pendingByteCount = max(0, pendingByteCount - prefixByteCount)
+            return Chunk(
+                workspaceID: pendingChunks[0].workspaceID,
+                terminalID: pendingChunks[0].terminalID,
+                text: prefix
+            )
         }
         let chunk = pendingChunks.removeFirst()
         pendingByteCount = max(0, pendingByteCount - chunk.text.utf8.count)

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileTerminalInputSendBuffer.swift
@@ -99,15 +99,21 @@ public struct MobileTerminalInputSendBuffer: Equatable, Sendable {
             var prefixByteCount = 0
             var splitIndex = text.unicodeScalars.startIndex
             while splitIndex < text.unicodeScalars.endIndex {
-                let scalar = text.unicodeScalars[splitIndex]
-                let scalarByteCount = String(scalar).utf8.count
+                let scalarByteCount = UTF8.width(text.unicodeScalars[splitIndex])
                 guard prefixByteCount + scalarByteCount <= maximumByteCount else {
                     break
                 }
                 prefixByteCount += scalarByteCount
                 splitIndex = text.unicodeScalars.index(after: splitIndex)
             }
-            precondition(splitIndex != text.unicodeScalars.startIndex)
+            if splitIndex == text.unicodeScalars.startIndex {
+                // A cap narrower than the first scalar (< 4 bytes) cannot be
+                // honored at a scalar boundary; emit that scalar whole so the
+                // drain always makes progress instead of trapping. Production
+                // caps are KiB-scale, so this branch is pathological-only.
+                prefixByteCount = UTF8.width(text.unicodeScalars[splitIndex])
+                splitIndex = text.unicodeScalars.index(after: splitIndex)
+            }
             let prefix = String(text.unicodeScalars[..<splitIndex])
             pendingChunks[0].text = String(text.unicodeScalars[splitIndex...])
             pendingByteCount = max(0, pendingByteCount - prefixByteCount)

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
@@ -78,6 +78,20 @@ import Testing
         #expect(buffer.nextBatch(maximumByteCount: 4) == nil)
     }
 
+    @Test func emitsWholeScalarWhenCapIsNarrowerThanFirstScalar() {
+        var buffer = MobileTerminalInputSendBuffer()
+        let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let terminalID = MobileTerminalPreview.ID(rawValue: "terminal-a")
+
+        #expect(buffer.enqueue("漢z", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
+        // "漢" is 3 UTF-8 bytes; a 1-byte cap cannot split at a scalar boundary,
+        // so the drain must still make progress by emitting the scalar whole.
+        #expect(buffer.nextBatch(maximumByteCount: 1)?.text == "漢")
+        #expect(buffer.nextBatch(maximumByteCount: 1)?.text == "z")
+        #expect(buffer.pendingByteCount == 0)
+        #expect(buffer.nextBatch(maximumByteCount: 1) == nil)
+    }
+
     @Test func passesThroughExactCapAndSmallChunks() {
         var buffer = MobileTerminalInputSendBuffer()
         let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-a")

--- a/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Tests/CmuxMobileShellModelTests/MobileTerminalInputSendBufferTests.swift
@@ -51,4 +51,44 @@ import Testing
         #expect(buffer.nextBatch() == nil)
         #expect(buffer.enqueue("c", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
     }
+
+    @Test func splitsOversizedCoalescedInputAtUnicodeScalarBoundaries() {
+        var buffer = MobileTerminalInputSendBuffer()
+        let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let terminalID = MobileTerminalPreview.ID(rawValue: "terminal-a")
+        let text = "abcéé漢漢z"
+
+        #expect(buffer.enqueue("abc", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
+        #expect(buffer.enqueue("éé漢漢z", workspaceID: workspaceID, terminalID: terminalID) == .queued)
+        #expect(buffer.pendingByteCount == text.utf8.count)
+
+        let first = buffer.nextBatch(maximumByteCount: 4)
+        #expect(first?.text == "abc")
+        #expect(buffer.pendingByteCount == "éé漢漢z".utf8.count)
+        let second = buffer.nextBatch(maximumByteCount: 4)
+        #expect(second?.text == "éé")
+        #expect(buffer.pendingByteCount == "漢漢z".utf8.count)
+        let third = buffer.nextBatch(maximumByteCount: 4)
+        #expect(third?.text == "漢")
+        #expect(buffer.pendingByteCount == "漢z".utf8.count)
+        let fourth = buffer.nextBatch(maximumByteCount: 4)
+        #expect(fourth?.text == "漢z")
+        #expect(buffer.pendingByteCount == 0)
+        #expect([first?.text, second?.text, third?.text, fourth?.text].compactMap { $0 }.joined() == text)
+        #expect(buffer.nextBatch(maximumByteCount: 4) == nil)
+    }
+
+    @Test func passesThroughExactCapAndSmallChunks() {
+        var buffer = MobileTerminalInputSendBuffer()
+        let workspaceID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let terminalID = MobileTerminalPreview.ID(rawValue: "terminal-a")
+
+        #expect(buffer.enqueue("éé", workspaceID: workspaceID, terminalID: terminalID) == .startDraining)
+        #expect(buffer.nextBatch(maximumByteCount: 4)?.text == "éé")
+        #expect(buffer.pendingByteCount == 0)
+        #expect(buffer.enqueue("漢", workspaceID: workspaceID, terminalID: terminalID) == .queued)
+        #expect(buffer.nextBatch(maximumByteCount: 4)?.text == "漢")
+        #expect(buffer.pendingByteCount == 0)
+        #expect(buffer.nextBatch(maximumByteCount: 4) == nil)
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -182,12 +182,9 @@ extension GhosttySurfaceRepresentable.Coordinator {
 
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didProduceInput data: Data) {
             // Bytes the iPhone wants to send TO the PTY (typing, paste,
-            // mouse reports). Forward to the Mac sync server which
-            // writes them into the Mac's libghostty surface, which in
-            // turn writes them down the PTY.
-            Task { @MainActor [weak store] in
-                await store?.submitTerminalRawInput(data, surfaceID: self.surfaceID)
-            }
+            // mouse reports). Enqueue synchronously so keystroke order is enqueue
+            // order; the composite's single drain preserves that order on the wire.
+            store?.sendTerminalRawInput(data, surfaceID: surfaceID)
         }
 
         func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didPasteImage data: Data, format: String) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceChatPane.swift
@@ -200,9 +200,7 @@ struct WorkspaceChatPane: View {
         guard let terminalID = session.terminalID,
               let data = text.data(using: .utf8)
         else { return }
-        Task {
-            await store.submitTerminalRawInput(data, surfaceID: terminalID)
-        }
+        store.sendTerminalRawInput(data, surfaceID: terminalID)
     }
 
     private func validSymbolName(_ symbolName: String?) -> String? {


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/6082 (fast typing on iOS lands out of order, e.g. "aziz" → "aizz").

Root cause: the iOS terminal's per-keystroke path lost ordering after the surface delegate. `GhosttySurfaceCoordinator.didProduceInput` spawned one unstructured `Task` per keystroke, and `submitTerminalRawInput(data:surfaceID:)` sent each directly through `sendRemoteTerminalInput`, bypassing the FIFO `MobileTerminalInputSendBuffer` that the sibling text path already used for exactly this reason. Concurrent keystroke tasks then crossed reentrant actors (`MobileTerminalLaneCoordinator` → `MobileIrohTerminalLane` → QUIC stream write) or the multi-await RPC `sendRequest`, so two keystrokes could reach the wire in either order. The Mac applies input strictly in arrival order (lane router reads one QUIC stream serially; `v2MobileTerminalInput` is synchronous per request), so the reorder was purely client-side.

Fix: every terminal raw-input producer (typing, backspace, accessory escape sequences, chat pane, composer submit, release-gate probes) now enqueues synchronously on the main actor into the one `rawTerminalInputBuffer`, and the single serial drain loop is the only sender: next chunk goes out only after the previous send completes, so wire order always equals keystroke order on both the iroh lane and the RPC fallback. The delegate call is now a synchronous enqueue (the per-keystroke `Task` is gone), and the drain dequeues with a 16 KiB cap split at Unicode-scalar boundaries so coalescing can never produce a frame the iroh lane rejects.

Commit 1 adds the regression test only (red): with the first `terminal.input` response held, four racing keystroke submissions previously produced 4 concurrent in-flight requests and unordered text. Commit 2 adds the fix (green): max one in-flight request, concatenated wire text exactly `aziz`. Splitter edge cases (multi-byte scalar straddling the cap, order across splits) are covered in `CmuxMobileShellModel` tests, which this PR also adds to the `test-ios` CI gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787349622&installation_model_id=21920&pr_number=8682&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8682&signature=feac808ab29b0ac4408a7572a0d36debe1a0fe71b991c5d74771f8b97e02f875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves terminal input ordering on iOS by sending all raw input through a single FIFO buffer with a serial drain. Fixes #6082 where fast typing could arrive out of order.

- Bug Fixes
  - All producers enqueue synchronously to `rawTerminalInputBuffer`; a single drain sends the next chunk only after the previous completes, keeping FIFO order over iroh and RPC.
  - Added a 16 KiB send cap and Unicode-scalar-safe splitting in `MobileTerminalInputSendBuffer.nextBatch(maximumByteCount:)`.
  - Replaced per-keystroke tasks with synchronous `sendTerminalRawInput(...)` in `CmuxMobileShellUI` (Ghostty surface and chat composer).
  - Added ordering regression tests in `CmuxMobileShell` and buffer-splitting tests in `CmuxMobileShellModel`; CI now runs `CmuxMobileShellModel` tests.

<sup>Written for commit 1123db371878ca904fa5390611008ad9e583eaf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal raw input ordering during rapid, concurrent typing.
  - Prevented input submissions from stalling during buffer drains and connection lifecycle resets (sign-out/reconnect/pairing).
  - Ensured large multilingual inputs are split safely at Unicode boundaries with capped batch sizing.
- **Tests**
  - Added ordering and routing test coverage for terminal raw input behavior, including queue/drain synchronization.
  - Expanded buffer tests for UTF-8/capped chunking edge cases.
- **CI**
  - Extended the iOS test gate to run additional SwiftPM tests for the MobileShellModel package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->