### PR TITLE
Fix iOS deleted Iroh Mac recovery

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -815,6 +815,31 @@ extension MobileShellComposite {
         await loadRegistryDevices()
     }
 
+    /// Connect a live account-discovered Iroh Mac while requiring its broker
+    /// advertised app-instance tag.
+    @discardableResult
+    func connectAccountDiscoveredIrohMac(
+        _ mac: MobileDiscoveredIrohMac,
+        accountID: String,
+        ifStillCurrent: (() -> Bool)? = nil
+    ) async -> Bool {
+        let supportedKinds = runtime?.supportedRouteKinds ?? []
+        let candidateRoutes = Self.storedReconnectRoutes(
+            mac.routes,
+            supportedKinds: supportedKinds,
+            preferNonLoopback: Self.prefersNonLoopbackRoutes
+        )
+        guard candidateRoutes.contains(where: { $0.kind == .iroh }) else { return false }
+        return (await connectStoredMacOutcome(
+            name: mac.displayName ?? mac.deviceID,
+            routes: candidateRoutes,
+            pairedMacDeviceID: mac.deviceID,
+            instanceTagExpectation: .require(mac.instanceTag),
+            automaticReconnectAccountID: accountID,
+            ifStillCurrent: ifStillCurrent
+        )).didConnect
+    }
+
     /// Re-fetch the authoritative workspace list from the connected Mac and apply
     /// it, awaiting the round-trip to completion.
     @discardableResult

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
@@ -4,18 +4,6 @@ import Foundation
 
 @MainActor
 extension MobileShellComposite {
-    /// Whether the current account/team scope has any locally forgotten Mac IDs.
-    public func hasForgottenMacsInCurrentScope() async -> Bool {
-        guard let scope = await currentScopeSnapshot() else {
-            hasRecoverableDeletedComputers = false
-            return false
-        }
-        let hasForgottenMacs = !(await forgottenMacDeviceIDs(scope: scope)).isEmpty
-        guard await isScopeCurrent(scope) else { return hasRecoverableDeletedComputers }
-        hasRecoverableDeletedComputers = hasForgottenMacs
-        return hasForgottenMacs
-    }
-
     /// Recover a deleted Mac through live same-account Iroh discovery.
     ///
     /// Passive zero-touch discovery continues to exclude forgotten Macs. This
@@ -80,7 +68,7 @@ extension MobileShellComposite {
             guard forgottenIDs.contains(cmxCanonicalDeviceID(mac.deviceID))
                     || forgottenIDs.contains(pairingID),
                   !mac.routes.isEmpty,
-                  mac.routes.allSatisfy({ $0.kind == .iroh }),
+                  mac.routes.contains(where: { $0.kind == .iroh }),
                   seen.insert(pairingID).inserted else { continue }
             candidates.append(mac)
             if candidates.count == Self.maximumAutomaticIrohCandidateCount {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
@@ -1,0 +1,92 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import Foundation
+
+@MainActor
+extension MobileShellComposite {
+    /// Whether the current account/team scope has any locally forgotten Mac IDs.
+    public func hasForgottenMacsInCurrentScope() async -> Bool {
+        guard let scope = await currentScopeSnapshot() else {
+            hasRecoverableDeletedComputers = false
+            return false
+        }
+        let hasForgottenMacs = !(await forgottenMacDeviceIDs(scope: scope)).isEmpty
+        guard await isScopeCurrent(scope) else { return hasRecoverableDeletedComputers }
+        hasRecoverableDeletedComputers = hasForgottenMacs
+        return hasForgottenMacs
+    }
+
+    /// Recover a deleted Mac through live same-account Iroh discovery.
+    ///
+    /// Passive zero-touch discovery continues to exclude forgotten Macs. This
+    /// method is the explicit user recovery path: it only considers live broker
+    /// candidates that match a remembered forgotten ID, then the normal Iroh
+    /// connection path must authenticate the Mac's device ID and app-instance tag
+    /// before persistence clears the forgotten marker.
+    @discardableResult
+    public func recoverForgottenIrohMacFromAccount() async -> Bool {
+        guard isSignedIn,
+              let scope = await currentScopeSnapshot(),
+              let personalIrohDiscovery else { return false }
+        let forgottenIDs = await forgottenMacDeviceIDs(scope: scope)
+        guard !forgottenIDs.isEmpty else { return false }
+
+        connectionRecoveryOwner.cancel()
+        applyConnectionRecoveryOwnerState()
+        invalidateStoredMacReconnectAttempt()
+
+        let discovered = await personalIrohDiscovery.discoverLiveMacs()
+        guard await isScopeCurrent(scope) else { return false }
+        let candidates = forgottenIrohRecoveryCandidates(
+            from: discovered,
+            forgottenIDs: forgottenIDs
+        )
+
+        for mac in candidates {
+            guard await isScopeCurrent(scope) else { return false }
+            guard await isForgottenMacDeviceID(
+                mac.deviceID,
+                instanceTag: mac.instanceTag,
+                scope: scope
+            ) else { continue }
+            let recovered = await connectAccountDiscoveredIrohMac(
+                mac,
+                accountID: scope.userID,
+                ifStillCurrent: { [weak self] in
+                    guard let self else { return false }
+                    return self.isSignedIn
+                        && self.identityProvider?.currentUserID == scope.userID
+                }
+            )
+            guard recovered else { continue }
+            await loadPairedMacs()
+            await loadRegistryDevices()
+            return true
+        }
+        return false
+    }
+
+    private func forgottenIrohRecoveryCandidates(
+        from discovered: [MobileDiscoveredIrohMac],
+        forgottenIDs: Set<String>
+    ) -> [MobileDiscoveredIrohMac] {
+        var seen: Set<String> = []
+        var candidates: [MobileDiscoveredIrohMac] = []
+        for mac in discovered {
+            let pairingID = MobilePairedMac.pairingID(
+                macDeviceID: mac.deviceID,
+                instanceTag: mac.instanceTag
+            )
+            guard forgottenIDs.contains(cmxCanonicalDeviceID(mac.deviceID))
+                    || forgottenIDs.contains(pairingID),
+                  !mac.routes.isEmpty,
+                  mac.routes.allSatisfy({ $0.kind == .iroh }),
+                  seen.insert(pairingID).inserted else { continue }
+            candidates.append(mac)
+            if candidates.count == Self.maximumAutomaticIrohCandidateCount {
+                break
+            }
+        }
+        return candidates
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1259,6 +1259,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         storedPairedMacs = []
         pairedMacAliasIDsByRepresentativeID = [:]
         pairedMacs = []
+        hasRecoverableDeletedComputers = false
         resetTerminalThemes()
         // Likewise drop the registry-backed device tree so a shared device never
         // shows the previous user's team devices after sign-out.
@@ -1371,6 +1372,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         pairedMacAliasIDsByRepresentativeID = [:]
         pairedMacs = []
         forgottenMacDeviceIDsByScope = [:]
+        hasRecoverableDeletedComputers = false
         registryDevices = []
         teamScopeReconnectTask?.cancel()
         teamScopeReconnectTask = Task { @MainActor [weak self] in
@@ -2131,6 +2133,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// completes. Filtering the current scope keeps that late write hidden until
     /// the user explicitly pairs/connects that Mac again.
     @ObservationIgnored var forgottenMacDeviceIDsByScope: [String: Set<String>] = [:]
+    /// True when the current account/team scope has a deleted-computer marker
+    /// that can be recovered through explicit same-account Iroh discovery.
+    public internal(set) var hasRecoverableDeletedComputers = false
 
     var pairedMacsForIdentityMatching: [MobilePairedMac] {
         storedPairedMacs.isEmpty ? pairedMacs : storedPairedMacs
@@ -2365,6 +2370,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             storedPairedMacs = []
             pairedMacAliasIDsByRepresentativeID = [:]
             pairedMacs = []
+            hasRecoverableDeletedComputers = false
             return
         }
         let loaded: [MobilePairedMac]
@@ -2381,9 +2387,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         let visibleLoaded = await visibleStoredPairedMacs(from: loaded, scope: scope)
+        let hasForgottenMacs = !(await forgottenMacDeviceIDs(scope: scope)).isEmpty
         guard await isScopeCurrent(scope) else {
             return
         }
+        hasRecoverableDeletedComputers = hasForgottenMacs
         storedPairedMacs = visibleLoaded
         let supportedRouteKinds = runtime?.supportedRouteKinds ?? []
         let coalesced = Self.coalescePairedMacsByDialEndpoint(

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -96,7 +96,8 @@ struct IrohZeroTouchDiscoveryTests {
             scope: scope
         )
 
-        #expect(await fixture.shell.hasForgottenMacsInCurrentScope())
+        await fixture.shell.loadPairedMacs()
+        #expect(fixture.shell.hasRecoverableDeletedComputers)
         #expect(await fixture.shell.recoverForgottenIrohMacFromAccount())
 
         #expect(fixture.shell.connectionState == .connected)
@@ -106,12 +107,47 @@ struct IrohZeroTouchDiscoveryTests {
         #expect(rows.count == 1)
         #expect(saved.macDeviceID == "mac-a")
         #expect(saved.instanceTag == "stable")
-        #expect(!(await fixture.shell.hasForgottenMacsInCurrentScope()))
+        #expect(!fixture.shell.hasRecoverableDeletedComputers)
         #expect(!(await fixture.shell.isForgottenMacDeviceID(
             "mac-a",
             instanceTag: "stable",
             scope: scope
         )))
+    }
+
+    @Test
+    func explicitAccountRecoveryAcceptsMixedRouteCandidateWhenIrohRouteExists() async throws {
+        let mixedRouteCandidate = try candidate(
+            deviceID: "mac-a",
+            endpointByte: "a",
+            extraRoutes: [
+                try CmxAttachRoute(
+                    id: "tailscale-mac-a",
+                    kind: .tailscale,
+                    endpoint: .hostPort(host: "100.64.0.1", port: 58465)
+                ),
+            ]
+        )
+        let fixture = try await makeFixture(
+            candidates: [mixedRouteCandidate],
+            reportedDeviceID: "mac-a"
+        )
+        defer { fixture.cleanup() }
+        let scope = try #require(await fixture.shell.currentScopeSnapshot(userID: "user-1"))
+        await fixture.shell.rememberForgottenMacDeviceID(
+            MobilePairedMac.pairingID(macDeviceID: "mac-a", instanceTag: "stable"),
+            scope: scope
+        )
+
+        await fixture.shell.loadPairedMacs()
+        #expect(fixture.shell.hasRecoverableDeletedComputers)
+        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount())
+
+        #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"])
+        let rows = try await fixture.store.loadAll(stackUserID: "user-1", teamID: nil)
+        let saved = try #require(rows.first)
+        #expect(saved.routes.map(\.kind) == [.iroh])
+        #expect(!fixture.shell.hasRecoverableDeletedComputers)
     }
 
     @Test
@@ -388,7 +424,8 @@ struct IrohZeroTouchDiscoveryTests {
 
     private func candidate(
         deviceID: String,
-        endpointByte: Character
+        endpointByte: Character,
+        extraRoutes: [CmxAttachRoute] = []
     ) throws -> MobileDiscoveredIrohMac {
         let endpointID = String(repeating: String(endpointByte), count: 64)
         return MobileDiscoveredIrohMac(
@@ -403,7 +440,7 @@ struct IrohZeroTouchDiscoveryTests {
                     pathHints: []
                 ),
                 priority: -10_000
-            )],
+            )] + extraRoutes,
             lastSeenAt: Self.fixedNow
         )
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -84,6 +84,62 @@ struct IrohZeroTouchDiscoveryTests {
     }
 
     @Test
+    func explicitAccountRecoveryDialsForgottenLiveMacAndClearsMarker() async throws {
+        let fixture = try await makeFixture(
+            candidates: [try candidate(deviceID: "mac-a", endpointByte: "a")],
+            reportedDeviceID: "mac-a"
+        )
+        defer { fixture.cleanup() }
+        let scope = try #require(await fixture.shell.currentScopeSnapshot(userID: "user-1"))
+        await fixture.shell.rememberForgottenMacDeviceID(
+            MobilePairedMac.pairingID(macDeviceID: "mac-a", instanceTag: "stable"),
+            scope: scope
+        )
+
+        #expect(await fixture.shell.hasForgottenMacsInCurrentScope())
+        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount())
+
+        #expect(fixture.shell.connectionState == .connected)
+        #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"])
+        let rows = try await fixture.store.loadAll(stackUserID: "user-1", teamID: nil)
+        let saved = try #require(rows.first)
+        #expect(rows.count == 1)
+        #expect(saved.macDeviceID == "mac-a")
+        #expect(saved.instanceTag == "stable")
+        #expect(!(await fixture.shell.hasForgottenMacsInCurrentScope()))
+        #expect(!(await fixture.shell.isForgottenMacDeviceID(
+            "mac-a",
+            instanceTag: "stable",
+            scope: scope
+        )))
+    }
+
+    @Test
+    func failedExplicitAccountRecoveryLeavesForgottenMarker() async throws {
+        let fixture = try await makeFixture(
+            candidates: [try candidate(deviceID: "mac-a", endpointByte: "a")],
+            reportedDeviceID: "different-mac"
+        )
+        defer { fixture.cleanup() }
+        let scope = try #require(await fixture.shell.currentScopeSnapshot(userID: "user-1"))
+        await fixture.shell.rememberForgottenMacDeviceID(
+            MobilePairedMac.pairingID(macDeviceID: "mac-a", instanceTag: "stable"),
+            scope: scope
+        )
+
+        #expect(!(await fixture.shell.recoverForgottenIrohMacFromAccount()))
+
+        #expect(fixture.shell.connectionState == .disconnected)
+        #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"])
+        #expect(try await fixture.store.loadAll(stackUserID: "user-1", teamID: nil).isEmpty)
+        #expect(await fixture.shell.isForgottenMacDeviceID(
+            "mac-a",
+            instanceTag: "stable",
+            scope: scope
+        ))
+    }
+
+    @Test
     func unreachableCandidateFallsThroughToNextLiveMac() async throws {
         let first = try candidate(deviceID: "mac-a", endpointByte: "a")
         let second = try candidate(deviceID: "mac-b", endpointByte: "b")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -29,6 +29,8 @@ struct DeviceTreeView: View {
     /// Stored at list scope so reusable rows do not own transient presentation
     /// state while `List` is recycling swipe-action rows.
     @State private var computerPendingRemovalID: String?
+    @State private var isRecoveringDeletedComputer = false
+    @State private var recoveryAlertMessage: String?
 
     /// The user's computers as immutable snapshots, sourced from the paired-Mac
     /// backup (`pairedMacs`) — this feature's source of truth, the same set that
@@ -68,6 +70,9 @@ struct DeviceTreeView: View {
                         ))
                     }
                 }
+                if store.hasRecoverableDeletedComputers {
+                    deletedComputerRecoverySection
+                }
             }
             .listStyle(.insetGrouped)
             .navigationDestination(for: String.self) { pairingID in
@@ -99,6 +104,19 @@ struct DeviceTreeView: View {
                 }
             }
             .refreshable { await reload() }
+            .alert(
+                L10n.string(
+                    "mobile.computers.recoverFailedTitle",
+                    defaultValue: "Couldn't recover computer"
+                ),
+                isPresented: recoveryAlertPresented
+            ) {
+                Button(L10n.string("mobile.common.ok", defaultValue: "OK"), role: .cancel) {
+                    recoveryAlertMessage = nil
+                }
+            } message: {
+                Text(recoveryAlertMessage ?? "")
+            }
             .task {
                 // This screen is the user's connection-debug view. The online dots
                 // (presence) and secondary workspace counts already update live via
@@ -136,6 +154,38 @@ struct DeviceTreeView: View {
     private func addComputer() {
         showAddDevice?()
         dismiss()
+    }
+
+    @ViewBuilder
+    private var deletedComputerRecoverySection: some View {
+        Section {
+            Button(action: recoverDeletedComputer) {
+                Label {
+                    Text(isRecoveringDeletedComputer
+                        ? L10n.string(
+                            "mobile.computers.recoveringDeleted",
+                            defaultValue: "Recovering Deleted Computer…"
+                        )
+                        : L10n.string(
+                            "mobile.computers.recoverDeleted",
+                            defaultValue: "Recover Deleted Computer"
+                        ))
+                } icon: {
+                    if isRecoveringDeletedComputer {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Image(systemName: "arrow.uturn.backward")
+                    }
+                }
+            }
+            .disabled(isRecoveringDeletedComputer)
+            .accessibilityIdentifier("MobileRecoverDeletedComputerButton")
+        } footer: {
+            Text(L10n.string(
+                "mobile.computers.recoverDeletedFooter",
+                defaultValue: "Deleted computers stay hidden on this phone. To recover one, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
+            ))
+        }
     }
 
     @ViewBuilder
@@ -178,6 +228,32 @@ struct DeviceTreeView: View {
                 instanceTag: computer.instanceTag
             )
             await reload()
+        }
+    }
+
+    private var recoveryAlertPresented: Binding<Bool> {
+        Binding(
+            get: { recoveryAlertMessage != nil },
+            set: { isPresented in
+                if !isPresented { recoveryAlertMessage = nil }
+            }
+        )
+    }
+
+    private func recoverDeletedComputer() {
+        guard !isRecoveringDeletedComputer else { return }
+        isRecoveringDeletedComputer = true
+        recoveryAlertMessage = nil
+        Task {
+            let recovered = await store.recoverForgottenIrohMacFromAccount()
+            await reload()
+            isRecoveringDeletedComputer = false
+            if !recovered {
+                recoveryAlertMessage = L10n.string(
+                    "mobile.computers.recoverFailedMessage",
+                    defaultValue: "No deleted computer was recovered. Open cmux on the Mac, sign in to this same account, and try again."
+                )
+            }
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -31,6 +31,8 @@ struct DeviceTreeView: View {
     @State private var computerPendingRemovalID: String?
     @State private var isRecoveringDeletedComputer = false
     @State private var recoveryAlertMessage: String?
+    @State private var recoveryTask: Task<Void, Never>?
+    @State private var recoveryAttemptID = 0
 
     /// The user's computers as immutable snapshots, sourced from the paired-Mac
     /// backup (`pairedMacs`) — this feature's source of truth, the same set that
@@ -132,6 +134,7 @@ struct DeviceTreeView: View {
                     await store.refreshComputersScreen()
                 }
             }
+            .onDisappear(perform: cancelRecoveryTask)
         }
         .accessibilityIdentifier("MobileDeviceTree")
     }
@@ -244,10 +247,15 @@ struct DeviceTreeView: View {
         guard !isRecoveringDeletedComputer else { return }
         isRecoveringDeletedComputer = true
         recoveryAlertMessage = nil
-        Task {
+        recoveryAttemptID += 1
+        let attemptID = recoveryAttemptID
+        recoveryTask = Task { @MainActor in
             let recovered = await store.recoverForgottenIrohMacFromAccount()
+            guard isCurrentRecoveryAttempt(attemptID) else { return }
             await reload()
+            guard isCurrentRecoveryAttempt(attemptID) else { return }
             isRecoveringDeletedComputer = false
+            recoveryTask = nil
             if !recovered {
                 recoveryAlertMessage = L10n.string(
                     "mobile.computers.recoverFailedMessage",
@@ -255,6 +263,17 @@ struct DeviceTreeView: View {
                 )
             }
         }
+    }
+
+    private func cancelRecoveryTask() {
+        recoveryAttemptID += 1
+        recoveryTask?.cancel()
+        recoveryTask = nil
+        isRecoveringDeletedComputer = false
+    }
+
+    private func isCurrentRecoveryAttempt(_ attemptID: Int) -> Bool {
+        !Task.isCancelled && recoveryAttemptID == attemptID
     }
 
     private func reload() async {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -244,7 +244,7 @@ struct MacComputerDetailView: View {
     private var removeMessage: String {
         L10n.string(
             "mobile.computers.removeMessage",
-            defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back."
+            defaultValue: "This computer and its workspaces stop appearing here. To recover it later, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -173,12 +173,12 @@ struct MacComputerRow: View {
         guard computer.aliasIDs.count > 1 else {
             return L10n.string(
                 "mobile.computers.removeMessage",
-                defaultValue: "This computer and its workspaces stop appearing here. Pair it again to add it back."
+                defaultValue: "This computer and its workspaces stop appearing here. To recover it later, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
             )
         }
         return L10n.string(
             "mobile.computers.removeMessageRepresentativeFormat",
-            defaultValue: "This removes this computer and its matching paired records. Its workspaces stop appearing here. Pair it again to add it back."
+            defaultValue: "This removes this computer and its matching paired records. Its workspaces stop appearing here. To recover it later, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
         )
     }
 

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1503,13 +1503,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This computer and its workspaces stop appearing here. Pair it again to add it back."
+            "value": "This computer and its workspaces stop appearing here. To recover it later, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このコンピュータとそのワークスペースは表示されなくなります。再度ペアリングすると追加できます。"
+            "value": "このコンピュータとそのワークスペースは表示されなくなります。後で復元するには、そのMacでcmuxを開き、この同じアカウントにサインインしてから「削除したコンピュータを復元」をタップしてください。"
           }
         }
       }
@@ -1520,13 +1520,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This removes this computer and its matching paired records. Its workspaces stop appearing here. Pair it again to add it back."
+            "value": "This removes this computer and its matching paired records. Its workspaces stop appearing here. To recover it later, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このコンピュータと一致するペアリング済みレコードを削除します。そのワークスペースは表示されなくなります。再度ペアリングすると追加できます。"
+            "value": "このコンピュータと一致するペアリング済みレコードを削除します。そのワークスペースは表示されなくなります。後で復元するには、そのMacでcmuxを開き、この同じアカウントにサインインしてから「削除したコンピュータを復元」をタップしてください。"
           }
         }
       }
@@ -1544,6 +1544,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@を削除しますか？"
+          }
+        }
+      }
+    },
+    "mobile.computers.recoverDeleted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recover Deleted Computer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除したコンピュータを復元"
+          }
+        }
+      }
+    },
+    "mobile.computers.recoverDeletedFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deleted computers stay hidden on this phone. To recover one, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除したコンピュータはこの電話では非表示のままです。復元するには、そのMacでcmuxを開き、この同じアカウントにサインインしてから「削除したコンピュータを復元」をタップしてください。"
+          }
+        }
+      }
+    },
+    "mobile.computers.recoverFailedMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No deleted computer was recovered. Open cmux on the Mac, sign in to this same account, and try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除したコンピュータは復元されませんでした。そのMacでcmuxを開き、この同じアカウントにサインインして、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "mobile.computers.recoverFailedTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't recover computer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンピュータを復元できませんでした"
+          }
+        }
+      }
+    },
+    "mobile.computers.recoveringDeleted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recovering Deleted Computer…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除したコンピュータを復元中…"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Keep passive zero-touch honoring forgotten Mac markers.
- Add explicit same-account deleted Mac recovery that scans live account-discovered Iroh Macs, filters to forgotten canonical or pairing IDs, requires Iroh routes, dials through the existing stored-Mac outcome path with the required instance tag, and clears the marker only after authenticated persistence.
- Explain recovery in delete confirmations and show a Computers recovery action with footer copy when the current account scope has forgotten Macs.

## Verification
- `swift test --filter IrohZeroTouchDiscoveryTests`
- `git diff --check origin/main...HEAD`
- `jq empty ios/cmux/Resources/Localizable.xcstrings`
- Touched localization keys audited for `en,ja` coverage.
- `CMUX_PORT=3842 CMUX_PORT_RANGE=10 CMUX_PORT_END=3851 ./scripts/reload.sh --tag irecov --launch --swift-frontend-workaround`
- `CMUX_PORT=3842 CMUX_PORT_RANGE=10 CMUX_PORT_END=3851 ./ios/scripts/reload.sh --tag irecov --simulator cmux-irecov-0722`
- `CMUX_PORT=3842 CMUX_PORT_RANGE=10 CMUX_PORT_END=3851 ./scripts/mobile-dev-launch.sh --tag irecov --simulator cmux-irecov-0722 --ensure-mac`
- Warmed `http://127.0.0.1:3842/`, `/handler/sign-in`, and `/handler/after-sign-in`.

## Dogfood
Tagged macOS build: `http://127.0.0.1:17320/irecov`
iOS tag: `irecov` on simulator `cmux-irecov-0722` (`0A967C23-FCCE-4140-B0D9-EF9A4C63A0F8`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787349905&installation_model_id=21920&pr_number=8683&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8683&signature=b8c91478da7ff3f3bad62139478b122dda208ab4d216914312f848a444fbfac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables explicit recovery of deleted Iroh Macs on iOS via same-account discovery. Adds a Recover Deleted Computer action and keeps zero-touch discovery from auto-reviving forgotten Macs.

- **New Features**
  - Recovery flow: discover live same-account Iroh Macs, filter to forgotten canonical/pairing IDs, require `.iroh` routes and matching instance tag, accept mixed-route candidates only when `.iroh` exists (persist `.iroh`), connect via stored-Mac path, and clear the marker only after authenticated save.
  - UI: show “Recover Deleted Computer” with a helper footer; progress indicator and failure alert; cancel in-flight recovery when leaving the screen; clearer delete confirmation copy.
  - State: track `hasRecoverableDeletedComputers` per scope, set on paired‑Mac load, reset on sign-out and data reload; added `connectAccountDiscoveredIrohMac`.
  - Tests & i18n: added success, mixed-route acceptance, and failure tests; new `en`/`ja` strings for the recover button, footer, progress, and alert copy.

<sup>Written for commit 1f78f1c3ebbce8fcea8fd37f0e940999355ae675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Recover Deleted Computer” to restore previously removed Macs from a live discovery on the same account.
  * Recovery automatically reconnects eligible Macs, then reloads paired devices.
  * Shows a “recovering” progress state and presents a failure alert when recovery can’t be completed.
  * Recovery availability and status are reset on sign-out and when switching teams.

* **Documentation**
  * Updated English and Japanese delete/removal copy and added new localized strings for the recovery flow.

* **Tests**
  * Added/expanded tests covering successful recovery, failed recovery (marker preserved), and mixed eligible-route scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->