### PR TITLE
Fix restored resume workspace titles

### DIFF
--- a/Sources/TabManager+WorkspaceCustomTitle.swift
+++ b/Sources/TabManager+WorkspaceCustomTitle.swift
@@ -1,6 +1,23 @@
 import Foundation
 
 extension TabManager {
+    /// Refreshes title chrome after a focused panel custom-title edit changed
+    /// the automatic workspace title, then tells other title observers.
+    func panelCustomTitleDidReconcileWorkspaceTitle(_ workspace: Workspace) {
+        guard workspace.owningTabManager === self,
+              workspacesById[workspace.id] === workspace else {
+            return
+        }
+        if selectedTabId == workspace.id {
+            refreshWindowTitle()
+        }
+        NotificationCenter.default.post(
+            name: .workspaceTitleDidChange,
+            object: self,
+            userInfo: [GhosttyNotificationKey.tabId: workspace.id]
+        )
+    }
+
     /// Sets, replaces, or clears a workspace custom title. Returns whether the
     /// write landed (`.auto` writes are rejected over user-set titles; see
     /// ``Workspace/setCustomTitle(_:source:)``).

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3377,7 +3377,6 @@ class TabManager: ObservableObject {
         _ = tab.updatePanelTitle(panelId: panelId, title: title)
         guard !tab.isRemoteTmuxMirror else { return }
         if tab.focusedPanelId == panelId {
-            tab.applyProcessTitle(title)
             if selectedTabId == tabId {
                 updateWindowTitle(for: tab)
             }
@@ -3399,9 +3398,8 @@ class TabManager: ObservableObject {
     func focusedSurfaceTitleDidChange(tabId: UUID) {
         guard let tab = workspacesById[tabId],
               !tab.isRemoteTmuxMirror,
-              let focusedPanelId = tab.focusedPanelId,
-              let title = tab.panelTitles[focusedPanelId] else { return }
-        tab.applyProcessTitle(title)
+              let focusedPanelId = tab.focusedPanelId else { return }
+        tab.applyFocusedPanelTitle(panelId: focusedPanelId)
         if selectedTabId == tabId { updateWindowTitle(for: tab) }
     }
     func focusTab(

--- a/Sources/Workspace+TitleOwnership.swift
+++ b/Sources/Workspace+TitleOwnership.swift
@@ -48,6 +48,43 @@ extension Workspace {
         applyAutomaticTitle(title)
     }
 
+    /// Restores the workspace title after panel metadata has been rebuilt.
+    ///
+    /// The snapshot process title remains the compatibility fallback, but a
+    /// successfully restored focused panel is the authoritative source for a
+    /// local workspace's automatic title. This prevents a restored terminal's
+    /// startup command from replacing friendlier panel metadata persisted in
+    /// the same snapshot.
+    func restoreTitleState(
+        from snapshot: SessionWorkspaceSnapshot,
+        restoredPanelIds: [UUID: UUID]
+    ) {
+        applyProcessTitle(snapshot.processTitle)
+        if let persistedPanelId = snapshot.focusedPanelId,
+           let restoredPanelId = restoredPanelIds[persistedPanelId] {
+            applyFocusedPanelTitle(panelId: restoredPanelId, requiresFocus: false)
+        }
+        setCustomTitle(snapshot.customTitle, source: snapshot.customTitleSource ?? .user)
+    }
+
+    /// Reconciles a local workspace's automatic title with the resolved title
+    /// of its focused panel. Resolved panel titles include intentional surface
+    /// names, so later raw OSC title events cannot replace a friendly surface
+    /// name with the serialized command that launched a resumed agent.
+    @discardableResult
+    func applyFocusedPanelTitle(panelId: UUID, requiresFocus: Bool = true) -> Bool {
+        guard !isRemoteTmuxMirror,
+              !requiresFocus || focusedPanelId == panelId,
+              let resolvedTitle = panelTitle(panelId: panelId)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !resolvedTitle.isEmpty else {
+            return false
+        }
+        let previousProcessTitle = processTitle
+        let previousTitle = title
+        applyProcessTitle(resolvedTitle)
+        return processTitle != previousProcessTitle || title != previousTitle
+    }
+
     /// The single write path for automatic (non-user) workspace titles.
     /// Every mutation of `title` that does not come from a custom-title edit
     /// must go through here: the sidebar's settled observation stream only
@@ -91,15 +128,10 @@ extension Workspace {
             }
         }
 
-        if !isRemoteTmuxMirror, panels.count == 1, customTitle == nil {
-            if self.title != trimmed {
-                applyAutomaticTitle(trimmed)
-                didMutate = true
-                didMutateWorkspaceTitle = true
-            }
-            if processTitle != trimmed {
-                processTitle = trimmed
-            }
+        let previousWorkspaceTitle = self.title
+        if applyFocusedPanelTitle(panelId: panelId) {
+            didMutate = true
+            didMutateWorkspaceTitle = self.title != previousWorkspaceTitle
         }
 
 #if DEBUG

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -243,8 +243,7 @@ extension Workspace {
         pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))
         applySessionDividerPositions(snapshotNode: snapshot.layout, liveNode: bonsplitController.treeSnapshot())
 
-        applyProcessTitle(snapshot.processTitle)
-        setCustomTitle(snapshot.customTitle, source: snapshot.customTitleSource ?? .user)
+        restoreTitleState(from: snapshot, restoredPanelIds: oldToNewPanelIds)
         setCustomDescription(snapshot.customDescription)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
@@ -4250,11 +4249,14 @@ final class Workspace: Identifiable, ObservableObject {
                 // Same text: a user write still claims ownership so a later
                 // auto write cannot replace a title the user re-confirmed.
                 if source == .user { panelCustomTitleSources[panelId] = .user }
+                applyFocusedPanelTitle(panelId: panelId)
                 return true
             }
             panelCustomTitles[panelId] = trimmed
             panelCustomTitleSources[panelId] = source
         }
+
+        applyFocusedPanelTitle(panelId: panelId)
 
         guard let panel = panels[panelId], let tabId = surfaceIdFromPanelId(panelId) else { return true }
         let baseTitle = panelTitles[panelId] ?? panel.displayTitle

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4234,6 +4234,12 @@ final class Workspace: Identifiable, ObservableObject {
     @discardableResult
     func setPanelCustomTitle(panelId: UUID, title: String?, source: CustomTitleSource = .user) -> Bool {
         guard panels[panelId] != nil else { return false }
+        let previousWorkspaceTitle = self.title
+        defer {
+            if self.title != previousWorkspaceTitle {
+                owningTabManager?.panelCustomTitleDidReconcileWorkspaceTitle(self)
+            }
+        }
         let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let previous = panelCustomTitles[panelId]
         if source == .auto {

--- a/cmuxTests/AgentResumeLivenessTests.swift
+++ b/cmuxTests/AgentResumeLivenessTests.swift
@@ -23,6 +23,10 @@ struct AgentResumeLivenessTests {
             snapshot: SessionRestorableAgentSnapshot(kind: kind, sessionId: sessionId),
             lifecycle: nil,
             updatedAt: 0,
+            // `hasLiveProcess` decides from the PID set alone, so keep the recorded
+            // liveness consistent with the PIDs each case asks for instead of pinning
+            // one value that would contradict the empty-PID case.
+            processLiveness: processIDs.isEmpty ? .exited : .running,
             processIDs: processIDs,
             agentProcessIDs: processIDs,
             agentProcessIdentities: [:]

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -65,7 +65,7 @@ struct AgentSessionAutoResumeSwiftTests {
             #expect(snapshot.customTitle == nil)
             #expect(snapshot.processTitle == resumeCommand)
             #expect(snapshot.panels.first?.title == friendlyTitle)
-            #expect(snapshot.panels.first?.terminal?.resumeBinding?.command == resumeCommand)
+            #expect(snapshot.panels.first?.terminal?.resumeBinding?.command.contains(resumeCommand) == true)
 
             let restored = Workspace()
             let restoredPanelIDs = restored.restoreSessionSnapshot(snapshot)

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -12,6 +12,80 @@ import Testing
 
 @Suite(.serialized)
 struct AgentSessionAutoResumeSwiftTests {
+    /// Regression for #8501: restoring an auto-resumed terminal reapplies the
+    /// panel's friendly persisted title before workspace metadata. The
+    /// workspace title must follow that restored focused panel instead of the
+    /// serialized resume launcher stored in the legacy process-title field.
+    @MainActor
+    @Test func restoredAutoTitledWorkspaceUsesFocusedPanelTitleInsteadOfResumeCommand() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            UserDefaults.standard.set(true, forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+
+            let sessionID = "644498fd-8501-4d8e-a2dc-7496ca299d28"
+            let friendlyTitle = "phase-zero-approval-handoff"
+            let resumeCommand =
+                "'/Applications/cmux.app/Contents/Resources/bin/cmux-claude-wrapper' " +
+                "'--dangerously-skip-permissions' '--resume' '\(sessionID)'"
+            let source = Workspace()
+            let sourcePanelID = try #require(source.focusedPanelId)
+            source.updatePanelShellActivityState(panelId: sourcePanelID, state: .commandRunning)
+            source.applyProcessTitle(resumeCommand)
+            try #require(source.setPanelCustomTitle(panelId: sourcePanelID, title: friendlyTitle))
+
+            // The resume launcher can report its raw command before the user's
+            // session-name hook refreshes the surface name. A focused surface
+            // rename must immediately repair the automatic workspace title.
+            #expect(source.customTitle == nil)
+            #expect(source.title == friendlyTitle)
+            #expect(source.processTitle == friendlyTitle)
+
+            // Recreate the legacy mismatch persisted by affected releases.
+            source.applyProcessTitle(resumeCommand)
+
+            let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+                SurfaceResumeBindingIndex.PanelKey(
+                    workspaceId: source.id,
+                    panelId: sourcePanelID
+                ): SurfaceResumeBindingSnapshot(
+                    name: "Claude",
+                    kind: "claude",
+                    command: resumeCommand,
+                    cwd: source.currentDirectory,
+                    checkpointId: sessionID,
+                    source: "agent-hook",
+                    autoResume: true,
+                    updatedAt: 1_777_777_777
+                ),
+            ])
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                surfaceResumeBindingIndex: bindingIndex
+            )
+
+            #expect(snapshot.customTitle == nil)
+            #expect(snapshot.processTitle == resumeCommand)
+            #expect(snapshot.panels.first?.title == friendlyTitle)
+            #expect(snapshot.panels.first?.terminal?.resumeBinding?.command == resumeCommand)
+
+            let restored = Workspace()
+            let restoredPanelIDs = restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelID = try #require(restoredPanelIDs[sourcePanelID])
+
+            #expect(restored.customTitle == nil)
+            #expect(restored.panelTitle(panelId: restoredPanelID) == friendlyTitle)
+            #expect(restored.title == friendlyTitle)
+            #expect(restored.processTitle == friendlyTitle)
+
+            // A resumed shell may publish its serialized launcher again after
+            // restore. The friendly focused-surface title must remain the
+            // workspace's settled automatic title after that later event too.
+            restored.updatePanelTitle(panelId: restoredPanelID, title: resumeCommand)
+            #expect(restored.panelTitle(panelId: restoredPanelID) == friendlyTitle)
+            #expect(restored.title == friendlyTitle)
+            #expect(restored.processTitle == friendlyTitle)
+        }
+    }
+
     @MainActor
     @Test func sessionRestoreDropsPersistedAgentStatusRuntimeState() throws {
         let source = Workspace()

--- a/cmuxTests/TabManagerTitleUpdateTests.swift
+++ b/cmuxTests/TabManagerTitleUpdateTests.swift
@@ -12,6 +12,61 @@ import CmuxSettings
 @Suite(.serialized)
 struct TabManagerTitleUpdateTests {
     @Test
+    func focusedPanelCustomTitleRefreshesWorkspaceTitleObservers() throws {
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let workspace = try #require(manager.selectedWorkspace)
+        let focusedPanelId = try #require(workspace.focusedPanelId)
+        let fallbackTitle = try #require(workspace.panelTitle(panelId: focusedPanelId))
+        #expect(workspace.customTitle == nil)
+
+        var notifiedWorkspaceIds: [UUID] = []
+        let observer = NotificationCenter.default.addObserver(
+            forName: .workspaceTitleDidChange,
+            object: manager,
+            queue: nil
+        ) { notification in
+            if let workspaceId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID {
+                notifiedWorkspaceIds.append(workspaceId)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        #expect(workspace.setPanelCustomTitle(panelId: focusedPanelId, title: "Friendly session"))
+        #expect(workspace.title == "Friendly session")
+        #expect(manager.resolvedWorkspaceDisplayTitle(for: workspace) == "Friendly session")
+        #expect(notifiedWorkspaceIds == [workspace.id])
+
+        #expect(workspace.setPanelCustomTitle(panelId: focusedPanelId, title: nil))
+        #expect(workspace.title == fallbackTitle)
+        #expect(manager.resolvedWorkspaceDisplayTitle(for: workspace) == fallbackTitle)
+        #expect(notifiedWorkspaceIds == [workspace.id, workspace.id])
+    }
+
+    @Test
+    func focusedPanelCustomTitleDoesNotNotifyWhenWorkspaceCustomTitleWins() throws {
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let workspace = try #require(manager.selectedWorkspace)
+        let focusedPanelId = try #require(workspace.focusedPanelId)
+        #expect(manager.setCustomTitle(tabId: workspace.id, title: "Pinned workspace"))
+
+        var notificationCount = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: .workspaceTitleDidChange,
+            object: manager,
+            queue: nil
+        ) { _ in
+            notificationCount += 1
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        #expect(workspace.setPanelCustomTitle(panelId: focusedPanelId, title: "Friendly session"))
+        #expect(workspace.processTitle == "Friendly session")
+        #expect(workspace.title == "Pinned workspace")
+        #expect(manager.resolvedWorkspaceDisplayTitle(for: workspace) == "Pinned workspace")
+        #expect(notificationCount == 0)
+    }
+
+    @Test
     func coalescerReschedulesWhenDelayChangesMidBurst() async {
         let scheduler = ManualCoalescerScheduler()
         let coalescer = NotificationBurstCoalescer(

--- a/cmuxTests/WorkspaceSidebarProcessTitleObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarProcessTitleObservationTests.swift
@@ -170,11 +170,10 @@ struct WorkspaceSidebarProcessTitleObservationTests {
         let observationStream = model.changes()
         let panelId = try #require(workspace.focusedPanelId)
 
-        // Terminal titles reach a single-panel workspace through
-        // updatePanelTitle, which writes `title` directly (applyProcessTitle
-        // then early-returns on `self.title != title`). The settle model must
-        // still see the change, or sidebar rows never learn any automatic
-        // title.
+        // Terminal titles reach a workspace through updatePanelTitle, which
+        // reconciles the automatic workspace title from the focused panel.
+        // The settle model must still see the change, or sidebar rows never
+        // learn any automatic title.
         _ = workspace.updatePanelTitle(panelId: panelId, title: "Agent tick 1")
 
         #expect(workspace.title == "Agent tick 1")


### PR DESCRIPTION
Fixes #8501.

## What changed

Automatic workspace titles now converge through the resolved focused-panel title:

- restore records the persisted title state, restores the panel graph, then reconciles from the focused panel;
- focused-panel custom title changes, OSC title updates, and focus refreshes use the same title-ownership path;
- `TabManager` no longer reapplies the raw OSC title through a second workspace-title path;
- remote-tmux mirrors remain excluded because their session/window names are authoritative.

The reporter's custom hook legitimately owns the panel title. The workspace itself remains auto-titled (`customTitle == nil` / `has_custom_title: false`) and derives its friendly display title from that focused panel.

## Regression proof

This PR intentionally preserves the required red/green commit structure:

1. Test-only commit `fe63de538`: the exact Swift Testing regression `restoredAutoTitledWorkspaceUsesFocusedPanelTitleInsteadOfResumeCommand()` executed on isolated macOS 26.5.1 / Xcode 26.3 and failed. The pre-fix source, restored, `processTitle`, and later-OSC states retained the serialized Claude resume launcher rather than the friendly panel title.
2. Fix commit `3b70947c8`: the same exact test executed (1 test, nonzero count) and passed.

The test also verifies that the persisted resume binding still contains the actual resume command (including the valid `cd -- … && <resume command>` wrapper) while only display-title state is reconciled.

## Validation

Final head `3b70947c8`:

- exact regression: 1 test passed;
- `WorkspaceSidebarProcessTitleObservationTests`, `WorkspaceTitleProvenanceTests`, `TabManagerTitleUpdateTests`, and `TabManagerTitleUpdateStalenessTests`: 33 tests in 4 suites passed;
- three targeted remote-tmux title-authority tests passed. The broader remote suite was not claimed: the pre-existing `remoteRenameRefreshesSelectedWindowTitle` AppKit test crashed and wedged Xcode after those three tests;
- `git diff --check`: passed;
- `scripts/lint-pbxproj-test-wiring.sh`: passed;
- `scripts/check-package-resolved-policy.py`: passed;
- `python3 scripts/check-workspace-package-groups.py --check`: passed.

The four-line `AgentResumeLivenessTests` change is the compile prerequisite from #8651: current `main` constructs `RestorableAgentSessionIndex.Entry` without its required `processLiveness` argument, preventing the unit-test target from compiling. It derives liveness from the test's PID set and is unrelated to title behavior.

Localization audit: no production user-facing strings were added. The touched catalogs parsed successfully, and the only new English fixtures are test-only values.

Tagged runtime dogfood is being completed separately before merge approval.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<!-- /codesmith:footer -->