### PR TITLE
Fix Dock terminal working-directory inheritance

### DIFF
--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -253,7 +253,7 @@ extension DockSplitStore {
 
         // Split button: the new pane is empty. Seed a terminal in it, matching
         // the main area (which always seeds a terminal on a UI split).
-        let sourcePanelId = controller.selectedTab(inPane: originalPane)?.id
+        let sourcePanelId = (controller.selectedTab(inPane: originalPane)?.id)
             .flatMap { surfaceIdToPanelId[$0] }
         _ = newSurface(
             kind: .terminal,

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -2,6 +2,64 @@ import AppKit
 import Bonsplit
 
 extension DockSplitStore {
+    var focusedPanelId: UUID? {
+        guard let paneId = bonsplitController.focusedPaneId,
+              let tabId = bonsplitController.selectedTab(inPane: paneId)?.id else { return nil }
+        return surfaceIdToPanelId[tabId]
+    }
+
+    /// Whether a panel id is present in the Dock tree.
+    func containsPanel(_ panelId: UUID) -> Bool {
+        panels[panelId] != nil
+    }
+
+    func containsPane(_ paneId: UUID) -> Bool {
+        bonsplitController.allPaneIds.contains(where: { $0.id == paneId })
+    }
+
+    /// Resolves a Dock pane for `surface.create --placement dock`. An explicit
+    /// `requestedPaneID` must match a Dock pane; otherwise the focused/first pane
+    /// is used after ensuring the Dock has loaded its root pane.
+    func resolvePane(requestedPaneID: UUID?) -> PaneID? {
+        ensureLoaded()
+        if let requestedPaneID {
+            return bonsplitController.allPaneIds.first(where: { $0.id == requestedPaneID })
+        }
+        return bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first
+    }
+
+    func resolveSourcePanelId(_ requested: UUID?, preferredPaneId: PaneID? = nil) -> UUID? {
+        if let requested, panels[requested] != nil { return requested }
+        if let preferredPaneId,
+           let tabId = bonsplitController.selectedTab(inPane: preferredPaneId)?.id,
+           let panelId = surfaceIdToPanelId[tabId] {
+            return panelId
+        }
+        if let focused = focusedPanelId { return focused }
+        return panels.keys.first
+    }
+
+    func focusPanel(_ panelId: UUID) {
+        guard let paneId = paneId(forPanelId: panelId), let tabId = surfaceId(forPanelId: panelId) else { return }
+        bonsplitController.focusPane(paneId)
+        bonsplitController.selectTab(tabId)
+        applyDockSelection(tabId: tabId, inPane: paneId)
+    }
+
+    func triggerFocusFlash(panelId: UUID) {
+        panels[panelId]?.triggerFlash(reason: .navigation)
+    }
+
+    func focusFirstControl() -> Bool {
+        guard let paneId = bonsplitController.allPaneIds.first else { return false }
+        bonsplitController.focusPane(paneId)
+        guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id,
+              let panelId = surfaceIdToPanelId[tabId],
+              let panel = panels[panelId] else { return false }
+        panel.focus()
+        return true
+    }
+
     func noteKeyboardFocusIntent(window: NSWindow?) {
         AppDelegate.shared?.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
     }
@@ -195,7 +253,14 @@ extension DockSplitStore {
 
         // Split button: the new pane is empty. Seed a terminal in it, matching
         // the main area (which always seeds a terminal on a UI split).
-        _ = newSurface(kind: .terminal, inPane: newPane, focus: true)
+        let sourcePanelId = controller.selectedTab(inPane: originalPane)?.id
+            .flatMap { surfaceIdToPanelId[$0] }
+        _ = newSurface(
+            kind: .terminal,
+            inPane: newPane,
+            sourcePanelId: sourcePanelId,
+            focus: true
+        )
     }
 
     /// Mirrors `Workspace.splitTabBar(_:didMoveTab:…)`: keep the moved panel

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -82,9 +82,9 @@ extension DockSplitStore {
         // foreground process is the local relay, not the remote shell.
         let liveTerminalDirectory: String?
         if preservedTransfer?.isRemoteTerminal != true,
-           let terminal = panel as? TerminalPanel,
-           let pid = terminal.surface.foregroundProcessID() {
-            liveTerminalDirectory = Workspace.processCurrentWorkingDirectory(pid: Int32(clamping: pid))
+           let terminal = panel as? TerminalPanel {
+            liveTerminalDirectory = terminalWorkingDirectoryResolver
+                .liveForegroundProcessWorkingDirectory(for: terminal)
         } else {
             liveTerminalDirectory = nil
         }

--- a/Sources/DockSplitStore+TerminalLinkOpening.swift
+++ b/Sources/DockSplitStore+TerminalLinkOpening.swift
@@ -7,15 +7,7 @@ extension DockSplitStore: TerminalLinkOpenContainer {
     }
 
     func terminalLinkWorkingDirectory(for sourcePanelId: UUID) -> String? {
-        if let directory = detachedSurfaceTransfersByPanelId[sourcePanelId]?.directory,
-           !directory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return directory
-        }
-        guard let tabId = surfaceId(forPanelId: sourcePanelId),
-              let terminal = panel(for: tabId) as? TerminalPanel else {
-            return nil
-        }
-        return terminal.requestedWorkingDirectory
+        terminalWorkingDirectory(for: sourcePanelId)
     }
 
     func terminalLinkIsRemoteTerminal(_ sourcePanelId: UUID) -> Bool {

--- a/Sources/DockSplitStore+WorkingDirectory.swift
+++ b/Sources/DockSplitStore+WorkingDirectory.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 extension DockSplitStore {
+    /// Returns a source directory only when it is valid for a new local terminal.
+    func inheritedLocalTerminalWorkingDirectory(for sourcePanelId: UUID) -> String? {
+        guard detachedSurfaceTransfersByPanelId[sourcePanelId]?.isRemoteTerminal != true else { return nil }
+        return terminalWorkingDirectory(for: sourcePanelId)
+    }
+
     /// Returns the best current directory owned by a Dock terminal.
     ///
     /// Local terminals prefer the foreground process because the Dock does not

--- a/Sources/DockSplitStore+WorkingDirectory.swift
+++ b/Sources/DockSplitStore+WorkingDirectory.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension DockSplitStore {
+    /// Returns the best current directory owned by a Dock terminal.
+    ///
+    /// Local terminals prefer the foreground process because the Dock does not
+    /// receive main-workspace cwd reports. Remote terminals must keep their
+    /// transferred remote directory because their local foreground process is
+    /// only the relay.
+    func terminalWorkingDirectory(for sourcePanelId: UUID) -> String? {
+        guard let terminal = panels[sourcePanelId] as? TerminalPanel else { return nil }
+        let transfer = detachedSurfaceTransfersByPanelId[sourcePanelId]
+        if transfer?.isRemoteTerminal == true {
+            return TerminalWorkingDirectoryResolver.firstAvailable([
+                transfer?.directory,
+                terminal.directory,
+                terminal.requestedWorkingDirectory,
+            ])
+        }
+        return TerminalWorkingDirectoryResolver.firstAvailable([
+            terminalWorkingDirectoryResolver.liveForegroundProcessWorkingDirectory(for: terminal),
+            terminal.directory,
+            transfer?.directory,
+            terminal.requestedWorkingDirectory,
+        ])
+    }
+}

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -616,7 +616,7 @@ final class DockSplitStore: BonsplitDelegate {
         guard kind == .terminal else { return currentBaseDirectory() }
         let baseDirectory = currentBaseDirectory()
         let inheritedDirectory = settings.value(for: settingsCatalog.app.workspaceInheritWorkingDirectory)
-            ? sourcePanelId.flatMap { terminalWorkingDirectory(for: $0) }
+            ? sourcePanelId.flatMap { inheritedLocalTerminalWorkingDirectory(for: $0) }
             : nil
         return TerminalWorkingDirectoryResolver.firstAvailable([
             requestedWorkingDirectory,

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -62,6 +62,7 @@ final class DockSplitStore: BonsplitDelegate {
     @ObservationIgnored var terminalViewReattachCoalescingDepth = 0
     @ObservationIgnored var pendingTerminalViewReattachPanelIds: Set<UUID> = []
     @ObservationIgnored let focusHistoryNavigation: any FocusHistoryNavigating
+    @ObservationIgnored let terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver
     private let settings: any SettingsReading
     private let settingsCatalog = SettingCatalog()
 
@@ -80,7 +81,8 @@ final class DockSplitStore: BonsplitDelegate {
         baseDirectoryProvider: @escaping () -> String?,
         remoteBrowserSettingsProvider: @escaping () -> DockRemoteBrowserSettings = { .local },
         browserAvailabilityProvider: @escaping () -> Bool = { BrowserAvailabilitySettings.isEnabled() },
-        settings: any SettingsReading = UserDefaultsSettingsClient(defaults: .standard)
+        settings: any SettingsReading = UserDefaultsSettingsClient(defaults: .standard),
+        terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver = TerminalWorkingDirectoryResolver()
     ) {
         self.workspaceId = workspaceId
         self.scope = scope
@@ -88,6 +90,7 @@ final class DockSplitStore: BonsplitDelegate {
         self.remoteBrowserSettingsProvider = remoteBrowserSettingsProvider
         self.browserAvailabilityProvider = browserAvailabilityProvider
         self.settings = settings
+        self.terminalWorkingDirectoryResolver = terminalWorkingDirectoryResolver
         let focusHistoryScopeKey = SettingCatalog().app.focusHistoryIncludesPanesAndTabs
         self.focusHistoryNavigation = FocusHistoryModel(navigationScope: {
             settings.value(for: focusHistoryScopeKey) ? .panesAndTabs : .workspacesOnly
@@ -160,12 +163,6 @@ final class DockSplitStore: BonsplitDelegate {
             return paneId
         }
         return nil
-    }
-
-    var focusedPanelId: UUID? {
-        guard let paneId = bonsplitController.focusedPaneId,
-              let tabId = bonsplitController.selectedTab(inPane: paneId)?.id else { return nil }
-        return surfaceIdToPanelId[tabId]
     }
 
     // MARK: - Lifecycle
@@ -243,16 +240,6 @@ final class DockSplitStore: BonsplitDelegate {
         startConfigurationLoad(replacingPanels: false)
     }
 
-    func focusFirstControl() -> Bool {
-        guard let paneId = bonsplitController.allPaneIds.first else { return false }
-        bonsplitController.focusPane(paneId)
-        guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id,
-              let panelId = surfaceIdToPanelId[tabId],
-              let panel = panels[panelId] else { return false }
-        panel.focus()
-        return true
-    }
-
     // MARK: - In-app creation
 
     /// Creates a new surface (tab) in an existing Dock pane. Used by the tab-bar
@@ -265,6 +252,7 @@ final class DockSplitStore: BonsplitDelegate {
         initialRequest: URLRequest? = nil,
         command: String? = nil,
         workingDirectory: String? = nil,
+        sourcePanelId: UUID? = nil,
         environment: [String: String] = [:],
         tmuxStartCommand: String? = nil,
         focus: Bool = true,
@@ -272,13 +260,18 @@ final class DockSplitStore: BonsplitDelegate {
         bypassInsecureHTTPHostOnce: String? = nil
     ) -> UUID? {
         ensureLoaded()
+        let source = resolveSourcePanelId(sourcePanelId, preferredPaneId: paneId)
         guard let panel = makePanel(
             kind: kind,
             command: command,
             url: url,
             initialRequest: initialRequest,
             environment: environment,
-            workingDirectory: workingDirectory ?? currentBaseDirectory(),
+            workingDirectory: resolvedTerminalStartupWorkingDirectory(
+                kind: kind,
+                requestedWorkingDirectory: workingDirectory,
+                sourcePanelId: source
+            ),
             tmuxStartCommand: tmuxStartCommand,
             preferredProfileID: preferredProfileID,
             bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce
@@ -316,16 +309,21 @@ final class DockSplitStore: BonsplitDelegate {
         focus: Bool = true
     ) -> UUID? {
         ensureLoaded()
+        let source = resolveSourcePanelId(sourcePanelId)
         guard let panel = makePanel(
             kind: kind,
             command: command,
             url: url,
             environment: environment,
-            workingDirectory: workingDirectory ?? currentBaseDirectory(),
+            workingDirectory: resolvedTerminalStartupWorkingDirectory(
+                kind: kind,
+                requestedWorkingDirectory: workingDirectory,
+                sourcePanelId: source
+            ),
             tmuxStartCommand: tmuxStartCommand
         ) else { return nil }
 
-        guard let source = resolveSourcePanelId(sourcePanelId), let sourcePaneId = paneId(forPanelId: source) else {
+        guard let source, let sourcePaneId = paneId(forPanelId: source) else {
             // Empty tree: place into the root pane rather than splitting.
             let previousFocus = focus ? nil : focusedDockPaneSelection()
             guard let rootPane = bonsplitController.allPaneIds.first,
@@ -377,42 +375,6 @@ final class DockSplitStore: BonsplitDelegate {
             restoreDockPaneSelection(previousFocus)
         }
         return panel.id
-    }
-
-    /// Resolves a Dock pane for `surface.create --placement dock`. An explicit
-    /// `requestedPaneID` must match a Dock pane (else `nil` → the caller reports
-    /// not-found, like the workspace path); with no explicit id, returns the
-    /// focused/first Dock pane. Ensures config is loaded so the Dock always has
-    /// at least its root pane.
-    func resolvePane(requestedPaneID: UUID?) -> PaneID? {
-        ensureLoaded()
-        if let requestedPaneID {
-            return bonsplitController.allPaneIds.first(where: { $0.id == requestedPaneID })
-        }
-        return bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first
-    }
-
-    /// Whether a panel id is present in the Dock tree.
-    func containsPanel(_ panelId: UUID) -> Bool {
-        return panels[panelId] != nil
-    }
-    func containsPane(_ paneId: UUID) -> Bool { bonsplitController.allPaneIds.contains(where: { $0.id == paneId }) }
-
-    func focusPanel(_ panelId: UUID) {
-        guard let paneId = paneId(forPanelId: panelId), let tabId = surfaceId(forPanelId: panelId) else { return }
-        bonsplitController.focusPane(paneId)
-        bonsplitController.selectTab(tabId)
-        applyDockSelection(tabId: tabId, inPane: paneId)
-    }
-
-    func triggerFocusFlash(panelId: UUID) {
-        panels[panelId]?.triggerFlash(reason: .navigation)
-    }
-
-    private func resolveSourcePanelId(_ requested: UUID?) -> UUID? {
-        if let requested, panels[requested] != nil { return requested }
-        if let focused = focusedPanelId { return focused }
-        return panels.keys.first
     }
 
     func recordExplicitPanelCreation() {
@@ -644,6 +606,23 @@ final class DockSplitStore: BonsplitDelegate {
             return directory
         }
         return resolvedBaseDirectory
+    }
+
+    private func resolvedTerminalStartupWorkingDirectory(
+        kind: DockSurfaceKind,
+        requestedWorkingDirectory: String?,
+        sourcePanelId: UUID?
+    ) -> String {
+        guard kind == .terminal else { return currentBaseDirectory() }
+        let baseDirectory = currentBaseDirectory()
+        let inheritedDirectory = settings.value(for: settingsCatalog.app.workspaceInheritWorkingDirectory)
+            ? sourcePanelId.flatMap { terminalWorkingDirectory(for: $0) }
+            : nil
+        return TerminalWorkingDirectoryResolver.firstAvailable([
+            requestedWorkingDirectory,
+            inheritedDirectory,
+            baseDirectory,
+        ]) ?? baseDirectory
     }
 
     // MARK: - Config loading

--- a/Sources/TerminalWorkingDirectoryResolver.swift
+++ b/Sources/TerminalWorkingDirectoryResolver.swift
@@ -1,0 +1,55 @@
+import Darwin
+import Foundation
+
+/// Resolves terminal working-directory candidates and live local process state.
+@MainActor
+struct TerminalWorkingDirectoryResolver {
+    typealias LiveDirectoryProvider = @MainActor (TerminalPanel) -> String?
+
+    private let liveDirectoryProvider: LiveDirectoryProvider
+
+    init(liveDirectoryProvider: LiveDirectoryProvider? = nil) {
+        if let liveDirectoryProvider {
+            self.liveDirectoryProvider = liveDirectoryProvider
+        } else {
+            self.liveDirectoryProvider = { terminal in
+                guard let pid = terminal.surface.foregroundProcessID() else { return nil }
+                return Self.processCurrentWorkingDirectory(pid: Int32(clamping: pid))
+            }
+        }
+    }
+
+    func liveForegroundProcessWorkingDirectory(for terminal: TerminalPanel) -> String? {
+        Self.normalized(liveDirectoryProvider(terminal))
+    }
+
+    nonisolated static func firstAvailable(_ candidates: [String?]) -> String? {
+        for candidate in candidates {
+            if let candidate = normalized(candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    nonisolated static func normalized(_ workingDirectory: String?) -> String? {
+        let trimmed = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// The current working directory of `pid` via
+    /// `proc_pidinfo(PROC_PIDVNODEPATHINFO)`, or nil when the process is gone
+    /// or unreadable.
+    nonisolated static func processCurrentWorkingDirectory(pid: pid_t) -> String? {
+        guard pid > 0 else { return nil }
+        var info = proc_vnodepathinfo()
+        let expectedSize = MemoryLayout<proc_vnodepathinfo>.size
+        let size = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &info, Int32(expectedSize))
+        guard size == expectedSize else { return nil }
+        let path = withUnsafeBytes(of: info.pvi_cdir.vip_path) { rawBuffer -> String in
+            let endIndex = rawBuffer.firstIndex(of: 0) ?? rawBuffer.endIndex
+            return String(decoding: rawBuffer[..<endIndex], as: UTF8.self)
+        }
+        return normalized(path)
+    }
+}

--- a/Sources/TerminalWorkingDirectoryResolver.swift
+++ b/Sources/TerminalWorkingDirectoryResolver.swift
@@ -2,7 +2,6 @@ import Darwin
 import Foundation
 
 /// Resolves terminal working-directory candidates and live local process state.
-@MainActor
 struct TerminalWorkingDirectoryResolver {
     typealias LiveDirectoryProvider = @MainActor (TerminalPanel) -> String?
 
@@ -19,7 +18,7 @@ struct TerminalWorkingDirectoryResolver {
         }
     }
 
-    func liveForegroundProcessWorkingDirectory(for terminal: TerminalPanel) -> String? {
+    @MainActor func liveForegroundProcessWorkingDirectory(for terminal: TerminalPanel) -> String? {
         Self.normalized(liveDirectoryProvider(terminal))
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6571,27 +6571,22 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
-    nonisolated private static func normalizedTerminalWorkingDirectory(_ workingDirectory: String?) -> String? {
-        let trimmed = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
-    }
-
     private func resolvedTerminalStartupWorkingDirectory(
         requestedWorkingDirectory: String?,
         sourcePanelId: UUID?
     ) -> String? {
-        if let requested = Self.normalizedTerminalWorkingDirectory(requestedWorkingDirectory) {
+        if let requested = TerminalWorkingDirectoryResolver.normalized(requestedWorkingDirectory) {
             return requested
         }
         if let sourcePanelId,
            let rescued = resumedAgentPaneWorkingDirectoryRescue(panelId: sourcePanelId) {
             return rescued
         }
-        return [
+        return TerminalWorkingDirectoryResolver.firstAvailable([
             sourcePanelId.flatMap { panelDirectories[$0] },
             sourcePanelId.flatMap { terminalPanel(for: $0)?.requestedWorkingDirectory },
             currentDirectory,
-        ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
+        ])
     }
 
     /// The foreground-process cwd read consulted by
@@ -6622,13 +6617,13 @@ final class Workspace: Identifiable, ObservableObject {
         // policy, whose resume command never cds) — the tracked cwd is
         // genuine, so there is nothing to rescue and the live foreground
         // process must not be consulted either.
-        guard let sessionDirectory = Self.normalizedTerminalWorkingDirectory(
+        guard let sessionDirectory = TerminalWorkingDirectoryResolver.normalized(
             restoredResumeSessionWorkingDirectoriesByPanelId[panelId]
         ) else { return nil }
-        let trackedDirectory = Self.normalizedTerminalWorkingDirectory(panelDirectories[panelId])
+        let trackedDirectory = TerminalWorkingDirectoryResolver.normalized(panelDirectories[panelId])
         if trackedDirectory == sessionDirectory { return nil }
         for candidate in [liveForegroundProcessWorkingDirectory(panelId: panelId), sessionDirectory] {
-            guard let candidate = Self.normalizedTerminalWorkingDirectory(candidate) else { continue }
+            guard let candidate = TerminalWorkingDirectoryResolver.normalized(candidate) else { continue }
             if candidate == trackedDirectory {
                 continue
             }
@@ -6660,17 +6655,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// `proc_pidinfo(PROC_PIDVNODEPATHINFO)`, or nil when the process is gone
     /// or unreadable.
     nonisolated static func processCurrentWorkingDirectory(pid: pid_t) -> String? {
-        guard pid > 0 else { return nil }
-        var info = proc_vnodepathinfo()
-        let expectedSize = MemoryLayout<proc_vnodepathinfo>.size
-        let size = proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, &info, Int32(expectedSize))
-        guard size == expectedSize else { return nil }
-        let path = withUnsafeBytes(of: info.pvi_cdir.vip_path) { rawBuffer -> String in
-            let endIndex = rawBuffer.firstIndex(of: 0) ?? rawBuffer.endIndex
-            return String(decoding: rawBuffer[..<endIndex], as: UTF8.self)
-        }
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+        TerminalWorkingDirectoryResolver.processCurrentWorkingDirectory(pid: pid)
     }
 
     /// The directory a new tab (`new-window`) should inherit in a remote-tmux

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -806,6 +806,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DCDC1000000000000000B00D /* DockSurfaceKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00E /* DockSurfaceKind.swift */; };
 		D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */; };
 		DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B010 /* DockTrustRequest.swift */; };
+		D86860000000000000000001 /* DockWorkingDirectoryInheritanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */; };
 		D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */; };
 		D75280040000000000000001 /* DynamicTracingSignpostInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */; };
 		D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */; };
@@ -2980,6 +2981,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DCDC1000000000000000B00E /* DockSurfaceKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSurfaceKind.swift; sourceTree = "<group>"; };
 		D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTerminalReattachTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B010 /* DockTrustRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTrustRequest.swift; sourceTree = "<group>"; };
+		D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockWorkingDirectoryInheritanceTests.swift; sourceTree = "<group>"; };
 		D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOverlayRoutingPolicy.swift; sourceTree = "<group>"; };
 		D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTracingSignpostInterval.swift; sourceTree = "<group>"; };
 		D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableTextViewArrowKeyForwardingTests.swift; sourceTree = "<group>"; };
@@ -6131,6 +6133,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
 				D77800010000000000000002 /* DockPortalReconcileTests.swift */,
 				D81390010000000000000002 /* DockShortcutRoutingTests.swift */,
+				D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */,
 				D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */,
 				D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */,
 				D6212D0C00000000000000D2 /* WindowDockLifecycleTests.swift */,
@@ -8825,6 +8828,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */,
 				D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */,
 				D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */,
+				D86860000000000000000001 /* DockWorkingDirectoryInheritanceTests.swift in Sources */,
 				D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */,
 				E50320010000000000000001 /* ExtensionWorktreeSpawnArgsTests.swift in Sources */,
 				FEEDC0DEC0DEC0DEC0DE0001 /* FeedCoordinatorTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -802,6 +802,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DCDC1000000000000000C010 /* DockSplitStore+SurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */; };
 		859110000000000000000003 /* DockSplitStore+TerminalLinkOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859110000000000000000004 /* DockSplitStore+TerminalLinkOpening.swift */; };
 		DCDC1000000000000000B017 /* DockSplitStore+TerminalStartup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B018 /* DockSplitStore+TerminalStartup.swift */; };
+		D86861000000000000000001 /* DockSplitStore+WorkingDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86861000000000000000002 /* DockSplitStore+WorkingDirectory.swift */; };
 		DCDC0000000000000000A001 /* DockSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000A002 /* DockSplitStore.swift */; };
 		DCDC1000000000000000B00D /* DockSurfaceKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00E /* DockSurfaceKind.swift */; };
 		D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */; };
@@ -1948,6 +1949,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B5EE1F85425A4223B017226C /* TerminalWindowPortalEngineDivergenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F4341871F2416AB0E1F5DE /* TerminalWindowPortalEngineDivergenceTests.swift */; };
 		AA11BB22CC33DD44EE55F002 /* TerminalWindowPortalLayoutPassRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11BB22CC33DD44EE55F001 /* TerminalWindowPortalLayoutPassRefreshTests.swift */; };
 		C95BAC3D37A6111B487582DC /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DB195131CD53CCCCEEEB79 /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift */; };
+		D86862000000000000000001 /* TerminalWorkingDirectoryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86862000000000000000002 /* TerminalWorkingDirectoryResolver.swift */; };
 		B7758A010000000000000001 /* TerminationWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7758A010000000000000002 /* TerminationWatchdog.swift */; };
 		B7758A030000000000000001 /* TerminationWatchdogAtomic.c in Sources */ = {isa = PBXBuildFile; fileRef = B7758A030000000000000002 /* TerminationWatchdogAtomic.c */; };
 		B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7758A020000000000000002 /* TerminationWatchdogTests.swift */; };
@@ -2977,6 +2979,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+SurfaceTransfer.swift"; sourceTree = "<group>"; };
 		859110000000000000000004 /* DockSplitStore+TerminalLinkOpening.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+TerminalLinkOpening.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B018 /* DockSplitStore+TerminalStartup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+TerminalStartup.swift"; sourceTree = "<group>"; };
+		D86861000000000000000002 /* DockSplitStore+WorkingDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+WorkingDirectory.swift"; sourceTree = "<group>"; };
 		DCDC0000000000000000A002 /* DockSplitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitStore.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B00E /* DockSurfaceKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSurfaceKind.swift; sourceTree = "<group>"; };
 		D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTerminalReattachTests.swift; sourceTree = "<group>"; };
@@ -4102,6 +4105,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		54F4341871F2416AB0E1F5DE /* TerminalWindowPortalEngineDivergenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortalEngineDivergenceTests.swift; sourceTree = "<group>"; };
 		AA11BB22CC33DD44EE55F001 /* TerminalWindowPortalLayoutPassRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortalLayoutPassRefreshTests.swift; sourceTree = "<group>"; };
 		43DB195131CD53CCCCEEEB79 /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWindowPortalLifecycleHiddenRefreshTests.swift; sourceTree = "<group>"; };
+		D86862000000000000000002 /* TerminalWorkingDirectoryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWorkingDirectoryResolver.swift; sourceTree = "<group>"; };
 		B7758A010000000000000002 /* TerminationWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminationWatchdog.swift; sourceTree = "<group>"; };
 		B7758A030000000000000002 /* TerminationWatchdogAtomic.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = TerminationWatchdogAtomic.c; sourceTree = "<group>"; };
 		B7758A040000000000000002 /* TerminationWatchdogAtomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TerminationWatchdogAtomic.h; sourceTree = "<group>"; };
@@ -5125,6 +5129,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				859110000000000000000006 /* TerminalLinkOpenContainer.swift */,
 				859110000000000000000008 /* TerminalLinkOpenCoordinator.swift */,
 				85911000000000000000000A /* TerminalLinkOpenRequest.swift */,
+				D86862000000000000000002 /* TerminalWorkingDirectoryResolver.swift */,
 				85911000000000000000000C /* Workspace+TerminalLinkOpening.swift */,
 				C40410010000000000000020 /* FileExplorerDoubleClickActionSettings.swift */,
 				C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */,
@@ -5905,6 +5910,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000C031 /* AppDelegate+WindowDock.swift */,
 				D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */,
 				DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */,
+				D86861000000000000000002 /* DockSplitStore+WorkingDirectory.swift */,
 				DCDC1000000000000000C041 /* DockSplitStore+PortalDrop.swift */,
 				D77800020000000000000002 /* DockSplitStore+PortalReconcile.swift */,
 				DCDC1000000000000000B018 /* DockSplitStore+TerminalStartup.swift */,
@@ -7515,6 +7521,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000C010 /* DockSplitStore+SurfaceTransfer.swift in Sources */,
 				859110000000000000000003 /* DockSplitStore+TerminalLinkOpening.swift in Sources */,
 				DCDC1000000000000000B017 /* DockSplitStore+TerminalStartup.swift in Sources */,
+				D86861000000000000000001 /* DockSplitStore+WorkingDirectory.swift in Sources */,
 				DCDC0000000000000000A001 /* DockSplitStore.swift in Sources */,
 				DCDC1000000000000000B00D /* DockSurfaceKind.swift in Sources */,
 				DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */,
@@ -8292,6 +8299,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				793800000000000000000006 /* TerminalWindowPortal+DebugDiagnostics.swift in Sources */,
 				A5001532 /* TerminalWindowPortal.swift in Sources */,
 				D0B10006A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift in Sources */,
+				D86862000000000000000001 /* TerminalWorkingDirectoryResolver.swift in Sources */,
 				B7758A010000000000000001 /* TerminationWatchdog.swift in Sources */,
 				B7758A030000000000000001 /* TerminationWatchdogAtomic.c in Sources */,
 				C0DE7B330000000000000001 /* TextBoxAgentDetection.swift in Sources */,

--- a/cmuxTests/AgentResumeLivenessTests.swift
+++ b/cmuxTests/AgentResumeLivenessTests.swift
@@ -23,6 +23,10 @@ struct AgentResumeLivenessTests {
             snapshot: SessionRestorableAgentSnapshot(kind: kind, sessionId: sessionId),
             lifecycle: nil,
             updatedAt: 0,
+            // `hasLiveProcess` decides from the PID set alone, so keep the recorded
+            // liveness consistent with the PIDs each case asks for instead of pinning
+            // one value that would contradict the empty-PID case.
+            processLiveness: processIDs.isEmpty ? .exited : .running,
             processIDs: processIDs,
             agentProcessIDs: processIDs,
             agentProcessIdentities: [:]

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -117,6 +117,31 @@ struct DockWorkingDirectoryInheritanceTests {
         }
     }
 
+    @Test("Remote Dock directory is not inherited by a new local terminal")
+    @MainActor
+    func remoteDirectoryDoesNotBecomeLocalStartupDirectory() throws {
+        try withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
+            let sourcePanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: sourceDirectory.path,
+                focus: true
+            ))
+            let sourcePanel = try terminalPanel(in: store, panelId: sourcePanelId)
+            let remoteDirectory = "/home/cmux/remote-project"
+            store.detachedSurfaceTransfersByPanelId[sourcePanelId] = remoteTerminalTransfer(
+                panel: sourcePanel,
+                sourceWorkspaceId: store.workspaceId,
+                directory: remoteDirectory
+            )
+
+            #expect(store.terminalLinkWorkingDirectory(for: sourcePanelId) == remoteDirectory)
+            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == root.path)
+        }
+    }
+
     @Test("Explicit Dock terminal directory overrides inherited directory")
     @MainActor
     func explicitDirectoryOverridesInheritance() throws {
@@ -179,5 +204,44 @@ struct DockWorkingDirectoryInheritanceTests {
     private func terminalPanel(in store: DockSplitStore, panelId: UUID) throws -> TerminalPanel {
         let tabId = try #require(store.surfaceId(forPanelId: panelId))
         return try #require(store.panel(for: tabId) as? TerminalPanel)
+    }
+
+    @MainActor
+    private func remoteTerminalTransfer(
+        panel: TerminalPanel,
+        sourceWorkspaceId: UUID,
+        directory: String
+    ) -> Workspace.DetachedSurfaceTransfer {
+        Workspace.DetachedSurfaceTransfer(
+            sourceWorkspaceId: sourceWorkspaceId,
+            panelId: panel.id,
+            panel: panel,
+            title: panel.displayTitle,
+            icon: panel.displayIcon,
+            iconImageData: nil,
+            kind: "terminal",
+            isLoading: false,
+            isPinned: false,
+            directory: directory,
+            directoryIsTrustedRemoteReport: true,
+            directoryDisplayLabel: nil,
+            ttyName: nil,
+            cachedTitle: nil,
+            customTitle: nil,
+            customTitleSource: nil,
+            manuallyUnread: false,
+            restoredUnreadIndicator: nil,
+            restorableAgent: nil,
+            restorableAgentResumeState: nil,
+            restoredAgentCompletedGeneration: nil,
+            shellActivityState: nil,
+            restoredResumeSessionWorkingDirectory: nil,
+            resumeBinding: nil,
+            agentRuntime: nil,
+            isRemoteTerminal: true,
+            remoteRelayPort: nil,
+            remotePTYSessionID: nil,
+            remoteCleanupConfiguration: nil
+        )
     }
 }

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -1,0 +1,158 @@
+import Bonsplit
+import CmuxSettings
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Dock working-directory inheritance", .serialized)
+struct DockWorkingDirectoryInheritanceTests {
+    @Test("New terminal surface inherits the selected Dock terminal directory")
+    @MainActor
+    func newSurfaceInheritsSelectedTerminalDirectory() throws {
+        try withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
+            let sourcePanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: sourceDirectory.path,
+                focus: true
+            ))
+
+            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+
+            #expect(sourcePanelId != newPanelId)
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == sourceDirectory.path)
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory != root.path)
+        }
+    }
+
+    @Test("Programmatic Dock split inherits its source terminal directory")
+    @MainActor
+    func newSplitInheritsSourceTerminalDirectory() throws {
+        try withDock(inheritanceEnabled: true) { store, rootPane, _, sourceDirectory in
+            let sourcePanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: sourceDirectory.path,
+                focus: true
+            ))
+
+            let newPanelId = try #require(store.newSplit(
+                kind: .terminal,
+                orientation: .horizontal,
+                insertFirst: false,
+                sourcePanelId: sourcePanelId,
+                focus: true
+            ))
+
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == sourceDirectory.path)
+        }
+    }
+
+    @Test("Interactive Dock split inherits the original pane terminal directory")
+    @MainActor
+    func interactiveSplitInheritsOriginalPaneTerminalDirectory() throws {
+        try withDock(inheritanceEnabled: true) { store, rootPane, _, sourceDirectory in
+            _ = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: sourceDirectory.path,
+                focus: true
+            ))
+
+            let newPane = try #require(store.bonsplitController.splitPane(
+                rootPane,
+                orientation: .horizontal,
+                withTab: nil,
+                initialDividerPosition: 0.5
+            ))
+            let newTabId = try #require(store.bonsplitController.selectedTab(inPane: newPane)?.id)
+            let newPanelId = try #require(store.surfaceIdToPanelId[newTabId])
+
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == sourceDirectory.path)
+        }
+    }
+
+    @Test("Disabled inheritance starts new Dock terminals in the workspace root")
+    @MainActor
+    func disabledInheritanceUsesWorkspaceRoot() throws {
+        try withDock(inheritanceEnabled: false) { store, rootPane, root, sourceDirectory in
+            _ = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: sourceDirectory.path,
+                focus: true
+            ))
+
+            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == root.path)
+        }
+    }
+
+    @Test("Explicit Dock terminal directory overrides inherited directory")
+    @MainActor
+    func explicitDirectoryOverridesInheritance() throws {
+        try withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
+            let explicitDirectory = root.appending(path: "Explicit", directoryHint: .isDirectory)
+            try FileManager.default.createDirectory(at: explicitDirectory, withIntermediateDirectories: true)
+            _ = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: sourceDirectory.path,
+                focus: true
+            ))
+
+            let newPanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: explicitDirectory.path,
+                focus: true
+            ))
+
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == explicitDirectory.path)
+        }
+    }
+
+    @MainActor
+    private func withDock(
+        inheritanceEnabled: Bool,
+        _ body: (DockSplitStore, PaneID, URL, URL) throws -> Void
+    ) throws {
+        let root = URL.temporaryDirectory.appending(
+            path: "cmux-dock-cwd-\(UUID().uuidString)",
+            directoryHint: .isDirectory
+        )
+        let sourceDirectory = root.appending(path: "Sources", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+
+        let suiteName = "DockWorkingDirectoryInheritanceTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        settings.set(inheritanceEnabled, for: SettingCatalog().app.workspaceInheritWorkingDirectory)
+
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { root.path },
+            settings: settings
+        )
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+        defer {
+            store.closeAllPanels()
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        try body(store, rootPane, root, sourceDirectory)
+    }
+
+    @MainActor
+    private func terminalPanel(in store: DockSplitStore, panelId: UUID) throws -> TerminalPanel {
+        let tabId = try #require(store.surfaceId(forPanelId: panelId))
+        return try #require(store.panel(for: tabId) as? TerminalPanel)
+    }
+}

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -94,6 +94,29 @@ struct DockWorkingDirectoryInheritanceTests {
         }
     }
 
+    @Test("Live foreground-process directory wins over the Dock terminal startup directory")
+    @MainActor
+    func liveDirectoryWinsOverRequestedDirectory() throws {
+        var liveDirectory: String?
+        let resolver = TerminalWorkingDirectoryResolver(liveDirectoryProvider: { _ in liveDirectory })
+        try withDock(
+            inheritanceEnabled: true,
+            terminalWorkingDirectoryResolver: resolver
+        ) { store, rootPane, root, sourceDirectory in
+            _ = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: root.path,
+                focus: true
+            ))
+            liveDirectory = sourceDirectory.path
+
+            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == sourceDirectory.path)
+        }
+    }
+
     @Test("Explicit Dock terminal directory overrides inherited directory")
     @MainActor
     func explicitDirectoryOverridesInheritance() throws {
@@ -121,6 +144,7 @@ struct DockWorkingDirectoryInheritanceTests {
     @MainActor
     private func withDock(
         inheritanceEnabled: Bool,
+        terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver = TerminalWorkingDirectoryResolver(),
         _ body: (DockSplitStore, PaneID, URL, URL) throws -> Void
     ) throws {
         let root = URL.temporaryDirectory.appending(
@@ -138,7 +162,8 @@ struct DockWorkingDirectoryInheritanceTests {
         let store = DockSplitStore(
             workspaceId: UUID(),
             baseDirectoryProvider: { root.path },
-            settings: settings
+            settings: settings,
+            terminalWorkingDirectoryResolver: terminalWorkingDirectoryResolver
         )
         let rootPane = try #require(store.bonsplitController.allPaneIds.first)
         defer {


### PR DESCRIPTION
## Summary

- make Dock terminal tabs and panes inherit the focused/source Dock terminal working directory
- route buttons, shortcuts, Bonsplit interactive splits, and `surface.create` / `pane.create --placement dock` through the same Dock cwd policy
- honor `app.workspaceInheritWorkingDirectory`, preserve explicit cwd overrides, and keep remote-only paths out of new local terminals
- leave browser creation unchanged

## Architecture

- add an injected `TerminalWorkingDirectoryResolver` for normalized candidate selection and live foreground-process cwd lookup
- resolve Dock terminal cwd once at the `DockSplitStore.newSurface` / `newSplit` boundary: explicit request, inherited live/cached local source directory, then workspace root
- reuse the resolver from the main Workspace process-cwd path, Dock link opening, and Dock surface transfer
- keep remote-aware link resolution separate from local terminal startup inheritance
- carry the original selected panel explicitly through Bonsplit interactive split creation

## Testing

- focused final Actions run: https://github.com/manaflow-ai/cmux/actions/runs/29968202373 — 7/7 tests passed
- focused remote-cwd red proof: https://github.com/manaflow-ai/cmux/actions/runs/29967543508 — failed on the regression test before the guard fix
- coverage includes selected-tab creation, programmatic pane creation, interactive Bonsplit splits, setting-disabled fallback, explicit override, live cwd precedence, and remote cwd isolation
- the initial test-only run https://github.com/manaflow-ai/cmux/actions/runs/29963371278 could not provide behavioral red proof because current main's test target first hit the unrelated `AgentResumeLivenessTests.swift` compile regression; this branch includes the exact four-line prerequisite from upstream PR #8651
- local `xcodebuild` / XCUITests were intentionally not run per issue instructions
- changed Swift files parse; pbxproj normalization/checks pass; the 567-file test-wiring guard, workspace package grouping, Package.resolved policy, and diff checks pass
- final canonical autoreview is clean; Greptile is 5/5; no unresolved review threads remain
- localization audit: no user-facing strings or localization catalogs changed

Closes #8686