### PR TITLE
tests: stop three fixtures from killing the test host on window close

### DIFF
--- a/cmuxTests/FilePreviewReviewFeedbackTests.swift
+++ b/cmuxTests/FilePreviewReviewFeedbackTests.swift
@@ -307,6 +307,9 @@ struct FilePreviewReviewFeedbackTests {
         #expect(!coordinator.focus(.textEditor))
 
         let window = NSWindow(contentRect: textView.bounds, styleMask: [], backing: .buffered, defer: false)
+        // AppKit releases a closed window unless the owner opts out, and callers close
+        // this window. Without this the close over-releases and kills the test host,
+        // losing this suite's verdict and its shard-mates' along with it.
         window.isReleasedWhenClosed = false
         defer {
             window.contentView = nil

--- a/cmuxTests/TerminalNotificationSocketActionTests.swift
+++ b/cmuxTests/TerminalNotificationSocketActionTests.swift
@@ -305,6 +305,11 @@ final class TerminalNotificationSocketActionTests: XCTestCase {
                 backing: .buffered,
                 defer: false
             )
+            // AppKit releases a closed window unless the owner opts out, and this
+            // fixture's window is closed below. Without this the close over-releases
+            // and kills the test host, losing this suite's verdict and its
+            // shard-mates' along with it.
+            testWindow.isReleasedWhenClosed = false
             testWindow.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(registeredWindowId.uuidString)")
             testWindow.makeKeyAndOrderFront(nil)
             windowId = registeredWindowId

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -3671,6 +3671,10 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        // AppKit releases a closed window unless the owner opts out, and callers close
+        // this window. Without this the close over-releases and kills the test host,
+        // losing this suite's verdict and its shard-mates' along with it.
+        window.isReleasedWhenClosed = false
         let scrollView = NSScrollView(frame: window.contentView?.bounds ?? .zero)
         scrollView.autoresizingMask = [.width, .height]
         window.contentView?.addSubview(scrollView)


### PR DESCRIPTION
Three suites built an `NSWindow` and later closed it without opting out of AppKit's close-time release. ARC still holds a strong reference, so each close over-releases and takes the whole test host down.

A dead host is worse than a failing test. The suite reports no verdict at all, and every suite sharing that host loses its verdict too, which is how a single unguarded window turns into a spray of unexplained reds elsewhere.

## Measured, one suite per app host

Both arms ran on the same worktree with the same warm derived-data path, with only this change between them. `#8651` is applied in both, since the `cmuxTests` target does not compile without it.

| suite | before | after |
|---|---|---|
| `TerminalNotificationSocketActionTests` | 2 restarts, **0 of 7** tests ran, `** TEST FAILED **` | 0 restarts, **7 of 7**, `** TEST SUCCEEDED **` |
| `FilePreviewPanelTextSavingTests` | 2 restarts, 2 of 27 ran, `** TEST FAILED **` | 0 restarts, **27 run**, 24 pass |
| `FilePreviewReviewFeedbackTests` | 1 restart, 11 of 17 ran, `** TEST FAILED **` | 0 restarts, **17 run**, 16 pass |

## Where the guard goes, and why not everywhere

`FilePreviewPanelTextSavingTests` creates three windows across two tests, and all three go through one private `windowHosting` helper, so the guard belongs there rather than at three call sites. The other window fixtures declared in `WindowAndDragTests.swift` build windows and only ever `orderOut` them, which does not release, so they need nothing. I mapped every `NSWindow` site in that file to its enclosing suite before touching it rather than applying the flag broadly.

That mapping is the same rule that predicted these three suites in the first place: counting the tests that close a self-created unguarded window matches the measured host-restart count. Across the browser suites it lands at 16, 3, 1 and 1, and correctly predicts 0 for the one suite that fails assertions without ever restarting.

The product already sets `isReleasedWhenClosed = false` everywhere it owns a window (`BrowserPanel.swift`, `BrowserPrewarmedWebViewPool.swift`, `BrowserPopupWindowController.swift`, `ReleasingWindowController.swift`). Only these fixtures were missing it, which is why nothing in `Sources` changes here.

## What is still red behind the crash

Fixing the crash exposed assertions nobody could see while the host was dying. These are separate bugs and get their own change:

```
FilePreviewPanelTextSavingTests  (24 of 27 pass)
  testSavingTextViewUsesConfiguredSaveShortcut      ("") != ("saved by configured shortcut")
  testTextEditorInsetsReapplyWhenMovedBetweenWindows  ("nil") != ("Optional(0.0)")   x2

FilePreviewReviewFeedbackTests   (16 of 17 pass)
  testSavingTextViewUsesChordedSaveShortcut         ("") != ("saved by chord")
```

The two `SavingTextView…SaveShortcut` failures look like one mechanism: a convenience initializer that builds the view without a text container, so there is no text to save.

Read the restart count and the test count when checking this, not the verdict line. A host that dies mid-run still prints a summary, and these logs also carry earlier `Executed 0 tests, with 0 failures` lines that a tail-only grep would read as fine.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787358441&installation_model_id=21920&pr_number=8701&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8701&signature=503a885c9538095de02aed44187e98e44e2b1d8da9fb9a9d431c3aef7aa10571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents test host crashes when three test fixtures close their NSWindow. Sets `isReleasedWhenClosed = false` so closing doesn’t over-release under ARC, removing host restarts and letting all tests run.

- **Bug Fixes**
  - TerminalNotificationSocketActionTests: set `testWindow.isReleasedWhenClosed = false`.
  - FilePreviewPanelTextSavingTests: set the flag in the private `windowHosting` helper used by two tests that create three windows.
  - FilePreviewReviewFeedbackTests: set `window.isReleasedWhenClosed = false`.
  - Result: no host restarts; suites run to completion. Any newly visible assertion failures are separate. Tests-only change; no product code touched.

<sup>Written for commit 4b048911b62be329892b59a96be868b3204a5e43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test window lifecycle handling to prevent over-release errors.
  * Increased stability and reliability of window, file preview, terminal notification, and drag-related test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

