### PR TITLE
Define cmux Browser public-import gates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,18 @@
 Copyright (c) 2024-present Manaflow, Inc.
 
-This software is dual-licensed:
+Other contributors and third parties retain copyright in their material.
 
-1. Open source: GNU General Public License v3.0 or later (GPL-3.0-or-later).
-   See the full text below.
+Except where a file or accompanying notice states otherwise, material
+contributed under the cmux project license is licensed under the GNU General
+Public License v3.0 or later (GPL-3.0-or-later). See the full text below.
 
-2. Commercial: For organizations that cannot comply with GPL, a commercial license
-   is available. Contact founders@manaflow.com for details.
+Manaflow may separately offer commercial terms only for material for which it
+controls the necessary rights. Those terms do not relicense third-party
+material or outside contributions for which Manaflow lacks a separate grant.
+A product that combines cmux material with third-party material remains subject
+to every applicable third-party license and notice. See
+THIRD_PARTY_LICENSES.md and file-level notices. Contact founders@manaflow.com
+for details about the eligible scope.
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -440,4 +440,8 @@ cmux is free, open source, and always will be. If you'd like to support developm
 
 cmux is open source under [GPL-3.0-or-later](LICENSE).
 
-If your organization cannot comply with GPL, a commercial license is available. Contact [founders@manaflow.com](mailto:founders@manaflow.com) for details.
+If your organization cannot comply with GPL, commercial terms may be available
+for portions for which Manaflow controls the necessary rights. They do not
+relicense third-party material or outside contributions for which Manaflow
+lacks a separate grant. See [LICENSE](LICENSE) for the exact scope and contact
+[founders@manaflow.com](mailto:founders@manaflow.com) for details.

--- a/cmux-browser/AGENTS.md
+++ b/cmux-browser/AGENTS.md
@@ -21,8 +21,9 @@ builder configuration here.
 Every imported or new source file must have a recorded provenance and license.
 Do not apply the repository's default license over third-party material.
 
-- Manaflow-authored files use the repository's GPL-3.0-or-later/commercial
-  policy unless a narrower file-level notice says otherwise.
+- Manaflow rights-controlled files use GPL-3.0-or-later. Commercial terms may
+  be offered separately only for portions whose necessary rights Manaflow
+  controls; authorship alone is not proof of that control.
 - Chromium-derived files retain Chromium's BSD-3-Clause notice.
 - Helium-derived files retain GPL-3.0-only provenance and the exact source
   revision. Helium-derived code is not available under Manaflow's commercial
@@ -33,6 +34,10 @@ Do not apply the repository's default license over third-party material.
 When changing a shipped dependency, update its exact revision or digest,
 source URL, license text, and source-offer record in the same change. A build
 must fail closed if any shipped file has no license mapping.
+
+Do not add a nested copy of the root `LICENSE` that could be read as licensing
+third-party or mixed-origin files commercially. Use per-file notices, exact
+provenance, and a generated release composition manifest.
 
 ## Validation
 

--- a/cmux-browser/AGENTS.md
+++ b/cmux-browser/AGENTS.md
@@ -1,0 +1,46 @@
+# cmux Browser contributor notes
+
+This directory contains the Chromium-based cmux Browser product. It is a
+source overlay and build harness, not a Chromium checkout. Never vendor
+Chromium, generated build output, signed applications, update keys, or private
+builder configuration here.
+
+## Repository boundaries
+
+- Resolve the cmux TUI backend from `../cmux-tui`.
+- Resolve Ghostty from the repository's `../ghostty` gitlink.
+- Keep Chromium overlay paths under `overlay/` identical to their destination
+  paths in a Chromium source tree.
+- Derive paths from the monorepo and Browser roots. Do not add developer home
+  directories, private hostnames, tailnet addresses, or volume paths.
+- Pin Chromium with a full commit ID and preserve enough build metadata to
+  reproduce every distributed binary.
+
+## Licensing and provenance
+
+Every imported or new source file must have a recorded provenance and license.
+Do not apply the repository's default license over third-party material.
+
+- Manaflow-authored files use the repository's GPL-3.0-or-later/commercial
+  policy unless a narrower file-level notice says otherwise.
+- Chromium-derived files retain Chromium's BSD-3-Clause notice.
+- Helium-derived files retain GPL-3.0-only provenance and the exact source
+  revision. Helium-derived code is not available under Manaflow's commercial
+  license.
+- Other bundled dependencies retain their own terms and must appear in the
+  generated notices and corresponding-source manifest.
+
+When changing a shipped dependency, update its exact revision or digest,
+source URL, license text, and source-offer record in the same change. A build
+must fail closed if any shipped file has no license mapping.
+
+## Validation
+
+Run the fast host, patch-fixture, script, and protocol tests before review.
+Release candidates additionally require a full Chromium build, generated
+Chromium third-party notices, bundle-license verification, and the macOS
+XCUITest terminal-render suite against the exact packaged cmux and Ghostty
+revisions.
+
+Never run untrusted pull-request code on a self-hosted builder with private
+network access or signing credentials.

--- a/cmux-browser/IMPORT_PROVENANCE.md
+++ b/cmux-browser/IMPORT_PROVENANCE.md
@@ -53,7 +53,9 @@ upstream sources.
 - **Chromium:** pin a full source commit and DEPS state. Generate the shipped
   target's license/credits output with Chromium's license tooling.
 - **Ghostty:** use the root gitlink, retain its MIT notice, and include licenses
-  for linked libraries, fonts, themes, and shell-integration resources.
+  for linked libraries, fonts, themes, and shell-integration resources. Do not
+  infer that every converted theme is MIT from the theme collection's license;
+  ship only themes with verified per-theme redistribution provenance.
 - **cmux TUI:** build the sibling workspace and record the exact helper receipt.
 - **Helium:** retain exact patch provenance and GPL-3.0-only terms. A future
   proprietary Browser requires independently reimplementing or separately
@@ -81,6 +83,9 @@ upstream sources.
   commit, uBlock payload digest, and all packaged resource manifests are exact.
 - [ ] Generated Chromium, Cargo, Ghostty/Zig, resource, and extension notices
   are included in the app and its About UI.
+- [ ] Static LGPL dependencies have an explicit GPL-compliance path; any
+  commercial build instead omits them, links them appropriately, or ships the
+  relinkable material and permissions their license requires.
 - [ ] Complete corresponding source can be reconstructed for the distributed
   GPL build.
 - [ ] Fast public CI passes without private infrastructure.

--- a/cmux-browser/IMPORT_PROVENANCE.md
+++ b/cmux-browser/IMPORT_PROVENANCE.md
@@ -58,6 +58,9 @@ upstream sources.
 - **Helium:** retain exact patch provenance and GPL-3.0-only terms. A future
   proprietary Browser requires independently reimplementing or separately
   licensing Helium-derived behavior.
+- **Bonsplit:** preserve the MIT notice and exact source revision for adapted
+  split-layout and animation behavior, even though cmux already ships Bonsplit
+  elsewhere in the monorepo.
 - **uBlock Origin:** pin the extension payload digest and upstream source tag,
   preserve GPLv3 notices, and distribute the corresponding source or a valid
   source offer with the binary.

--- a/cmux-browser/IMPORT_PROVENANCE.md
+++ b/cmux-browser/IMPORT_PROVENANCE.md
@@ -1,0 +1,87 @@
+# cmux Browser import provenance
+
+This document is the release gate for moving cmux Browser from its private
+development repository into public `manaflow-ai/cmux` history. The import uses
+a curated snapshot rather than publishing the private repository's Git graph.
+
+## Snapshot identity
+
+The snapshot commit, tree hash, import timestamp, and immutable private archive
+tag will be recorded in the source-import commit. The imported bytes must land
+unchanged in that commit; path relocation and public-build rewrites belong in
+later commits so reviewers can reproduce the import independently.
+
+## Included source
+
+- Chromium overlay sources and build metadata
+- Chromium patch fixtures and compatibility tests
+- build, packaging, verification, and updater scripts after secret and
+  infrastructure review
+- XCUITest and host-side test harnesses
+- durable architecture and contributor documentation
+
+## Excluded material
+
+- the private repository's commit history, side branches, refs, and stash
+- local `dist` symlinks and generated application bundles
+- Chromium checkouts, `out/` directories, caches, staged frameworks, and
+  generated Xcode projects
+- private hostnames, tailnet addresses, developer paths, signing material,
+  release credentials, and fleet-specific builder adapters
+- transient implementation ledgers, screenshots containing local identity or
+  paths, and tool stubs that are unavailable to public contributors
+
+## License classes
+
+Every imported source path must be classified before public distribution.
+
+| Class | Required treatment |
+| --- | --- |
+| Manaflow-authored | cmux GPL-3.0-or-later/commercial policy and Manaflow copyright |
+| Chromium-derived | Preserve BSD-3-Clause copyright, license, source revision, and modification notice |
+| Helium-derived | Preserve GPL-3.0-only copyright, exact source revision, and modification notice; exclude from commercial-license claims |
+| Mixed provenance | Preserve every applicable notice and document the copied regions; do not replace the obligations with an `OR` expression |
+| Other dependency | Preserve its upstream license and add exact source/artifact identity to generated notices |
+
+A root license never overrides a more specific file-level or third-party
+license. The initial private tree's generic Chromium headers are not accepted
+as classification evidence; each file must be reviewed against its history and
+upstream sources.
+
+## Dependency obligations
+
+- **Chromium:** pin a full source commit and DEPS state. Generate the shipped
+  target's license/credits output with Chromium's license tooling.
+- **Ghostty:** use the root gitlink, retain its MIT notice, and include licenses
+  for linked libraries, fonts, themes, and shell-integration resources.
+- **cmux TUI:** build the sibling workspace and record the exact helper receipt.
+- **Helium:** retain exact patch provenance and GPL-3.0-only terms. A future
+  proprietary Browser requires independently reimplementing or separately
+  licensing Helium-derived behavior.
+- **uBlock Origin:** pin the extension payload digest and upstream source tag,
+  preserve GPLv3 notices, and distribute the corresponding source or a valid
+  source offer with the binary.
+
+## Required gates
+
+- [ ] Canonical private Browser validation is complete and its source SHA is
+  frozen.
+- [ ] A redacted full-history secret scan and a current-tree scan are clean,
+  with false positives documented without publishing candidate secrets.
+- [ ] Every imported source file has a reviewed provenance/license mapping.
+- [ ] Private infrastructure defaults and links have been removed or moved to
+  a private operations adapter.
+- [ ] The Chromium commit, DEPS state, GN arguments, cmux commit, Ghostty
+  commit, uBlock payload digest, and all packaged resource manifests are exact.
+- [ ] Generated Chromium, Cargo, Ghostty/Zig, resource, and extension notices
+  are included in the app and its About UI.
+- [ ] Complete corresponding source can be reconstructed for the distributed
+  GPL build.
+- [ ] Fast public CI passes without private infrastructure.
+- [ ] A trusted full Chromium build and the terminal-render XCUITest matrix
+  pass against the packaged application.
+- [ ] The final public diff passes code review and a release-compliance review.
+
+This engineering inventory is not a legal opinion. Manaflow should have
+counsel review chain of title, contributor agreements, static LGPL compliance,
+and any commercial distribution before relying on the dual-license path.

--- a/cmux-browser/IMPORT_PROVENANCE.md
+++ b/cmux-browser/IMPORT_PROVENANCE.md
@@ -37,7 +37,7 @@ Every imported source path must be classified before public distribution.
 
 | Class | Required treatment |
 | --- | --- |
-| Manaflow-authored | cmux GPL-3.0-or-later/commercial policy and Manaflow copyright |
+| Manaflow rights-controlled | GPL-3.0-or-later; separately offered commercial terms only when Manaflow controls the necessary rights |
 | Chromium-derived | Preserve BSD-3-Clause copyright, license, source revision, and modification notice |
 | Helium-derived | Preserve GPL-3.0-only copyright, exact source revision, and modification notice; exclude from commercial-license claims |
 | Mixed provenance | Preserve every applicable notice and document the copied regions; do not replace the obligations with an `OR` expression |
@@ -47,6 +47,41 @@ A root license never overrides a more specific file-level or third-party
 license. The initial private tree's generic Chromium headers are not accepted
 as classification evidence; each file must be reviewed against its history and
 upstream sources.
+
+"Rights-controlled" is intentionally narrower than "authored." Git authorship
+alone does not establish employment assignment, contractor assignment,
+employer authorization, patent rights, or an effective relicensing grant.
+
+## License policy decision
+
+The desktop Browser follows cmux's existing GPL-3.0-or-later policy for
+Manaflow rights-controlled code. The import does not switch cmux or this
+directory to AGPL. GPL already covers distribution of modified desktop forks;
+AGPL's additional source requirement is material when a modified program is
+offered for remote interaction over a network. If cmux later ships a hosted
+service for which that distinction matters, license it as a separately
+reviewed component rather than changing the desktop product incidentally.
+
+Manaflow can release later versions of rights-controlled code under different
+terms, but an already published GPL or AGPL grant remains available for that
+published version. Third-party rights and outside contributions do not become
+relicensable merely because Manaflow maintains the repository.
+
+## Release composition
+
+The public GPL release and any future commercial release have different
+composition gates.
+
+| Component | Public GPL release | Future commercial release |
+| --- | --- | --- |
+| Manaflow rights-controlled Browser code | GPL-3.0-or-later with complete corresponding source | Eligible only after chain-of-title and contributor-grant review |
+| Chromium-derived code | Preserve BSD-3-Clause notices and generated Chromium credits | Permissive terms may allow use; retain every notice and condition |
+| Ghostty and Bonsplit | Preserve MIT notices plus every transitive dependency obligation | Permissive portions may allow use; audit the exact linked/resource closure |
+| Helium-derived code | Preserve GPL-3.0-only terms, provenance, and source | Exclude, replace independently, or obtain separate permission |
+| uBlock Origin | Preserve GPL-3.0-only terms and provide exact corresponding source | Not covered by Manaflow's commercial offer; exclude or use only in a counsel-reviewed aggregation that preserves its GPL rights |
+| cmux TUI | Preserve its GPL terms and corresponding source | Exclude from commercial claims unless all necessary rights exist; a process boundary is not by itself a legal conclusion |
+| Static LGPL components | Preserve notices/source and provide the required relinking route | Remove, link appropriately, or provide the exact relinking materials and permissions required by the license |
+| Fonts, themes, and other resources | Ship only resources with per-item redistribution provenance | Same requirement; an application license cannot cure a missing asset license |
 
 ## Dependency obligations
 
@@ -64,7 +99,7 @@ upstream sources.
   split-layout and animation behavior, even though cmux already ships Bonsplit
   elsewhere in the monorepo.
 - **uBlock Origin:** pin the extension payload digest and upstream source tag,
-  preserve GPLv3 notices, and distribute the corresponding source or a valid
+  preserve GPL-3.0-only notices, and distribute the corresponding source or a valid
   source offer with the binary.
 
 ## Required gates
@@ -75,8 +110,14 @@ upstream sources.
   with false positives documented without publishing candidate secrets.
 - [ ] Every imported source file has a reviewed provenance/license mapping.
 - [ ] Manaflow has documented ownership or an explicit relicensing grant for
-  every first-party contribution, and a counsel-approved CLA workflow records
-  future contributor assent if later relicensing remains a product goal.
+  every rights-controlled contribution.
+- [ ] A counsel-approved, versioned ICLA/CCLA workflow records durable,
+  affirmative assent for future Browser contributions, including copyright and
+  patent grants, contributor representations, employer authority, and
+  re-consent when the agreement changes.
+- [ ] `cmux-browser/**` is protected by required CODEOWNER review, a required
+  contributor-agreement status check, and branch rules that cannot be bypassed
+  by an ordinary merge.
 - [ ] Private infrastructure defaults and links have been removed or moved to
   a private operations adapter.
 - [ ] The Chromium commit, DEPS state, GN arguments, cmux commit, Ghostty

--- a/cmux-browser/IMPORT_PROVENANCE.md
+++ b/cmux-browser/IMPORT_PROVENANCE.md
@@ -72,6 +72,9 @@ upstream sources.
 - [ ] A redacted full-history secret scan and a current-tree scan are clean,
   with false positives documented without publishing candidate secrets.
 - [ ] Every imported source file has a reviewed provenance/license mapping.
+- [ ] Manaflow has documented ownership or an explicit relicensing grant for
+  every first-party contribution, and a counsel-approved CLA workflow records
+  future contributor assent if later relicensing remains a product goal.
 - [ ] Private infrastructure defaults and links have been removed or moved to
   a private operations adapter.
 - [ ] The Chromium commit, DEPS state, GN arguments, cmux commit, Ghostty

--- a/cmux-browser/IMPORT_PROVENANCE.md
+++ b/cmux-browser/IMPORT_PROVENANCE.md
@@ -61,6 +61,11 @@ AGPL's additional source requirement is material when a modified program is
 offered for remote interaction over a network. If cmux later ships a hosted
 service for which that distinction matters, license it as a separately
 reviewed component rather than changing the desktop product incidentally.
+AGPL obligations attach to the AGPL-covered network-interactive program; they
+do not automatically relicense independent neighboring services. If an
+AGPLv3-covered component is combined with GPLv3-covered code, the GPLv3/AGPLv3
+section 13 compatibility rule and the AGPL network-source requirement for the
+combination must be reviewed as part of that service's architecture.
 
 Manaflow can release later versions of rights-controlled code under different
 terms, but an already published GPL or AGPL grant remains available for that
@@ -88,9 +93,17 @@ composition gates.
 - **Chromium:** pin a full source commit and DEPS state. Generate the shipped
   target's license/credits output with Chromium's license tooling.
 - **Ghostty:** use the root gitlink, retain its MIT notice, and include licenses
-  for linked libraries, fonts, themes, and shell-integration resources. Do not
-  infer that every converted theme is MIT from the theme collection's license;
-  ship only themes with verified per-theme redistribution provenance.
+  for linked libraries, fonts, themes, and shell-integration resources. The
+  current Darwin link includes static GNU gettext/libintl 0.24 under
+  LGPL-2.1-or-later even when Ghostty is built with `-Di18n=false`; that option
+  disables catalogs but does not remove the unconditional Darwin link. Inspect
+  the produced archive rather than treating a build flag as license evidence.
+  The embedded font closure includes JetBrains Mono 2.304 under OFL-1.1 and
+  Nerd Fonts Symbols Only 3.4.0 under MIT; preserve their exact notices, and
+  review OFL Reserved Font Name conditions before modifying or rebuilding the
+  OFL font. Do not infer that every converted theme is MIT from the theme
+  collection's license; ship only themes with verified per-theme
+  redistribution provenance.
 - **cmux TUI:** build the sibling workspace and record the exact helper receipt.
 - **Helium:** retain exact patch provenance and GPL-3.0-only terms. A future
   proprietary Browser requires independently reimplementing or separately
@@ -99,8 +112,10 @@ composition gates.
   split-layout and animation behavior, even though cmux already ships Bonsplit
   elsewhere in the monorepo.
 - **uBlock Origin:** pin the extension payload digest and upstream source tag,
-  preserve GPL-3.0-only notices, and distribute the corresponding source or a valid
-  source offer with the binary.
+  preserve GPL-3.0-only notices, and distribute the corresponding source or a
+  valid source offer with the binary. Preserve and inventory the extension's
+  own embedded third-party licenses and assets as well; the uBlock GPL notice
+  is not a substitute for those notices.
 
 ## Required gates
 

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -1,0 +1,43 @@
+# cmux Browser
+
+cmux Browser combines Chromium web surfaces with Ghostty terminal frontends
+backed by the cmux TUI process. It is being moved into this repository so the
+Browser, its terminal protocol, and its exact Ghostty dependency can be built
+and reviewed from one public source tree.
+
+The Browser is maintained as a small source overlay and patch set against an
+exact Chromium revision. Chromium itself is not vendored into this repository.
+
+## Import status
+
+The public import is staged deliberately:
+
+1. establish the provenance, licensing, and reproducibility contract;
+2. import one curated source snapshot without private Git history;
+3. make monorepo-relative build and dependency changes in reviewable commits;
+4. add public CI and release-compliance gates; and
+5. publish a Browser artifact only after the full build and UI matrix passes.
+
+The source snapshot is not release-ready until every item in
+[`IMPORT_PROVENANCE.md`](IMPORT_PROVENANCE.md) is resolved.
+
+## Planned layout
+
+- `overlay/` mirrors paths in the Chromium source tree.
+- `patches/` contains reviewable changes to existing Chromium files.
+- `scripts/` bootstraps, applies, builds, tests, packages, and verifies the
+  pinned product.
+- `tests/` contains UI and end-to-end coverage.
+- `tools/` contains focused local test harnesses.
+- `docs/` contains durable architecture and contributor documentation.
+
+## License
+
+Manaflow-owned Browser code follows cmux's root
+GPL-3.0-or-later/commercial dual-license policy unless a file says otherwise.
+Third-party and derived files retain their original licenses. In particular,
+Chromium-derived material is BSD-3-Clause and Helium-derived material is
+GPL-3.0-only; neither is relicensed merely by being stored here.
+
+See [`IMPORT_PROVENANCE.md`](IMPORT_PROVENANCE.md) for the import boundary and
+the repository's `THIRD_PARTY_LICENSES.md` for shipped notices.

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -56,4 +56,6 @@ published GPL version, and it does not extend to third-party code or outside
 contributions without the necessary relicensing rights.
 
 See [`IMPORT_PROVENANCE.md`](IMPORT_PROVENANCE.md) for the import boundary and
-the repository's `THIRD_PARTY_LICENSES.md` for shipped notices.
+the repository's `THIRD_PARTY_LICENSES.md` for the current cmux dependency
+inventory. That root inventory is not a complete Browser binary notice bundle;
+target-specific Browser notices remain a release gate.

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -33,11 +33,22 @@ The source snapshot is not release-ready until every item in
 
 ## License
 
-Manaflow-owned Browser code follows cmux's root
-GPL-3.0-or-later/commercial dual-license policy unless a file says otherwise.
+This import does not change cmux's root license. Browser code for which
+Manaflow controls the necessary rights is available under
+GPL-3.0-or-later. Manaflow may separately offer commercial terms only for
+those rights-controlled portions. This is not a blanket dual-license claim
+over the Browser binary or every file in this directory.
+
 Third-party and derived files retain their original licenses. In particular,
-Chromium-derived material is BSD-3-Clause and Helium-derived material is
-GPL-3.0-only; neither is relicensed merely by being stored here.
+Chromium-derived material is BSD-3-Clause, Helium-derived material and uBlock
+Origin are GPL-3.0-only, and Ghostty and Bonsplit are MIT;
+none is relicensed merely by being stored or distributed with the Browser.
+
+AGPL is not the default for the desktop Browser. Its additional protection is
+aimed at modified software offered for remote network use, while GPL already
+requires source for distributed desktop forks. A future hosted service may use
+AGPL as a separately reviewed component decision, but changing this directory
+to AGPL would require a distinct policy and legal review.
 
 Manaflow may offer later versions of code for which it controls the copyright
 under different terms. That does not revoke the rights already granted for a

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -39,5 +39,10 @@ Third-party and derived files retain their original licenses. In particular,
 Chromium-derived material is BSD-3-Clause and Helium-derived material is
 GPL-3.0-only; neither is relicensed merely by being stored here.
 
+Manaflow may offer later versions of code for which it controls the copyright
+under different terms. That does not revoke the rights already granted for a
+published GPL version, and it does not extend to third-party code or outside
+contributions without the necessary relicensing rights.
+
 See [`IMPORT_PROVENANCE.md`](IMPORT_PROVENANCE.md) for the import boundary and
 the repository's `THIRD_PARTY_LICENSES.md` for shipped notices.


### PR DESCRIPTION
This is the first PR in the Browser-to-cmux migration stack. It is intentionally a foundation-only change: no private Browser source or history is published yet.

It establishes:
- the monorepo boundary for the Chromium overlay product;
- curated-snapshot provenance instead of importing private Git history;
- per-file treatment for Manaflow, Chromium, Helium, and mixed-origin code;
- exact Chromium, Ghostty, cmux TUI, uBlock, notices, and corresponding-source gates;
- private-infrastructure and self-hosted-runner safety rules; and
- the staged source/build/CI/release import sequence.

The desktop default remains GPL-3.0-or-later for Browser code whose necessary rights Manaflow controls; commercial terms can cover only those rights-controlled portions. AGPL is reserved for a separately reviewed hosted-service component if the network-use clause becomes relevant. Third-party terms remain file-specific, and Helium-derived GPL-3.0-only code is never covered by Manaflow commercial terms.

Stack:
- base: #8476
- next: #8713, the CI-backed cmux TUI protocol source slice from frozen Browser snapshot `b3ea02c2`
- then: #8717, the audited terminal-host wire-protocol slice
- later: additional per-file audited source slices and packaged-binary compliance gates

Validation:
- git diff --check
- public-path/private-infrastructure string audit for the new files
- redacted gitleaks v8.30.1 full-history scan of the private source branch; one documented sequential test-fixture false positive, no credential finding

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787359090&installation_model_id=21920&pr_number=8702&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8702&signature=a430aa6799aad47e6ed6623c29bf7c474d8fab159d8fb3699fe8dc0c875cbd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up the public-import foundation for the Chromium-based `cmux` Browser with strict provenance, license boundaries, and fail-closed gates; imports a curated snapshot without private history and tightens commercial-license scope in the root `LICENSE`/`README`.

- `cmux-browser/README.md`, `AGENTS.md`, and `IMPORT_PROVENANCE.md` added; root `LICENSE` and `README.md` updated to bound commercial terms to Manaflow rights-controlled code and to avoid implied relicensing of third-party material.

- **Migration**
  - Defines Chromium overlay layout and monorepo resolution to `../cmux-tui` and `../ghostty` (gitlink).
  - Uses a curated snapshot import and excludes private infra and generated artifacts.

- **Compliance Gates**
  - Rights-controlled boundary: GPL-3.0-or-later for Manaflow-controlled code; commercial terms only where rights exist; no relicensing of third-party or outside contributions; see `THIRD_PARTY_LICENSES.md`; AGPL is not the desktop default.
  - Per-file provenance classes with exact mapping; fail closed if any shipped file lacks a license mapping.
  - Exact pins/manifests: `Chromium` commit+DEPS, `Ghostty` commit, `uBlock` payload digest, `Bonsplit` revision; include generated notices and in-app corresponding source; static LGPL relinking path must be provided.
  - Bundled resources: per-item license checks for fonts/themes/assets with source URLs and revisions.
  - Safety/validation: redacted secret scans, public CI only (no private runners), trusted full `Chromium` build, and macOS XCUITest terminal-render matrix before release.
  - Governance: documented chain of title, ICLA/CCLA workflow, required CODEOWNER review, and non-bypassable branch/status checks.
  - Release composition gates for public GPL vs any future commercial build, including treatment of `Helium` (GPL-3.0-only), `uBlock` (GPL-3.0-only), `cmux` TUI (GPL), and static LGPL relinking.

<sup>Written for commit e897f771e1107395c455769fee7aaaf56b3cc714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



