### PR TITLE
Preserve surface IDs in workstream events

### DIFF
--- a/Sources/CmuxEventPublishing.swift
+++ b/Sources/CmuxEventPublishing.swift
@@ -424,6 +424,7 @@ extension CmuxEventBus {
             category: "agent",
             source: event.source,
             workspaceId: event.workspaceId,
+            surfaceId: event.surfaceId,
             payload: payload
         )
 
@@ -432,6 +433,7 @@ extension CmuxEventBus {
             category: "feed",
             source: event.source,
             workspaceId: event.workspaceId,
+            surfaceId: event.surfaceId,
             payload: payload
         )
     }
@@ -442,6 +444,7 @@ extension CmuxEventBus {
             "hook_event_name": event.hookEventName.rawValue,
             "_source": event.source,
             "workspace_id": event.workspaceId ?? NSNull(),
+            "surface_id": event.surfaceId ?? NSNull(),
             "cwd": event.cwd ?? NSNull(),
             "tool_name": event.toolName ?? NSNull(),
             "_opencode_request_id": event.requestId ?? NSNull(),

--- a/cmuxTests/CmuxEventBusTests.swift
+++ b/cmuxTests/CmuxEventBusTests.swift
@@ -497,6 +497,31 @@ final class CmuxEventBusTests: XCTestCase {
         XCTAssertFalse(line.contains("secret"))
     }
 
+    func testPublishWorkstreamEventPreservesSurfaceId() throws {
+        let bus = CmuxEventBus(retainedEventLimit: 4)
+        let event = WorkstreamEvent(
+            sessionId: "session",
+            hookEventName: .stop,
+            source: "codex",
+            workspaceId: "workspace",
+            surfaceId: "surface"
+        )
+
+        bus.publishWorkstreamEvent(event, phase: "received")
+
+        let published = bus.retainedSnapshot()
+        XCTAssertEqual(published.count, 2)
+        XCTAssertEqual(published.compactMap { $0["name"] as? String }, [
+            "agent.hook.Stop",
+            "feed.item.received",
+        ])
+        for publishedEvent in published {
+            XCTAssertEqual(publishedEvent["surface_id"] as? String, "surface")
+            let payload = try XCTUnwrap(publishedEvent["payload"] as? [String: Any])
+            XCTAssertEqual(payload["surface_id"] as? String, "surface")
+        }
+    }
+
     func testPublishAppendsDurableEventLog() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-event-log-\(UUID().uuidString)", isDirectory: true)

--- a/docs/events.md
+++ b/docs/events.md
@@ -349,15 +349,17 @@ plugin bridge. The event stream publishes both agent and Feed events:
 
 ```json
 {
-  "name": "agent.hook.PermissionRequest",
+  "name": "agent.hook.Stop",
   "category": "agent",
   "source": "codex",
   "workspace_id": "9B6920C1-6C29-4C27-A069-78CF285F932A",
+  "surface_id": "83F4E6A4-5246-4DB8-A412-9CE7B059FA6C",
   "payload": {
     "session_id": "session-123",
-    "hook_event_name": "PermissionRequest",
+    "hook_event_name": "Stop",
     "_source": "codex",
-    "tool_name": "exec_command",
+    "surface_id": "83F4E6A4-5246-4DB8-A412-9CE7B059FA6C",
+    "tool_name": null,
     "_opencode_request_id": "request-456",
     "phase": "received"
   }
@@ -366,6 +368,8 @@ plugin bridge. The event stream publishes both agent and Feed events:
 
 The `feed.item.completed` event contains the same workstream payload plus a
 `result` object matching the `feed.push` socket response.
+When an incoming hook event includes a `surface_id`, it is preserved both on
+the event envelope and in its workstream payload.
 
 ## Privacy
 


### PR DESCRIPTION
## Summary

- Preserve `surface_id` in agent and feed events.
- Let event consumers map events to the correct terminal surface.

## Testing

- Added a regression test for both event types.
- Ran Swift parse, test determinism, and project wiring checks.
- Full Xcode tests were not run because this machine only has Command Line Tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved surface identifiers when publishing agent hook and workstream feed events.
  * Included surface identifiers consistently in event metadata and payloads.

* **Documentation**
  * Updated agent hook examples and documented surface identifier propagation.

* **Tests**
  * Added coverage verifying surface identifiers are retained across published events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->