### PR TITLE
remote-tmux: parse a session list that arrives with CRLF line endings

### DIFF
--- a/Sources/RemoteTmuxSessionListParser.swift
+++ b/Sources/RemoteTmuxSessionListParser.swift
@@ -43,12 +43,15 @@ enum RemoteTmuxSessionListParser {
     /// - Returns: one ``RemoteTmuxSession`` per well-formed line, in input order.
     static func parse(_ output: String) -> [RemoteTmuxSession] {
         var sessions: [RemoteTmuxSession] = []
-        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
-            var line = String(rawLine)
-            if line.last == "\r" {
-                line.removeLast()
-            }
-            if line.isEmpty { continue }
+        // Swift treats CRLF as one Character, so `split(separator: "\n")` finds no
+        // separator in a CRLF listing and `line.last == "\r"` never matches either:
+        // the last Character of `…crlf\r\n` is `"\r\n"`. The whole listing then parses
+        // as one session whose name swallows the rest. A remote running the command
+        // under a pty sends CRLF, because ONLCR rewrites every `\n`. `isNewline`
+        // matches `\n`, `\r` and CRLF, and empty subsequences are omitted, so blank
+        // lines drop out. The sibling parser in RemoteTmuxVersion.swift already does this.
+        for rawLine in output.split(whereSeparator: \.isNewline) {
+            let line = String(rawLine)
             // Unbounded split: the first four fields are id/windows/attached/
             // created, and the name (which may itself contain `:`) is reassembled
             // from the remainder below via `fields[4...].joined`, so a name with


### PR DESCRIPTION
A remote that runs tmux under a pty sends CRLF, because ONLCR rewrites every newline on the way out. The session-list parser could not read that.

It split on `"\n"` and then tried to strip a trailing `"\r"`, and neither step works. Swift treats CRLF as a **single** `Character`, so the split finds no separator, and `line.last == "\r"` never matches either, because the last `Character` of `…crlf\r\n` is `"\r\n"`. Both halves of the existing handling are dead on exactly the input they were written for.

The whole listing then parsed as one session whose name swallowed the rest of the output, so a host like that showed a single bogus workspace instead of its sessions.

The fix splits on any newline, which is what the sibling parser for this same transport's stdout already does in `RemoteTmuxVersion.swift`. The manual `\r` strip and the empty-line guard both go away, since `split(whereSeparator:)` omits empty subsequences. `TerminalController.swift` documents this Swift trap in a comment, and a dozen other call sites in `Sources/` already use the newline-aware form, so this parser was the outlier rather than the precedent.

## Verified

```
before   RemoteTmuxSessionListParserTests   8 tests   ** TEST FAILED **
after    RemoteTmuxSessionListParserTests   8 tests   ** TEST SUCCEEDED **
```

Both arms on the same worktree and warm derived-data path, one suite per app host, with only this change between them. The failing test is `preservesNameWhitespaceAndStripsLineTerminator`, which asserts `sessions[1].name == "crlf"` and got `"crlf\r\n"`. Its line count was already correct at 2, so the defect was the name rather than the split, which is what pointed at the dead strip.

## Scope

`RemoteTmuxSSHTransport.listSessions()` is the only production caller and it passes raw ssh stdout straight through, so the change can only parse more listings correctly. The wire format is untouched: the `-F` request and the `:` delimiter are unchanged.

One honest edge: `Character.isNewline` also matches VT, FF, NEL, LS and PS, so a session name containing one of those would now split where it previously came through raw. That is hard to hit in practice, since tmux rewrites non-printable ASCII to `_` for a non-UTF-8 client, and such a name is already ambiguous in a newline-delimited protocol. If the tighter set is preferred, `split(whereSeparator: { $0 == "\n" || $0 == "\r" || $0 == "\r\n" })` keeps the fix and changes nothing else.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787359938&installation_model_id=21920&pr_number=8704&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8704&signature=ecde980af43f23bcde7c8a4ff5429108169b0ceaf4ea19e57a37c51bd5878247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix tmux session list parsing when output uses CRLF line endings (e.g., tmux under a pty with ONLCR). We now split on any newline, so names are correct and listings don’t collapse into one entry.

- **Bug Fixes**
  - Parse with `split(whereSeparator: \.isNewline)` to handle `LF`, `CR`, and `CRLF`; removed manual `\r` trim and the empty-line guard.
  - Aligns with `RemoteTmuxVersion.swift`; fixes the failing test (`preservesNameWhitespaceAndStripsLineTerminator`).

<sup>Written for commit f03e46027dd4c5aadf17e232bab5aa88f7133a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote session list parsing for Windows-style CRLF line endings.
  * Empty lines are now ignored, ensuring sessions are displayed individually and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->