### PR TITLE
Open a browser at the end of the tab strip, not one slot short

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7838,9 +7838,13 @@ final class Workspace: Identifiable, ObservableObject {
         setPreferredBrowserProfileID(browserPanel.profileID)
 
         // Keyboard/browser-open paths want "new tab at end" regardless of global new-tab placement.
+        // `reorderTab` takes a bonsplit insertion gap, not a final position, so the end of
+        // the strip is `count`, not `count - 1`. The old value asked for the gap in front of
+        // the last tab, which left the browser one slot short. It looked correct whenever
+        // exactly one tab followed the insertion point, because then the two agree.
         if insertAtEnd {
-            let targetIndex = max(0, bonsplitController.tabs(inPane: paneId).count - 1)
-            _ = bonsplitController.reorderTab(newTabId, toIndex: targetIndex)
+            let endInsertionGap = bonsplitController.tabs(inPane: paneId).count
+            _ = bonsplitController.reorderTab(newTabId, toIndex: endInsertionGap)
         }
         publishCmuxSurfaceCreated(browserPanel.id, paneId: paneId, kind: "browser", origin: "browser_tab", focused: shouldFocusNewTab)
 


### PR DESCRIPTION
`openBrowser(insertAtEnd:)` passed a final position to `reorderTab`, which is addressed in bonsplit insertion gaps rather than positions. The end of the strip is `count`, not `count - 1`, so the old value asked for the gap in front of the last tab and left the new browser one slot short of the end.

It looked correct whenever exactly one tab followed the insertion point, because a position and a gap agree there. That is why the existing test did not catch it: it builds only two tabs, so the bug shows up as "the reorder did nothing" rather than "the browser landed in the wrong place".

## Verified

```
before   TabManagerSurfaceCreationTests   11 tests   1 failure    ** TEST FAILED **
after    TabManagerSurfaceCreationTests   11 tests   0 failures   ** TEST SUCCEEDED **
```

Both arms on the same worktree and warm derived-data path, one suite per app host, with only this change between them.

## Notes

`max(0, …)` is dropped because the tab being reordered was just created in this pane, so the count is at least one, and `reorderTab` already clamps its argument with `max(0, min(toIndex, pane.tabs.count))`. The statement count, the guard and the discarded return are otherwise unchanged.

Worth pairing with a test that puts more than one tab after the insertion point, so a future off-by-one shows up as a wrong index instead of a silent no-op. I left that out of this change to keep the diff to the defect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787359973&installation_model_id=21920&pr_number=8705&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8705&signature=8592ce87dd51f330811d6a71693523b41281c06508ccc3a7756bd2740a3c5ec6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix off-by-one that placed a new browser one slot before the end of the tab strip. When `insertAtEnd` is true, we now pass the pane’s tab `count` (insertion gap) to `reorderTab` so the tab opens at the true end; this also fixes the failing `TabManagerSurfaceCreationTests`.

<sup>Written for commit d531738c4b7140543039c6acff96d29bfea6bef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed new browser tabs being placed incorrectly when opened at the end of the tab strip.
  * New tabs now consistently appear after all existing tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->