### PR TITLE
Fix sendable shell executable check

### DIFF
--- a/Sources/TerminalShellResolver+CurrentUser.swift
+++ b/Sources/TerminalShellResolver+CurrentUser.swift
@@ -7,7 +7,9 @@ extension TerminalShellResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         shellsFileURL: URL = URL(fileURLWithPath: "/etc/shells")
     ) -> String? {
-        TerminalShellResolver(isExecutable: FileManager.default.isExecutableFile(atPath:))
+        TerminalShellResolver(isExecutable: { path in
+            FileManager.default.isExecutableFile(atPath: path)
+        })
             .resolve(
                 loginShell: currentUserDatabaseShell(),
                 environmentShell: environment["SHELL"],


### PR DESCRIPTION
`TerminalShellResolver` requires an `@Sendable` executable predicate. Passing the `FileManager` method reference directly emits a Swift 6 conversion warning and breaks the zero-warning CI budget on current `main`.

Wrap the call in an inferred `@Sendable` closure so the compiler checks the actual implementation instead of converting a non-sendable function value. Runtime behavior is unchanged.

Caught by the exact machine-sidebar prerequisite and full-stack gates:
- https://github.com/manaflow-ai/cmux/actions/runs/29970840237
- https://github.com/manaflow-ai/cmux/actions/runs/29970840276

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787361666&installation_model_id=21920&pr_number=8707&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8707&signature=fb2ac160cf252a3e476b79d870ac15b698db4df4f3450e63a9d09fbcc200da33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `TerminalShellResolver` executable predicate to be `@Sendable` by wrapping `FileManager.default.isExecutableFile(atPath:)` in a closure. This removes the Swift 6 conversion warning and keeps CI zero-warning; no runtime behavior change.

<sup>Written for commit 7f416131737001b4de5be702d8279f09b3d1e144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the current user’s terminal shell by reliably verifying whether the shell path is executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->