### PR TITLE
Fix iOS deleted computer recovery empty state

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
@@ -10,6 +10,8 @@ public enum MobileDeletedComputerRecoveryResult: Equatable, Sendable {
     case notFound
     /// A previous recovery attempt is still running, so this tap did not start another scan.
     case alreadyInProgress
+    /// The account or team changed while recovery was running.
+    case staleScope
 }
 
 @MainActor
@@ -38,14 +40,14 @@ extension MobileShellComposite {
         invalidateStoredMacReconnectAttempt()
 
         let discovered = await personalIrohDiscovery.discoverLiveMacs()
-        guard await isScopeCurrent(scope) else { return .notFound }
+        guard await isScopeCurrent(scope) else { return .staleScope }
         let candidates = forgottenIrohRecoveryCandidates(
             from: discovered,
             forgottenIDs: forgottenIDs
         )
 
         for mac in candidates {
-            guard await isScopeCurrent(scope) else { return .notFound }
+            guard await isScopeCurrent(scope) else { return .staleScope }
             guard await isForgottenMacDeviceID(
                 mac.deviceID,
                 instanceTag: mac.instanceTag,
@@ -60,6 +62,7 @@ extension MobileShellComposite {
                         && self.identityProvider?.currentUserID == scope.userID
                 }
             )
+            guard await isScopeCurrent(scope) else { return .staleScope }
             guard recovered else { continue }
             await loadPairedMacs()
             await loadRegistryDevices()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
@@ -2,6 +2,16 @@ import CMUXMobileCore
 import CmuxMobilePairedMac
 import Foundation
 
+/// Result of an explicit, user-triggered deleted-computer recovery attempt.
+public enum MobileDeletedComputerRecoveryResult: Equatable, Sendable {
+    /// A forgotten Mac was found through same-account Iroh discovery and persisted again.
+    case recovered
+    /// No eligible forgotten Mac was live for the current account/team scope.
+    case notFound
+    /// A previous recovery attempt is still running, so this tap did not start another scan.
+    case alreadyInProgress
+}
+
 @MainActor
 extension MobileShellComposite {
     /// Recover a deleted Mac through live same-account Iroh discovery.
@@ -12,30 +22,30 @@ extension MobileShellComposite {
     /// connection path must authenticate the Mac's device ID and app-instance tag
     /// before persistence clears the forgotten marker.
     @discardableResult
-    public func recoverForgottenIrohMacFromAccount() async -> Bool {
-        guard !isRecoveringDeletedComputer else { return false }
+    public func recoverForgottenIrohMacFromAccount() async -> MobileDeletedComputerRecoveryResult {
+        guard !isRecoveringDeletedComputer else { return .alreadyInProgress }
         isRecoveringDeletedComputer = true
         defer { isRecoveringDeletedComputer = false }
 
         guard isSignedIn,
               let scope = await currentScopeSnapshot(),
-              let personalIrohDiscovery else { return false }
+              let personalIrohDiscovery else { return .notFound }
         let forgottenIDs = await forgottenMacDeviceIDs(scope: scope)
-        guard !forgottenIDs.isEmpty else { return false }
+        guard !forgottenIDs.isEmpty else { return .notFound }
 
         connectionRecoveryOwner.cancel()
         applyConnectionRecoveryOwnerState()
         invalidateStoredMacReconnectAttempt()
 
         let discovered = await personalIrohDiscovery.discoverLiveMacs()
-        guard await isScopeCurrent(scope) else { return false }
+        guard await isScopeCurrent(scope) else { return .notFound }
         let candidates = forgottenIrohRecoveryCandidates(
             from: discovered,
             forgottenIDs: forgottenIDs
         )
 
         for mac in candidates {
-            guard await isScopeCurrent(scope) else { return false }
+            guard await isScopeCurrent(scope) else { return .notFound }
             guard await isForgottenMacDeviceID(
                 mac.deviceID,
                 instanceTag: mac.instanceTag,
@@ -53,9 +63,9 @@ extension MobileShellComposite {
             guard recovered else { continue }
             await loadPairedMacs()
             await loadRegistryDevices()
-            return true
+            return .recovered
         }
-        return false
+        return .notFound
     }
 
     private func forgottenIrohRecoveryCandidates(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
@@ -13,6 +13,10 @@ extension MobileShellComposite {
     /// before persistence clears the forgotten marker.
     @discardableResult
     public func recoverForgottenIrohMacFromAccount() async -> Bool {
+        guard !isRecoveringDeletedComputer else { return false }
+        isRecoveringDeletedComputer = true
+        defer { isRecoveringDeletedComputer = false }
+
         guard isSignedIn,
               let scope = await currentScopeSnapshot(),
               let personalIrohDiscovery else { return false }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacRecovery.swift
@@ -59,6 +59,7 @@ extension MobileShellComposite {
                 ifStillCurrent: { [weak self] in
                     guard let self else { return false }
                     return self.isSignedIn
+                        && self.secondaryAggregationScopeGeneration == scope.generation
                         && self.identityProvider?.currentUserID == scope.userID
                 }
             )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2136,6 +2136,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// True when the current account/team scope has a deleted-computer marker
     /// that can be recovered through explicit same-account Iroh discovery.
     public internal(set) var hasRecoverableDeletedComputers = false
+    /// True while the explicit deleted-computer recovery path is scanning and
+    /// reconnecting through account-scoped Iroh discovery.
+    public internal(set) var isRecoveringDeletedComputer = false
 
     var pairedMacsForIdentityMatching: [MobilePairedMac] {
         storedPairedMacs.isEmpty ? pairedMacs : storedPairedMacs
@@ -2378,6 +2381,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             loaded = try await pairedMacStore.loadAll(stackUserID: scope.userID, teamID: scope.teamID)
         } catch {
             mobileShellLog.error("paired mac store loadAll failed: \(String(describing: error), privacy: .public)")
+            hasRecoverableDeletedComputers = false
             return
         }
         // The await above suspended the main actor; a sign-out, user switch, or

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1259,6 +1259,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         storedPairedMacs = []
         pairedMacAliasIDsByRepresentativeID = [:]
         pairedMacs = []
+        pairedMacLoadState = .notLoaded
         hasRecoverableDeletedComputers = false
         resetTerminalThemes()
         // Likewise drop the registry-backed device tree so a shared device never
@@ -1371,6 +1372,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         storedPairedMacs = []
         pairedMacAliasIDsByRepresentativeID = [:]
         pairedMacs = []
+        pairedMacLoadState = .notLoaded
         forgottenMacDeviceIDsByScope = [:]
         hasRecoverableDeletedComputers = false
         registryDevices = []
@@ -2107,6 +2109,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     // MARK: - Paired Mac switching
 
+    /// Whether the current signed-in scope's paired-Mac list is known.
+    public enum PairedMacLoadState: Equatable, Sendable {
+        /// No load has completed for the current scope.
+        case notLoaded
+        /// The current scope's paired-Mac list loaded successfully.
+        case loaded
+        /// The current scope's paired-Mac list could not be loaded.
+        case failed
+    }
+
     /// Every Mac paired with this device, for the host switcher. Refreshed via
     /// ``loadPairedMacs()`` and after switch/forget. Cleared on sign-out so a
     /// shared device never shows the previous user's Macs. The active row is
@@ -2122,6 +2134,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Full store rows for identity-sensitive paths; ``pairedMacs`` is display-coalesced.
     private var storedPairedMacs: [MobilePairedMac] = []
+    /// Load status for ``pairedMacs`` in the current signed-in account/team scope.
+    public internal(set) var pairedMacLoadState: PairedMacLoadState = .notLoaded
     /// Visible representative id to all stored ids for that logical paired Mac.
     public private(set) var pairedMacAliasIDsByRepresentativeID: [String: [String]] = [:]
     /// Same-session delete tombstones keyed by signed-in account/team scope.
@@ -2373,15 +2387,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             storedPairedMacs = []
             pairedMacAliasIDsByRepresentativeID = [:]
             pairedMacs = []
+            pairedMacLoadState = .failed
             hasRecoverableDeletedComputers = false
             return
         }
+        pairedMacLoadState = .notLoaded
         let loaded: [MobilePairedMac]
         do {
             loaded = try await pairedMacStore.loadAll(stackUserID: scope.userID, teamID: scope.teamID)
         } catch {
             mobileShellLog.error("paired mac store loadAll failed: \(String(describing: error), privacy: .public)")
             if await isScopeCurrent(scope) {
+                pairedMacLoadState = .failed
                 hasRecoverableDeletedComputers = false
             }
             return
@@ -2398,6 +2415,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return
         }
         hasRecoverableDeletedComputers = hasForgottenMacs
+        pairedMacLoadState = .loaded
         storedPairedMacs = visibleLoaded
         let supportedRouteKinds = runtime?.supportedRouteKinds ?? []
         let coalesced = Self.coalescePairedMacsByDialEndpoint(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -2381,7 +2381,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             loaded = try await pairedMacStore.loadAll(stackUserID: scope.userID, teamID: scope.teamID)
         } catch {
             mobileShellLog.error("paired mac store loadAll failed: \(String(describing: error), privacy: .public)")
-            hasRecoverableDeletedComputers = false
+            if await isScopeCurrent(scope) {
+                hasRecoverableDeletedComputers = false
+            }
             return
         }
         // The await above suspended the main actor; a sign-out, user switch, or

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -176,6 +176,59 @@ struct IrohZeroTouchDiscoveryTests {
     }
 
     @Test
+    func concurrentExplicitRecoveryReturnsAlreadyInProgress() async throws {
+        let live = try candidate(deviceID: "mac-a", endpointByte: "a")
+        let discovery = SuspendedIrohDiscovery(candidates: [live])
+        let fixture = try await makeFixture(
+            discovery: discovery,
+            reportedDeviceID: "mac-a"
+        )
+        defer { fixture.cleanup() }
+        let scope = try #require(await fixture.shell.currentScopeSnapshot(userID: "user-1"))
+        await fixture.shell.rememberForgottenMacDeviceID(
+            MobilePairedMac.pairingID(macDeviceID: "mac-a", instanceTag: "stable"),
+            scope: scope
+        )
+        let firstRecovery = Task { @MainActor in
+            await fixture.shell.recoverForgottenIrohMacFromAccount()
+        }
+        await discovery.waitUntilRequested()
+
+        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount() == .alreadyInProgress)
+
+        discovery.resume()
+        #expect(await firstRecovery.value == .recovered)
+        #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"])
+    }
+
+    @Test
+    func signOutWhileExplicitRecoveryIsSuspendedReturnsStaleScope() async throws {
+        let live = try candidate(deviceID: "mac-a", endpointByte: "a")
+        let discovery = SuspendedIrohDiscovery(candidates: [live])
+        let fixture = try await makeFixture(
+            discovery: discovery,
+            reportedDeviceID: "mac-a"
+        )
+        defer { fixture.cleanup() }
+        let scope = try #require(await fixture.shell.currentScopeSnapshot(userID: "user-1"))
+        await fixture.shell.rememberForgottenMacDeviceID(
+            MobilePairedMac.pairingID(macDeviceID: "mac-a", instanceTag: "stable"),
+            scope: scope
+        )
+        let recovery = Task { @MainActor in
+            await fixture.shell.recoverForgottenIrohMacFromAccount()
+        }
+        await discovery.waitUntilRequested()
+
+        fixture.shell.signOut()
+        discovery.resume()
+
+        #expect(await recovery.value == .staleScope)
+        #expect(fixture.factory.attemptedRouteIDs().isEmpty)
+        #expect(try await fixture.store.loadAll(stackUserID: "user-1", teamID: nil).isEmpty)
+    }
+
+    @Test
     func unreachableCandidateFallsThroughToNextLiveMac() async throws {
         let first = try candidate(deviceID: "mac-a", endpointByte: "a")
         let second = try candidate(deviceID: "mac-b", endpointByte: "b")

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -229,6 +229,33 @@ struct IrohZeroTouchDiscoveryTests {
     }
 
     @Test
+    func teamSwitchWhileExplicitRecoveryIsSuspendedReturnsStaleScope() async throws {
+        let live = try candidate(deviceID: "mac-a", endpointByte: "a")
+        let discovery = SuspendedIrohDiscovery(candidates: [live])
+        let fixture = try await makeFixture(
+            discovery: discovery,
+            reportedDeviceID: "mac-a"
+        )
+        defer { fixture.cleanup() }
+        let scope = try #require(await fixture.shell.currentScopeSnapshot(userID: "user-1"))
+        await fixture.shell.rememberForgottenMacDeviceID(
+            MobilePairedMac.pairingID(macDeviceID: "mac-a", instanceTag: "stable"),
+            scope: scope
+        )
+        let recovery = Task { @MainActor in
+            await fixture.shell.recoverForgottenIrohMacFromAccount()
+        }
+        await discovery.waitUntilRequested()
+
+        fixture.shell.currentTeamDidChange()
+        discovery.resume()
+
+        #expect(await recovery.value == .staleScope)
+        #expect(fixture.factory.attemptedRouteIDs().isEmpty)
+        #expect(try await fixture.store.loadAll(stackUserID: "user-1", teamID: nil).isEmpty)
+    }
+
+    @Test
     func unreachableCandidateFallsThroughToNextLiveMac() async throws {
         let first = try candidate(deviceID: "mac-a", endpointByte: "a")
         let second = try candidate(deviceID: "mac-b", endpointByte: "b")

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -98,7 +98,7 @@ struct IrohZeroTouchDiscoveryTests {
 
         await fixture.shell.loadPairedMacs()
         #expect(fixture.shell.hasRecoverableDeletedComputers)
-        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount())
+        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount() == .recovered)
 
         #expect(fixture.shell.connectionState == .connected)
         #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"])
@@ -141,7 +141,7 @@ struct IrohZeroTouchDiscoveryTests {
 
         await fixture.shell.loadPairedMacs()
         #expect(fixture.shell.hasRecoverableDeletedComputers)
-        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount())
+        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount() == .recovered)
 
         #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"])
         let rows = try await fixture.store.loadAll(stackUserID: "user-1", teamID: nil)
@@ -163,7 +163,7 @@ struct IrohZeroTouchDiscoveryTests {
             scope: scope
         )
 
-        #expect(!(await fixture.shell.recoverForgottenIrohMacFromAccount()))
+        #expect(await fixture.shell.recoverForgottenIrohMacFromAccount() == .notFound)
 
         #expect(fixture.shell.connectionState == .disconnected)
         #expect(fixture.factory.attemptedRouteIDs() == ["iroh-mac-a"])

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
@@ -1,14 +1,16 @@
 #if os(iOS)
+import CmuxMobileShell
 import CmuxMobileSupport
 import SwiftUI
 
 struct DeletedComputerRecoveryButton: View {
     var isProminent = false
     let isRecovering: Bool
-    let recover: @MainActor () async -> Bool
+    let recover: @MainActor () async -> MobileDeletedComputerRecoveryResult
     let reloadAfterFailure: @MainActor () async -> Void
 
     @State private var alertMessage: String?
+    @State private var recoveryTask: Task<Void, Never>?
 
     @ViewBuilder
     var body: some View {
@@ -45,6 +47,7 @@ struct DeletedComputerRecoveryButton: View {
         } message: {
             Text(alertMessage ?? "")
         }
+        .onDisappear(perform: cancelRecoveryTask)
     }
 
     private var alertPresented: Binding<Bool> {
@@ -57,15 +60,26 @@ struct DeletedComputerRecoveryButton: View {
     }
 
     private func recoverDeletedComputer() {
-        guard !isRecovering else { return }
+        guard !isRecovering, recoveryTask == nil else { return }
         alertMessage = nil
-        Task { @MainActor in
-            let recovered = await recover()
-            if !recovered {
+        recoveryTask = Task { @MainActor in
+            let result = await recover()
+            guard !Task.isCancelled else { return }
+            switch result {
+            case .recovered, .alreadyInProgress:
+                break
+            case .notFound:
                 await reloadAfterFailure()
+                guard !Task.isCancelled else { return }
                 alertMessage = failureMessage
             }
+            recoveryTask = nil
         }
+    }
+
+    private func cancelRecoveryTask() {
+        recoveryTask?.cancel()
+        recoveryTask = nil
     }
 
     private var recoveringTitle: String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
@@ -26,16 +26,16 @@ struct DeletedComputerRecoveryButton: View {
     private var recoveryButton: some View {
         Button(action: recoverDeletedComputer) {
             Label {
-                Text(isRecovering ? recoveringTitle : title)
+                Text(isRecoveryInProgress ? recoveringTitle : title)
             } icon: {
-                if isRecovering {
+                if isRecoveryInProgress {
                     ProgressView().controlSize(.small)
                 } else {
                     Image(systemName: "arrow.uturn.backward")
                 }
             }
         }
-        .disabled(isRecovering)
+        .disabled(isRecoveryInProgress)
         .accessibilityIdentifier("MobileRecoverDeletedComputerButton")
         .alert(
             failureTitle,
@@ -50,6 +50,10 @@ struct DeletedComputerRecoveryButton: View {
         .onDisappear(perform: cancelRecoveryTask)
     }
 
+    private var isRecoveryInProgress: Bool {
+        isRecovering || recoveryTask != nil
+    }
+
     private var alertPresented: Binding<Bool> {
         Binding(
             get: { alertMessage != nil },
@@ -60,9 +64,10 @@ struct DeletedComputerRecoveryButton: View {
     }
 
     private func recoverDeletedComputer() {
-        guard !isRecovering, recoveryTask == nil else { return }
+        guard !isRecoveryInProgress else { return }
         alertMessage = nil
         recoveryTask = Task { @MainActor in
+            defer { recoveryTask = nil }
             let result = await recover()
             guard !Task.isCancelled else { return }
             switch result {
@@ -73,7 +78,6 @@ struct DeletedComputerRecoveryButton: View {
                 guard !Task.isCancelled else { return }
                 alertMessage = failureMessage
             }
-            recoveryTask = nil
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
@@ -66,7 +66,7 @@ struct DeletedComputerRecoveryButton: View {
             let result = await recover()
             guard !Task.isCancelled else { return }
             switch result {
-            case .recovered, .alreadyInProgress:
+            case .recovered, .alreadyInProgress, .staleScope:
                 break
             case .notFound:
                 await reloadAfterFailure()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
@@ -1,0 +1,137 @@
+#if os(iOS)
+import CmuxMobileSupport
+import SwiftUI
+
+@MainActor
+private enum DeletedComputerRecoveryCopy {
+    static var recoveringTitle: String {
+        L10n.string(
+            "mobile.computers.recoveringDeleted",
+            defaultValue: "Recovering Deleted Computer..."
+        )
+    }
+
+    static var title: String {
+        L10n.string(
+            "mobile.computers.recoverDeleted",
+            defaultValue: "Recover Deleted Computer"
+        )
+    }
+
+    static var footer: String {
+        L10n.string(
+            "mobile.computers.recoverDeletedFooter",
+            defaultValue: "Deleted computers stay hidden on this phone. To recover one, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
+        )
+    }
+
+    static var failureTitle: String {
+        L10n.string(
+            "mobile.computers.recoverFailedTitle",
+            defaultValue: "Couldn't recover computer"
+        )
+    }
+
+    static var failureMessage: String {
+        L10n.string(
+            "mobile.computers.recoverFailedMessage",
+            defaultValue: "No deleted computer was recovered. Open cmux on the Mac, sign in to this same account, and try again."
+        )
+    }
+}
+
+struct DeletedComputerRecoveryButton: View {
+    var isProminent = false
+    let recover: @MainActor () async -> Bool
+    let reload: @MainActor () async -> Void
+
+    @State private var isRecovering = false
+    @State private var alertMessage: String?
+    @State private var recoveryTask: Task<Void, Never>?
+    @State private var recoveryAttemptID = 0
+
+    @ViewBuilder
+    var body: some View {
+        if isProminent {
+            recoveryButton
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
+        } else {
+            recoveryButton
+        }
+    }
+
+    private var recoveryButton: some View {
+        Button(action: recoverDeletedComputer) {
+            Label {
+                Text(isRecovering ? DeletedComputerRecoveryCopy.recoveringTitle : DeletedComputerRecoveryCopy.title)
+            } icon: {
+                if isRecovering {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.uturn.backward")
+                }
+            }
+        }
+        .disabled(isRecovering)
+        .accessibilityIdentifier("MobileRecoverDeletedComputerButton")
+        .alert(
+            DeletedComputerRecoveryCopy.failureTitle,
+            isPresented: alertPresented
+        ) {
+            Button(L10n.string("mobile.common.ok", defaultValue: "OK"), role: .cancel) {
+                alertMessage = nil
+            }
+        } message: {
+            Text(alertMessage ?? "")
+        }
+        .onDisappear(perform: cancelRecoveryTask)
+    }
+
+    private var alertPresented: Binding<Bool> {
+        Binding(
+            get: { alertMessage != nil },
+            set: { isPresented in
+                if !isPresented { alertMessage = nil }
+            }
+        )
+    }
+
+    private func recoverDeletedComputer() {
+        guard !isRecovering else { return }
+        isRecovering = true
+        alertMessage = nil
+        recoveryAttemptID += 1
+        let attemptID = recoveryAttemptID
+        recoveryTask = Task { @MainActor in
+            let recovered = await recover()
+            guard isCurrentRecoveryAttempt(attemptID) else { return }
+            await reload()
+            guard isCurrentRecoveryAttempt(attemptID) else { return }
+            isRecovering = false
+            recoveryTask = nil
+            if !recovered {
+                alertMessage = DeletedComputerRecoveryCopy.failureMessage
+            }
+        }
+    }
+
+    private func cancelRecoveryTask() {
+        recoveryAttemptID += 1
+        recoveryTask?.cancel()
+        recoveryTask = nil
+        isRecovering = false
+    }
+
+    private func isCurrentRecoveryAttempt(_ attemptID: Int) -> Bool {
+        !Task.isCancelled && recoveryAttemptID == attemptID
+    }
+}
+
+@MainActor
+struct DeletedComputerRecoveryFooter: View {
+    var body: some View {
+        Text(DeletedComputerRecoveryCopy.footer)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeletedComputerRecoveryButton.swift
@@ -2,53 +2,13 @@
 import CmuxMobileSupport
 import SwiftUI
 
-@MainActor
-private enum DeletedComputerRecoveryCopy {
-    static var recoveringTitle: String {
-        L10n.string(
-            "mobile.computers.recoveringDeleted",
-            defaultValue: "Recovering Deleted Computer..."
-        )
-    }
-
-    static var title: String {
-        L10n.string(
-            "mobile.computers.recoverDeleted",
-            defaultValue: "Recover Deleted Computer"
-        )
-    }
-
-    static var footer: String {
-        L10n.string(
-            "mobile.computers.recoverDeletedFooter",
-            defaultValue: "Deleted computers stay hidden on this phone. To recover one, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
-        )
-    }
-
-    static var failureTitle: String {
-        L10n.string(
-            "mobile.computers.recoverFailedTitle",
-            defaultValue: "Couldn't recover computer"
-        )
-    }
-
-    static var failureMessage: String {
-        L10n.string(
-            "mobile.computers.recoverFailedMessage",
-            defaultValue: "No deleted computer was recovered. Open cmux on the Mac, sign in to this same account, and try again."
-        )
-    }
-}
-
 struct DeletedComputerRecoveryButton: View {
     var isProminent = false
+    let isRecovering: Bool
     let recover: @MainActor () async -> Bool
-    let reload: @MainActor () async -> Void
+    let reloadAfterFailure: @MainActor () async -> Void
 
-    @State private var isRecovering = false
     @State private var alertMessage: String?
-    @State private var recoveryTask: Task<Void, Never>?
-    @State private var recoveryAttemptID = 0
 
     @ViewBuilder
     var body: some View {
@@ -64,7 +24,7 @@ struct DeletedComputerRecoveryButton: View {
     private var recoveryButton: some View {
         Button(action: recoverDeletedComputer) {
             Label {
-                Text(isRecovering ? DeletedComputerRecoveryCopy.recoveringTitle : DeletedComputerRecoveryCopy.title)
+                Text(isRecovering ? recoveringTitle : title)
             } icon: {
                 if isRecovering {
                     ProgressView().controlSize(.small)
@@ -76,7 +36,7 @@ struct DeletedComputerRecoveryButton: View {
         .disabled(isRecovering)
         .accessibilityIdentifier("MobileRecoverDeletedComputerButton")
         .alert(
-            DeletedComputerRecoveryCopy.failureTitle,
+            failureTitle,
             isPresented: alertPresented
         ) {
             Button(L10n.string("mobile.common.ok", defaultValue: "OK"), role: .cancel) {
@@ -85,7 +45,6 @@ struct DeletedComputerRecoveryButton: View {
         } message: {
             Text(alertMessage ?? "")
         }
-        .onDisappear(perform: cancelRecoveryTask)
     }
 
     private var alertPresented: Binding<Bool> {
@@ -99,39 +58,56 @@ struct DeletedComputerRecoveryButton: View {
 
     private func recoverDeletedComputer() {
         guard !isRecovering else { return }
-        isRecovering = true
         alertMessage = nil
-        recoveryAttemptID += 1
-        let attemptID = recoveryAttemptID
-        recoveryTask = Task { @MainActor in
+        Task { @MainActor in
             let recovered = await recover()
-            guard isCurrentRecoveryAttempt(attemptID) else { return }
-            await reload()
-            guard isCurrentRecoveryAttempt(attemptID) else { return }
-            isRecovering = false
-            recoveryTask = nil
             if !recovered {
-                alertMessage = DeletedComputerRecoveryCopy.failureMessage
+                await reloadAfterFailure()
+                alertMessage = failureMessage
             }
         }
     }
 
-    private func cancelRecoveryTask() {
-        recoveryAttemptID += 1
-        recoveryTask?.cancel()
-        recoveryTask = nil
-        isRecovering = false
+    private var recoveringTitle: String {
+        L10n.string(
+            "mobile.computers.recoveringDeleted",
+            defaultValue: "Recovering Deleted Computer..."
+        )
     }
 
-    private func isCurrentRecoveryAttempt(_ attemptID: Int) -> Bool {
-        !Task.isCancelled && recoveryAttemptID == attemptID
+    private var title: String {
+        L10n.string(
+            "mobile.computers.recoverDeleted",
+            defaultValue: "Recover Deleted Computer"
+        )
+    }
+
+    private var failureTitle: String {
+        L10n.string(
+            "mobile.computers.recoverFailedTitle",
+            defaultValue: "Couldn't recover computer"
+        )
+    }
+
+    private var failureMessage: String {
+        L10n.string(
+            "mobile.computers.recoverFailedMessage",
+            defaultValue: "No deleted computer was recovered. Open cmux on the Mac, sign in to this same account, and try again."
+        )
     }
 }
 
 @MainActor
 struct DeletedComputerRecoveryFooter: View {
     var body: some View {
-        Text(DeletedComputerRecoveryCopy.footer)
+        Text(footer)
+    }
+
+    private var footer: String {
+        L10n.string(
+            "mobile.computers.recoverDeletedFooter",
+            defaultValue: "Deleted computers stay hidden on this phone. To recover one, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
+        )
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -29,10 +29,6 @@ struct DeviceTreeView: View {
     /// Stored at list scope so reusable rows do not own transient presentation
     /// state while `List` is recycling swipe-action rows.
     @State private var computerPendingRemovalID: String?
-    @State private var isRecoveringDeletedComputer = false
-    @State private var recoveryAlertMessage: String?
-    @State private var recoveryTask: Task<Void, Never>?
-    @State private var recoveryAttemptID = 0
 
     /// The user's computers as immutable snapshots, sourced from the paired-Mac
     /// backup (`pairedMacs`) — this feature's source of truth, the same set that
@@ -106,19 +102,6 @@ struct DeviceTreeView: View {
                 }
             }
             .refreshable { await reload() }
-            .alert(
-                L10n.string(
-                    "mobile.computers.recoverFailedTitle",
-                    defaultValue: "Couldn't recover computer"
-                ),
-                isPresented: recoveryAlertPresented
-            ) {
-                Button(L10n.string("mobile.common.ok", defaultValue: "OK"), role: .cancel) {
-                    recoveryAlertMessage = nil
-                }
-            } message: {
-                Text(recoveryAlertMessage ?? "")
-            }
             .task {
                 // This screen is the user's connection-debug view. The online dots
                 // (presence) and secondary workspace counts already update live via
@@ -134,7 +117,6 @@ struct DeviceTreeView: View {
                     await store.refreshComputersScreen()
                 }
             }
-            .onDisappear(perform: cancelRecoveryTask)
         }
         .accessibilityIdentifier("MobileDeviceTree")
     }
@@ -162,32 +144,14 @@ struct DeviceTreeView: View {
     @ViewBuilder
     private var deletedComputerRecoverySection: some View {
         Section {
-            Button(action: recoverDeletedComputer) {
-                Label {
-                    Text(isRecoveringDeletedComputer
-                        ? L10n.string(
-                            "mobile.computers.recoveringDeleted",
-                            defaultValue: "Recovering Deleted Computer…"
-                        )
-                        : L10n.string(
-                            "mobile.computers.recoverDeleted",
-                            defaultValue: "Recover Deleted Computer"
-                        ))
-                } icon: {
-                    if isRecoveringDeletedComputer {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Image(systemName: "arrow.uturn.backward")
-                    }
+            DeletedComputerRecoveryButton(
+                recover: { await store.recoverForgottenIrohMacFromAccount() },
+                reload: {
+                    await reload()
                 }
-            }
-            .disabled(isRecoveringDeletedComputer)
-            .accessibilityIdentifier("MobileRecoverDeletedComputerButton")
+            )
         } footer: {
-            Text(L10n.string(
-                "mobile.computers.recoverDeletedFooter",
-                defaultValue: "Deleted computers stay hidden on this phone. To recover one, open cmux on that Mac, sign in to this same account, then tap Recover Deleted Computer."
-            ))
+            DeletedComputerRecoveryFooter()
         }
     }
 
@@ -232,48 +196,6 @@ struct DeviceTreeView: View {
             )
             await reload()
         }
-    }
-
-    private var recoveryAlertPresented: Binding<Bool> {
-        Binding(
-            get: { recoveryAlertMessage != nil },
-            set: { isPresented in
-                if !isPresented { recoveryAlertMessage = nil }
-            }
-        )
-    }
-
-    private func recoverDeletedComputer() {
-        guard !isRecoveringDeletedComputer else { return }
-        isRecoveringDeletedComputer = true
-        recoveryAlertMessage = nil
-        recoveryAttemptID += 1
-        let attemptID = recoveryAttemptID
-        recoveryTask = Task { @MainActor in
-            let recovered = await store.recoverForgottenIrohMacFromAccount()
-            guard isCurrentRecoveryAttempt(attemptID) else { return }
-            await reload()
-            guard isCurrentRecoveryAttempt(attemptID) else { return }
-            isRecoveringDeletedComputer = false
-            recoveryTask = nil
-            if !recovered {
-                recoveryAlertMessage = L10n.string(
-                    "mobile.computers.recoverFailedMessage",
-                    defaultValue: "No deleted computer was recovered. Open cmux on the Mac, sign in to this same account, and try again."
-                )
-            }
-        }
-    }
-
-    private func cancelRecoveryTask() {
-        recoveryAttemptID += 1
-        recoveryTask?.cancel()
-        recoveryTask = nil
-        isRecoveringDeletedComputer = false
-    }
-
-    private func isCurrentRecoveryAttempt(_ attemptID: Int) -> Bool {
-        !Task.isCancelled && recoveryAttemptID == attemptID
     }
 
     private func reload() async {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -145,8 +145,9 @@ struct DeviceTreeView: View {
     private var deletedComputerRecoverySection: some View {
         Section {
             DeletedComputerRecoveryButton(
+                isRecovering: store.isRecoveringDeletedComputer,
                 recover: { await store.recoverForgottenIrohMacFromAccount() },
-                reload: {
+                reloadAfterFailure: {
                     await reload()
                 }
             )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -235,8 +235,9 @@ struct DisconnectedWorkspaceShellView: View {
             if showsDeletedComputerRecoveryAction, let store {
                 DeletedComputerRecoveryButton(
                     isProminent: true,
+                    isRecovering: store.isRecoveringDeletedComputer,
                     recover: { await store.recoverForgottenIrohMacFromAccount() },
-                    reload: { await reloadAfterDeletedComputerRecovery() }
+                    reloadAfterFailure: { await reloadAfterFailedDeletedComputerRecovery() }
                 )
                 DeletedComputerRecoveryFooter()
                     .font(.footnote)
@@ -270,8 +271,9 @@ struct DisconnectedWorkspaceShellView: View {
     private func deletedComputerRecoverySection(store: CMUXMobileShellStore) -> some View {
         Section {
             DeletedComputerRecoveryButton(
+                isRecovering: store.isRecoveringDeletedComputer,
                 recover: { await store.recoverForgottenIrohMacFromAccount() },
-                reload: { await reloadAfterDeletedComputerRecovery() }
+                reloadAfterFailure: { await reloadAfterFailedDeletedComputerRecovery() }
             )
         } footer: {
             DeletedComputerRecoveryFooter()
@@ -355,7 +357,7 @@ struct DisconnectedWorkspaceShellView: View {
         }
     }
 
-    private func reloadAfterDeletedComputerRecovery() async {
+    private func reloadAfterFailedDeletedComputerRecovery() async {
         await store?.loadPairedMacs()
         await store?.loadRegistryDevices()
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -147,7 +147,10 @@ struct DisconnectedWorkspaceShellView: View {
     }
 
     var shouldAutoPresentAddDeviceAfterLoadingSavedMacs: Bool {
-        (store?.pairedMacs.isEmpty ?? true) && !showsDeletedComputerRecoveryAction
+        guard let store else { return false }
+        return store.pairedMacLoadState == .loaded
+            && store.pairedMacs.isEmpty
+            && !showsDeletedComputerRecoveryAction
     }
 
     @ViewBuilder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -73,7 +73,7 @@ struct DisconnectedWorkspaceShellView: View {
                     // auto-present the pairing sheet when there is nothing to pick,
                     // so a returning user is not buried under the add-device flow.
                     await store?.loadPairedMacs()
-                    if store?.pairedMacs.isEmpty ?? true {
+                    if shouldAutoPresentAddDeviceAfterLoadingSavedMacs {
                         showAddDevice()
                         return
                     }
@@ -142,6 +142,14 @@ struct DisconnectedWorkspaceShellView: View {
         store.map { MacComputerSnapshot.snapshots(from: $0) } ?? []
     }
 
+    var showsDeletedComputerRecoveryAction: Bool {
+        store?.hasRecoverableDeletedComputers == true
+    }
+
+    var shouldAutoPresentAddDeviceAfterLoadingSavedMacs: Bool {
+        (store?.pairedMacs.isEmpty ?? true) && !showsDeletedComputerRecoveryAction
+    }
+
     @ViewBuilder
     private var content: some View {
         if !savedComputers.isEmpty {
@@ -177,6 +185,9 @@ struct DisconnectedWorkspaceShellView: View {
                     "mobile.disconnected.listFooter",
                     defaultValue: "Tap a computer to reconnect. Swipe left to remove one."
                 ))
+            }
+            if showsDeletedComputerRecoveryAction, let store {
+                deletedComputerRecoverySection(store: store)
             }
             Section {
                 Button(action: showAddDevice) {
@@ -221,12 +232,31 @@ struct DisconnectedWorkspaceShellView: View {
                 defaultValue: "Add a computer to start syncing terminal workspaces."
             ))
         } actions: {
-            Button(action: showAddDevice) {
-                Text(L10n.string("mobile.addDevice.title", defaultValue: "Add Computer"))
+            if showsDeletedComputerRecoveryAction, let store {
+                DeletedComputerRecoveryButton(
+                    isProminent: true,
+                    recover: { await store.recoverForgottenIrohMacFromAccount() },
+                    reload: { await reloadAfterDeletedComputerRecovery() }
+                )
+                DeletedComputerRecoveryFooter()
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 320)
+                    .padding(.top, 2)
+                Button(action: showAddDevice) {
+                    Text(L10n.string("mobile.addDevice.title", defaultValue: "Add Computer"))
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("MobileShowAddDeviceButton")
+            } else {
+                Button(action: showAddDevice) {
+                    Text(L10n.string("mobile.addDevice.title", defaultValue: "Add Computer"))
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
+                .accessibilityIdentifier("MobileShowAddDeviceButton")
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.blue)
-            .accessibilityIdentifier("MobileShowAddDeviceButton")
             Button {
                 isShowingSetupHelp = true
             } label: {
@@ -234,6 +264,17 @@ struct DisconnectedWorkspaceShellView: View {
             }
             .font(.callout)
             .accessibilityIdentifier("MobileDisconnectedSetupHelpButton")
+        }
+    }
+
+    private func deletedComputerRecoverySection(store: CMUXMobileShellStore) -> some View {
+        Section {
+            DeletedComputerRecoveryButton(
+                recover: { await store.recoverForgottenIrohMacFromAccount() },
+                reload: { await reloadAfterDeletedComputerRecovery() }
+            )
+        } footer: {
+            DeletedComputerRecoveryFooter()
         }
     }
 
@@ -312,6 +353,11 @@ struct DisconnectedWorkspaceShellView: View {
             )
             await store?.loadPairedMacs()
         }
+    }
+
+    private func reloadAfterDeletedComputerRecovery() async {
+        await store?.loadPairedMacs()
+        await store?.loadRegistryDevices()
     }
     #else
     /// Saved Macs restored/known on this device (macOS fallback shell).

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
@@ -1,4 +1,6 @@
 #if os(iOS)
+import CMUXMobileCore
+import CmuxMobilePairedMac
 @testable import CmuxMobileShell
 import CmuxMobileShellModel
 import Foundation
@@ -27,6 +29,29 @@ struct DisconnectedWorkspaceShellRecoveryTests {
         #expect(!view.shouldAutoPresentAddDeviceAfterLoadingSavedMacs)
     }
 
+    @Test func emptyStateAutoPresentsAddComputerOnlyAfterSuccessfulLoad() async throws {
+        let store = try await shellStore()
+        var view = disconnectedView(store: store)
+        #expect(!view.shouldAutoPresentAddDeviceAfterLoadingSavedMacs)
+
+        await store.loadPairedMacs()
+        view = disconnectedView(store: store)
+
+        #expect(view.shouldAutoPresentAddDeviceAfterLoadingSavedMacs)
+    }
+
+    @Test func failedPairedMacLoadDoesNotAutoPresentAddComputer() async throws {
+        let store = try await shellStore(pairedMacStore: FailingLoadPairedMacStore())
+        store.hasRecoverableDeletedComputers = true
+
+        await store.loadPairedMacs()
+        let view = disconnectedView(store: store)
+
+        #expect(store.pairedMacLoadState == .failed)
+        #expect(!view.showsDeletedComputerRecoveryAction)
+        #expect(!view.shouldAutoPresentAddDeviceAfterLoadingSavedMacs)
+    }
+
     private func disconnectedView(store: CMUXMobileShellStore) -> DisconnectedWorkspaceShellView {
         DisconnectedWorkspaceShellView(
             hasKnownPairedMac: true,
@@ -37,12 +62,14 @@ struct DisconnectedWorkspaceShellRecoveryTests {
         )
     }
 
-    private func shellStore() async throws -> CMUXMobileShellStore {
+    private func shellStore(
+        pairedMacStore: any MobilePairedMacStoring = WorkspaceMacSelectionPairedMacStore([])
+    ) async throws -> CMUXMobileShellStore {
         let suiteName = "DisconnectedWorkspaceShellRecoveryTests-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         return MobileShellComposite(
             isSignedIn: true,
-            pairedMacStore: WorkspaceMacSelectionPairedMacStore([]),
+            pairedMacStore: pairedMacStore,
             clientIDRepository: MobileClientIDRepository(defaults: defaults),
             identityProvider: WorkspaceMacSelectionIdentityProvider(userID: "user-1"),
             teamIDProvider: { "team-a" },
@@ -50,5 +77,60 @@ struct DisconnectedWorkspaceShellRecoveryTests {
             multiMacAggregationDefaults: defaults
         )
     }
+}
+
+private enum FailingLoadPairedMacStoreError: Error {
+    case loadFailed
+}
+
+private actor FailingLoadPairedMacStore: MobilePairedMacStoring {
+    func upsert(
+        macDeviceID: String,
+        displayName: String?,
+        routes: [CmxAttachRoute],
+        instanceTag: String?,
+        markActive: Bool,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {}
+
+    func upsertIfNewer(
+        macDeviceID: String,
+        displayName: String?,
+        routes: [CmxAttachRoute],
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        markActive: Bool,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws -> Bool { false }
+
+    func loadAll(stackUserID: String?, teamID: String?) async throws -> [MobilePairedMac] {
+        throw FailingLoadPairedMacStoreError.loadFailed
+    }
+
+    func activeMac(stackUserID: String?, teamID: String?) async throws -> MobilePairedMac? { nil }
+
+    func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {}
+
+    func clearActive(stackUserID: String?, teamID: String?) async throws {}
+
+    func setCustomization(
+        macDeviceID: String,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {}
+
+    func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {}
+
+    func removeAll() async throws {}
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
@@ -1,0 +1,54 @@
+#if os(iOS)
+@testable import CmuxMobileShell
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShellUI
+
+@MainActor
+@Suite
+struct DisconnectedWorkspaceShellRecoveryTests {
+    @Test func emptyDisconnectedStateOffersDeletedComputerRecovery() async {
+        let store = await shellStore()
+        store.hasRecoverableDeletedComputers = true
+
+        let view = disconnectedView(store: store)
+
+        #expect(view.showsDeletedComputerRecoveryAction)
+    }
+
+    @Test func recoverableDeletedComputerSuppressesAutomaticAddComputerSheet() async {
+        let store = await shellStore()
+        store.hasRecoverableDeletedComputers = true
+        await store.loadPairedMacs()
+
+        let view = disconnectedView(store: store)
+
+        #expect(!view.shouldAutoPresentAddDeviceAfterLoadingSavedMacs)
+    }
+
+    private func disconnectedView(store: CMUXMobileShellStore) -> DisconnectedWorkspaceShellView {
+        DisconnectedWorkspaceShellView(
+            hasKnownPairedMac: true,
+            showAddDevice: {},
+            showPairingScanner: {},
+            signOut: {},
+            store: store
+        )
+    }
+
+    private func shellStore() async -> CMUXMobileShellStore {
+        let suiteName = "DisconnectedWorkspaceShellRecoveryTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        return MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: WorkspaceMacSelectionPairedMacStore([]),
+            clientIDRepository: MobileClientIDRepository(defaults: defaults),
+            identityProvider: WorkspaceMacSelectionIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" },
+            pairingHintDefaults: defaults,
+            multiMacAggregationDefaults: defaults
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
@@ -19,8 +19,8 @@ struct DisconnectedWorkspaceShellRecoveryTests {
 
     @Test func recoverableDeletedComputerSuppressesAutomaticAddComputerSheet() async {
         let store = await shellStore()
-        store.hasRecoverableDeletedComputers = true
         await store.loadPairedMacs()
+        store.hasRecoverableDeletedComputers = true
 
         let view = disconnectedView(store: store)
 

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/DisconnectedWorkspaceShellRecoveryTests.swift
@@ -8,8 +8,8 @@ import Testing
 @MainActor
 @Suite
 struct DisconnectedWorkspaceShellRecoveryTests {
-    @Test func emptyDisconnectedStateOffersDeletedComputerRecovery() async {
-        let store = await shellStore()
+    @Test func emptyDisconnectedStateOffersDeletedComputerRecovery() async throws {
+        let store = try await shellStore()
         store.hasRecoverableDeletedComputers = true
 
         let view = disconnectedView(store: store)
@@ -17,8 +17,8 @@ struct DisconnectedWorkspaceShellRecoveryTests {
         #expect(view.showsDeletedComputerRecoveryAction)
     }
 
-    @Test func recoverableDeletedComputerSuppressesAutomaticAddComputerSheet() async {
-        let store = await shellStore()
+    @Test func recoverableDeletedComputerSuppressesAutomaticAddComputerSheet() async throws {
+        let store = try await shellStore()
         await store.loadPairedMacs()
         store.hasRecoverableDeletedComputers = true
 
@@ -37,9 +37,9 @@ struct DisconnectedWorkspaceShellRecoveryTests {
         )
     }
 
-    private func shellStore() async -> CMUXMobileShellStore {
+    private func shellStore() async throws -> CMUXMobileShellStore {
         let suiteName = "DisconnectedWorkspaceShellRecoveryTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
         return MobileShellComposite(
             isSignedIn: true,
             pairedMacStore: WorkspaceMacSelectionPairedMacStore([]),


### PR DESCRIPTION
## Summary
- show the deleted-computer recovery action on the iOS No devices disconnected empty state
- keep Add Computer available, but stop auto-presenting it when a recoverable deleted Mac marker exists
- share the recovery button/footer between the Computers screen and the empty state so both use the same account-scoped restore path

## Verification
- `git diff --check`
- `jq empty ios/cmux/Resources/Localizable.xcstrings`
- `swift test --filter IrohZeroTouchDiscoveryTests` from `Packages/iOS/CmuxMobileShell`
- `xcodebuild build -workspace ios/cmux.xcworkspace -scheme CmuxMobileShellUI -destination platform=iOS Simulator,id=9369A943-7279-4969-A73D-5AA001A458AC -derivedDataPath /tmp/cmux-recov-empty-ui-dd`
- `xcodebuild build -workspace ios/cmux.xcworkspace -scheme cmux-ios -destination platform=iOS Simulator,id=9369A943-7279-4969-A73D-5AA001A458AC -derivedDataPath /tmp/cmux-recov-empty-app-build-dd CODE_SIGNING_ALLOWED=NO`

## Notes
- A focused app-scheme test invocation compiled the new test but the test target is currently blocked by an unrelated `TerminalSurfaceMountOwnershipTests` compile error on main: missing `terminalFolderTapEnabled`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787365045&installation_model_id=21920&pr_number=8712&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8712&signature=c7a3c7cd601a8bd8303b6bf02eddc56c585605f214e1b5372602a9bbc0f5ba93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes deleted-computer recovery in the iOS disconnected empty state and makes Add Computer secondary. Keeps the recovery button busy through reload, adds explicit results, and only auto‑opens Add Computer after a successful paired‑Mac load.

- **Bug Fixes**
  - Show recovery in the disconnected empty state; make Add Computer secondary and don’t auto‑present when recovery is available. Auto‑present only when `pairedMacLoadState == .loaded`, the list is empty, and no recovery exists; hide recovery and suppress auto‑present on `.failed`.
  - Keep the recovery button disabled with inline progress through reload; block duplicate taps; return `.staleScope` on sign‑out/team switch; on `.notFound` reload paired Macs + registry and show a localized error.

- **Refactors**
  - Centralized state in `MobileShellComposite` (`isRecoveringDeletedComputer`, `hasRecoverableDeletedComputers`, `pairedMacLoadState`) and made `recoverForgottenIrohMacFromAccount()` return `MobileDeletedComputerRecoveryResult` (`.recovered`, `.notFound`, `.alreadyInProgress`, `.staleScope`). Extracted shared `DeletedComputerRecoveryButton` and `DeletedComputerRecoveryFooter` used in both `DeviceTreeView` and `DisconnectedWorkspaceShellView`.

<sup>Written for commit 946ffa245546e6c25b582772580240c96fbf5e73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deleted-computer recovery controls to the disconnected-workspace empty state, including a prominent recovery button with inline progress and a localized explanatory footer.
* **Bug Fixes**
  * Improved the recovery flow by preventing re-entry, disabling interaction during recovery, and showing a localized failure alert when recovery can’t be completed.
  * Ensured recovery availability and the auto “add device” experience are correctly gated and cleared based on paired-device loading outcomes.
* **Tests**
  * Added/expanded iOS UI and unit tests to verify recovery visibility, auto-add suppression, and explicit recovery result states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->