### PR TITLE
Import cmux Browser TUI protocol core

### DIFF
--- a/.github/workflows/cmux-browser.yml
+++ b/.github/workflows/cmux-browser.yml
@@ -1,0 +1,34 @@
+name: cmux-browser
+
+on:
+  pull_request:
+    paths:
+      - "cmux-browser/**"
+      - ".github/workflows/cmux-browser.yml"
+  push:
+    branches: [main]
+    paths:
+      - "cmux-browser/**"
+      - ".github/workflows/cmux-browser.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  host-tests:
+    # Browser pull requests are untrusted code and must not run on a
+    # configurable self-hosted runner with private network access.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Browser host tests
+        run: ./cmux-browser/scripts/run-host-tests.sh

--- a/cmux-browser/README.md
+++ b/cmux-browser/README.md
@@ -21,6 +21,26 @@ The public import is staged deliberately:
 The source snapshot is not release-ready until every item in
 [`IMPORT_PROVENANCE.md`](IMPORT_PROVENANCE.md) is resolved.
 
+### Current public slice
+
+The first source slice is the host-compilable browser-to-cmux-TUI protocol
+core:
+
+- `overlay/chrome/browser/cmux_term/cmux_tui_protocol.{h,cc}`
+- `overlay/chrome/browser/cmux_term/cmux_tui_protocol_test.cc`
+
+It covers protocol identity, durable-registry revision fencing, ordered
+workspace events, input backpressure, resize coalescing, replay palette
+filtering, and JSON-lines framing. Run it without Chromium:
+
+```sh
+./cmux-browser/scripts/run-host-tests.sh
+```
+
+The exact private source object and imported blob identities are recorded in
+[`SOURCE_SNAPSHOT.md`](SOURCE_SNAPSHOT.md). Later slices remain gated by
+[`IMPORT_PROVENANCE.md`](IMPORT_PROVENANCE.md).
+
 ## Planned layout
 
 - `overlay/` mirrors paths in the Chromium source tree.

--- a/cmux-browser/SOURCE_SNAPSHOT.md
+++ b/cmux-browser/SOURCE_SNAPSHOT.md
@@ -1,0 +1,31 @@
+# cmux Browser source snapshot
+
+This ledger records immutable Git objects and content digests for public
+source slices imported from the private Browser candidate. It contains no
+private repository URL, filesystem path, builder identity, or release
+credential.
+
+## Slice 1: cmux-TUI protocol core
+
+- Import date: 2026-07-22
+- Private candidate commit:
+  `0821bef9ec386799dc80f7ef67263d31461c2b4a`
+- Private candidate tree:
+  `8f65f11a28479674dcb1d0a20f849c2f00b6073c`
+- Private archive tag:
+  `cmux-browser-public-snapshot-20260722-slice1`
+- Provenance: Manaflow rights-controlled
+- License: GPL-3.0-or-later
+
+| Public path | Source blob | SHA-256 |
+| --- | --- | --- |
+| `overlay/chrome/browser/cmux_term/cmux_tui_protocol.h` | `96be295235f03caa7db2b59e0ccd0eb69f8ca273` | `ae3177c8791cabaf5d4f6098aa30c69a52a70f019440d75189ee65321ed89fcb` |
+| `overlay/chrome/browser/cmux_term/cmux_tui_protocol.cc` | `74a1bf36a1d49c71f64ab9019e806f5fbe6e9a59` | `660c117fb35026167b1f0ae0660ecb711c99a68613bcfa2bdd4c54724e8ab570` |
+| `overlay/chrome/browser/cmux_term/cmux_tui_protocol_test.cc` | `8fb0689767dc238683baaad5948a9e8eec97ea54` | `239846863313da157e964e6573226708ee8c55b70350cf55f606d91f635bc5ec` |
+
+The three source files were copied byte-for-byte. The public-only host-test
+wrapper and documentation are not private snapshot material.
+
+The private archive retains the annotated tag above. The commit, tree, blob,
+and content IDs provide the reproducible identity needed to audit this slice
+without exposing private history.

--- a/cmux-browser/overlay/chrome/browser/cmux_term/cmux_tui_protocol.cc
+++ b/cmux-browser/overlay/chrome/browser/cmux_term/cmux_tui_protocol.cc
@@ -1,0 +1,277 @@
+// Copyright 2026 Manaflow, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "chrome/browser/cmux_term/cmux_tui_protocol.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
+namespace cmux {
+
+CmuxTuiRegistryFenceDecision FenceCmuxTuiRegistrySnapshot(
+    bool has_current,
+    std::string_view current_registry_id,
+    std::string_view current_generation,
+    uint64_t current_revision,
+    std::string_view incoming_registry_id,
+    std::string_view incoming_generation,
+    uint64_t incoming_revision) {
+  if (incoming_registry_id.empty() || incoming_generation.empty()) {
+    return CmuxTuiRegistryFenceDecision::kInvalid;
+  }
+  if (!has_current || current_registry_id != incoming_registry_id ||
+      current_generation != incoming_generation) {
+    return CmuxTuiRegistryFenceDecision::kAccept;
+  }
+  if (incoming_revision < current_revision) {
+    return CmuxTuiRegistryFenceDecision::kRefetch;
+  }
+  if (incoming_revision == current_revision) {
+    return CmuxTuiRegistryFenceDecision::kIgnore;
+  }
+  return CmuxTuiRegistryFenceDecision::kAccept;
+}
+
+bool ValidateCmuxTuiTerminalEventRevisions(
+    uint64_t after_revision,
+    uint64_t batch_revision,
+    const std::vector<uint64_t>& event_revisions) {
+  if (batch_revision < after_revision) {
+    return false;
+  }
+  uint64_t expected = after_revision;
+  for (const uint64_t revision : event_revisions) {
+    if (expected == std::numeric_limits<uint64_t>::max() ||
+        revision != expected + 1) {
+      return false;
+    }
+    expected = revision;
+  }
+  return expected == batch_revision;
+}
+
+bool IsCmuxTuiTreeEventName(std::string_view event_name) {
+  constexpr std::array<std::string_view, 13> kTreeEvents = {
+      "tree-changed",      "workspace-added", "workspace-closed",
+      "workspace-renamed", "workspace-moved", "screen-added",
+      "screen-closed",     "screen-renamed",  "pane-added",
+      "pane-closed",       "tab-added",       "tab-closed",
+      "tab-renamed",
+  };
+  return std::find(kTreeEvents.begin(), kTreeEvents.end(), event_name) !=
+         kTreeEvents.end();
+}
+
+CmuxTuiIdentityError ValidateCmuxTuiIdentity(
+    std::string_view app,
+    uint64_t protocol,
+    uint64_t pid,
+    std::optional<std::string_view> build_commit,
+    std::string_view required_build_commit,
+    std::optional<std::string_view> ghostty_commit,
+    std::string_view required_ghostty_commit) {
+  if (app != "cmux-tui" || protocol < kMinCmuxTuiProtocolVersion ||
+      protocol > kCmuxTuiProtocolVersion || pid == 0) {
+    return CmuxTuiIdentityError::kInvalidEndpoint;
+  }
+  if (!required_build_commit.empty()) {
+    if (!build_commit || build_commit->empty()) {
+      return CmuxTuiIdentityError::kBuildCommitMissing;
+    }
+    if (*build_commit != required_build_commit) {
+      return CmuxTuiIdentityError::kBuildCommitMismatch;
+    }
+  }
+  // A recognizable older daemon must reach the stamped-build checks above so
+  // the browser can replace it safely. It must never become ready, even in an
+  // unpinned source-tree build.
+  if (protocol != kCmuxTuiProtocolVersion) {
+    return CmuxTuiIdentityError::kInvalidEndpoint;
+  }
+  if (required_ghostty_commit.empty()) {
+    return CmuxTuiIdentityError::kNone;
+  }
+  if (!ghostty_commit || ghostty_commit->empty()) {
+    return CmuxTuiIdentityError::kGhosttyCommitMissing;
+  }
+  if (*ghostty_commit != required_ghostty_commit) {
+    return CmuxTuiIdentityError::kGhosttyCommitMismatch;
+  }
+  return CmuxTuiIdentityError::kNone;
+}
+
+bool IsReplaceableCmuxTuiIdentityError(CmuxTuiIdentityError error) {
+  switch (error) {
+    case CmuxTuiIdentityError::kBuildCommitMissing:
+    case CmuxTuiIdentityError::kBuildCommitMismatch:
+    case CmuxTuiIdentityError::kGhosttyCommitMissing:
+    case CmuxTuiIdentityError::kGhosttyCommitMismatch:
+      return true;
+    case CmuxTuiIdentityError::kNone:
+    case CmuxTuiIdentityError::kInvalidEndpoint:
+      return false;
+  }
+  // Fail closed for an unrecognized value. Besides keeping GCC's control-flow
+  // analysis honest, this prevents a future protocol error from silently
+  // becoming permission to replace a process until it is classified above.
+  return false;
+}
+
+std::string SelectCmuxTuiSocketPath(std::string_view preferred,
+                                    std::string_view fallback,
+                                    size_t native_path_capacity) {
+  return preferred.size() < native_path_capacity ? std::string(preferred)
+                                                  : std::string(fallback);
+}
+
+std::vector<uint8_t> StripCmuxTuiReplayPalette(std::string_view replay) {
+  std::vector<uint8_t> filtered;
+  filtered.reserve(replay.size());
+  size_t cursor = 0;
+  while (cursor < replay.size()) {
+    const bool seven_bit_osc4 =
+        cursor + 3 < replay.size() && replay[cursor] == '\x1b' &&
+        replay[cursor + 1] == ']' && replay[cursor + 2] == '4' &&
+        replay[cursor + 3] == ';';
+    const bool eight_bit_osc4 = cursor + 2 < replay.size() &&
+                                static_cast<uint8_t>(replay[cursor]) == 0x9d &&
+                                replay[cursor + 1] == '4' &&
+                                replay[cursor + 2] == ';';
+    if (!seven_bit_osc4 && !eight_bit_osc4) {
+      filtered.push_back(static_cast<uint8_t>(replay[cursor++]));
+      continue;
+    }
+
+    size_t end = cursor + (seven_bit_osc4 ? 4 : 3);
+    bool terminated = false;
+    while (end < replay.size()) {
+      const uint8_t byte = static_cast<uint8_t>(replay[end]);
+      if (byte == 0x07 || byte == 0x9c) {
+        ++end;
+        terminated = true;
+        break;
+      }
+      if (byte == 0x1b && end + 1 < replay.size() && replay[end + 1] == '\\') {
+        end += 2;
+        terminated = true;
+        break;
+      }
+      ++end;
+    }
+    if (!terminated) {
+      filtered.insert(filtered.end(), replay.begin() + cursor, replay.end());
+      break;
+    }
+    cursor = end;
+  }
+  return filtered;
+}
+
+CmuxTuiInputQueue::CmuxTuiInputQueue(size_t max_pending_bytes)
+    : max_pending_bytes_(max_pending_bytes) {}
+
+CmuxTuiInputQueue::~CmuxTuiInputQueue() = default;
+
+bool CmuxTuiInputQueue::Push(std::string_view bytes) {
+  if (bytes.empty()) {
+    return true;
+  }
+  if (pending_.size() > max_pending_bytes_ ||
+      bytes.size() > max_pending_bytes_ - pending_.size()) {
+    return false;
+  }
+  pending_.insert(pending_.end(), bytes.begin(), bytes.end());
+  return true;
+}
+
+std::vector<uint8_t> CmuxTuiInputQueue::BeginWrite() {
+  if (write_in_flight_ || pending_.empty()) {
+    return {};
+  }
+  write_in_flight_ = true;
+  std::vector<uint8_t> result;
+  result.swap(pending_);
+  return result;
+}
+
+void CmuxTuiInputQueue::FinishWrite() {
+  write_in_flight_ = false;
+}
+
+void CmuxTuiInputQueue::CancelWrite() {
+  write_in_flight_ = false;
+}
+
+void CmuxTuiInputQueue::Clear() {
+  pending_.clear();
+  write_in_flight_ = false;
+}
+
+void CmuxTuiResizeCoalescer::SetDesired(uint16_t cols, uint16_t rows) {
+  desired_ = {std::max<uint16_t>(cols, 1), std::max<uint16_t>(rows, 1)};
+}
+
+std::optional<CmuxTuiGridSize> CmuxTuiResizeCoalescer::BeginWrite(
+    CmuxTuiGridSize current) {
+  if (write_in_flight_ || desired_ == current) {
+    return std::nullopt;
+  }
+  write_in_flight_ = true;
+  return desired_;
+}
+
+void CmuxTuiResizeCoalescer::FinishWrite() {
+  write_in_flight_ = false;
+}
+
+void CmuxTuiResizeCoalescer::CancelWrite() {
+  write_in_flight_ = false;
+}
+
+CmuxTuiLineFramer::CmuxTuiLineFramer(size_t max_line_bytes)
+    : max_line_bytes_(max_line_bytes) {}
+
+CmuxTuiLineFramer::~CmuxTuiLineFramer() = default;
+
+CmuxTuiLineFramer::Result CmuxTuiLineFramer::Push(
+    std::string_view bytes,
+    std::vector<std::string>* lines) {
+  if (!lines) {
+    Reset();
+    return Result::kLineTooLarge;
+  }
+
+  while (!bytes.empty()) {
+    const size_t newline = bytes.find('\n');
+    const std::string_view piece =
+        newline == std::string_view::npos ? bytes : bytes.substr(0, newline);
+    if (piece.size() > max_line_bytes_ - pending_.size()) {
+      Reset();
+      return Result::kLineTooLarge;
+    }
+    pending_.append(piece);
+
+    if (newline == std::string_view::npos) {
+      return Result::kOk;
+    }
+
+    if (!pending_.empty() && pending_.back() == '\r') {
+      pending_.pop_back();
+    }
+    if (!pending_.empty()) {
+      lines->push_back(std::move(pending_));
+      pending_.clear();
+    }
+    bytes.remove_prefix(newline + 1);
+  }
+
+  return Result::kOk;
+}
+
+void CmuxTuiLineFramer::Reset() {
+  pending_.clear();
+}
+
+}  // namespace cmux

--- a/cmux-browser/overlay/chrome/browser/cmux_term/cmux_tui_protocol.h
+++ b/cmux-browser/overlay/chrome/browser/cmux_term/cmux_tui_protocol.h
@@ -1,0 +1,190 @@
+// Copyright 2026 Manaflow, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef CHROME_BROWSER_CMUX_TERM_CMUX_TUI_PROTOCOL_H_
+#define CHROME_BROWSER_CMUX_TERM_CMUX_TUI_PROTOCOL_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace cmux {
+
+// The browser and its packaged cmux-tui helper are revision-pinned together.
+// Recognize the additive protocol range needed to identify and safely hand off
+// a stale pinned daemon, while rejecting unknown future wire contracts. A
+// ready connection still requires the exact current version bundled with the
+// browser.
+inline constexpr uint64_t kMinCmuxTuiProtocolVersion = 7;
+inline constexpr uint64_t kCmuxTuiProtocolVersion = 9;
+
+enum class CmuxTuiIdentityError {
+  kNone,
+  kInvalidEndpoint,
+  kBuildCommitMissing,
+  kBuildCommitMismatch,
+  kGhosttyCommitMissing,
+  kGhosttyCommitMismatch,
+};
+
+// A durable registry is identified by both its database identity and the
+// daemon boot generation. Snapshots may replace state across either boundary,
+// but responses from an older revision in the same epoch must never move a
+// frontend cursor backwards.
+enum class CmuxTuiRegistryFenceDecision {
+  kAccept,
+  kIgnore,
+  kRefetch,
+  kInvalid,
+};
+
+CmuxTuiRegistryFenceDecision FenceCmuxTuiRegistrySnapshot(
+    bool has_current,
+    std::string_view current_registry_id,
+    std::string_view current_generation,
+    uint64_t current_revision,
+    std::string_view incoming_registry_id,
+    std::string_view incoming_generation,
+    uint64_t incoming_revision);
+
+// Validates the revision envelope returned by `terminal-events`. A successful
+// batch contains every revision strictly after `after_revision`, in order,
+// through `batch_revision`. This makes a missing/pruned event fail closed to a
+// fresh list-terminals snapshot instead of partially mutating the GUI.
+bool ValidateCmuxTuiTerminalEventRevisions(
+    uint64_t after_revision,
+    uint64_t batch_revision,
+    const std::vector<uint64_t>& event_revisions);
+
+// Protocol-v7 and newer subscriptions can request detailed tree deltas. Every
+// detailed workspace/screen/pane/tab event invalidates the active path just
+// like the legacy `tree-changed` event, even when Chromium only applies
+// workspace lifecycle deltas incrementally and refetches the rest.
+bool IsCmuxTuiTreeEventName(std::string_view event_name);
+
+// Validates the stable protocol identity independently of Chromium JSON
+// types, so packaged-build provenance is covered by the host test suite. An
+// empty required commits keep source-tree development compatible with
+// unstamped binaries; production packaging supplies exact cmux and Ghostty
+// commits.
+CmuxTuiIdentityError ValidateCmuxTuiIdentity(
+    std::string_view app,
+    uint64_t protocol,
+    uint64_t pid,
+    std::optional<std::string_view> build_commit,
+    std::string_view required_build_commit,
+    std::optional<std::string_view> ghostty_commit,
+    std::string_view required_ghostty_commit);
+
+// Only a valid cmux-tui protocol endpoint with stale/missing build stamps is
+// eligible for an in-place daemon handoff. An arbitrary socket endpoint must
+// never gain the ability to make the browser signal a process.
+bool IsReplaceableCmuxTuiIdentityError(CmuxTuiIdentityError error);
+
+// Selects the preferred runtime socket path when it fits the native Unix
+// sockaddr buffer (including its trailing NUL), otherwise the short private
+// fallback. Keeping this byte-level rule shared with the host test prevents
+// the browser launcher and cmux-tui daemon from silently choosing different
+// endpoints on macOS, where sun_path is only 104 bytes.
+std::string SelectCmuxTuiSocketPath(std::string_view preferred,
+                                    std::string_view fallback,
+                                    size_t native_path_capacity);
+
+// Removes OSC 4 palette definitions from a state replay before it reaches a
+// configured Ghostty frontend. cmux-tui reports the PTY-authored overrides
+// separately; replaying its complete parser palette would otherwise replace
+// every frontend theme color with the headless parser's compiled defaults.
+// Unterminated OSC strings are preserved byte-for-byte.
+std::vector<uint8_t> StripCmuxTuiReplayPalette(std::string_view replay);
+
+// Bounded per-surface input queue. At most one batch may be in flight; bytes
+// arriving behind it are coalesced up to the pending cap. A failed or canceled
+// in-flight batch is never requeued because the server may have committed it
+// before the response was lost.
+class CmuxTuiInputQueue {
+ public:
+  static constexpr size_t kDefaultMaxPendingBytes = 1024 * 1024;
+
+  explicit CmuxTuiInputQueue(
+      size_t max_pending_bytes = kDefaultMaxPendingBytes);
+  ~CmuxTuiInputQueue();
+
+  bool Push(std::string_view bytes);
+  std::vector<uint8_t> BeginWrite();
+  void FinishWrite();
+  void CancelWrite();
+  void Clear();
+
+  size_t pending_bytes() const { return pending_.size(); }
+  bool write_in_flight() const { return write_in_flight_; }
+
+ private:
+  const size_t max_pending_bytes_;
+  std::vector<uint8_t> pending_;
+  bool write_in_flight_ = false;
+};
+
+struct CmuxTuiGridSize {
+  uint16_t cols = 80;
+  uint16_t rows = 24;
+
+  bool operator==(const CmuxTuiGridSize& other) const {
+    return cols == other.cols && rows == other.rows;
+  }
+};
+
+// Coalesces resize storms to the latest desired grid while one request is in
+// flight. `current` is supplied by the backend because authoritative replay
+// can change it independently (including from another attached client).
+class CmuxTuiResizeCoalescer {
+ public:
+  void SetDesired(uint16_t cols, uint16_t rows);
+  std::optional<CmuxTuiGridSize> BeginWrite(CmuxTuiGridSize current);
+  void FinishWrite();
+  void CancelWrite();
+
+  CmuxTuiGridSize desired() const { return desired_; }
+  bool write_in_flight() const { return write_in_flight_; }
+
+ private:
+  CmuxTuiGridSize desired_;
+  bool write_in_flight_ = false;
+};
+
+// Incrementally splits cmux-tui's Unix JSON-lines transport. A single socket
+// read can contain part of a JSON object, several objects, or both. The cap is
+// deliberately above the server's 16 MiB attach queue: base64 expansion plus
+// the JSON envelope can make a valid replay line a little over 21 MiB.
+class CmuxTuiLineFramer {
+ public:
+  static constexpr size_t kDefaultMaxLineBytes = 32 * 1024 * 1024;
+
+  enum class Result {
+    kOk,
+    kLineTooLarge,
+  };
+
+  explicit CmuxTuiLineFramer(size_t max_line_bytes = kDefaultMaxLineBytes);
+  CmuxTuiLineFramer(const CmuxTuiLineFramer&) = delete;
+  CmuxTuiLineFramer& operator=(const CmuxTuiLineFramer&) = delete;
+  ~CmuxTuiLineFramer();
+
+  // Appends bytes and moves every complete, non-empty line into `lines`.
+  // Accepts either LF or CRLF. On overflow, clears buffered state so callers
+  // cannot accidentally resume parsing the tail of an oversized frame.
+  Result Push(std::string_view bytes, std::vector<std::string>* lines);
+
+  void Reset();
+  size_t buffered_bytes() const { return pending_.size(); }
+
+ private:
+  const size_t max_line_bytes_;
+  std::string pending_;
+};
+
+}  // namespace cmux
+
+#endif  // CHROME_BROWSER_CMUX_TERM_CMUX_TUI_PROTOCOL_H_

--- a/cmux-browser/overlay/chrome/browser/cmux_term/cmux_tui_protocol_test.cc
+++ b/cmux-browser/overlay/chrome/browser/cmux_term/cmux_tui_protocol_test.cc
@@ -1,0 +1,341 @@
+// Copyright 2026 Manaflow, Inc.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Host-compilable tests for cmux-tui JSON-lines framing. No Chromium or gtest.
+
+#include "chrome/browser/cmux_term/cmux_tui_protocol.h"
+
+#include <cstdio>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+
+int checks = 0;
+int failures = 0;
+
+void Check(bool condition, const char* message) {
+  ++checks;
+  if (!condition) {
+    ++failures;
+    std::fprintf(stderr, "FAIL: %s\n", message);
+  }
+}
+
+void CheckLines(const std::vector<std::string>& actual,
+                const std::vector<std::string>& expected,
+                const char* message) {
+  Check(actual == expected, message);
+}
+
+}  // namespace
+
+int main() {
+  using cmux::CmuxTuiIdentityError;
+  using cmux::CmuxTuiLineFramer;
+  using cmux::CmuxTuiRegistryFenceDecision;
+
+  {
+    for (const std::string_view event : {
+             "tree-changed", "workspace-added", "workspace-closed",
+             "workspace-renamed", "workspace-moved", "screen-added",
+             "screen-closed", "screen-renamed", "pane-added", "pane-closed",
+             "tab-added", "tab-closed", "tab-renamed"}) {
+      Check(cmux::IsCmuxTuiTreeEventName(event),
+            "every supported tree delta invalidates the active path");
+    }
+    Check(!cmux::IsCmuxTuiTreeEventName("terminal-registry-changed"),
+          "terminal registry events remain on their independent stream");
+    Check(!cmux::IsCmuxTuiTreeEventName("title-changed"),
+          "surface metadata does not force a tree snapshot");
+  }
+
+  {
+    Check(cmux::SelectCmuxTuiSocketPath("/run/u/cmux.sock",
+                                        "/tmp/cmux-tui-501/cmux.sock", 104) ==
+              "/run/u/cmux.sock",
+          "socket selector preserves a fitting runtime path");
+    Check(cmux::SelectCmuxTuiSocketPath(std::string(103, 'p'),
+                                        "/tmp/cmux-tui-501/cmux.sock", 104) ==
+              std::string(103, 'p'),
+          "socket selector reserves exactly one byte for the terminator");
+    Check(cmux::SelectCmuxTuiSocketPath(std::string(104, 'p'),
+                                        "/tmp/cmux-tui-501/cmux.sock", 104) ==
+              "/tmp/cmux-tui-501/cmux.sock",
+          "socket selector falls back at the native capacity boundary");
+  }
+
+  {
+    Check(cmux::FenceCmuxTuiRegistrySnapshot(false, "", "", 0, "registry-a",
+                                             "generation-a", 4) ==
+              CmuxTuiRegistryFenceDecision::kAccept,
+          "first terminal snapshot establishes the cursor");
+    Check(cmux::FenceCmuxTuiRegistrySnapshot(
+              true, "registry-a", "generation-a", 4, "registry-a",
+              "generation-a", 5) == CmuxTuiRegistryFenceDecision::kAccept,
+          "newer terminal snapshot in one epoch advances the cursor");
+    Check(cmux::FenceCmuxTuiRegistrySnapshot(
+              true, "registry-a", "generation-a", 5, "registry-a",
+              "generation-a", 5) == CmuxTuiRegistryFenceDecision::kIgnore,
+          "equal terminal snapshot is idempotent");
+    Check(cmux::FenceCmuxTuiRegistrySnapshot(
+              true, "registry-a", "generation-a", 5, "registry-a",
+              "generation-a", 4) == CmuxTuiRegistryFenceDecision::kRefetch,
+          "older same-epoch response cannot time-travel the GUI");
+    Check(cmux::FenceCmuxTuiRegistrySnapshot(
+              true, "registry-a", "generation-a", 9, "registry-a",
+              "generation-b", 9) == CmuxTuiRegistryFenceDecision::kAccept,
+          "new daemon generation is an authoritative epoch boundary");
+    Check(cmux::FenceCmuxTuiRegistrySnapshot(
+              true, "registry-a", "generation-a", 9, "registry-b",
+              "generation-c", 0) == CmuxTuiRegistryFenceDecision::kAccept,
+          "new durable registry replaces the old namespace");
+    Check(cmux::FenceCmuxTuiRegistrySnapshot(true, "registry-a", "generation-a",
+                                             9, "", "generation-c", 10) ==
+              CmuxTuiRegistryFenceDecision::kInvalid,
+          "snapshot without durable registry identity is invalid");
+  }
+
+  {
+    Check(cmux::ValidateCmuxTuiTerminalEventRevisions(7, 7, {}),
+          "empty event batch is valid only at the requested cursor");
+    Check(cmux::ValidateCmuxTuiTerminalEventRevisions(7, 10, {8, 9, 10}),
+          "contiguous event batch reaches its advertised barrier");
+    Check(!cmux::ValidateCmuxTuiTerminalEventRevisions(7, 10, {8, 10}),
+          "event gap fails closed to a snapshot");
+    Check(!cmux::ValidateCmuxTuiTerminalEventRevisions(7, 9, {8, 9, 10}),
+          "event beyond the advertised barrier is rejected");
+    Check(!cmux::ValidateCmuxTuiTerminalEventRevisions(7, 6, {}),
+          "event response cannot move its cursor backwards");
+    Check(!cmux::ValidateCmuxTuiTerminalEventRevisions(
+              std::numeric_limits<uint64_t>::max(),
+              std::numeric_limits<uint64_t>::max(),
+              {std::numeric_limits<uint64_t>::max()}),
+          "event revision overflow is rejected");
+  }
+
+  {
+    constexpr std::string_view kCommit =
+        "0123456789abcdef0123456789abcdef01234567";
+    constexpr std::string_view kGhosttyCommit =
+        "89abcdef0123456789abcdef0123456789abcdef";
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kMinCmuxTuiProtocolVersion, 42, kCommit,
+              "ffffffffffffffffffffffffffffffffffffffff", kGhosttyCommit,
+              kGhosttyCommit) == CmuxTuiIdentityError::kBuildCommitMismatch,
+          "a stale protocol-v7 build remains eligible for safe replacement");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kMinCmuxTuiProtocolVersion, 42, kCommit,
+              kCommit, kGhosttyCommit, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kInvalidEndpoint,
+          "a legacy protocol cannot become ready with a matching stamp");
+    Check(cmux::ValidateCmuxTuiIdentity("cmux-tui", 8, 42, kCommit, kCommit,
+                                        kGhosttyCommit, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kInvalidEndpoint,
+          "an intermediate protocol cannot become ready");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kCmuxTuiProtocolVersion, 42, kCommit, kCommit,
+                                        kGhosttyCommit, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kNone,
+          "exact stamped identity succeeds");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "not-cmux", cmux::kCmuxTuiProtocolVersion, 42, kCommit, kCommit,
+                                        kGhosttyCommit, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kInvalidEndpoint,
+          "wrong application is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity("cmux-tui", 6, 42, kCommit, kCommit,
+                                        kGhosttyCommit, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kInvalidEndpoint,
+          "older incompatible protocol is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity("cmux-tui", 10, 42, kCommit, kCommit,
+                                        kGhosttyCommit, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kInvalidEndpoint,
+          "unknown future protocol is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kCmuxTuiProtocolVersion, 0, kCommit, kCommit,
+                                        kGhosttyCommit, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kInvalidEndpoint,
+          "zero server pid is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kCmuxTuiProtocolVersion, 42, std::nullopt,
+              kCommit, kGhosttyCommit,
+              kGhosttyCommit) == CmuxTuiIdentityError::kBuildCommitMissing,
+          "unstamped production server is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kCmuxTuiProtocolVersion, 42,
+              "ffffffffffffffffffffffffffffffffffffffff",
+              kCommit, kGhosttyCommit,
+              kGhosttyCommit) == CmuxTuiIdentityError::kBuildCommitMismatch,
+          "different stamped build is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kCmuxTuiProtocolVersion, 42, kCommit, kCommit,
+              std::nullopt, kGhosttyCommit) ==
+              CmuxTuiIdentityError::kGhosttyCommitMissing,
+          "server without a Ghostty stamp is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kCmuxTuiProtocolVersion, 42, kCommit, kCommit,
+              "ffffffffffffffffffffffffffffffffffffffff",
+              kGhosttyCommit) == CmuxTuiIdentityError::kGhosttyCommitMismatch,
+          "server built from a different Ghostty commit is rejected");
+    Check(cmux::ValidateCmuxTuiIdentity(
+              "cmux-tui", cmux::kCmuxTuiProtocolVersion, 42, std::nullopt, "",
+              std::nullopt, "") == CmuxTuiIdentityError::kNone,
+          "source-tree development can omit a build pin");
+    Check(!cmux::IsReplaceableCmuxTuiIdentityError(
+              CmuxTuiIdentityError::kNone),
+          "an exact server does not need replacement");
+    Check(!cmux::IsReplaceableCmuxTuiIdentityError(
+              CmuxTuiIdentityError::kInvalidEndpoint),
+          "an arbitrary endpoint cannot trigger process replacement");
+    Check(cmux::IsReplaceableCmuxTuiIdentityError(
+              CmuxTuiIdentityError::kBuildCommitMissing) &&
+              cmux::IsReplaceableCmuxTuiIdentityError(
+                  CmuxTuiIdentityError::kBuildCommitMismatch) &&
+              cmux::IsReplaceableCmuxTuiIdentityError(
+                  CmuxTuiIdentityError::kGhosttyCommitMissing) &&
+              cmux::IsReplaceableCmuxTuiIdentityError(
+                  CmuxTuiIdentityError::kGhosttyCommitMismatch),
+          "only stale or unstamped cmux-tui builds are replaceable");
+    Check(!cmux::IsReplaceableCmuxTuiIdentityError(
+              static_cast<CmuxTuiIdentityError>(255)),
+          "an unclassified identity error fails closed");
+  }
+
+  {
+    const std::string replay =
+        "before\x1b]4;0;rgb:01/02/03\x1b\\middle"
+        "\x1b]10;#abcdef\x07"
+        "\x1b]4;15;#fefefe\x07"
+        "after";
+    const std::vector<uint8_t> filtered =
+        cmux::StripCmuxTuiReplayPalette(replay);
+    Check(std::string(filtered.begin(), filtered.end()) ==
+              "beforemiddle\x1b]10;#abcdef\x07"
+              "after",
+          "state replay drops only terminated OSC 4 palette definitions");
+
+    const std::string c1 = std::string("a") + static_cast<char>(0x9d) +
+                           "4;1;#010203" + static_cast<char>(0x9c) + "b";
+    const std::vector<uint8_t> c1_filtered =
+        cmux::StripCmuxTuiReplayPalette(c1);
+    Check(std::string(c1_filtered.begin(), c1_filtered.end()) == "ab",
+          "state replay drops C1 OSC 4 palette definitions");
+
+    const std::string unterminated = "keep\x1b]4;2;#112233";
+    const std::vector<uint8_t> unchanged =
+        cmux::StripCmuxTuiReplayPalette(unterminated);
+    Check(std::string(unchanged.begin(), unchanged.end()) == unterminated,
+          "unterminated OSC 4 is preserved");
+
+    std::string full_palette = "prefix";
+    for (int index = 0; index < 256; ++index) {
+      full_palette.append("\x1b]4;");
+      full_palette.append(std::to_string(index));
+      full_palette.append(";#010203\x1b\\");
+    }
+    full_palette.append("\x1b]10;#abcdef\x1b\\suffix");
+    const std::vector<uint8_t> full_filtered =
+        cmux::StripCmuxTuiReplayPalette(full_palette);
+    Check(std::string(full_filtered.begin(), full_filtered.end()) ==
+              "prefix\x1b]10;#abcdef\x1b\\suffix",
+          "all 256 replay palette slots are removed without touching OSC 10");
+  }
+
+  {
+    cmux::CmuxTuiInputQueue input(5);
+    Check(input.Push(std::string_view("a\0b", 3)),
+          "binary input is queued within the cap");
+    Check(input.pending_bytes() == 3, "pending input counts embedded NUL");
+    Check(input.BeginWrite() == std::vector<uint8_t>({'a', 0, 'b'}),
+          "first input batch preserves exact bytes");
+    Check(input.write_in_flight(), "input batch becomes in flight");
+    Check(input.Push("cd"), "input coalesces behind an in-flight batch");
+    Check(!input.Push("efgh"), "pending input cap rejects the whole new chunk");
+    Check(input.BeginWrite().empty(),
+          "second input write waits for completion");
+    input.FinishWrite();
+    Check(input.BeginWrite() == std::vector<uint8_t>({'c', 'd'}),
+          "coalesced input starts after completion");
+    input.CancelWrite();
+    Check(!input.write_in_flight(), "cancel releases input backpressure");
+    Check(input.Push("xy"), "queue accepts input after cancellation");
+    input.Clear();
+    Check(input.pending_bytes() == 0 && !input.write_in_flight(),
+          "clear drops pending input and in-flight state");
+  }
+
+  {
+    cmux::CmuxTuiResizeCoalescer resizes;
+    Check(!resizes.BeginWrite({80, 24}),
+          "default desired grid does not emit a redundant resize");
+    resizes.SetDesired(0, 0);
+    Check(resizes.desired() == cmux::CmuxTuiGridSize{1, 1},
+          "desired resize clamps to a valid grid");
+    const std::optional<cmux::CmuxTuiGridSize> first =
+        resizes.BeginWrite({80, 24});
+    Check(first && *first == cmux::CmuxTuiGridSize{1, 1},
+          "first changed grid starts a resize");
+    resizes.SetDesired(120, 41);
+    Check(!resizes.BeginWrite({1, 1}),
+          "new resize is held while one is in flight");
+    resizes.FinishWrite();
+    const std::optional<cmux::CmuxTuiGridSize> latest =
+        resizes.BeginWrite({1, 1});
+    Check(latest && *latest == cmux::CmuxTuiGridSize{120, 41},
+          "resize completion releases only the latest desired grid");
+    resizes.CancelWrite();
+    Check(!resizes.write_in_flight(), "resize cancellation releases the gate");
+  }
+
+  {
+    CmuxTuiLineFramer framer;
+    std::vector<std::string> lines;
+    Check(framer.Push("{\"id\":1", &lines) == CmuxTuiLineFramer::Result::kOk,
+          "partial first read succeeds");
+    Check(lines.empty(), "partial line is buffered");
+    Check(framer.buffered_bytes() == 7, "partial byte count is exact");
+    Check(framer.Push(",\"ok\":true}\n", &lines) ==
+              CmuxTuiLineFramer::Result::kOk,
+          "partial second read succeeds");
+    CheckLines(lines, {"{\"id\":1,\"ok\":true}"},
+               "partial reads join into one frame");
+    Check(framer.buffered_bytes() == 0, "complete frame drains buffer");
+  }
+
+  {
+    CmuxTuiLineFramer framer;
+    std::vector<std::string> lines;
+    Check(framer.Push("\n{\"event\":\"output\"}\r\n\n{\"id\":2}\ntrail",
+                      &lines) == CmuxTuiLineFramer::Result::kOk,
+          "mixed frames succeed");
+    CheckLines(lines, {"{\"event\":\"output\"}", "{\"id\":2}"},
+               "blank lines are ignored and CRLF is stripped");
+    Check(framer.buffered_bytes() == 5, "trailing partial line remains");
+    lines.clear();
+    Check(framer.Push("ing\n", &lines) == CmuxTuiLineFramer::Result::kOk,
+          "trailing frame completes");
+    CheckLines(lines, {"trailing"}, "trailing pieces preserve order");
+  }
+
+  {
+    CmuxTuiLineFramer framer(8);
+    std::vector<std::string> lines;
+    Check(framer.Push("12345678\n", &lines) == CmuxTuiLineFramer::Result::kOk,
+          "line exactly at cap succeeds");
+    CheckLines(lines, {"12345678"}, "capped line is emitted");
+    lines.clear();
+    Check(framer.Push("12345", &lines) == CmuxTuiLineFramer::Result::kOk,
+          "oversize prefix buffers");
+    Check(
+        framer.Push("6789", &lines) == CmuxTuiLineFramer::Result::kLineTooLarge,
+        "oversize frame is rejected across reads");
+    Check(framer.buffered_bytes() == 0, "overflow clears buffered tail");
+    Check(framer.Push("ok\n", &lines) == CmuxTuiLineFramer::Result::kOk,
+          "framer can restart after overflow");
+    CheckLines(lines, {"ok"}, "restart does not retain oversized bytes");
+  }
+
+  std::printf("cmux-tui-protocol: %d checks, %d failures\n", checks, failures);
+  return failures == 0 ? 0 : 1;
+}

--- a/cmux-browser/scripts/run-host-tests.sh
+++ b/cmux-browser/scripts/run-host-tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright 2026 Manaflow, Inc.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Build and run the host-only tests in the current public Browser slice. This
+# intentionally needs neither a Chromium checkout nor gtest.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$ROOT/overlay/chrome/browser/cmux_term"
+TMP_OUT="$(mktemp -d)"
+trap 'rm -rf "$TMP_OUT"' EXIT
+
+CXX="${CXX:-c++}"
+CXXFLAGS=(
+  -std=c++17
+  -Wall
+  -Wextra
+  -Werror
+  -Wno-comment
+  -pthread
+  -I "$ROOT/overlay"
+)
+
+"$CXX" "${CXXFLAGS[@]}" \
+  "$TEST_DIR/cmux_tui_protocol.cc" \
+  "$TEST_DIR/cmux_tui_protocol_test.cc" \
+  -o "$TMP_OUT/cmux_tui_protocol_test"
+
+"$TMP_OUT/cmux_tui_protocol_test"
+echo "PASS cmux_tui_protocol_test.cc"


### PR DESCRIPTION
This is the first curated Browser source slice, stacked on #8702. It publishes the host-compilable Browser ↔ cmux-TUI protocol core without exposing the private repository history or infrastructure.

Included:
- `cmux_tui_protocol.{h,cc}`;
- the host-only protocol test;
- a public test runner that requires neither Chromium nor gtest;
- a least-privilege GitHub Actions gate for Browser source changes; and
- an immutable snapshot ledger with the private candidate commit/tree, archive tag, source blob IDs, and SHA-256 digests.

The imported source bytes are exact copies of the audited private publication-prep snapshot. Manaflow-controlled files use `GPL-3.0-or-later`; this slice contains no Chromium, Helium, Bonsplit, Ghostty, uBlock, or mixed-provenance source.

Behavior covered:
- exact helper/Ghostty identity and protocol pin checks;
- durable-registry and ordered workspace-event revision fencing;
- input backpressure;
- resize coalescing;
- replay palette filtering; and
- JSON-lines framing.

Validation:
- `./cmux-browser/scripts/run-host-tests.sh`: 87 checks, 0 failures;
- public `cmux-browser / host-tests` run 29974836650: passed;
- all three public source SHA-256 values match their recorded private Git blobs;
- `git diff --check`;
- SPDX/header review;
- private path, builder host, volume, and credential-pattern scan.

Stack:
- base: #8702
- this PR: first source slice
- next: #8717, the terminal-host wire-protocol slice
- later PRs: remaining audited overlay slices, public build wiring, generated notices/corresponding source, and packaged-app release gates

This PR is intentionally draft. It is source-reviewable now but is not a complete or releasable Browser import.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787365059&installation_model_id=21920&pr_number=8713&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8713&signature=70c0442cf7e341f8fe2d7b577ee6a9a4b2e365faa1dcc36a5a777276e9cd7a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Imports the first public Browser slice: the host-compilable Browser↔`cmux-tui` protocol core. Adds a Chromium-free host test, CI to run it on PRs, and a reproducible source snapshot; this is not yet release-ready.

- **New Features**
  - Adds `overlay/chrome/browser/cmux_term/cmux_tui_protocol.{h,cc}` and `cmux_tui_protocol_test.cc`.
  - Includes `./cmux-browser/scripts/run-host-tests.sh` to build and run the host tests without Chromium.
  - Adds `.github/workflows/cmux-browser.yml` to run host tests on Ubuntu for PRs and pushes.
  - Implements and tests: identity pin checks (build/Ghostty and replaceability), durable-registry fencing and ordered terminal event revisions, input backpressure, resize coalescing, replay palette stripping, JSON-lines framing, and socket-path selection.
  - Records immutable provenance in `SOURCE_SNAPSHOT.md` (blob IDs and SHA-256); code is `GPL-3.0-or-later` and contains no Chromium or mixed-provenance sources.

<sup>Written for commit bf91480ac1814c98daaeb76c6083e3f88ace5bc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



