### PR TITLE
Remove iroh rate limiting: make limiter optional and fail open

### DIFF
--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -234,7 +234,11 @@ export const env = createEnv({
     CMUX_IROH_MINT_URL: irohMinterUrl.optional(),
     CMUX_IROH_MINT_HMAC_SECRET_B64:
       z.string().max(512).regex(/^[A-Za-z0-9+/]{43,}={0,2}$/).optional(),
-    CMUX_IROH_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_IROH_RATE_LIMIT_ID"),
+    // Optional: leave unset to disable iroh rate limiting entirely. When unset,
+    // the firewall gate in routeHandler.ts is skipped. Matches the other
+    // optional rate-limit IDs (CMUX_PUSH_RATE_LIMIT_ID,
+    // CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID).
+    CMUX_IROH_RATE_LIMIT_ID: z.string().min(1).optional(),
     CMUX_IROH_DEV_ALLOW_INSECURE_LOOPBACK_MINTER: localDevelopmentOptIn(
       "CMUX_IROH_DEV_ALLOW_INSECURE_LOOPBACK_MINTER",
     ),

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -140,9 +140,12 @@ export async function handleIrohRoute(
     if (rateLimited || error === "blocked") {
       return irohJsonResponse({ error: "rate_limited" }, 429, { "retry-after": "60" });
     }
-    if (error) {
-      console.error("iroh trust broker firewall unavailable", { operation, failure: error });
-      return jsonResponse({ error: "iroh_service_unavailable" }, 503);
+    if (error === "not-found") {
+      // The configured rule no longer exists (Vercel returns 404). That means
+      // the operator deleted the limit, so treat it as "no limit" and fail open
+      // rather than 503-ing every request. Genuine unavailability (timeout or an
+      // unexpected status) still fails closed via the catch above.
+      console.warn("iroh rate-limit rule not found; failing open", { operation });
     }
   }
 

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -65,6 +65,33 @@ describe("Iroh route boundary", () => {
     expect(brokerCalled).toBe(false);
   });
 
+  test("fails open when the configured rate-limit rule no longer exists", async () => {
+    let brokerCalled = false;
+    const dependencies = {
+      verify: async () => USER,
+      broker: broker({
+        discover: () => {
+          brokerCalled = true;
+          return Effect.succeed({ bindings: [] });
+        },
+      }),
+      firewall: {
+        id: "iroh-test-rule",
+        check: async () => ({ rateLimited: false, error: "not-found" as const }),
+      },
+    };
+
+    const response = await handleIrohRoute(
+      new Request("https://cmux.test/api/devices/iroh"),
+      "discover",
+      dependencies,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ bindings: [] });
+    expect(brokerCalled).toBe(true);
+  });
+
   test("bounds a firewall check that never settles", async () => {
     let brokerCalled = false;
     let aborted = false;

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -67,6 +67,7 @@ describe("Iroh route boundary", () => {
 
   test("fails open when the configured rate-limit rule no longer exists", async () => {
     let brokerCalled = false;
+    let firewallCalled = false;
     const dependencies = {
       verify: async () => USER,
       broker: broker({
@@ -77,7 +78,10 @@ describe("Iroh route boundary", () => {
       }),
       firewall: {
         id: "iroh-test-rule",
-        check: async () => ({ rateLimited: false, error: "not-found" as const }),
+        check: async () => {
+          firewallCalled = true;
+          return { rateLimited: false, error: "not-found" as const };
+        },
       },
     };
 
@@ -89,6 +93,9 @@ describe("Iroh route boundary", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ bindings: [] });
+    // Prove the not-found path specifically: the firewall must have run and
+    // returned not-found, and the handler must have failed open to the broker.
+    expect(firewallCalled).toBe(true);
     expect(brokerCalled).toBe(true);
   });
 


### PR DESCRIPTION
## Problem

`CMUX_IROH_RATE_LIMIT_ID` was required on prod, and `routeHandler.ts` ran the Vercel firewall check on every authed iroh op whenever that env was set. When the rate-limit rule was deleted from the Vercel firewall (the owner removed iroh limiting), the `.well-known/vercel/rate-limit-api/<id>` check returns 404 → `firewall.ts` maps it to `error: "not-found"` → the old `if (error)` branch returned **503 `iroh_service_unavailable`** on every `discover`/`challenge`/`register`, for **all** accounts, before the broker was ever reached.

That took off-tailnet iroh discovery down entirely: the review Mac could not publish an iroh binding, and phones off the tailnet could not discover it. `/api/devices` (a plain registry read) kept returning 200, which is why only the iroh endpoints were affected.

## Fix

- **env**: make `CMUX_IROH_RATE_LIMIT_ID` optional (`z.string().min(1).optional()`), matching the existing optional rate-limit IDs (`CMUX_PUSH_RATE_LIMIT_ID`, `CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID`). Unsetting the var now skips the firewall gate instead of failing env validation at boot.
- **routeHandler**: treat a missing rule (`"not-found"`) as "no limit" and fail **open** (continue to the broker) instead of 503. A deleted rule means the operator removed the limit, not that the service is down. Genuine unavailability (firewall timeout / unexpected status) still fails **closed** via the existing `catch`, and `"blocked"`/`rateLimited` still return 429.

Deploying this clears the outage on its own, even before the env var is unset, and prevents a deleted rule from ever bricking iroh again. After deploy the owner can unset `CMUX_IROH_RATE_LIMIT_ID` in Vercel prod to fully remove the gate.

## Test

Adds `fails open when the configured rate-limit rule no longer exists` — asserts a `not-found` result reaches the broker and returns 200. Existing fail-closed tests (firewall reject / never-settles → 503) and the 429/blocked path are unchanged. Full file: 14 pass, `bun run typecheck` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787365583&installation_model_id=21920&pr_number=8714&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8714&signature=190484d956e915fa27188b9247fab889bc2925df40b93881ec360a94e70a041d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make iroh rate limiting optional and fail open when the Vercel firewall rule is missing. This prevents 503s and restores off‑tailnet iroh discovery when a rate-limit rule is deleted.

- **Bug Fixes**
  - Made `CMUX_IROH_RATE_LIMIT_ID` optional; when unset, the firewall check is skipped.
  - Treated firewall `error: "not-found"` as “no limit” and continued to the broker; still return 429 for `blocked`/rate-limited and fail closed on timeouts/unexpected errors.
  - Added a regression test that asserts `not-found` reaches the broker and the firewall check ran, returning 200.

<sup>Written for commit feaeb36709dc1ad266953cf008ced930294b0330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Iroh requests now **fail open** when the configured rate-limit rule is missing, instead of returning a service-unavailable error.
  * Rate-limited or blocked requests continue to receive the appropriate rejection responses.
  * The Iroh rate-limit configuration is now optional; leaving it unset disables rate limiting.

* **Tests**
  * Added coverage confirming requests succeed when the rate-limit rule is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->