### PR TITLE
Fix Codex code mode rollout identity conflicts

### DIFF
--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
@@ -34,4 +34,22 @@ extension AgentChatSessionRegistry {
         }
         return paths
     }
+
+    /// Most recent durable Codex session binding for each terminal surface.
+    nonisolated static func storedCodexSessionIDBySurfaceID(
+        from entries: [AgentChatHookSessionStore.Entry]
+    ) -> [String: String] {
+        let ordered = entries.sorted {
+            let left = $0.updatedAt ?? .distantPast
+            let right = $1.updatedAt ?? .distantPast
+            if left != right { return left < right }
+            return $0.sessionID < $1.sessionID
+        }
+        var result: [String: String] = [:]
+        for entry in ordered {
+            guard let surfaceID = entry.surfaceID else { continue }
+            result[surfaceID] = entry.sessionID
+        }
+        return result
+    }
 }

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension AgentChatSessionRegistry {
+    /// libproc: the `~/.codex/sessions/**/rollout-*.jsonl` paths the process
+    /// holds open (codex keeps its rollouts open for writing).
+    nonisolated static func openCodexRolloutPaths(pid: Int) -> [String] {
+        let listSize = proc_pidinfo(pid_t(pid), PROC_PIDLISTFDS, 0, nil, 0)
+        guard listSize > 0 else { return [] }
+        let count = Int(listSize) / MemoryLayout<proc_fdinfo>.stride
+        guard count > 0 else { return [] }
+        var fds = [proc_fdinfo](repeating: proc_fdinfo(), count: count)
+        let used = proc_pidinfo(pid_t(pid), PROC_PIDLISTFDS, 0, &fds, listSize)
+        guard used > 0 else { return [] }
+        let actual = Int(used) / MemoryLayout<proc_fdinfo>.stride
+        var paths: [String] = []
+        for index in 0..<min(actual, fds.count) {
+            guard fds[index].proc_fdtype == UInt32(PROX_FDTYPE_VNODE) else { continue }
+            var info = vnode_fdinfowithpath()
+            let size = proc_pidfdinfo(
+                pid_t(pid),
+                fds[index].proc_fd,
+                PROC_PIDFDVNODEPATHINFO,
+                &info,
+                Int32(MemoryLayout<vnode_fdinfowithpath>.size)
+            )
+            guard size > 0 else { continue }
+            let path = withUnsafeBytes(of: &info.pvip.vip_path) { raw -> String in
+                guard let base = raw.baseAddress else { return "" }
+                return String(cString: base.assumingMemoryBound(to: CChar.self))
+            }
+            if path.hasSuffix(".jsonl"), path.contains("/.codex/sessions/") {
+                paths.append(path)
+            }
+        }
+        return paths
+    }
+}

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
@@ -35,20 +35,18 @@ extension AgentChatSessionRegistry {
         return paths
     }
 
-    /// Most recent durable Codex session binding for each terminal surface.
-    nonisolated static func storedCodexSessionIDBySurfaceID(
-        from entries: [AgentChatHookSessionStore.Entry]
+    /// Most recent known Codex session binding for each requested terminal surface.
+    nonisolated static func preferredCodexSessionIDBySurfaceID(
+        from records: [AgentChatSessionRecord],
+        onlySurfaceIDs: Set<UUID>?
     ) -> [String: String] {
-        let ordered = entries.sorted {
-            let left = $0.updatedAt ?? .distantPast
-            let right = $1.updatedAt ?? .distantPast
-            if left != right { return left < right }
-            return $0.sessionID < $1.sessionID
-        }
+        let requestedSurfaceIDs = onlySurfaceIDs.map { Set($0.map(\.uuidString)) }
         var result: [String: String] = [:]
-        for entry in ordered {
-            guard let surfaceID = entry.surfaceID else { continue }
-            result[surfaceID] = entry.sessionID
+        for record in records where record.agentKind == .codex {
+            guard let surfaceID = record.surfaceID,
+                  requestedSurfaceIDs?.contains(surfaceID) ?? true,
+                  result[surfaceID] == nil else { continue }
+            result[surfaceID] = record.sessionID
         }
         return result
     }

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+CodexRolloutFiles.swift
@@ -1,6 +1,39 @@
 import Foundation
 
 extension AgentChatSessionRegistry {
+    func preferredCodexSessionIDBySurfaceID(
+        onlySurfaceIDs: Set<UUID>?
+    ) -> [String: String] {
+        let requestedSurfaceIDs = onlySurfaceIDs.map { Set($0.map(\.uuidString)) }
+        return codexHookBindingBySurfaceID.reduce(into: [:]) { result, element in
+            guard requestedSurfaceIDs?.contains(element.key) ?? true else { return }
+            result[element.key] = element.value.sessionID
+        }
+    }
+
+    func rememberCodexHookBinding(
+        sessionID: String,
+        surfaceID: String,
+        updatedAt: Date
+    ) {
+        if let current = codexHookBindingBySurfaceID[surfaceID] {
+            guard updatedAt > current.updatedAt
+                || (updatedAt == current.updatedAt && sessionID > current.sessionID) else {
+                return
+            }
+        }
+        codexHookBindingBySurfaceID[surfaceID] = (sessionID, updatedAt)
+        if codexHookBindingBySurfaceID.count > Self.codexHookBindingCapacity,
+           let oldest = codexHookBindingBySurfaceID.min(by: { left, right in
+               if left.value.updatedAt != right.value.updatedAt {
+                   return left.value.updatedAt < right.value.updatedAt
+               }
+               return left.key < right.key
+           }) {
+            codexHookBindingBySurfaceID.removeValue(forKey: oldest.key)
+        }
+    }
+
     /// libproc: the `~/.codex/sessions/**/rollout-*.jsonl` paths the process
     /// holds open (codex keeps its rollouts open for writing).
     nonisolated static func openCodexRolloutPaths(pid: Int) -> [String] {
@@ -35,19 +68,4 @@ extension AgentChatSessionRegistry {
         return paths
     }
 
-    /// Most recent known Codex session binding for each requested terminal surface.
-    nonisolated static func preferredCodexSessionIDBySurfaceID(
-        from records: [AgentChatSessionRecord],
-        onlySurfaceIDs: Set<UUID>?
-    ) -> [String: String] {
-        let requestedSurfaceIDs = onlySurfaceIDs.map { Set($0.map(\.uuidString)) }
-        var result: [String: String] = [:]
-        for record in records where record.agentKind == .codex {
-            guard let surfaceID = record.surfaceID,
-                  requestedSurfaceIDs?.contains(surfaceID) ?? true,
-                  result[surfaceID] == nil else { continue }
-            result[surfaceID] = record.sessionID
-        }
-        return result
-    }
 }

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+LiveAgentPID.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+LiveAgentPID.swift
@@ -94,7 +94,8 @@ extension AgentChatSessionRegistry {
                 guard let candidateSessionID = observedSessionID(
                     agentID: def.id,
                     pid: pid,
-                    details: loadDetails()
+                    details: loadDetails(),
+                    preferredSessionIDs: expectedSessionIDs
                 ) else {
                     if allowUnidentifiedFallback {
                         unidentifiedFallbackPID = preferredLiveAgentPID(
@@ -192,11 +193,16 @@ extension AgentChatSessionRegistry {
     private nonisolated static func observedSessionID(
         agentID: String,
         pid: Int,
-        details: CmuxTopProcessArguments?
+        details: CmuxTopProcessArguments?,
+        preferredSessionIDs: Set<String>
     ) -> String? {
         if agentID == "codex",
-           let rollout = openCodexRolloutPaths(pid: pid).first {
-            return firstUUIDLike(in: (rollout as NSString).lastPathComponent)
+           let identity = CodexRolloutIdentityResolver().resolve(
+               openRolloutPaths: openCodexRolloutPaths(pid: pid),
+               preferredSessionIDs: preferredSessionIDs,
+               sessionIDFromPath: firstUUIDLike(in:)
+           ) {
+            return identity.sessionID
         }
         let isClaudeForkLaunch = agentID == "claude"
             && (details?.arguments).map(Self.containsClaudeForkSessionOption(_:)) == true

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+LiveAgentPID.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+LiveAgentPID.swift
@@ -195,7 +195,7 @@ extension AgentChatSessionRegistry {
         details: CmuxTopProcessArguments?
     ) -> String? {
         if agentID == "codex",
-           let rollout = openCodexRolloutPath(pid: pid) {
+           let rollout = openCodexRolloutPaths(pid: pid).first {
             return firstUUIDLike(in: (rollout as NSString).lastPathComponent)
         }
         let isClaudeForkLaunch = agentID == "claude"

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
@@ -161,7 +161,7 @@ extension AgentChatSessionRegistry {
         }
         observeLastStartedAt = Date()
         let id = UUID()
-        let hookStore = hookStore
+        let hookStore = self.hookStore
         let scanTask = Task.detached {
             let preferredCodexSessionIDBySurfaceID = Self.storedCodexSessionIDBySurfaceID(
                 from: hookStore.entries(agentSource: "codex")

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
@@ -161,8 +161,7 @@ extension AgentChatSessionRegistry {
         }
         observeLastStartedAt = Date()
         let id = UUID()
-        let preferredCodexSessionIDBySurfaceID = Self.preferredCodexSessionIDBySurfaceID(
-            from: sessions(workspaceID: nil),
+        let preferredCodexSessionIDBySurfaceID = preferredCodexSessionIDBySurfaceID(
             onlySurfaceIDs: scope.surfaceIDs
         )
         let scanTask = Task.detached {

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
@@ -161,11 +161,11 @@ extension AgentChatSessionRegistry {
         }
         observeLastStartedAt = Date()
         let id = UUID()
-        let hookStore = self.hookStore
+        let preferredCodexSessionIDBySurfaceID = Self.preferredCodexSessionIDBySurfaceID(
+            from: sessions(workspaceID: nil),
+            onlySurfaceIDs: scope.surfaceIDs
+        )
         let scanTask = Task.detached {
-            let preferredCodexSessionIDBySurfaceID = Self.storedCodexSessionIDBySurfaceID(
-                from: hookStore.entries(agentSource: "codex")
-            )
             return Self.scanObservedAgentSessions(
                 onlySurfaceIDs: scope.surfaceIDs,
                 preferredCodexSessionIDBySurfaceID: preferredCodexSessionIDBySurfaceID

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
@@ -161,8 +161,15 @@ extension AgentChatSessionRegistry {
         }
         observeLastStartedAt = Date()
         let id = UUID()
+        let hookStore = hookStore
         let scanTask = Task.detached {
-            Self.scanObservedAgentSessions(onlySurfaceIDs: scope.surfaceIDs)
+            let preferredCodexSessionIDBySurfaceID = Self.storedCodexSessionIDBySurfaceID(
+                from: hookStore.entries(agentSource: "codex")
+            )
+            return Self.scanObservedAgentSessions(
+                onlySurfaceIDs: scope.surfaceIDs,
+                preferredCodexSessionIDBySurfaceID: preferredCodexSessionIDBySurfaceID
+            )
         }
         let task = Task { @MainActor [weak self] in
             let observed = await withTaskCancellationHandler {
@@ -184,7 +191,8 @@ extension AgentChatSessionRegistry {
     /// Off-main: one entry per distinct live codex/claude session under any cmux
     /// surface, identity resolved without hooks.
     private nonisolated static func scanObservedAgentSessions(
-        onlySurfaceIDs surfaceIDs: Set<UUID>? = nil
+        onlySurfaceIDs surfaceIDs: Set<UUID>? = nil,
+        preferredCodexSessionIDBySurfaceID: [String: String]
     ) -> [ObservedAgentSession] {
         guard !Task.isCancelled else { return [] }
         let snapshot = CmuxTopProcessSnapshot.capture(
@@ -195,6 +203,7 @@ extension AgentChatSessionRegistry {
         return scanObservedAgentSessions(
             in: snapshot,
             onlySurfaceIDs: surfaceIDs,
+            preferredCodexSessionIDBySurfaceID: preferredCodexSessionIDBySurfaceID,
             processArgumentsAndEnvironment: CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for:),
             codexRolloutPaths: openCodexRolloutPaths(pid:)
         )
@@ -212,6 +221,7 @@ extension AgentChatSessionRegistry {
             let depth: Int
         }
 
+        let codexIdentityResolver = CodexRolloutIdentityResolver()
         var candidateBySessionID: [String: Candidate] = [:]
         var rootPIDsBySurfaceID: [UUID: Set<Int>] = [:]
         func rootPIDs(for surfaceID: UUID) -> Set<Int> {
@@ -248,9 +258,15 @@ extension AgentChatSessionRegistry {
             let isClaudeForkLaunch = def.id == "claude" && argv.map(Self.containsClaudeForkSessionOption(_:)) == true
             var sessionID: String?
             var transcriptPath: String?
-            if def.id == "codex", let rollout = codexRolloutPaths(process.pid).first {
-                transcriptPath = rollout
-                sessionID = firstUUIDLike(in: (rollout as NSString).lastPathComponent)
+            if def.id == "codex",
+               let identity = codexIdentityResolver.resolve(
+                   openRolloutPaths: codexRolloutPaths(process.pid),
+                   preferredSessionIDs: preferredCodexSessionIDBySurfaceID[surfaceID.uuidString]
+                       .map { Set([$0]) } ?? [],
+                   sessionIDFromPath: firstUUIDLike(in:)
+               ) {
+                transcriptPath = identity.transcriptPath
+                sessionID = identity.sessionID
             }
             if def.id == "claude",
                !isClaudeForkLaunch,

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry+ObserveScan.swift
@@ -196,15 +196,16 @@ extension AgentChatSessionRegistry {
             in: snapshot,
             onlySurfaceIDs: surfaceIDs,
             processArgumentsAndEnvironment: CmuxTopProcessSnapshot.processArgumentsAndEnvironment(for:),
-            codexRolloutPath: openCodexRolloutPath(pid:)
+            codexRolloutPaths: openCodexRolloutPaths(pid:)
         )
     }
 
     nonisolated static func scanObservedAgentSessions(
         in snapshot: CmuxTopProcessSnapshot,
         onlySurfaceIDs surfaceIDs: Set<UUID>? = nil,
+        preferredCodexSessionIDBySurfaceID: [String: String] = [:],
         processArgumentsAndEnvironment: (Int) -> CmuxTopProcessArguments?,
-        codexRolloutPath: (Int) -> String?
+        codexRolloutPaths: (Int) -> [String]
     ) -> [ObservedAgentSession] {
         struct Candidate {
             let session: ObservedAgentSession
@@ -247,7 +248,7 @@ extension AgentChatSessionRegistry {
             let isClaudeForkLaunch = def.id == "claude" && argv.map(Self.containsClaudeForkSessionOption(_:)) == true
             var sessionID: String?
             var transcriptPath: String?
-            if def.id == "codex", let rollout = codexRolloutPath(process.pid) {
+            if def.id == "codex", let rollout = codexRolloutPaths(process.pid).first {
                 transcriptPath = rollout
                 sessionID = firstUUIDLike(in: (rollout as NSString).lastPathComponent)
             }
@@ -450,39 +451,6 @@ extension AgentChatSessionRegistry {
         guard !trimmed.hasPrefix("-") else { return nil }
         return firstUUIDLike(in: trimmed)
     }
-    /// libproc: the path of a `~/.codex/sessions/**/rollout-*.jsonl` the process
-    /// holds open (codex keeps its rollout open for writing), or nil.
-    nonisolated static func openCodexRolloutPath(pid: Int) -> String? {
-        let listSize = proc_pidinfo(pid_t(pid), PROC_PIDLISTFDS, 0, nil, 0)
-        guard listSize > 0 else { return nil }
-        let count = Int(listSize) / MemoryLayout<proc_fdinfo>.stride
-        guard count > 0 else { return nil }
-        var fds = [proc_fdinfo](repeating: proc_fdinfo(), count: count)
-        let used = proc_pidinfo(pid_t(pid), PROC_PIDLISTFDS, 0, &fds, listSize)
-        guard used > 0 else { return nil }
-        let actual = Int(used) / MemoryLayout<proc_fdinfo>.stride
-        for index in 0..<min(actual, fds.count) {
-            guard fds[index].proc_fdtype == UInt32(PROX_FDTYPE_VNODE) else { continue }
-            var info = vnode_fdinfowithpath()
-            let size = proc_pidfdinfo(
-                pid_t(pid),
-                fds[index].proc_fd,
-                PROC_PIDFDVNODEPATHINFO,
-                &info,
-                Int32(MemoryLayout<vnode_fdinfowithpath>.size)
-            )
-            guard size > 0 else { continue }
-            let path = withUnsafeBytes(of: &info.pvip.vip_path) { raw -> String in
-                guard let base = raw.baseAddress else { return "" }
-                return String(cString: base.assumingMemoryBound(to: CChar.self))
-            }
-            if path.hasSuffix(".jsonl"), path.contains("/.codex/sessions/") {
-                return path
-            }
-        }
-        return nil
-    }
-
     private nonisolated static let uuidLikeRegex = try? NSRegularExpression(
         pattern: "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
     )

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -10,6 +10,9 @@ final class AgentChatSessionRegistry {
     private var sessionSurfaceIndex = ChatSessionSurfaceIndex<String>()
     private var liveSessionIDBySurfaceID: [String: String] = [:]
     private var liveClaudeSessionIDsBySurfaceID: [String: Set<String>] = [:]
+    static let codexHookBindingCapacity = 256
+    /// Latest authoritative Codex hook/store binding per terminal surface.
+    var codexHookBindingBySurfaceID: [String: (sessionID: String, updatedAt: Date)] = [:]
     private let hookStore: AgentChatHookSessionStore
 
     /// Called after a record mutation with the previous value (nil for a
@@ -291,6 +294,13 @@ final class AgentChatSessionRegistry {
             store.entry(agentSource: source, sessionID: lookupSessionID)
         }.value
         guard let entry else { return records[sessionID] }
+        if source == "codex", let surfaceID = entry.surfaceID {
+            rememberCodexHookBinding(
+                sessionID: entry.sessionID,
+                surfaceID: surfaceID,
+                updatedAt: entry.updatedAt ?? .distantPast
+            )
+        }
         update(sessionID: sessionID) { $0.adoptBindings(from: entry, includingPID: false) }
         return records[sessionID]
     }
@@ -359,6 +369,13 @@ final class AgentChatSessionRegistry {
         for (source, entries) in parsed {
             let kind = ChatAgentKind(source: source)
             for entry in entries {
+                if source == "codex", let surfaceID = entry.surfaceID {
+                    rememberCodexHookBinding(
+                        sessionID: entry.sessionID,
+                        surfaceID: surfaceID,
+                        updatedAt: entry.updatedAt ?? .distantPast
+                    )
+                }
                 let sessionID = canonicalClaudeSessionID(
                     incomingSessionID: entry.sessionID,
                     source: source,
@@ -406,6 +423,15 @@ final class AgentChatSessionRegistry {
     @discardableResult
     func noteHookEvent(_ event: WorkstreamEvent) -> AgentChatSessionRecord {
         let hookSessionID = Self.normalizedSessionID(event.sessionId, source: event.source)
+        if event.source == "codex",
+           let surfaceID = event.surfaceId,
+           !surfaceID.isEmpty {
+            rememberCodexHookBinding(
+                sessionID: hookSessionID,
+                surfaceID: surfaceID,
+                updatedAt: event.receivedAt
+            )
+        }
         let sessionID = canonicalClaudeSessionID(
             incomingSessionID: hookSessionID,
             source: event.source,
@@ -658,6 +684,13 @@ final class AgentChatSessionRegistry {
                 store.entry(agentSource: agentSource, sessionID: lookupSessionID)
             }.value
             guard let self, let entry else { return }
+            if agentSource == "codex", let surfaceID = entry.surfaceID {
+                self.rememberCodexHookBinding(
+                    sessionID: entry.sessionID,
+                    surfaceID: surfaceID,
+                    updatedAt: entry.updatedAt ?? .distantPast
+                )
+            }
             self.applyStoreBackfill(sessionID: sessionID, entry: entry)
         }
     }

--- a/Sources/Mobile/AgentChat/CodexRolloutIdentity.swift
+++ b/Sources/Mobile/AgentChat/CodexRolloutIdentity.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// The canonical Codex session represented by one of a process's open rollouts.
+nonisolated struct CodexRolloutIdentity: Equatable, Sendable {
+    let sessionID: String
+    let transcriptPath: String
+}

--- a/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
+++ b/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Collapses open Codex rollout files into one logical parent session.
+nonisolated struct CodexRolloutIdentityResolver: Sendable {
+    private let maximumSessionMetaBytes = 4 * 1_024 * 1_024
+
+    func resolve(
+        openRolloutPaths: [String],
+        preferredSessionIDs: Set<String> = [],
+        sessionIDFromPath: (String) -> String?
+    ) -> CodexRolloutIdentity? {
+        var orderedSessionIDs: [String] = []
+        var pathBySessionID: [String: String] = [:]
+        var parentBySessionID: [String: String] = [:]
+
+        for path in openRolloutPaths {
+            let fallbackSessionID = sessionIDFromPath((path as NSString).lastPathComponent)
+            let metadata = sessionMetadata(atPath: path)
+            guard let sessionID = metadata.sessionID ?? fallbackSessionID else { continue }
+            if pathBySessionID[sessionID] == nil {
+                orderedSessionIDs.append(sessionID)
+                pathBySessionID[sessionID] = path
+            }
+            if let parentSessionID = metadata.parentSessionID,
+               parentSessionID != sessionID {
+                parentBySessionID[sessionID] = parentSessionID
+            }
+        }
+
+        guard !orderedSessionIDs.isEmpty else { return nil }
+        let openSessionIDs = Set(orderedSessionIDs)
+        let roots = orderedSessionIDs.compactMap {
+            rootSessionID(
+                for: $0,
+                parentBySessionID: parentBySessionID,
+                openSessionIDs: openSessionIDs
+            )
+        }
+        if roots.count == orderedSessionIDs.count,
+           let root = Set(roots).onlyElement,
+           let path = pathBySessionID[root] {
+            return CodexRolloutIdentity(sessionID: root, transcriptPath: path)
+        }
+
+        if let preferred = orderedSessionIDs.first(where: preferredSessionIDs.contains),
+           let path = pathBySessionID[preferred] {
+            return CodexRolloutIdentity(sessionID: preferred, transcriptPath: path)
+        }
+
+        let fallback = orderedSessionIDs[0]
+        guard let path = pathBySessionID[fallback] else { return nil }
+        return CodexRolloutIdentity(sessionID: fallback, transcriptPath: path)
+    }
+
+    private func rootSessionID(
+        for sessionID: String,
+        parentBySessionID: [String: String],
+        openSessionIDs: Set<String>
+    ) -> String? {
+        var current = sessionID
+        var visited: Set<String> = []
+        while let parent = parentBySessionID[current], openSessionIDs.contains(parent) {
+            guard visited.insert(current).inserted else { return nil }
+            current = parent
+        }
+        return current
+    }
+
+    private func sessionMetadata(atPath path: String) -> (sessionID: String?, parentSessionID: String?) {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return (nil, nil) }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: maximumSessionMetaBytes + 1),
+              !data.isEmpty,
+              let newline = data.firstIndex(of: 0x0A),
+              data.distance(from: data.startIndex, to: newline) <= maximumSessionMetaBytes,
+              let object = try? JSONSerialization.jsonObject(with: data[..<newline]) as? [String: Any],
+              object["type"] as? String == "session_meta",
+              let payload = object["payload"] as? [String: Any] else {
+            return (nil, nil)
+        }
+        return (
+            normalized(payload["id"] as? String),
+            normalized(payload["parent_thread_id"] as? String)
+        )
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+}
+
+private extension Set {
+    var onlyElement: Element? {
+        count == 1 ? first : nil
+    }
+}

--- a/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
+++ b/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
@@ -1,7 +1,27 @@
 import Foundation
+import os
+
+private struct CodexRolloutSessionMetadata: Sendable {
+    let sessionID: String?
+    let canonicalSessionID: String?
+    let parentSessionID: String?
+}
+
+private struct CodexRolloutMetadataCacheState {
+    var metadataByPath: [String: CodexRolloutSessionMetadata] = [:]
+    var pathsByRecency: [String] = []
+}
+
+// A rollout's session_meta line is immutable once complete and its path embeds
+// a unique session UUID. Keep only the parsed identity strings so forced mobile
+// listings do not repeatedly read and JSON-decode active transcripts.
+private nonisolated let codexRolloutMetadataCache = OSAllocatedUnfairLock(
+    initialState: CodexRolloutMetadataCacheState()
+)
 
 /// Collapses open Codex rollout files into one logical parent session.
 nonisolated struct CodexRolloutIdentityResolver: Sendable {
+    private let metadataCacheCapacity = 128
     private let maximumSessionMetaBytes = 4 * 1_024 * 1_024
     private let sessionMetaReadChunkBytes = 4 * 1_024
 
@@ -20,16 +40,16 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
             guard !Task.isCancelled else { return nil }
             let fallbackSessionID = sessionIDFromPath((path as NSString).lastPathComponent)
             let metadata = sessionMetadata(atPath: path)
-            guard let sessionID = metadata.sessionID ?? fallbackSessionID else { continue }
+            guard let sessionID = metadata?.sessionID ?? fallbackSessionID else { continue }
             if pathBySessionID[sessionID] == nil {
                 orderedSessionIDs.append(sessionID)
                 pathBySessionID[sessionID] = path
             }
-            if let parentSessionID = metadata.parentSessionID,
+            if let parentSessionID = metadata?.parentSessionID,
                parentSessionID != sessionID {
                 parentBySessionID[sessionID] = parentSessionID
             }
-            if let canonicalSessionID = metadata.canonicalSessionID {
+            if let canonicalSessionID = metadata?.canonicalSessionID {
                 canonicalSessionIDBySessionID[sessionID] = canonicalSessionID
             }
         }
@@ -88,19 +108,42 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
 
     private func sessionMetadata(
         atPath path: String
-    ) -> (sessionID: String?, canonicalSessionID: String?, parentSessionID: String?) {
-        guard let handle = FileHandle(forReadingAtPath: path) else { return (nil, nil, nil) }
+    ) -> CodexRolloutSessionMetadata? {
+        if let cached = codexRolloutMetadataCache.withLock({ state -> CodexRolloutSessionMetadata? in
+            guard let metadata = state.metadataByPath[path] else { return nil }
+            state.pathsByRecency.removeAll { $0 == path }
+            state.pathsByRecency.append(path)
+            return metadata
+        }) {
+            return cached
+        }
+
+        guard let metadata = parseSessionMetadata(atPath: path) else { return nil }
+        codexRolloutMetadataCache.withLock { state in
+            state.metadataByPath[path] = metadata
+            state.pathsByRecency.removeAll { $0 == path }
+            state.pathsByRecency.append(path)
+            while state.pathsByRecency.count > metadataCacheCapacity {
+                let evictedPath = state.pathsByRecency.removeFirst()
+                state.metadataByPath.removeValue(forKey: evictedPath)
+            }
+        }
+        return metadata
+    }
+
+    private func parseSessionMetadata(atPath path: String) -> CodexRolloutSessionMetadata? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
         defer { try? handle.close() }
         guard let data = sessionMetaLine(from: handle),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               object["type"] as? String == "session_meta",
               let payload = object["payload"] as? [String: Any] else {
-            return (nil, nil, nil)
+            return nil
         }
-        return (
-            normalized(payload["id"] as? String),
-            normalized(payload["session_id"] as? String),
-            normalized(payload["parent_thread_id"] as? String)
+        return CodexRolloutSessionMetadata(
+            sessionID: normalized(payload["id"] as? String),
+            canonicalSessionID: normalized(payload["session_id"] as? String),
+            parentSessionID: normalized(payload["parent_thread_id"] as? String)
         )
     }
 

--- a/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
+++ b/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
@@ -1,27 +1,7 @@
 import Foundation
-import os
-
-private struct CodexRolloutSessionMetadata: Sendable {
-    let sessionID: String?
-    let canonicalSessionID: String?
-    let parentSessionID: String?
-}
-
-private struct CodexRolloutMetadataCacheState {
-    var metadataByPath: [String: CodexRolloutSessionMetadata] = [:]
-    var pathsByRecency: [String] = []
-}
-
-// A rollout's session_meta line is immutable once complete and its path embeds
-// a unique session UUID. Keep only the parsed identity strings so forced mobile
-// listings do not repeatedly read and JSON-decode active transcripts.
-private nonisolated let codexRolloutMetadataCache = OSAllocatedUnfairLock(
-    initialState: CodexRolloutMetadataCacheState()
-)
 
 /// Collapses open Codex rollout files into one logical parent session.
 nonisolated struct CodexRolloutIdentityResolver: Sendable {
-    private let metadataCacheCapacity = 128
     private let maximumSessionMetaBytes = 4 * 1_024 * 1_024
     private let sessionMetaReadChunkBytes = 4 * 1_024
 
@@ -40,16 +20,16 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
             guard !Task.isCancelled else { return nil }
             let fallbackSessionID = sessionIDFromPath((path as NSString).lastPathComponent)
             let metadata = sessionMetadata(atPath: path)
-            guard let sessionID = metadata?.sessionID ?? fallbackSessionID else { continue }
+            guard let sessionID = metadata.sessionID ?? fallbackSessionID else { continue }
             if pathBySessionID[sessionID] == nil {
                 orderedSessionIDs.append(sessionID)
                 pathBySessionID[sessionID] = path
             }
-            if let parentSessionID = metadata?.parentSessionID,
+            if let parentSessionID = metadata.parentSessionID,
                parentSessionID != sessionID {
                 parentBySessionID[sessionID] = parentSessionID
             }
-            if let canonicalSessionID = metadata?.canonicalSessionID {
+            if let canonicalSessionID = metadata.canonicalSessionID {
                 canonicalSessionIDBySessionID[sessionID] = canonicalSessionID
             }
         }
@@ -108,42 +88,19 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
 
     private func sessionMetadata(
         atPath path: String
-    ) -> CodexRolloutSessionMetadata? {
-        if let cached = codexRolloutMetadataCache.withLock({ state -> CodexRolloutSessionMetadata? in
-            guard let metadata = state.metadataByPath[path] else { return nil }
-            state.pathsByRecency.removeAll { $0 == path }
-            state.pathsByRecency.append(path)
-            return metadata
-        }) {
-            return cached
-        }
-
-        guard let metadata = parseSessionMetadata(atPath: path) else { return nil }
-        codexRolloutMetadataCache.withLock { state in
-            state.metadataByPath[path] = metadata
-            state.pathsByRecency.removeAll { $0 == path }
-            state.pathsByRecency.append(path)
-            while state.pathsByRecency.count > metadataCacheCapacity {
-                let evictedPath = state.pathsByRecency.removeFirst()
-                state.metadataByPath.removeValue(forKey: evictedPath)
-            }
-        }
-        return metadata
-    }
-
-    private func parseSessionMetadata(atPath path: String) -> CodexRolloutSessionMetadata? {
-        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+    ) -> (sessionID: String?, canonicalSessionID: String?, parentSessionID: String?) {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return (nil, nil, nil) }
         defer { try? handle.close() }
         guard let data = sessionMetaLine(from: handle),
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               object["type"] as? String == "session_meta",
               let payload = object["payload"] as? [String: Any] else {
-            return nil
+            return (nil, nil, nil)
         }
-        return CodexRolloutSessionMetadata(
-            sessionID: normalized(payload["id"] as? String),
-            canonicalSessionID: normalized(payload["session_id"] as? String),
-            parentSessionID: normalized(payload["parent_thread_id"] as? String)
+        return (
+            normalized(payload["id"] as? String),
+            normalized(payload["session_id"] as? String),
+            normalized(payload["parent_thread_id"] as? String)
         )
     }
 

--- a/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
+++ b/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Collapses open Codex rollout files into one logical parent session.
 nonisolated struct CodexRolloutIdentityResolver: Sendable {
     private let maximumSessionMetaBytes = 4 * 1_024 * 1_024
+    private let sessionMetaReadChunkBytes = 4 * 1_024
 
     func resolve(
         openRolloutPaths: [String],
@@ -12,8 +13,11 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
         var orderedSessionIDs: [String] = []
         var pathBySessionID: [String: String] = [:]
         var parentBySessionID: [String: String] = [:]
+        var canonicalSessionIDBySessionID: [String: String] = [:]
+        var seenPaths: Set<String> = []
 
-        for path in openRolloutPaths {
+        for path in openRolloutPaths where seenPaths.insert(path).inserted {
+            guard !Task.isCancelled else { return nil }
             let fallbackSessionID = sessionIDFromPath((path as NSString).lastPathComponent)
             let metadata = sessionMetadata(atPath: path)
             guard let sessionID = metadata.sessionID ?? fallbackSessionID else { continue }
@@ -25,10 +29,28 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
                parentSessionID != sessionID {
                 parentBySessionID[sessionID] = parentSessionID
             }
+            if let canonicalSessionID = metadata.canonicalSessionID {
+                canonicalSessionIDBySessionID[sessionID] = canonicalSessionID
+            }
         }
 
         guard !orderedSessionIDs.isEmpty else { return nil }
         let openSessionIDs = Set(orderedSessionIDs)
+        let canonicalSessionIDs = orderedSessionIDs.compactMap {
+            canonicalSessionIDBySessionID[$0]
+        }
+        if let canonicalSessionID = Set(canonicalSessionIDs).onlyElement,
+           orderedSessionIDs.allSatisfy({ sessionID in
+               sessionID == canonicalSessionID
+                   || canonicalSessionIDBySessionID[sessionID] == canonicalSessionID
+           }),
+           let path = pathBySessionID[canonicalSessionID] {
+            return CodexRolloutIdentity(
+                sessionID: canonicalSessionID,
+                transcriptPath: path
+            )
+        }
+
         let roots = orderedSessionIDs.compactMap {
             rootSessionID(
                 for: $0,
@@ -47,9 +69,15 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
             return CodexRolloutIdentity(sessionID: preferred, transcriptPath: path)
         }
 
-        let fallback = orderedSessionIDs[0]
-        guard let path = pathBySessionID[fallback] else { return nil }
-        return CodexRolloutIdentity(sessionID: fallback, transcriptPath: path)
+        if orderedSessionIDs.count == 1,
+           let onlySessionID = orderedSessionIDs.first,
+           canonicalSessionIDBySessionID[onlySessionID].map({ $0 == onlySessionID }) ?? true,
+           parentBySessionID[onlySessionID] == nil,
+           let path = pathBySessionID[onlySessionID] {
+            return CodexRolloutIdentity(sessionID: onlySessionID, transcriptPath: path)
+        }
+
+        return nil
     }
 
     private func rootSessionID(
@@ -59,29 +87,54 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
     ) -> String? {
         var current = sessionID
         var visited: Set<String> = []
-        while let parent = parentBySessionID[current], openSessionIDs.contains(parent) {
+        while let parent = parentBySessionID[current] {
+            guard openSessionIDs.contains(parent) else { return nil }
             guard visited.insert(current).inserted else { return nil }
             current = parent
         }
         return current
     }
 
-    private func sessionMetadata(atPath path: String) -> (sessionID: String?, parentSessionID: String?) {
-        guard let handle = FileHandle(forReadingAtPath: path) else { return (nil, nil) }
+    private func sessionMetadata(
+        atPath path: String
+    ) -> (sessionID: String?, canonicalSessionID: String?, parentSessionID: String?) {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return (nil, nil, nil) }
         defer { try? handle.close() }
-        guard let data = try? handle.read(upToCount: maximumSessionMetaBytes + 1),
-              !data.isEmpty,
-              let newline = data.firstIndex(of: 0x0A),
-              data.distance(from: data.startIndex, to: newline) <= maximumSessionMetaBytes,
-              let object = try? JSONSerialization.jsonObject(with: data[..<newline]) as? [String: Any],
+        guard let data = sessionMetaLine(from: handle),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               object["type"] as? String == "session_meta",
               let payload = object["payload"] as? [String: Any] else {
-            return (nil, nil)
+            return (nil, nil, nil)
         }
         return (
             normalized(payload["id"] as? String),
+            normalized(payload["session_id"] as? String),
             normalized(payload["parent_thread_id"] as? String)
         )
+    }
+
+    private func sessionMetaLine(from handle: FileHandle) -> Data? {
+        var line = Data()
+        while line.count <= maximumSessionMetaBytes {
+            guard !Task.isCancelled,
+                  let chunk = try? handle.read(
+                      upToCount: min(
+                          sessionMetaReadChunkBytes,
+                          maximumSessionMetaBytes + 1 - line.count
+                      )
+                  ),
+                  !chunk.isEmpty else {
+                return nil
+            }
+            if let newline = chunk.firstIndex(of: 0x0A) {
+                let prefix = chunk[..<newline]
+                guard line.count + prefix.count <= maximumSessionMetaBytes else { return nil }
+                line.append(contentsOf: prefix)
+                return line
+            }
+            line.append(chunk)
+        }
+        return nil
     }
 
     private func normalized(_ value: String?) -> String? {

--- a/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
+++ b/Sources/Mobile/AgentChat/CodexRolloutIdentityResolver.swift
@@ -69,14 +69,6 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
             return CodexRolloutIdentity(sessionID: preferred, transcriptPath: path)
         }
 
-        if orderedSessionIDs.count == 1,
-           let onlySessionID = orderedSessionIDs.first,
-           canonicalSessionIDBySessionID[onlySessionID].map({ $0 == onlySessionID }) ?? true,
-           parentBySessionID[onlySessionID] == nil,
-           let path = pathBySessionID[onlySessionID] {
-            return CodexRolloutIdentity(sessionID: onlySessionID, transcriptPath: path)
-        }
-
         return nil
     }
 
@@ -87,8 +79,7 @@ nonisolated struct CodexRolloutIdentityResolver: Sendable {
     ) -> String? {
         var current = sessionID
         var visited: Set<String> = []
-        while let parent = parentBySessionID[current] {
-            guard openSessionIDs.contains(parent) else { return nil }
+        while let parent = parentBySessionID[current], openSessionIDs.contains(parent) {
             guard visited.insert(current).inserted else { return nil }
             current = parent
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -718,6 +718,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
 		C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */; };
+		C8711C000000000000000002 /* CodexRolloutIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711C000000000000000001 /* CodexRolloutIdentity.swift */; };
+		C8711D000000000000000002 /* CodexRolloutIdentityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711D000000000000000001 /* CodexRolloutIdentityResolver.swift */; };
 		C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */; };
@@ -2900,6 +2902,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
 		C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCodeModeRolloutIdentityTests.swift; sourceTree = "<group>"; };
+		C8711C000000000000000001 /* CodexRolloutIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexRolloutIdentity.swift; sourceTree = "<group>"; };
+		C8711D000000000000000001 /* CodexRolloutIdentityResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodexRolloutIdentityResolver.swift; sourceTree = "<group>"; };
 		C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsApprovalBridge.swift; sourceTree = "<group>"; };
 		C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTerminalErrorNotificationTests.swift; sourceTree = "<group>"; };
 		C4041001000000000000001A /* CommandClickFileOpenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandClickFileOpenRouter.swift; sourceTree = "<group>"; };
@@ -4548,6 +4552,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7AF10000000000000000002 /* AgentChatArtifactIndex.swift */,
 				C7AF10000000000000000006 /* AgentChatArtifactGalleryBuilder.swift */,
 				ACA7C4A70000000000000004 /* AgentChatHookSessionStore.swift */,
+				C8711C000000000000000001 /* CodexRolloutIdentity.swift */,
+				C8711D000000000000000001 /* CodexRolloutIdentityResolver.swift */,
 				C7A531000000000000000001 /* AgentChatObservationHandle.swift */,
 				C7A532000000000000000001 /* AgentChatObservationInFlight.swift */,
 				C7A530000000000000000001 /* AgentChatObservationScope.swift */,
@@ -7476,6 +7482,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0A1E5CE01C0A1E5CE01A001 /* CoalesceLatestPublisher.swift in Sources */,
 				A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */,
 				A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */,
+					C8711C000000000000000002 /* CodexRolloutIdentity.swift in Sources */,
+					C8711D000000000000000002 /* CodexRolloutIdentityResolver.swift in Sources */,
 				C4041001000000000000001B /* CommandClickFileOpenRouter.swift in Sources */,
 				C0DE86060000000000000001 /* CommandPaletteFocusRestoreCoordinator.swift in Sources */,
 				C0DEFF200000000000000001 /* CommandPaletteOverlay.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		CDFE000000000000000000A1 /* AgentChatProseStreamer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFE000000000000000000A2 /* AgentChatProseStreamer.swift */; };
 		CDFE000000000000000000C1 /* AgentChatProseStreamerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFE000000000000000000C2 /* AgentChatProseStreamerTests.swift */; };
 		ACA7C4A70000000000000001 /* AgentChatSessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A70000000000000002 /* AgentChatSessionRecord.swift */; };
+		C8711A000000000000000002 /* AgentChatSessionRegistry+CodexRolloutFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711A000000000000000001 /* AgentChatSessionRegistry+CodexRolloutFiles.swift */; };
 		C7A52D100000000000000002 /* AgentChatSessionRegistry+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A52D100000000000000001 /* AgentChatSessionRegistry+Lifecycle.swift */; };
 		C7A52D200000000000000002 /* AgentChatSessionRegistry+LiveAgentPID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A52D200000000000000001 /* AgentChatSessionRegistry+LiveAgentPID.swift */; };
 		C7A52D000000000000000002 /* AgentChatSessionRegistry+ObserveScan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A52D000000000000000001 /* AgentChatSessionRegistry+ObserveScan.swift */; };
@@ -716,6 +717,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
+		C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */; };
 		C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */; };
 		C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */; };
@@ -2265,6 +2267,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		CDFE000000000000000000A2 /* AgentChatProseStreamer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatProseStreamer.swift"; sourceTree = "<group>"; };
 		CDFE000000000000000000C2 /* AgentChatProseStreamerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatProseStreamerTests.swift; sourceTree = "<group>"; };
 		ACA7C4A70000000000000002 /* AgentChatSessionRecord.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatSessionRecord.swift"; sourceTree = "<group>"; };
+		C8711A000000000000000001 /* AgentChatSessionRegistry+CodexRolloutFiles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatSessionRegistry+CodexRolloutFiles.swift"; sourceTree = "<group>"; };
 		C7A52D100000000000000001 /* AgentChatSessionRegistry+Lifecycle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatSessionRegistry+Lifecycle.swift"; sourceTree = "<group>"; };
 		C7A52D200000000000000001 /* AgentChatSessionRegistry+LiveAgentPID.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatSessionRegistry+LiveAgentPID.swift"; sourceTree = "<group>"; };
 		C7A52D000000000000000001 /* AgentChatSessionRegistry+ObserveScan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatSessionRegistry+ObserveScan.swift"; sourceTree = "<group>"; };
@@ -2896,6 +2899,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
+		C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexCodeModeRolloutIdentityTests.swift; sourceTree = "<group>"; };
 		C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTeamsApprovalBridge.swift; sourceTree = "<group>"; };
 		C0DE7101C0DE7101C0DE7101 /* CodexTerminalErrorNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTerminalErrorNotificationTests.swift; sourceTree = "<group>"; };
 		C4041001000000000000001A /* CommandClickFileOpenRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandClickFileOpenRouter.swift; sourceTree = "<group>"; };
@@ -4552,6 +4556,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					C7A52D100000000000000001 /* AgentChatSessionRegistry+Lifecycle.swift */,
 					C7A52D200000000000000001 /* AgentChatSessionRegistry+LiveAgentPID.swift */,
 					C7A52D000000000000000001 /* AgentChatSessionRegistry+ObserveScan.swift */,
+					C8711A000000000000000001 /* AgentChatSessionRegistry+CodexRolloutFiles.swift */,
 					C7A52E000000000000000001 /* AgentChatEndedTranscriptListabilityCache.swift */,
 					ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */,
 				ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */,
@@ -6118,6 +6123,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A51E000000000000000001 /* AgentChatSessionRegistryLifecycleTests.swift */,
 				C7A51D100000000000000001 /* AgentChatSessionRegistryObservationReviewRegressionTests.swift */,
 				C7A51D000000000000000001 /* AgentChatSessionRegistryObservationTests.swift */,
+				C8711B000000000000000001 /* CodexCodeModeRolloutIdentityTests.swift */,
 				21EBB654187F880170B92ED9 /* AgentResumeLaunchGuardTests.swift */,
 				85FA9F7370322CC65A15774E /* AgentResumeLivenessTests.swift */,
 				B714B27E46014592B9CB2D3A /* WorkspaceIsStaleAgentHookBindingTests.swift */,
@@ -7116,6 +7122,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A530000000000000000002 /* AgentChatObservationScope.swift in Sources */,
 				CDFE000000000000000000A1 /* AgentChatProseStreamer.swift in Sources */,
 					ACA7C4A70000000000000001 /* AgentChatSessionRecord.swift in Sources */,
+					C8711A000000000000000002 /* AgentChatSessionRegistry+CodexRolloutFiles.swift in Sources */,
 					C7A52D100000000000000002 /* AgentChatSessionRegistry+Lifecycle.swift in Sources */,
 					C7A52D200000000000000002 /* AgentChatSessionRegistry+LiveAgentPID.swift in Sources */,
 					C7A52D000000000000000002 /* AgentChatSessionRegistry+ObserveScan.swift in Sources */,
@@ -8819,6 +8826,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					A6AC72080000000000000001 /* CMUXWorkspaceLoadingCLIRegressionTests.swift in Sources */,
 				AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
+				C8711B000000000000000002 /* CodexCodeModeRolloutIdentityTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,
 				C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */,
 				C0DEC0DE000000000000F302 /* CommandPaletteEmojiTitleSearchTests.swift in Sources */,

--- a/cmuxTests/AgentChatSessionRegistryClaudeObservationTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryClaudeObservationTests.swift
@@ -43,7 +43,7 @@ struct AgentChatSessionRegistryClaudeObservationTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -90,7 +90,7 @@ struct AgentChatSessionRegistryClaudeObservationTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -132,7 +132,7 @@ struct AgentChatSessionRegistryClaudeObservationTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -168,7 +168,7 @@ struct AgentChatSessionRegistryClaudeObservationTests {
                     environment: [:]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         #expect(observed.isEmpty)
@@ -219,7 +219,7 @@ struct AgentChatSessionRegistryClaudeObservationTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -260,7 +260,7 @@ struct AgentChatSessionRegistryClaudeObservationTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         #expect(observed.isEmpty)

--- a/cmuxTests/AgentChatSessionRegistryHookStoreTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryHookStoreTests.swift
@@ -174,6 +174,51 @@ struct AgentChatSessionRegistryHookStoreTests {
     }
 
     @MainActor
+    @Test func preferredCodexBindingUsesOnlyLatestDurableEvidence() async throws {
+        let home = try temporaryHomeDirectory()
+        let surfaceUUID = UUID()
+        let surfaceID = surfaceUUID.uuidString
+        let observedID = "019f8a6d-fa11-7ad0-9df4-4c1d28f04e3e"
+        let tieLowID = "019f8a6d-e3af-7882-9470-c5824a40ec86"
+        let tieHighID = "019f8a6d-f2c9-7ad0-9df4-4c1d28f04e3e"
+        try writeCodexHookStore(
+            home: home,
+            surfaceID: surfaceID,
+            entries: [
+                (sessionID: observedID, updatedAt: 100),
+                (sessionID: tieLowID, updatedAt: 200),
+                (sessionID: tieHighID, updatedAt: 200),
+            ]
+        )
+        let observed = AgentChatSessionRecord(
+            sessionID: observedID,
+            agentKind: .codex,
+            workspaceID: UUID().uuidString,
+            surfaceID: surfaceID,
+            workingDirectory: nil,
+            transcriptPath: nil,
+            state: .idle,
+            lastActivityAt: Date(timeIntervalSince1970: 300),
+            title: nil,
+            pid: nil
+        )
+        let registry = AgentChatSessionRegistry(
+            hookStore: AgentChatHookSessionStore(homeDirectory: home),
+            restoredRecords: [observed]
+        )
+
+        #expect(registry.preferredCodexSessionIDBySurfaceID(
+            onlySurfaceIDs: Set([surfaceUUID])
+        ).isEmpty)
+
+        await registry.seedFromHookStores(agentSources: ["codex"])
+
+        #expect(registry.preferredCodexSessionIDBySurfaceID(
+            onlySurfaceIDs: Set([surfaceUUID])
+        )[surfaceID] == tieHighID)
+    }
+
+    @MainActor
     @Test func hookStoreSeedMergesPidMatchedRealEntryIntoPendingClaudeSession() async throws {
         let home = try temporaryHomeDirectory()
         let workspaceID = UUID().uuidString
@@ -281,5 +326,25 @@ struct AgentChatSessionRegistryHookStoreTests {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
         try data.write(to: directory.appendingPathComponent("claude-hook-sessions.json"))
+    }
+
+    private func writeCodexHookStore(
+        home: URL,
+        surfaceID: String,
+        entries: [(sessionID: String, updatedAt: TimeInterval)]
+    ) throws {
+        let directory = home.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let sessions = Dictionary(uniqueKeysWithValues: entries.map { entry in
+            (entry.sessionID, [
+                "surfaceId": surfaceID,
+                "updatedAt": entry.updatedAt,
+            ] as [String: Any])
+        })
+        let data = try JSONSerialization.data(
+            withJSONObject: ["sessions": sessions],
+            options: [.sortedKeys]
+        )
+        try data.write(to: directory.appendingPathComponent("codex-hook-sessions.json"))
     }
 }

--- a/cmuxTests/AgentChatSessionRegistryHookStoreTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryHookStoreTests.swift
@@ -44,7 +44,7 @@ struct AgentChatSessionRegistryHookStoreTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -128,7 +128,7 @@ struct AgentChatSessionRegistryHookStoreTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         #expect(observed.isEmpty)

--- a/cmuxTests/AgentChatSessionRegistryObservationReviewRegressionTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryObservationReviewRegressionTests.swift
@@ -63,7 +63,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
                     nil
                 }
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -126,7 +126,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
         let observed = AgentChatSessionRegistry.scanObservedAgentSessions(
             in: snapshot,
             processArgumentsAndEnvironment: details,
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
         let livePID = AgentChatSessionRegistry.liveAgentPID(
             in: snapshot,
@@ -196,7 +196,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
         let observed = AgentChatSessionRegistry.scanObservedAgentSessions(
             in: snapshot,
             processArgumentsAndEnvironment: details,
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
         let livePID = AgentChatSessionRegistry.liveAgentPID(
             in: snapshot,
@@ -263,7 +263,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
         let observed = AgentChatSessionRegistry.scanObservedAgentSessions(
             in: snapshot,
             processArgumentsAndEnvironment: details,
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
         let livePID = AgentChatSessionRegistry.liveAgentPID(
             in: snapshot,
@@ -297,7 +297,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
             )
         }
 
-        let observed = AgentChatSessionRegistry.scanObservedAgentSessions(in: snapshot, processArgumentsAndEnvironment: details, codexRolloutPath: { _ in nil })
+        let observed = AgentChatSessionRegistry.scanObservedAgentSessions(in: snapshot, processArgumentsAndEnvironment: details, codexRolloutPaths: { _ in [] })
         let liveParentPID = AgentChatSessionRegistry.liveAgentPID(
             in: snapshot,
             surfaceID: surfaceID.uuidString,
@@ -355,7 +355,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
         let observed = AgentChatSessionRegistry.scanObservedAgentSessions(
             in: snapshot,
             processArgumentsAndEnvironment: details,
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
         let livePID = AgentChatSessionRegistry.liveAgentPID(
             in: snapshot,
@@ -397,7 +397,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
         let observed = AgentChatSessionRegistry.scanObservedAgentSessions(
             in: snapshot,
             processArgumentsAndEnvironment: { _ in nil },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -437,7 +437,7 @@ struct AgentChatSessionRegistryObservationReviewRegressionTests {
                     detailReads.increment()
                     return CmuxTopProcessArguments(arguments: ["claude.exe"], environment: [:])
                 },
-                codexRolloutPath: { _ in nil }
+                codexRolloutPaths: { _ in [] }
             )
         }
         scan.cancel()

--- a/cmuxTests/AgentChatSessionRegistryObservationTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryObservationTests.swift
@@ -43,7 +43,7 @@ struct AgentChatSessionRegistryObservationTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -82,7 +82,7 @@ struct AgentChatSessionRegistryObservationTests {
                     environment: ["CMUX_AGENT_LAUNCH_CWD": "/Users/example/project"]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         let session = try #require(observed.first)
@@ -274,7 +274,7 @@ struct AgentChatSessionRegistryObservationTests {
                 detailReadCount += 1
                 return nil
             },
-            codexRolloutPath: { pid in pid == 202 ? rolloutPath : nil }
+            codexRolloutPaths: { pid in pid == 202 ? [rolloutPath] : [] }
         )
 
         let session = try #require(observed.first)
@@ -317,7 +317,7 @@ struct AgentChatSessionRegistryObservationTests {
                     ]
                 )
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         #expect(observed.isEmpty)
@@ -462,7 +462,7 @@ struct AgentChatSessionRegistryObservationTests {
                 detailReadCount += 1
                 return nil
             },
-            codexRolloutPath: { _ in nil }
+            codexRolloutPaths: { _ in [] }
         )
 
         #expect(observed.isEmpty)

--- a/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
+++ b/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
@@ -61,6 +61,27 @@ struct CodexCodeModeRolloutIdentityTests {
     }
 
     @Test
+    func canonicalSessionIDResolvesAcrossClosedIntermediateRollout() throws {
+        let fixture = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let primary = try writeRollout(directory: fixture.rollouts, sessionID: Self.primaryID)
+        let grandchild = try writeRollout(
+            directory: fixture.rollouts,
+            sessionID: Self.grandchildID,
+            canonicalSessionID: Self.primaryID,
+            parentThreadID: Self.childID
+        )
+
+        let session = try #require(observedSession(
+            openRollouts: [grandchild, primary],
+            preferredSessionID: nil
+        ))
+
+        #expect(session.sessionID == Self.primaryID)
+        #expect(session.transcriptPath == primary)
+    }
+
+    @Test
     func partialMetadataFallsBackToStoredSurfaceBinding() throws {
         let fixture = try makeFixtureDirectory()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
@@ -74,6 +95,22 @@ struct CodexCodeModeRolloutIdentityTests {
 
         #expect(session.sessionID == Self.primaryID)
         #expect(session.transcriptPath == primary)
+    }
+
+    @Test
+    func ambiguousPartialMetadataDoesNotChooseDescriptorOrder() throws {
+        let fixture = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let child = try writePartialRollout(directory: fixture.rollouts, sessionID: Self.childID)
+        let grandchild = try writePartialRollout(
+            directory: fixture.rollouts,
+            sessionID: Self.grandchildID
+        )
+
+        #expect(observedSession(
+            openRollouts: [grandchild, child],
+            preferredSessionID: nil
+        ) == nil)
     }
 
     private func observedSession(
@@ -123,6 +160,7 @@ struct CodexCodeModeRolloutIdentityTests {
     private func writeRollout(
         directory: URL,
         sessionID: String,
+        canonicalSessionID: String? = nil,
         parentThreadID: String? = nil,
         trailingBytes: Int = 0
     ) throws -> String {
@@ -132,7 +170,7 @@ struct CodexCodeModeRolloutIdentityTests {
             "originator": "codex-tui",
         ]
         if let parentThreadID {
-            payload["session_id"] = parentThreadID
+            payload["session_id"] = canonicalSessionID ?? parentThreadID
             payload["parent_thread_id"] = parentThreadID
             payload["source"] = ["subagent": ["other": "guardian"]]
             payload["multi_agent_version"] = "1"

--- a/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
+++ b/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
@@ -82,6 +82,26 @@ struct CodexCodeModeRolloutIdentityTests {
     }
 
     @Test
+    func singleOpenChildWithClosedParentKeepsCurrentIdentity() throws {
+        let fixture = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let child = try writeRollout(
+            directory: fixture.rollouts,
+            sessionID: Self.childID,
+            canonicalSessionID: Self.primaryID,
+            parentThreadID: Self.primaryID
+        )
+
+        let session = try #require(observedSession(
+            openRollouts: [child],
+            preferredSessionID: nil
+        ))
+
+        #expect(session.sessionID == Self.childID)
+        #expect(session.transcriptPath == child)
+    }
+
+    @Test
     func partialMetadataFallsBackToStoredSurfaceBinding() throws {
         let fixture = try makeFixtureDirectory()
         defer { try? FileManager.default.removeItem(at: fixture.root) }

--- a/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
+++ b/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
@@ -1,0 +1,161 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct CodexCodeModeRolloutIdentityTests {
+    private static let primaryID = "019f8a6d-e3af-7882-9470-c5824a40ec86"
+    private static let childID = "019f8a6d-f2c9-7ad0-9df4-4c1d28f04e3e"
+    private static let grandchildID = "019f8a6d-fa11-7ad0-9df4-4c1d28f04e3e"
+
+    @Test
+    func codeModeGuardianRolloutResolvesToOpenParent() throws {
+        let directory = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let primary = try writeRollout(directory: directory, sessionID: Self.primaryID)
+        let child = try writeRollout(
+            directory: directory,
+            sessionID: Self.childID,
+            parentThreadID: Self.primaryID
+        )
+
+        let session = try #require(observedSession(
+            openRollouts: [child, primary],
+            preferredSessionID: nil
+        ))
+
+        #expect(session.sessionID == Self.primaryID)
+        #expect(session.transcriptPath == primary)
+    }
+
+    @Test
+    func codeModeRolloutChainResolvesToRootParent() throws {
+        let directory = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let primary = try writeRollout(directory: directory, sessionID: Self.primaryID)
+        let child = try writeRollout(
+            directory: directory,
+            sessionID: Self.childID,
+            parentThreadID: Self.primaryID
+        )
+        let grandchild = try writeRollout(
+            directory: directory,
+            sessionID: Self.grandchildID,
+            parentThreadID: Self.childID
+        )
+
+        let session = try #require(observedSession(
+            openRollouts: [grandchild, child, primary],
+            preferredSessionID: nil
+        ))
+
+        #expect(session.sessionID == Self.primaryID)
+        #expect(session.transcriptPath == primary)
+    }
+
+    @Test
+    func partialMetadataFallsBackToStoredSurfaceBinding() throws {
+        let directory = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let primary = try writeRollout(directory: directory, sessionID: Self.primaryID)
+        let partial = try writePartialRollout(directory: directory, sessionID: Self.childID)
+
+        let session = try #require(observedSession(
+            openRollouts: [partial, primary],
+            preferredSessionID: Self.primaryID
+        ))
+
+        #expect(session.sessionID == Self.primaryID)
+        #expect(session.transcriptPath == primary)
+    }
+
+    private func observedSession(
+        openRollouts: [String],
+        preferredSessionID: String?
+    ) -> ObservedAgentSession? {
+        let workspaceID = UUID()
+        let surfaceID = UUID()
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [CmuxTopProcessInfo(
+                pid: 202,
+                parentPID: 1,
+                name: "codex",
+                path: "/opt/homebrew/bin/codex",
+                ttyDevice: nil,
+                cmuxWorkspaceID: workspaceID,
+                cmuxSurfaceID: surfaceID,
+                cmuxAttributionReason: "test",
+                processGroupID: 202,
+                terminalProcessGroupID: 202,
+                cpuPercent: 0,
+                residentBytes: 1,
+                virtualBytes: 1,
+                threadCount: 1
+            )],
+            sampledAt: Date(timeIntervalSince1970: 200),
+            includesProcessDetails: true
+        )
+        let preferred = preferredSessionID.map { [surfaceID.uuidString: $0] } ?? [:]
+        return AgentChatSessionRegistry.scanObservedAgentSessions(
+            in: snapshot,
+            preferredCodexSessionIDBySurfaceID: preferred,
+            processArgumentsAndEnvironment: { _ in nil },
+            codexRolloutPaths: { pid in pid == 202 ? openRollouts : [] }
+        ).first
+    }
+
+    private func makeFixtureDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-code-mode-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent(".codex/sessions/2026/07/22", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func writeRollout(
+        directory: URL,
+        sessionID: String,
+        parentThreadID: String? = nil
+    ) throws -> String {
+        var payload: [String: Any] = [
+            "id": sessionID,
+            "cwd": "/Users/example/project",
+            "originator": "codex-tui",
+        ]
+        if let parentThreadID {
+            payload["session_id"] = parentThreadID
+            payload["parent_thread_id"] = parentThreadID
+            payload["source"] = ["subagent": ["other": "guardian"]]
+            payload["multi_agent_version"] = "1"
+        }
+        let line: [String: Any] = [
+            "timestamp": "2026-07-22T12:00:00.000Z",
+            "type": "session_meta",
+            "payload": payload,
+        ]
+        var data = try JSONSerialization.data(withJSONObject: line, options: [.sortedKeys])
+        data.append(0x0A)
+        let url = directory.appendingPathComponent(
+            "rollout-2026-07-22T12-00-00-\(sessionID).jsonl",
+            isDirectory: false
+        )
+        try data.write(to: url, options: .atomic)
+        return url.path
+    }
+
+    private func writePartialRollout(directory: URL, sessionID: String) throws -> String {
+        let url = directory.appendingPathComponent(
+            "rollout-2026-07-22T12-00-01-\(sessionID).jsonl",
+            isDirectory: false
+        )
+        try Data(#"{"type":"session_meta","payload":{"id":"partial""#.utf8)
+            .write(to: url, options: .atomic)
+        return url.path
+    }
+}

--- a/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
+++ b/cmuxTests/CodexCodeModeRolloutIdentityTests.swift
@@ -16,13 +16,14 @@ struct CodexCodeModeRolloutIdentityTests {
 
     @Test
     func codeModeGuardianRolloutResolvesToOpenParent() throws {
-        let directory = try makeFixtureDirectory()
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let primary = try writeRollout(directory: directory, sessionID: Self.primaryID)
+        let fixture = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let primary = try writeRollout(directory: fixture.rollouts, sessionID: Self.primaryID)
         let child = try writeRollout(
-            directory: directory,
+            directory: fixture.rollouts,
             sessionID: Self.childID,
-            parentThreadID: Self.primaryID
+            parentThreadID: Self.primaryID,
+            trailingBytes: 4 * 1_024 * 1_024 + 1
         )
 
         let session = try #require(observedSession(
@@ -36,16 +37,16 @@ struct CodexCodeModeRolloutIdentityTests {
 
     @Test
     func codeModeRolloutChainResolvesToRootParent() throws {
-        let directory = try makeFixtureDirectory()
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let primary = try writeRollout(directory: directory, sessionID: Self.primaryID)
+        let fixture = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let primary = try writeRollout(directory: fixture.rollouts, sessionID: Self.primaryID)
         let child = try writeRollout(
-            directory: directory,
+            directory: fixture.rollouts,
             sessionID: Self.childID,
             parentThreadID: Self.primaryID
         )
         let grandchild = try writeRollout(
-            directory: directory,
+            directory: fixture.rollouts,
             sessionID: Self.grandchildID,
             parentThreadID: Self.childID
         )
@@ -61,10 +62,10 @@ struct CodexCodeModeRolloutIdentityTests {
 
     @Test
     func partialMetadataFallsBackToStoredSurfaceBinding() throws {
-        let directory = try makeFixtureDirectory()
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let primary = try writeRollout(directory: directory, sessionID: Self.primaryID)
-        let partial = try writePartialRollout(directory: directory, sessionID: Self.childID)
+        let fixture = try makeFixtureDirectory()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let primary = try writeRollout(directory: fixture.rollouts, sessionID: Self.primaryID)
+        let partial = try writePartialRollout(directory: fixture.rollouts, sessionID: Self.childID)
 
         let session = try #require(observedSession(
             openRollouts: [partial, primary],
@@ -110,18 +111,20 @@ struct CodexCodeModeRolloutIdentityTests {
         ).first
     }
 
-    private func makeFixtureDirectory() throws -> URL {
-        let directory = FileManager.default.temporaryDirectory
+    private func makeFixtureDirectory() throws -> (root: URL, rollouts: URL) {
+        let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-codex-code-mode-\(UUID().uuidString)", isDirectory: true)
+        let rollouts = root
             .appendingPathComponent(".codex/sessions/2026/07/22", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return directory
+        try FileManager.default.createDirectory(at: rollouts, withIntermediateDirectories: true)
+        return (root, rollouts)
     }
 
     private func writeRollout(
         directory: URL,
         sessionID: String,
-        parentThreadID: String? = nil
+        parentThreadID: String? = nil,
+        trailingBytes: Int = 0
     ) throws -> String {
         var payload: [String: Any] = [
             "id": sessionID,
@@ -141,6 +144,7 @@ struct CodexCodeModeRolloutIdentityTests {
         ]
         var data = try JSONSerialization.data(withJSONObject: line, options: [.sortedKeys])
         data.append(0x0A)
+        data.append(Data(repeating: 0x20, count: trailingBytes))
         let url = directory.appendingPathComponent(
             "rollout-2026-07-22T12-00-00-\(sessionID).jsonl",
             isDirectory: false


### PR DESCRIPTION
## Summary

- collect and de-duplicate every open Codex rollout instead of accepting descriptor order as identity
- parse `session_meta.id`, canonical `session_id`, and `parent_thread_id`, then collapse open guardian/child/grandchild chains to their logical root
- preserve the only open rollout when its parent is closed, and resolve through canonical `session_id` when an intermediate rollout is closed
- prefer the authoritative stored surface binding when genuinely ambiguous metadata still names that open session
- keep authoritative Codex hook/store bindings in a deterministic, 256-entry per-surface registry index and snapshot it before off-main scanning
- share the same bounded resolver between observation and process-liveness validation

No settings escape hatch is added: parent/canonical resolution plus the existing authoritative hook binding restores deterministic identity without exposing quarantine policy as user configuration.

## Root cause

Codex code mode keeps a primary rollout and a guardian child rollout open in the same process. The child identifies the primary through top-level `parent_thread_id` and canonical `session_id`, but cmux previously treated each open rollout filename as an independent exact identity. One healthy logical agent therefore appeared to have conflicting exact identities and was quarantined.

## Regression coverage

The first commit intentionally reproduces the bug before the fix. Its CI run, [29974557099](https://github.com/manaflow-ai/cmux/actions/runs/29974557099), fails the new guardian, grandchild, and stored-binding assertions by resolving child IDs.

The final suite covers:

- guardian child to open primary resolution, using a rollout with more than 4 MiB after the first metadata line to prove bounded first-line parsing
- grandchild-to-child-to-root resolution
- canonical `session_id` resolution across a closed intermediate rollout
- sole open child stability when its parent is closed
- partial/unreadable metadata falling back to an authoritative stored surface binding
- genuinely ambiguous partial metadata returning `nil` instead of choosing descriptor order
- authoritative binding selection only after hook-store evidence, with latest-timestamp and deterministic session-ID tie-breaking

The fixed-head targeted run, [29976220406](https://github.com/manaflow-ai/cmux/actions/runs/29976220406), passes on commit `881e29a8b958e61794ec0be2db8d1159ee5def58`.

## Validation

Local app builds and tests were intentionally not run per the issue instructions. Static Swift parsing/type-checking, pbxproj normalization, project checks, test-target wiring lint, and diff checks pass. The requested `scripts/swift_file_length_budget.py` check could not run because that script and its TSV are absent from this `main`; all new Swift files remain under 500 lines and no warning-budget file is changed.

The optional full-matrix branch run [29976221709](https://github.com/manaflow-ai/cmux/actions/runs/29976221709) passed every lane except app-host shard 4. That shard failed twice on different fresh runners with the same broad, unrelated current-base cascade across browser/DevTools, shortcuts, terminal, workspace, remote-tmux, sidebar, and socket tests; no new Codex rollout resolver test failed. The attached required PR checks and automated reviews are green.

Closes #8711

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787365660&installation_model_id=21920&pr_number=8715&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8715&signature=0e55bc4a42013918bb76acf7d8b326c0386cf4808d90190e6b165e37e61b392e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve Codex code mode session identity conflicts by collapsing multiple open rollout files to a single stable session per agent, and preferring a durable per-surface binding when metadata is incomplete or ambiguous. Stops flapping across code/guardian chains. Closes #8711.

- **Bug Fixes**
  - Scan all open `~/.codex/sessions/**/rollout-*.jsonl` per process; de‑dupe; read only the first `session_meta` line (max 4MB); honor canonical `session_id` and collapse `parent_thread_id` chains; keep child-only identity when the parent is closed.
  - Index authoritative Codex hook/store bindings per surface (cap 256); choose latest by `updatedAt` (tie-break by session ID); use for observation and PID selection when metadata is missing or multiple roots exist.
  - Reuse the same bounded identity resolver for both observation scans and live-PID matching; add tests for guardian/grandchild chains, single-open-child stability, canonical-session across closed intermediates, partial-metadata fallback, and durable-binding preference.

<sup>Written for commit 881e29a8b958e61794ec0be2db8d1159ee5def58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Codex session detection by scanning multiple open rollout files and resolving a single effective identity across rollout chains.
  * Added per-surface preferred session fallback to handle incomplete rollout metadata more reliably.
* **Bug Fixes**
  * Fixes active agent to session association when multiple rollout paths are available, ensuring consistent transcript/session selection.
* **Tests**
  * Added new test suite covering Codex rollout identity resolution.
  * Updated observation-related tests to use the new multi-path Codex rollout configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
