### PR TITLE
Name every iroh disconnect: classify client read errors + host close reasons

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3627,6 +3627,10 @@ struct CMUXCLI {
             let response = try sendV1Command("ping", client: client)
             print(response)
 
+        case "iroh-diag":
+            let response = try sendV1Command("iroh_diag", client: client)
+            print(response)
+
         case "capabilities":
             let response = try client.sendV2(method: "system.capabilities")
             print(jsonString(formatIDs(response, mode: idFormat)))
@@ -14944,6 +14948,13 @@ struct CMUXCLI {
             Usage: cmux ping
 
             Check connectivity to the cmux socket server.
+            """
+        case "iroh-diag":
+            return """
+            Usage: cmux iroh-diag
+
+            Print the host's iroh Connection Report (cmuxdiag v1 compact export),
+            the same data as Settings > Networking > Connection Report.
             """
         case "capabilities":
             return """
@@ -35140,6 +35151,7 @@ export default CMUXSessionRestore;
           hooks <agent> <install|uninstall|event> [options; opencode supports --project]
           hooks feed --source <agent> [--event <event>]
           ping
+          iroh-diag
           version
           capabilities
           events [--after <seq>] [--cursor-file <path>] [--name <event>] [--category <category>] [--reconnect] [--limit <n>] [--no-ack] [--no-heartbeat]

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -61,6 +61,8 @@ public enum DiagnosticFailureKind: Int, Sendable, Codable, CaseIterable {
     case connectionClosed = 18
     case superseded = 19
     case cancelled = 20
+    /// The established transport exceeded its negotiated inactivity window.
+    case transportIdleTimedOut = 21
     case unknown = 255
 
     /// Reduces a typed or system error to the bounded diagnostic vocabulary.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -238,6 +238,7 @@ import Testing
         #expect(DiagnosticTransportKind(.debugLoopback) == .debugLoopback)
         #expect(CmxAttachTransportKind.iroh.diagnosticTransportKind.rawValue == 1)
         #expect(DiagnosticFailureKind.cancelled.rawValue == 20)
+        #expect(DiagnosticFailureKind.transportIdleTimedOut.rawValue == 21)
         #expect(DiagnosticFailureKind.unknown.rawValue == 255)
         #expect(DiagnosticSessionLifecycleKind.established.rawValue == 1)
         #expect(DiagnosticSessionLifecycleKind.controlOwnerReleased.rawValue == 2)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedConnectionExit.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedConnectionExit.swift
@@ -1,0 +1,23 @@
+public import CMUXMobileCore
+
+/// The privacy-safe reason an admitted host connection supervisor stopped.
+public struct CmxIrohAdmittedConnectionExit: Equatable, Sendable {
+    /// The local operation that ended the admitted connection.
+    public let lifecycle: DiagnosticSessionLifecycleKind
+
+    /// The bounded failure category, or ``DiagnosticFailureKind/none`` for an expected close.
+    public let failure: DiagnosticFailureKind
+
+    /// Creates a terminal result for one admitted host connection.
+    ///
+    /// - Parameters:
+    ///   - lifecycle: The local operation that ended the connection.
+    ///   - failure: The bounded failure category, or ``DiagnosticFailureKind/none``.
+    public init(
+        lifecycle: DiagnosticSessionLifecycleKind,
+        failure: DiagnosticFailureKind
+    ) {
+        self.lifecycle = lifecycle
+        self.failure = failure
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedConnectionSupervisor.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedConnectionSupervisor.swift
@@ -7,19 +7,31 @@
 ///
 /// ```swift
 /// let supervisor = CmxIrohAdmittedConnectionSupervisor(
-///     runControl: { await serveControl() },
-///     runApplicationLanes: { await serveApplicationLanes() },
+///     runControl: {
+///         await serveControl()
+///         return CmxIrohAdmittedConnectionExit(
+///             lifecycle: .remoteClosed,
+///             failure: .connectionClosed
+///         )
+///     },
+///     runApplicationLanes: {
+///         await serveApplicationLanes()
+///         return CmxIrohAdmittedConnectionExit(
+///             lifecycle: .applicationLaneFailed,
+///             failure: .connectionClosed
+///         )
+///     },
 ///     closeConnection: { await connection.close() },
 ///     stopApplicationLanes: { await lanes.stop() }
 /// )
-/// await supervisor.run()
+/// let exit = await supervisor.run()
 /// ```
 public actor CmxIrohAdmittedConnectionSupervisor {
-    private let runControl: @Sendable () async -> Void
-    private let runApplicationLanes: @Sendable () async -> Void
+    private let runControl: @Sendable () async -> CmxIrohAdmittedConnectionExit
+    private let runApplicationLanes: @Sendable () async -> CmxIrohAdmittedConnectionExit
     private let closeConnection: @Sendable () async -> Void
     private let stopApplicationLanes: @Sendable () async -> Void
-    private var didRun = false
+    private var runTask: Task<CmxIrohAdmittedConnectionExit, Never>?
 
     /// Creates the sole lifetime owner for one admitted connection.
     ///
@@ -33,8 +45,8 @@ public actor CmxIrohAdmittedConnectionSupervisor {
     ///   - stopApplicationLanes: Cancels and joins every accepted application
     ///     lane after the connection starts closing.
     public init(
-        runControl: @escaping @Sendable () async -> Void,
-        runApplicationLanes: @escaping @Sendable () async -> Void,
+        runControl: @escaping @Sendable () async -> CmxIrohAdmittedConnectionExit,
+        runApplicationLanes: @escaping @Sendable () async -> CmxIrohAdmittedConnectionExit,
         closeConnection: @escaping @Sendable () async -> Void,
         stopApplicationLanes: @escaping @Sendable () async -> Void
     ) {
@@ -44,26 +56,43 @@ public actor CmxIrohAdmittedConnectionSupervisor {
         self.stopApplicationLanes = stopApplicationLanes
     }
 
-    /// Runs the connection until either child exits, then closes all owned work.
-    public func run() async {
-        guard !didRun else { return }
-        didRun = true
+    /// Runs until either child exits, closes owned work, and returns that first exit reason.
+    public func run() async -> CmxIrohAdmittedConnectionExit {
+        if let runTask { return await runTask.value }
         let runControl = runControl
         let runApplicationLanes = runApplicationLanes
         let closeConnection = closeConnection
         let stopApplicationLanes = stopApplicationLanes
 
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                await runControl()
+        let task = Task {
+            await withTaskGroup(
+                of: CmxIrohAdmittedConnectionExit.self,
+                returning: CmxIrohAdmittedConnectionExit.self
+            ) { group in
+                group.addTask {
+                    await runControl()
+                }
+                group.addTask {
+                    await runApplicationLanes()
+                }
+                let firstExit = await group.next() ?? CmxIrohAdmittedConnectionExit(
+                    lifecycle: .explicitlyInvalidated,
+                    failure: .none
+                )
+                group.cancelAll()
+                await closeConnection()
+                await stopApplicationLanes()
+                return firstExit
             }
-            group.addTask {
-                await runApplicationLanes()
-            }
-            _ = await group.next()
-            group.cancelAll()
-            await closeConnection()
-            await stopApplicationLanes()
         }
+        runTask = task
+        return await withTaskCancellationHandler(
+            operation: {
+                await task.value
+            },
+            onCancel: {
+                task.cancel()
+            }
+        )
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
@@ -1,8 +1,75 @@
 public import CMUXMobileCore
+public import IrohLib
 
 // These conformances are deliberately categorical. They prevent callers from
 // exporting `String(describing: error)`, which may contain endpoint identities,
 // relay URLs, credentials, or private network addresses.
+
+extension IrohError: @retroactive DiagnosticFailureProviding {
+    public var diagnosticFailureKind: DiagnosticFailureKind {
+        Self.diagnosticFailureKind(message: message())
+    }
+
+    /// iroh-ffi 1.0.2-cmux.4 (iroh 1.0.2) exposes one opaque `IrohError`
+    /// object. Its `message()` retains `ReadError` case names and other errors'
+    /// stable display chains, but no structured discriminator. These pinned
+    /// tokens are the narrowest fallback until the binding exports a taxonomy.
+    private static func diagnosticFailureKind(
+        message: String
+    ) -> DiagnosticFailureKind {
+        if message.contains("ConnectionLost(TimedOut)") {
+            return .transportIdleTimedOut
+        }
+        if message.contains("ConnectionLost(LocallyClosed)") {
+            return .cancelled
+        }
+        if message.contains("ConnectionLost(TransportError(")
+            && (message.contains("Code::crypto(")
+                || message.contains("TLS error:")) {
+            return .secureChannelFailed
+        }
+        if message.contains("ConnectionLost(Reset)")
+            || message.contains("ConnectionLost(TransportError(")
+            || message.contains("ConnectionLost(ApplicationClosed(")
+            || message.contains("ConnectionLost(ConnectionClosed(") {
+            return .connectionClosed
+        }
+        if message.contains("AddressLookupFailed")
+            || message.contains("DnsLookup")
+            || message.contains("DNS lookup")
+            || message.contains("No addressing information available")
+            || message.contains("No address lookup configured")
+            || message.contains("All address lookup services failed or produced no results")
+            || message.contains("Failed to resolve TXT record")
+            || message.contains("Resolve failed, IPv4:")
+            || message.contains("Failed to resolve") {
+            return .dnsFailed
+        }
+        if message.contains("timed out")
+            || message.contains("Timed out")
+            || message.contains("Timeout") {
+            return .timedOut
+        }
+        if message.contains("Tls")
+            || message.contains("TLS")
+            || message.contains("CryptoError")
+            || message.contains("Code::crypto(")
+            || message.contains("Certificate")
+            || message.contains("certificate")
+            || message.contains("Handshake")
+            || message.contains("handshake")
+            || message.contains("crypto provider") {
+            return .secureChannelFailed
+        }
+        if message.contains("ConnectionLost(")
+            || message.contains("ClosedStream")
+            || message.contains("Reset(")
+            || message.contains("Stopped(") {
+            return .connectionClosed
+        }
+        return .unknown
+    }
+}
 
 extension CmxIrohTrustBrokerClientError: DiagnosticFailureProviding {
     public var diagnosticFailureKind: DiagnosticFailureKind {

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohAdmittedConnectionSupervisorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohAdmittedConnectionSupervisorTests.swift
@@ -18,11 +18,19 @@ struct CmxIrohAdmittedConnectionSupervisorTests {
                 started.continuation.yield()
                 for await _ in control.stream {}
                 await childExitRecorder.record("control")
+                return CmxIrohAdmittedConnectionExit(
+                    lifecycle: .controlReadFailed,
+                    failure: .transportIdleTimedOut
+                )
             },
             runApplicationLanes: {
                 started.continuation.yield()
                 for await _ in lanes.stream {}
                 await childExitRecorder.record("lanes")
+                return CmxIrohAdmittedConnectionExit(
+                    lifecycle: .applicationLaneFailed,
+                    failure: .connectionClosed
+                )
             },
             closeConnection: {
                 await cleanupRecorder.record("connection.close")
@@ -54,11 +62,11 @@ struct CmxIrohAdmittedConnectionSupervisorTests {
         default:
             runTask.cancel()
         }
-        await runTask.value
+        let exit = await runTask.value
 
         // One actor instance owns one admitted connection lifetime. A repeated
         // call cannot launch or clean up the same connection again.
-        await supervisor.run()
+        let repeatedExit = await supervisor.run()
 
         #expect(
             await cleanupRecorder.observedEvents()
@@ -68,5 +76,21 @@ struct CmxIrohAdmittedConnectionSupervisorTests {
             Set(await childExitRecorder.observedEvents())
                 == Set(["control", "lanes"])
         )
+        if trigger == "control" {
+            #expect(
+                exit == CmxIrohAdmittedConnectionExit(
+                    lifecycle: .controlReadFailed,
+                    failure: .transportIdleTimedOut
+                )
+            )
+        } else if trigger == "lanes" {
+            #expect(
+                exit == CmxIrohAdmittedConnectionExit(
+                    lifecycle: .applicationLaneFailed,
+                    failure: .connectionClosed
+                )
+            )
+        }
+        #expect(repeatedExit == exit)
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import IrohLib
 import Testing
 
 @testable import CmuxIrohTransport
@@ -31,5 +32,69 @@ import Testing
             DiagnosticFailureKind.classify(CmxIrohClientRuntimeError.superseded)
                 == .superseded
         )
+    }
+
+    @Test(arguments: [
+        ("ConnectionLost(TimedOut)", DiagnosticFailureKind.transportIdleTimedOut),
+        ("timed out", DiagnosticFailureKind.timedOut),
+        ("ConnectionLost(Reset)", DiagnosticFailureKind.connectionClosed),
+        (
+            "ConnectionLost(TransportError(TransportError { code: INTERNAL_ERROR }))",
+            DiagnosticFailureKind.connectionClosed
+        ),
+        (
+            "ConnectionLost(ApplicationClosed(ApplicationClose { error_code: 0 }))",
+            DiagnosticFailureKind.connectionClosed
+        ),
+        (
+            "ConnectionLost(ConnectionClosed(ConnectionClose { error_code: 0 }))",
+            DiagnosticFailureKind.connectionClosed
+        ),
+        ("ConnectionLost(LocallyClosed)", DiagnosticFailureKind.cancelled),
+        (
+            "No addressing information available\nCaused by:\n    All address lookup services failed or produced no results",
+            DiagnosticFailureKind.dnsFailed
+        ),
+        (
+            "Failed to connect to relay server\nCaused by:\n    Failed to resolve",
+            DiagnosticFailureKind.dnsFailed
+        ),
+        (
+            "Error constructing TLS configuration\nCaused by:\n    The configured crypto provider is incompatible with iroh and QUIC encryption",
+            DiagnosticFailureKind.secureChannelFailed
+        ),
+        (
+            "ConnectionLost(TransportError(Error { code: Code::crypto(2a), reason: \"TLS error\" }))",
+            DiagnosticFailureKind.secureChannelFailed
+        ),
+        ("ReadError(ClosedStream)", DiagnosticFailureKind.connectionClosed),
+        ("opaque unclassified bridge failure", DiagnosticFailureKind.unknown),
+    ])
+    func mapsPinnedIrohFFIErrors(
+        message: String,
+        expected: DiagnosticFailureKind
+    ) {
+        #expect(
+            DiagnosticFailureKind.classify(TestIrohError(message: message))
+                == expected
+        )
+    }
+}
+
+private final class TestIrohError: IrohError, @unchecked Sendable {
+    private let testMessage: String
+
+    required init(unsafeFromHandle handle: UInt64) {
+        testMessage = ""
+        super.init(unsafeFromHandle: handle)
+    }
+
+    init(message: String) {
+        testMessage = message
+        super.init(noHandle: NoHandle())
+    }
+
+    override func message() -> String {
+        testMessage
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -329,6 +329,11 @@ private extension MobileIrohSettingsView {
             L10n.string("mobile.iroh.diagnostics.failure.offline", defaultValue: "Offline")
         case .some(.timedOut):
             L10n.string("mobile.iroh.diagnostics.failure.timedOut", defaultValue: "Timed Out")
+        case .some(.transportIdleTimedOut):
+            L10n.string(
+                "mobile.iroh.diagnostics.failure.transportIdleTimedOut",
+                defaultValue: "Transport Idle Timeout"
+            )
         case .some(.connectionRefused):
             L10n.string(
                 "mobile.iroh.diagnostics.failure.connectionRefused",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -872,6 +872,13 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "タイムアウト" } }
       }
     },
+    "mobile.iroh.diagnostics.failure.transportIdleTimedOut" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Transport Idle Timeout" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "接続アイドルタイムアウト" } }
+      }
+    },
     "mobile.iroh.diagnostics.failure.connectionRefused" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -389,6 +389,13 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         "read_screen",
     ]
 
+    /// The v1 diagnostic-read family. These commands await actor-owned
+    /// diagnostic snapshots, so they run on the socket worker and are not
+    /// callable from the main thread.
+    static let diagnosticReadV1Commands: Set<String> = [
+        "iroh_diag",
+    ]
+
     /// The v1 resolution-read family (tranche D): the v1 twins of the v2
     /// resolution reads. Nonisolated `TerminalController` bodies take one
     /// `v2MainSync` snapshot hop and format their reply lines on the worker.
@@ -426,6 +433,7 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         sidebarTelemetryV1Commands
             .union(notificationV1Commands)
             .union(terminalReadV1Commands)
+            .union(diagnosticReadV1Commands)
             .union(resolutionReadV1Commands)
             .union(terminalSendV1Commands)
             .union(["ping"])

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
@@ -153,6 +153,10 @@ struct ControlCommandExecutionPolicyTests {
         #expect(ControlCommandExecutionPolicy(forV1Command: "read_screen") == .socketWorker(mainThreadCallable: false))
     }
 
+    @Test func diagnosticReadsRunOnTheWorkerAndAreNotMainThreadCallable() {
+        #expect(ControlCommandExecutionPolicy(forV1Command: "iroh_diag") == .socketWorker(mainThreadCallable: false))
+    }
+
     @Test func v1PingRunsOnTheWorkerAndIsMainThreadCallable() {
         // `ping` is the dispatcher's former hard-coded worker fast path; it is
         // a pure probe, so in-process main-thread callers may run it inline.
@@ -289,6 +293,8 @@ struct ControlCommandExecutionPolicyTests {
         #expect(ControlCommandExecutionPolicy.notificationV1Commands == notification)
         let terminalRead: Set<String> = ["read_screen"]
         #expect(ControlCommandExecutionPolicy.terminalReadV1Commands == terminalRead)
+        let diagnosticRead: Set<String> = ["iroh_diag"]
+        #expect(ControlCommandExecutionPolicy.diagnosticReadV1Commands == diagnosticRead)
         let resolutionReads: Set<String> = [
             "list_windows", "current_window", "list_workspaces",
             "list_surfaces", "current_workspace",
@@ -300,15 +306,15 @@ struct ControlCommandExecutionPolicyTests {
         ]
         #expect(ControlCommandExecutionPolicy.terminalSendV1Commands == sends)
         let expectedWorker = telemetry.union(notification).union(terminalRead)
+            .union(diagnosticRead)
             .union(resolutionReads).union(sends).union(["ping"])
         #expect(ControlCommandExecutionPolicy.socketWorkerV1Commands == expectedWorker)
-        // Every member except read_screen is deliberately main-thread
+        // Every member except terminal and diagnostic reads is deliberately main-thread
         // callable (deadlock-free inline: bus enqueues plus inline-collapsing
-        // hops). read_screen opts out so its multi-MB formatting can never
-        // run inline on the main thread.
+        // hops). The read families opt out because their bodies must stay off-main.
         #expect(
             ControlCommandExecutionPolicy.mainThreadCallableSocketWorkerV1Commands
-                == expectedWorker.subtracting(terminalRead)
+                == expectedWorker.subtracting(terminalRead).subtracting(diagnosticRead)
         )
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -497,6 +497,11 @@ private struct IrohDiagnosticsReportRows: View {
             String(localized: "settings.networking.diagnostics.failure.offline", defaultValue: "Offline")
         case .some(.timedOut):
             String(localized: "settings.networking.diagnostics.failure.timedOut", defaultValue: "Timed Out")
+        case .some(.transportIdleTimedOut):
+            String(
+                localized: "settings.networking.diagnostics.failure.transportIdleTimedOut",
+                defaultValue: "Transport Idle Timeout"
+            )
         case .some(.connectionRefused):
             String(
                 localized: "settings.networking.diagnostics.failure.connectionRefused",

--- a/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
+++ b/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxAgentChat
 import CmuxIrohTransport
 import Darwin

--- a/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
+++ b/Sources/Mobile/MobileHostIrohApplicationLaneRouter.swift
@@ -456,7 +456,11 @@ actor MobileHostIrohApplicationLaneRouter {
 
     func run(
         isCurrent: @escaping CmxIrohHostRuntime.CurrentGeneration
-    ) async {
+    ) async -> CmxIrohAdmittedConnectionExit {
+        var exit = CmxIrohAdmittedConnectionExit(
+            lifecycle: .explicitlyInvalidated,
+            failure: .none
+        )
         while !stopped, !Task.isCancelled, await isCurrent() {
             do {
                 let accepted = try await session.acceptBidirectionalLane()
@@ -476,6 +480,10 @@ actor MobileHostIrohApplicationLaneRouter {
                 continue
             } catch {
                 if !stopped, !Task.isCancelled {
+                    exit = CmxIrohAdmittedConnectionExit(
+                        lifecycle: .applicationLaneFailed,
+                        failure: DiagnosticFailureKind.classify(error)
+                    )
                     mobileHostIrohLaneLog.error(
                         "Iroh application lane accept failed: \(String(describing: error), privacy: .private)"
                     )
@@ -484,6 +492,7 @@ actor MobileHostIrohApplicationLaneRouter {
             }
         }
         await stop()
+        return exit
     }
 
     func stop() async {

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -211,10 +211,22 @@ extension MobileHostIrohRuntime {
             configuration: configuration,
             pendingRevocations: pendingRevocations,
             protocolConfiguration: protocolConfiguration,
-            handleTransport: { [diagnosticLog] session, isCurrent in
+            handleTransport: { [weak self] session, isCurrent in
+                guard let self else {
+                    await session.close()
+                    return
+                }
+                let diagnosticSessionID = await self.makeDiagnosticSessionID()
+                let diagnosticLog = await self.diagnosticLog
                 diagnosticLog.record(DiagnosticEvent(
                     .admissionSucceeded,
                     a: DiagnosticTransportKind.iroh.rawValue
+                ))
+                diagnosticLog.record(DiagnosticEvent(
+                    .transportSessionLifecycle,
+                    a: DiagnosticSessionLifecycleKind.established.rawValue,
+                    b: Int(CmxTransportSessionPurpose.foregroundControl.rawValue),
+                    c: diagnosticSessionID
                 ))
                 let eventWriter = MobileHostIrohServerEventWriter(
                     session: session
@@ -246,10 +258,18 @@ extension MobileHostIrohRuntime {
                         await laneRouter.stop()
                     }
                 )
-                await connectionSupervisor.run()
+                let exit = await connectionSupervisor.run()
+                diagnosticLog.record(DiagnosticEvent(
+                    .transportSessionLifecycle,
+                    a: exit.lifecycle.rawValue,
+                    b: Int(CmxTransportSessionPurpose.foregroundControl.rawValue),
+                    c: diagnosticSessionID
+                ))
                 diagnosticLog.record(DiagnosticEvent(
                     .sessionClosed,
-                    a: DiagnosticTransportKind.iroh.rawValue
+                    a: DiagnosticTransportKind.iroh.rawValue,
+                    b: exit.failure == .none ? nil : exit.failure.rawValue,
+                    c: diagnosticSessionID
                 ))
             },
             handleBinding: { [weak self] registration, discovery, attestation in

--- a/Sources/Mobile/MobileHostIrohRuntime.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime.swift
@@ -120,10 +120,7 @@ final class MobileHostIrohRuntime {
 
     private init() {
         let installState = CmxIrohUserDefaultsInstallStateStore()
-        diagnosticLog = DiagnosticLog(
-            buildStamp: Self.diagnosticBuildStamp,
-            role: .macHost
-        )
+        diagnosticLog = Self.hostDiagnosticLog
         appInstances = CmxIrohAppInstanceRepository(store: installState)
         brokerBackpressureGate = CmxIrohBrokerBackpressureGate(store: installState)
         #if DEBUG
@@ -195,7 +192,16 @@ final class MobileHostIrohRuntime {
         lanPublisher = CmxIrohLANHostPublisher()
     }
 
-    private static var diagnosticBuildStamp: String {
+    /// The host diagnostic ring, deliberately `nonisolated` so read paths like
+    /// the `iroh_diag` socket verb can snapshot it without a main-actor hop:
+    /// the ring must stay exportable even when the main thread is wedged,
+    /// which is exactly when connection diagnostics matter most.
+    nonisolated static let hostDiagnosticLog = DiagnosticLog(
+        buildStamp: Self.diagnosticBuildStamp,
+        role: .macHost
+    )
+
+    private nonisolated static var diagnosticBuildStamp: String {
         let info = Bundle.main.infoDictionary ?? [:]
         let name = info["CFBundleName"] as? String ?? "cmux"
         let version = info["CFBundleShortVersionString"] as? String ?? "?"

--- a/Sources/Mobile/MobileHostIrohRuntime.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime.swift
@@ -197,7 +197,7 @@ final class MobileHostIrohRuntime {
     /// the ring must stay exportable even when the main thread is wedged,
     /// which is exactly when connection diagnostics matter most.
     nonisolated static let hostDiagnosticLog = DiagnosticLog(
-        buildStamp: Self.diagnosticBuildStamp,
+        buildStamp: MobileHostIrohRuntime.diagnosticBuildStamp,
         role: .macHost
     )
 

--- a/Sources/Mobile/MobileHostIrohRuntime.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime.swift
@@ -116,6 +116,7 @@ final class MobileHostIrohRuntime {
     var signOutPreparationTask: Task<Void, Never>?
     var signOutPreparationRevision: UInt64 = 0
     var lifecycleRevision: UInt64 = 0
+    var nextDiagnosticSessionID = 0
 
     private init() {
         let installState = CmxIrohUserDefaultsInstallStateStore()
@@ -290,5 +291,14 @@ final class MobileHostIrohRuntime {
         for error: any Error
     ) -> DiagnosticFailureKind {
         DiagnosticFailureKind.classify(error)
+    }
+
+    func makeDiagnosticSessionID() -> Int {
+        if nextDiagnosticSessionID == Int.max {
+            nextDiagnosticSessionID = 1
+        } else {
+            nextDiagnosticSessionID += 1
+        }
+        return nextDiagnosticSessionID
     }
 }

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1029,19 +1029,24 @@ final class MobileHostService {
         }
     }
 
+    @discardableResult
     nonisolated static func acceptTransport(
         _ transport: any CmxByteTransport,
         authorization: MobileHostConnectionAuthorizationContext,
         artifactTransfers: MobileHostIrohArtifactTransferRegistry? = nil,
         independentEventWriter: (any MobileHostIndependentEventWriting)? = nil,
         isCurrent: @escaping @Sendable () async -> Bool
-    ) async {
+    ) async -> CmxIrohAdmittedConnectionExit {
+        let expectedExit = CmxIrohAdmittedConnectionExit(
+            lifecycle: .explicitlyInvalidated,
+            failure: .none
+        )
         MobileHostRequestActivity.beginConnection()
         guard await isCurrent() else {
             mobileHostLog.info("mobile host rejected stale transport")
             await transport.close()
             MobileHostRequestActivity.endConnection()
-            return
+            return expectedExit
         }
 
         let id = UUID()
@@ -1099,7 +1104,7 @@ final class MobileHostService {
         guard await isCurrent() else {
             await transport.close()
             MobileHostRequestActivity.endConnection()
-            return
+            return expectedExit
         }
         guard MobileHostConnectionRegistry.shared.insert(
             session,
@@ -1112,9 +1117,9 @@ final class MobileHostService {
             )
             await transport.close()
             MobileHostRequestActivity.endConnection()
-            return
+            return expectedExit
         }
-        await session.run()
+        return await session.run()
     }
 
     nonisolated static func connectionAuthorizationError(
@@ -1704,6 +1709,10 @@ actor MobileHostConnection {
     private var independentEventNegotiationInProgress = false
     private var didDecodeFirstFrame = false
     private var isClosed = false
+    private var exit = CmxIrohAdmittedConnectionExit(
+        lifecycle: .explicitlyInvalidated,
+        failure: .none
+    )
     /// stream_id → topics and their negotiated event delivery path.
     /// Populated by `mobile.events.subscribe`; cleared on close.
     private var subscriptions: [String: EventSubscription] = [:]
@@ -1760,8 +1769,8 @@ actor MobileHostConnection {
     /// The caller retains connection ownership until this method returns. This
     /// matters for Iroh, whose sibling application-lane task closes the shared
     /// QUIC session when either side of the task group finishes.
-    func run() async {
-        guard receiveTask == nil, !isClosed else { return }
+    func run() async -> CmxIrohAdmittedConnectionExit {
+        guard receiveTask == nil, !isClosed else { return exit }
         startFirstFrameTimeout()
         let transport = transport
         let connectionID = id
@@ -1773,7 +1782,13 @@ actor MobileHostConnection {
                 )
                 while !Task.isCancelled {
                     guard let data = try await transport.receive() else {
-                        await self?.close(reason: "remote closed")
+                        await self?.close(
+                            reason: "remote closed",
+                            exit: CmxIrohAdmittedConnectionExit(
+                                lifecycle: .remoteClosed,
+                                failure: .connectionClosed
+                            )
+                        )
                         return
                     }
                     await self?.handleReceive(data: data)
@@ -1781,7 +1796,13 @@ actor MobileHostConnection {
             } catch is CancellationError {
                 await self?.close(reason: "cancelled")
             } catch {
-                await self?.close(reason: String(describing: error))
+                await self?.close(
+                    reason: String(describing: error),
+                    exit: CmxIrohAdmittedConnectionExit(
+                        lifecycle: .controlReadFailed,
+                        failure: DiagnosticFailureKind.classify(error)
+                    )
+                )
             }
         }
         receiveTask = task
@@ -1793,13 +1814,21 @@ actor MobileHostConnection {
                 task.cancel()
             }
         )
+        return exit
     }
 
-    func close(reason: String) async {
+    func close(
+        reason: String,
+        exit: CmxIrohAdmittedConnectionExit = CmxIrohAdmittedConnectionExit(
+            lifecycle: .explicitlyInvalidated,
+            failure: .none
+        )
+    ) async {
         guard !isClosed else {
             return
         }
         isClosed = true
+        self.exit = exit
         firstFrameTimeoutTask?.cancel()
         firstFrameTimeoutTask = nil
         idleTimeoutTask?.cancel()
@@ -1841,7 +1870,13 @@ actor MobileHostConnection {
                         message: "Invalid frame"
                     )
                 )
-                await close(reason: "receive buffer exceeded frame limit")
+                await close(
+                    reason: "receive buffer exceeded frame limit",
+                    exit: CmxIrohAdmittedConnectionExit(
+                        lifecycle: .controlReadFailed,
+                        failure: .protocolViolation
+                    )
+                )
                 return
             }
             receiveBuffer.append(data)
@@ -1861,7 +1896,13 @@ actor MobileHostConnection {
                         return
                     }
                     guard startResponseTask(for: frame) else {
-                        await close(reason: "rpc work capacity exceeded")
+                        await close(
+                            reason: "rpc work capacity exceeded",
+                            exit: CmxIrohAdmittedConnectionExit(
+                                lifecycle: .controlReadFailed,
+                                failure: .protocolViolation
+                            )
+                        )
                         return
                     }
                 }
@@ -1877,7 +1918,13 @@ actor MobileHostConnection {
                         message: "Invalid frame"
                     )
                 )
-                await close(reason: "frame decode error")
+                await close(
+                    reason: "frame decode error",
+                    exit: CmxIrohAdmittedConnectionExit(
+                        lifecycle: .controlReadFailed,
+                        failure: .protocolViolation
+                    )
+                )
                 return
             }
         }
@@ -1928,7 +1975,13 @@ actor MobileHostConnection {
         guard !didDecodeFirstFrame else {
             return
         }
-        await close(reason: "first frame timed out")
+        await close(
+            reason: "first frame timed out",
+            exit: CmxIrohAdmittedConnectionExit(
+                lifecycle: .controlReadFailed,
+                failure: .timedOut
+            )
+        )
     }
 
     private func startIdleTimeout() {
@@ -1953,7 +2006,13 @@ actor MobileHostConnection {
         guard didDecodeFirstFrame, subscriptions.isEmpty, responseTasks.isEmpty else {
             return
         }
-        await close(reason: "idle after frame timed out")
+        await close(
+            reason: "idle after frame timed out",
+            exit: CmxIrohAdmittedConnectionExit(
+                lifecycle: .controlReadFailed,
+                failure: .timedOut
+            )
+        )
     }
 
     private func respond(to frame: Data) async {
@@ -1999,7 +2058,13 @@ actor MobileHostConnection {
                 return
             }
             _ = await sendResponse(MobileHostRPCEnvelope.encodeResponse(id: nil, result: .failure(error)))
-            await close(reason: "invalid rpc envelope")
+            await close(
+                reason: "invalid rpc envelope",
+                exit: CmxIrohAdmittedConnectionExit(
+                    lifecycle: .controlReadFailed,
+                    failure: .protocolViolation
+                )
+            )
         }
     }
 
@@ -2157,12 +2222,24 @@ actor MobileHostConnection {
         do {
             frame = try MobileSyncFrameCodec.encodeFrame(data)
         } catch {
-            await close(reason: "event frame encode failed")
+            await close(
+                reason: "event frame encode failed",
+                exit: CmxIrohAdmittedConnectionExit(
+                    lifecycle: .controlWriteFailed,
+                    failure: .protocolViolation
+                )
+            )
             return false
         }
         guard queuedEvents.count < Self.maximumQueuedEventCount,
               frame.count <= Self.maximumQueuedEventByteCount - queuedEventByteCount else {
-            await close(reason: "event queue exceeded bounded capacity")
+            await close(
+                reason: "event queue exceeded bounded capacity",
+                exit: CmxIrohAdmittedConnectionExit(
+                    lifecycle: .controlWriteFailed,
+                    failure: .protocolViolation
+                )
+            )
             return false
         }
         queuedEvents.append(QueuedEvent(topic: topic, frame: frame))
@@ -2272,7 +2349,13 @@ actor MobileHostConnection {
         do {
             frame = try MobileSyncFrameCodec.encodeFrame(response)
         } catch {
-            await close(reason: "response frame encode failed")
+            await close(
+                reason: "response frame encode failed",
+                exit: CmxIrohAdmittedConnectionExit(
+                    lifecycle: .controlWriteFailed,
+                    failure: .protocolViolation
+                )
+            )
             return false
         }
 
@@ -2285,7 +2368,13 @@ actor MobileHostConnection {
             try await writer.send(frame)
             return true
         } catch {
-            await close(reason: String(describing: error))
+            await close(
+                reason: String(describing: error),
+                exit: CmxIrohAdmittedConnectionExit(
+                    lifecycle: .controlWriteFailed,
+                    failure: DiagnosticFailureKind.classify(error)
+                )
+            )
             return false
         }
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -10680,8 +10680,12 @@ class TerminalController {
         let semaphore = DispatchSemaphore(value: 0)
         nonisolated(unsafe) var export = ""
         Task {
-            let log = await MainActor.run { MobileHostIrohRuntime.shared.diagnosticLog }
-            let report = await log.snapshot()
+            // Reads the nonisolated static ring directly: no main-actor hop, so
+            // the verb keeps working when the main thread is wedged (the case
+            // connection diagnostics exist for). The wait blocks only on the
+            // log's own drain actor, and the execution policy keeps this
+            // command off the main thread, so the wait cannot self-deadlock.
+            let report = await MobileHostIrohRuntime.hostDiagnosticLog.snapshot()
             export = String(decoding: report.compactExport(), as: UTF8.self)
             semaphore.signal()
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1083,6 +1083,12 @@ class TerminalController {
             // the formatting can never run inline on the main thread.
             case "read_screen":
                 return (true, readScreenText(args))
+            // The v1 diagnostic-read family: the host's iroh DiagnosticLog is
+            // actor-owned, so the snapshot await bridges to this worker via
+            // the established semaphore pattern. NOT mainThreadCallable — the
+            // wait must never block the main thread.
+            case "iroh_diag":
+                return (true, irohDiagText())
             // The v1 resolution reads (tranche D): one v2MainSync snapshot
             // hop each, reply lines formatted here on this worker thread.
             // All mainThreadCallable (the hop collapses inline); the bodies
@@ -10666,6 +10672,23 @@ class TerminalController {
     /// base64 encode/decode round-trip — kept verbatim so the reply bytes
     /// match the legacy `readTerminalTextBase64` pipeline exactly — run off
     /// the main actor.
+    /// Serves the v1 `iroh_diag` socket command: the host's iroh Connection
+    /// Report in the same `cmuxdiag v1` compact format the Settings pane
+    /// exports, read from the same `DiagnosticLog` snapshot path so the two
+    /// can never disagree. Empty ring prints just the header (count=0).
+    private nonisolated func irohDiagText() -> String {
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var export = ""
+        Task {
+            let log = await MainActor.run { MobileHostIrohRuntime.shared.diagnosticLog }
+            let report = await log.snapshot()
+            export = String(decoding: report.compactExport(), as: UTF8.self)
+            semaphore.signal()
+        }
+        semaphore.wait()
+        return export
+    }
+
     private nonisolated func readScreenText(_ args: String) -> String {
         let options: ReadScreenOptions
         switch parseReadScreenArgs(args) {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -14961,6 +14961,23 @@
         }
       }
     },
+    "mobile.iroh.diagnostics.failure.transportIdleTimedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transport Idle Timeout"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続アイドルタイムアウト"
+          }
+        }
+      }
+    },
     "mobile.iroh.diagnostics.failure.unknown": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Part of the never-get-disconnected program (https://github.com/manaflow-ai/cmux/issues/8531). Field rings from a real phone↔Mac flap session (decoded in https://github.com/manaflow-ai/cmux/issues/8531#issuecomment-5052125439 and https://github.com/manaflow-ai/cmux/issues/8531#issuecomment-5052222249) showed two blind spots: 4 of 7 involuntary client-side deaths logged `DiagnosticFailureKind.unknown` because raw iroh/QUIC errors were never classified, and the Mac host logged every `sessionClosed` with no reason and no session id (`MobileHostIrohRuntime+Activation.swift` passed only the transport kind).

Client: `IrohError` now conforms to `DiagnosticFailureProviding`, classifying the opaque `message()` by pinned iroh-ffi 1.0.2-cmux.4 token families. QUIC idle timeout (`ConnectionLost(TimedOut)`, the prime suspect for the 1-5 min field deaths) gets a new append-only `DiagnosticFailureKind.transportIdleTimedOut = 21`, distinguishable from handshake timeouts. String matching is a documented bridge until the iroh-ffi bump exports a structured error taxonomy (next slice, together with keepalive knobs).

Host: `CmxIrohAdmittedConnectionSupervisor.run()` now returns a typed privacy-safe exit (`CmxIrohAdmittedConnectionExit`) naming which child ended the session (control read/write, lanes, remote close, expected shutdown). The admission site emits correlated `transportSessionLifecycle` established→terminal events plus `sessionClosed` with the classified reason (`b`) and a process-local correlation id (`c`), mirroring the client ring. Next flap repro produces attributable rings on both ends.

Two-commit red/green: 5e8b121e73 tests only, c08cadeb33 fix. `CmuxIrohTransport` 461 passed / `CMUXMobileCore` 277 passed. New failure name localized (en+ja) in all three catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787365942&installation_model_id=21920&pr_number=8716&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8716&signature=0609756e88e433f0c8382ceb217118cb595a1986c3183e747f78c3e42196dac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies iroh disconnects and adds a Transport Idle Timeout reason, with headless Connection Report export. The host now emits lifecycle events with close reasons and a local session id; `iroh_diag` runs off-main via a nonisolated diagnostic ring.

- **New Features**
  - Map `IrohLib.IrohError` to `DiagnosticFailureKind`, adding `.transportIdleTimedOut` (21) for QUIC idle timeout; tokens pinned to `iroh-ffi` 1.0.2-cmux.4.
  - Typed exits via `CmxIrohAdmittedConnectionExit`; host records `transportSessionLifecycle` and `sessionClosed` with reason and per-process session id.
  - `cmux iroh-diag` CLI and v1 `iroh_diag` socket command export the iroh Connection Report (cmuxdiag v1) from the same `DiagnosticLog` snapshot.
  - Localized UI copy (en/ja) for “Transport Idle Timeout” in iOS/macOS settings.

- **Bug Fixes**
  - Serve `iroh_diag` without a main-actor hop by moving the host ring to `MobileHostIrohRuntime.hostDiagnosticLog`; execution policy and tests enforce worker-only, not main-thread callable.
  - Supervisor runs and cleans up exactly once; repeat calls return the first child’s exit.
  - Fixed app-target compile break by importing `CMUXMobileCore` in the lane router.
  - If the host runtime is unavailable during transport setup, the session closes early instead of proceeding.

<sup>Written for commit f477e364324becbf8b3ba9aa2c420871931a9773. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Transport Idle Timeout** diagnostic failure with localized UI labels across mobile and settings.
  * Introduced the **`iroh-diag`** CLI/terminal command, returning a compact snapshot of host diagnostics.
  * Transport shutdowns now surface structured **lifecycle + failure** details via richer exit reporting.
* **Bug Fixes**
  * Improved admitted-connection supervisor run behavior to ensure cleanup runs only once and results are consistent across repeated runs.
  * Enhanced diagnostic session correlation and safer transport-session handling when the runtime is deallocated.
* **Tests**
  * Expanded diagnostics and classification coverage for the new failure case and additional error-message mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Addendum: also adds a `cmux iroh-diag` CLI verb (v1 `iroh_diag` socket command, worker lane, not main-thread callable) printing the host ring in the exact `cmuxdiag v1` format from the same `DiagnosticLog` snapshot path Settings uses, so flap repros export headlessly. Live-verified E2E on a tagged build with a simulator attach: host ring recorded correlated established/terminal/closed events, distinguishing a failed session (`51 a=7` + `41 b=255 c=1`) from an explicit supersede (`51 a=10` + `41 b=<empty>` `c=2`), admissions paired with `established` records (`c=2`, `c=3`). CmuxControlSocket 278 tests green.