### PR TITLE
Fix four unsatisfiable tests in the sidebar git suites

### DIFF
--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -67,6 +67,43 @@ private func waitForCondition(
     return true
 }
 
+/// Awaits `condition` by suspending instead of blocking the main actor.
+///
+/// An `async` test body runs as a main-actor job, i.e. inside a main-queue
+/// drain, and libdispatch does not re-enter that drain: a nested run loop spun
+/// from there runs no main-queue work. `waitForCondition` above therefore
+/// starves both its own poll hops and any product code that applies through
+/// `MainActor.run`, so in an `async` test it can only time out. Async tests
+/// must use this form; the budget is identical.
+@MainActor
+@discardableResult
+private func waitForConditionSuspending(
+    timeout: TimeInterval = 3.0,
+    pollInterval: TimeInterval = 0.05,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ condition: @MainActor () -> Bool
+) async -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while true {
+        if condition() {
+            return true
+        }
+        guard Date() < deadline else {
+            XCTFail("Timed out waiting for condition", file: file, line: line)
+            return false
+        }
+        do {
+            try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        } catch {
+            // Cancellation, not a timeout. Swallowing it would spin the condition at
+            // full speed until the deadline instead of unwinding, and this helper's
+            // doc comment tells future async tests to copy it.
+            return condition()
+        }
+    }
+}
+
 private func restoreUserDefaultForTabManagerTests(_ value: Any?, key: String) {
     let defaults = UserDefaults.standard
     if let value {
@@ -1066,10 +1103,14 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         XCTAssertEqual(observedMaxActiveCallCount, 1)
 
         await reader.releaseAll()
+        // Suspending, not blocking: this test body is a main-actor job, so a
+        // blocking wait would starve the snapshot's `MainActor.run` apply hop and
+        // could only expire. See waitForConditionSuspending.
+        let didApplyToEveryPanel = await waitForConditionSuspending {
+            panelIds.allSatisfy { workspace.panelGitBranches[$0]?.branch == "main" }
+        }
         XCTAssertTrue(
-            waitForCondition {
-                panelIds.allSatisfy { workspace.panelGitBranches[$0]?.branch == "main" }
-            },
+            didApplyToEveryPanel,
             "One same-directory snapshot should update every queued panel."
         )
         let finalObservedCallCount = await reader.observedCallCount

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -84,17 +84,18 @@ private func waitForConditionSuspending(
     line: UInt = #line,
     _ condition: @MainActor () -> Bool
 ) async -> Bool {
-    let deadline = Date().addingTimeInterval(timeout)
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: .seconds(timeout))
     while true {
         if condition() {
             return true
         }
-        guard Date() < deadline else {
+        guard clock.now < deadline else {
             XCTFail("Timed out waiting for condition", file: file, line: line)
             return false
         }
         do {
-            try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            try await clock.sleep(for: .seconds(pollInterval))
         } catch {
             // Cancellation, not a timeout. Swallowing it would spin the condition at
             // full speed until the deadline instead of unwinding, and this helper's

--- a/cmuxTests/WorkspacePullRequestSidebarTests.swift
+++ b/cmuxTests/WorkspacePullRequestSidebarTests.swift
@@ -384,15 +384,22 @@ private func writeGitIndexVersion2EntryFromStat(
 private func writeGitIndexVersion4(
     at repoURL: URL,
     trackedPath: String,
-    signatureByte: UInt8
+    signatureByte: UInt8,
+    objectIDBytes: [UInt8] = Array(repeating: 0, count: 20)
 ) throws {
-    try writeGitIndexVersion4(at: repoURL, trackedPaths: [trackedPath], signatureByte: signatureByte)
+    try writeGitIndexVersion4(
+        at: repoURL,
+        trackedPaths: [trackedPath],
+        signatureByte: signatureByte,
+        objectIDBytes: objectIDBytes
+    )
 }
 
 private func writeGitIndexVersion4(
     at repoURL: URL,
     trackedPaths: [String],
-    signatureByte: UInt8
+    signatureByte: UInt8,
+    objectIDBytes: [UInt8] = Array(repeating: 0, count: 20)
 ) throws {
     var data = Data()
     data.append(contentsOf: [0x44, 0x49, 0x52, 0x43])
@@ -417,7 +424,10 @@ private func writeGitIndexVersion4(
         appendBigEndianUInt32(gitIndexUInt32Field(statValue.st_uid), to: &data)
         appendBigEndianUInt32(gitIndexUInt32Field(statValue.st_gid), to: &data)
         appendBigEndianUInt32(gitIndexUInt32Field(statValue.st_size), to: &data)
-        data.append(Data(repeating: 0, count: 20))
+        data.append(contentsOf: objectIDBytes.prefix(20))
+        if objectIDBytes.count < 20 {
+            data.append(Data(repeating: 0, count: 20 - objectIDBytes.count))
+        }
 
         let pathBytes = Array(trackedPath.utf8)
         appendBigEndianUInt16(UInt16(min(pathBytes.count, 0x0fff)), to: &data)
@@ -820,10 +830,23 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
         XCTAssertTrue(workspace.panelPullRequests.isEmpty)
         XCTAssertEqual(workspace.sidebarPullRequestsInDisplayOrder(orderedPanelIds: [panelId]), [])
 
+        // A scoped `report_git_branch` resolves its workspace through AppDelegate's
+        // main-window contexts, not through the controller's active manager, so a
+        // manager only the controller knows about is invisible to it. Register a
+        // windowless context the way the other socket-routing tests do.
+        let previousSharedAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let registeredWindowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
         TerminalController.shared.setActiveTabManager(manager)
         defer {
             TerminalController.shared.setActiveTabManager(nil)
+            appDelegate.unregisterMainWindowContextForTesting(windowId: registeredWindowId)
+            AppDelegate.shared = previousSharedAppDelegate
         }
+        XCTAssertNotNil(
+            AppDelegate.shared?.tabManagerFor(tabId: workspace.id),
+            "The scoped git-branch report can only reach a workspace AppDelegate can resolve."
+        )
         let response = TerminalController.shared.handleSocketLine(
             "report_pr 2722 https://github.com/manaflow-ai/cmux/pull/2722 --label=PR --state=open --branch=issue-2722-git-index-lock-poll --tab=\(workspace.id.uuidString) --panel=\(panelId.uuidString)"
         )
@@ -1141,7 +1164,17 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
             "The sidebar refresh path should parse Git index v4 entries as clean when file stats match."
         )
 
-        try writeGitIndexVersion4(at: repoURL, trackedPath: "tracked.txt", signatureByte: 0x22)
+        // Staging content rewrites the entry's object id, which is what the index
+        // content signature tracks. Bumping only the trailing checksum would
+        // describe a file git cannot produce (the trailer is the SHA-1 of the
+        // index content), and such a rewrite is deliberately rebaselined as clean
+        // by testCleanIndexSignatureRebaselinesWhenIndexRewriteKeepsTrackedContentClean.
+        try writeGitIndexVersion4(
+            at: repoURL,
+            trackedPath: "tracked.txt",
+            signatureByte: 0x22,
+            objectIDBytes: Array(repeating: UInt8(0x22), count: 20)
+        )
         manager.refreshTrackedWorkspaceGitMetadataForTesting()
 
         XCTAssertTrue(
@@ -1461,14 +1494,31 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
             "A valid empty index should establish a clean signature baseline."
         )
 
-        try writeEmptyGitIndex(at: repoURL, signatureByte: 0x22)
+        // An index rewrite out of an empty index adds an entry, which is what the
+        // content signature tracks. Re-writing zero entries with a different
+        // trailer would describe a file git cannot produce (the trailer is the
+        // SHA-1 of the index content) and is deliberately rebaselined as clean.
+        // The new entry's stat matches the worktree, so the stat scan stays clean
+        // and the dirty verdict has to come from the index content signature.
+        try "seed\n".write(
+            to: repoURL.appendingPathComponent("tracked.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try writeGitIndexVersion2EntryFromStat(
+            at: repoURL,
+            trackedPath: "tracked.txt",
+            indexMode: 0o100644,
+            signatureByte: 0x22,
+            objectIDBytes: Array(repeating: UInt8(0x22), count: 20)
+        )
         manager.refreshTrackedWorkspaceGitMetadataForTesting()
 
         XCTAssertTrue(
             waitForCondition {
                 workspace.panelGitBranches[panelId]?.isDirty == true
             },
-            "Empty-index signature changes should keep staged deletes visible as dirty."
+            "An index rewrite that stages an entry should show dirty even when the worktree matches the index."
         )
     }
 


### PR DESCRIPTION
Four tests in the sidebar git suites could never pass. On current `main` they fail for three
unrelated reasons, and this change fixes all four.

## Two tests describe a file git cannot produce

`testGitIndexVersionFourRefreshTracksIndexSignatureChanges` and
`testEmptyGitIndexRefreshTracksIndexSignatureChanges` each wrote an index twice and changed only the
trailing 20-byte checksum, leaving the entry table byte-identical, then asserted the sidebar went
dirty.

The index trailer is the SHA-1 of the index content, so identical content cannot carry two different
trailers. No repository reaches that state. The product reads it deliberately:
`gitIndexContentSignature` hashes the entry count and each entry's path, mode and object id, and never
the trailer, so both writes produce the same content signature. The apply then takes the rebaseline
branch in `SidebarGitMetadataService+Probe.swift` — index signature changed, content signature
unchanged, so the stored clean signature moves forward and the panel stays clean. That is what
`testCleanIndexSignatureRebaselinesWhenIndexRewriteKeepsTrackedContentClean` pins, immediately after
the v4 test in the same file, and it passes. Two tests asked for opposite outcomes from the same input, so one had to fail, and the
rebaseline test is the correct one: it describes a stash-like rewrite.

Both now stage a real change — a new object id for the v4 index, an added entry for the empty one —
with a stat that still matches the worktree, so the stat scan stays clean and the dirty verdict has to
come from the content signature, which is the path a real staged change takes. The predicates are
unchanged. The empty-index test's scenario and message do change, from a staged delete to a staged
add, because staging the first entry out of an empty index is what actually moves the content
signature; its name still says "TracksIndexSignatureChanges", which remains true.

`writeGitIndexVersion4` gains the `objectIDBytes` parameter that
`writeGitIndexVersion2EntryFromStat` already had. It defaults to the zero id, so the callers that do
not stage a change need no edit. `writeGitIndexVersion3SkipWorktreeEntry` still hard-codes a zero object id —
it has no need to express a staged change.

## A scoped branch report went to a manager nothing could resolve

`testDisablingGitWatchClearsCachedPullRequestBadgesWhenPullRequestsAreShownByDefault` seeded a badge,
then sent `report_git_branch` with both `--tab` and `--panel`. That scoped path resolves its workspace
through AppDelegate's main-window contexts, not through TerminalController's active manager, so a
manager only the controller knew about was invisible to it: the handler returned before reaching the
clear and the seeded entry survived. A nearby `report_pr` test passes because the PR path resolves through `controlSidebarTabForMutation`, which checks the controller's own manager first and
then falls back to AppDelegate.

The test now registers a windowless context the way the other socket-routing tests do, and asserts the
workspace is resolvable before sending, so a future wiring break reports at that line instead of at
the far assertion. This is test wiring, not a product defect: `tabManagerFor(tabId:)` resolves every
real window, so no user-visible path depends on the difference.

## An async test waited in a way that could only expire

`testSameDirectoryInitialGitMetadataProbesShareOneSnapshotRead` used a helper that blocks the thread on
`XCTWaiter` while polling through `DispatchQueue.main`. That works in a synchronous test, whose body
runs from an ordinary run-loop callback. This body is `async` on a `@MainActor` class, so it runs as a
main-actor job — already inside a main-queue drain, which libdispatch will not re-enter. The nested
run loop therefore ran neither the helper's own poll hops nor the snapshot's `MainActor.run` apply, and
the wait expired every time while the work it waited for landed immediately after the body suspended
again.

I confirmed the mechanism with a standalone binary rather than reasoning about it: a nested
`CFRunLoopRunInMode` entered from a main-actor async job does not run `DispatchQueue.main` blocks,
while the same nested loop entered from a run-loop callback does.

The test now awaits a suspending sibling helper with the same 3s budget and 0.05s interval. It is a
separate function rather than an inline loop so the next async test does not reintroduce the blocking
form, and its doc comment says why. It was the only async test in this target using the blocking
helper.

When reading a failure log in these suites, note that a timeout from the file-private helper is
reported twice, once for the `XCTAssertTrue` and once for the helper's own `XCTFail`, because its
`line: UInt = #line` resolves at the call site. Consecutive line numbers are one failure, not two.

## Test plan

Measured on `4253cc2884`, one GUI test host at a time, same checkout and DerivedData for both arms:

```
xcodebuild test -scheme cmux-unit -configuration Debug -destination 'platform=macOS' \
  -only-testing:cmuxTests/WorkspacePullRequestSidebarTests \
  -only-testing:cmuxTests/TabManagerPullRequestProbeTests \
  -only-testing:cmuxTests/TabManagerWorkspaceOwnershipTests \
  -only-testing:cmuxTests/CLICodexHookTimeoutRegressionTests
```

| arm | XCTest failures across a 36-test run | distinct tests red |
|---|---|---|
| `main` unchanged | 15 of 36 | 9 |
| this branch | 8 of 36 | 5 |

No host restarts in either arm, and `CLICodexHookTimeoutRegressionTests` reports
`Test run with 8 tests in 1 suite passed` in both.

The four tests this fixes are `testGitIndexVersionFourRefreshTracksIndexSignatureChanges`,
`testEmptyGitIndexRefreshTracksIndexSignatureChanges`,
`testDisablingGitWatchClearsCachedPullRequestBadgesWhenPullRequestsAreShownByDefault` and
`testSameDirectoryInitialGitMetadataProbesShareOneSnapshotRead`.

Pull-request CI on this repo runs review bots and security scanners, not the
test suite, so the arms above are the only test evidence this carries.

## Still red on this branch, and not addressed here

- `testFocusedPanelTitleRefreshesAutoWorkspaceTitleInSplitWorkspace`,
  `testRemoteSplitSkipsInitialGitMetadataProbe` and
  `testUnrelatedDefaultsChangeDoesNotRestartGitMetadataRefreshes` — all three pass an explicit
  `timeout:` to `waitForCondition`, which resolves to a blocking helper that starves the main-actor
  work they wait on. #8725 fixes them.
- `testPullRequestRefreshRepositoryDiscoveryDoesNotBlockMainRunLoop` — its stub watches a `git remote
  -v` subprocess the product stopped spawning in #2797, so its counter cannot leave zero. #8724 fixes
  it.
- `testCloseWorkspaceIgnoresWorkspaceNotOwnedByManager` — a real product bug in
  `TabManager.closeWorkspace`. #8753 fixes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of async UI assertions by adding a suspending wait helper that polls a main-thread condition until it succeeds or times out.
  * Expanded Git metadata refresh and pull request sidebar coverage, including scenarios where dirty/clean state changes based on index content signatures (now controllable per v4 index entry).
  * Updated workspace/scoped git-branch reporting tests to ensure consistent workspace resolution across different window contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->