### PR TITLE
fix(sidebar): prevent top scrim gradient overlay on first tab

### DIFF
--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -61,8 +61,8 @@ enum SidebarWorkspaceListMetrics {
     static let rowVerticalPadding: CGFloat = 8
     static let rowOuterHorizontalPadding: CGFloat = 6
     static let rowContentHorizontalPadding: CGFloat = 10
-    static let topScrimHeight: CGFloat = firstRowTopOffset + 20
-    static let bottomScrimHeight: CGFloat = topScrimHeight
+    static let topScrimHeight: CGFloat = firstRowTopOffset
+    static let bottomScrimHeight: CGFloat = firstRowTopOffset + 20
 
     static var trailingAccessoryRightEdgeOffset: CGFloat {
         rowOuterHorizontalPadding + rowContentHorizontalPadding


### PR DESCRIPTION
**Note: Gemini 3.6 Flash was used to create this PR. Given how tiny of a change it is, it seems safe enough, but disclosing it here.**

Fixes #5339

> **Issue #5339**:
> "For some reason, the first tab on the sidebar always seems to have this odd vertical gradient that I don't seem to see in other people's screenshots and it doesn't happen on any of the following sidebar tabs when you go down the list."

### What changed

`SidebarWorkspaceScrollEdgeFadeMask` applies a top fade mask over the sidebar scroll view. `topScrimHeight` was set to `firstRowTopOffset + 20`, extending the top fade gradient 20 points past where the first tab starts when the list isn't scrolled. That 20pt gradient region was dimming the top part of the first tab and making it look like an unintended dark overlay.

We changed `topScrimHeight` in `Sources/WindowChromeMetrics.swift` to equal `firstRowTopOffset`. Now, when the sidebar isn't scrolled, the mask is 100% opaque at the start of the first tab so there's no gradient overlay on it. When tabs are scrolled up past the top offset under the titlebar, they still fade out cleanly as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted sidebar workspace list spacing to improve the positioning of the top and bottom fade effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->