### PR TITLE
Color sidebar workspaces from title keyword rules

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/WorkspaceColorsCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/WorkspaceColorsCatalogSection.swift
@@ -26,6 +26,15 @@ public struct WorkspaceColorsCatalogSection: SettingCatalogSection {
         userDefaultsKey: "workspaceTabColor.colors"
     )
 
+    /// Keyword → color rules that tint a workspace whose title contains the
+    /// keyword. Values are palette names or `#RRGGBB` hexes; a color set
+    /// explicitly on a workspace always wins over a rule.
+    public let autoColorRules = DefaultsKey<[String: String]>(
+        id: "workspaceColors.autoColorRules",
+        defaultValue: [:],
+        userDefaultsKey: "workspaceTabColor.autoColorRules"
+    )
+
     public let paletteOverrides = JSONKey<[String: String]>(
         id: "workspaceColors.paletteOverrides",
         defaultValue: [:]

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -322,6 +322,13 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .workspaceColors, id: "selection", title: "Selection Highlight", synonyms: "workspaceColors.selectionColor selected workspace color highlight background active tab"),
             .init(section: .workspaceColors, id: "badge", title: "Notification Badge", synonyms: "workspaceColors.notificationBadgeColor unread notification badge color dot count"),
             .init(section: .workspaceColors, id: "palette", title: "Reset Palette", synonyms: "reset palette named colors restore built-in custom remove default"),
+            .init(
+                section: .workspaceColors,
+                id: "autoColorRules",
+                title: String(localized: "settings.workspaceColors.autoColorRules", defaultValue: "Automatic Colors by Keyword"),
+                detailText: String(localized: "settings.workspaceColors.autoColorRules.subtitle", defaultValue: "Workspaces whose title contains a keyword take that color. A color set on the workspace itself always wins."),
+                synonyms: String(localized: "settings.search.alias.setting.workspaceColors.autoColorRules", defaultValue: "workspaceColors.autoColorRules automatic auto color rule keyword title name match group project topic tint")
+            ),
 
             // cmux.json
             .init(section: .settingsJSON, id: "open-file", title: "User config file", synonyms: "open config file json jsonc config editor ~/.config cmux preferences"),

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
@@ -208,22 +208,34 @@ public struct WorkspaceColorsSection: View {
     }
 
     /// Rules in the order the app matches them: longest keyword first (most
-    /// specific rule wins), ties broken alphabetically. Mirrors
-    /// `WorkspaceTabAutoColorRules.ruleSet` in the app target.
+    /// specific rule wins), then locale-independent tie-breaks. Mirrors
+    /// `WorkspaceTabAutoColorRules.ruleSet` in the app target, folding
+    /// included, so this list reads in the order rules actually apply.
     private func orderedAutoColorRules(
         stored: [String: String]
     ) -> [(keyword: String, value: String, hex: String?)] {
         let palette = effectivePaletteMap(stored: paletteModel.current)
         return stored
-            .compactMap { rawKeyword, value -> (keyword: String, value: String, hex: String?)? in
+            .compactMap { rawKeyword, value -> (keyword: String, folded: String, value: String, hex: String?)? in
                 let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !keyword.isEmpty else { return nil }
-                return (keyword: keyword, value: value, hex: resolvedRuleHex(value, palette: palette))
+                let folded = keyword.folding(
+                    options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+                    locale: nil
+                )
+                guard !folded.isEmpty else { return nil }
+                return (
+                    keyword: keyword,
+                    folded: folded,
+                    value: value,
+                    hex: resolvedRuleHex(value, palette: palette)
+                )
             }
             .sorted { lhs, rhs in
-                if lhs.keyword.count != rhs.keyword.count { return lhs.keyword.count > rhs.keyword.count }
-                return lhs.keyword.localizedStandardCompare(rhs.keyword) == .orderedAscending
+                if lhs.folded.count != rhs.folded.count { return lhs.folded.count > rhs.folded.count }
+                if lhs.folded != rhs.folded { return lhs.folded < rhs.folded }
+                return lhs.keyword < rhs.keyword
             }
+            .map { (keyword: $0.keyword, value: $0.value, hex: $0.hex) }
     }
 
     /// Resolves a rule value (palette name or `#RRGGBB`) to a hex, or `nil`

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
@@ -215,7 +215,7 @@ public struct WorkspaceColorsSection: View {
         stored: [String: String]
     ) -> [(keyword: String, value: String, hex: String?)] {
         let palette = effectivePaletteMap(stored: paletteModel.current)
-        return stored
+        let candidates = stored
             .compactMap { rawKeyword, value -> (keyword: String, folded: String, value: String, hex: String?)? in
                 let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
                 let folded = keyword.folding(
@@ -230,12 +230,37 @@ public struct WorkspaceColorsSection: View {
                     hex: resolvedRuleHex(value, palette: palette)
                 )
             }
+        return canonicalizedAutoColorRules(candidates)
             .sorted { lhs, rhs in
                 if lhs.folded.count != rhs.folded.count { return lhs.folded.count > rhs.folded.count }
                 if lhs.folded != rhs.folded { return lhs.folded < rhs.folded }
                 return lhs.keyword < rhs.keyword
             }
             .map { (keyword: $0.keyword, value: $0.value, hex: $0.hex) }
+    }
+
+    /// Mirrors `WorkspaceTabAutoColorRules.canonicalized` in the app target:
+    /// entries that trim to the same keyword are one rule, and duplicates that
+    /// disagree on the resolved color are dropped rather than arbitrated — the
+    /// app paints nothing in that case, so the card must not claim otherwise.
+    /// It is also what keeps `ForEach(rules, id: \.keyword)` free of duplicate
+    /// identities.
+    ///
+    /// A keyword whose entries all resolve to no color is kept, so a typo still
+    /// surfaces as an "unknown color" row instead of vanishing silently.
+    private func canonicalizedAutoColorRules(
+        _ candidates: [(keyword: String, folded: String, value: String, hex: String?)]
+    ) -> [(keyword: String, folded: String, value: String, hex: String?)] {
+        Dictionary(grouping: candidates, by: { $0.keyword })
+            .values
+            .compactMap { group in
+                let resolved = group.filter { $0.hex != nil }
+                guard let winner = resolved.min(by: { $0.value < $1.value }) else {
+                    return group.min(by: { $0.value < $1.value })
+                }
+                guard resolved.allSatisfy({ $0.hex == winner.hex }) else { return nil }
+                return winner
+            }
     }
 
     /// Resolves a rule value (palette name or `#RRGGBB`) to a hex, or `nil`

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/WorkspaceColorsSection.swift
@@ -17,6 +17,7 @@ public struct WorkspaceColorsSection: View {
     @State private var selectionHex: DefaultsValueModel<String>
     @State private var badgeHex: DefaultsValueModel<String>
     @State private var paletteModel: DefaultsValueModel<[String: String]>
+    @State private var autoColorRulesModel: DefaultsValueModel<[String: String]>
     @State private var paletteReconcileTracker = WorkspacePaletteColorReconcileTracker()
 
     /// Built-in palette order and default hexes. Mirrors
@@ -56,12 +57,14 @@ public struct WorkspaceColorsSection: View {
         _selectionHex = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.workspaceColors.selectionColorHex))
         _badgeHex = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.workspaceColors.notificationBadgeColorHex))
         _paletteModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.workspaceColors.palette))
+        _autoColorRulesModel = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.workspaceColors.autoColorRules))
     }
 
     public var body: some View {
         Group {
             SettingsSectionHeader(String(localized: "settings.section.workspaceColors", defaultValue: "Workspace Colors"), section: .workspaceColors)
             mainCard
+            autoColorRulesCard
         }
         .task {
             startObservingSettings()
@@ -78,6 +81,7 @@ public struct WorkspaceColorsSection: View {
             selectionHex,
             badgeHex,
             paletteModel,
+            autoColorRulesModel,
         ]
         models.forEach { $0.startObserving() }
     }
@@ -149,6 +153,89 @@ public struct WorkspaceColorsSection: View {
                 .controlSize(.small)
             }
         }
+    }
+
+    /// **Automatic colors** — keyword → color rules that tint any workspace
+    /// whose title contains the keyword and that has no color of its own.
+    ///
+    /// Rules are authored in cmux.json (same story as the palette dictionary
+    /// above); this card renders the effective list in match order so the
+    /// precedence between overlapping keywords is visible.
+    @ViewBuilder
+    private var autoColorRulesCard: some View {
+        let rules = orderedAutoColorRules(stored: autoColorRulesModel.current)
+        SettingsCard {
+            SettingsCardRow(
+                configurationReview: .json("workspaceColors.autoColorRules"),
+                searchAnchorID: "setting:workspaceColors:autoColorRules",
+                String(localized: "settings.workspaceColors.autoColorRules", defaultValue: "Automatic Colors by Keyword"),
+                subtitle: String(localized: "settings.workspaceColors.autoColorRules.subtitle", defaultValue: "Workspaces whose title contains a keyword take that color. A color set on the workspace itself always wins.")
+            ) {
+                EmptyView()
+            }
+
+            SettingsCardNote(
+                String(localized: "settings.workspaceColors.autoColorRules.note", defaultValue: "Add rules in cmux.json under workspaceColors.autoColorRules, for example {\"deploy\": \"Red\", \"docs\": \"#1565C0\"}. Matching ignores case and accents; when several keywords match a title, the longest one wins.")
+            )
+
+            ForEach(rules, id: \.keyword) { rule in
+                SettingsCardDivider()
+                autoColorRuleRow(rule)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func autoColorRuleRow(_ rule: (keyword: String, value: String, hex: String?)) -> some View {
+        SettingsCardRow(
+            configurationReview: .json("workspaceColors.autoColorRules"),
+            rule.keyword,
+            subtitle: rule.hex == nil
+                ? String(localized: "settings.workspaceColors.autoColorRules.unknownColor", defaultValue: "Unknown color — use a palette name or a #RRGGBB hex.")
+                : String(localized: "settings.workspaceColors.autoColorRules.matches", defaultValue: "Titles containing \"\(rule.keyword)\".")
+        ) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(rule.hex.flatMap { NSColor(hex: $0) }.map { Color(nsColor: $0) } ?? .clear)
+                    .overlay(Circle().strokeBorder(Color.primary.opacity(0.15)))
+                    .frame(width: 14, height: 14)
+                Text(rule.value)
+                    .cmuxFont(size: 12, weight: .medium, design: .monospaced)
+                    .foregroundStyle(rule.hex == nil ? .secondary : .primary)
+                    .frame(width: 96, alignment: .trailing)
+            }
+        }
+    }
+
+    /// Rules in the order the app matches them: longest keyword first (most
+    /// specific rule wins), ties broken alphabetically. Mirrors
+    /// `WorkspaceTabAutoColorRules.ruleSet` in the app target.
+    private func orderedAutoColorRules(
+        stored: [String: String]
+    ) -> [(keyword: String, value: String, hex: String?)] {
+        let palette = effectivePaletteMap(stored: paletteModel.current)
+        return stored
+            .compactMap { rawKeyword, value -> (keyword: String, value: String, hex: String?)? in
+                let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !keyword.isEmpty else { return nil }
+                return (keyword: keyword, value: value, hex: resolvedRuleHex(value, palette: palette))
+            }
+            .sorted { lhs, rhs in
+                if lhs.keyword.count != rhs.keyword.count { return lhs.keyword.count > rhs.keyword.count }
+                return lhs.keyword.localizedStandardCompare(rhs.keyword) == .orderedAscending
+            }
+    }
+
+    /// Resolves a rule value (palette name or `#RRGGBB`) to a hex, or `nil`
+    /// when it names nothing in the palette.
+    private func resolvedRuleHex(_ raw: String, palette: [String: String]) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let body = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        if body.count == 6, UInt64(body, radix: 16) != nil {
+            return "#" + body.uppercased()
+        }
+        return palette.first { name, _ in name.caseInsensitiveCompare(trimmed) == .orderedSame }?.value
     }
 
     @ViewBuilder

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -475,6 +475,7 @@ extension CmuxSettingsFileStore {
         "workspaceColors.selectionColor",
         "workspaceColors.notificationBadgeColor",
         "workspaceColors.colors",
+        "workspaceColors.autoColorRules",
         "workspaceColors.paletteOverrides",
         "workspaceColors.customColors",
         "sidebarAppearance.matchTerminalBackground",

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -167,6 +167,7 @@ extension CmuxSettingsFileStore {
                     "colors": Dictionary(
                         uniqueKeysWithValues: WorkspaceTabColorSettings.defaultPalette.map { ($0.name, $0.hex) }
                     ),
+                    "autoColorRules": [String: String](),
                 ],
             ],
             [

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -764,6 +764,27 @@ final class CmuxSettingsFileStore {
             ) else { return }
             snapshot.managedUserDefaults["sidebarNotificationBadgeColorHex"] = .nullableString(value)
         }
+        if section.keys.contains("autoColorRules") {
+            if let rawRules = section["autoColorRules"] as? [String: Any] {
+                var rules: [String: String] = [:]
+                for (rawKeyword, rawValue) in rawRules {
+                    guard let color = jsonString(rawValue) else {
+                        cmuxSettingsFileStoreLogger.warning("ignoring non-string workspace auto color rule '\(rawKeyword, privacy: .private(mask: .hash))' in \(sourcePath, privacy: .private(mask: .hash))")
+                        continue
+                    }
+                    rules[rawKeyword] = color
+                }
+                // Trims keywords and normalizes hexes; palette names stay as
+                // written so they keep tracking palette edits.
+                let normalizedRules = WorkspaceTabAutoColorRules.normalizedRuleMap(rules)
+                if normalizedRules.count != rules.count {
+                    cmuxSettingsFileStoreLogger.warning("ignoring \(rules.count - normalizedRules.count) empty workspace auto color rule(s) in \(sourcePath, privacy: .private(mask: .hash))")
+                }
+                snapshot.managedUserDefaults[WorkspaceTabAutoColorRules.rulesKey] = .stringDictionary(normalizedRules)
+            } else {
+                logInvalid("workspaceColors.autoColorRules", sourcePath: sourcePath)
+            }
+        }
         if section.keys.contains("colors") {
             guard let rawColors = section["colors"] as? [String: Any] else {
                 logInvalid("workspaceColors.colors", sourcePath: sourcePath)

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -182,6 +182,7 @@ enum SettingsSearchAliasIndex {
         "workspaceColors:selection": localized("settings.search.alias.setting.workspaceColors.selection", defaultValue: "workspaceColors.selectionColor selected workspace color highlight background active tab"),
         "workspaceColors:badge": localized("settings.search.alias.setting.workspaceColors.badge", defaultValue: "workspaceColors.notificationBadgeColor unread notification badge color dot count"),
         "workspaceColors:palette": localized("settings.search.alias.setting.workspaceColors.palette", defaultValue: "workspaceColors.colors workspace palette named colors custom color reset built-in"),
+        "workspaceColors:autoColorRules": localized("settings.search.alias.setting.workspaceColors.autoColorRules", defaultValue: "workspaceColors.autoColorRules automatic auto color rule keyword title name match group project topic tint"),
         "settingsJSON:open-file": localized("settings.search.alias.setting.settingsJSON.open-file", defaultValue: "open config file json jsonc config editor ~/.config cmux preferences"),
         "settingsJSON:documentation": localized("settings.search.alias.setting.settingsJSON.documentation", defaultValue: "docs documentation schema reference cmux json keys configuration"),
         "reset:reset-all": localized("settings.search.alias.setting.reset.reset-all", defaultValue: "factory reset restore defaults clear preferences")

--- a/Sources/SidebarTabItemSettingsSnapshot.swift
+++ b/Sources/SidebarTabItemSettingsSnapshot.swift
@@ -27,6 +27,9 @@ struct SidebarTabItemSettingsSnapshot: Equatable {
     let notificationBadgePosition: SidebarIndicatorPosition
     let selectionColorHex: String?
     let notificationBadgeColorHex: String?
+    /// Keyword → color rules applied to workspaces without their own color.
+    /// Resolved once here so rows never touch `UserDefaults` while rendering.
+    let workspaceAutoColorRules: WorkspaceTabAutoColorRuleSet
     let visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility
     let iMessageModeEnabled: Bool
     let workspaceTodoChecklistStyle: WorkspaceTodoChecklistStyle
@@ -89,6 +92,7 @@ struct SidebarTabItemSettingsSnapshot: Equatable {
         notificationBadgePosition = settings.value(for: sidebar.notificationBadgePosition)
         selectionColorHex = settings.value(for: workspaceColors.selectionColorHex).nilIfEmpty
         notificationBadgeColorHex = settings.value(for: workspaceColors.notificationBadgeColorHex).nilIfEmpty
+        workspaceAutoColorRules = WorkspaceTabAutoColorRules.ruleSet(defaults: defaults)
         iMessageModeEnabled = IMessageModeSettings.isEnabled(defaults: defaults)
         workspaceTodoChecklistStyle = settings.value(for: betaFeatures.workspaceTodosChecklistStyle)
     }

--- a/Sources/SidebarWorkspaceSnapshotFactory.swift
+++ b/Sources/SidebarWorkspaceSnapshotFactory.swift
@@ -80,7 +80,10 @@ struct SidebarWorkspaceSnapshotFactory {
             title: workspace.title,
             customDescription: settings.showsWorkspaceDescription ? visibleCustomDescription : nil,
             isPinned: workspace.isPinned,
-            customColorHex: workspace.customColor,
+            customColorHex: settings.workspaceAutoColorRules.effectiveColorHex(
+                explicit: workspace.customColor,
+                title: workspace.title
+            ),
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,

--- a/Sources/WorkspaceTabAutoColorRules.swift
+++ b/Sources/WorkspaceTabAutoColorRules.swift
@@ -21,6 +21,11 @@ struct WorkspaceTabAutoColorRule: Equatable {
 /// derived instead of authored: the longest matching keyword wins (the most
 /// specific rule), ties broken alphabetically. That keeps resolution
 /// deterministic without asking users to reason about rule order.
+///
+/// `keyword` is unique across `rules` — entries that trim to the same keyword
+/// are collapsed or dropped before ordering, see
+/// ``WorkspaceTabAutoColorRules/canonicalized(_:)``. The settings card relies
+/// on that to key its rows.
 struct WorkspaceTabAutoColorRuleSet: Equatable {
     static let empty = WorkspaceTabAutoColorRuleSet(rules: [])
 
@@ -73,7 +78,7 @@ enum WorkspaceTabAutoColorRules {
     ) -> WorkspaceTabAutoColorRuleSet {
         guard !raw.isEmpty else { return .empty }
         let palette = WorkspaceTabColorSettings.resolvedPaletteMap(defaults: defaults)
-        let rules = raw
+        let candidates = raw
             .compactMap { rawKeyword, rawColor -> WorkspaceTabAutoColorRule? in
                 let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
                 let foldedKeyword = folded(keyword)
@@ -88,6 +93,7 @@ enum WorkspaceTabAutoColorRules {
                     colorHex: hex
                 )
             }
+        let rules = canonicalized(candidates)
             .sorted { lhs, rhs in
                 if lhs.foldedKeyword.count != rhs.foldedKeyword.count {
                     return lhs.foldedKeyword.count > rhs.foldedKeyword.count
@@ -100,6 +106,33 @@ enum WorkspaceTabAutoColorRules {
                 return lhs.keyword < rhs.keyword
             }
         return WorkspaceTabAutoColorRuleSet(rules: rules)
+    }
+
+    /// Reduces entries that trim to the same keyword down to at most one rule.
+    ///
+    /// The map is keyed by the keyword *as typed*, so `"deploy"` and
+    /// `" deploy "` are two entries that mean one keyword. Left alone they
+    /// produce two rules with an identical sort key, which ties the comparator
+    /// completely and hands the color to dictionary iteration order — and gives
+    /// the settings card two rows with the same `ForEach` identity.
+    ///
+    /// Duplicates that resolve to the same color collapse. Duplicates that
+    /// disagree are dropped entirely: there is no non-arbitrary winner, and
+    /// leaving a workspace uncolored is better than painting it a color the
+    /// user did not unambiguously ask for. A conflict on one keyword never
+    /// affects the others.
+    private static func canonicalized(
+        _ candidates: [WorkspaceTabAutoColorRule]
+    ) -> [WorkspaceTabAutoColorRule] {
+        Dictionary(grouping: candidates, by: \.keyword)
+            .values
+            .compactMap { group in
+                // `colorValue` picks the winner among agreeing duplicates so
+                // the survivor does not depend on iteration order either.
+                guard let winner = group.min(by: { $0.colorValue < $1.colorValue }) else { return nil }
+                guard group.allSatisfy({ $0.colorHex == winner.colorHex }) else { return nil }
+                return winner
+            }
     }
 
     /// Normalizes a raw `keyword: color` map for persistence: trims keywords,

--- a/Sources/WorkspaceTabAutoColorRules.swift
+++ b/Sources/WorkspaceTabAutoColorRules.swift
@@ -92,7 +92,12 @@ enum WorkspaceTabAutoColorRules {
                 if lhs.foldedKeyword.count != rhs.foldedKeyword.count {
                     return lhs.foldedKeyword.count > rhs.foldedKeyword.count
                 }
-                return lhs.keyword.localizedStandardCompare(rhs.keyword) == .orderedAscending
+                // Locale-independent tie-breaks: the same rules must resolve to
+                // the same color whatever the user's locale is. `folded` uses
+                // no locale either, and `keyword` is the final tie-break
+                // because two keywords can fold to the same string.
+                if lhs.foldedKeyword != rhs.foldedKeyword { return lhs.foldedKeyword < rhs.foldedKeyword }
+                return lhs.keyword < rhs.keyword
             }
         return WorkspaceTabAutoColorRuleSet(rules: rules)
     }

--- a/Sources/WorkspaceTabAutoColorRules.swift
+++ b/Sources/WorkspaceTabAutoColorRules.swift
@@ -1,0 +1,122 @@
+import CmuxSettings
+import Foundation
+
+/// One keyword → color rule for automatic workspace colors.
+///
+/// `keyword` is kept as written for display; `foldedKeyword` is the
+/// case/diacritic/width-folded form actually used for matching so the same
+/// rule fires for `Deploy`, `deploy`, and `ｄｅｐｌｏｙ`.
+struct WorkspaceTabAutoColorRule: Equatable {
+    let keyword: String
+    let foldedKeyword: String
+    /// The value as written in settings: a palette name or a `#RRGGBB` hex.
+    let colorValue: String
+    /// `colorValue` resolved against the palette, always `#RRGGBB`.
+    let colorHex: String
+}
+
+/// The resolved, ordered set of automatic workspace color rules.
+///
+/// Rules are stored as an unordered `keyword: color` map, so ordering is
+/// derived instead of authored: the longest matching keyword wins (the most
+/// specific rule), ties broken alphabetically. That keeps resolution
+/// deterministic without asking users to reason about rule order.
+struct WorkspaceTabAutoColorRuleSet: Equatable {
+    static let empty = WorkspaceTabAutoColorRuleSet(rules: [])
+
+    /// Ordered longest keyword first; first match wins.
+    let rules: [WorkspaceTabAutoColorRule]
+
+    var isEmpty: Bool { rules.isEmpty }
+
+    func matchingRule(forTitle title: String) -> WorkspaceTabAutoColorRule? {
+        guard !rules.isEmpty else { return nil }
+        let foldedTitle = WorkspaceTabAutoColorRules.folded(title)
+        guard !foldedTitle.isEmpty else { return nil }
+        return rules.first { foldedTitle.contains($0.foldedKeyword) }
+    }
+
+    func colorHex(forTitle title: String) -> String? {
+        matchingRule(forTitle: title)?.colorHex
+    }
+
+    /// The color a workspace row should draw.
+    ///
+    /// A color set on the workspace itself (context menu, CLI, restored
+    /// session) always wins; rules only fill in when there is none.
+    func effectiveColorHex(explicit: String?, title: String) -> String? {
+        if let explicit, let normalized = WorkspaceTabColorSettings.normalizedHex(explicit) {
+            return normalized
+        }
+        return colorHex(forTitle: title)
+    }
+}
+
+/// Persistence and normalization for ``WorkspaceTabAutoColorRuleSet``.
+///
+/// Rules live in the `workspaceColors.autoColorRules` catalog entry, edited
+/// from `~/.config/cmux/cmux.json`, and are read once per settings change
+/// into the sidebar's value snapshot — never per row render.
+enum WorkspaceTabAutoColorRules {
+    static let rulesKey = WorkspaceColorsCatalogSection().autoColorRules.userDefaultsKey
+
+    static func ruleSet(defaults: UserDefaults = .standard) -> WorkspaceTabAutoColorRuleSet {
+        guard let raw = defaults.dictionary(forKey: rulesKey) as? [String: String] else {
+            return .empty
+        }
+        return ruleSet(raw: raw, defaults: defaults)
+    }
+
+    static func ruleSet(
+        raw: [String: String],
+        defaults: UserDefaults = .standard
+    ) -> WorkspaceTabAutoColorRuleSet {
+        guard !raw.isEmpty else { return .empty }
+        let palette = WorkspaceTabColorSettings.resolvedPaletteMap(defaults: defaults)
+        let rules = raw
+            .compactMap { rawKeyword, rawColor -> WorkspaceTabAutoColorRule? in
+                let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+                let foldedKeyword = folded(keyword)
+                guard !foldedKeyword.isEmpty else { return nil }
+                guard let hex = WorkspaceTabColorSettings.resolvedColorHex(rawColor, palette: palette) else {
+                    return nil
+                }
+                return WorkspaceTabAutoColorRule(
+                    keyword: keyword,
+                    foldedKeyword: foldedKeyword,
+                    colorValue: rawColor,
+                    colorHex: hex
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.foldedKeyword.count != rhs.foldedKeyword.count {
+                    return lhs.foldedKeyword.count > rhs.foldedKeyword.count
+                }
+                return lhs.keyword.localizedStandardCompare(rhs.keyword) == .orderedAscending
+            }
+        return WorkspaceTabAutoColorRuleSet(rules: rules)
+    }
+
+    /// Normalizes a raw `keyword: color` map for persistence: trims keywords,
+    /// drops empty ones, and keeps the color value as written so palette names
+    /// survive a round-trip.
+    static func normalizedRuleMap(_ rawRules: [String: String]) -> [String: String] {
+        var normalized: [String: String] = [:]
+        for (rawKeyword, rawColor) in rawRules {
+            let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+            let color = rawColor.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !keyword.isEmpty, !color.isEmpty else { continue }
+            normalized[keyword] = WorkspaceTabColorSettings.normalizedHex(color) ?? color
+        }
+        return normalized
+    }
+
+    /// Locale-independent folding so matching never depends on the user's
+    /// current locale (Turkish dotless-i and friends).
+    static func folded(_ text: String) -> String {
+        text.folding(
+            options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: nil
+        )
+    }
+}

--- a/Sources/WorkspaceTabColorResolution.swift
+++ b/Sources/WorkspaceTabColorResolution.swift
@@ -2,13 +2,19 @@ import Foundation
 
 extension WorkspaceTabColorSettings {
     static func resolvedColorHex(_ raw: String, defaults: UserDefaults = .standard) -> String? {
+        resolvedColorHex(raw, palette: resolvedPaletteMap(defaults: defaults))
+    }
+
+    /// Same resolution against an already-read palette, so callers resolving a
+    /// batch of values read the palette once.
+    static func resolvedColorHex(_ raw: String, palette: [String: String]) -> String? {
         if let normalized = normalizedHex(raw) {
             return normalized
         }
 
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return resolvedPaletteMap(defaults: defaults)
+        return palette
             .first { name, _ in name.caseInsensitiveCompare(trimmed) == .orderedSame }?
             .value
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2159,6 +2159,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 		D7AB34400000000000000001 /* WorkspaceSurfaceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34400000000000000002 /* WorkspaceSurfaceConfig.swift */; };
 		C0DE32470000000000000003 /* WorkspaceSurfaceIdentifierClipboardText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000004 /* WorkspaceSurfaceIdentifierClipboardText.swift */; };
+		FA1F7B927115B59F19503E0C /* WorkspaceTabAutoColorRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CDF8463C66D0E17558D944 /* WorkspaceTabAutoColorRules.swift */; };
+		905962A0DCF8FC08F2ECB384 /* WorkspaceTabAutoColorRulesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757E066B8ADE77AAB4134F57 /* WorkspaceTabAutoColorRulesTests.swift */; };
 		E3B7A4000000000000000003 /* WorkspaceTabColorEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A4000000000000000004 /* WorkspaceTabColorEntry.swift */; };
 		E30750000000000000000002 /* WorkspaceTabColorResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000001 /* WorkspaceTabColorResolution.swift */; };
 		E3B7A4000000000000000001 /* WorkspaceTabColorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A4000000000000000002 /* WorkspaceTabColorSettings.swift */; };
@@ -4318,6 +4320,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
 		D7AB34400000000000000002 /* WorkspaceSurfaceConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSurfaceConfig.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000004 /* WorkspaceSurfaceIdentifierClipboardText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSurfaceIdentifierClipboardText.swift; sourceTree = "<group>"; };
+		14CDF8463C66D0E17558D944 /* WorkspaceTabAutoColorRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTabAutoColorRules.swift; sourceTree = "<group>"; };
+		757E066B8ADE77AAB4134F57 /* WorkspaceTabAutoColorRulesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTabAutoColorRulesTests.swift; sourceTree = "<group>"; };
 		E3B7A4000000000000000004 /* WorkspaceTabColorEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTabColorEntry.swift; sourceTree = "<group>"; };
 		E30750000000000000000001 /* WorkspaceTabColorResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTabColorResolution.swift; sourceTree = "<group>"; };
 		E3B7A4000000000000000002 /* WorkspaceTabColorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTabColorSettings.swift; sourceTree = "<group>"; };
@@ -5040,6 +5044,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				737100000000000000000002 /* TabManager+NonInteractiveClose.swift */,
 				604500100000000000000008 /* TabManager+WindowTitle.swift */,
 				E30750000000000000000001 /* WorkspaceTabColorResolution.swift */,
+				14CDF8463C66D0E17558D944 /* WorkspaceTabAutoColorRules.swift */,
 				E3B7A4000000000000000002 /* WorkspaceTabColorSettings.swift */,
 				E3B7A4000000000000000004 /* WorkspaceTabColorEntry.swift */,
 				E3B7A4000000000000000022 /* PaneChromeSettings.swift */,
@@ -6433,6 +6438,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */,
 				9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */,
 				9F007352E96022D7EFBE73C9 /* WorkspaceTodoSidebarModelTests.swift */,
+				757E066B8ADE77AAB4134F57 /* WorkspaceTabAutoColorRulesTests.swift */,
 				5B0C00010000000000000004 /* SidebarResizerOcclusionResolverTests.swift */,
 				5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */,
 				C0DE1A080000000000000002 /* SavedLayoutDefinitionTests.swift */,
@@ -8458,6 +8464,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				4CC1722A934F4D8B99FC64C5 /* WorkspaceSidebarProcessTitleObservationModel.swift in Sources */,
 				D7AB34400000000000000001 /* WorkspaceSurfaceConfig.swift in Sources */,
 				C0DE32470000000000000003 /* WorkspaceSurfaceIdentifierClipboardText.swift in Sources */,
+				FA1F7B927115B59F19503E0C /* WorkspaceTabAutoColorRules.swift in Sources */,
 				E3B7A4000000000000000003 /* WorkspaceTabColorEntry.swift in Sources */,
 				E30750000000000000000002 /* WorkspaceTabColorResolution.swift in Sources */,
 				E3B7A4000000000000000001 /* WorkspaceTabColorSettings.swift in Sources */,
@@ -9203,6 +9210,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */,
 				F6120000A1B2C3D4E5F60718 /* WorkspaceSSHFishShellTests.swift in Sources */,
 				FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
+				905962A0DCF8FC08F2ECB384 /* WorkspaceTabAutoColorRulesTests.swift in Sources */,
 				6342F0C10000000000000001 /* WorkspaceTerminalFocusRecoveryTests.swift in Sources */,
 				6047C0DE6047C0DE60470001 /* WorkspaceTerminalTabWorkingDirectoryTests.swift in Sources */,
 				634AA6233A5BBF781FE83E89 /* WorkspaceTerminalWorkingDirectoryFallbackTests.swift in Sources */,

--- a/cmuxTests/WorkspaceTabAutoColorRulesTests.swift
+++ b/cmuxTests/WorkspaceTabAutoColorRulesTests.swift
@@ -73,14 +73,75 @@ struct WorkspaceTabAutoColorRulesTests {
 
     /// Two keywords that fold to the same string still get a total order, so
     /// the winner never depends on dictionary iteration order.
+    ///
+    /// Asserted as a concrete expected order rather than "two runs agree":
+    /// equal runs stay equal even if the raw-keyword tie-break is dropped, so
+    /// only naming the winner proves the secondary ordering is still there.
     @Test
     func keywordsFoldingToTheSameStringStillOrderDeterministically() throws {
         try withDefaults("foldedTies") { defaults in
-            let raw = ["Deploy": "Red", "déploy": "Blue"]
-            let first = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
-            let second = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
-            #expect(first.rules.map(\.keyword) == second.rules.map(\.keyword))
-            #expect(first.colorHex(forTitle: "deploy prod") == second.colorHex(forTitle: "deploy prod"))
+            var oneOrder: [String: String] = [:]
+            oneOrder["Deploy"] = "Red"
+            oneOrder["déploy"] = "Blue"
+
+            var otherOrder: [String: String] = [:]
+            otherOrder["déploy"] = "Blue"
+            otherOrder["Deploy"] = "Red"
+
+            for raw in [oneOrder, otherOrder] {
+                let ruleSet = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
+                // Both fold to "deploy", so the raw keyword decides: "D" sorts
+                // before "d".
+                #expect(ruleSet.rules.map(\.keyword) == ["Deploy", "déploy"])
+                #expect(ruleSet.colorHex(forTitle: "deploy prod") == "#C0392B")
+            }
+        }
+    }
+
+    /// `raw` is keyed by the keyword *as typed*, so `"deploy"` and `" deploy "`
+    /// are two entries that trim down to one keyword. Duplicates that agree
+    /// collapse to a single rule; duplicates that disagree are dropped, because
+    /// no tie-break can pick a non-arbitrary winner and painting the wrong
+    /// color is worse than painting none.
+    @Test
+    func duplicateTrimmedKeywordsCollapseWhenTheyAgreeAndAreDroppedWhenTheyConflict() throws {
+        try withDefaults("duplicates") { defaults in
+            let agreeing = WorkspaceTabAutoColorRules.ruleSet(
+                raw: ["deploy": "Red", "  deploy  ": "Red"],
+                defaults: defaults
+            )
+            #expect(agreeing.rules.map(\.keyword) == ["deploy"])
+            #expect(agreeing.colorHex(forTitle: "deploy staging") == "#C0392B")
+
+            let conflicting = WorkspaceTabAutoColorRules.ruleSet(
+                raw: ["deploy": "Red", "  deploy  ": "Blue"],
+                defaults: defaults
+            )
+            #expect(conflicting.rules.isEmpty)
+            #expect(conflicting.colorHex(forTitle: "deploy staging") == nil)
+
+            // One ambiguous keyword must not take the unambiguous ones down.
+            let mixed = WorkspaceTabAutoColorRules.ruleSet(
+                raw: ["deploy": "Red", " deploy ": "Blue", "docs": "Blue"],
+                defaults: defaults
+            )
+            #expect(mixed.rules.map(\.keyword) == ["docs"])
+            #expect(mixed.colorHex(forTitle: "deploy docs") == "#1565C0")
+        }
+    }
+
+    /// The settings card keys its rows by keyword, so a duplicate keyword would
+    /// mean duplicate `ForEach` IDs. Canonicalization is what guarantees it.
+    @Test
+    func resolvedRulesNeverRepeatAKeyword() throws {
+        try withDefaults("uniqueKeywords") { defaults in
+            let ruleSet = WorkspaceTabAutoColorRules.ruleSet(
+                raw: ["deploy": "Red", " deploy": "Red", "deploy ": "Red", "docs": "Blue"],
+                defaults: defaults
+            )
+            let keywords = ruleSet.rules.map(\.keyword)
+            #expect(keywords.count == Set(keywords).count)
+            #expect(keywords.sorted() == ["deploy", "docs"])
         }
     }
 

--- a/cmuxTests/WorkspaceTabAutoColorRulesTests.swift
+++ b/cmuxTests/WorkspaceTabAutoColorRulesTests.swift
@@ -57,16 +57,30 @@ struct WorkspaceTabAutoColorRulesTests {
         }
     }
 
-    /// Equal-length keywords resolve alphabetically so the same config always
-    /// paints the same color.
+    /// Equal-length keywords resolve on a locale-independent order, so the same
+    /// config paints the same color on every machine.
     @Test
     func equalLengthKeywordsResolveDeterministically() throws {
         try withDefaults("ties") { defaults in
             let raw = ["zzz": "Red", "aaa": "Blue"]
             let first = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
             let second = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
+            #expect(first.rules.map(\.keyword) == ["aaa", "zzz"])
             #expect(first.rules.map(\.keyword) == second.rules.map(\.keyword))
             #expect(first.colorHex(forTitle: "aaa zzz") == "#1565C0")
+        }
+    }
+
+    /// Two keywords that fold to the same string still get a total order, so
+    /// the winner never depends on dictionary iteration order.
+    @Test
+    func keywordsFoldingToTheSameStringStillOrderDeterministically() throws {
+        try withDefaults("foldedTies") { defaults in
+            let raw = ["Deploy": "Red", "déploy": "Blue"]
+            let first = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
+            let second = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
+            #expect(first.rules.map(\.keyword) == second.rules.map(\.keyword))
+            #expect(first.colorHex(forTitle: "deploy prod") == second.colorHex(forTitle: "deploy prod"))
         }
     }
 

--- a/cmuxTests/WorkspaceTabAutoColorRulesTests.swift
+++ b/cmuxTests/WorkspaceTabAutoColorRulesTests.swift
@@ -1,0 +1,158 @@
+import CmuxSettings
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+    @testable import cmux_DEV
+#elseif canImport(cmux)
+    @testable import cmux
+#endif
+
+/// Keyword → color rules that tint workspaces by title
+/// (`workspaceColors.autoColorRules`).
+struct WorkspaceTabAutoColorRulesTests {
+    private func withDefaults<T>(
+        _ label: String,
+        _ body: (UserDefaults) throws -> T
+    ) throws -> T {
+        let suiteName = "cmux.workspace.autoColorRules.\(label).\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        return try body(defaults)
+    }
+
+    @Test
+    func paletteNameRuleColorsMatchingTitle() throws {
+        try withDefaults("paletteName") { defaults in
+            let ruleSet = WorkspaceTabAutoColorRules.ruleSet(raw: ["deploy": "Red"], defaults: defaults)
+            #expect(ruleSet.colorHex(forTitle: "deploy staging") == "#C0392B")
+            #expect(ruleSet.colorHex(forTitle: "unrelated workspace") == nil)
+        }
+    }
+
+    @Test
+    func hexRuleIsNormalizedAndMatchingIgnoresCaseAccentsAndWidth() throws {
+        try withDefaults("folding") { defaults in
+            let ruleSet = WorkspaceTabAutoColorRules.ruleSet(
+                raw: ["déploiement": "#1565c0"],
+                defaults: defaults
+            )
+            #expect(ruleSet.colorHex(forTitle: "Déploiement prod") == "#1565C0")
+            #expect(ruleSet.colorHex(forTitle: "DEPLOIEMENT prod") == "#1565C0")
+            #expect(ruleSet.colorHex(forTitle: "ｄéｐｌｏｉｅｍｅｎｔ") == "#1565C0")
+        }
+    }
+
+    /// Rules are stored as an unordered map, so specificity — not authoring
+    /// order — decides: the longest matching keyword wins.
+    @Test
+    func longestMatchingKeywordWins() throws {
+        try withDefaults("longest") { defaults in
+            let ruleSet = WorkspaceTabAutoColorRules.ruleSet(
+                raw: ["api": "Red", "api-gateway": "Blue"],
+                defaults: defaults
+            )
+            #expect(ruleSet.colorHex(forTitle: "api-gateway prod") == "#1565C0")
+            #expect(ruleSet.colorHex(forTitle: "api prod") == "#C0392B")
+        }
+    }
+
+    /// Equal-length keywords resolve alphabetically so the same config always
+    /// paints the same color.
+    @Test
+    func equalLengthKeywordsResolveDeterministically() throws {
+        try withDefaults("ties") { defaults in
+            let raw = ["zzz": "Red", "aaa": "Blue"]
+            let first = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
+            let second = WorkspaceTabAutoColorRules.ruleSet(raw: raw, defaults: defaults)
+            #expect(first.rules.map(\.keyword) == second.rules.map(\.keyword))
+            #expect(first.colorHex(forTitle: "aaa zzz") == "#1565C0")
+        }
+    }
+
+    @Test
+    func explicitWorkspaceColorWinsOverRules() throws {
+        try withDefaults("explicit") { defaults in
+            let ruleSet = WorkspaceTabAutoColorRules.ruleSet(raw: ["deploy": "Red"], defaults: defaults)
+            #expect(ruleSet.effectiveColorHex(explicit: "#196F3D", title: "deploy staging") == "#196F3D")
+            #expect(ruleSet.effectiveColorHex(explicit: nil, title: "deploy staging") == "#C0392B")
+            // A workspace with an unusable stored color still falls back to rules.
+            #expect(ruleSet.effectiveColorHex(explicit: "nonsense", title: "deploy staging") == "#C0392B")
+            #expect(ruleSet.effectiveColorHex(explicit: nil, title: "scratch") == nil)
+        }
+    }
+
+    @Test
+    func unusableRulesAreDropped() throws {
+        try withDefaults("invalid") { defaults in
+            let ruleSet = WorkspaceTabAutoColorRules.ruleSet(
+                raw: [
+                    "   ": "Red",
+                    "docs": "Not A Color",
+                    "infra": "Orange",
+                ],
+                defaults: defaults
+            )
+            #expect(ruleSet.rules.map(\.keyword) == ["infra"])
+            #expect(ruleSet.colorHex(forTitle: "docs site") == nil)
+        }
+    }
+
+    @Test
+    func keywordsAreTrimmedAndCustomPaletteEntriesResolve() throws {
+        try withDefaults("customPalette") { defaults in
+            defaults.set(["Neon Mint": "#00F5D4"], forKey: WorkspaceTabColorSettings.paletteKey)
+            let ruleSet = WorkspaceTabAutoColorRules.ruleSet(
+                raw: ["  release  ": "neon mint"],
+                defaults: defaults
+            )
+            #expect(ruleSet.rules.map(\.keyword) == ["release"])
+            #expect(ruleSet.colorHex(forTitle: "release 1.2") == "#00F5D4")
+        }
+    }
+
+    @Test
+    func ruleSetReadsStoredDefaultsAndEmptyStorageMatchesNothing() throws {
+        try withDefaults("storage") { defaults in
+            #expect(WorkspaceTabAutoColorRules.ruleSet(defaults: defaults).isEmpty)
+            #expect(WorkspaceTabAutoColorRules.ruleSet(defaults: defaults).colorHex(forTitle: "deploy") == nil)
+
+            defaults.set(["deploy": "Red"], forKey: WorkspaceTabAutoColorRules.rulesKey)
+            #expect(WorkspaceTabAutoColorRules.ruleSet(defaults: defaults).colorHex(forTitle: "deploy") == "#C0392B")
+        }
+    }
+
+    @Test
+    func rulesKeyMatchesCatalogEntry() {
+        #expect(WorkspaceTabAutoColorRules.rulesKey == WorkspaceColorsCatalogSection().autoColorRules.userDefaultsKey)
+        #expect(WorkspaceColorsCatalogSection().autoColorRules.id == "workspaceColors.autoColorRules")
+    }
+
+    /// The sidebar reads rules once per settings change, through the row
+    /// settings snapshot — never per row render.
+    @Test
+    @MainActor
+    func sidebarSettingsSnapshotCarriesStoredRules() throws {
+        try withDefaults("sidebarSnapshot") { defaults in
+            #expect(SidebarTabItemSettingsSnapshot(defaults: defaults).workspaceAutoColorRules.isEmpty)
+
+            defaults.set(["deploy": "Red"], forKey: WorkspaceTabAutoColorRules.rulesKey)
+            let snapshot = SidebarTabItemSettingsSnapshot(defaults: defaults)
+            #expect(
+                snapshot.workspaceAutoColorRules.effectiveColorHex(explicit: nil, title: "deploy prod")
+                    == "#C0392B"
+            )
+        }
+    }
+
+    @Test
+    func normalizedRuleMapTrimsAndKeepsPaletteNames() {
+        let normalized = WorkspaceTabAutoColorRules.normalizedRuleMap([
+            "  deploy ": " Red ",
+            "docs": "#1565c0",
+            " ": "Red",
+            "empty": "   ",
+        ])
+        #expect(normalized == ["deploy": "Red", "docs": "#1565C0"])
+    }
+}

--- a/web/app/[locale]/(landing)/docs/configuration/page.tsx
+++ b/web/app/[locale]/(landing)/docs/configuration/page.tsx
@@ -415,6 +415,23 @@ working-directory = ~/code`}</CodeBlock>
     }
   }
 }`}</CodeBlock>
+                <p>
+                  <code>workspaceColors.autoColorRules</code> colors workspaces by keyword, so
+                  related workspaces group visually without setting a color on each one. A
+                  workspace whose title contains a keyword takes that rule&apos;s color; a color
+                  set on the workspace itself (context menu or CLI) always wins. Matching ignores
+                  case and accents, and when several keywords match a title the longest one wins.
+                  Values are palette names or <code>#RRGGBB</code> hexes.
+                </p>
+                <CodeBlock lang="json">{`{
+  "workspaceColors": {
+    "autoColorRules": {
+      "deploy": "Red",
+      "docs": "#1565C0",
+      "infra": "Orange"
+    }
+  }
+}`}</CodeBlock>
               </>
             )}
           </section>

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1179,6 +1179,21 @@
             "$ref": "#/$defs/colorHex"
           }
         },
+        "autoColorRules": {
+          "type": "object",
+          "description": "Keyword to color rules. A workspace whose title contains the keyword takes that color unless a color was set on the workspace itself. Matching ignores case and accents; when several keywords match, the longest one wins. Values are palette names from workspaceColors.colors or #RRGGBB hexes.",
+          "default": {},
+          "examples": [
+            {
+              "deploy": "Red",
+              "docs": "#1565C0",
+              "infra": "Orange"
+            }
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "paletteOverrides": {
           "type": "object",
           "description": "Legacy workspace color overrides for built-in palette names. Prefer workspaceColors.colors for new configs.",


### PR DESCRIPTION
## Problem

Workspace colors are manual and per-workspace today. When several workspaces belong to the same topic (a repo, a service, a client), you re-pick the same color by hand every time you open one, and new workspaces start uncolored — so the sidebar never groups visually on its own.

Asked for in #1766 (persistent color rules) and #1463 (auto-assign a workspace color instead of setting each one).

## What this adds

`workspaceColors.autoColorRules` in `~/.config/cmux/cmux.json`: a `keyword: color` map. A workspace whose **title** contains a keyword takes that color.

```json
{
  "workspaceColors": {
    "autoColorRules": {
      "deploy": "Red",
      "docs": "#1565C0",
      "infra": "Orange"
    }
  }
}
```

- Values are palette names (from `workspaceColors.colors`) or `#RRGGBB` hexes.
- Matching ignores case, accents, and full/half width.
- Rules are an unordered map, so specificity decides instead of authoring order: **the longest matching keyword wins**, ties broken alphabetically. `api-gateway` beats `api`.
- **A color set on the workspace itself always wins** (context menu, CLI, restored session). Clearing it falls back to the rule.
- Nothing is written to the workspace: the rule is a display fallback, so deleting a rule reverts those rows and no persisted state is left behind.
- The color re-resolves when the title changes, so renaming a workspace (or an agent renaming it) re-colors the row.

Scope: this is the title-keyword half of #1766. Path/repo-based rules (#1463) are complementary and can reuse the same resolver.

## Where it applies

`SidebarWorkspaceSnapshotFactory` — the one place the sidebar resolves a row's color — so the SwiftUI rows and the AppKit list rows both pick it up, under both indicator styles (left rail and solid fill).

Rules are resolved once per settings change into `SidebarTabItemSettingsSnapshot`, the row settings value snapshot, so rows never touch `UserDefaults` while rendering (snapshot-boundary rule in CLAUDE.md).

## Settings

Settings → Workspace Colors gets an "Automatic Colors by Keyword" card that lists the effective rules in match order with their resolved swatch, and flags a rule whose color name resolves to nothing. Editing stays in cmux.json, like the palette dictionary above it.

## Tests

`cmuxTests/WorkspaceTabAutoColorRulesTests.swift` (wired into `project.pbxproj`): palette-name and hex rules, case/accent/width folding, longest-keyword precedence, deterministic ties, explicit-color precedence, invalid rules dropped, UserDefaults round-trip, catalog key identity, and the sidebar settings snapshot carrying the rules.

## Localization

New UI strings added to `Resources/Localizable.xcstrings` with `en` + `ja`: the section title, subtitle, the cmux.json note, the unknown-color subtitle, the per-rule subtitle, and the settings-search alias. The `workspaceColors` schema descriptions and the configuration docs prose are English-only in this repo (that section carries no `descriptionKey`), so no `web/messages/*` change was needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787410074&installation_model_id=21920&pr_number=8747&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8747&signature=75c88b991926e692c42c6eeeaee82b82f08ef981b32d9ed1d2f370c2034ebdac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic workspace tab coloring driven by keyword→color rules.
  * Rules support palette names and `#RRGGBB`, with longest-keyword matching precedence and explicit workspace colors overriding rules.
  * Added settings UI (including rule listing/resolution feedback), search aliasing, and JSON/config persistence.

* **Documentation**
  * Updated configuration docs and added localized descriptions/tooltips for the new rule setting.

* **Bug Fixes**
  * Improved rule and color normalization, validation, and deterministic matching; unknown/unresolvable colors are handled gracefully.

* **Tests**
  * Added a dedicated test suite covering matching, precedence, persistence, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically color sidebar workspaces by title keywords so related workspaces group visually without manual coloring. Adds `workspaceColors.autoColorRules` in `~/.config/cmux/cmux.json` and a settings card to preview the effective rules.

- **New Features**
  - Keyword → color rules in `workspaceColors.autoColorRules`; values can be palette names from `workspaceColors.colors` or `#RRGGBB` hexes.
  - Matching ignores case, accents, and full/half width; the longest matching keyword wins. Ties resolve deterministically by folded keyword, then raw keyword.
  - Duplicate keywords that trim to the same word canonicalize: entries that agree collapse to one rule; conflicting entries are dropped. Empty keywords/values are ignored and hexes are normalized.
  - A color set on the workspace itself always wins; rules don’t persist to the workspace and re-evaluate on title changes.
  - Resolution happens once per settings change and is applied in the sidebar snapshot factory, covering both SwiftUI and AppKit rows.
  - Settings card lists rules in true match order (mirrors the same canonicalization and locale-independent ordering) and flags unknown colors; search alias added; strings localized (en, ja). Schema, docs, and tests updated.

<sup>Written for commit bc13fe14835636332d082db14ed06cb9c9dd4ef1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

