### PR TITLE
Fix markdown code span double-escaping

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -985,15 +985,6 @@ html { scroll-behavior: smooth; }
     return template.innerHTML;
   }
 
-  // Configure marked: GitHub-flavored, with custom renderers for
-  // code (syntax-highlighted via highlight.js), headings (with
-  // GitHub-style slug ids for anchor links), and local markdown file
-  // detection in inline code spans.
-  // Note: when customizing via `marked.use({renderer})`, marked
-  // calls these methods with the *legacy* positional signature
-  // (text, level, raw / code, lang, escaped / href, title, text)
-  // — NOT a single token object. Inline children are already
-  // rendered to HTML and passed in as `text`.
   var headingSlugCounts = Object.create(null);
   function uniqueHeadingSlug(raw) {
     var base = String(raw || '').toLowerCase()
@@ -1006,15 +997,35 @@ html { scroll-behavior: smooth; }
     return count === 0 ? base : base + '-' + count;
   }
 
+  // Configure marked: GitHub-flavored, with custom renderers for fenced
+  // code (syntax-highlighted via highlight.js), headings (GitHub-style
+  // slug ids for anchor links), and links.
+  //
+  // `renderer` here is a partial override, not a complete renderer.
+  // marked starts from its own default renderer and replaces only the
+  // methods named below; every method not named keeps marked's built-in
+  // implementation, and the parser calls one per token type
+  // unconditionally. So there is no fall-through case to handle.
+  //
+  // `codespan` is deliberately absent: marked's renderer already handles
+  // it correctly. The default implementation is
+  // `'<code>' + token.text + '</code>'`, and token.text is already
+  // HTML-escaped by the codespan tokenizer.
+  //
+  // Fenced `code` below is the opposite case: its `code` argument is
+  // the raw source, so it must be escaped exactly once — which is what
+  // hljs (or the escapeHtml fallback) does.
+  //
+  // Note: when customizing via `marked.use({renderer})`, marked calls
+  // these methods with the *legacy* positional signature
+  // (text, level, raw / code, lang, escaped / href, title, text) — NOT
+  // a single token object. Inline children are already rendered to HTML
+  // and passed in as `text`.
   marked.use({
     gfm: true,
     breaks: false,
     pedantic: false,
     renderer: {
-      codespan(code) {
-        var raw = code || '';
-        return '<code>' + escapeHtml(raw) + '</code>';
-      },
       code(code, infostring, escaped) {
         var raw = code || '';
         var langMatch = (infostring || '').match(/^[A-Za-z0-9_+\-.]+/);

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1031,6 +1031,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		730600000000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730600010000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift */; };
 		730600020000000000000002 /* MainWindowVisibleFrameFitRescue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730600020000000000000001 /* MainWindowVisibleFrameFitRescue.swift */; };
 		A9D9000000000000000F0017 /* markdown-viewer in Resources */ = {isa = PBXBuildFile; fileRef = A9D9000000000000000F0016 /* markdown-viewer */; };
+		C0DE5A02C0DE5A02C0DE5A02 /* MarkdownCodeSpanEscapeRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A01C0DE5A01C0DE5A01 /* MarkdownCodeSpanEscapeRegressionTests.swift */; };
 		A28B087F0000000000000003 /* MarkdownEditableFocusMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F0000000000000004 /* MarkdownEditableFocusMessageHandler.swift */; };
 		F5168A040000000000000001 /* MarkdownFontFamily.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A040000000000000002 /* MarkdownFontFamily.swift */; };
 		F5168A070000000000000001 /* MarkdownFontFamilyCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */; };
@@ -3200,6 +3201,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		730600010000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowVisibleFrameFitCoreTests.swift; sourceTree = "<group>"; };
 		730600020000000000000001 /* MainWindowVisibleFrameFitRescue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MainWindowVisibleFrameFitRescue.swift; sourceTree = "<group>"; };
 		A9D9000000000000000F0016 /* markdown-viewer */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = "markdown-viewer"; sourceTree = "<group>"; };
+		C0DE5A01C0DE5A01C0DE5A01 /* MarkdownCodeSpanEscapeRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownCodeSpanEscapeRegressionTests.swift; sourceTree = "<group>"; };
 		A28B087F0000000000000004 /* MarkdownEditableFocusMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownEditableFocusMessageHandler.swift; sourceTree = "<group>"; };
 		F5168A040000000000000002 /* MarkdownFontFamily.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontFamily.swift; sourceTree = "<group>"; };
 		F5168A070000000000000002 /* MarkdownFontFamilyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownFontFamilyCache.swift; sourceTree = "<group>"; };
@@ -6363,6 +6365,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEFB300000000000000002 /* FocusSurfaceBroadcasterTests.swift */,
 				A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */,
 				D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */,
+				C0DE5A01C0DE5A01C0DE5A01 /* MarkdownCodeSpanEscapeRegressionTests.swift */,
 				D8072A01D8072A01D8072A01 /* BrowserViewportRuntimeLoadDelegate.swift */,
 				D8072A03D8072A03D8072A03 /* BrowserViewportRuntimeTests.swift */,
 				D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */,
@@ -8888,6 +8891,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				17C9F5BA0DD14EDC8C3E5001 /* MainWindowVisibilityControllerTests.swift in Sources */,
 				A6D1F0100000000000000002 /* MainWindowVisibilityLifecycleTests.swift in Sources */,
 				730600000000000000000001 /* MainWindowVisibleFrameFitCoreTests.swift in Sources */,
+				C0DE5A02C0DE5A02C0DE5A02 /* MarkdownCodeSpanEscapeRegressionTests.swift in Sources */,
 				D7470002D7470002D7470002 /* MarkdownLinkBoundaryRegressionTests.swift in Sources */,
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,

--- a/cmuxTests/MarkdownCodeSpanEscapeRegressionTests.swift
+++ b/cmuxTests/MarkdownCodeSpanEscapeRegressionTests.swift
@@ -1,0 +1,213 @@
+import AppKit
+import Testing
+import WebKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// The markdown viewer used to escape inline code spans twice: marked's
+/// codespan tokenizer already HTML-escapes the span text, and the shell's
+/// custom `codespan` renderer escaped that escaped text again. A file
+/// containing `` `<encoded>` `` rendered as a literal `&lt;encoded&gt;`.
+///
+/// These cases assert on the rendered DOM, so they fail for any renderer that
+/// escapes a code span zero times (raw HTML leaks) or twice (entities on
+/// screen).
+@MainActor
+@Suite
+final class MarkdownCodeSpanEscapeRegressionTests {
+    @Test(arguments: MarkdownCodeSpanEscapeCase.all)
+    func renderedCodeIsEscapedExactlyOnce(_ escapeCase: MarkdownCodeSpanEscapeCase) async throws {
+        try await withLoadedMarkdownShell { webView in
+            let snapshot = try await renderCodeSnapshot(
+                escapeCase.markdown,
+                selector: escapeCase.selector,
+                in: webView
+            )
+
+            #expect(snapshot.text == escapeCase.expectedText)
+            if let expectedInnerHTML = escapeCase.expectedInnerHTML {
+                #expect(snapshot.innerHTML == expectedInnerHTML)
+            }
+        }
+    }
+
+    /// A code span holding a path is also the viewer's markdown-file link
+    /// candidate, and the candidate is read back off `textContent`. Escaped
+    /// entities in that text would silently break link detection too.
+    @Test
+    func codeSpanFileLinkCandidateSeesUnescapedText() async throws {
+        try await withLoadedMarkdownShell { webView in
+            let snapshot = try await renderCodeSnapshot(
+                "Open `docs/<name>/notes.md` next.",
+                selector: "code[data-cmux-file]",
+                in: webView
+            )
+
+            #expect(snapshot.text == "docs/<name>/notes.md")
+        }
+    }
+
+    private func withLoadedMarkdownShell<T>(
+        _ body: (WKWebView) async throws -> T
+    ) async throws -> T {
+        let markdownURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-code-span-\(UUID().uuidString).md")
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 900, height: 600))
+        defer { webView.navigationDelegate = nil }
+
+        let loadDelegate = MarkdownCodeSpanShellLoadDelegate()
+        webView.navigationDelegate = loadDelegate
+        try await loadDelegate.load(
+            MarkdownViewerAssets.shared.shellHTML(isDark: true),
+            in: webView,
+            baseURL: markdownURL
+        )
+        return try await body(webView)
+    }
+
+    private func renderCodeSnapshot(
+        _ markdown: String,
+        selector: String,
+        in webView: WKWebView
+    ) async throws -> CodeSpanSnapshot {
+        let data = try JSONSerialization.data(withJSONObject: [markdown, selector])
+        let literal = try #require(String(data: data, encoding: .utf8))
+        let result = try await webView.evaluateJavaScript(
+            """
+            (function(args) {
+              window.__cmuxRenderMarkdown(args[0]);
+              var el = document.querySelector(args[1]);
+              if (!el) { return { found: false }; }
+              return { found: true, text: el.textContent, innerHTML: el.innerHTML };
+            })(\(literal));
+            """
+        )
+        let raw = try #require(result as? [String: Any])
+        #expect((raw["found"] as? Bool) == true, "no element matched \(selector)")
+        return CodeSpanSnapshot(
+            text: raw["text"] as? String,
+            innerHTML: raw["innerHTML"] as? String
+        )
+    }
+}
+
+struct MarkdownCodeSpanEscapeCase: Sendable, CustomTestStringConvertible {
+    let name: String
+    let markdown: String
+    let selector: String
+    let expectedText: String
+    /// `nil` where highlight.js wraps the text in spans, so only the visible
+    /// text is stable enough to assert on.
+    let expectedInnerHTML: String?
+
+    var testDescription: String { name }
+
+    static let all: [MarkdownCodeSpanEscapeCase] = [
+        MarkdownCodeSpanEscapeCase(
+            name: "code span with angle brackets",
+            markdown: "The sessions persist under `~/.claude/projects/<encoded>/` on disk.",
+            selector: "code",
+            expectedText: "~/.claude/projects/<encoded>/",
+            expectedInnerHTML: "~/.claude/projects/&lt;encoded&gt;/"
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "code span with an ampersand",
+            markdown: "Run `foo & bar` now.",
+            selector: "code",
+            expectedText: "foo & bar",
+            expectedInnerHTML: "foo &amp; bar"
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "code span with literal entity text",
+            markdown: "Type `&amp;` here.",
+            selector: "code",
+            expectedText: "&amp;",
+            expectedInnerHTML: "&amp;amp;"
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "code span with quotes",
+            markdown: "Use `--flag=\"a 'b'\"` today.",
+            selector: "code",
+            expectedText: "--flag=\"a 'b'\"",
+            expectedInnerHTML: "--flag=\"a 'b'\""
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "code span inside a link label",
+            markdown: "See [the `<encoded>` doc](docs/x.md).",
+            selector: "a code",
+            expectedText: "<encoded>",
+            expectedInnerHTML: "&lt;encoded&gt;"
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "code span inside a heading",
+            markdown: "# Path `<encoded>` layout",
+            selector: "h1 code",
+            expectedText: "<encoded>",
+            expectedInnerHTML: "&lt;encoded&gt;"
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "code span inside a table cell",
+            markdown: "| a | b |\n| - | - |\n| `<x>` | y |",
+            selector: "td code",
+            expectedText: "<x>",
+            expectedInnerHTML: "&lt;x&gt;"
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "fenced block without a language",
+            markdown: "```\n<tag> & 'quote'\n```",
+            selector: "pre code",
+            expectedText: "<tag> & 'quote'",
+            expectedInnerHTML: nil
+        ),
+        MarkdownCodeSpanEscapeCase(
+            name: "fenced block with a language",
+            markdown: "```swift\nlet x: Array<Int> = []  // a & b\n```",
+            selector: "pre code",
+            expectedText: "let x: Array<Int> = []  // a & b",
+            expectedInnerHTML: nil
+        )
+    ]
+}
+
+private struct CodeSpanSnapshot {
+    let text: String?
+    let innerHTML: String?
+}
+
+private final class MarkdownCodeSpanShellLoadDelegate: NSObject, WKNavigationDelegate {
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    func load(_ html: String, in webView: WKWebView, baseURL: URL) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            webView.loadHTMLString(html, baseURL: baseURL)
+        }
+    }
+
+    private func finish(_ result: Result<Void, Error>) {
+        guard let continuation else { return }
+        self.continuation = nil
+        switch result {
+        case .success:
+            continuation.resume()
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        finish(.success(()))
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        finish(.failure(error))
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        finish(.failure(error))
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** Removed the markdown viewer's custom `codespan`
  renderer in `Resources/markdown-viewer/shell.html`, so marked's default
  applies. Added
  `cmuxTests/MarkdownCodeSpanEscapeRegressionTests.swift`.
- **Why?** The viewer escaped inline code spans twice, so entity text
  reached the screen. A file containing
  `` `~/.claude/projects/<encoded>/` `` rendered as
  `~/.claude/projects/&lt;encoded&gt;/`. GitHub, Typora and Obsidian
  render the same bytes correctly.

  `Tokenizer.codespan` in marked ends with `text = escape(text, true)`,
  which is why marked's own default renderer is a bare
  `codespan({text}) => '<code>' + text + '</code>'`. Because
  `marked.use()` here is called without `useNewRenderer`, marked wraps
  the custom renderer in its legacy-signature adapter, which passes that
  already-escaped `token.text` as the single positional argument. The
  override escaped it again: `<` reached the DOM as `&amp;lt;`.

  Every character marked escapes is affected — `<`, `>`, `&`, `"`, `'` —
  in every position a code span can appear: paragraphs, headings, table
  cells, link labels. It also degraded the markdown-file link
  affordance, since `markMarkdownFileLinks()` reads candidate paths off
  `code.textContent`.

  Fenced blocks are unaffected and stay that way: the same adapter hands
  `code` the raw source plus an `escaped` flag, and highlight.js escapes
  it once.

## Testing

Two commits, red then green, per the regression test commit policy.

```bash
xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
  -destination 'platform=macOS' \
  test -only-testing:cmuxTests/MarkdownCodeSpanEscapeRegressionTests
```

- **Without the fix:** `TEST FAILED` — 15 issues. All 7 inline code-span
  cases fail (angle brackets, `&`, literal `&amp;` text, quotes, in a
  heading, in a table cell, in a link label) plus the
  `code[data-cmux-file]` link-candidate test. Sample:
  `(snapshot.text → "~/.claude/projects/&lt;encoded&gt;/") == (expectedText
  → "~/.claude/projects/<encoded>/")`.
- **With the fix:** `TEST SUCCEEDED` — 2 tests (one parameterized over 9
  cases) in 0.59s.
- **Both fenced-block controls pass in both runs**, confirming fenced
  code was never double-escaped and is not changed by this patch.
- Dogfooded in a tagged debug build (`./scripts/reload.sh --tag
  md-codespan`) against a file exercising code spans in a paragraph,
  heading, table cell and link label, plus a fenced block. Before/after
  screenshots below.
- `scripts/lint-pbxproj-test-wiring.sh` and `scripts/check-pbxproj.sh`
  both pass; the new test file is wired into `project.pbxproj`.

**Localization audit:** no user-facing strings changed. The diff deletes
a JavaScript renderer override in a bundled web asset and adds a test;
it introduces no `String(localized:)` call, no `Text()`/`Button()`
literal, and no schema, menu, docs or help text. `Localizable.xcstrings`
and the `web/messages/*.json` catalogs are untouched and need no entry.
The only user-visible change is that code-span text now renders as the
author wrote it in every locale.

## Demo Video

Same file, same build tag, before and after the fix. Note `<encoded>`,
`foo & bar` and `--flag="a 'b'"` in the code spans, and that the fenced
block is identical in both.

Before: <img width="380" height="660" alt="Before-crop" src="https://github.com/user-attachments/assets/7b56cb8a-3ccd-4a75-afcd-8748e0ba6df7" />
After: <img width="380" height="660" alt="After-crop" src="https://github.com/user-attachments/assets/cd0a32b4-feaa-4b20-b9b4-5affe111287c" />

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or
  equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787413117&installation_model_id=21920&pr_number=8749&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8749&signature=e6e5d0437c54e8a0f4417416edcf0a4e9b0a8d6d5c5e404f58a3b50abf64bb37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-escaping of inline code spans in the markdown viewer by removing the custom `codespan` renderer and using `marked`’s default. Restores correct display of <, >, &, and quotes, and fixes markdown-file link detection from `code[data-cmux-file]`.

- **Bug Fixes**
  - Drop custom `codespan` in `Resources/markdown-viewer/shell.html`; keep fenced `code` handling as-is (escaped once via `highlight.js`).
  - Add `cmuxTests/MarkdownCodeSpanEscapeRegressionTests.swift` covering code spans in paragraphs, headings, table cells, link labels, and the file-link candidate; includes fenced-block controls.

<sup>Written for commit 02c4789c9d0a87296f5235947b9565d25b0a9dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown code span rendering to prevent double-escaping special characters.
  * Preserved correct display of code spans in headings, links, tables, and fenced code blocks.
  * Ensured literal entities, angle brackets, ampersands, and quotes render as intended.

* **Tests**
  * Added regression coverage for Markdown code span escaping across supported contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->