### PR TITLE
Close only the workspaces a tab manager actually owns

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2058,6 +2058,12 @@ class TabManager: ObservableObject {
 
     func closeWorkspace(_ workspace: Workspace, recordHistory: Bool = true) {
         guard tabs.count > 1 else { return }
+        // Only this manager's own workspaces close here. The teardown below frees
+        // Ghostty surfaces, which SIGHUPs the child processes, empties `panels`, and
+        // publishes a workspace-closed event, so running it for a workspace that
+        // lives in another window or was already detached kills terminals nobody
+        // asked to close and announces a close that did not happen.
+        guard tabs.contains(where: { $0.id == workspace.id }) else { return }
         panelTitleUpdateCoalescer.flushNow()
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
         // Closing a mirrored remote tmux workspace DETACHES from the remote session,


### PR DESCRIPTION
`closeWorkspace` tears a workspace down before it checks that the workspace belongs to this manager, so
handing it a workspace from another window destroys that workspace while leaving it on screen.

## What the user sees

Two windows open. Something asks window A's tab manager to close a workspace that lives in window B.
Window B's workspace keeps its tab and stays visible, but its terminals are gone: the panels were torn
down, the Ghostty surfaces freed, and freeing a surface SIGHUPs the child processes. A workspace-closed
event is published for a workspace that is still open, so anything listening downstream is told about a
close that did not happen, and `owningTabManager` is left nil.

## Why it happens

```swift
func closeWorkspace(_ workspace: Workspace, recordHistory: Bool = true) {
    guard tabs.count > 1 else { return }
```

That is the only precondition. Everything destructive then runs unconditionally:
`workspace.teardownAllPanels()`, `workspace.teardownRemoteConnection()`, `owningTabManager = nil`, and
`publishCmuxWorkspaceClosed(workspace)`. `teardownAllPanels` runs `discardClosedPanelLifecycleState`
per panel, which calls `panel?.close()` and removes the entry from `panels` and `panelTitles`.

Membership in `tabs` is only *enforced* at the very end, when the array element is removed. The
`recordHistory` block does look the index up earlier, but only to decide where in the history to
record, and it does not stop the teardown.

## The guard was there, and a merge dropped it

#889 ("Fix orphaned child processes when closing workspace tabs") added `teardownAllPanels()` and,
directly above it, a `tabs.firstIndex(where:)` guard — the destructive step and its precondition landed
in the same commit, along with the test that covers this. `git log -L` on those lines shows the guard
removed, restored by a revert, then removed again by a "Reapply" merge commit that kept the teardown.

Two call sites already make this check themselves rather than relying on `closeWorkspace`: `AppDelegate`
re-checks `sourceManager.tabs.contains` before closing a source workspace, and `TerminalController`
records `existedBefore` and skips candidates that fail it. Both predate #889, so they are not
compensating for the lost guard — they are evidence that callers have always needed this precondition
and have been paying for it individually.

One path does change behavior. `Workspace.swift` resolves a manager as
`owningTabManager ?? AppDelegate.shared?.tabManagerFor(tabId:) ?? AppDelegate.shared?.tabManager`, and
that last fallback is reached precisely when no manager owns the workspace. Previously such a call tore
the workspace down through an unrelated manager; now it returns early. That is the intent of the guard,
but it is a real change rather than a no-op, so it is worth a reviewer's attention.

## Test plan

Measured on `4253cc2884`, one GUI test host at a time, same checkout and DerivedData for both arms:

```
xcodebuild test -scheme cmux-unit -configuration Debug -destination 'platform=macOS' \
  -only-testing:cmuxTests/WorkspacePullRequestSidebarTests \
  -only-testing:cmuxTests/TabManagerPullRequestProbeTests \
  -only-testing:cmuxTests/TabManagerWorkspaceOwnershipTests \
  -only-testing:cmuxTests/CLICodexHookTimeoutRegressionTests
```

| arm | XCTest failures across a 36-test run | distinct tests red |
|---|---|---|
| `main` unchanged | 15 of 36 | 9 |
| this branch | 13 of 36 | 8 |

`testCloseWorkspaceIgnoresWorkspaceNotOwnedByManager` is the test that flips: it hands the manager a
foreign workspace and checks that the workspace keeps its panel, which is the terminal that would
otherwise be killed. On `main` it fails twice, `XCTAssertEqual failed: ("0") is not equal to ("1")` for
the panel count and `("[:]")` for the panel titles, which is the foreign workspace being emptied.

No host restarts in either arm, and `CLICodexHookTimeoutRegressionTests` reports `Test run with 8 tests
in 1 suite passed` in both.

Pull-request CI on this repo runs review bots and security scanners, not the test suite, so the arms
above are the only test evidence this carries.

The eight tests still red on this branch are test-side failures in the same suites: two git-index
fixtures describing a state git cannot produce, a scoped socket report sent to an unresolvable manager,
a stub watching a subprocess the product no longer spawns, and four waits that resolve to a blocking
helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended workspace shutdown actions when attempting to close a workspace that isn’t currently managed by the active tab manager.
  * Avoided unwanted focus/selection changes and suppressed the workspace-closed event when an invalid close request is received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->