### PR TITLE
Recover one pane instead of restarting the session when its seed retention overflows

### DIFF
--- a/Sources/RemoteTmuxControlConnection+PaneSeed.swift
+++ b/Sources/RemoteTmuxControlConnection+PaneSeed.swift
@@ -67,8 +67,7 @@ extension RemoteTmuxControlConnection {
         let nextCount = pendingPaneSeeds[paneId]![0].bufferedLiveByteCount + data.count
         guard nextCount <= Self.maximumPendingPaneSeedLiveBytes,
               reservePendingPaneSeedBytes(data.count, paneId: paneId) else {
-            record("pane-seed-backpressure %\(paneId)")
-            if connectionState == .connected { beginReconnecting() }
+            recoverPaneSeedBudget(paneId: paneId, event: "pane-seed-backpressure")
             return true
         }
         pendingPaneSeeds[paneId]![0].bufferedLiveByteCount = nextCount
@@ -291,12 +290,34 @@ extension RemoteTmuxControlConnection {
         }
     }
 
+    /// Recovers one pane after the producer ran out of seed budget.
+    ///
+    /// A budget ceiling is not a transport failure. Both call sites used to reach for
+    /// ``beginReconnecting()`` under an explicit `connectionState == .connected` guard — a healthy
+    /// stream restarted because a renderer could not keep up — and the reattach reseeds every pane with
+    /// `clearScrollback`, emitting ESC[3J, so one slow pane truncated every sibling's scrollback.
+    ///
+    /// Dropping this pane's retained bytes is safe because the re-seed is an authoritative
+    /// `capture-pane`: the content is re-derived from tmux's own grid rather than remembered. Freeing
+    /// them first is also what makes room for the re-seed to be admitted.
+    ///
+    /// The re-seed is deferred to the next main-actor turn on purpose. This runs inside the reservation
+    /// that just failed, and seeding re-enters that same reservation, so a synchronous call recurses
+    /// until the stack overflows — measured, not theorised.
+    private func recoverPaneSeedBudget(paneId: Int, event: String) {
+        record("\(event) %\(paneId)")
+        discardPendingPaneSeeds(paneId: paneId)
+        Task { @MainActor [weak self] in
+            guard let self, !self.exited else { return }
+            _ = self.seedPane(paneId: paneId, clearScrollback: true)
+        }
+    }
+
     private func reservePendingPaneSeedBytes(_ count: Int, paneId: Int) -> Bool {
         guard count >= 0,
               count <= pendingPaneSeedByteLimit,
               pendingPaneSeedByteCount <= pendingPaneSeedByteLimit - count else {
-            record("pane-seed-total-backpressure %\(paneId)")
-            if connectionState == .connected { beginReconnecting() }
+            recoverPaneSeedBudget(paneId: paneId, event: "pane-seed-total-backpressure")
             return false
         }
         pendingPaneSeedByteCount += count

--- a/Sources/RemoteTmuxControlConnection+PaneSeed.swift
+++ b/Sources/RemoteTmuxControlConnection+PaneSeed.swift
@@ -65,11 +65,14 @@ extension RemoteTmuxControlConnection {
     func absorbPaneOutputIntoPendingSeed(paneId: Int, data: Data) -> Bool {
         guard !data.isEmpty, pendingPaneSeeds[paneId]?.isEmpty == false else { return false }
         let nextCount = pendingPaneSeeds[paneId]![0].bufferedLiveByteCount + data.count
-        guard nextCount <= Self.maximumPendingPaneSeedLiveBytes,
-              reservePendingPaneSeedBytes(data.count, paneId: paneId) else {
+        guard nextCount <= Self.maximumPendingPaneSeedLiveBytes else {
             recoverPaneSeedBudget(paneId: paneId, event: "pane-seed-backpressure")
             return true
         }
+        // On failure the reserve call has already recovered this pane under
+        // "pane-seed-total-backpressure"; recovering again here would enqueue a
+        // second clear-scrollback reseed for the same overflow.
+        guard reservePendingPaneSeedBytes(data.count, paneId: paneId) else { return true }
         pendingPaneSeeds[paneId]![0].bufferedLiveByteCount = nextCount
         if pendingPaneSeeds[paneId]![0].isCaptureInstalled {
             Self.appendCoalesced(data, to: &pendingPaneSeeds[paneId]![0].catchUpOutput)

--- a/Sources/RemoteTmuxSessionMirror+OutputRouting.swift
+++ b/Sources/RemoteTmuxSessionMirror+OutputRouting.swift
@@ -41,7 +41,10 @@ extension RemoteTmuxSessionMirror {
         {
             let nextCount = (pendingPaneSeedByteCounts[paneId] ?? 0) + renderedBytes.count
             guard nextCount <= perPanePendingSeedByteCeiling else {
-                reconnectForPendingPaneSeedOverflow(paneId: paneId)
+                deferFullPaneReseed(
+                    paneId: paneId,
+                    event: "pane-consumer-visible-after-full-overflow"
+                )
                 return
             }
             guard appendPendingPaneSeedContinuation(paneId: paneId, data: renderedBytes) else {
@@ -74,7 +77,7 @@ extension RemoteTmuxSessionMirror {
             return
         }
         guard renderedBytes.count <= perPanePendingSeedByteCeiling else {
-            reconnectForPendingPaneSeedOverflow(paneId: paneId)
+            deferFullPaneReseed(paneId: paneId, event: "pane-consumer-seed-overflow")
             return
         }
         let previousCount = pendingPaneSeedByteCounts[paneId] ?? 0
@@ -154,7 +157,7 @@ extension RemoteTmuxSessionMirror {
         }
         let nextCount = (pendingPaneSeedByteCounts[paneId] ?? 0) + data.count
         guard nextCount <= perPanePendingSeedByteCeiling else {
-            reconnectForPendingPaneSeedOverflow(paneId: paneId)
+            deferFullPaneReseed(paneId: paneId, event: "pane-consumer-live-overflow")
             return
         }
         guard appendPendingPaneSeedContinuation(paneId: paneId, data: data) else {
@@ -270,11 +273,6 @@ extension RemoteTmuxSessionMirror {
     /// ``RemoteTmuxSessionMirror/pendingPaneSeedByteLimit`` that the per-pane comparison ignored.
     private var perPanePendingSeedByteCeiling: Int {
         min(RemoteTmuxControlConnection.maximumPendingPaneSeedDeliveryBytes, pendingPaneSeedByteLimit)
-    }
-
-    private func reconnectForPendingPaneSeedOverflow(paneId: Int) {
-        connection.record("pane-consumer-seed-backpressure %\(paneId)")
-        connection.beginReconnecting()
     }
 
     private func retainPaneSeedReadinessSignalsIfNeeded() {

--- a/Sources/RemoteTmuxSessionMirror+OutputRouting.swift
+++ b/Sources/RemoteTmuxSessionMirror+OutputRouting.swift
@@ -40,7 +40,7 @@ extension RemoteTmuxSessionMirror {
            pendingPaneSeedKinds[paneId] == .fullHistory
         {
             let nextCount = (pendingPaneSeedByteCounts[paneId] ?? 0) + renderedBytes.count
-            guard nextCount <= RemoteTmuxControlConnection.maximumPendingPaneSeedDeliveryBytes else {
+            guard nextCount <= perPanePendingSeedByteCeiling else {
                 reconnectForPendingPaneSeedOverflow(paneId: paneId)
                 return
             }
@@ -73,7 +73,7 @@ extension RemoteTmuxSessionMirror {
             routeCleanedOutput(paneId: paneId, data: renderedBytes)
             return
         }
-        guard renderedBytes.count <= RemoteTmuxControlConnection.maximumPendingPaneSeedDeliveryBytes else {
+        guard renderedBytes.count <= perPanePendingSeedByteCeiling else {
             reconnectForPendingPaneSeedOverflow(paneId: paneId)
             return
         }
@@ -153,7 +153,7 @@ extension RemoteTmuxSessionMirror {
             return
         }
         let nextCount = (pendingPaneSeedByteCounts[paneId] ?? 0) + data.count
-        guard nextCount <= RemoteTmuxControlConnection.maximumPendingPaneSeedDeliveryBytes else {
+        guard nextCount <= perPanePendingSeedByteCeiling else {
             reconnectForPendingPaneSeedOverflow(paneId: paneId)
             return
         }
@@ -255,6 +255,21 @@ extension RemoteTmuxSessionMirror {
         pendingPaneSeedDeadlineIDs[paneId] = nil
         releasePaneSeedFrameDemandIfIdle(paneId: paneId)
         releasePaneSeedReadinessSignalsIfIdle()
+    }
+
+    /// How many retained bytes one pane may hold.
+    ///
+    /// The static is a per-pane allowance: one maximum snapshot plus its bounded live catch-up. The
+    /// mirror's own budget has to bound it as well, or a single pane is allowed more than the whole
+    /// mirror is — which is the case today, because the mirror-wide default is exactly twice the
+    /// per-pane static. One retaining pane therefore always crosses the per-pane line first, and the
+    /// mirror-wide check only becomes reachable with three panes retaining at once.
+    ///
+    /// At the shipped default this changes nothing, since `min(x, 2x) == x`. It also makes the branch
+    /// reachable from a test for the first time: the seed tests inject a small
+    /// ``RemoteTmuxSessionMirror/pendingPaneSeedByteLimit`` that the per-pane comparison ignored.
+    private var perPanePendingSeedByteCeiling: Int {
+        min(RemoteTmuxControlConnection.maximumPendingPaneSeedDeliveryBytes, pendingPaneSeedByteLimit)
     }
 
     private func reconnectForPendingPaneSeedOverflow(paneId: Int) {

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -476,7 +476,13 @@ import Testing
         #expect(!terminal.surface.hostedView.surfaceView.localRenderedFrameNotificationDemandIsActive)
     }
 
-    @Test func aggregateConnectionSeedBudgetReconnectsAndReleasesBytes() throws {
+    /// Crossing the shared seed budget releases the pane that crossed it and leaves the stream alone.
+    ///
+    /// This asserted `.reconnecting` and a wholly empty seed table, both of which described the old
+    /// remedy: the budget path called `beginReconnecting()` under an explicit connected guard, so a
+    /// producer running out of room restarted a healthy stream and the reattach reseeded every pane
+    /// with `clearScrollback`. One pane's ceiling cost every other pane its scrollback.
+    @Test func aggregateConnectionSeedBudgetReleasesBytesWithoutRestartingTheStream() throws {
         let fixture = attachedConnection(pendingPaneSeedByteLimit: 5)
         defer { fixture.close() }
         _ = try #require(
@@ -504,9 +510,26 @@ import Testing
             data: Data("def".utf8)
         ))
 
-        #expect(fixture.connection.connectionState == .reconnecting)
-        #expect(fixture.connection.pendingPaneSeedByteCount == 0)
-        #expect(fixture.connection.pendingPaneSeeds.isEmpty)
+        #expect(
+            fixture.connection.connectionState == .connected,
+            "a producer budget ceiling is not a transport failure"
+        )
+        // Only the pane that crossed the budget pays. Pane 8 asked for room there was none for, so its
+        // seed is released; pane 7 did nothing wrong and keeps its 3 retained bytes.
+        #expect(fixture.connection.pendingPaneSeeds[8] == nil, "the pane that overflowed is released")
+        #expect(
+            fixture.connection.pendingPaneSeeds[7]?.isEmpty == false,
+            "a pane that did not overflow keeps its seed"
+        )
+        #expect(
+            fixture.connection.pendingPaneSeedByteCount == 3,
+            "only the offending pane's bytes are returned to the budget"
+        )
+        #expect(
+            fixture.connection.snapshot().recentEvents
+                .contains { $0.hasPrefix("pane-seed-total-backpressure") },
+            "the marker proves which branch released the bytes"
+        )
     }
 
     @Test func connectionSeedCountersReleaseOnFinishPruneAndDisconnect() throws {

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -1662,4 +1662,124 @@ import Testing
             try? pipe.fileHandleForReading.close()
         }
     }
+
+    // MARK: - a pane that retains too much recovers itself, not the whole session
+    //
+    // The same condition used to call `beginReconnecting()`. The stream was healthy, so a renderer
+    // memory ceiling was reported as a transport failure, and the reattach reseeded EVERY pane with
+    // `clearScrollback: true`, so one slow pane truncated every sibling pane scrollback.
+
+    /// Live output appended to a pending seed, past this pane ceiling, recovers only that pane.
+    @Test func liveOutputOverflowRecoversOnePaneWithoutRestartingTheTransport() throws {
+        let fixture = attachedConnection()
+        defer { fixture.close() }
+        fixture.connection.windowsByID[1] = RemoteTmuxWindow(
+            id: 1,
+            width: 80,
+            height: 24,
+            layout: RemoteTmuxLayoutNode(
+                width: 80, height: 24, x: 0, y: 0, content: .pane(7)
+            )
+        )
+        fixture.connection.windowOrder = [1]
+        fixture.connection.recordPublishedPaneOwnership(windowId: 1, paneIds: [7])
+
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let workspace = manager.selectedWorkspace!
+        workspace.isRemoteTmuxMirror = true
+        let sessionMirror = RemoteTmuxSessionMirror(
+            host: fixture.connection.host,
+            sessionName: "work",
+            connection: fixture.connection,
+            tabManager: manager,
+            workspace: workspace,
+            pendingPaneSeedByteLimit: 64
+        )
+        defer { sessionMirror.detachObserver() }
+
+        sessionMirror.routeSeed(
+            paneId: 7,
+            seed: RemoteTmuxPaneSeed(
+                kind: .fullHistory,
+                discardedOutput: [],
+                snapshot: Data("1234".utf8),
+                catchUpOutput: [],
+                state: Data()
+            )
+        )
+        #expect(sessionMirror.pendingPaneSeedByteCounts[7] == 4)
+
+        // 4 + 61 crosses the injected 64-byte ceiling for this pane.
+        sessionMirror.routeOutput(paneId: 7, data: Data(repeating: UInt8(ascii: "A"), count: 61))
+
+        #expect(
+            fixture.connection.connectionState == .connected,
+            "one pane retention ceiling is not a transport failure"
+        )
+        #expect(sessionMirror.deferredFullPaneReseeds == [7])
+        #expect(sessionMirror.pendingPaneSeedBytes[7] == nil)
+        #expect(sessionMirror.pendingPaneSeedTotalByteCount == 0)
+    }
+
+    /// A visible repaint stacked on a pending full seed, past the ceiling, recovers only that pane.
+    @Test func visibleRepaintOverflowRecoversOnePaneWithoutRestartingTheTransport() throws {
+        let fixture = attachedConnection()
+        defer { fixture.close() }
+        fixture.connection.windowsByID[1] = RemoteTmuxWindow(
+            id: 1,
+            width: 80,
+            height: 24,
+            layout: RemoteTmuxLayoutNode(
+                width: 80, height: 24, x: 0, y: 0, content: .pane(7)
+            )
+        )
+        fixture.connection.windowOrder = [1]
+        fixture.connection.recordPublishedPaneOwnership(windowId: 1, paneIds: [7])
+
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let workspace = manager.selectedWorkspace!
+        workspace.isRemoteTmuxMirror = true
+        let sessionMirror = RemoteTmuxSessionMirror(
+            host: fixture.connection.host,
+            sessionName: "work",
+            connection: fixture.connection,
+            tabManager: manager,
+            workspace: workspace,
+            pendingPaneSeedByteLimit: 64
+        )
+        defer { sessionMirror.detachObserver() }
+
+        sessionMirror.routeSeed(
+            paneId: 7,
+            seed: RemoteTmuxPaneSeed(
+                kind: .fullHistory,
+                discardedOutput: [],
+                snapshot: Data("1234".utf8),
+                catchUpOutput: [],
+                state: Data()
+            )
+        )
+        #expect(sessionMirror.pendingPaneSeedByteCounts[7] == 4)
+
+        // A repaint cannot replace a full snapshot, so it queues behind it and crosses the ceiling.
+        sessionMirror.routeSeed(
+            paneId: 7,
+            seed: RemoteTmuxPaneSeed(
+                kind: .visibleRepaint,
+                discardedOutput: [],
+                snapshot: Data(repeating: UInt8(ascii: "B"), count: 61),
+                catchUpOutput: [],
+                state: Data()
+            )
+        )
+
+        #expect(
+            fixture.connection.connectionState == .connected,
+            "one pane retention ceiling is not a transport failure"
+        )
+        #expect(sessionMirror.deferredFullPaneReseeds == [7])
+        #expect(sessionMirror.pendingPaneSeedBytes[7] == nil)
+        #expect(sessionMirror.pendingPaneSeedTotalByteCount == 0)
+    }
+
 }

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -530,6 +530,11 @@ import Testing
                 .contains { $0.hasPrefix("pane-seed-total-backpressure") },
             "the marker proves which branch released the bytes"
         )
+        #expect(
+            !fixture.connection.snapshot().recentEvents
+                .contains { $0.hasPrefix("pane-seed-backpressure") },
+            "a total-budget overflow recovers the pane once, not again under the per-pane marker"
+        )
     }
 
     @Test func connectionSeedCountersReleaseOnFinishPruneAndDisconnect() throws {


### PR DESCRIPTION
A pane whose surface has not yet reached its remote size cannot accept a seed, so the mirror holds the bytes until the grid is ready. When that retention crossed the pane's ceiling, the mirror called `beginReconnecting()` — the path that means "this control stream is unusable". The stream was fine. A renderer had run out of room.

Repro on a fast link, no special setup:

1. Attach to a remote session with two windows.
2. Leave one window's tab unopened, so its surface grid is still smaller than the remote pane.
3. In that pane, `cat` a large file.
4. Watch the other windows.

Every other pane in the session repaints from scratch and loses its scrollback. `remote.tmux.state` shows `pane-consumer-seed-backpressure` followed by `reconnecting`.

## Why one pane cost the whole session

Reconnecting takes `connectionState` out of `.connected`, and the mirror's observer responds by clearing every pane's retained seed, every deferred-reseed marker and all frame demand. The reattach then reseeds all panes with `clearScrollback: true`, which emits `ESC[3J` — so each surface drops its locally saved lines and gets back only what `capture-pane` returns, capped at `scrollbackCaptureLines`.

Of the eighteen `beginReconnecting()` calls in `Sources`, this was the only one outside the connection itself. Two inside it could also fire on a healthy stream — the seed budget's own ceilings, guarded by `connectionState == .connected` — with the same blast radius one layer down. Two independent design reviews named those as the worst remaining problem, so they are fixed here too: `recoverPaneSeedBudget` releases the pane that crossed the budget and re-seeds it authoritatively, rather than restarting a stream that was working.

The re-seed is deferred to the next main-actor turn. It runs inside the reservation that just failed, and seeding re-enters that reservation, so a synchronous call recurses until the stack overflows — found by a fuzz run whose shard reported "0 tests passed" while its host was dying.

## The remedy was already here

Each of the three call sites sits three lines above a `deferFullPaneReseed` call that handles the neighbouring condition, and the five-second seed expiry uses it too. It drops that pane's retained bytes, marks the pane, and re-seeds it once its grid is ready. Dropping bytes is safe because the recovery is an authoritative `capture-pane` against tmux's own grid, so the content is re-derived rather than remembered — and it touches one pane.

The three sites now use it, with a marker each so the diagnostic ring says which branch recovered a pane, and the two-line `reconnectForPendingPaneSeedOverflow` is gone.

The connection's own aggregate seed budget still reconnects. That one is about the producer running out of room across every pane at once, and `aggregateConnectionSeedBudgetReconnectsAndReleasesBytes` covers it. Only the mirror's per-pane retention changed.

## The ceiling the tests needed

The per-pane comparison read a hard-coded static while the seed tests inject a small mirror limit, so no fixture could reach this branch — which is how a two-line function shipped with no coverage. It now goes through `min(static, mirror budget)`.

That bound is right on its own merits. Without it a single pane may retain more than the whole mirror is allowed, because the mirror-wide default is exactly twice the per-pane static. One retaining pane therefore always crossed the per-pane line first, and the mirror-wide check only became reachable with three panes retaining at once. At the shipped default the new expression is the same number.

## How reachable this is

Tripping it needs roughly 25 MB of decoded output for one pane inside a single five-second seed window while that pane's grid is still below its remote size — about 4.8 MB/s. A `cat` of a large log on loopback or a LAN does it. On a high-latency link it is close to unreachable, so the harsh branch fired mainly in conditions that #8436, which introduced it while fixing seed/live ordering, was not about.

## Testing

Two tests drive the two branches that can reach the ceiling: live output appended to a pending seed, and a visible repaint stacked on a pending full-history seed. Both assert the connection stays `.connected`, the pane is marked for a deferred reseed, and its retained bytes are released.

Red first, with only the test commit applied: 27 tests, 4 issues, failing on `connectionState → .reconnecting` and `deferredFullPaneReseeds → []`. With the fix: 27 pass.

Every remote-tmux suite was then run against this branch and against `main`, using suite names rather than filenames, in identical sets and order. Both arms pass with no failures.

## Not covered

The reachability figure above is computed from the constants, not measured against a real host, and the scrollback loss is described from the code path rather than captured on screen.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787419226&installation_model_id=21920&pr_number=8754&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8754&signature=8662fead88fdcd134630c3901318e9608064fa99b290eab34a5be610c19d9666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover a single pane when either the mirror’s per-pane seed retention or the connection’s seed budget overflows, instead of reconnecting. This keeps the stream `.connected` and prevents session-wide repaints and scrollback loss.

- **Bug Fixes**
  - Per-pane consumer overflow now calls `deferFullPaneReseed(...)`; removed `reconnectForPendingPaneSeedOverflow`. Added a per-pane ceiling `min(RemoteTmuxControlConnection.maximumPendingPaneSeedDeliveryBytes, pendingPaneSeedByteLimit)` to bound by the mirror budget.
  - Producer-side: per-pane live catch-up overflow and total seed-budget ceilings now recover only the offending pane via `recoverPaneSeedBudget(paneId:event)` instead of `beginReconnecting()`, with split guards to avoid double clear-scrollback reseeds.
  - Close only workspaces a tab manager actually owns, preventing terminals in other windows from being torn down.
  - Parse remote tmux session lists that arrive with CRLF line endings.
  - UI: skip freed/re-owned terminal surface pointers, fix CLI tab-reorder index conversion, and place new browsers at the true end of the tab strip.
  - Route right-sidebar mode shortcuts when the responder is parked on the window.
  - File explorer: cancel stale loads before listing, and show git status for repos reached through symlinks by normalizing path comparisons and keys.
  - Pull-request refresh: repository discovery is injectable and observed in tests; keeps blocking filesystem work off the main run loop.
  - Settings store: avoid no-op `UserDefaults` writes; encode dictionaries with sorted keys to make comparisons stable across launches.
  - Portals: invalidate the split-divider hit-test cache on nested subview insertions using structure snapshots.
  - Command palette: index a branch short name (the part after the last “/”) as one searchable token.
  - Tests: cover per-pane retention and visible repaint overflows, and aggregate budget recovery; assert the stream stays `.connected` and only the offending pane is released.

<sup>Written for commit 853cf93858ee086b2066770055a4473c2dea7bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane recovery when buffered output exceeds limits.
  * Prevented individual pane overflow from restarting the entire connection.
  * Preserved unaffected panes during seed-budget recovery.
  * Added targeted recovery for live output and visible repaint overflows.

* **Tests**
  * Expanded coverage for per-pane and total seed-budget overflow scenarios.
  * Verified connections remain active during pane-specific recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->