### PR TITLE
Add deterministic mixed-workload performance harness

### DIFF
--- a/.github/workflows/perf-mixed-workload.yml
+++ b/.github/workflows/perf-mixed-workload.yml
@@ -1,0 +1,458 @@
+name: Mixed workload performance
+
+on:
+  workflow_dispatch:
+    inputs:
+      baseline_sha:
+        description: Exact 40-hex baseline commit
+        required: true
+        type: string
+      candidate_sha:
+        description: Exact 40-hex candidate commit
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# A single repository-wide lane keeps two manually dispatched experiments from
+# contending for the same class of GitHub-hosted macOS benchmark host.
+concurrency:
+  group: perf-mixed-workload-macos-15
+  cancel-in-progress: false
+
+jobs:
+  paired-experiment:
+    runs-on: macos-15
+    # The driver performs 108 measured clean invocations, plus warmups, fixture
+    # recreation, profiling, and two clean builds. Use the hosted-runner maximum.
+    timeout-minutes: 360
+    env:
+      BASELINE_TAG: perfmixedb${{ github.run_id }}a${{ github.run_attempt }}
+      CANDIDATE_TAG: perfmixedc${{ github.run_id }}a${{ github.run_attempt }}
+      RESULTS_DIR: ${{ runner.temp }}/perf-mixed-workload-${{ github.run_id }}-${{ github.run_attempt }}
+      PERF_HOST_CONTROLS_PATH: ${{ runner.temp }}/perf-mixed-workload-${{ github.run_id }}-${{ github.run_attempt }}/host-controls.json
+    steps:
+      - name: Initialize evidence directory
+        env:
+          BASELINE_SHA_INPUT: ${{ inputs.baseline_sha }}
+          CANDIDATE_SHA_INPUT: ${{ inputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RESULTS_DIR"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          context = {
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "workflow_sha": os.environ["GITHUB_SHA"],
+              "run_id": os.environ["GITHUB_RUN_ID"],
+              "run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "baseline_sha_input": os.environ["BASELINE_SHA_INPUT"],
+              "candidate_sha_input": os.environ["CANDIDATE_SHA_INPUT"],
+          }
+          path = Path(os.environ["RESULTS_DIR"]) / "workflow-context.json"
+          path.write_text(json.dumps(context, indent=2, sort_keys=True) + "\n")
+          PY
+
+      - name: Validate immutable experiment inputs
+        env:
+          BASELINE_SHA_INPUT: ${{ inputs.baseline_sha }}
+          CANDIDATE_SHA_INPUT: ${{ inputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REPOSITORY" != "usr-bin-roygbiv/cmux" ]]; then
+            echo "::error::This workflow may run only in usr-bin-roygbiv/cmux."
+            exit 1
+          fi
+          if [[ ! "$BASELINE_SHA_INPUT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::baseline_sha must be exactly 40 hexadecimal characters."
+            exit 1
+          fi
+          if [[ ! "$CANDIDATE_SHA_INPUT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::candidate_sha must be exactly 40 hexadecimal characters."
+            exit 1
+          fi
+          BASELINE_SHA="$(printf '%s' "$BASELINE_SHA_INPUT" | tr '[:upper:]' '[:lower:]')"
+          CANDIDATE_SHA="$(printf '%s' "$CANDIDATE_SHA_INPUT" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$BASELINE_SHA" == "$CANDIDATE_SHA" ]]; then
+            echo "::error::baseline_sha and candidate_sha must identify distinct commits."
+            exit 1
+          fi
+          {
+            echo "BASELINE_SHA=$BASELINE_SHA"
+            echo "CANDIDATE_SHA=$CANDIDATE_SHA"
+            echo "BASELINE_DERIVED_DATA=$HOME/Library/Developer/Xcode/DerivedData/cmux-$BASELINE_TAG"
+            echo "CANDIDATE_DERIVED_DATA=$HOME/Library/Developer/Xcode/DerivedData/cmux-$CANDIDATE_TAG"
+            echo "BASELINE_APP=$HOME/Library/Developer/Xcode/DerivedData/cmux-$BASELINE_TAG/Build/Products/Debug/cmux DEV $BASELINE_TAG.app"
+            echo "CANDIDATE_APP=$HOME/Library/Developer/Xcode/DerivedData/cmux-$CANDIDATE_TAG/Build/Products/Debug/cmux DEV $CANDIDATE_TAG.app"
+          } >> "$GITHUB_ENV"
+
+      - name: Checkout workflow and harness ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: usr-bin-roygbiv/cmux
+          ref: ${{ github.sha }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Checkout exact baseline commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: usr-bin-roygbiv/cmux
+          ref: ${{ inputs.baseline_sha }}
+          path: variants/baseline
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Checkout exact candidate commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: usr-bin-roygbiv/cmux
+          ref: ${{ inputs.candidate_sha }}
+          path: variants/candidate
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Verify exact variant commits
+        run: |
+          set -euo pipefail
+          baseline_head="$(git -C variants/baseline rev-parse HEAD)"
+          candidate_head="$(git -C variants/candidate rev-parse HEAD)"
+          [[ "$baseline_head" == "$BASELINE_SHA" ]] || {
+            echo "::error::Baseline checkout resolved to $baseline_head, expected $BASELINE_SHA."
+            exit 1
+          }
+          [[ "$candidate_head" == "$CANDIDATE_SHA" ]] || {
+            echo "::error::Candidate checkout resolved to $candidate_head, expected $CANDIDATE_SHA."
+            exit 1
+          }
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          ./scripts/select-ci-xcode.sh
+
+      - name: Record host and control metadata
+        env:
+          RUNNER_CONTEXT_NAME: ${{ runner.name }}
+          RUNNER_CONTEXT_OS: ${{ runner.os }}
+          RUNNER_CONTEXT_ARCH: ${{ runner.arch }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import shutil
+          import subprocess
+
+          def capture(*command):
+              try:
+                  completed = subprocess.run(
+                      command,
+                      check=False,
+                      capture_output=True,
+                      text=True,
+                      timeout=30,
+                  )
+              except (OSError, subprocess.TimeoutExpired) as error:
+                  return {"available": False, "error": str(error)}
+              return {
+                  "available": True,
+                  "returncode": completed.returncode,
+                  "stdout": completed.stdout.strip(),
+                  "stderr": completed.stderr.strip(),
+              }
+
+          controls = {}
+          for name in ("pmset", "powermetrics", "caffeinate"):
+              controls[name] = shutil.which(name)
+          controls["passwordless_sudo"] = capture("sudo", "-n", "true")
+          if controls["pmset"]:
+              controls["power_settings"] = capture("pmset", "-g", "custom")
+              controls["thermal_state"] = capture("pmset", "-g", "therm")
+
+          metadata = {
+              "runner": {
+                  "name": os.environ.get("RUNNER_CONTEXT_NAME"),
+                  "os": os.environ.get("RUNNER_CONTEXT_OS"),
+                  "arch": os.environ.get("RUNNER_CONTEXT_ARCH"),
+                  "image_os": os.environ.get("ImageOS"),
+                  "image_version": os.environ.get("ImageVersion"),
+                  "machine_arch": capture("uname", "-m"),
+              },
+              "macos": capture("sw_vers"),
+              "xcode": capture("xcodebuild", "-version"),
+              "sdk_version": capture("xcrun", "--sdk", "macosx", "--show-sdk-version"),
+              "sdk_path": capture("xcrun", "--sdk", "macosx", "--show-sdk-path"),
+              "uptime": capture("uptime"),
+              "load_average": capture("sysctl", "-n", "vm.loadavg"),
+              "available_controls": controls,
+          }
+          output = Path(os.environ["PERF_HOST_CONTROLS_PATH"])
+          output.parent.mkdir(parents=True, exist_ok=True)
+          output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+          PY
+
+      - name: Install build dependencies
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+          HOMEBREW_NO_ENV_HINTS: "1"
+        run: |
+          set -euo pipefail
+          ./scripts/install-zig-ci.sh
+          ./scripts/install-rust-ci.sh
+
+      - name: Download pre-built GhosttyKit frameworks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          (
+            cd variants/baseline
+            ./scripts/download-prebuilt-ghosttykit.sh
+          )
+          (
+            cd variants/candidate
+            ./scripts/download-prebuilt-ghosttykit.sh
+          )
+
+      - name: Cache Swift packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            variants/baseline/.ci-source-packages
+            variants/candidate/.ci-source-packages
+          key: spm-mixed-${{ runner.os }}-${{ runner.arch }}-${{ inputs.baseline_sha }}-${{ inputs.candidate_sha }}-${{ hashFiles('variants/baseline/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'variants/candidate/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+
+      - name: Resolve Swift packages for both commits
+        run: |
+          set -euo pipefail
+          resolve_packages() {
+            local checkout="$1"
+            local derived_data="$2"
+            local source_packages="$checkout/.ci-source-packages"
+            mkdir -p "$source_packages"
+            python3 scripts/ci/sanitize-xcode-source-packages-cache.py "$source_packages"
+            (
+              cd "$checkout"
+              for attempt in 1 2 3; do
+                if xcodebuild -project cmux.xcodeproj -scheme cmux -configuration Debug \
+                  -derivedDataPath "$derived_data" \
+                  -clonedSourcePackagesDirPath "$source_packages" \
+                  -resolvePackageDependencies; then
+                  exit 0
+                fi
+                if [[ "$attempt" -eq 3 ]]; then
+                  echo "Failed to resolve Swift packages for $checkout after 3 attempts" >&2
+                  exit 1
+                fi
+                sleep $((attempt * 5))
+              done
+            )
+          }
+          resolve_packages "$GITHUB_WORKSPACE/variants/baseline" "$BASELINE_DERIVED_DATA"
+          resolve_packages "$GITHUB_WORKSPACE/variants/candidate" "$CANDIDATE_DERIVED_DATA"
+
+      - name: Build exact tagged variants
+        run: |
+          set -euo pipefail
+          (
+            cd variants/baseline
+            CMUX_SKIP_ZIG_BUILD=1 \
+              CMUX_RELOAD_NO_GLOBAL_CLI_LINKS=1 \
+              CMUX_SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
+              CMUX_DISABLE_AUTOMATIC_PACKAGE_RESOLUTION=1 \
+              ./scripts/reload.sh --tag "$BASELINE_TAG"
+          )
+          (
+            cd variants/candidate
+            CMUX_SKIP_ZIG_BUILD=1 \
+              CMUX_RELOAD_NO_GLOBAL_CLI_LINKS=1 \
+              CMUX_SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
+              CMUX_DISABLE_AUTOMATIC_PACKAGE_RESOLUTION=1 \
+              ./scripts/reload.sh --tag "$CANDIDATE_TAG"
+          )
+          [[ -x "$BASELINE_APP/Contents/MacOS/cmux DEV" ]] || {
+            echo "::error::Baseline binary missing at $BASELINE_APP/Contents/MacOS/cmux DEV"
+            exit 1
+          }
+          [[ -x "$CANDIDATE_APP/Contents/MacOS/cmux DEV" ]] || {
+            echo "::error::Candidate binary missing at $CANDIDATE_APP/Contents/MacOS/cmux DEV"
+            exit 1
+          }
+
+      - name: Run focused prompt detector tests for both commits
+        run: |
+          set -euo pipefail
+          swift test \
+            --package-path variants/baseline/Packages/macOS/CmuxTerminalCore \
+            --filter PromptLineTurnDetectorTests
+          swift test \
+            --package-path variants/candidate/Packages/macOS/CmuxTerminalCore \
+            --filter PromptLineTurnDetectorTests
+
+      - name: Run complete paired mixed-workload matrix
+        env:
+          CMUX_PERF_HOST_CONTROLS_PATH: ${{ env.PERF_HOST_CONTROLS_PATH }}
+        run: |
+          set -euo pipefail
+          python3 scripts/perf_mixed_workload_driver.py \
+            --baseline-sha "$BASELINE_SHA" \
+            --baseline-tag "$BASELINE_TAG" \
+            --baseline-app "$BASELINE_APP" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --candidate-tag "$CANDIDATE_TAG" \
+            --candidate-app "$CANDIDATE_APP" \
+            --output-dir "$RESULTS_DIR" \
+            --warmups 1 \
+            --repetitions 3
+
+      - name: Upload complete experiment evidence
+        id: evidence-upload
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-mixed-workload-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.RESULTS_DIR }}/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Append experiment summary
+        if: always()
+        env:
+          ARTIFACT_URL: ${{ steps.evidence-upload.outputs.artifact-url }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          import os
+          from pathlib import Path
+
+          results = Path(os.environ["RESULTS_DIR"])
+          manifest_path = results / "experiment-manifest.json"
+          analysis_path = results / "analysis.json"
+
+          def load(path):
+              try:
+                  return json.loads(path.read_text())
+              except (OSError, json.JSONDecodeError):
+                  return None
+
+          manifest = load(manifest_path)
+          analysis = load(analysis_path)
+          print("## Mixed workload performance")
+          print()
+          print(f"- Baseline: `{os.environ.get('BASELINE_SHA', 'unavailable')}`")
+          print(f"- Candidate: `{os.environ.get('CANDIDATE_SHA', 'unavailable')}`")
+          run_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+          print(f"- Run: [{os.environ['GITHUB_RUN_ID']}]({run_url})")
+          artifact_url = os.environ.get("ARTIFACT_URL")
+          print(f"- Evidence: [artifact]({artifact_url})" if artifact_url else "- Evidence: artifact upload unavailable")
+
+          if manifest is None or analysis is None:
+              missing = []
+              if manifest is None:
+                  missing.append("experiment-manifest.json")
+              if analysis is None:
+                  missing.append("analysis.json")
+              print(f"- Result: **incomplete** (missing or invalid {', '.join(missing)})")
+          else:
+              for key in ("schema", "status", "final_acceptance"):
+                  if key in analysis:
+                      print(f"- {key.replace('_', ' ').title()}: `{analysis[key]}`")
+                  elif key in manifest:
+                      print(f"- {key.replace('_', ' ').title()}: `{manifest[key]}`")
+
+              failures = []
+              for document in (manifest, analysis):
+                  value = document.get("failures", [])
+                  if isinstance(value, list):
+                      failures.extend(value)
+              if failures:
+                  print(f"- Failures: **{len(failures)}**")
+                  for failure in failures[:10]:
+                      detail = failure if isinstance(failure, str) else json.dumps(failure, sort_keys=True)
+                      print(f"  - `{detail}`")
+
+              conclusions = analysis.get("scenario_conclusions", analysis.get("scenarios", []))
+              if isinstance(conclusions, dict):
+                  conclusions = [dict({"scenario": key}, **value) if isinstance(value, dict) else {"scenario": key, "conclusion": value} for key, value in sorted(conclusions.items())]
+              if isinstance(conclusions, list) and conclusions:
+                  print("- Scenario conclusions:")
+                  for conclusion in conclusions:
+                      if isinstance(conclusion, dict):
+                          scenario = conclusion.get("scenario_id", conclusion.get("scenario", "unknown"))
+                          verdict = conclusion.get("conclusion", conclusion.get("status", conclusion.get("verdict", "reported")))
+                          print(f"  - `{scenario}`: {verdict}")
+          PY
+
+      - name: Require complete accepted results
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          results = Path(os.environ["RESULTS_DIR"])
+          paths = [
+              results / "host-controls.json",
+              results / "experiment-manifest.json",
+              results / "analysis.json",
+          ]
+          missing = [str(path) for path in paths if not path.is_file()]
+          if missing:
+              raise SystemExit("required experiment evidence is missing: " + ", ".join(missing))
+
+          documents = []
+          for path in paths:
+              try:
+                  documents.append(json.loads(path.read_text()))
+              except json.JSONDecodeError as error:
+                  raise SystemExit(f"invalid JSON in {path}: {error}") from error
+
+          manifest, analysis = documents[1:]
+          failures = []
+          for name, document in (("manifest", manifest), ("analysis", analysis)):
+              value = document.get("failures", [])
+              if not isinstance(value, list):
+                  raise SystemExit(f"{name} failures must be an array")
+              failures.extend((name, failure) for failure in value)
+          if failures:
+              raise SystemExit(f"experiment reported {len(failures)} failure(s)")
+          if analysis.get("final_acceptance") is False:
+              raise SystemExit("analysis final_acceptance is false")
+          if str(analysis.get("status", "")).lower() in {"failed", "failure", "incomplete", "rejected"}:
+              raise SystemExit(f"analysis status is {analysis['status']!r}")
+          PY
+
+      - name: Cleanup owned tagged state
+        if: always()
+        run: |
+          set -euo pipefail
+          cleanup_tag() {
+            local tag="$1"
+            local derived_data="$2"
+            local bundle_id="com.cmuxterm.app.debug.${tag}"
+            pkill -f "cmux DEV ${tag}.app/Contents/MacOS/cmux DEV" 2>/dev/null || true
+            rm -rf \
+              "$derived_data" \
+              "/tmp/cmux-${tag}" \
+              "$HOME/Library/Application Support/cmux/${bundle_id}" \
+              "$HOME/Library/Saved Application State/${bundle_id}.savedState"
+            rm -f \
+              "/tmp/cmux-debug-${tag}.sock" \
+              "/tmp/cmux-debug-${tag}.log" \
+              "$HOME/Library/Application Support/cmux/cmuxd-dev-${tag}.sock" \
+              "$HOME/Library/Application Support/cmux/session-${bundle_id}.json" \
+              "$HOME/Library/Application Support/cmux/session-${bundle_id}-previous.json" \
+              "$HOME/Library/Preferences/${bundle_id}.plist"
+          }
+          cleanup_tag "$BASELINE_TAG" "$HOME/Library/Developer/Xcode/DerivedData/cmux-$BASELINE_TAG"
+          cleanup_tag "$CANDIDATE_TAG" "$HOME/Library/Developer/Xcode/DerivedData/cmux-$CANDIDATE_TAG"

--- a/.github/workflows/perf-mixed-workload.yml
+++ b/.github/workflows/perf-mixed-workload.yml
@@ -30,8 +30,6 @@ jobs:
     env:
       BASELINE_TAG: perfmixedb${{ github.run_id }}a${{ github.run_attempt }}
       CANDIDATE_TAG: perfmixedc${{ github.run_id }}a${{ github.run_attempt }}
-      RESULTS_DIR: ${{ runner.temp }}/perf-mixed-workload-${{ github.run_id }}-${{ github.run_attempt }}
-      PERF_HOST_CONTROLS_PATH: ${{ runner.temp }}/perf-mixed-workload-${{ github.run_id }}-${{ github.run_attempt }}/host-controls.json
     steps:
       - name: Initialize evidence directory
         env:
@@ -39,6 +37,13 @@ jobs:
           CANDIDATE_SHA_INPUT: ${{ inputs.candidate_sha }}
         run: |
           set -euo pipefail
+          RESULTS_DIR="$RUNNER_TEMP/perf-mixed-workload-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          PERF_HOST_CONTROLS_PATH="$RESULTS_DIR/host-controls.json"
+          export RESULTS_DIR PERF_HOST_CONTROLS_PATH
+          {
+            echo "RESULTS_DIR=$RESULTS_DIR"
+            echo "PERF_HOST_CONTROLS_PATH=$PERF_HOST_CONTROLS_PATH"
+          } >> "$GITHUB_ENV"
           mkdir -p "$RESULTS_DIR"
           python3 - <<'PY'
           import json

--- a/.github/workflows/perf-mixed-workload.yml
+++ b/.github/workflows/perf-mixed-workload.yml
@@ -291,15 +291,30 @@ jobs:
             exit 1
           }
 
-      - name: Run focused prompt detector tests for both commits
+      - name: Run terminal core tests for both commits
         run: |
           set -euo pipefail
-          swift test \
-            --package-path variants/baseline/Packages/macOS/CmuxTerminalCore \
-            --filter PromptLineTurnDetectorTests
-          swift test \
-            --package-path variants/candidate/Packages/macOS/CmuxTerminalCore \
-            --filter PromptLineTurnDetectorTests
+          run_terminal_core_tests() {
+            local checkout="$1"
+            local test_derived_data="$2"
+            rm -rf "$test_derived_data"
+            (
+              cd "$checkout/Packages/macOS/CmuxTerminalCore"
+              xcodebuild \
+                -scheme CmuxTerminalCore-Package \
+                -destination "platform=macOS" \
+                -derivedDataPath "$test_derived_data" \
+                build-for-testing
+            )
+            xcrun xctest \
+              "$test_derived_data/Build/Products/Debug/CmuxTerminalCoreTests.xctest"
+          }
+          run_terminal_core_tests \
+            variants/baseline \
+            "$RUNNER_TEMP/cmux-terminal-core-baseline-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          run_terminal_core_tests \
+            variants/candidate \
+            "$RUNNER_TEMP/cmux-terminal-core-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
       - name: Run complete paired mixed-workload matrix
         env:

--- a/.github/workflows/perf-mixed-workload.yml
+++ b/.github/workflows/perf-mixed-workload.yml
@@ -419,6 +419,10 @@ jobs:
           import json
           import os
           from pathlib import Path
+          import sys
+
+          sys.path.insert(0, str(Path(os.environ["GITHUB_WORKSPACE"]) / "scripts"))
+          from perf_mixed_workload_driver import validate_accepted_analysis
 
           results = Path(os.environ["RESULTS_DIR"])
           paths = [
@@ -446,10 +450,10 @@ jobs:
               failures.extend((name, failure) for failure in value)
           if failures:
               raise SystemExit(f"experiment reported {len(failures)} failure(s)")
-          if analysis.get("final_acceptance") is False:
-              raise SystemExit("analysis final_acceptance is false")
-          if str(analysis.get("status", "")).lower() in {"failed", "failure", "incomplete", "rejected"}:
-              raise SystemExit(f"analysis status is {analysis['status']!r}")
+          try:
+              validate_accepted_analysis(analysis)
+          except ValueError as error:
+              raise SystemExit(str(error)) from error
           PY
 
       - name: Cleanup owned tagged state

--- a/scripts/perf-activation-session.py
+++ b/scripts/perf-activation-session.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import pathlib
@@ -168,11 +169,30 @@ class CmuxPerfRunner:
             ]
         )
 
-    def clean_persisted_state(self) -> None:
+    def _session_snapshot_path(self, suffix: str = "") -> pathlib.Path:
         app_support = pathlib.Path.home() / "Library/Application Support/cmux"
         bundle_id = f"com.cmuxterm.app.debug.{self.tag_id}"
+        return app_support / f"session-{bundle_id}{suffix}.json"
+
+    def persisted_snapshot_fingerprint(self) -> dict[str, object]:
+        path = self._session_snapshot_path()
+        if path.is_symlink() or not path.is_file():
+            raise PerfFailure("tagged persisted session snapshot is missing or invalid")
+        try:
+            payload = path.read_bytes()
+        except OSError as error:
+            raise PerfFailure("tagged persisted session snapshot is unreadable") from error
+        if not payload:
+            raise PerfFailure("tagged persisted session snapshot is empty")
+        return {
+            "algorithm": "sha256",
+            "digest": hashlib.sha256(payload).hexdigest(),
+            "byte_count": len(payload),
+        }
+
+    def clean_persisted_state(self) -> None:
         for suffix in ("", "-previous"):
-            (app_support / f"session-{bundle_id}{suffix}.json").unlink(missing_ok=True)
+            self._session_snapshot_path(suffix).unlink(missing_ok=True)
         self.socket_path.unlink(missing_ok=True)
         self.cmuxd_socket_path.unlink(missing_ok=True)
         self.debug_log_path.unlink(missing_ok=True)

--- a/scripts/perf-activation-session.py
+++ b/scripts/perf-activation-session.py
@@ -174,16 +174,23 @@ class CmuxPerfRunner:
         bundle_id = f"com.cmuxterm.app.debug.{self.tag_id}"
         return app_support / f"session-{bundle_id}{suffix}.json"
 
-    def persisted_snapshot_fingerprint(self) -> dict[str, object]:
-        path = self._session_snapshot_path()
+    def persisted_snapshot_fingerprint(self, source: str = "primary") -> dict[str, object]:
+        suffix_by_source = {"primary": "", "previous": "-previous"}
+        if source not in suffix_by_source:
+            raise ValueError("persisted snapshot source must be primary or previous")
+        path = self._session_snapshot_path(suffix_by_source[source])
         if path.is_symlink() or not path.is_file():
-            raise PerfFailure("tagged persisted session snapshot is missing or invalid")
+            raise PerfFailure(
+                f"tagged persisted {source} session snapshot is missing or invalid"
+            )
         try:
             payload = path.read_bytes()
         except OSError as error:
-            raise PerfFailure("tagged persisted session snapshot is unreadable") from error
+            raise PerfFailure(
+                f"tagged persisted {source} session snapshot is unreadable"
+            ) from error
         if not payload:
-            raise PerfFailure("tagged persisted session snapshot is empty")
+            raise PerfFailure(f"tagged persisted {source} session snapshot is empty")
         return {
             "algorithm": "sha256",
             "digest": hashlib.sha256(payload).hexdigest(),

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -28,6 +28,7 @@ from urllib.parse import unquote, urlparse
 
 
 _SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
 _MAX_TIMING_SECONDS = 300.0
 _PROCESS_GROUPS = ("parent_direct", "terminal", "webkit", "full_tree")
 _BROWSER_RECOVERY_RETRY = (
@@ -169,6 +170,29 @@ def _plain(value: Any) -> Any:
         return value
     raise ValueError(f"value is not JSON-friendly: {type(value).__name__}")
 
+
+def _strict_persisted_fingerprint(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "algorithm",
+        "digest",
+        "byte_count",
+    }:
+        raise ValueError("persisted snapshot fingerprint fields are invalid")
+    algorithm = value["algorithm"]
+    digest = value["digest"]
+    byte_count = value["byte_count"]
+    if algorithm != "sha256":
+        raise ValueError("persisted snapshot fingerprint algorithm must be sha256")
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        raise ValueError("persisted snapshot fingerprint digest is invalid")
+    if type(byte_count) is not int or byte_count <= 0:
+        raise ValueError("persisted snapshot fingerprint byte count is invalid")
+    return {
+        "algorithm": algorithm,
+        "digest": digest,
+        "byte_count": byte_count,
+    }
+
 class _ProfileCollectionError(RuntimeError):
     def __init__(self, message: str, evidence: Mapping[str, Any]) -> None:
         super().__init__(message)
@@ -247,6 +271,7 @@ class CmuxRuntimeAdapter:
         self._pane_id: str | None = None
         self._terminal_actual_ids: dict[str, str] = {}
         self._browser_actual_ids: dict[str, str] = {}
+        self._captured_persisted_fingerprint: dict[str, Any] | None = None
         self._last_accounting: Any | None = None
         self._launched = False
         self._owned_browser_screenshot_paths: set[Path] = set()
@@ -1124,8 +1149,13 @@ class CmuxRuntimeAdapter:
         _contract.validate_runtime_snapshot(
             self.config.scenario, self._snapshot_contract(payload)
         )
+        fingerprint = _strict_persisted_fingerprint(
+            self._runner.persisted_snapshot_fingerprint()
+        )
+        self._captured_persisted_fingerprint = fingerprint
         captured = _plain(payload)
         self._details["snapshot"]["captured"] = captured
+        self._details["snapshot"]["persisted_before"] = deepcopy(fingerprint)
         return captured
 
     def _reconcile_restored_workspace(self) -> None:
@@ -1206,9 +1236,29 @@ class CmuxRuntimeAdapter:
         self._terminal_actual_ids = dict(
             zip(self._terminal_actual_ids, terminal_ids)
         )
-        self._browser_actual_ids = dict(
-            zip(self._browser_actual_ids, browser_ids)
-        )
+        planned_browser_by_url = {
+            item.url: item.surface_id for item in self._plan.browser_surfaces
+        }
+        if len(planned_browser_by_url) != len(self._plan.browser_surfaces):
+            raise ValueError("restored browser fixture URLs are not unique")
+        actual_browser_by_planned: dict[str, str] = {}
+        for actual_id in browser_ids:
+            self._wait_for_browser(actual_id)
+            url_payload = self._runner.rpc(
+                "browser.url.get",
+                {"workspace_id": restored_workspace_id, "surface_id": actual_id},
+                timeout=self.config.rpc_timeout_s,
+            )
+            planned_id = planned_browser_by_url.get(url_payload.get("url"))
+            if planned_id is None or planned_id in actual_browser_by_planned:
+                raise ValueError("restored browser identity does not match the fixture plan")
+            actual_browser_by_planned[planned_id] = actual_id
+        if set(actual_browser_by_planned) != set(self._browser_actual_ids):
+            raise ValueError("restored browser identities are incomplete")
+        self._browser_actual_ids = {
+            planned_id: actual_browser_by_planned[planned_id]
+            for planned_id in self._browser_actual_ids
+        }
         self._details["snapshot"]["restored_rebinding"] = {
             "previous_workspace_id": previous_workspace_id,
             "restored_workspace_id": restored_workspace_id,
@@ -1221,23 +1271,22 @@ class CmuxRuntimeAdapter:
     def restore(self, snapshot: Any) -> None:
         captured_contract = self._snapshot_contract(snapshot)
         _contract.validate_runtime_snapshot(self.config.scenario, captured_contract)
+        if self._captured_persisted_fingerprint is None:
+            raise RuntimeError("persisted snapshot fingerprint was not captured")
         self._runner.stop_app()
         self._launched = False
         elapsed = self._runner.launch("restore")
         self._launched = True
-        self._reconcile_restored_workspace()
-        restored = self._runner.rpc(
-            "debug.session_snapshot_benchmark",
-            {"include_scrollback": True, "persist": True},
-            timeout=self.config.rpc_timeout_s,
+        persisted_after = _strict_persisted_fingerprint(
+            self._runner.persisted_snapshot_fingerprint()
         )
-        restored_contract = self._snapshot_contract(restored)
-        _contract.validate_runtime_snapshot(self.config.scenario, restored_contract)
-        _contract.validate_restored_snapshot(captured_contract, restored_contract)
+        self._details["snapshot"]["persisted_after"] = deepcopy(persisted_after)
+        if persisted_after != self._captured_persisted_fingerprint:
+            raise ValueError("persisted snapshot fingerprint changed across restore")
+        self._reconcile_restored_workspace()
         identity = self.observe_fixture()
         self._details["snapshot"]["restored"] = {
             "launch_socket_ready_ms": elapsed,
-            "snapshot": _plain(restored),
             "identity": identity,
         }
 

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -1,0 +1,1257 @@
+#!/usr/bin/env python3
+"""Tagged macOS runtime adapter for the deterministic mixed-workload harness.
+
+All platform effects are routed through a ``CmuxPerfRunner``-shaped seam.  The
+adapter itself is therefore importable and testable on non-macOS hosts.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from copy import deepcopy
+from dataclasses import dataclass
+import importlib.util
+import json
+import math
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import time
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
+from urllib.parse import unquote, urlparse
+
+
+_SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
+_MAX_TIMING_SECONDS = 300.0
+_PROCESS_GROUPS = ("parent_direct", "terminal", "webkit", "full_tree")
+
+
+def _load_sibling(module_name: str, filename: str | None = None) -> Any:
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    path = Path(__file__).with_name(filename or f"{module_name}.py")
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {module_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_contract = _load_sibling("perf_mixed_workload_contract")
+_top_payload = _load_sibling("perf_top_payload")
+
+
+def _scenario_dict(value: Any) -> dict[str, Any]:
+    if hasattr(value, "to_dict"):
+        value = value.to_dict()
+    if not isinstance(value, Mapping):
+        raise ValueError("scenario must be a Scenario or mapping")
+    required = {
+        "scenario_id",
+        "kind",
+        "load",
+        "terminal_surfaces",
+        "browser_surfaces",
+        "aggregate_scrollback_chars",
+    }
+    if set(value) != required:
+        raise ValueError("scenario fields do not match the mixed-workload contract")
+    result = {key: value[key] for key in required}
+    if not isinstance(result["scenario_id"], str) or not result["scenario_id"]:
+        raise ValueError("scenario_id must be a nonempty string")
+    for name in (
+        "terminal_surfaces",
+        "browser_surfaces",
+        "aggregate_scrollback_chars",
+    ):
+        if type(result[name]) is not int or result[name] < 0:
+            raise ValueError(f"scenario {name} must be a nonnegative integer")
+    terminals = result["terminal_surfaces"]
+    browsers = result["browser_surfaces"]
+    scrollback = result["aggregate_scrollback_chars"]
+    if terminals + browsers == 0:
+        raise ValueError("scenario must contain at least one surface")
+    if terminals == 0 and scrollback != 0:
+        raise ValueError("browser-only scenarios cannot request scrollback")
+    if terminals and scrollback % terminals:
+        raise ValueError(
+            "aggregate_scrollback_chars must divide exactly across terminal surfaces"
+        )
+    return result
+
+
+def _bounded_seconds(value: Any, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or not 0.0 < float(value) <= _MAX_TIMING_SECONDS
+    ):
+        raise ValueError(f"{name} must be a positive bounded timing setting")
+    return float(value)
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterConfig:
+    """Immutable identity, fixture, ownership, and bounded timing configuration."""
+
+    sha: str
+    tag: str
+    app_path: str
+    scenario: Any
+    output_root: Path
+    warmup: bool
+    profile_enabled: bool
+    launch_timeout_s: float = 45.0
+    rpc_timeout_s: float = 60.0
+    steady_duration_s: float = 5.0
+    steady_interval_s: float = 1.0
+    churn_duration_s: float = 5.0
+    churn_interval_s: float = 1.0
+    profile_duration_s: float = 5.0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.sha, str) or _SHA_RE.fullmatch(self.sha) is None:
+            raise ValueError("sha must be exactly 40 hexadecimal characters")
+        if not isinstance(self.tag, str) or not self.tag or "/" in self.tag or "\\" in self.tag:
+            raise ValueError("tag must be a nonempty path-safe string")
+        if not isinstance(self.app_path, str) or not self.app_path:
+            raise ValueError("app_path must be a nonempty string")
+        if type(self.warmup) is not bool or type(self.profile_enabled) is not bool:
+            raise ValueError("warmup and profile_enabled must be booleans")
+        scenario = _scenario_dict(self.scenario)
+        object.__setattr__(self, "scenario", MappingProxyType(scenario))
+        root = Path(self.output_root).expanduser().resolve()
+        object.__setattr__(self, "output_root", root)
+        for name in (
+            "launch_timeout_s",
+            "rpc_timeout_s",
+            "steady_duration_s",
+            "steady_interval_s",
+            "churn_duration_s",
+            "churn_interval_s",
+            "profile_duration_s",
+        ):
+            object.__setattr__(self, name, _bounded_seconds(getattr(self, name), name))
+        if self.steady_interval_s > self.steady_duration_s:
+            raise ValueError("steady_interval_s cannot exceed steady_duration_s")
+        if self.churn_interval_s > self.churn_duration_s:
+            raise ValueError("churn_interval_s cannot exceed churn_duration_s")
+
+
+class _SystemClock:
+    monotonic = staticmethod(time.monotonic)
+    sleep = staticmethod(time.sleep)
+
+
+def _plain(value: Any) -> Any:
+    if hasattr(value, "to_dict"):
+        return _plain(value.to_dict())
+    if isinstance(value, Mapping):
+        return {str(key): _plain(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise ValueError(f"value is not JSON-friendly: {type(value).__name__}")
+
+
+def _make_default_runner(config: AdapterConfig) -> Any:
+    runner_module = _load_sibling(
+        "perf_activation_session", "perf-activation-session.py"
+    )
+    args = Namespace(
+        tag=config.tag,
+        app_path=config.app_path,
+        fixture_root=str(config.output_root),
+        launch_timeout=config.launch_timeout_s,
+        snapshot_timeout=config.rpc_timeout_s,
+    )
+    return runner_module.CmuxPerfRunner(args)
+
+
+def _extract_ref(payload: Mapping[str, Any], kind: str) -> str:
+    for key in (f"{kind}_id", f"{kind}_ref", "id", "ref"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    raise ValueError(f"missing {kind} identity in {payload!r}")
+
+
+def _surface_type(item: Mapping[str, Any]) -> str:
+    value = item.get("type") or item.get("kind")
+    if not isinstance(value, str):
+        raise ValueError("surface observation is missing its type")
+    return value
+
+
+class CmuxRuntimeAdapter:
+    """RuntimeAdapter implementation scoped to one exact tagged app invocation."""
+
+    def __init__(
+        self,
+        config: AdapterConfig,
+        *,
+        runner: Any | None = None,
+        clock: Any | None = None,
+        sampler: Any | None = None,
+        profiler: Callable[..., Any] | Any | None = None,
+    ) -> None:
+        if not isinstance(config, AdapterConfig):
+            raise TypeError("config must be an AdapterConfig")
+        self.config = config
+        self._runner = runner if runner is not None else _make_default_runner(config)
+        self._clock = clock if clock is not None else _SystemClock()
+        self._sampler = sampler
+        self._profiler = profiler
+        self._plan: Any | None = None
+        self._workspace_id: str | None = None
+        self._pane_id: str | None = None
+        self._terminal_actual_ids: dict[str, str] = {}
+        self._browser_actual_ids: dict[str, str] = {}
+        self._last_accounting: Any | None = None
+        self._launched = False
+        self._details: dict[str, Any] = {
+            "invocation": {
+                "sha": config.sha,
+                "tag": config.tag,
+                "app_path": config.app_path,
+                "warmup": config.warmup,
+                "profile_enabled": config.profile_enabled,
+                "timings": {
+                    "launch_timeout_s": config.launch_timeout_s,
+                    "rpc_timeout_s": config.rpc_timeout_s,
+                    "steady_duration_s": config.steady_duration_s,
+                    "steady_interval_s": config.steady_interval_s,
+                    "churn_duration_s": config.churn_duration_s,
+                    "churn_interval_s": config.churn_interval_s,
+                    "profile_duration_s": config.profile_duration_s,
+                },
+            },
+            "scenario": dict(config.scenario),
+            "fixture": {},
+            "observations": [],
+            "steady": {},
+            "churn": {},
+            "snapshot": {},
+            "profiles": [],
+            "cleanup": {},
+        }
+
+    @property
+    def raw_details(self) -> dict[str, Any]:
+        """Return an isolated, JSON-friendly copy of all raw invocation evidence."""
+
+        value = _plain(self._details)
+        json.dumps(value, allow_nan=False)
+        return value
+
+    def clean_state(self) -> None:
+        self._runner.stop_app()
+        self._runner.clean_persisted_state()
+        browser_fixture_root = self.config.output_root / "browser-fixtures"
+        if browser_fixture_root.exists():
+            shutil.rmtree(browser_fixture_root)
+        self.config.output_root.mkdir(parents=True, exist_ok=True)
+        self._details["cleanup"] = {"prelaunch_cleaned": True}
+
+    def launch(self, sha: str) -> None:
+        if sha != self.config.sha:
+            raise ValueError("launch SHA does not match the configured exact build identity")
+        runner_app = getattr(self._runner, "app_path", None)
+        if runner_app is not None and Path(runner_app).expanduser() != Path(self.config.app_path).expanduser():
+            raise ValueError("runner app path does not match the configured app path")
+        self._runner.check_paths()
+        elapsed = self._runner.launch("launch")
+        self._launched = True
+        self._details["invocation"]["launch_socket_ready_ms"] = elapsed
+
+    def _create_workspace(self) -> str:
+        payload = self._runner.json_cli(
+            [
+                "workspace",
+                "create",
+                "--name",
+                f"cmux-perf-{self.config.scenario['scenario_id']}",
+                "--cwd",
+                str(self.config.output_root),
+            ],
+            timeout=self.config.rpc_timeout_s,
+        )
+        return _extract_ref(payload, "workspace")
+
+    def _new_surface(self, kind: str, *, url: str | None = None) -> str:
+        if self._workspace_id is None or self._pane_id is None:
+            raise RuntimeError("fixture pane is not initialized")
+        args = [
+            "new-surface",
+            "--workspace",
+            self._workspace_id,
+            "--pane",
+            self._pane_id,
+            "--type",
+            kind,
+        ]
+        if url is not None:
+            if not url.startswith("file://"):
+                raise ValueError("browser fixture URLs must be local file URLs")
+            args.extend(("--url", url))
+        args.extend(("--focus", "false"))
+        payload = self._runner.json_cli(args, timeout=self.config.rpc_timeout_s)
+        if _extract_ref(payload, "pane") != self._pane_id:
+            raise ValueError("surface was created outside the owned fixture pane")
+        return _extract_ref(payload, "surface")
+
+    def create_fixture(self, plan: Any) -> None:
+        expected = self.config.scenario
+        if (
+            getattr(plan, "scenario_id", None) != expected["scenario_id"]
+            or getattr(plan, "terminal_count", None) != expected["terminal_surfaces"]
+            or getattr(plan, "browser_count", None) != expected["browser_surfaces"]
+        ):
+            raise ValueError("fixture plan does not match adapter configuration")
+        for browser in plan.browser_surfaces:
+            parsed_url = urlparse(browser.url)
+            if (
+                parsed_url.scheme != "file"
+                or parsed_url.netloc
+                or parsed_url.query
+                or parsed_url.fragment
+            ):
+                raise ValueError("browser fixture plan contains a non-local URL")
+            fixture_path = Path(unquote(parsed_url.path))
+            if not fixture_path.resolve().is_relative_to(self.config.output_root):
+                raise ValueError("browser fixture is outside the owned output root")
+
+        before = self._runner.json_cli(
+            ["list-workspaces"], timeout=self.config.rpc_timeout_s
+        ).get("workspaces", [])
+        prior_workspaces = [
+            _extract_ref(item, "workspace")
+            for item in before
+            if isinstance(item, Mapping)
+        ]
+        self._workspace_id = self._create_workspace()
+        panes_payload = self._runner.json_cli(
+            ["list-panes", "--workspace", self._workspace_id],
+            timeout=self.config.rpc_timeout_s,
+        )
+        panes = panes_payload.get("panes", [])
+        if not isinstance(panes, list) or len(panes) != 1:
+            raise ValueError("new fixture workspace must contain exactly one pane")
+        self._pane_id = _extract_ref(panes[0], "pane")
+        initial_refs = panes[0].get("surface_ids") or panes[0].get("surface_refs") or []
+        if not isinstance(initial_refs, list) or len(initial_refs) != 1:
+            raise ValueError("new fixture workspace must contain one initial terminal")
+        initial_terminal = initial_refs[0]
+        if not isinstance(initial_terminal, str):
+            raise ValueError("initial terminal reference is invalid")
+
+        self._plan = plan
+        self._terminal_actual_ids.clear()
+        self._browser_actual_ids.clear()
+        terminals = expected["terminal_surfaces"]
+        if terminals:
+            self._terminal_actual_ids["terminal-001"] = initial_terminal
+            for index in range(2, terminals + 1):
+                self._terminal_actual_ids[f"terminal-{index:03d}"] = self._new_surface(
+                    "terminal"
+                )
+        for browser in plan.browser_surfaces:
+            self._browser_actual_ids[browser.surface_id] = self._new_surface(
+                "browser", url=browser.url
+            )
+        if terminals == 0:
+            self._runner.run_cli(
+                [
+                    "close-surface",
+                    "--workspace",
+                    self._workspace_id,
+                    "--surface",
+                    initial_terminal,
+                ],
+                timeout=self.config.rpc_timeout_s,
+            )
+
+        for old in prior_workspaces:
+            if isinstance(old, str) and old != self._workspace_id:
+                self._runner.run_cli(
+                    ["close-workspace", "--workspace", old],
+                    timeout=self.config.rpc_timeout_s,
+                    check=False,
+                )
+        self._runner.run_cli(
+            ["select-workspace", "--workspace", self._workspace_id],
+            timeout=self.config.rpc_timeout_s,
+            check=False,
+        )
+
+        scrollback = expected["aggregate_scrollback_chars"]
+        seed_evidence: dict[str, Any] | None = None
+        if terminals:
+            per_terminal = scrollback // terminals
+            seed_evidence = self._runner.rpc(
+                "debug.session_snapshot_seed_scrollback",
+                {"characters_per_terminal": per_terminal},
+                timeout=self.config.rpc_timeout_s,
+            )
+            required = {
+                "characters_per_terminal": per_terminal,
+                "workspaces": 1,
+                "terminals": terminals,
+                "scrollback_chars": scrollback,
+            }
+            if any(seed_evidence.get(key) != value for key, value in required.items()):
+                raise ValueError("synthetic scrollback seed did not produce the exact aggregate")
+
+        mapping = dict(self._terminal_actual_ids)
+        mapping.update(self._browser_actual_ids)
+        self._details["fixture"] = {
+            "workspace_id": self._workspace_id,
+            "pane_id": self._pane_id,
+            "planned_to_actual": mapping,
+            "terminal_ids": list(self._terminal_actual_ids),
+            "browser_ids": list(self._browser_actual_ids),
+            "scrollback_request": {
+                "aggregate_characters": scrollback,
+                "characters_per_terminal": scrollback // terminals if terminals else 0,
+            },
+            "scrollback_evidence": seed_evidence,
+        }
+
+    def _surfaces(self) -> list[Mapping[str, Any]]:
+        if self._workspace_id is None or self._pane_id is None:
+            raise RuntimeError("fixture has not been created")
+        workspaces = self._runner.json_cli(
+            ["list-workspaces"], timeout=self.config.rpc_timeout_s
+        ).get("workspaces", [])
+        workspace_ids = {
+            _extract_ref(item, "workspace")
+            for item in workspaces
+            if isinstance(item, Mapping)
+        }
+        if workspace_ids != {self._workspace_id}:
+            raise ValueError("fixture must occupy exactly one owned workspace")
+        panes = self._runner.json_cli(
+            ["list-panes", "--workspace", self._workspace_id],
+            timeout=self.config.rpc_timeout_s,
+        ).get("panes", [])
+        if not isinstance(panes, list) or len(panes) != 1:
+            raise ValueError("fixture workspace must contain exactly one pane")
+        if _extract_ref(panes[0], "pane") != self._pane_id:
+            raise ValueError("fixture pane identity changed")
+        payload = self._runner.json_cli(
+            [
+                "list-pane-surfaces",
+                "--workspace",
+                self._workspace_id,
+                "--pane",
+                self._pane_id,
+            ],
+            timeout=self.config.rpc_timeout_s,
+        )
+        if any(key in payload for key in ("pane_id", "pane_ref")) and _extract_ref(payload, "pane") != self._pane_id:
+            raise ValueError("surface listing came from the wrong pane")
+        surfaces = payload.get("surfaces", [])
+        if not isinstance(surfaces, list):
+            raise ValueError("surface listing must be an array")
+        return surfaces
+
+    def observe_fixture(self) -> dict[str, Any]:
+        if self._plan is None:
+            raise RuntimeError("fixture has not been created")
+        surfaces = self._surfaces()
+        actual_types = {
+            _extract_ref(item, "surface"): _surface_type(item) for item in surfaces
+        }
+        expected_actual = set(self._terminal_actual_ids.values()) | set(
+            self._browser_actual_ids.values()
+        )
+        if set(actual_types) != expected_actual:
+            raise ValueError("observed surface identities do not match the fixture plan")
+        if any(actual_types[actual] != "terminal" for actual in self._terminal_actual_ids.values()):
+            raise ValueError("planned terminal identity resolved to another surface kind")
+        if any(actual_types[actual] != "browser" for actual in self._browser_actual_ids.values()):
+            raise ValueError("planned browser identity resolved to another surface kind")
+
+        planned_by_id = {item.surface_id: item for item in self._plan.browser_surfaces}
+        browsers: list[dict[str, str]] = []
+        browser_evidence: list[dict[str, Any]] = []
+        for planned_id, actual_id in self._browser_actual_ids.items():
+            planned = planned_by_id[planned_id]
+            wait_payload = self._runner.rpc(
+                "browser.wait",
+                {
+                    "workspace_id": self._workspace_id,
+                    "surface_id": actual_id,
+                    "load_state": "complete",
+                    "timeout_ms": int(self.config.rpc_timeout_s * 1000),
+                },
+                timeout=self.config.rpc_timeout_s,
+            )
+            url_payload = self._runner.rpc(
+                "browser.url.get",
+                {"workspace_id": self._workspace_id, "surface_id": actual_id},
+                timeout=self.config.rpc_timeout_s,
+            )
+            title_payload = self._runner.rpc(
+                "browser.get.title",
+                {"workspace_id": self._workspace_id, "surface_id": actual_id},
+                timeout=self.config.rpc_timeout_s,
+            )
+            content_payload = self._runner.rpc(
+                "browser.eval",
+                {
+                    "workspace_id": self._workspace_id,
+                    "surface_id": actual_id,
+                    "script": "document.querySelector('main')?.textContent?.trim() ?? ''",
+                },
+                timeout=self.config.rpc_timeout_s,
+            )
+            observed = {
+                "surface_id": planned_id,
+                "url": url_payload.get("url"),
+                "title": title_payload.get("title"),
+                "content_marker": content_payload.get("value"),
+            }
+            expected = {
+                "surface_id": planned.surface_id,
+                "url": planned.url,
+                "title": planned.title,
+                "content_marker": planned.content_marker,
+            }
+            if observed != expected:
+                raise ValueError(f"browser identity mismatch for {planned_id}")
+            browsers.append(observed)
+            browser_evidence.append(
+                {
+                    "planned_surface_id": planned_id,
+                    "actual_surface_id": actual_id,
+                    "load_wait": _plain(wait_payload),
+                    **observed,
+                }
+            )
+
+        observation = {
+            "shape": {
+                "terminal_surfaces": len(self._terminal_actual_ids),
+                "browser_surfaces": len(self._browser_actual_ids),
+            },
+            "browsers": browsers,
+        }
+        self._details["observations"].append(
+            {**deepcopy(observation), "browser_evidence": browser_evidence}
+        )
+        return observation
+
+    def _raw_top(self) -> Mapping[str, Any]:
+        if self._sampler is None:
+            payload = self._runner.rpc(
+                "system.top",
+                {"all_windows": True, "include_processes": True},
+                timeout=self.config.rpc_timeout_s,
+            )
+        elif callable(self._sampler):
+            payload = self._sampler()
+        elif hasattr(self._sampler, "sample"):
+            payload = self._sampler.sample()
+        else:
+            raise TypeError("sampler must be callable or expose sample()")
+        if not isinstance(payload, Mapping):
+            raise ValueError("system.top sampler must return a mapping")
+        return payload
+
+    @staticmethod
+    def _host_evidence(payload: Mapping[str, Any]) -> dict[str, Any]:
+        names = (
+            "host",
+            "foreground",
+            "background",
+            "load",
+            "load_average",
+            "app_is_active",
+            "window_visible",
+        )
+        return {name: _plain(payload[name]) for name in names if name in payload}
+
+    def _parsed_sample(
+        self, payload: Mapping[str, Any], *, index: int, elapsed_seconds: float
+    ) -> dict[str, Any]:
+        accounting = _top_payload.parse_system_top_payload(payload)
+        self._last_accounting = accounting
+        plain = accounting.to_dict()
+        return {
+            "sample_index": index,
+            "elapsed_seconds": round(elapsed_seconds, 6),
+            "process_attribution": {
+                group: plain[group] for group in _PROCESS_GROUPS
+            },
+            "coverage": plain["coverage"],
+            "process_roots": {
+                "app_pid": plain["app_pid"],
+                "terminal_root_pids": plain["terminal_root_pids"],
+                "webkit_root_pids": plain["webkit_root_pids"],
+                "webkit_role_pids": plain["webkit_role_pids"],
+            },
+            "host_evidence": self._host_evidence(payload),
+            "raw_payload": _plain(payload),
+        }
+
+    def sample_steady(self) -> list[dict[str, Any]]:
+        prime = self._raw_top()
+        count = max(
+            1,
+            math.ceil(
+                self.config.steady_duration_s / self.config.steady_interval_s
+            ),
+        )
+        start = self._clock.monotonic()
+        samples: list[dict[str, Any]] = []
+        for index in range(count):
+            self._clock.sleep(self.config.steady_interval_s)
+            raw = self._raw_top()
+            samples.append(
+                self._parsed_sample(
+                    raw,
+                    index=index,
+                    elapsed_seconds=self._clock.monotonic() - start,
+                )
+            )
+        self._details["steady"] = {
+            "prime_raw_payload": _plain(prime),
+            "sample_interval_s": self.config.steady_interval_s,
+            "samples": samples,
+        }
+        return deepcopy(samples)
+
+    def _timed_rpc(
+        self, label: str, planned_id: str, method: str, params: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        start = self._clock.monotonic()
+        payload = self._runner.rpc(
+            method, params, timeout=self.config.rpc_timeout_s
+        )
+        elapsed = max(0.0, (self._clock.monotonic() - start) * 1000.0)
+        return (
+            {
+                "label": label,
+                "surface_id": planned_id,
+                "milliseconds": round(elapsed, 6),
+            },
+            _plain(payload),
+        )
+
+    def _terminal_ansi_line_target(self) -> int:
+        return max(256, math.ceil(self.config.churn_duration_s * 1_600))
+
+    def _terminal_churn(self, planned_id: str, actual_id: str, cycles: int) -> dict[str, Any]:
+        del cycles
+        ansi_lines = self._terminal_ansi_line_target()
+        batch_size = 32
+        batch_count = math.ceil(ansi_lines / batch_size)
+        batch_interval = self.config.churn_duration_s / batch_count
+        marker = f"CMUX_PERF_FINAL_COUNT={ansi_lines}:{planned_id}"
+        script = (
+            "import sys,time\n"
+            "line='\\033[31m\\033[1mCMUX_ANSI_################"
+            "\\033[0m\\033[1G\\033[2K\\n'\n"
+            f"remaining={ansi_lines}\n"
+            f"batch_size={batch_size}\n"
+            "while remaining:\n"
+            "    count=min(batch_size,remaining)\n"
+            "    sys.stdout.write(line*count)\n"
+            "    sys.stdout.flush()\n"
+            "    remaining-=count\n"
+            f"    time.sleep({batch_interval!r})\n"
+            f"print({marker!r},flush=True)\n"
+        )
+        command = f"python3 -c {shlex.quote(script)}\n"
+        start = self._clock.monotonic()
+        self._runner.run_cli(
+            [
+                "send",
+                "--workspace",
+                self._workspace_id,
+                "--surface",
+                actual_id,
+                command,
+            ],
+            timeout=self.config.rpc_timeout_s,
+        )
+        self._clock.sleep(self.config.churn_duration_s)
+        deadline = self._clock.monotonic() + self.config.rpc_timeout_s
+        while True:
+            captured = self._runner.run_cli(
+                [
+                    "capture-pane",
+                    "--workspace",
+                    self._workspace_id,
+                    "--surface",
+                    actual_id,
+                ],
+                timeout=self.config.rpc_timeout_s,
+            )
+            if marker in captured:
+                break
+            if self._clock.monotonic() >= deadline:
+                raise TimeoutError(f"terminal churn marker not observed for {planned_id}")
+            self._clock.sleep(min(0.25, self.config.churn_interval_s))
+        elapsed = max(0.0, (self._clock.monotonic() - start) * 1000.0)
+        return {
+            "operations": ansi_lines,
+            "latencies": [
+                {
+                    "label": "terminal_ansi_completion",
+                    "surface_id": planned_id,
+                    "milliseconds": round(elapsed, 6),
+                }
+            ],
+            "evidence": {
+                "actual_surface_id": actual_id,
+                "final_marker": marker,
+                "batch_size": batch_size,
+                "target_duration_s": self.config.churn_duration_s,
+            },
+        }
+
+    def _browser_churn(self, planned_id: str, actual_id: str, cycles: int) -> dict[str, Any]:
+        latencies: list[dict[str, Any]] = []
+        evidence: list[dict[str, Any]] = []
+        methods = (
+            ("browser_focus", "browser.focus_webview"),
+            ("browser_reload", "browser.reload"),
+            ("browser_snapshot", "browser.snapshot"),
+        )
+        for _ in range(cycles):
+            for label, method in methods:
+                latency, payload = self._timed_rpc(
+                    label,
+                    planned_id,
+                    method,
+                    {"workspace_id": self._workspace_id, "surface_id": actual_id},
+                )
+                latencies.append(latency)
+                evidence.append({"label": label, "payload": payload})
+        return {
+            "operations": cycles * len(methods),
+            "latencies": latencies,
+            "evidence": {"actual_surface_id": actual_id, "cycles": evidence},
+        }
+
+    def _temporary_browser_cycle(self) -> dict[str, Any] | None:
+        if not self._browser_actual_ids or self._plan is None:
+            return None
+        url = self._plan.browser_surfaces[0].url
+        opened = self._runner.rpc(
+            "surface.create",
+            {
+                "workspace_id": self._workspace_id,
+                "pane_id": self._pane_id,
+                "type": "browser",
+                "url": url,
+                "focus": False,
+            },
+            timeout=self.config.rpc_timeout_s,
+        )
+        temporary_id = _extract_ref(opened, "surface")
+        closed = self._runner.rpc(
+            "surface.close",
+            {"workspace_id": self._workspace_id, "surface_id": temporary_id},
+            timeout=self.config.rpc_timeout_s,
+        )
+        return {
+            "url": url,
+            "surface_id": temporary_id,
+            "open": _plain(opened),
+            "close": _plain(closed),
+        }
+
+    def _render_stats(self) -> dict[str, Any]:
+        capture = getattr(self._runner, "capture_render_stats", None)
+        if capture is not None:
+            value = capture()
+            if not isinstance(value, Mapping):
+                raise ValueError("render stats capture must return a mapping")
+            return _plain(value)
+        stats: dict[str, Any] = {}
+        for actual_id in self._terminal_actual_ids.values():
+            payload = self._runner.rpc(
+                "debug.terminal.render_stats",
+                {"surface_id": actual_id},
+                timeout=self.config.rpc_timeout_s,
+            )
+            value = payload.get("stats")
+            if not isinstance(value, Mapping):
+                raise ValueError(
+                    f"terminal render stats missing for surface {actual_id}"
+                )
+            stats[actual_id] = _plain(value)
+        return stats
+
+    def run_churn(self, operations: list[dict[str, Any]]) -> dict[str, Any]:
+        cycles = max(
+            1,
+            math.ceil(self.config.churn_duration_s / self.config.churn_interval_s),
+        )
+        before_render = self._render_stats()
+        churn_start = self._clock.monotonic()
+        failures: list[dict[str, Any]] = []
+        latencies: list[dict[str, Any]] = []
+        evidence: list[dict[str, Any]] = []
+        operation_counts = {"terminal": 0, "browser": 0}
+        profile_pool: ThreadPoolExecutor | None = None
+        profile_futures: dict[Any, dict[str, Any]] = {}
+        if self.config.profile_enabled:
+            try:
+                work_units = {
+                    "terminal_ansi_lines": len(self._terminal_actual_ids)
+                    * self._terminal_ansi_line_target(),
+                    "browser_reload_snapshot_operations": len(
+                        self._browser_actual_ids
+                    )
+                    * cycles
+                    * 2,
+                    "temporary_browser_open_close_operations": 2
+                    if self._browser_actual_ids
+                    else 0,
+                }
+                metadata = self._profile_metadata(
+                    phase="churn", work_units=work_units
+                )
+                profile_pool = ThreadPoolExecutor(
+                    max_workers=max(1, len(metadata))
+                )
+                profile_futures = {
+                    profile_pool.submit(self._run_profile, item): item
+                    for item in metadata
+                }
+            except BaseException as error:
+                failures.append({"phase": "profile_setup", "message": str(error)})
+        futures: dict[Any, tuple[str, str]] = {}
+        worker_count = len(self._terminal_actual_ids) + len(self._browser_actual_ids)
+        with ThreadPoolExecutor(max_workers=max(1, worker_count)) as pool:
+            for planned, actual in self._terminal_actual_ids.items():
+                future = pool.submit(self._terminal_churn, planned, actual, cycles)
+                futures[future] = ("terminal", planned)
+            for planned, actual in self._browser_actual_ids.items():
+                future = pool.submit(self._browser_churn, planned, actual, cycles)
+                futures[future] = ("browser", planned)
+
+            sample_count = max(1, cycles)
+            samples: list[dict[str, Any]] = []
+            for index in range(sample_count):
+                self._clock.sleep(self.config.churn_interval_s)
+                try:
+                    raw = self._raw_top()
+                    samples.append(
+                        self._parsed_sample(
+                            raw,
+                            index=index,
+                            elapsed_seconds=self._clock.monotonic() - churn_start,
+                        )
+                    )
+                except BaseException as error:
+                    failures.append(
+                        {
+                            "phase": "churn_sampling",
+                            "operation_index": index,
+                            "message": str(error),
+                        }
+                    )
+
+            for future in as_completed(futures):
+                kind, planned = futures[future]
+                try:
+                    result = future.result()
+                except BaseException as error:
+                    failures.append(
+                        {
+                            "phase": "churn",
+                            "surface_id": planned,
+                            "message": str(error),
+                        }
+                    )
+                    continue
+                operation_counts[kind] += result["operations"]
+                latencies.extend(result["latencies"])
+                evidence.append(
+                    {
+                        "surface_kind": kind,
+                        "surface_id": planned,
+                        **result["evidence"],
+                    }
+                )
+
+        temporary: dict[str, Any] | None = None
+        try:
+            temporary = self._temporary_browser_cycle()
+            if temporary is not None:
+                operation_counts["browser"] += 2
+        except BaseException as error:
+            failures.append(
+                {"phase": "temporary_browser_cycle", "message": str(error)}
+            )
+        churn_elapsed_s = max(
+            1e-9, self._clock.monotonic() - churn_start
+        )
+
+        profile_records: list[dict[str, Any]] = []
+        for future in as_completed(profile_futures):
+            metadata = profile_futures[future]
+            try:
+                profile_records.append(future.result())
+            except BaseException as error:
+                failures.append(
+                    {
+                        "phase": "profile_churn",
+                        "role": metadata["role"],
+                        "pid": metadata["pid"],
+                        "message": str(error),
+                    }
+                )
+        if profile_pool is not None:
+            profile_pool.shutdown(wait=True)
+        if profile_records:
+            self._details["profiles"] = sorted(
+                profile_records, key=lambda item: (item["role"], item["pid"])
+            )
+
+        after_render = self._render_stats()
+        presents: list[dict[str, Any]] = []
+        for planned, actual in self._terminal_actual_ids.items():
+            before = before_render.get(actual)
+            after = after_render.get(actual)
+            if not isinstance(before, Mapping) or not isinstance(after, Mapping):
+                raise ValueError(f"terminal render stats missing for {planned}")
+            present_delta = float(
+                after.get("presentCount", after.get("present_count", 0))
+            ) - float(before.get("presentCount", before.get("present_count", 0)))
+            draw_delta = float(
+                after.get("drawCount", after.get("draw_count", 0))
+            ) - float(before.get("drawCount", before.get("draw_count", 0)))
+            presents.append(
+                {
+                    "surface_kind": "terminal",
+                    "surface_id": planned,
+                    "measurement": "debug.terminal.render_stats",
+                    "present_delta": max(0.0, present_delta),
+                    "draw_delta": max(0.0, draw_delta),
+                    "present_rate": max(0.0, present_delta)
+                    / churn_elapsed_s,
+                }
+            )
+        for planned in self._browser_actual_ids:
+            completed_presenting_operations = cycles * 2
+            presents.append(
+                {
+                    "surface_kind": "browser",
+                    "surface_id": planned,
+                    "measurement": "completed_local_reload_snapshot_operations_proxy",
+                    "present_delta": completed_presenting_operations,
+                    "draw_delta": None,
+                    "present_rate": completed_presenting_operations
+                    / churn_elapsed_s,
+                }
+            )
+
+        throughput = {
+            kind: count / churn_elapsed_s
+            for kind, count in operation_counts.items()
+            if (kind == "terminal" and self._terminal_actual_ids)
+            or (kind == "browser" and self._browser_actual_ids)
+        }
+        result = {
+            "samples": samples,
+            "latencies_ms": sorted(
+                latencies, key=lambda item: (item["surface_id"], item["label"])
+            ),
+            "throughput_ops_per_second": throughput,
+            "presents": presents,
+            "failures": failures,
+        }
+        self._details["churn"] = {
+            "requested_operations": _plain(operations),
+            "fixed_duration_s": self.config.churn_duration_s,
+            "measured_elapsed_s": churn_elapsed_s,
+            "cycles_per_surface": cycles,
+            "surface_evidence": sorted(
+                evidence, key=lambda item: (item["surface_kind"], item["surface_id"])
+            ),
+            "temporary_browser_cycle": temporary,
+            "render_stats_before": before_render,
+            "render_stats_after": after_render,
+            **deepcopy(result),
+        }
+        return result
+
+    @staticmethod
+    def _snapshot_contract(payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, Mapping):
+            raise ValueError("snapshot benchmark payload must be a mapping")
+        fields = ("built", "include_scrollback", "persist", "saved", "shape")
+        try:
+            return {field: payload[field] for field in fields}
+        except KeyError as error:
+            raise ValueError(f"snapshot benchmark is missing {error.args[0]}") from None
+
+    def snapshot(self) -> dict[str, Any]:
+        payload = self._runner.rpc(
+            "debug.session_snapshot_benchmark",
+            {"include_scrollback": True, "persist": True},
+            timeout=self.config.rpc_timeout_s,
+        )
+        _contract.validate_snapshot(
+            self.config.scenario, self._snapshot_contract(payload)
+        )
+        captured = _plain(payload)
+        self._details["snapshot"]["captured"] = captured
+        return captured
+
+    def restore(self, snapshot: Any) -> None:
+        _contract.validate_snapshot(
+            self.config.scenario, self._snapshot_contract(snapshot)
+        )
+        self._runner.stop_app()
+        self._launched = False
+        elapsed = self._runner.launch("restore")
+        self._launched = True
+        restored = self._runner.rpc(
+            "debug.session_snapshot_benchmark",
+            {"include_scrollback": True, "persist": True},
+            timeout=self.config.rpc_timeout_s,
+        )
+        _contract.validate_snapshot(
+            self.config.scenario, self._snapshot_contract(restored)
+        )
+        identity = self.observe_fixture()
+        self._details["snapshot"]["restored"] = {
+            "launch_socket_ready_ms": elapsed,
+            "snapshot": _plain(restored),
+            "identity": identity,
+        }
+
+    def stop(self) -> None:
+        self._runner.stop_app()
+        self._launched = False
+
+    def cleanup_owned(self) -> dict[str, Any]:
+        browser_fixture_root = self.config.output_root / "browser-fixtures"
+        runtime_paths = [browser_fixture_root]
+        runner_cleanup = getattr(self._runner, "cleanup_owned", None)
+        if runner_cleanup is not None:
+            runner_evidence = runner_cleanup()
+        else:
+            for name in (
+                "socket_path",
+                "cmuxd_socket_path",
+                "debug_log_path",
+                "stdout_path",
+                "fixture_root",
+            ):
+                value = getattr(self._runner, name, None)
+                if value is not None:
+                    runtime_paths.append(Path(value))
+            self._runner.clean_persisted_state()
+            runner_evidence = {"tag_state_removed": True}
+        for path in runtime_paths:
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink(missing_ok=True)
+        evidence = {
+            "stopped": not self._launched,
+            "owned_state_removed": all(not path.exists() for path in runtime_paths),
+            "owned_paths": sorted({str(path) for path in runtime_paths}),
+            "preserved_output_root": str(self.config.output_root),
+            "runner": _plain(runner_evidence),
+        }
+        self._details["cleanup"] = evidence
+        return deepcopy(evidence)
+
+    def _default_profile(self, **kwargs: Any) -> dict[str, Any]:
+        path = Path(kwargs["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        completed = subprocess.run(
+            [
+                "/usr/bin/sample",
+                str(kwargs["pid"]),
+                f"{kwargs['duration_s']:g}",
+                "-file",
+                str(path),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=self.config.profile_duration_s + 30.0,
+        )
+        return {
+            "path": str(path),
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+
+    def _profile_metadata(
+        self, *, phase: str, work_units: Mapping[str, int]
+    ) -> list[dict[str, Any]]:
+        if self._last_accounting is None:
+            self._last_accounting = _top_payload.parse_system_top_payload(
+                self._raw_top()
+            )
+        accounting = self._last_accounting
+        roots: list[tuple[str, int]] = [("parent", accounting.app_pid)]
+        for root_pid in accounting.webkit_root_pids:
+            matching = [
+                role
+                for role, pids in accounting.webkit_role_pids.items()
+                if root_pid in pids
+            ]
+            if len(matching) != 1:
+                raise ValueError(f"WebKit root PID {root_pid} has no unique role")
+            roots.append((f"webkit-{matching[0]}", root_pid))
+        profile_root = self.config.output_root / "profiles"
+        profile_root.mkdir(parents=True, exist_ok=True)
+        return [
+            {
+                "role": role,
+                "pid": pid,
+                "path": str(profile_root / f"{role}-{pid}.sample.txt"),
+                "duration_s": self.config.profile_duration_s,
+                "work_unit": self.config.scenario["scenario_id"],
+                "phase": phase,
+                "work_units": dict(work_units),
+            }
+            for role, pid in roots
+        ]
+
+    def _run_profile(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        profile_callable = self._profiler or self._default_profile
+        if callable(profile_callable):
+            result = profile_callable(**metadata)
+        elif hasattr(profile_callable, "sample"):
+            result = profile_callable.sample(**metadata)
+        else:
+            raise TypeError("profiler must be callable or expose sample()")
+        return {**metadata, "result": _plain(result)}
+
+    def collect_profiles(self) -> list[dict[str, Any]]:
+        if not self.config.profile_enabled:
+            return []
+        metadata = self._profile_metadata(phase="manual", work_units={})
+        records = [self._run_profile(item) for item in metadata]
+        self._details["profiles"] = records
+        return deepcopy(records)
+
+
+def _field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _mean(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _sample_cpu(samples: Any, group: str) -> float | None:
+    if not isinstance(samples, (list, tuple)):
+        return None
+    values: list[float] = []
+    for sample in samples:
+        attribution = _field(sample, "process_attribution", {})
+        subtotal = _field(attribution, group, {})
+        value = _field(subtotal, "cpu_percent")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            values.append(float(value))
+    return _mean(values)
+
+
+def extract_metrics(result: Any, raw_details: Mapping[str, Any] | None = None) -> dict[str, float]:
+    """Extract only existing driver ``METRIC_GATES`` names from raw evidence."""
+
+    details = raw_details or {}
+    scenario = details.get("scenario", {}) if isinstance(details, Mapping) else {}
+    requested = _field(result, "requested_shape", {})
+    terminals = scenario.get(
+        "terminal_surfaces", _field(requested, "terminal_surfaces", 0)
+    )
+    browsers = scenario.get(
+        "browser_surfaces", _field(requested, "browser_surfaces", 0)
+    )
+    terminals = terminals if type(terminals) is int else 0
+    browsers = browsers if type(browsers) is int else 0
+
+    metrics: dict[str, float] = {}
+    steady = _field(result, "steady_samples", [])
+    churn = _field(result, "churn_samples", [])
+    for phase, samples in (("steady", steady), ("churn", churn)):
+        for group, suffix in (
+            ("parent_direct", "parent"),
+            ("full_tree", "full_tree"),
+        ):
+            value = _sample_cpu(samples, group)
+            if value is not None:
+                metrics[f"{phase}_{suffix}_cpu_percent"] = value
+        if terminals:
+            value = _sample_cpu(samples, "terminal")
+            if value is not None:
+                metrics[f"{phase}_terminal_cpu_percent"] = value
+        if browsers:
+            value = _sample_cpu(samples, "webkit")
+            if value is not None:
+                metrics[f"{phase}_webkit_cpu_percent"] = value
+
+    if browsers:
+        latencies = _field(result, "latencies_ms", [])
+        browser_latency_values: list[float] = []
+        if isinstance(latencies, (list, tuple)):
+            for item in latencies:
+                label = _field(item, "label", "")
+                value = _field(item, "milliseconds")
+                if (
+                    isinstance(label, str)
+                    and label.startswith("browser_")
+                    and isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                ):
+                    browser_latency_values.append(float(value))
+        value = _mean(browser_latency_values)
+        if value is not None:
+            metrics["browser_latency_ms"] = value
+
+    throughput = _field(result, "throughput_ops_per_second", {})
+    if isinstance(throughput, Mapping):
+        for kind, present in (("terminal", bool(terminals)), ("browser", bool(browsers))):
+            value = throughput.get(kind)
+            if present and isinstance(value, (int, float)) and not isinstance(value, bool):
+                metrics[f"{kind}_throughput_per_second"] = float(value)
+
+    presents = _field(result, "presents", [])
+    if isinstance(presents, (list, tuple)):
+        for kind, present in (("terminal", bool(terminals)), ("browser", bool(browsers))):
+            if not present:
+                continue
+            rates = [
+                float(_field(item, "present_rate"))
+                for item in presents
+                if _field(item, "surface_kind") == kind
+                and isinstance(_field(item, "present_rate"), (int, float))
+                and not isinstance(_field(item, "present_rate"), bool)
+            ]
+            value = _mean(rates)
+            if value is not None:
+                metrics[f"{kind}_present_rate"] = value
+    return metrics
+
+
+__all__ = ["AdapterConfig", "CmuxRuntimeAdapter", "extract_metrics"]

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -820,6 +820,14 @@ class CmuxRuntimeAdapter:
     def _browser_churn(self, planned_id: str, actual_id: str, cycles: int) -> dict[str, Any]:
         latencies: list[dict[str, Any]] = []
         evidence: list[dict[str, Any]] = []
+        surface_latency, surface_payload = self._timed_rpc(
+            "browser_surface_focus",
+            planned_id,
+            "surface.focus",
+            {"workspace_id": self._workspace_id, "surface_id": actual_id},
+        )
+        latencies.append(surface_latency)
+        evidence.append({"label": "browser_surface_focus", "payload": surface_payload})
         methods = (
             ("browser_focus", "browser.focus_webview"),
             ("browser_reload", "browser.reload"),
@@ -851,7 +859,7 @@ class CmuxRuntimeAdapter:
         }
         screenshot_evidence["png_base64_length"] = len(encoded_png)
         return {
-            "operations": cycles * len(methods) + 1,
+            "operations": cycles * len(methods) + 2,
             "latencies": latencies,
             "render_observations": 1,
             "owned_screenshot_path": screenshot.get("path"),
@@ -861,6 +869,14 @@ class CmuxRuntimeAdapter:
                 "screenshot": screenshot_evidence,
             },
         }
+
+    def _browser_churn_batch(
+        self, cycles: int
+    ) -> list[tuple[str, dict[str, Any]]]:
+        return [
+            (planned, self._browser_churn(planned, actual, cycles))
+            for planned, actual in self._browser_actual_ids.items()
+        ]
 
     def _temporary_browser_cycle(self) -> dict[str, Any] | None:
         if not self._browser_actual_ids or self._plan is None:
@@ -932,7 +948,7 @@ class CmuxRuntimeAdapter:
                     "terminal_ansi_lines": len(self._terminal_actual_ids)
                     * self._terminal_ansi_line_target(),
                     "browser_churn_rpc_operations": len(self._browser_actual_ids)
-                    * (cycles * 3 + 1),
+                    * (cycles * 3 + 2),
                     "temporary_browser_open_close_operations": 2
                     if self._browser_actual_ids
                     else 0,
@@ -950,14 +966,14 @@ class CmuxRuntimeAdapter:
             except BaseException as error:
                 failures.append({"phase": "profile_setup", "message": str(error)})
         futures: dict[Any, tuple[str, str]] = {}
-        worker_count = len(self._terminal_actual_ids) + len(self._browser_actual_ids)
+        worker_count = len(self._terminal_actual_ids) + bool(self._browser_actual_ids)
         with ThreadPoolExecutor(max_workers=max(1, worker_count)) as pool:
             for planned, actual in self._terminal_actual_ids.items():
                 future = pool.submit(self._terminal_churn, planned, actual, cycles)
                 futures[future] = ("terminal", planned)
-            for planned, actual in self._browser_actual_ids.items():
-                future = pool.submit(self._browser_churn, planned, actual, cycles)
-                futures[future] = ("browser", planned)
+            if self._browser_actual_ids:
+                future = pool.submit(self._browser_churn_batch, cycles)
+                futures[future] = ("browser_batch", "browser-batch")
 
             sample_count = max(1, cycles)
             samples: list[dict[str, Any]] = []
@@ -984,7 +1000,7 @@ class CmuxRuntimeAdapter:
             for future in as_completed(futures):
                 kind, planned = futures[future]
                 try:
-                    result = future.result()
+                    value = future.result()
                 except BaseException as error:
                     failures.append(
                         {
@@ -994,31 +1010,34 @@ class CmuxRuntimeAdapter:
                         }
                     )
                     continue
-                operation_counts[kind] += result["operations"]
-                if kind == "browser":
-                    browser_render_counts[planned] = result["render_observations"]
-                    screenshot_path = result.get("owned_screenshot_path")
-                    if isinstance(screenshot_path, str) and screenshot_path:
-                        candidate = Path(screenshot_path).absolute()
-                        expected_root = (
-                            Path(tempfile.gettempdir()) / "cmux-browser-screenshots"
-                        ).resolve()
-                        if (
-                            candidate.parent.resolve() == expected_root
-                            and candidate.name.startswith("surface-")
-                            and candidate.suffix == ".png"
-                            and candidate.is_file()
-                            and not candidate.is_symlink()
-                        ):
-                            self._owned_browser_screenshot_paths.add(candidate)
-                latencies.extend(result["latencies"])
-                evidence.append(
-                    {
-                        "surface_kind": kind,
-                        "surface_id": planned,
-                        **result["evidence"],
-                    }
-                )
+                results = value if kind == "browser_batch" else [(planned, value)]
+                result_kind = "browser" if kind == "browser_batch" else kind
+                for result_planned, result in results:
+                    operation_counts[result_kind] += result["operations"]
+                    if result_kind == "browser":
+                        browser_render_counts[result_planned] = result["render_observations"]
+                        screenshot_path = result.get("owned_screenshot_path")
+                        if isinstance(screenshot_path, str) and screenshot_path:
+                            candidate = Path(screenshot_path).absolute()
+                            expected_root = (
+                                Path(tempfile.gettempdir()) / "cmux-browser-screenshots"
+                            ).resolve()
+                            if (
+                                candidate.parent.resolve() == expected_root
+                                and candidate.name.startswith("surface-")
+                                and candidate.suffix == ".png"
+                                and candidate.is_file()
+                                and not candidate.is_symlink()
+                            ):
+                                self._owned_browser_screenshot_paths.add(candidate)
+                    latencies.extend(result["latencies"])
+                    evidence.append(
+                        {
+                            "surface_kind": result_kind,
+                            "surface_id": result_planned,
+                            **result["evidence"],
+                        }
+                    )
 
         temporary: dict[str, Any] | None = None
         try:

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -303,6 +303,40 @@ class CmuxRuntimeAdapter:
         self._details["invocation"]["launch_socket_ready_ms"] = elapsed
 
 
+    def _json_cli(self, args: list[str]) -> dict[str, Any]:
+        return self._runner.json_cli(
+            ["--id-format", "both", *args], timeout=self.config.rpc_timeout_s
+        )
+
+    def _create_workspace(self) -> str:
+        payload = self._json_cli(
+            [
+                "workspace",
+                "create",
+                "--name",
+                f"cmux-perf-{self.config.scenario['scenario_id']}",
+                "--cwd",
+                str(self.config.output_root),
+            ]
+        )
+        return _extract_ref(payload, "workspace")
+
+    def _close_workspace(self, workspace_id: str) -> None:
+        self._runner.run_cli(
+            [
+                "workspace-action",
+                "--workspace",
+                workspace_id,
+                "--action",
+                "unpin",
+            ],
+            timeout=self.config.rpc_timeout_s,
+        )
+        self._runner.run_cli(
+            ["close-workspace", "--workspace", workspace_id],
+            timeout=self.config.rpc_timeout_s,
+        )
+
     def _new_surface(self, kind: str, *, url: str | None = None) -> str:
         if self._workspace_id is None or self._pane_id is None:
             raise RuntimeError("fixture pane is not initialized")
@@ -322,7 +356,7 @@ class CmuxRuntimeAdapter:
                 raise ValueError("browser fixture URLs must be local file URLs")
             args.extend(("--url", url))
         args.extend(("--focus", "false"))
-        payload = self._runner.json_cli(args, timeout=self.config.rpc_timeout_s)
+        payload = self._json_cli(args)
         if _extract_ref(payload, "pane") != self._pane_id:
             raise ValueError("surface was created outside the owned fixture pane")
         return _extract_ref(payload, "surface")
@@ -348,60 +382,55 @@ class CmuxRuntimeAdapter:
             if not fixture_path.resolve().is_relative_to(self.config.output_root):
                 raise ValueError("browser fixture is outside the owned output root")
 
-        before = self._runner.json_cli(
-            ["list-workspaces"], timeout=self.config.rpc_timeout_s
-        ).get("workspaces", [])
+        before = self._json_cli(["list-workspaces"]).get("workspaces", [])
         if not isinstance(before, list) or len(before) != 1 or not isinstance(before[0], Mapping):
             raise ValueError("fixture requires exactly one clean startup workspace")
-        self._workspace_id = _extract_ref(before[0], "workspace")
-        panes_payload = self._runner.json_cli(
-            ["list-panes", "--workspace", self._workspace_id],
-            timeout=self.config.rpc_timeout_s,
+        startup_workspace_id = _extract_ref(before[0], "workspace")
+
+        self._workspace_id = self._create_workspace()
+        panes_payload = self._json_cli(
+            ["list-panes", "--workspace", self._workspace_id]
         )
         panes = panes_payload.get("panes", [])
-        if not isinstance(panes, list) or len(panes) != 1:
-            raise ValueError("clean startup workspace must contain exactly one pane")
+        if not isinstance(panes, list) or len(panes) != 1 or not isinstance(panes[0], Mapping):
+            raise ValueError("owned fixture workspace must contain exactly one pane")
         self._pane_id = _extract_ref(panes[0], "pane")
         initial_refs = panes[0].get("surface_ids") or panes[0].get("surface_refs") or []
         if not isinstance(initial_refs, list) or len(initial_refs) != 1:
-            raise ValueError("clean startup workspace must contain one initial terminal")
+            raise ValueError("owned fixture workspace must contain one initial terminal")
         initial_terminal = initial_refs[0]
         if not isinstance(initial_terminal, str):
-            raise ValueError("initial terminal reference is invalid")
-        startup_surfaces = self._surfaces(include_uuids=True)
-        if len(startup_surfaces) != 1 or not isinstance(startup_surfaces[0], Mapping):
-            raise ValueError("clean startup workspace must contain one observable surface")
-        startup_surface = startup_surfaces[0]
-        if not any(
-            startup_surface.get(key) == initial_terminal
-            for key in ("surface_id", "surface_ref", "id", "ref")
+            raise ValueError("initial terminal identity is invalid")
+        initial_payload = self._json_cli(
+            [
+                "list-pane-surfaces",
+                "--workspace",
+                self._workspace_id,
+                "--pane",
+                self._pane_id,
+            ]
+        )
+        initial_surfaces = initial_payload.get("surfaces", [])
+        if (
+            not isinstance(initial_surfaces, list)
+            or len(initial_surfaces) != 1
+            or not isinstance(initial_surfaces[0], Mapping)
+            or _extract_ref(initial_surfaces[0], "surface") != initial_terminal
+            or _surface_type(initial_surfaces[0]) != "terminal"
         ):
-            raise ValueError("startup surface identity changed before fixture creation")
-        if _surface_type(startup_surface) != "terminal":
-            raise ValueError("startup surface must be a terminal")
-        startup_surface_id = startup_surface.get("surface_id") or startup_surface.get("id")
-        if not isinstance(startup_surface_id, str) or not startup_surface_id:
-            raise ValueError("startup surface listing is missing its UUID")
+            raise ValueError("owned fixture workspace must start with one terminal surface")
+
+        self._close_workspace(startup_workspace_id)
+        self._runner.run_cli(
+            ["select-workspace", "--workspace", self._workspace_id],
+            timeout=self.config.rpc_timeout_s,
+        )
 
         self._plan = plan
         self._terminal_actual_ids.clear()
         self._browser_actual_ids.clear()
         terminals = expected["terminal_surfaces"]
         if terminals:
-            respawned = self._runner.rpc(
-                "surface.respawn",
-                {
-                    "surface_id": startup_surface_id,
-                    "working_directory": str(self.config.output_root),
-                    "focus": False,
-                },
-                timeout=self.config.rpc_timeout_s,
-            )
-            if not isinstance(respawned, Mapping) or not any(
-                respawned.get(key) == startup_surface_id
-                for key in ("surface_id", "surface_ref", "id", "ref")
-            ):
-                raise ValueError("startup terminal identity changed while setting fixture cwd")
             self._terminal_actual_ids["terminal-001"] = initial_terminal
             for index in range(2, terminals + 1):
                 self._terminal_actual_ids[f"terminal-{index:03d}"] = self._new_surface(
@@ -423,12 +452,6 @@ class CmuxRuntimeAdapter:
                 timeout=self.config.rpc_timeout_s,
             )
 
-        self._runner.run_cli(
-            ["select-workspace", "--workspace", self._workspace_id],
-            timeout=self.config.rpc_timeout_s,
-            check=False,
-        )
-
         scrollback = expected["aggregate_scrollback_chars"]
         seed_evidence: dict[str, Any] | None = None
         if terminals:
@@ -445,7 +468,9 @@ class CmuxRuntimeAdapter:
                 "scrollback_chars": scrollback,
             }
             if any(seed_evidence.get(key) != value for key, value in required.items()):
-                raise ValueError("synthetic scrollback seed did not produce the exact aggregate")
+                raise ValueError(
+                    f"synthetic scrollback seed mismatch: expected={required!r} actual={seed_evidence!r}"
+                )
 
         mapping = dict(self._terminal_actual_ids)
         mapping.update(self._browser_actual_ids)
@@ -462,12 +487,10 @@ class CmuxRuntimeAdapter:
             "scrollback_evidence": seed_evidence,
         }
 
-    def _surfaces(self, *, include_uuids: bool = False) -> list[Mapping[str, Any]]:
+    def _surfaces(self) -> list[Mapping[str, Any]]:
         if self._workspace_id is None or self._pane_id is None:
             raise RuntimeError("fixture has not been created")
-        workspaces = self._runner.json_cli(
-            ["list-workspaces"], timeout=self.config.rpc_timeout_s
-        ).get("workspaces", [])
+        workspaces = self._json_cli(["list-workspaces"]).get("workspaces", [])
         workspace_ids = {
             _extract_ref(item, "workspace")
             for item in workspaces
@@ -475,26 +498,21 @@ class CmuxRuntimeAdapter:
         }
         if workspace_ids != {self._workspace_id}:
             raise ValueError("fixture must occupy exactly one owned workspace")
-        panes = self._runner.json_cli(
-            ["list-panes", "--workspace", self._workspace_id],
-            timeout=self.config.rpc_timeout_s,
+        panes = self._json_cli(
+            ["list-panes", "--workspace", self._workspace_id]
         ).get("panes", [])
         if not isinstance(panes, list) or len(panes) != 1:
             raise ValueError("fixture workspace must contain exactly one pane")
         if _extract_ref(panes[0], "pane") != self._pane_id:
             raise ValueError("fixture pane identity changed")
-        surface_args = [
-            "list-pane-surfaces",
-            "--workspace",
-            self._workspace_id,
-            "--pane",
-            self._pane_id,
-        ]
-        if include_uuids:
-            surface_args[0:0] = ["--id-format", "both"]
-        payload = self._runner.json_cli(
-            surface_args,
-            timeout=self.config.rpc_timeout_s,
+        payload = self._json_cli(
+            [
+                "list-pane-surfaces",
+                "--workspace",
+                self._workspace_id,
+                "--pane",
+                self._pane_id,
+            ]
         )
         if any(key in payload for key in ("pane_id", "pane_ref")) and not any(
             payload.get(key) == self._pane_id for key in ("pane_id", "pane_ref")
@@ -1098,6 +1116,30 @@ class CmuxRuntimeAdapter:
         self._details["snapshot"]["captured"] = captured
         return captured
 
+    def _reconcile_restored_workspace(self) -> None:
+        if self._workspace_id is None:
+            raise RuntimeError("fixture workspace is not initialized")
+        deadline = self._clock.monotonic() + self.config.rpc_timeout_s
+        while True:
+            workspaces = self._json_cli(["list-workspaces"]).get("workspaces", [])
+            workspace_ids = [
+                _extract_ref(item, "workspace")
+                for item in workspaces
+                if isinstance(item, Mapping)
+            ]
+            if self._workspace_id in workspace_ids:
+                self._runner.run_cli(
+                    ["select-workspace", "--workspace", self._workspace_id],
+                    timeout=self.config.rpc_timeout_s,
+                )
+                for workspace_id in workspace_ids:
+                    if workspace_id != self._workspace_id:
+                        self._close_workspace(workspace_id)
+                return
+            if self._clock.monotonic() >= deadline:
+                raise ValueError("restored fixture workspace did not appear before timeout")
+            self._clock.sleep(0.1)
+
     def restore(self, snapshot: Any) -> None:
         _contract.validate_snapshot(
             self.config.scenario, self._snapshot_contract(snapshot)
@@ -1106,6 +1148,7 @@ class CmuxRuntimeAdapter:
         self._launched = False
         elapsed = self._runner.launch("restore")
         self._launched = True
+        self._reconcile_restored_workspace()
         restored = self._runner.rpc(
             "debug.session_snapshot_benchmark",
             {"include_scrollback": True, "persist": True},

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -980,152 +980,179 @@ class CmuxRuntimeAdapter:
         browser_render_counts: dict[str, int] = {}
         profile_pool: ThreadPoolExecutor | None = None
         profile_futures: dict[Any, dict[str, Any]] = {}
-        if self.config.profile_enabled:
-            try:
-                work_units = {
-                    "terminal_ansi_lines": len(self._terminal_actual_ids)
-                    * self._terminal_ansi_line_target(),
-                    "browser_churn_rpc_operations": len(self._browser_actual_ids)
-                    * (browser_cycles * 2 + 2),
-                    "temporary_browser_open_close_operations": 2
-                    if self._browser_actual_ids
-                    else 0,
-                }
-                metadata = self._profile_metadata(
-                    phase="churn", work_units=work_units
-                )
-                profile_pool = ThreadPoolExecutor(
-                    max_workers=max(1, len(metadata))
-                )
-                profile_futures = {
-                    profile_pool.submit(self._run_profile, item): item
-                    for item in metadata
-                }
-            except BaseException as error:
-                failures.append({"phase": "profile_setup", "message": str(error)})
-        futures: dict[Any, tuple[str, str]] = {}
-        browser_batch_future: Any | None = None
-        worker_count = len(self._terminal_actual_ids) + bool(self._browser_actual_ids)
-        with ThreadPoolExecutor(max_workers=max(1, worker_count)) as pool:
-            for planned, actual in self._terminal_actual_ids.items():
-                future = pool.submit(self._terminal_churn, planned, actual, cycles)
-                futures[future] = ("terminal", planned)
-            if self._browser_actual_ids:
-                browser_batch_future = pool.submit(
-                    self._browser_churn_batch, browser_cycles
-                )
-                futures[browser_batch_future] = ("browser_batch", "browser-batch")
-
-            sample_count = max(
-                1,
-                math.ceil(
-                    self.config.churn_measurement_duration_s
-                    / self.config.churn_interval_s
-                ),
-            )
-            samples: list[dict[str, Any]] = []
-            for index in range(sample_count):
-                self._clock.sleep(self.config.churn_interval_s)
-                try:
-                    raw = self._raw_top()
-                    samples.append(
-                        self._parsed_sample(
-                            raw,
-                            index=index,
-                            elapsed_seconds=self._clock.monotonic() - churn_start,
-                        )
-                    )
-                except BaseException as error:
-                    failures.append(
-                        {
-                            "phase": "churn_sampling",
-                            "operation_index": index,
-                            "message": str(error),
-                        }
-                    )
-
-            if browser_batch_future is not None and not browser_batch_future.done():
-                failures.append(
-                    {
-                        "phase": "browser_measurement_window",
-                        "surface_id": "browser-batch",
-                        "message": "browser churn exceeded the fixed measurement window",
-                    }
-                )
-
-            for future in as_completed(futures):
-                kind, planned = futures[future]
-                try:
-                    value = future.result()
-                except BaseException as error:
-                    failures.append(
-                        {
-                            "phase": "churn",
-                            "surface_id": planned,
-                            "message": str(error),
-                        }
-                    )
-                    continue
-                results = value if kind == "browser_batch" else [(planned, value)]
-                result_kind = "browser" if kind == "browser_batch" else kind
-                for result_planned, result in results:
-                    operation_counts[result_kind] += result["operations"]
-                    if result_kind == "browser":
-                        browser_render_counts[result_planned] = result["render_observations"]
-                        screenshot_path = result.get("owned_screenshot_path")
-                        if isinstance(screenshot_path, str) and screenshot_path:
-                            candidate = Path(screenshot_path).absolute()
-                            expected_root = (
-                                Path(tempfile.gettempdir()) / "cmux-browser-screenshots"
-                            ).resolve()
-                            if (
-                                candidate.parent.resolve() == expected_root
-                                and candidate.name.startswith("surface-")
-                                and candidate.suffix == ".png"
-                                and candidate.is_file()
-                                and not candidate.is_symlink()
-                            ):
-                                self._owned_browser_screenshot_paths.add(candidate)
-                    latencies.extend(result["latencies"])
-                    evidence.append(
-                        {
-                            "surface_kind": result_kind,
-                            "surface_id": result_planned,
-                            **result["evidence"],
-                        }
-                    )
-
-        temporary: dict[str, Any] | None = None
         try:
-            temporary = self._temporary_browser_cycle()
-            if temporary is not None:
-                operation_counts["browser"] += 2
-        except BaseException as error:
-            failures.append(
-                {"phase": "temporary_browser_cycle", "message": str(error)}
-            )
-        churn_elapsed_s = max(
-            1e-9, self._clock.monotonic() - churn_start
-        )
+            if self.config.profile_enabled:
+                try:
+                    work_units = {
+                        "terminal_ansi_lines": len(self._terminal_actual_ids)
+                        * self._terminal_ansi_line_target(),
+                        "browser_churn_rpc_operations": len(self._browser_actual_ids)
+                        * (browser_cycles * 2 + 2),
+                        "temporary_browser_open_close_operations": 2
+                        if self._browser_actual_ids
+                        else 0,
+                    }
+                    metadata = self._profile_metadata(
+                        phase="churn", work_units=work_units
+                    )
+                    profile_pool = ThreadPoolExecutor(
+                        max_workers=max(1, len(metadata))
+                    )
+                    profile_futures = {
+                        profile_pool.submit(self._run_profile, item): item
+                        for item in metadata
+                    }
+                except Exception as error:
+                    failures.append(
+                        {"phase": "profile_setup", "message": str(error)}
+                    )
 
-        profile_records: list[dict[str, Any]] = []
-        for future in as_completed(profile_futures):
-            metadata = profile_futures[future]
+            futures: dict[Any, tuple[str, str]] = {}
+            browser_batch_future: Any | None = None
+            worker_count = len(self._terminal_actual_ids) + bool(
+                self._browser_actual_ids
+            )
+            with ThreadPoolExecutor(max_workers=max(1, worker_count)) as pool:
+                for planned, actual in self._terminal_actual_ids.items():
+                    future = pool.submit(
+                        self._terminal_churn, planned, actual, cycles
+                    )
+                    futures[future] = ("terminal", planned)
+                if self._browser_actual_ids:
+                    browser_batch_future = pool.submit(
+                        self._browser_churn_batch, browser_cycles
+                    )
+                    futures[browser_batch_future] = (
+                        "browser_batch",
+                        "browser-batch",
+                    )
+
+                sample_count = max(
+                    1,
+                    math.ceil(
+                        self.config.churn_measurement_duration_s
+                        / self.config.churn_interval_s
+                    ),
+                )
+                samples: list[dict[str, Any]] = []
+                for index in range(sample_count):
+                    self._clock.sleep(self.config.churn_interval_s)
+                    try:
+                        raw = self._raw_top()
+                        samples.append(
+                            self._parsed_sample(
+                                raw,
+                                index=index,
+                                elapsed_seconds=self._clock.monotonic()
+                                - churn_start,
+                            )
+                        )
+                    except Exception as error:
+                        failures.append(
+                            {
+                                "phase": "churn_sampling",
+                                "operation_index": index,
+                                "message": str(error),
+                            }
+                        )
+
+                if (
+                    browser_batch_future is not None
+                    and not browser_batch_future.done()
+                ):
+                    failures.append(
+                        {
+                            "phase": "browser_measurement_window",
+                            "surface_id": "browser-batch",
+                            "message": (
+                                "browser churn exceeded the fixed measurement window"
+                            ),
+                        }
+                    )
+
+                for future in as_completed(futures):
+                    kind, planned = futures[future]
+                    try:
+                        value = future.result()
+                    except BaseException as error:
+                        failures.append(
+                            {
+                                "phase": "churn",
+                                "surface_id": planned,
+                                "message": str(error),
+                            }
+                        )
+                        continue
+                    results = (
+                        value
+                        if kind == "browser_batch"
+                        else [(planned, value)]
+                    )
+                    result_kind = "browser" if kind == "browser_batch" else kind
+                    for result_planned, result in results:
+                        operation_counts[result_kind] += result["operations"]
+                        if result_kind == "browser":
+                            browser_render_counts[result_planned] = result[
+                                "render_observations"
+                            ]
+                            screenshot_path = result.get("owned_screenshot_path")
+                            if isinstance(screenshot_path, str) and screenshot_path:
+                                candidate = Path(screenshot_path).absolute()
+                                expected_root = (
+                                    Path(tempfile.gettempdir())
+                                    / "cmux-browser-screenshots"
+                                ).resolve()
+                                if (
+                                    candidate.parent.resolve() == expected_root
+                                    and candidate.name.startswith("surface-")
+                                    and candidate.suffix == ".png"
+                                    and candidate.is_file()
+                                    and not candidate.is_symlink()
+                                ):
+                                    self._owned_browser_screenshot_paths.add(
+                                        candidate
+                                    )
+                        latencies.extend(result["latencies"])
+                        evidence.append(
+                            {
+                                "surface_kind": result_kind,
+                                "surface_id": result_planned,
+                                **result["evidence"],
+                            }
+                        )
+
+            temporary: dict[str, Any] | None = None
             try:
-                profile_records.append(future.result())
-            except BaseException as error:
-                failure = {
-                    "phase": "profile_churn",
-                    "role": metadata["role"],
-                    "pid": metadata["pid"],
-                    "message": str(error),
-                }
-                profile_evidence = getattr(error, "evidence", None)
-                if profile_evidence is not None:
-                    failure["evidence"] = _plain(profile_evidence)
-                failures.append(failure)
-        if profile_pool is not None:
-            profile_pool.shutdown(wait=True)
+                temporary = self._temporary_browser_cycle()
+                if temporary is not None:
+                    operation_counts["browser"] += 2
+            except Exception as error:
+                failures.append(
+                    {"phase": "temporary_browser_cycle", "message": str(error)}
+                )
+            churn_elapsed_s = max(
+                1e-9, self._clock.monotonic() - churn_start
+            )
+
+            profile_records: list[dict[str, Any]] = []
+            for future in as_completed(profile_futures):
+                metadata = profile_futures[future]
+                try:
+                    profile_records.append(future.result())
+                except BaseException as error:
+                    failure = {
+                        "phase": "profile_churn",
+                        "role": metadata["role"],
+                        "pid": metadata["pid"],
+                        "message": str(error),
+                    }
+                    profile_evidence = getattr(error, "evidence", None)
+                    if profile_evidence is not None:
+                        failure["evidence"] = _plain(profile_evidence)
+                    failures.append(failure)
+        finally:
+            if profile_pool is not None:
+                profile_pool.shutdown(wait=True, cancel_futures=True)
         if profile_records:
             self._details["profiles"] = sorted(
                 profile_records, key=lambda item: (item["role"], item["pid"])

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from argparse import Namespace
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import ExitStack
 from copy import deepcopy
 from dataclasses import dataclass
 import importlib.util
@@ -1377,9 +1378,7 @@ class CmuxRuntimeAdapter:
         browser_fixture_root = self.config.output_root / "browser-fixtures"
         runtime_paths = [browser_fixture_root, *self._owned_browser_screenshot_paths]
         runner_cleanup = getattr(self._runner, "cleanup_owned", None)
-        if runner_cleanup is not None:
-            runner_evidence = runner_cleanup()
-        else:
+        if runner_cleanup is None:
             for name in (
                 "socket_path",
                 "cmuxd_socket_path",
@@ -1390,13 +1389,18 @@ class CmuxRuntimeAdapter:
                 value = getattr(self._runner, name, None)
                 if value is not None:
                     runtime_paths.append(Path(value))
-            self._runner.clean_persisted_state()
-            runner_evidence = {"tag_state_removed": True}
-        for path in runtime_paths:
-            if path.is_dir():
-                shutil.rmtree(path)
+
+        with ExitStack() as owned_path_cleanup:
+            for path in runtime_paths:
+                if path.is_dir():
+                    owned_path_cleanup.callback(shutil.rmtree, path)
+                else:
+                    owned_path_cleanup.callback(path.unlink, missing_ok=True)
+            if runner_cleanup is not None:
+                runner_evidence = runner_cleanup()
             else:
-                path.unlink(missing_ok=True)
+                self._runner.clean_persisted_state()
+                runner_evidence = {"tag_state_removed": True}
         evidence = {
             "stopped": not self._launched,
             "owned_state_removed": all(not path.exists() for path in runtime_paths),

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -933,6 +933,11 @@ class CmuxRuntimeAdapter:
             1,
             math.ceil(self.config.churn_duration_s / self.config.churn_interval_s),
         )
+        browser_cycles = (
+            max(1, math.ceil(cycles / len(self._browser_actual_ids)))
+            if self._browser_actual_ids
+            else 0
+        )
         before_render = self._render_stats()
         churn_start = self._clock.monotonic()
         failures: list[dict[str, Any]] = []
@@ -948,7 +953,7 @@ class CmuxRuntimeAdapter:
                     "terminal_ansi_lines": len(self._terminal_actual_ids)
                     * self._terminal_ansi_line_target(),
                     "browser_churn_rpc_operations": len(self._browser_actual_ids)
-                    * (cycles * 3 + 2),
+                    * (browser_cycles * 3 + 2),
                     "temporary_browser_open_close_operations": 2
                     if self._browser_actual_ids
                     else 0,
@@ -966,14 +971,17 @@ class CmuxRuntimeAdapter:
             except BaseException as error:
                 failures.append({"phase": "profile_setup", "message": str(error)})
         futures: dict[Any, tuple[str, str]] = {}
+        browser_batch_future: Any | None = None
         worker_count = len(self._terminal_actual_ids) + bool(self._browser_actual_ids)
         with ThreadPoolExecutor(max_workers=max(1, worker_count)) as pool:
             for planned, actual in self._terminal_actual_ids.items():
                 future = pool.submit(self._terminal_churn, planned, actual, cycles)
                 futures[future] = ("terminal", planned)
             if self._browser_actual_ids:
-                future = pool.submit(self._browser_churn_batch, cycles)
-                futures[future] = ("browser_batch", "browser-batch")
+                browser_batch_future = pool.submit(
+                    self._browser_churn_batch, browser_cycles
+                )
+                futures[browser_batch_future] = ("browser_batch", "browser-batch")
 
             sample_count = max(1, cycles)
             samples: list[dict[str, Any]] = []
@@ -996,6 +1004,15 @@ class CmuxRuntimeAdapter:
                             "message": str(error),
                         }
                     )
+
+            if browser_batch_future is not None and not browser_batch_future.done():
+                failures.append(
+                    {
+                        "phase": "browser_measurement_window",
+                        "surface_id": "browser-batch",
+                        "message": "browser churn exceeded the fixed measurement window",
+                    }
+                )
 
             for future in as_completed(futures):
                 kind, planned = futures[future]
@@ -1138,7 +1155,10 @@ class CmuxRuntimeAdapter:
             "requested_operations": _plain(operations),
             "fixed_duration_s": self.config.churn_duration_s,
             "measured_elapsed_s": churn_elapsed_s,
-            "cycles_per_surface": cycles,
+            "cycles_per_surface": {
+                "terminal": cycles if self._terminal_actual_ids else 0,
+                "browser": browser_cycles,
+            },
             "surface_evidence": sorted(
                 evidence, key=lambda item: (item["surface_kind"], item["surface_id"])
             ),

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -820,16 +820,7 @@ class CmuxRuntimeAdapter:
     def _browser_churn(self, planned_id: str, actual_id: str, cycles: int) -> dict[str, Any]:
         latencies: list[dict[str, Any]] = []
         evidence: list[dict[str, Any]] = []
-        surface_latency, surface_payload = self._timed_rpc(
-            "browser_surface_focus",
-            planned_id,
-            "surface.focus",
-            {"workspace_id": self._workspace_id, "surface_id": actual_id},
-        )
-        latencies.append(surface_latency)
-        evidence.append({"label": "browser_surface_focus", "payload": surface_payload})
         methods = (
-            ("browser_focus", "browser.focus_webview"),
             ("browser_reload", "browser.reload"),
             ("browser_snapshot", "browser.snapshot"),
         )
@@ -859,7 +850,7 @@ class CmuxRuntimeAdapter:
         }
         screenshot_evidence["png_base64_length"] = len(encoded_png)
         return {
-            "operations": cycles * len(methods) + 2,
+            "operations": cycles * len(methods) + 1,
             "latencies": latencies,
             "render_observations": 1,
             "owned_screenshot_path": screenshot.get("path"),
@@ -873,10 +864,42 @@ class CmuxRuntimeAdapter:
     def _browser_churn_batch(
         self, cycles: int
     ) -> list[tuple[str, dict[str, Any]]]:
-        return [
-            (planned, self._browser_churn(planned, actual, cycles))
-            for planned, actual in self._browser_actual_ids.items()
-        ]
+        activations: dict[str, tuple[list[dict[str, Any]], list[dict[str, Any]]]] = {}
+        for planned, actual in self._browser_actual_ids.items():
+            activation_latencies: list[dict[str, Any]] = []
+            activation_evidence: list[dict[str, Any]] = []
+            for label, method in (
+                ("browser_surface_focus", "surface.focus"),
+                ("browser_focus", "browser.focus_webview"),
+            ):
+                latency, payload = self._timed_rpc(
+                    label,
+                    planned,
+                    method,
+                    {"workspace_id": self._workspace_id, "surface_id": actual},
+                )
+                activation_latencies.append(latency)
+                activation_evidence.append({"label": label, "payload": payload})
+            activations[planned] = (activation_latencies, activation_evidence)
+
+        results_by_planned: dict[str, dict[str, Any]] = {}
+        with ThreadPoolExecutor(max_workers=max(1, len(self._browser_actual_ids))) as pool:
+            futures = {
+                pool.submit(self._browser_churn, planned, actual, cycles): planned
+                for planned, actual in self._browser_actual_ids.items()
+            }
+            for future in as_completed(futures):
+                results_by_planned[futures[future]] = future.result()
+
+        results: list[tuple[str, dict[str, Any]]] = []
+        for planned in self._browser_actual_ids:
+            result = results_by_planned[planned]
+            activation_latencies, activation_evidence = activations[planned]
+            result["operations"] += len(activation_evidence)
+            result["latencies"] = activation_latencies + result["latencies"]
+            result["evidence"]["activation"] = activation_evidence
+            results.append((planned, result))
+        return results
 
     def _temporary_browser_cycle(self) -> dict[str, Any] | None:
         if not self._browser_actual_ids or self._plan is None:
@@ -953,7 +976,7 @@ class CmuxRuntimeAdapter:
                     "terminal_ansi_lines": len(self._terminal_actual_ids)
                     * self._terminal_ansi_line_target(),
                     "browser_churn_rpc_operations": len(self._browser_actual_ids)
-                    * (browser_cycles * 3 + 2),
+                    * (browser_cycles * 2 + 3),
                     "temporary_browser_open_close_operations": 2
                     if self._browser_actual_ids
                     else 0,

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -368,14 +368,20 @@ class CmuxRuntimeAdapter:
         initial_terminal = initial_refs[0]
         if not isinstance(initial_terminal, str):
             raise ValueError("initial terminal reference is invalid")
-        startup_surfaces = self._surfaces()
+        startup_surfaces = self._surfaces(include_uuids=True)
         if len(startup_surfaces) != 1 or not isinstance(startup_surfaces[0], Mapping):
             raise ValueError("clean startup workspace must contain one observable surface")
         startup_surface = startup_surfaces[0]
-        if _extract_ref(startup_surface, "surface") != initial_terminal:
+        if not any(
+            startup_surface.get(key) == initial_terminal
+            for key in ("surface_id", "surface_ref", "id", "ref")
+        ):
             raise ValueError("startup surface identity changed before fixture creation")
         if _surface_type(startup_surface) != "terminal":
             raise ValueError("startup surface must be a terminal")
+        startup_surface_id = startup_surface.get("surface_id") or startup_surface.get("id")
+        if not isinstance(startup_surface_id, str) or not startup_surface_id:
+            raise ValueError("startup surface listing is missing its UUID")
 
         self._plan = plan
         self._terminal_actual_ids.clear()
@@ -385,15 +391,14 @@ class CmuxRuntimeAdapter:
             respawned = self._runner.rpc(
                 "surface.respawn",
                 {
-                    "workspace_id": self._workspace_id,
-                    "surface_id": initial_terminal,
+                    "surface_id": startup_surface_id,
                     "working_directory": str(self.config.output_root),
                     "focus": False,
                 },
                 timeout=self.config.rpc_timeout_s,
             )
             if not isinstance(respawned, Mapping) or not any(
-                respawned.get(key) == initial_terminal
+                respawned.get(key) == startup_surface_id
                 for key in ("surface_id", "surface_ref", "id", "ref")
             ):
                 raise ValueError("startup terminal identity changed while setting fixture cwd")
@@ -457,7 +462,7 @@ class CmuxRuntimeAdapter:
             "scrollback_evidence": seed_evidence,
         }
 
-    def _surfaces(self) -> list[Mapping[str, Any]]:
+    def _surfaces(self, *, include_uuids: bool = False) -> list[Mapping[str, Any]]:
         if self._workspace_id is None or self._pane_id is None:
             raise RuntimeError("fixture has not been created")
         workspaces = self._runner.json_cli(
@@ -478,17 +483,22 @@ class CmuxRuntimeAdapter:
             raise ValueError("fixture workspace must contain exactly one pane")
         if _extract_ref(panes[0], "pane") != self._pane_id:
             raise ValueError("fixture pane identity changed")
+        surface_args = [
+            "list-pane-surfaces",
+            "--workspace",
+            self._workspace_id,
+            "--pane",
+            self._pane_id,
+        ]
+        if include_uuids:
+            surface_args[0:0] = ["--id-format", "both"]
         payload = self._runner.json_cli(
-            [
-                "list-pane-surfaces",
-                "--workspace",
-                self._workspace_id,
-                "--pane",
-                self._pane_id,
-            ],
+            surface_args,
             timeout=self.config.rpc_timeout_s,
         )
-        if any(key in payload for key in ("pane_id", "pane_ref")) and _extract_ref(payload, "pane") != self._pane_id:
+        if any(key in payload for key in ("pane_id", "pane_ref")) and not any(
+            payload.get(key) == self._pane_id for key in ("pane_id", "pane_ref")
+        ):
             raise ValueError("surface listing came from the wrong pane")
         surfaces = payload.get("surfaces", [])
         if not isinstance(surfaces, list):

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -315,6 +315,8 @@ class CmuxRuntimeAdapter:
             "--type",
             kind,
         ]
+        if kind == "terminal":
+            args.extend(("--working-directory", str(self.config.output_root)))
         if url is not None:
             if not url.startswith("file://"):
                 raise ValueError("browser fixture URLs must be local file URLs")
@@ -366,32 +368,37 @@ class CmuxRuntimeAdapter:
         initial_terminal = initial_refs[0]
         if not isinstance(initial_terminal, str):
             raise ValueError("initial terminal reference is invalid")
+        startup_surfaces = self._surfaces()
+        if len(startup_surfaces) != 1 or not isinstance(startup_surfaces[0], Mapping):
+            raise ValueError("clean startup workspace must contain one observable surface")
+        startup_surface = startup_surfaces[0]
+        if _extract_ref(startup_surface, "surface") != initial_terminal:
+            raise ValueError("startup surface identity changed before fixture creation")
+        if _surface_type(startup_surface) != "terminal":
+            raise ValueError("startup surface must be a terminal")
 
         self._plan = plan
         self._terminal_actual_ids.clear()
         self._browser_actual_ids.clear()
         terminals = expected["terminal_surfaces"]
-        if terminals:
-            self._terminal_actual_ids["terminal-001"] = initial_terminal
-            for index in range(2, terminals + 1):
-                self._terminal_actual_ids[f"terminal-{index:03d}"] = self._new_surface(
-                    "terminal"
-                )
+        for index in range(1, terminals + 1):
+            self._terminal_actual_ids[f"terminal-{index:03d}"] = self._new_surface(
+                "terminal"
+            )
         for browser in plan.browser_surfaces:
             self._browser_actual_ids[browser.surface_id] = self._new_surface(
                 "browser", url=browser.url
             )
-        if terminals == 0:
-            self._runner.run_cli(
-                [
-                    "close-surface",
-                    "--workspace",
-                    self._workspace_id,
-                    "--surface",
-                    initial_terminal,
-                ],
-                timeout=self.config.rpc_timeout_s,
-            )
+        self._runner.run_cli(
+            [
+                "close-surface",
+                "--workspace",
+                self._workspace_id,
+                "--surface",
+                initial_terminal,
+            ],
+            timeout=self.config.rpc_timeout_s,
+        )
 
         self._runner.run_cli(
             ["select-workspace", "--workspace", self._workspace_id],

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -120,6 +120,7 @@ class AdapterConfig:
     steady_duration_s: float = 5.0
     steady_interval_s: float = 1.0
     churn_duration_s: float = 5.0
+    churn_measurement_duration_s: float = 5.0
     churn_interval_s: float = 1.0
     profile_duration_s: float = 5.0
 
@@ -142,6 +143,7 @@ class AdapterConfig:
             "steady_duration_s",
             "steady_interval_s",
             "churn_duration_s",
+            "churn_measurement_duration_s",
             "churn_interval_s",
             "profile_duration_s",
         ):
@@ -150,6 +152,14 @@ class AdapterConfig:
             raise ValueError("steady_interval_s cannot exceed steady_duration_s")
         if self.churn_interval_s > self.churn_duration_s:
             raise ValueError("churn_interval_s cannot exceed churn_duration_s")
+        if self.churn_measurement_duration_s < self.churn_duration_s:
+            raise ValueError(
+                "churn_measurement_duration_s cannot be shorter than churn_duration_s"
+            )
+        if self.profile_enabled and self.profile_duration_s < self.churn_measurement_duration_s:
+            raise ValueError(
+                "profile_duration_s cannot be shorter than the churn measurement window"
+            )
 
 
 class _SystemClock:
@@ -288,6 +298,7 @@ class CmuxRuntimeAdapter:
                     "steady_duration_s": config.steady_duration_s,
                     "steady_interval_s": config.steady_interval_s,
                     "churn_duration_s": config.churn_duration_s,
+                    "churn_measurement_duration_s": config.churn_measurement_duration_s,
                     "churn_interval_s": config.churn_interval_s,
                     "profile_duration_s": config.profile_duration_s,
                 },
@@ -1004,7 +1015,13 @@ class CmuxRuntimeAdapter:
                 )
                 futures[browser_batch_future] = ("browser_batch", "browser-batch")
 
-            sample_count = max(1, cycles)
+            sample_count = max(
+                1,
+                math.ceil(
+                    self.config.churn_measurement_duration_s
+                    / self.config.churn_interval_s
+                ),
+            )
             samples: list[dict[str, Any]] = []
             for index in range(sample_count):
                 self._clock.sleep(self.config.churn_interval_s)
@@ -1174,7 +1191,8 @@ class CmuxRuntimeAdapter:
         }
         self._details["churn"] = {
             "requested_operations": _plain(operations),
-            "fixed_duration_s": self.config.churn_duration_s,
+            "fixed_duration_s": self.config.churn_measurement_duration_s,
+            "workload_target_duration_s": self.config.churn_duration_s,
             "measured_elapsed_s": churn_elapsed_s,
             "cycles_per_surface": {
                 "terminal": cycles if self._terminal_actual_ids else 0,

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -392,7 +392,10 @@ class CmuxRuntimeAdapter:
                 },
                 timeout=self.config.rpc_timeout_s,
             )
-            if _extract_ref(respawned, "surface") != initial_terminal:
+            if not isinstance(respawned, Mapping) or not any(
+                respawned.get(key) == initial_terminal
+                for key in ("surface_id", "surface_ref", "id", "ref")
+            ):
                 raise ValueError("startup terminal identity changed while setting fixture cwd")
             self._terminal_actual_ids["terminal-001"] = initial_terminal
             for index in range(2, terminals + 1):

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -1150,7 +1150,7 @@ class CmuxRuntimeAdapter:
             self.config.scenario, self._snapshot_contract(payload)
         )
         fingerprint = _strict_persisted_fingerprint(
-            self._runner.persisted_snapshot_fingerprint()
+            self._runner.persisted_snapshot_fingerprint(source="primary")
         )
         self._captured_persisted_fingerprint = fingerprint
         captured = _plain(payload)
@@ -1278,9 +1278,10 @@ class CmuxRuntimeAdapter:
         elapsed = self._runner.launch("restore")
         self._launched = True
         persisted_after = _strict_persisted_fingerprint(
-            self._runner.persisted_snapshot_fingerprint()
+            self._runner.persisted_snapshot_fingerprint(source="previous")
         )
         self._details["snapshot"]["persisted_after"] = deepcopy(persisted_after)
+        self._details["snapshot"]["persisted_after_source"] = "startup_previous_backup"
         if persisted_after != self._captured_persisted_fingerprint:
             raise ValueError("persisted snapshot fingerprint changed across restore")
         self._reconcile_restored_workspace()

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -865,27 +865,27 @@ class CmuxRuntimeAdapter:
         self, cycles: int
     ) -> list[tuple[str, dict[str, Any]]]:
         activations: dict[str, tuple[list[dict[str, Any]], list[dict[str, Any]]]] = {}
-        for planned, actual in self._browser_actual_ids.items():
-            activation_latencies: list[dict[str, Any]] = []
-            activation_evidence: list[dict[str, Any]] = []
-            latency, payload = self._timed_rpc(
-                "browser_surface_focus",
-                planned,
-                "surface.focus",
-                {"workspace_id": self._workspace_id, "surface_id": actual},
-            )
-            activation_latencies.append(latency)
-            activation_evidence.append(
-                {"label": "browser_surface_focus", "payload": payload}
-            )
-            activations[planned] = (activation_latencies, activation_evidence)
-
         results_by_planned: dict[str, dict[str, Any]] = {}
         with ThreadPoolExecutor(max_workers=max(1, len(self._browser_actual_ids))) as pool:
             futures = {
                 pool.submit(self._browser_churn, planned, actual, cycles): planned
                 for planned, actual in self._browser_actual_ids.items()
             }
+            for planned, actual in self._browser_actual_ids.items():
+                activation_latencies: list[dict[str, Any]] = []
+                activation_evidence: list[dict[str, Any]] = []
+                latency, payload = self._timed_rpc(
+                    "browser_surface_focus",
+                    planned,
+                    "surface.focus",
+                    {"workspace_id": self._workspace_id, "surface_id": actual},
+                )
+                activation_latencies.append(latency)
+                activation_evidence.append(
+                    {"label": "browser_surface_focus", "payload": payload}
+                )
+                activations[planned] = (activation_latencies, activation_evidence)
+
             for future in as_completed(futures):
                 results_by_planned[futures[future]] = future.result()
 

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -302,19 +302,6 @@ class CmuxRuntimeAdapter:
         self._launched = True
         self._details["invocation"]["launch_socket_ready_ms"] = elapsed
 
-    def _create_workspace(self) -> str:
-        payload = self._runner.json_cli(
-            [
-                "workspace",
-                "create",
-                "--name",
-                f"cmux-perf-{self.config.scenario['scenario_id']}",
-                "--cwd",
-                str(self.config.output_root),
-            ],
-            timeout=self.config.rpc_timeout_s,
-        )
-        return _extract_ref(payload, "workspace")
 
     def _new_surface(self, kind: str, *, url: str | None = None) -> str:
         if self._workspace_id is None or self._pane_id is None:
@@ -362,23 +349,20 @@ class CmuxRuntimeAdapter:
         before = self._runner.json_cli(
             ["list-workspaces"], timeout=self.config.rpc_timeout_s
         ).get("workspaces", [])
-        prior_workspaces = [
-            _extract_ref(item, "workspace")
-            for item in before
-            if isinstance(item, Mapping)
-        ]
-        self._workspace_id = self._create_workspace()
+        if not isinstance(before, list) or len(before) != 1 or not isinstance(before[0], Mapping):
+            raise ValueError("fixture requires exactly one clean startup workspace")
+        self._workspace_id = _extract_ref(before[0], "workspace")
         panes_payload = self._runner.json_cli(
             ["list-panes", "--workspace", self._workspace_id],
             timeout=self.config.rpc_timeout_s,
         )
         panes = panes_payload.get("panes", [])
         if not isinstance(panes, list) or len(panes) != 1:
-            raise ValueError("new fixture workspace must contain exactly one pane")
+            raise ValueError("clean startup workspace must contain exactly one pane")
         self._pane_id = _extract_ref(panes[0], "pane")
         initial_refs = panes[0].get("surface_ids") or panes[0].get("surface_refs") or []
         if not isinstance(initial_refs, list) or len(initial_refs) != 1:
-            raise ValueError("new fixture workspace must contain one initial terminal")
+            raise ValueError("clean startup workspace must contain one initial terminal")
         initial_terminal = initial_refs[0]
         if not isinstance(initial_terminal, str):
             raise ValueError("initial terminal reference is invalid")
@@ -409,13 +393,6 @@ class CmuxRuntimeAdapter:
                 timeout=self.config.rpc_timeout_s,
             )
 
-        for old in prior_workspaces:
-            if isinstance(old, str) and old != self._workspace_id:
-                self._runner.run_cli(
-                    ["close-workspace", "--workspace", old],
-                    timeout=self.config.rpc_timeout_s,
-                    check=False,
-                )
         self._runner.run_cli(
             ["select-workspace", "--workspace", self._workspace_id],
             timeout=self.config.rpc_timeout_s,

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -868,18 +868,16 @@ class CmuxRuntimeAdapter:
         for planned, actual in self._browser_actual_ids.items():
             activation_latencies: list[dict[str, Any]] = []
             activation_evidence: list[dict[str, Any]] = []
-            for label, method in (
-                ("browser_surface_focus", "surface.focus"),
-                ("browser_focus", "browser.focus_webview"),
-            ):
-                latency, payload = self._timed_rpc(
-                    label,
-                    planned,
-                    method,
-                    {"workspace_id": self._workspace_id, "surface_id": actual},
-                )
-                activation_latencies.append(latency)
-                activation_evidence.append({"label": label, "payload": payload})
+            latency, payload = self._timed_rpc(
+                "browser_surface_focus",
+                planned,
+                "surface.focus",
+                {"workspace_id": self._workspace_id, "surface_id": actual},
+            )
+            activation_latencies.append(latency)
+            activation_evidence.append(
+                {"label": "browser_surface_focus", "payload": payload}
+            )
             activations[planned] = (activation_latencies, activation_evidence)
 
         results_by_planned: dict[str, dict[str, Any]] = {}
@@ -976,7 +974,7 @@ class CmuxRuntimeAdapter:
                     "terminal_ansi_lines": len(self._terminal_actual_ids)
                     * self._terminal_ansi_line_target(),
                     "browser_churn_rpc_operations": len(self._browser_actual_ids)
-                    * (browser_cycles * 2 + 3),
+                    * (browser_cycles * 2 + 2),
                     "temporary_browser_open_close_operations": 2
                     if self._browser_actual_ids
                     else 0,

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -20,6 +20,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from types import MappingProxyType
 from typing import Any, Callable, Mapping
@@ -165,6 +166,13 @@ def _plain(value: Any) -> Any:
         return value
     raise ValueError(f"value is not JSON-friendly: {type(value).__name__}")
 
+class _ProfileCollectionError(RuntimeError):
+    def __init__(self, message: str, evidence: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.evidence = evidence
+
+
+
 
 def _make_default_runner(config: AdapterConfig) -> Any:
     runner_module = _load_sibling(
@@ -186,6 +194,23 @@ def _extract_ref(payload: Mapping[str, Any], kind: str) -> str:
         if isinstance(value, str) and value:
             return value
     raise ValueError(f"missing {kind} identity in {payload!r}")
+
+
+def _required_counter(stats: Mapping[str, Any], camel: str, snake: str) -> float:
+    if camel in stats:
+        value = stats[camel]
+    elif snake in stats:
+        value = stats[snake]
+    else:
+        raise ValueError(f"terminal render stats missing {camel}")
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) < 0.0
+    ):
+        raise ValueError(f"terminal render stats {camel} must be nonnegative and finite")
+    return float(value)
 
 
 def _surface_type(item: Mapping[str, Any]) -> str:
@@ -221,6 +246,7 @@ class CmuxRuntimeAdapter:
         self._browser_actual_ids: dict[str, str] = {}
         self._last_accounting: Any | None = None
         self._launched = False
+        self._owned_browser_screenshot_paths: set[Path] = set()
         self._details: dict[str, Any] = {
             "invocation": {
                 "sha": config.sha,
@@ -742,10 +768,31 @@ class CmuxRuntimeAdapter:
                 )
                 latencies.append(latency)
                 evidence.append({"label": label, "payload": payload})
+
+        screenshot_latency, screenshot = self._timed_rpc(
+            "browser_screenshot",
+            planned_id,
+            "browser.screenshot",
+            {"workspace_id": self._workspace_id, "surface_id": actual_id},
+        )
+        encoded_png = screenshot.get("png_base64")
+        if not isinstance(encoded_png, str) or not encoded_png:
+            raise ValueError(f"browser screenshot returned no PNG for {planned_id}")
+        latencies.append(screenshot_latency)
+        screenshot_evidence = {
+            key: value for key, value in screenshot.items() if key != "png_base64"
+        }
+        screenshot_evidence["png_base64_length"] = len(encoded_png)
         return {
-            "operations": cycles * len(methods),
+            "operations": cycles * len(methods) + 1,
             "latencies": latencies,
-            "evidence": {"actual_surface_id": actual_id, "cycles": evidence},
+            "render_observations": 1,
+            "owned_screenshot_path": screenshot.get("path"),
+            "evidence": {
+                "actual_surface_id": actual_id,
+                "cycles": evidence,
+                "screenshot": screenshot_evidence,
+            },
         }
 
     def _temporary_browser_cycle(self) -> dict[str, Any] | None:
@@ -809,6 +856,7 @@ class CmuxRuntimeAdapter:
         latencies: list[dict[str, Any]] = []
         evidence: list[dict[str, Any]] = []
         operation_counts = {"terminal": 0, "browser": 0}
+        browser_render_counts: dict[str, int] = {}
         profile_pool: ThreadPoolExecutor | None = None
         profile_futures: dict[Any, dict[str, Any]] = {}
         if self.config.profile_enabled:
@@ -816,11 +864,8 @@ class CmuxRuntimeAdapter:
                 work_units = {
                     "terminal_ansi_lines": len(self._terminal_actual_ids)
                     * self._terminal_ansi_line_target(),
-                    "browser_reload_snapshot_operations": len(
-                        self._browser_actual_ids
-                    )
-                    * cycles
-                    * 2,
+                    "browser_churn_rpc_operations": len(self._browser_actual_ids)
+                    * (cycles * 3 + 1),
                     "temporary_browser_open_close_operations": 2
                     if self._browser_actual_ids
                     else 0,
@@ -883,6 +928,22 @@ class CmuxRuntimeAdapter:
                     )
                     continue
                 operation_counts[kind] += result["operations"]
+                if kind == "browser":
+                    browser_render_counts[planned] = result["render_observations"]
+                    screenshot_path = result.get("owned_screenshot_path")
+                    if isinstance(screenshot_path, str) and screenshot_path:
+                        candidate = Path(screenshot_path).absolute()
+                        expected_root = (
+                            Path(tempfile.gettempdir()) / "cmux-browser-screenshots"
+                        ).resolve()
+                        if (
+                            candidate.parent.resolve() == expected_root
+                            and candidate.name.startswith("surface-")
+                            and candidate.suffix == ".png"
+                            and candidate.is_file()
+                            and not candidate.is_symlink()
+                        ):
+                            self._owned_browser_screenshot_paths.add(candidate)
                 latencies.extend(result["latencies"])
                 evidence.append(
                     {
@@ -911,14 +972,16 @@ class CmuxRuntimeAdapter:
             try:
                 profile_records.append(future.result())
             except BaseException as error:
-                failures.append(
-                    {
-                        "phase": "profile_churn",
-                        "role": metadata["role"],
-                        "pid": metadata["pid"],
-                        "message": str(error),
-                    }
-                )
+                failure = {
+                    "phase": "profile_churn",
+                    "role": metadata["role"],
+                    "pid": metadata["pid"],
+                    "message": str(error),
+                }
+                profile_evidence = getattr(error, "evidence", None)
+                if profile_evidence is not None:
+                    failure["evidence"] = _plain(profile_evidence)
+                failures.append(failure)
         if profile_pool is not None:
             profile_pool.shutdown(wait=True)
         if profile_records:
@@ -927,40 +990,46 @@ class CmuxRuntimeAdapter:
             )
 
         after_render = self._render_stats()
-        presents: list[dict[str, Any]] = []
+        render_observations: list[dict[str, Any]] = []
         for planned, actual in self._terminal_actual_ids.items():
             before = before_render.get(actual)
             after = after_render.get(actual)
             if not isinstance(before, Mapping) or not isinstance(after, Mapping):
                 raise ValueError(f"terminal render stats missing for {planned}")
-            present_delta = float(
-                after.get("presentCount", after.get("present_count", 0))
-            ) - float(before.get("presentCount", before.get("present_count", 0)))
-            draw_delta = float(
-                after.get("drawCount", after.get("draw_count", 0))
-            ) - float(before.get("drawCount", before.get("draw_count", 0)))
-            presents.append(
+            drawable_delta = _required_counter(
+                after, "metalDrawableCount", "metal_drawable_count"
+            ) - _required_counter(
+                before, "metalDrawableCount", "metal_drawable_count"
+            )
+            draw_delta = _required_counter(
+                after, "drawCount", "draw_count"
+            ) - _required_counter(before, "drawCount", "draw_count")
+            observed_final_key_change_delta = _required_counter(
+                after, "presentCount", "present_count"
+            ) - _required_counter(before, "presentCount", "present_count")
+            render_observations.append(
                 {
                     "surface_kind": "terminal",
                     "surface_id": planned,
-                    "measurement": "debug.terminal.render_stats",
-                    "present_delta": max(0.0, present_delta),
+                    "measurement": "debug.terminal.render_stats.metalDrawableCount_render_proxy",
+                    "render_delta": max(0.0, drawable_delta),
                     "draw_delta": max(0.0, draw_delta),
-                    "present_rate": max(0.0, present_delta)
-                    / churn_elapsed_s,
+                    "observed_final_key_change_delta": max(
+                        0.0, observed_final_key_change_delta
+                    ),
+                    "render_rate": max(0.0, drawable_delta) / churn_elapsed_s,
                 }
             )
         for planned in self._browser_actual_ids:
-            completed_presenting_operations = cycles * 2
-            presents.append(
+            completed_screenshots = browser_render_counts.get(planned, 0)
+            render_observations.append(
                 {
                     "surface_kind": "browser",
                     "surface_id": planned,
-                    "measurement": "completed_local_reload_snapshot_operations_proxy",
-                    "present_delta": completed_presenting_operations,
+                    "measurement": "completed_browser_screenshot_render_proxy",
+                    "render_delta": completed_screenshots,
                     "draw_delta": None,
-                    "present_rate": completed_presenting_operations
-                    / churn_elapsed_s,
+                    "render_rate": completed_screenshots / churn_elapsed_s,
                 }
             )
 
@@ -976,7 +1045,7 @@ class CmuxRuntimeAdapter:
                 latencies, key=lambda item: (item["surface_id"], item["label"])
             ),
             "throughput_ops_per_second": throughput,
-            "presents": presents,
+            "render_observations": render_observations,
             "failures": failures,
         }
         self._details["churn"] = {
@@ -1046,7 +1115,7 @@ class CmuxRuntimeAdapter:
 
     def cleanup_owned(self) -> dict[str, Any]:
         browser_fixture_root = self.config.output_root / "browser-fixtures"
-        runtime_paths = [browser_fixture_root]
+        runtime_paths = [browser_fixture_root, *self._owned_browser_screenshot_paths]
         runner_cleanup = getattr(self._runner, "cleanup_owned", None)
         if runner_cleanup is not None:
             runner_evidence = runner_cleanup()
@@ -1135,6 +1204,8 @@ class CmuxRuntimeAdapter:
         ]
 
     def _run_profile(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        profile_path = Path(metadata["path"])
+        profile_path.unlink(missing_ok=True)
         profile_callable = self._profiler or self._default_profile
         if callable(profile_callable):
             result = profile_callable(**metadata)
@@ -1142,7 +1213,17 @@ class CmuxRuntimeAdapter:
             result = profile_callable.sample(**metadata)
         else:
             raise TypeError("profiler must be callable or expose sample()")
-        return {**metadata, "result": _plain(result)}
+
+        record = {**metadata, "result": _plain(result)}
+        if isinstance(result, Mapping):
+            returncode = result.get("returncode")
+            if isinstance(returncode, int) and returncode != 0:
+                raise _ProfileCollectionError(
+                    f"profile command returned nonzero status {returncode}", record
+                )
+        if not profile_path.is_file() or profile_path.stat().st_size == 0:
+            raise _ProfileCollectionError("profile command produced empty output", record)
+        return record
 
     def collect_profiles(self) -> list[dict[str, Any]]:
         if not self.config.profile_enabled:
@@ -1236,21 +1317,21 @@ def extract_metrics(result: Any, raw_details: Mapping[str, Any] | None = None) -
             if present and isinstance(value, (int, float)) and not isinstance(value, bool):
                 metrics[f"{kind}_throughput_per_second"] = float(value)
 
-    presents = _field(result, "presents", [])
-    if isinstance(presents, (list, tuple)):
+    render_observations = _field(result, "render_observations", [])
+    if isinstance(render_observations, (list, tuple)):
         for kind, present in (("terminal", bool(terminals)), ("browser", bool(browsers))):
             if not present:
                 continue
             rates = [
-                float(_field(item, "present_rate"))
-                for item in presents
+                float(_field(item, "render_rate"))
+                for item in render_observations
                 if _field(item, "surface_kind") == kind
-                and isinstance(_field(item, "present_rate"), (int, float))
-                and not isinstance(_field(item, "present_rate"), bool)
+                and isinstance(_field(item, "render_rate"), (int, float))
+                and not isinstance(_field(item, "render_rate"), bool)
             ]
             value = _mean(rates)
             if value is not None:
-                metrics[f"{kind}_present_rate"] = value
+                metrics[f"{kind}_render_rate"] = value
     return metrics
 
 

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -30,6 +30,9 @@ from urllib.parse import unquote, urlparse
 _SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
 _MAX_TIMING_SECONDS = 300.0
 _PROCESS_GROUPS = ("parent_direct", "terminal", "webkit", "full_tree")
+_BROWSER_RECOVERY_RETRY = (
+    "browser surface stopped responding and was recovered. Retry the command."
+)
 
 
 def _load_sibling(module_name: str, filename: str | None = None) -> Any:
@@ -523,6 +526,24 @@ class CmuxRuntimeAdapter:
             raise ValueError("surface listing must be an array")
         return surfaces
 
+    def _wait_for_browser(self, actual_id: str) -> dict[str, Any]:
+        params = {
+            "workspace_id": self._workspace_id,
+            "surface_id": actual_id,
+            "load_state": "complete",
+            "timeout_ms": int(self.config.rpc_timeout_s * 1000),
+        }
+        try:
+            return self._runner.rpc(
+                "browser.wait", params, timeout=self.config.rpc_timeout_s
+            )
+        except Exception as error:
+            if _BROWSER_RECOVERY_RETRY not in str(error):
+                raise
+        return self._runner.rpc(
+            "browser.wait", params, timeout=self.config.rpc_timeout_s
+        )
+
     def observe_fixture(self) -> dict[str, Any]:
         if self._plan is None:
             raise RuntimeError("fixture has not been created")
@@ -545,16 +566,7 @@ class CmuxRuntimeAdapter:
         browser_evidence: list[dict[str, Any]] = []
         for planned_id, actual_id in self._browser_actual_ids.items():
             planned = planned_by_id[planned_id]
-            wait_payload = self._runner.rpc(
-                "browser.wait",
-                {
-                    "workspace_id": self._workspace_id,
-                    "surface_id": actual_id,
-                    "load_state": "complete",
-                    "timeout_ms": int(self.config.rpc_timeout_s * 1000),
-                },
-                timeout=self.config.rpc_timeout_s,
-            )
+            wait_payload = self._wait_for_browser(actual_id)
             url_payload = self._runner.rpc(
                 "browser.url.get",
                 {"workspace_id": self._workspace_id, "surface_id": actual_id},
@@ -1109,7 +1121,7 @@ class CmuxRuntimeAdapter:
             {"include_scrollback": True, "persist": True},
             timeout=self.config.rpc_timeout_s,
         )
-        _contract.validate_snapshot(
+        _contract.validate_runtime_snapshot(
             self.config.scenario, self._snapshot_contract(payload)
         )
         captured = _plain(payload)
@@ -1117,33 +1129,98 @@ class CmuxRuntimeAdapter:
         return captured
 
     def _reconcile_restored_workspace(self) -> None:
-        if self._workspace_id is None:
+        if self._workspace_id is None or self._plan is None:
             raise RuntimeError("fixture workspace is not initialized")
+        previous_workspace_id = self._workspace_id
+        previous_pane_id = self._pane_id
+        target_title = f"cmux-perf-{self.config.scenario['scenario_id']}"
         deadline = self._clock.monotonic() + self.config.rpc_timeout_s
         while True:
             workspaces = self._json_cli(["list-workspaces"]).get("workspaces", [])
-            workspace_ids = [
-                _extract_ref(item, "workspace")
-                for item in workspaces
-                if isinstance(item, Mapping)
-            ]
-            if self._workspace_id in workspace_ids:
-                self._runner.run_cli(
-                    ["select-workspace", "--workspace", self._workspace_id],
-                    timeout=self.config.rpc_timeout_s,
-                )
-                for workspace_id in workspace_ids:
-                    if workspace_id != self._workspace_id:
-                        self._close_workspace(workspace_id)
-                return
+            if not isinstance(workspaces, list) or any(
+                not isinstance(item, Mapping) for item in workspaces
+            ):
+                raise ValueError("restored workspace listing is invalid")
+            matches = [item for item in workspaces if item.get("title") == target_title]
+            if len(matches) > 1:
+                raise ValueError("restored fixture workspace title is not unique")
+            if len(matches) == 1:
+                break
             if self._clock.monotonic() >= deadline:
                 raise ValueError("restored fixture workspace did not appear before timeout")
             self._clock.sleep(0.1)
 
-    def restore(self, snapshot: Any) -> None:
-        _contract.validate_snapshot(
-            self.config.scenario, self._snapshot_contract(snapshot)
+        restored_workspace_id = _extract_ref(matches[0], "workspace")
+        workspace_ids = [_extract_ref(item, "workspace") for item in workspaces]
+        self._workspace_id = restored_workspace_id
+        self._runner.run_cli(
+            ["select-workspace", "--workspace", restored_workspace_id],
+            timeout=self.config.rpc_timeout_s,
         )
+        for workspace_id in workspace_ids:
+            if workspace_id != restored_workspace_id:
+                self._close_workspace(workspace_id)
+
+        panes = self._json_cli(
+            ["list-panes", "--workspace", restored_workspace_id]
+        ).get("panes", [])
+        if not isinstance(panes, list) or len(panes) != 1 or not isinstance(panes[0], Mapping):
+            raise ValueError("restored fixture workspace must contain exactly one pane")
+        restored_pane_id = _extract_ref(panes[0], "pane")
+        self._pane_id = restored_pane_id
+        surface_payload = self._json_cli(
+            [
+                "list-pane-surfaces",
+                "--workspace",
+                restored_workspace_id,
+                "--pane",
+                restored_pane_id,
+            ]
+        )
+        if any(key in surface_payload for key in ("pane_id", "pane_ref")) and not any(
+            surface_payload.get(key) == restored_pane_id
+            for key in ("pane_id", "pane_ref")
+        ):
+            raise ValueError("restored surface listing came from the wrong pane")
+        surfaces = surface_payload.get("surfaces", [])
+        if not isinstance(surfaces, list) or any(
+            not isinstance(item, Mapping) for item in surfaces
+        ):
+            raise ValueError("restored surface listing must be an array")
+        terminal_ids = [
+            _extract_ref(item, "surface")
+            for item in surfaces
+            if _surface_type(item) == "terminal"
+        ]
+        browser_ids = [
+            _extract_ref(item, "surface")
+            for item in surfaces
+            if _surface_type(item) == "browser"
+        ]
+        if (
+            len(terminal_ids) != len(self._terminal_actual_ids)
+            or len(browser_ids) != len(self._browser_actual_ids)
+            or len(surfaces) != len(terminal_ids) + len(browser_ids)
+        ):
+            raise ValueError("restored surface topology does not match the fixture plan")
+        self._terminal_actual_ids = dict(
+            zip(self._terminal_actual_ids, terminal_ids)
+        )
+        self._browser_actual_ids = dict(
+            zip(self._browser_actual_ids, browser_ids)
+        )
+        self._details["snapshot"]["restored_rebinding"] = {
+            "previous_workspace_id": previous_workspace_id,
+            "restored_workspace_id": restored_workspace_id,
+            "previous_pane_id": previous_pane_id,
+            "restored_pane_id": restored_pane_id,
+            "terminal_planned_to_actual": dict(self._terminal_actual_ids),
+            "browser_planned_to_actual": dict(self._browser_actual_ids),
+        }
+
+    def restore(self, snapshot: Any) -> None:
+        captured_contract = self._snapshot_contract(snapshot)
+        _contract.validate_runtime_snapshot(self.config.scenario, captured_contract)
         self._runner.stop_app()
         self._launched = False
         elapsed = self._runner.launch("restore")
@@ -1154,9 +1231,9 @@ class CmuxRuntimeAdapter:
             {"include_scrollback": True, "persist": True},
             timeout=self.config.rpc_timeout_s,
         )
-        _contract.validate_snapshot(
-            self.config.scenario, self._snapshot_contract(restored)
-        )
+        restored_contract = self._snapshot_contract(restored)
+        _contract.validate_runtime_snapshot(self.config.scenario, restored_contract)
+        _contract.validate_restored_snapshot(captured_contract, restored_contract)
         identity = self.observe_fixture()
         self._details["snapshot"]["restored"] = {
             "launch_socket_ready_ms": elapsed,

--- a/scripts/perf_cmux_adapter.py
+++ b/scripts/perf_cmux_adapter.py
@@ -381,24 +381,39 @@ class CmuxRuntimeAdapter:
         self._terminal_actual_ids.clear()
         self._browser_actual_ids.clear()
         terminals = expected["terminal_surfaces"]
-        for index in range(1, terminals + 1):
-            self._terminal_actual_ids[f"terminal-{index:03d}"] = self._new_surface(
-                "terminal"
+        if terminals:
+            respawned = self._runner.rpc(
+                "surface.respawn",
+                {
+                    "workspace_id": self._workspace_id,
+                    "surface_id": initial_terminal,
+                    "working_directory": str(self.config.output_root),
+                    "focus": False,
+                },
+                timeout=self.config.rpc_timeout_s,
             )
+            if _extract_ref(respawned, "surface") != initial_terminal:
+                raise ValueError("startup terminal identity changed while setting fixture cwd")
+            self._terminal_actual_ids["terminal-001"] = initial_terminal
+            for index in range(2, terminals + 1):
+                self._terminal_actual_ids[f"terminal-{index:03d}"] = self._new_surface(
+                    "terminal"
+                )
         for browser in plan.browser_surfaces:
             self._browser_actual_ids[browser.surface_id] = self._new_surface(
                 "browser", url=browser.url
             )
-        self._runner.run_cli(
-            [
-                "close-surface",
-                "--workspace",
-                self._workspace_id,
-                "--surface",
-                initial_terminal,
-            ],
-            timeout=self.config.rpc_timeout_s,
-        )
+        if terminals == 0:
+            self._runner.run_cli(
+                [
+                    "close-surface",
+                    "--workspace",
+                    self._workspace_id,
+                    "--surface",
+                    initial_terminal,
+                ],
+                timeout=self.config.rpc_timeout_s,
+            )
 
         self._runner.run_cli(
             ["select-workspace", "--workspace", self._workspace_id],

--- a/scripts/perf_mixed_workload.py
+++ b/scripts/perf_mixed_workload.py
@@ -8,6 +8,7 @@ from html import escape
 from pathlib import Path
 import re
 from types import TracebackType
+import traceback
 from typing import Any, Mapping, Protocol, Sequence
 
 
@@ -265,6 +266,28 @@ def _validate_invocation_inputs(
     return _validate_requested_shape(requested_shape)
 
 
+def _cleanup_failure_evidence(
+    failures: Sequence[tuple[str, BaseException]],
+) -> list[dict[str, str]]:
+    return [
+        {
+            "phase": phase,
+            "type": type(error).__name__,
+            "message": str(error),
+            "traceback": "".join(traceback.format_exception(error)).rstrip(),
+        }
+        for phase, error in failures
+    ]
+
+
+def _attach_cleanup_failures(
+    error: BaseException, failures: Sequence[tuple[str, BaseException]]
+) -> list[dict[str, str]]:
+    evidence = _cleanup_failure_evidence(failures)
+    error.cleanup_failures = evidence
+    return evidence
+
+
 def run_invocation(
     *,
     scenario_id: str,
@@ -320,25 +343,41 @@ def run_invocation(
         primary_error = error
         primary_traceback = error.__traceback__
     finally:
-        cleanup_error: BaseException | None = None
-        cleanup_traceback: TracebackType | None = None
+        cleanup_errors: list[tuple[str, BaseException]] = []
         try:
             adapter.stop()
         except BaseException as error:
-            cleanup_error = error
-            cleanup_traceback = error.__traceback__
+            cleanup_errors.append(("adapter.stop()", error))
         try:
             cleanup = adapter.cleanup_owned()
         except BaseException as error:
-            if cleanup_error is None:
-                cleanup_error = error
-                cleanup_traceback = error.__traceback__
-        if primary_error is None and cleanup_error is not None:
-            primary_error = cleanup_error
-            primary_traceback = cleanup_traceback
+            cleanup_errors.append(("adapter.cleanup_owned()", error))
 
     if primary_error is not None:
+        cleanup_failure_evidence = _attach_cleanup_failures(
+            primary_error, cleanup_errors
+        )
+        for failure in cleanup_failure_evidence:
+            primary_error.add_note(
+                f"Invocation cleanup failed during {failure['phase']}:\n"
+                f"{failure['traceback']}"
+            )
         raise primary_error.with_traceback(primary_traceback)
+    if len(cleanup_errors) == 1:
+        phase, error = cleanup_errors[0]
+        _attach_cleanup_failures(error, cleanup_errors)
+        error.add_note(f"Invocation cleanup phase: {phase}")
+        raise error.with_traceback(error.__traceback__)
+    if cleanup_errors:
+        for phase, error in cleanup_errors:
+            error.add_note(f"Invocation cleanup phase: {phase}")
+        grouped_error = BaseExceptionGroup(
+            "multiple invocation cleanup failures",
+            [error for _, error in cleanup_errors],
+        )
+        _attach_cleanup_failures(grouped_error, cleanup_errors)
+        raise grouped_error
+
     if result_values is None:
         raise RuntimeError("invocation completed without observations")
 

--- a/scripts/perf_mixed_workload.py
+++ b/scripts/perf_mixed_workload.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Pure fixture planning and adapter-driven mixed-workload orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+import re
+from types import TracebackType
+from typing import Any, Mapping, Protocol, Sequence
+
+
+_SHA_PATTERN = re.compile(r"[0-9a-fA-F]{40}\Z")
+_SHAPE_FIELDS = frozenset({"terminal_surfaces", "browser_surfaces"})
+_BROWSER_IDENTITY_FIELDS = frozenset(
+    {"surface_id", "url", "title", "content_marker"}
+)
+_KNOWN_ORDERS = frozenset({"AB", "BA"})
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserSurface:
+    """Stable identity for one owned local browser fixture."""
+
+    surface_id: str
+    url: str
+    title: str
+    content_marker: str
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserFixturePlan:
+    """Immutable plan for browser surfaces in one scenario."""
+
+    scenario_id: str
+    terminal_count: int
+    browser_count: int
+    browser_surfaces: tuple[BrowserSurface, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class InvocationResult:
+    """Raw observations produced by one completely cleaned-up invocation."""
+
+    scenario_id: str
+    sha: str
+    order: str
+    repetition: int
+    requested_shape: Mapping[str, int]
+    observed_shape: Mapping[str, int]
+    steady_samples: Any
+    churn_samples: Any
+    latencies_ms: Any
+    throughput_ops_per_second: Any
+    presents: Any
+    failures: Any
+    cleanup: Any
+
+
+class RuntimeAdapter(Protocol):
+    """Synchronous side-effect seam used by :func:`run_invocation`."""
+
+    def clean_state(self) -> None: ...
+
+    def launch(self, sha: str) -> None: ...
+
+    def create_fixture(self, plan: BrowserFixturePlan) -> None: ...
+
+    def observe_fixture(self) -> Mapping[str, Any]: ...
+
+    def sample_steady(self) -> Any: ...
+
+    def run_churn(self, operations: list[dict[str, Any]]) -> Mapping[str, Any]: ...
+
+    def snapshot(self) -> Any: ...
+
+    def restore(self, snapshot: Any) -> None: ...
+
+    def stop(self) -> None: ...
+
+    def cleanup_owned(self) -> Any: ...
+
+
+def _require_nonnegative_exact_int(value: Any, name: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{name} must be a nonnegative integer")
+    return value
+
+
+def _validate_scenario_id(scenario_id: Any) -> str:
+    if type(scenario_id) is not str or not scenario_id:
+        raise ValueError("scenario_id must be a nonempty string")
+    return scenario_id
+
+
+def _validate_requested_shape(requested_shape: Any) -> Mapping[str, int]:
+    if not isinstance(requested_shape, Mapping):
+        raise ValueError("requested_shape must be a mapping")
+    if set(requested_shape) != _SHAPE_FIELDS:
+        raise ValueError(
+            "requested_shape must contain exactly terminal_surfaces and "
+            "browser_surfaces"
+        )
+    _require_nonnegative_exact_int(
+        requested_shape["terminal_surfaces"], "terminal_surfaces"
+    )
+    _require_nonnegative_exact_int(
+        requested_shape["browser_surfaces"], "browser_surfaces"
+    )
+    return requested_shape
+
+
+def build_browser_fixture_plan(
+    *,
+    scenario_id: str,
+    terminal_count: int,
+    browser_count: int,
+    owned_root: Path,
+) -> BrowserFixturePlan:
+    """Create deterministic local HTML fixtures and return their stable plan."""
+
+    scenario_id = _validate_scenario_id(scenario_id)
+    terminal_count = _require_nonnegative_exact_int(terminal_count, "terminal_count")
+    browser_count = _require_nonnegative_exact_int(browser_count, "browser_count")
+
+    fixture_root = Path(owned_root).resolve() / "browser-fixtures"
+    fixture_root.mkdir(parents=True, exist_ok=True)
+    surfaces: list[BrowserSurface] = []
+    for index in range(1, browser_count + 1):
+        ordinal = f"{index:03d}"
+        surface_id = f"browser-{scenario_id}-{ordinal}"
+        title = f"cmux perf {scenario_id} browser {ordinal}"
+        content_marker = f"cmux-perf:scenario={scenario_id};surface=browser-{ordinal}"
+        fixture_path = fixture_root / f"browser-{ordinal}.html"
+        html = (
+            "<!doctype html>\n"
+            '<html lang="en">\n'
+            "<head>\n"
+            '  <meta charset="utf-8">\n'
+            f"  <title>{escape(title)}</title>\n"
+            "</head>\n"
+            "<body>\n"
+            f"  <main>{escape(content_marker)}</main>\n"
+            "</body>\n"
+            "</html>\n"
+        )
+        fixture_path.write_text(html, encoding="utf-8")
+        surfaces.append(
+            BrowserSurface(
+                surface_id=surface_id,
+                url=fixture_path.as_uri(),
+                title=title,
+                content_marker=content_marker,
+            )
+        )
+
+    return BrowserFixturePlan(
+        scenario_id=scenario_id,
+        terminal_count=terminal_count,
+        browser_count=browser_count,
+        browser_surfaces=tuple(surfaces),
+    )
+
+
+def validate_browser_observations(
+    plan: BrowserFixturePlan, observations: Any
+) -> None:
+    """Require an ordered, exact identity match for every planned browser."""
+
+    if type(observations) is not list:
+        raise ValueError("browser observations must be a list")
+    if len(observations) != len(plan.browser_surfaces):
+        raise ValueError("browser observation count does not match the fixture plan")
+
+    for index, (planned, observed) in enumerate(
+        zip(plan.browser_surfaces, observations, strict=True)
+    ):
+        if type(observed) is not dict:
+            raise ValueError(f"browser observation {index} must be a dictionary")
+        if set(observed) != _BROWSER_IDENTITY_FIELDS:
+            raise ValueError(
+                f"browser observation {index} must contain exactly the identity fields"
+            )
+        for field in _BROWSER_IDENTITY_FIELDS:
+            if observed[field] != getattr(planned, field):
+                raise ValueError(
+                    f"browser observation {index} has mismatched {field}"
+                )
+
+
+def build_churn_operations(
+    plan: BrowserFixturePlan,
+) -> list[dict[str, Any]]:
+    """Build the deterministic churn sequence for the available surfaces."""
+
+    operations: list[dict[str, Any]] = []
+    if plan.terminal_count:
+        operations.append(
+            {
+                "operation": "activate",
+                "surface_kind": "terminal",
+                "surface_id": "terminal-001",
+            }
+        )
+    if plan.browser_surfaces:
+        operations.append(
+            {
+                "operation": "activate",
+                "surface_kind": "browser",
+                "surface_id": plan.browser_surfaces[0].surface_id,
+            }
+        )
+    if plan.terminal_count:
+        terminal_index = min(2, plan.terminal_count)
+        terminal_id = f"terminal-{terminal_index:03d}"
+        operations.append(
+            {
+                "operation": "terminal_input",
+                "surface_id": terminal_id,
+                "payload": (
+                    f"printf 'cmux-perf-churn:{plan.scenario_id}:"
+                    f"{terminal_id}\\n'"
+                ),
+            }
+        )
+    if plan.browser_surfaces:
+        browser_index = min(2, len(plan.browser_surfaces)) - 1
+        operations.append(
+            {
+                "operation": "browser_reload",
+                "surface_id": plan.browser_surfaces[browser_index].surface_id,
+            }
+        )
+    return operations
+
+
+def _validate_fixture_observation(
+    plan: BrowserFixturePlan,
+    requested_shape: Mapping[str, int],
+    observation: Any,
+) -> Mapping[str, int]:
+    if type(observation) is not dict or set(observation) != {"shape", "browsers"}:
+        raise ValueError("fixture observation must contain exactly shape and browsers")
+    observed_shape = _validate_requested_shape(observation["shape"])
+    if observed_shape != requested_shape:
+        raise ValueError("observed fixture shape does not match requested shape")
+    validate_browser_observations(plan, observation["browsers"])
+    return observed_shape
+
+
+def _validate_invocation_inputs(
+    scenario_id: Any,
+    sha: Any,
+    order: Any,
+    repetition: Any,
+    requested_shape: Any,
+) -> Mapping[str, int]:
+    _validate_scenario_id(scenario_id)
+    if type(sha) is not str or _SHA_PATTERN.fullmatch(sha) is None:
+        raise ValueError("sha must be exactly 40 hexadecimal characters")
+    if order not in _KNOWN_ORDERS or type(order) is not str:
+        raise ValueError(f"order must be one of {sorted(_KNOWN_ORDERS)}")
+    _require_nonnegative_exact_int(repetition, "repetition")
+    return _validate_requested_shape(requested_shape)
+
+
+def run_invocation(
+    *,
+    scenario_id: str,
+    sha: str,
+    order: str,
+    repetition: int,
+    requested_shape: Mapping[str, int],
+    owned_root: Path,
+    adapter: RuntimeAdapter,
+) -> InvocationResult:
+    """Run one invocation, preserving adapter data and always cleaning up."""
+
+    primary_error: BaseException | None = None
+    primary_traceback: TracebackType | None = None
+    cleanup: Any = None
+    result_values: dict[str, Any] | None = None
+
+    try:
+        requested_shape = _validate_invocation_inputs(
+            scenario_id, sha, order, repetition, requested_shape
+        )
+        adapter.clean_state()
+        adapter.launch(sha)
+        plan = build_browser_fixture_plan(
+            scenario_id=scenario_id,
+            terminal_count=requested_shape["terminal_surfaces"],
+            browser_count=requested_shape["browser_surfaces"],
+            owned_root=owned_root,
+        )
+        adapter.create_fixture(plan)
+
+        initial_observation = adapter.observe_fixture()
+        observed_shape = _validate_fixture_observation(
+            plan, requested_shape, initial_observation
+        )
+        steady_samples = adapter.sample_steady()
+        churn = adapter.run_churn(build_churn_operations(plan))
+        snapshot = adapter.snapshot()
+        adapter.restore(snapshot)
+        restored_observation = adapter.observe_fixture()
+        _validate_fixture_observation(plan, requested_shape, restored_observation)
+
+        result_values = {
+            "observed_shape": observed_shape,
+            "steady_samples": steady_samples,
+            "churn_samples": churn["samples"],
+            "latencies_ms": churn["latencies_ms"],
+            "throughput_ops_per_second": churn["throughput_ops_per_second"],
+            "presents": churn["presents"],
+            "failures": churn["failures"],
+        }
+    except BaseException as error:
+        primary_error = error
+        primary_traceback = error.__traceback__
+    finally:
+        cleanup_error: BaseException | None = None
+        cleanup_traceback: TracebackType | None = None
+        try:
+            adapter.stop()
+        except BaseException as error:
+            cleanup_error = error
+            cleanup_traceback = error.__traceback__
+        try:
+            cleanup = adapter.cleanup_owned()
+        except BaseException as error:
+            if cleanup_error is None:
+                cleanup_error = error
+                cleanup_traceback = error.__traceback__
+        if primary_error is None and cleanup_error is not None:
+            primary_error = cleanup_error
+            primary_traceback = cleanup_traceback
+
+    if primary_error is not None:
+        raise primary_error.with_traceback(primary_traceback)
+    if result_values is None:
+        raise RuntimeError("invocation completed without observations")
+
+    return InvocationResult(
+        scenario_id=scenario_id,
+        sha=sha,
+        order=order,
+        repetition=repetition,
+        requested_shape=requested_shape,
+        cleanup=cleanup,
+        **result_values,
+    )

--- a/scripts/perf_mixed_workload.py
+++ b/scripts/perf_mixed_workload.py
@@ -53,7 +53,7 @@ class InvocationResult:
     churn_samples: Any
     latencies_ms: Any
     throughput_ops_per_second: Any
-    presents: Any
+    render_observations: Any
     failures: Any
     cleanup: Any
 
@@ -313,7 +313,7 @@ def run_invocation(
             "churn_samples": churn["samples"],
             "latencies_ms": churn["latencies_ms"],
             "throughput_ops_per_second": churn["throughput_ops_per_second"],
-            "presents": churn["presents"],
+            "render_observations": churn["render_observations"],
             "failures": churn["failures"],
         }
     except BaseException as error:

--- a/scripts/perf_mixed_workload_contract.py
+++ b/scripts/perf_mixed_workload_contract.py
@@ -271,3 +271,56 @@ def validate_snapshot(
         actual_value = actual_shape[field]
         if type(actual_value) is not int or actual_value != expected_value:
             raise ValueError(f"snapshot shape field {field!r} does not match the contract")
+
+
+def validate_runtime_snapshot(
+    scenario: Scenario | Mapping[str, Any],
+    snapshot: SnapshotExpectation | Mapping[str, Any],
+) -> None:
+    """Validate live topology while accepting captured terminal scrollback growth."""
+    actual = _strict_snapshot_dict(snapshot)
+    expected = expected_snapshot(scenario).to_dict()
+
+    for flag in ("built", "include_scrollback", "persist", "saved"):
+        if type(actual[flag]) is not bool or actual[flag] is not expected[flag]:
+            raise ValueError(f"snapshot flag {flag!r} does not match the runtime contract")
+
+    actual_shape = actual["shape"]
+    expected_shape = expected["shape"]
+    for field, expected_value in expected_shape.items():
+        actual_value = actual_shape[field]
+        if field == "scrollback_chars":
+            if type(actual_value) is not int or actual_value < 0:
+                raise ValueError(
+                    "snapshot shape field 'scrollback_chars' must be a nonnegative integer"
+                )
+        elif type(actual_value) is not int or actual_value != expected_value:
+            raise ValueError(
+                f"snapshot shape field {field!r} does not match the runtime contract"
+            )
+
+
+def validate_restored_snapshot(
+    captured: SnapshotExpectation | Mapping[str, Any],
+    restored: SnapshotExpectation | Mapping[str, Any],
+) -> None:
+    """Require restoration to reproduce the exact captured persisted shape."""
+    captured_value = _strict_snapshot_dict(captured)
+    restored_value = _strict_snapshot_dict(restored)
+
+    for flag in ("built", "include_scrollback", "persist", "saved"):
+        if (
+            type(captured_value[flag]) is not bool
+            or type(restored_value[flag]) is not bool
+            or restored_value[flag] is not captured_value[flag]
+        ):
+            raise ValueError(f"restored snapshot flag {flag!r} changed")
+
+    for field, captured_field in captured_value["shape"].items():
+        restored_field = restored_value["shape"][field]
+        if (
+            type(captured_field) is not int
+            or type(restored_field) is not int
+            or restored_field != captured_field
+        ):
+            raise ValueError(f"restored snapshot shape field {field!r} changed")

--- a/scripts/perf_mixed_workload_contract.py
+++ b/scripts/perf_mixed_workload_contract.py
@@ -300,27 +300,3 @@ def validate_runtime_snapshot(
             )
 
 
-def validate_restored_snapshot(
-    captured: SnapshotExpectation | Mapping[str, Any],
-    restored: SnapshotExpectation | Mapping[str, Any],
-) -> None:
-    """Require restoration to reproduce the exact captured persisted shape."""
-    captured_value = _strict_snapshot_dict(captured)
-    restored_value = _strict_snapshot_dict(restored)
-
-    for flag in ("built", "include_scrollback", "persist", "saved"):
-        if (
-            type(captured_value[flag]) is not bool
-            or type(restored_value[flag]) is not bool
-            or restored_value[flag] is not captured_value[flag]
-        ):
-            raise ValueError(f"restored snapshot flag {flag!r} changed")
-
-    for field, captured_field in captured_value["shape"].items():
-        restored_field = restored_value["shape"][field]
-        if (
-            type(captured_field) is not int
-            or type(restored_field) is not int
-            or restored_field != captured_field
-        ):
-            raise ValueError(f"restored snapshot shape field {field!r} changed")

--- a/scripts/perf_mixed_workload_contract.py
+++ b/scripts/perf_mixed_workload_contract.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Pure contracts for the mixed terminal/browser performance experiment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any, Mapping
+
+
+_SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
+_LOADS = ("light", "realistic", "heavy")
+
+
+@dataclass(frozen=True)
+class Scenario:
+    scenario_id: str
+    kind: str
+    load: str
+    terminal_surfaces: int
+    browser_surfaces: int
+    aggregate_scrollback_chars: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "kind": self.kind,
+            "load": self.load,
+            "terminal_surfaces": self.terminal_surfaces,
+            "browser_surfaces": self.browser_surfaces,
+            "aggregate_scrollback_chars": self.aggregate_scrollback_chars,
+        }
+
+
+@dataclass(frozen=True)
+class Invocation:
+    variant: str
+    sha: str
+    recreate_process: bool = True
+    recreate_fixture: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "variant": self.variant,
+            "sha": self.sha,
+            "recreate_process": self.recreate_process,
+            "recreate_fixture": self.recreate_fixture,
+        }
+
+
+@dataclass(frozen=True)
+class RunPlan:
+    scenario_id: str
+    order: str
+    warmup: bool
+    repetition: int
+    invocations: tuple[Invocation, Invocation]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "order": self.order,
+            "warmup": self.warmup,
+            "repetition": self.repetition,
+            "invocations": [invocation.to_dict() for invocation in self.invocations],
+        }
+
+
+@dataclass(frozen=True)
+class SnapshotShape:
+    windows: int
+    workspaces: int
+    panels: int
+    terminals: int
+    browsers: int
+    markdown: int
+    scrollback_chars: int
+    status_entries: int
+    log_entries: int
+    progress_entries: int
+    git_entries: int
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "windows": self.windows,
+            "workspaces": self.workspaces,
+            "panels": self.panels,
+            "terminals": self.terminals,
+            "browsers": self.browsers,
+            "markdown": self.markdown,
+            "scrollback_chars": self.scrollback_chars,
+            "status_entries": self.status_entries,
+            "log_entries": self.log_entries,
+            "progress_entries": self.progress_entries,
+            "git_entries": self.git_entries,
+        }
+
+
+@dataclass(frozen=True)
+class SnapshotExpectation:
+    built: bool
+    include_scrollback: bool
+    persist: bool
+    saved: bool
+    shape: SnapshotShape
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "built": self.built,
+            "include_scrollback": self.include_scrollback,
+            "persist": self.persist,
+            "saved": self.saved,
+            "shape": self.shape.to_dict(),
+        }
+
+
+def scenario_matrix() -> tuple[Scenario, ...]:
+    """Return the fixed benchmark matrix in deterministic kind/load order."""
+    surface_counts = {
+        "terminal": ((4, 0), (16, 0), (40, 0)),
+        "browser": ((0, 1), (0, 4), (0, 12)),
+        "mixed": ((2, 1), (8, 4), (20, 12)),
+    }
+    scrollback_by_load = {
+        "light": 100_000,
+        "realistic": 1_000_000,
+        "heavy": 3_000_000,
+    }
+
+    scenarios: list[Scenario] = []
+    for kind, counts in surface_counts.items():
+        for load, (terminal_surfaces, browser_surfaces) in zip(_LOADS, counts):
+            scenarios.append(
+                Scenario(
+                    scenario_id=f"{kind}-{load}",
+                    kind=kind,
+                    load=load,
+                    terminal_surfaces=terminal_surfaces,
+                    browser_surfaces=browser_surfaces,
+                    aggregate_scrollback_chars=(
+                        scrollback_by_load[load] if terminal_surfaces else 0
+                    ),
+                )
+            )
+    return tuple(scenarios)
+
+
+def _validate_sha(name: str, sha: str) -> None:
+    if not isinstance(sha, str) or _SHA_RE.fullmatch(sha) is None:
+        raise ValueError(f"{name} must be exactly 40 hexadecimal characters")
+
+
+def build_experiment_plan(
+    baseline_sha: str,
+    candidate_sha: str,
+) -> tuple[RunPlan, ...]:
+    """Build warmup plus three measured repetitions for both AB/BA orders."""
+    _validate_sha("baseline_sha", baseline_sha)
+    _validate_sha("candidate_sha", candidate_sha)
+    if baseline_sha.casefold() == candidate_sha.casefold():
+        raise ValueError("baseline_sha and candidate_sha must identify distinct commits")
+
+    variants = {
+        "A": Invocation("A", baseline_sha),
+        "B": Invocation("B", candidate_sha),
+    }
+    runs: list[RunPlan] = []
+    for scenario in scenario_matrix():
+        for order in ("AB", "BA"):
+            invocations = (variants[order[0]], variants[order[1]])
+            for repetition in range(4):
+                runs.append(
+                    RunPlan(
+                        scenario_id=scenario.scenario_id,
+                        order=order,
+                        warmup=repetition == 0,
+                        repetition=repetition,
+                        invocations=invocations,
+                    )
+                )
+    return tuple(runs)
+
+
+def _scenario_field(scenario: Scenario | Mapping[str, Any], name: str) -> Any:
+    if isinstance(scenario, Scenario):
+        return getattr(scenario, name)
+    if isinstance(scenario, Mapping):
+        try:
+            return scenario[name]
+        except KeyError as error:
+            raise ValueError(f"scenario is missing {name!r}") from error
+    raise ValueError("scenario must be a Scenario or mapping")
+
+
+def expected_snapshot(
+    scenario: Scenario | Mapping[str, Any],
+) -> SnapshotExpectation:
+    """Return the exact persisted fixture shape for one scenario."""
+    terminals = _scenario_field(scenario, "terminal_surfaces")
+    browsers = _scenario_field(scenario, "browser_surfaces")
+    scrollback_chars = _scenario_field(scenario, "aggregate_scrollback_chars")
+    for name, value in (
+        ("terminal_surfaces", terminals),
+        ("browser_surfaces", browsers),
+        ("aggregate_scrollback_chars", scrollback_chars),
+    ):
+        if type(value) is not int or value < 0:
+            raise ValueError(f"scenario {name} must be a non-negative integer")
+
+    return SnapshotExpectation(
+        built=True,
+        include_scrollback=True,
+        persist=True,
+        saved=True,
+        shape=SnapshotShape(
+            windows=1,
+            workspaces=1,
+            panels=terminals + browsers,
+            terminals=terminals,
+            browsers=browsers,
+            markdown=0,
+            scrollback_chars=scrollback_chars,
+            status_entries=0,
+            log_entries=0,
+            progress_entries=0,
+            git_entries=0,
+        ),
+    )
+
+
+def _strict_snapshot_dict(snapshot: SnapshotExpectation | Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(snapshot, SnapshotExpectation):
+        return snapshot.to_dict()
+    if not isinstance(snapshot, Mapping):
+        raise ValueError("snapshot must be a SnapshotExpectation or mapping")
+
+    expected_top_keys = {"built", "include_scrollback", "persist", "saved", "shape"}
+    if set(snapshot.keys()) != expected_top_keys:
+        raise ValueError("snapshot fields do not match the expected contract")
+    shape = snapshot["shape"]
+    if not isinstance(shape, Mapping):
+        raise ValueError("snapshot shape must be a mapping")
+    expected_shape_keys = set(SnapshotShape.__dataclass_fields__)
+    if set(shape.keys()) != expected_shape_keys:
+        raise ValueError("snapshot shape fields do not match the expected contract")
+
+    return {
+        "built": snapshot["built"],
+        "include_scrollback": snapshot["include_scrollback"],
+        "persist": snapshot["persist"],
+        "saved": snapshot["saved"],
+        "shape": {key: shape[key] for key in SnapshotShape.__dataclass_fields__},
+    }
+
+
+def validate_snapshot(
+    scenario: Scenario | Mapping[str, Any],
+    snapshot: SnapshotExpectation | Mapping[str, Any],
+) -> None:
+    """Reject any flag, field, type, or fixture-shape deviation."""
+    actual = _strict_snapshot_dict(snapshot)
+    expected = expected_snapshot(scenario).to_dict()
+
+    for flag in ("built", "include_scrollback", "persist", "saved"):
+        if type(actual[flag]) is not bool or actual[flag] is not expected[flag]:
+            raise ValueError(f"snapshot flag {flag!r} does not match the contract")
+
+    actual_shape = actual["shape"]
+    expected_shape = expected["shape"]
+    for field, expected_value in expected_shape.items():
+        actual_value = actual_shape[field]
+        if type(actual_value) is not int or actual_value != expected_value:
+            raise ValueError(f"snapshot shape field {field!r} does not match the contract")

--- a/scripts/perf_mixed_workload_driver.py
+++ b/scripts/perf_mixed_workload_driver.py
@@ -686,6 +686,18 @@ def _invocation_result_evidence(result: Any) -> dict[str, Any]:
     return {name: _plain_json(getattr(result, name)) for name in fields}
 
 
+def _scenario_timing(scenario: Any) -> dict[str, float]:
+    workload_duration_s = 5.0
+    measurement_duration_s = (
+        12.0 if getattr(scenario, "scenario_id", None) == "mixed-heavy" else 5.0
+    )
+    return {
+        "churn_duration_s": workload_duration_s,
+        "churn_measurement_duration_s": measurement_duration_s,
+        "profile_duration_s": measurement_duration_s,
+    }
+
+
 def build_platform_run_variant(
     *,
     output_root: Path | str,
@@ -710,6 +722,7 @@ def build_platform_run_variant(
             output_root=invocation_root,
             warmup=run.warmup,
             profile_enabled=not run.warmup and run.repetition == 1,
+            **_scenario_timing(scenario),
         )
         adapter = adapter_api.CmuxRuntimeAdapter(config)
         try:

--- a/scripts/perf_mixed_workload_driver.py
+++ b/scripts/perf_mixed_workload_driver.py
@@ -13,6 +13,7 @@ import importlib.util
 import json
 import math
 import os
+import re
 from pathlib import Path
 import sys
 import tempfile
@@ -51,8 +52,8 @@ METRIC_GATES: Mapping[str, tuple[str, float]] = MappingProxyType(
         "browser_latency_ms": ("lower_is_better", 0.10),
         "terminal_throughput_per_second": ("higher_is_better", 0.05),
         "browser_throughput_per_second": ("higher_is_better", 0.05),
-        "terminal_present_rate": ("higher_is_better", 0.05),
-        "browser_present_rate": ("higher_is_better", 0.05),
+        "terminal_render_rate": ("higher_is_better", 0.05),
+        "browser_render_rate": ("higher_is_better", 0.05),
     }
 )
 _REQUIRED_METRICS_BY_KIND: Mapping[str, tuple[str, ...]] = MappingProxyType(
@@ -65,7 +66,7 @@ _REQUIRED_METRICS_BY_KIND: Mapping[str, tuple[str, ...]] = MappingProxyType(
             "churn_full_tree_cpu_percent",
             "churn_terminal_cpu_percent",
             "terminal_throughput_per_second",
-            "terminal_present_rate",
+            "terminal_render_rate",
         ),
         "browser": (
             "steady_parent_cpu_percent",
@@ -76,7 +77,7 @@ _REQUIRED_METRICS_BY_KIND: Mapping[str, tuple[str, ...]] = MappingProxyType(
             "churn_webkit_cpu_percent",
             "browser_latency_ms",
             "browser_throughput_per_second",
-            "browser_present_rate",
+            "browser_render_rate",
         ),
         "mixed": tuple(METRIC_GATES),
     }
@@ -84,6 +85,7 @@ _REQUIRED_METRICS_BY_KIND: Mapping[str, tuple[str, ...]] = MappingProxyType(
 
 _SCHEMA = "cmux.perf.mixed-workload-experiment/v1"
 _ANALYSIS_SCHEMA = "cmux.perf.mixed-workload-analysis/v1"
+_SHA_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
 
 
 def _plain_json(value: Any) -> Any:
@@ -314,21 +316,54 @@ def analyze_experiment(
         raise ValueError("records must be an iterable of experiment records")
     input_records = tuple(records)
 
+    scenarios = {
+        scenario.scenario_id: scenario for scenario in _contract.scenario_matrix()
+    }
+    variant_shas: dict[str, set[str]] = {"A": set(), "B": set()}
     paired: dict[tuple[str, str, int], dict[str, Mapping[str, Any] | object]] = {}
     for record in input_records:
-        if _record_field(record, "warmup") is True:
-            continue
         scenario_id = _record_field(record, "scenario_id")
+        scenario = scenarios.get(scenario_id)
+        if scenario is None:
+            raise ValueError(f"unknown scenario_id: {scenario_id!r}")
+        if (
+            _record_field(record, "kind") != scenario.kind
+            or _record_field(record, "load") != scenario.load
+        ):
+            raise ValueError(f"record scenario metadata does not match {scenario_id}")
+
         order = _record_field(record, "order")
         repetition = _record_field(record, "repetition")
         variant = _record_field(record, "variant")
+        warmup = _record_field(record, "warmup")
+        sha = _record_field(record, "sha")
         if order not in ("AB", "BA") or variant not in ("A", "B"):
             raise ValueError("record order and variant must use AB/BA and A/B")
+        if type(warmup) is not bool:
+            raise ValueError("record warmup must be a boolean")
+        if type(repetition) is not int:
+            raise ValueError("record repetition must be an integer")
+        if warmup:
+            if repetition != 0:
+                raise ValueError("warmup repetition must be zero")
+        elif repetition not in (1, 2, 3):
+            raise ValueError("measured repetition must be one of 1, 2, or 3")
+        if not isinstance(sha, str) or _SHA_RE.fullmatch(sha) is None:
+            raise ValueError("record sha must be exactly 40 hexadecimal characters")
+        variant_shas[variant].add(sha.lower())
+
+        if warmup:
+            continue
         key = (scenario_id, order, repetition)
         variants = paired.setdefault(key, {})
         if variant in variants:
             raise ValueError(f"duplicate record for {key!r} variant {variant}")
         variants[variant] = record
+
+    if any(len(shas) > 1 for shas in variant_shas.values()):
+        raise ValueError("each benchmark variant must use exactly one SHA")
+    if variant_shas["A"] and variant_shas["A"] == variant_shas["B"]:
+        raise ValueError("baseline and candidate require distinct build SHAs")
 
     grouped_values: dict[tuple[str, str, str], tuple[list[float], list[float]]] = {}
     for (scenario_id, order, repetition), variants in sorted(
@@ -644,7 +679,7 @@ def _invocation_result_evidence(result: Any) -> dict[str, Any]:
         "churn_samples",
         "latencies_ms",
         "throughput_ops_per_second",
-        "presents",
+        "render_observations",
         "failures",
         "cleanup",
     )

--- a/scripts/perf_mixed_workload_driver.py
+++ b/scripts/perf_mixed_workload_driver.py
@@ -690,11 +690,18 @@ def build_platform_run_variant(
                 owned_root=invocation_root,
                 adapter=adapter,
             )
+            if getattr(result, "failures", None):
+                failure = RuntimeError("adapter recorded workload failures")
+                failure.cleanup = _plain_json(result.cleanup)
+                failure.evidence = _plain_json(adapter.raw_details)
+                raise failure
         except Exception as error:
-            error.cleanup = _plain_json(
-                getattr(adapter, "raw_details", {}).get("cleanup", {})
-            )
-            error.evidence = _plain_json(getattr(adapter, "raw_details", {}))
+            if not hasattr(error, "cleanup"):
+                error.cleanup = _plain_json(
+                    getattr(adapter, "raw_details", {}).get("cleanup", {})
+                )
+            if not hasattr(error, "evidence"):
+                error.evidence = _plain_json(getattr(adapter, "raw_details", {}))
             raise
 
         evidence = _plain_json(adapter.raw_details)

--- a/scripts/perf_mixed_workload_driver.py
+++ b/scripts/perf_mixed_workload_driver.py
@@ -111,6 +111,27 @@ def _immutable_mapping(value: Mapping[str, Any] | None, *, name: str) -> Mapping
     return MappingProxyType(plain)
 
 
+def _immutable_cleanup_failures(
+    value: Any,
+) -> tuple[Mapping[str, str], ...]:
+    plain = _plain_json(value)
+    if not isinstance(plain, list):
+        raise ValueError("cleanup_failures must be a sequence")
+    required_fields = {"phase", "type", "message", "traceback"}
+    failures: list[Mapping[str, str]] = []
+    for failure in plain:
+        if (
+            not isinstance(failure, dict)
+            or set(failure) != required_fields
+            or any(not isinstance(failure[field], str) for field in required_fields)
+        ):
+            raise ValueError(
+                "cleanup failures must contain phase, type, message, and traceback strings"
+            )
+        failures.append(MappingProxyType(failure))
+    return tuple(failures)
+
+
 @dataclass(frozen=True, slots=True)
 class VariantConfig:
     """One immutable build identity passed to the execution adapter."""
@@ -199,12 +220,18 @@ class InvocationFailure:
     message: str
     raw_path: str
     cleanup: Mapping[str, Any] | None = None
+    cleanup_failures: tuple[Mapping[str, str], ...] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
             "cleanup",
             _immutable_mapping(self.cleanup, name="cleanup"),
+        )
+        object.__setattr__(
+            self,
+            "cleanup_failures",
+            _immutable_cleanup_failures(self.cleanup_failures),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -221,6 +248,7 @@ class InvocationFailure:
             "message": self.message,
             "raw_path": self.raw_path,
             "cleanup": _plain_json(self.cleanup),
+            "cleanup_failures": _plain_json(self.cleanup_failures),
         }
 
 
@@ -292,11 +320,17 @@ def _comparison_group(
     gate = _statistics.evaluate_metric_gate(
         _statistics_metric(metric), baseline_median, candidate_median
     ).to_dict()
-    gate["metric"] = metric
-    # These are predeclared by this driver; retaining them explicitly prevents a
-    # generic statistics name from leaking into machine output.
-    gate["direction"] = direction
-    gate["threshold"] = threshold
+    relative_change = gate["relative_change"]
+    relative_regression = (
+        relative_change if direction == "lower_is_better" else -relative_change
+    )
+    gate.update(
+        metric=metric,
+        direction=direction,
+        threshold=threshold,
+        relative_regression=relative_regression,
+        passed=relative_regression <= threshold,
+    )
     return {
         "scenario_id": scenario_id,
         "order": order,
@@ -306,6 +340,17 @@ def _comparison_group(
         "comparison": comparison.to_dict(),
         "gate": gate,
     }
+
+
+def validate_accepted_analysis(analysis: Mapping[str, Any]) -> None:
+    """Require the exact fail-closed producer verdict consumed by CI."""
+
+    if not isinstance(analysis, Mapping):
+        raise ValueError("analysis must be a mapping")
+    if analysis.get("final_acceptance") is not True:
+        raise ValueError("analysis final_acceptance must be exactly true")
+    if analysis.get("status") != "accepted":
+        raise ValueError("analysis status must be exactly 'accepted'")
 
 
 def analyze_experiment(
@@ -480,6 +525,7 @@ def analyze_experiment(
         "proven": proven,
         "inconclusive": inconclusive,
         "regressed": regressed,
+        "status": "accepted" if final_acceptance else "rejected",
         "final_acceptance": final_acceptance,
     }
 
@@ -576,6 +622,7 @@ def execute_experiment(
             except Exception as error:
                 cleanup = getattr(error, "cleanup", {})
                 evidence = getattr(error, "evidence", {})
+                cleanup_failures = getattr(error, "cleanup_failures", ())
                 if not isinstance(evidence, Mapping):
                     evidence = {"serialization_error": "exception evidence was not a mapping"}
                 failure = InvocationFailure(
@@ -591,6 +638,7 @@ def execute_experiment(
                     message=str(error),
                     raw_path=raw_path.as_posix(),
                     cleanup=cleanup,
+                    cleanup_failures=cleanup_failures,
                 )
                 failures.append(failure)
                 cleanup_summaries.append(
@@ -598,6 +646,9 @@ def execute_experiment(
                         "raw_path": raw_path.as_posix(),
                         "status": "failure",
                         "cleanup": _plain_json(failure.cleanup),
+                        "cleanup_failures": _plain_json(
+                            failure.cleanup_failures
+                        ),
                     }
                 )
                 _atomic_write_json(
@@ -802,6 +853,8 @@ __all__ = [
     "main",
     "parse_cli_args",
     "run_cli_experiment",
+    "validate_accepted_analysis",
+
 ]
 
 

--- a/scripts/perf_mixed_workload_driver.py
+++ b/scripts/perf_mixed_workload_driver.py
@@ -1,0 +1,753 @@
+#!/usr/bin/env python3
+"""Paired mixed-workload execution, macOS adapter binding, and analysis.
+
+Pure planning and analysis remain injectable for Linux behavior tests; the CLI
+binds them to the tagged cmux runtime adapter on the owned macOS runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import sys
+import tempfile
+from types import MappingProxyType
+from typing import Any, Callable, Iterable, Mapping
+
+
+def _load_sibling(module_name: str) -> Any:
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+    path = Path(__file__).with_name(f"{module_name}.py")
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {module_name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_contract = _load_sibling("perf_mixed_workload_contract")
+_statistics = _load_sibling("perf_mixed_workload_statistics")
+
+
+METRIC_GATES: Mapping[str, tuple[str, float]] = MappingProxyType(
+    {
+        "steady_parent_cpu_percent": ("lower_is_better", 0.05),
+        "steady_full_tree_cpu_percent": ("lower_is_better", 0.05),
+        "steady_terminal_cpu_percent": ("lower_is_better", 0.05),
+        "steady_webkit_cpu_percent": ("lower_is_better", 0.05),
+        "churn_parent_cpu_percent": ("lower_is_better", 0.05),
+        "churn_full_tree_cpu_percent": ("lower_is_better", 0.05),
+        "churn_terminal_cpu_percent": ("lower_is_better", 0.05),
+        "churn_webkit_cpu_percent": ("lower_is_better", 0.05),
+        "browser_latency_ms": ("lower_is_better", 0.10),
+        "terminal_throughput_per_second": ("higher_is_better", 0.05),
+        "browser_throughput_per_second": ("higher_is_better", 0.05),
+        "terminal_present_rate": ("higher_is_better", 0.05),
+        "browser_present_rate": ("higher_is_better", 0.05),
+    }
+)
+_REQUIRED_METRICS_BY_KIND: Mapping[str, tuple[str, ...]] = MappingProxyType(
+    {
+        "terminal": (
+            "steady_parent_cpu_percent",
+            "steady_full_tree_cpu_percent",
+            "steady_terminal_cpu_percent",
+            "churn_parent_cpu_percent",
+            "churn_full_tree_cpu_percent",
+            "churn_terminal_cpu_percent",
+            "terminal_throughput_per_second",
+            "terminal_present_rate",
+        ),
+        "browser": (
+            "steady_parent_cpu_percent",
+            "steady_full_tree_cpu_percent",
+            "steady_webkit_cpu_percent",
+            "churn_parent_cpu_percent",
+            "churn_full_tree_cpu_percent",
+            "churn_webkit_cpu_percent",
+            "browser_latency_ms",
+            "browser_throughput_per_second",
+            "browser_present_rate",
+        ),
+        "mixed": tuple(METRIC_GATES),
+    }
+)
+
+_SCHEMA = "cmux.perf.mixed-workload-experiment/v1"
+_ANALYSIS_SCHEMA = "cmux.perf.mixed-workload-analysis/v1"
+
+
+def _plain_json(value: Any) -> Any:
+    if hasattr(value, "to_dict"):
+        return _plain_json(value.to_dict())
+    if isinstance(value, Mapping):
+        return {str(key): _plain_json(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_plain_json(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise ValueError(f"value is not JSON-friendly: {type(value).__name__}")
+
+
+def _immutable_mapping(value: Mapping[str, Any] | None, *, name: str) -> Mapping[str, Any]:
+    if value is None:
+        return MappingProxyType({})
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    plain = _plain_json(value)
+    if not isinstance(plain, dict):
+        raise ValueError(f"{name} must be a mapping")
+    return MappingProxyType(plain)
+
+
+@dataclass(frozen=True, slots=True)
+class VariantConfig:
+    """One immutable build identity passed to the execution adapter."""
+
+    variant: str
+    sha: str
+    tag: str
+    app_path: str
+
+    def __post_init__(self) -> None:
+        if self.variant not in ("A", "B"):
+            raise ValueError("variant must be 'A' or 'B'")
+        if not isinstance(self.tag, str) or not self.tag:
+            raise ValueError("tag must be a nonempty string")
+        if not isinstance(self.app_path, str) or not self.app_path:
+            raise ValueError("app_path must be a nonempty string")
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "variant": self.variant,
+            "sha": self.sha,
+            "tag": self.tag,
+            "app_path": self.app_path,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ExperimentRecord:
+    """Successful raw observation from one variant invocation."""
+
+    scenario_id: str
+    kind: str
+    load: str
+    order: str
+    repetition: int
+    warmup: bool
+    variant: str
+    sha: str
+    metrics: Mapping[str, float]
+    cleanup: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        immutable_metrics = _immutable_mapping(self.metrics, name="metrics")
+        for metric, value in immutable_metrics.items():
+            if metric not in METRIC_GATES:
+                raise ValueError(f"unknown metric: {metric!r}")
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"metric {metric!r} must be a finite number")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"metric {metric!r} must be a finite number")
+        object.__setattr__(self, "metrics", immutable_metrics)
+        object.__setattr__(
+            self,
+            "cleanup",
+            _immutable_mapping(self.cleanup, name="cleanup"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "kind": self.kind,
+            "load": self.load,
+            "order": self.order,
+            "repetition": self.repetition,
+            "warmup": self.warmup,
+            "variant": self.variant,
+            "sha": self.sha,
+            "metrics": dict(self.metrics),
+            "cleanup": _plain_json(self.cleanup),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class InvocationFailure:
+    """Retained exception details for one failed invocation."""
+
+    scenario_id: str
+    kind: str
+    load: str
+    order: str
+    repetition: int
+    warmup: bool
+    variant: str
+    sha: str
+    error_type: str
+    message: str
+    raw_path: str
+    cleanup: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "cleanup",
+            _immutable_mapping(self.cleanup, name="cleanup"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "kind": self.kind,
+            "load": self.load,
+            "order": self.order,
+            "repetition": self.repetition,
+            "warmup": self.warmup,
+            "variant": self.variant,
+            "sha": self.sha,
+            "error_type": self.error_type,
+            "message": self.message,
+            "raw_path": self.raw_path,
+            "cleanup": _plain_json(self.cleanup),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ExperimentResult:
+    """In-memory result plus the two stable machine-output paths."""
+
+    records: tuple[ExperimentRecord, ...]
+    failures: tuple[InvocationFailure, ...]
+    manifest: Mapping[str, Any]
+    analysis: Mapping[str, Any]
+    manifest_path: Path
+    analysis_path: Path
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(_plain_json(payload), stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_name, path)
+    except BaseException:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _record_field(record: Mapping[str, Any] | object, name: str) -> Any:
+    if isinstance(record, Mapping):
+        try:
+            return record[name]
+        except KeyError as error:
+            raise ValueError(f"record is missing {name!r}") from error
+    try:
+        return getattr(record, name)
+    except AttributeError as error:
+        raise ValueError(f"record is missing {name!r}") from error
+
+
+def _statistics_metric(metric: str) -> str:
+    if metric.endswith("cpu_percent"):
+        return "cpu_percent"
+    if metric == "browser_latency_ms":
+        return "latency_ms"
+    return "throughput_per_second"
+
+
+def _comparison_group(
+    scenario_id: str,
+    order: str,
+    metric: str,
+    baseline_values: list[float],
+    candidate_values: list[float],
+) -> dict[str, Any]:
+    direction, threshold = METRIC_GATES[metric]
+    comparison = _statistics.compare_paired_samples(
+        baseline_values, candidate_values, direction
+    )
+    baseline_median = comparison.baseline.median
+    candidate_median = comparison.candidate.median
+    gate = _statistics.evaluate_metric_gate(
+        _statistics_metric(metric), baseline_median, candidate_median
+    ).to_dict()
+    gate["metric"] = metric
+    # These are predeclared by this driver; retaining them explicitly prevents a
+    # generic statistics name from leaking into machine output.
+    gate["direction"] = direction
+    gate["threshold"] = threshold
+    return {
+        "scenario_id": scenario_id,
+        "order": order,
+        "metric": metric,
+        "direction": direction,
+        "sample_count": len(baseline_values),
+        "comparison": comparison.to_dict(),
+        "gate": gate,
+    }
+
+
+def analyze_experiment(
+    records: Iterable[Mapping[str, Any] | ExperimentRecord],
+) -> dict[str, Any]:
+    """Analyze complete measured pairs without pooling scenario or order strata."""
+    if isinstance(records, (str, bytes)):
+        raise ValueError("records must be an iterable of experiment records")
+    input_records = tuple(records)
+
+    paired: dict[tuple[str, str, int], dict[str, Mapping[str, Any] | object]] = {}
+    for record in input_records:
+        if _record_field(record, "warmup") is True:
+            continue
+        scenario_id = _record_field(record, "scenario_id")
+        order = _record_field(record, "order")
+        repetition = _record_field(record, "repetition")
+        variant = _record_field(record, "variant")
+        if order not in ("AB", "BA") or variant not in ("A", "B"):
+            raise ValueError("record order and variant must use AB/BA and A/B")
+        key = (scenario_id, order, repetition)
+        variants = paired.setdefault(key, {})
+        if variant in variants:
+            raise ValueError(f"duplicate record for {key!r} variant {variant}")
+        variants[variant] = record
+
+    grouped_values: dict[tuple[str, str, str], tuple[list[float], list[float]]] = {}
+    for (scenario_id, order, repetition), variants in sorted(
+        paired.items(), key=lambda item: (item[0][0], item[0][1], item[0][2])
+    ):
+        del repetition
+        if set(variants) != {"A", "B"}:
+            continue
+        baseline_metrics = _record_field(variants["A"], "metrics")
+        candidate_metrics = _record_field(variants["B"], "metrics")
+        if not isinstance(baseline_metrics, Mapping) or not isinstance(
+            candidate_metrics, Mapping
+        ):
+            raise ValueError("record metrics must be mappings")
+        for metric in METRIC_GATES:
+            if metric not in baseline_metrics or metric not in candidate_metrics:
+                continue
+            values = grouped_values.setdefault(
+                (scenario_id, order, metric), ([], [])
+            )
+            values[0].append(float(baseline_metrics[metric]))
+            values[1].append(float(candidate_metrics[metric]))
+
+    scenario_order = {
+        scenario.scenario_id: index
+        for index, scenario in enumerate(_contract.scenario_matrix())
+    }
+    metric_order = {metric: index for index, metric in enumerate(METRIC_GATES)}
+    group_items = sorted(
+        grouped_values.items(),
+        key=lambda item: (
+            scenario_order.get(item[0][0], len(scenario_order)),
+            0 if item[0][1] == "AB" else 1,
+            metric_order[item[0][2]],
+        ),
+    )
+    groups = [
+        _comparison_group(scenario_id, order, metric, baseline, candidate)
+        for (scenario_id, order, metric), (baseline, candidate) in group_items
+    ]
+
+    scenarios: list[dict[str, Any]] = []
+    proven: list[str] = []
+    inconclusive: list[str] = []
+    regressed: list[str] = []
+    for scenario in _contract.scenario_matrix():
+        scenario_groups = [
+            group for group in groups if group["scenario_id"] == scenario.scenario_id
+        ]
+        has_failed_gate = any(
+            group["gate"]["passed"] is not True for group in scenario_groups
+        )
+        groups_by_key = {
+            (group["order"], group["metric"]): group for group in scenario_groups
+        }
+        missing_groups = [
+            f"{order}:{metric}"
+            for order in ("AB", "BA")
+            for metric in _REQUIRED_METRICS_BY_KIND[scenario.kind]
+            if (group := groups_by_key.get((order, metric))) is None
+            or group["sample_count"] != 3
+        ]
+        has_incomplete_group = bool(missing_groups)
+        cpu_improvement = any(
+            group["metric"].endswith("cpu_percent")
+            and group["gate"]["passed"] is True
+            and group["comparison"]["candidate"]["median"]
+            < group["comparison"]["baseline"]["median"]
+            and group["comparison"]["oriented_effect_size"] > 0.0
+            for group in scenario_groups
+        )
+        if has_failed_gate:
+            conclusion = "regressed"
+            regressed.append(scenario.scenario_id)
+        elif cpu_improvement and not has_incomplete_group:
+            conclusion = "proven"
+            proven.append(scenario.scenario_id)
+        else:
+            conclusion = "inconclusive"
+            inconclusive.append(scenario.scenario_id)
+        scenarios.append(
+            {
+                "scenario_id": scenario.scenario_id,
+                "kind": scenario.kind,
+                "load": scenario.load,
+                "conclusion": conclusion,
+                "group_count": len(scenario_groups),
+                "complete": not has_incomplete_group,
+                "missing_groups": missing_groups,
+                "failed_gates": [
+                    f'{group["order"]}:{group["metric"]}'
+                    for group in scenario_groups
+                    if group["gate"]["passed"] is not True
+                ],
+            }
+        )
+
+    complete_matrix = all(scenario["complete"] for scenario in scenarios)
+    any_gate_failed = any(group["gate"]["passed"] is not True for group in groups)
+    final_acceptance = (
+        complete_matrix and "terminal-heavy" in proven and not any_gate_failed
+    )
+    return {
+        "schema": _ANALYSIS_SCHEMA,
+        "predeclared_gates": {
+            metric: {
+                "direction": direction,
+                "max_relative_regression": threshold,
+            }
+            for metric, (direction, threshold) in METRIC_GATES.items()
+        },
+        "groups": groups,
+        "scenarios": scenarios,
+        "proven": proven,
+        "inconclusive": inconclusive,
+        "regressed": regressed,
+        "final_acceptance": final_acceptance,
+    }
+
+
+def _validate_variants(
+    baseline: VariantConfig, candidate: VariantConfig
+) -> dict[str, VariantConfig]:
+    if not isinstance(baseline, VariantConfig) or not isinstance(
+        candidate, VariantConfig
+    ):
+        raise ValueError("baseline and candidate must be VariantConfig values")
+    if baseline.variant != "A" or candidate.variant != "B":
+        raise ValueError("baseline must be variant A and candidate must be variant B")
+    # The contract builder performs the authoritative SHA format/distinctness
+    # validation before any adapter side effects occur.
+    _contract.build_experiment_plan(baseline.sha, candidate.sha)
+    return {"A": baseline, "B": candidate}
+
+
+def execute_experiment(
+    *,
+    baseline: VariantConfig,
+    candidate: VariantConfig,
+    output_dir: Path | str,
+    run_variant: Callable[[VariantConfig, Any, Any], Mapping[str, Any]],
+) -> ExperimentResult:
+    """Execute all 144 invocations, retain raw outcomes, analyze, and persist."""
+    variants = _validate_variants(baseline, candidate)
+    if not callable(run_variant):
+        raise ValueError("run_variant must be callable")
+    root = Path(output_dir)
+    raw_root = root / "raw"
+    raw_root.mkdir(parents=True, exist_ok=True)
+
+    scenarios = {scenario.scenario_id: scenario for scenario in _contract.scenario_matrix()}
+    plan = _contract.build_experiment_plan(baseline.sha, candidate.sha)
+    records: list[ExperimentRecord] = []
+    failures: list[InvocationFailure] = []
+    raw_paths: list[str] = []
+    cleanup_summaries: list[dict[str, Any]] = []
+
+    invocation_index = 0
+    for run in plan:
+        scenario = scenarios[run.scenario_id]
+        for planned_invocation in run.invocations:
+            invocation_index += 1
+            variant = variants[planned_invocation.variant]
+            raw_path = (
+                Path("raw")
+                / (
+                    f"{invocation_index:03d}-{scenario.scenario_id}-{run.order}"
+                    f"-r{run.repetition}-{variant.variant}.json"
+                )
+            )
+            raw_paths.append(raw_path.as_posix())
+            try:
+                outcome = run_variant(variant, scenario, run)
+                if not isinstance(outcome, Mapping):
+                    raise ValueError("run_variant must return a mapping")
+                metrics = outcome.get("metrics")
+                cleanup = outcome.get("cleanup", {})
+                evidence = outcome.get("evidence", {})
+                if not isinstance(evidence, Mapping):
+                    raise ValueError("run_variant evidence must be a mapping")
+                if not isinstance(metrics, Mapping):
+                    raise ValueError("run_variant result must contain a metrics mapping")
+                record = ExperimentRecord(
+                    scenario_id=scenario.scenario_id,
+                    kind=scenario.kind,
+                    load=scenario.load,
+                    order=run.order,
+                    repetition=run.repetition,
+                    warmup=run.warmup,
+                    variant=variant.variant,
+                    sha=variant.sha,
+                    metrics=metrics,
+                    cleanup=cleanup,
+                )
+                records.append(record)
+                cleanup_summary = {
+                    "raw_path": raw_path.as_posix(),
+                    "status": "success",
+                    "cleanup": _plain_json(record.cleanup),
+                }
+                cleanup_summaries.append(cleanup_summary)
+                _atomic_write_json(
+                    root / raw_path,
+                    {
+                        "status": "success",
+                        **record.to_dict(),
+                        "evidence": _plain_json(evidence),
+                    },
+                )
+            except Exception as error:
+                cleanup = getattr(error, "cleanup", {})
+                evidence = getattr(error, "evidence", {})
+                if not isinstance(evidence, Mapping):
+                    evidence = {"serialization_error": "exception evidence was not a mapping"}
+                failure = InvocationFailure(
+                    scenario_id=scenario.scenario_id,
+                    kind=scenario.kind,
+                    load=scenario.load,
+                    order=run.order,
+                    repetition=run.repetition,
+                    warmup=run.warmup,
+                    variant=variant.variant,
+                    sha=variant.sha,
+                    error_type=type(error).__name__,
+                    message=str(error),
+                    raw_path=raw_path.as_posix(),
+                    cleanup=cleanup,
+                )
+                failures.append(failure)
+                cleanup_summaries.append(
+                    {
+                        "raw_path": raw_path.as_posix(),
+                        "status": "failure",
+                        "cleanup": _plain_json(failure.cleanup),
+                    }
+                )
+                _atomic_write_json(
+                    root / raw_path,
+                    {
+                        "status": "failure",
+                        "failure": failure.to_dict(),
+                        "evidence": _plain_json(evidence),
+                    },
+                )
+
+    analysis = analyze_experiment(records)
+    manifest: dict[str, Any] = {
+        "schema": _SCHEMA,
+        "variants": {
+            "A": baseline.to_dict(),
+            "B": candidate.to_dict(),
+        },
+        "plan": {
+            "scenario_count": 9,
+            "order_count": 2,
+            "pairs_per_order": 4,
+            "warmup_pairs_per_order": 1,
+            "measured_pairs_per_order": 3,
+            "pair_count": len(plan),
+            "invocation_count": len(plan) * 2,
+            "warmup_invocation_count": sum(run.warmup for run in plan) * 2,
+            "measured_invocation_count": sum(not run.warmup for run in plan) * 2,
+        },
+        "scenarios": [
+            scenario.to_dict() for scenario in _contract.scenario_matrix()
+        ],
+        "raw_paths": raw_paths,
+        "successful_record_count": len(records),
+        "failures": [failure.to_dict() for failure in failures],
+        "cleanup_summaries": cleanup_summaries,
+    }
+    manifest_path = root / "experiment-manifest.json"
+    analysis_path = root / "analysis.json"
+    _atomic_write_json(manifest_path, manifest)
+    _atomic_write_json(analysis_path, analysis)
+    return ExperimentResult(
+        records=tuple(records),
+        failures=tuple(failures),
+        manifest=manifest,
+        analysis=analysis,
+        manifest_path=manifest_path,
+        analysis_path=analysis_path,
+    )
+
+
+def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse the fixed experiment CLI without permitting plan drift."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-sha", required=True)
+    parser.add_argument("--baseline-tag", required=True)
+    parser.add_argument("--baseline-app", required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--candidate-tag", required=True)
+    parser.add_argument("--candidate-app", required=True)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--warmups", required=True, type=int)
+    parser.add_argument("--repetitions", required=True, type=int)
+    args = parser.parse_args(argv)
+    if args.warmups != 1:
+        raise ValueError("the fixed experiment requires exactly one warmup pair")
+    if args.repetitions != 3:
+        raise ValueError("the fixed experiment requires exactly three measured pairs")
+    _contract.build_experiment_plan(args.baseline_sha, args.candidate_sha)
+    return args
+
+
+def _invocation_result_evidence(result: Any) -> dict[str, Any]:
+    fields = (
+        "requested_shape",
+        "observed_shape",
+        "steady_samples",
+        "churn_samples",
+        "latencies_ms",
+        "throughput_ops_per_second",
+        "presents",
+        "failures",
+        "cleanup",
+    )
+    return {name: _plain_json(getattr(result, name)) for name in fields}
+
+
+def build_platform_run_variant(
+    *,
+    output_root: Path | str,
+    adapter_module: Any | None = None,
+    runtime_module: Any | None = None,
+) -> Callable[[VariantConfig, Any, Any], Mapping[str, Any]]:
+    """Bind the pure paired driver to the tagged macOS runtime adapter."""
+
+    adapter_api = adapter_module or _load_sibling("perf_cmux_adapter")
+    runtime_api = runtime_module or _load_sibling("perf_mixed_workload")
+    root = Path(output_root)
+
+    def run_variant(variant: VariantConfig, scenario: Any, run: Any) -> Mapping[str, Any]:
+        invocation_root = root / "invocations" / (
+            f"{scenario.scenario_id}-{run.order}-r{run.repetition}-{variant.variant}"
+        )
+        config = adapter_api.AdapterConfig(
+            sha=variant.sha,
+            tag=variant.tag,
+            app_path=variant.app_path,
+            scenario=scenario,
+            output_root=invocation_root,
+            warmup=run.warmup,
+            profile_enabled=not run.warmup and run.repetition == 1,
+        )
+        adapter = adapter_api.CmuxRuntimeAdapter(config)
+        try:
+            result = runtime_api.run_invocation(
+                scenario_id=scenario.scenario_id,
+                sha=variant.sha,
+                order=run.order,
+                repetition=run.repetition,
+                requested_shape={
+                    "terminal_surfaces": scenario.terminal_surfaces,
+                    "browser_surfaces": scenario.browser_surfaces,
+                },
+                owned_root=invocation_root,
+                adapter=adapter,
+            )
+        except Exception as error:
+            error.cleanup = _plain_json(
+                getattr(adapter, "raw_details", {}).get("cleanup", {})
+            )
+            error.evidence = _plain_json(getattr(adapter, "raw_details", {}))
+            raise
+
+        evidence = _plain_json(adapter.raw_details)
+        evidence["invocation_result"] = _invocation_result_evidence(result)
+        return {
+            "metrics": adapter_api.extract_metrics(result, adapter.raw_details),
+            "cleanup": result.cleanup,
+            "evidence": evidence,
+        }
+
+    return run_variant
+
+
+def run_cli_experiment(args: argparse.Namespace) -> ExperimentResult:
+    baseline = VariantConfig(
+        variant="A",
+        sha=args.baseline_sha,
+        tag=args.baseline_tag,
+        app_path=args.baseline_app,
+    )
+    candidate = VariantConfig(
+        variant="B",
+        sha=args.candidate_sha,
+        tag=args.candidate_tag,
+        app_path=args.candidate_app,
+    )
+    return execute_experiment(
+        baseline=baseline,
+        candidate=candidate,
+        output_dir=args.output_dir,
+        run_variant=build_platform_run_variant(output_root=args.output_dir),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    result = run_cli_experiment(parse_cli_args(argv))
+    return 0 if not result.failures and result.analysis["final_acceptance"] is True else 1
+
+
+__all__ = [
+    "METRIC_GATES",
+    "ExperimentRecord",
+    "ExperimentResult",
+    "InvocationFailure",
+    "VariantConfig",
+    "build_platform_run_variant",
+    "analyze_experiment",
+    "execute_experiment",
+    "main",
+    "parse_cli_args",
+    "run_cli_experiment",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/perf_mixed_workload_driver.py
+++ b/scripts/perf_mixed_workload_driver.py
@@ -688,9 +688,10 @@ def _invocation_result_evidence(result: Any) -> dict[str, Any]:
 
 def _scenario_timing(scenario: Any) -> dict[str, float]:
     workload_duration_s = 5.0
-    measurement_duration_s = (
-        12.0 if getattr(scenario, "scenario_id", None) == "mixed-heavy" else 5.0
-    )
+    measurement_duration_s = {
+        "browser-heavy": 15.0,
+        "mixed-heavy": 12.0,
+    }.get(getattr(scenario, "scenario_id", None), 5.0)
     return {
         "churn_duration_s": workload_duration_s,
         "churn_measurement_duration_s": measurement_duration_s,

--- a/scripts/perf_mixed_workload_statistics.py
+++ b/scripts/perf_mixed_workload_statistics.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Pure statistics and acceptance gates for mixed-workload benchmarks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from numbers import Real
+from statistics import median
+from typing import Any, Iterable, Mapping
+
+
+_DIRECTIONS = frozenset(("lower_is_better", "higher_is_better"))
+_METRIC_GATES = {
+    "cpu_percent": ("lower_is_better", 0.05),
+    "latency_ms": ("lower_is_better", 0.10),
+    "throughput_per_second": ("higher_is_better", 0.05),
+}
+_REQUIRED_ACCEPTANCE_SCENARIOS = ("terminal-heavy", "browser-heavy", "mixed-heavy")
+
+
+@dataclass(frozen=True)
+class SampleSummary:
+    """Robust descriptive statistics plus the samples in observation order."""
+
+    raw_values: tuple[float, ...]
+    sample_count: int
+    median: float
+    iqr: float
+    mad: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "raw_values": list(self.raw_values),
+            "sample_count": self.sample_count,
+            "median": self.median,
+            "iqr": self.iqr,
+            "mad": self.mad,
+        }
+
+
+@dataclass(frozen=True)
+class PairedSampleComparison:
+    """Paired changes and a direction-oriented cross-sample effect."""
+
+    direction: str
+    baseline: SampleSummary
+    candidate: SampleSummary
+    absolute_deltas: tuple[float, ...]
+    relative_deltas: tuple[float, ...]
+    probability_candidate_better: float
+    oriented_effect_size: float
+
+    @property
+    def sample_count(self) -> int:
+        return len(self.absolute_deltas)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "direction": self.direction,
+            "baseline": self.baseline.to_dict(),
+            "candidate": self.candidate.to_dict(),
+            "sample_count": self.sample_count,
+            "absolute_deltas": list(self.absolute_deltas),
+            "relative_deltas": list(self.relative_deltas),
+            "probability_candidate_better": self.probability_candidate_better,
+            "oriented_effect_size": self.oriented_effect_size,
+        }
+
+
+@dataclass(frozen=True)
+class PairedSampleGroup:
+    """One scenario, order, and metric stratum of paired observations."""
+
+    scenario_id: str
+    order: str
+    metric: str
+    direction: str
+    baseline_values: tuple[float, ...]
+    candidate_values: tuple[float, ...]
+    comparison: PairedSampleComparison
+
+    @property
+    def sample_count(self) -> int:
+        return len(self.baseline_values)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "order": self.order,
+            "metric": self.metric,
+            "direction": self.direction,
+            "sample_count": self.sample_count,
+            "baseline_values": list(self.baseline_values),
+            "candidate_values": list(self.candidate_values),
+            "comparison": self.comparison.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class MetricGate:
+    """Maximum permitted regression for one benchmark metric."""
+
+    metric: str
+    direction: str
+    baseline_value: float
+    candidate_value: float
+    threshold: float
+    relative_change: float
+    relative_regression: float
+    passed: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "metric": self.metric,
+            "direction": self.direction,
+            "baseline_value": self.baseline_value,
+            "candidate_value": self.candidate_value,
+            "threshold": self.threshold,
+            "relative_change": self.relative_change,
+            "relative_regression": self.relative_regression,
+            "passed": self.passed,
+        }
+
+
+def _finite_values(values: Iterable[float], *, name: str) -> tuple[float, ...]:
+    if isinstance(values, (str, bytes)):
+        raise ValueError(f"{name} must be a nonempty iterable of finite numbers")
+
+    try:
+        raw_values = tuple(values)
+    except TypeError as error:
+        raise ValueError(f"{name} must be a nonempty iterable of finite numbers") from error
+
+    if not raw_values:
+        raise ValueError(f"{name} must not be empty")
+
+    converted: list[float] = []
+    for value in raw_values:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise ValueError(f"{name} must contain only finite numbers")
+        converted_value = float(value)
+        if not math.isfinite(converted_value):
+            raise ValueError(f"{name} must contain only finite numbers")
+        converted.append(converted_value)
+    return tuple(converted)
+
+
+def _finite_value(value: float, *, name: str) -> float:
+    return _finite_values((value,), name=name)[0]
+
+
+def _validate_direction(direction: str) -> None:
+    if direction not in _DIRECTIONS:
+        raise ValueError(
+            "direction must be 'lower_is_better' or 'higher_is_better'"
+        )
+
+
+def _quartiles(sorted_values: tuple[float, ...]) -> tuple[float, float]:
+    """Return Tukey hinges, excluding the center observation for odd counts."""
+    count = len(sorted_values)
+    if count == 1:
+        return sorted_values[0], sorted_values[0]
+
+    midpoint = count // 2
+    lower = sorted_values[:midpoint]
+    upper = sorted_values[-midpoint:]
+    return float(median(lower)), float(median(upper))
+
+
+def summarize_samples(values: Iterable[float]) -> SampleSummary:
+    """Summarize finite samples without changing their observation order."""
+    raw_values = _finite_values(values, name="values")
+    sorted_values = tuple(sorted(raw_values))
+    center = float(median(sorted_values))
+    first_quartile, third_quartile = _quartiles(sorted_values)
+    deviations = tuple(abs(value - center) for value in raw_values)
+    return SampleSummary(
+        raw_values=raw_values,
+        sample_count=len(raw_values),
+        median=center,
+        iqr=third_quartile - first_quartile,
+        mad=float(median(deviations)),
+    )
+
+
+def compare_paired_samples(
+    baseline_values: Iterable[float],
+    candidate_values: Iterable[float],
+    direction: str,
+) -> PairedSampleComparison:
+    """Compare matched observations and compute a common-language effect."""
+    _validate_direction(direction)
+    baseline = _finite_values(baseline_values, name="baseline_values")
+    candidate = _finite_values(candidate_values, name="candidate_values")
+    if len(baseline) != len(candidate):
+        raise ValueError("baseline_values and candidate_values must have matching lengths")
+    if any(value <= 0.0 for value in baseline):
+        raise ValueError("baseline_values must contain only positive nonzero values")
+
+    absolute_deltas = tuple(
+        candidate_value - baseline_value
+        for baseline_value, candidate_value in zip(baseline, candidate, strict=True)
+    )
+    relative_deltas = tuple(
+        delta / baseline_value
+        for delta, baseline_value in zip(absolute_deltas, baseline, strict=True)
+    )
+
+    wins = 0.0
+    for candidate_value in candidate:
+        for baseline_value in baseline:
+            if candidate_value == baseline_value:
+                wins += 0.5
+            elif (
+                direction == "lower_is_better" and candidate_value < baseline_value
+            ) or (
+                direction == "higher_is_better" and candidate_value > baseline_value
+            ):
+                wins += 1.0
+    probability_candidate_better = wins / (len(baseline) * len(candidate))
+
+    return PairedSampleComparison(
+        direction=direction,
+        baseline=summarize_samples(baseline),
+        candidate=summarize_samples(candidate),
+        absolute_deltas=absolute_deltas,
+        relative_deltas=relative_deltas,
+        probability_candidate_better=probability_candidate_better,
+        oriented_effect_size=2.0 * probability_candidate_better - 1.0,
+    )
+
+
+def _record_field(record: Mapping[str, Any] | object, name: str) -> Any:
+    if isinstance(record, Mapping):
+        try:
+            return record[name]
+        except KeyError as error:
+            raise ValueError(f"record is missing {name!r}") from error
+    try:
+        return getattr(record, name)
+    except AttributeError as error:
+        raise ValueError(f"record is missing {name!r}") from error
+
+
+def aggregate_paired_samples(
+    records: Iterable[Mapping[str, Any] | object],
+) -> tuple[PairedSampleGroup, ...]:
+    """Aggregate observations while retaining scenario and AB/BA strata."""
+    if isinstance(records, (str, bytes)):
+        raise ValueError("records must be a nonempty iterable")
+    try:
+        input_records = tuple(records)
+    except TypeError as error:
+        raise ValueError("records must be a nonempty iterable") from error
+    if not input_records:
+        raise ValueError("records must not be empty")
+
+    grouped: dict[
+        tuple[str, str, str], tuple[str, list[float], list[float]]
+    ] = {}
+    for record in input_records:
+        scenario_id = _record_field(record, "scenario_id")
+        order = _record_field(record, "order")
+        metric = _record_field(record, "metric")
+        direction = _record_field(record, "direction")
+        if not isinstance(scenario_id, str) or not scenario_id:
+            raise ValueError("record scenario_id must be a nonempty string")
+        if order not in ("AB", "BA"):
+            raise ValueError("record order must be 'AB' or 'BA'")
+        if metric not in _METRIC_GATES:
+            raise ValueError(f"unknown metric: {metric!r}")
+        _validate_direction(direction)
+        expected_direction, _ = _METRIC_GATES[metric]
+        if direction != expected_direction:
+            raise ValueError(
+                f"metric {metric!r} requires direction {expected_direction!r}"
+            )
+        baseline_value = _finite_value(
+            _record_field(record, "baseline_value"), name="baseline_value"
+        )
+        candidate_value = _finite_value(
+            _record_field(record, "candidate_value"), name="candidate_value"
+        )
+        if baseline_value <= 0.0:
+            raise ValueError("baseline_value must be positive and nonzero")
+
+        key = (scenario_id, order, metric)
+        if key not in grouped:
+            grouped[key] = (direction, [], [])
+        _, baseline_values, candidate_values = grouped[key]
+        baseline_values.append(baseline_value)
+        candidate_values.append(candidate_value)
+
+    groups: list[PairedSampleGroup] = []
+    for (scenario_id, order, metric), (
+        direction,
+        baseline_values,
+        candidate_values,
+    ) in grouped.items():
+        comparison = compare_paired_samples(
+            baseline_values, candidate_values, direction
+        )
+        groups.append(
+            PairedSampleGroup(
+                scenario_id=scenario_id,
+                order=order,
+                metric=metric,
+                direction=direction,
+                baseline_values=tuple(baseline_values),
+                candidate_values=tuple(candidate_values),
+                comparison=comparison,
+            )
+        )
+    return tuple(groups)
+
+
+def evaluate_metric_gate(
+    metric: str,
+    baseline_value: float,
+    candidate_value: float,
+) -> MetricGate:
+    """Evaluate a metric's candidate result against its regression budget."""
+    if metric not in _METRIC_GATES:
+        raise ValueError(f"unknown metric: {metric!r}")
+    baseline = _finite_value(baseline_value, name="baseline_value")
+    candidate = _finite_value(candidate_value, name="candidate_value")
+    if baseline <= 0.0:
+        raise ValueError("baseline_value must be positive and nonzero")
+
+    direction, threshold = _METRIC_GATES[metric]
+    relative_change = (candidate - baseline) / baseline
+    relative_regression = (
+        relative_change
+        if direction == "lower_is_better"
+        else -relative_change
+    )
+    return MetricGate(
+        metric=metric,
+        direction=direction,
+        baseline_value=baseline,
+        candidate_value=candidate,
+        threshold=threshold,
+        relative_change=relative_change,
+        relative_regression=relative_regression,
+        passed=relative_regression <= threshold,
+    )
+
+
+def evaluate_final_acceptance(
+    scenario_gates: Mapping[str, Mapping[str, Any] | MetricGate],
+) -> bool:
+    """Require the browser-heavy and mixed-heavy scenario gates to pass."""
+    if not isinstance(scenario_gates, Mapping):
+        raise ValueError("scenario_gates must be a mapping")
+
+    for scenario_id in _REQUIRED_ACCEPTANCE_SCENARIOS:
+        if scenario_id not in scenario_gates:
+            return False
+        gate = scenario_gates[scenario_id]
+        if isinstance(gate, Mapping):
+            passed = gate.get("passed")
+        else:
+            passed = getattr(gate, "passed", None)
+        if passed is not True:
+            return False
+    return True

--- a/scripts/perf_mixed_workload_statistics.py
+++ b/scripts/perf_mixed_workload_statistics.py
@@ -157,6 +157,16 @@ def _validate_direction(direction: str) -> None:
         )
 
 
+def _relative_delta(candidate: float, baseline: float) -> float:
+    """Return a finite relative delta, saturating zero-to-nonzero transitions."""
+    if baseline == 0.0:
+        if candidate == 0.0:
+            return 0.0
+        return 1.0 if candidate > 0.0 else -1.0
+    return (candidate - baseline) / baseline
+
+
+
 def _quartiles(sorted_values: tuple[float, ...]) -> tuple[float, float]:
     """Return Tukey hinges, excluding the center observation for odd counts."""
     count = len(sorted_values)
@@ -196,16 +206,16 @@ def compare_paired_samples(
     candidate = _finite_values(candidate_values, name="candidate_values")
     if len(baseline) != len(candidate):
         raise ValueError("baseline_values and candidate_values must have matching lengths")
-    if any(value <= 0.0 for value in baseline):
-        raise ValueError("baseline_values must contain only positive nonzero values")
+    if any(value < 0.0 for value in (*baseline, *candidate)):
+        raise ValueError("sample values must be nonnegative")
 
     absolute_deltas = tuple(
         candidate_value - baseline_value
         for baseline_value, candidate_value in zip(baseline, candidate, strict=True)
     )
     relative_deltas = tuple(
-        delta / baseline_value
-        for delta, baseline_value in zip(absolute_deltas, baseline, strict=True)
+        _relative_delta(candidate_value, baseline_value)
+        for baseline_value, candidate_value in zip(baseline, candidate, strict=True)
     )
 
     wins = 0.0
@@ -283,8 +293,8 @@ def aggregate_paired_samples(
         candidate_value = _finite_value(
             _record_field(record, "candidate_value"), name="candidate_value"
         )
-        if baseline_value <= 0.0:
-            raise ValueError("baseline_value must be positive and nonzero")
+        if baseline_value < 0.0 or candidate_value < 0.0:
+            raise ValueError("metric values must be nonnegative")
 
         key = (scenario_id, order, metric)
         if key not in grouped:
@@ -326,11 +336,11 @@ def evaluate_metric_gate(
         raise ValueError(f"unknown metric: {metric!r}")
     baseline = _finite_value(baseline_value, name="baseline_value")
     candidate = _finite_value(candidate_value, name="candidate_value")
-    if baseline <= 0.0:
-        raise ValueError("baseline_value must be positive and nonzero")
+    if baseline < 0.0 or candidate < 0.0:
+        raise ValueError("metric values must be nonnegative")
 
     direction, threshold = _METRIC_GATES[metric]
-    relative_change = (candidate - baseline) / baseline
+    relative_change = _relative_delta(candidate, baseline)
     relative_regression = (
         relative_change
         if direction == "lower_is_better"

--- a/scripts/perf_process_tree.py
+++ b/scripts/perf_process_tree.py
@@ -1,0 +1,290 @@
+"""Pure process-tree CPU accounting for performance benchmarks.
+
+This module deliberately contains no process sampling.  Callers provide one
+snapshot of process records and explicit roots, which keeps accounting
+repeatable and platform independent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import fsum, isfinite
+from typing import Iterable, Literal
+
+
+WebKitRole = Literal["content", "gpu", "network"]
+
+
+@dataclass(frozen=True)
+class ProcessRecord:
+    """One process from a caller-supplied snapshot."""
+
+    pid: int
+    parent_pid: int
+    command: str
+    cpu_percent: float | None
+    resident_bytes: int = 0
+    physical_footprint_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        for name, value in (("pid", self.pid), ("parent_pid", self.parent_pid)):
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} must be a nonnegative integer")
+        if type(self.command) is not str:
+            raise ValueError("command must be a string")
+        if self.cpu_percent is not None and (
+            isinstance(self.cpu_percent, bool)
+            or not isinstance(self.cpu_percent, (int, float))
+            or not isfinite(self.cpu_percent)
+            or self.cpu_percent < 0
+        ):
+            raise ValueError("cpu_percent must be None or a nonnegative finite number")
+        for name, value in (
+            ("resident_bytes", self.resident_bytes),
+            ("physical_footprint_bytes", self.physical_footprint_bytes),
+        ):
+            if type(value) is not int or value < 0:
+                raise ValueError(f"{name} must be a nonnegative integer")
+
+    def to_dict(self) -> dict[str, int | str | float | None]:
+        return {
+            "pid": self.pid,
+            "parent_pid": self.parent_pid,
+            "command": self.command,
+            "cpu_percent": self.cpu_percent,
+            "resident_bytes": self.resident_bytes,
+            "physical_footprint_bytes": self.physical_footprint_bytes,
+        }
+
+
+@dataclass(frozen=True)
+class ProcessSubtotal:
+    """Resource subtotal for a unique, deterministic collection of process IDs."""
+
+    pids: tuple[int, ...]
+    cpu_percent: float
+    resident_bytes: int = 0
+    physical_footprint_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "pids", tuple(sorted(set(self.pids))))
+
+    def to_dict(self) -> dict[str, list[int] | float | int]:
+        return {
+            "pids": list(self.pids),
+            "cpu_percent": self.cpu_percent,
+            "resident_bytes": self.resident_bytes,
+            "physical_footprint_bytes": self.physical_footprint_bytes,
+        }
+
+
+@dataclass(frozen=True)
+class ProcessCoverage:
+    """Sampling coverage for every process discovered in the app tree."""
+
+    discovered_pids: tuple[int, ...]
+    sampled_pids: tuple[int, ...]
+    missing_pids: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        discovered = tuple(sorted(set(self.discovered_pids)))
+        sampled = tuple(sorted(set(self.sampled_pids)))
+        missing = tuple(sorted(set(self.missing_pids)))
+
+        discovered_set = set(discovered)
+        sampled_set = set(sampled)
+        missing_set = set(missing)
+        if sampled_set & missing_set:
+            raise ValueError("sampled and missing process IDs must be disjoint")
+        if sampled_set | missing_set != discovered_set:
+            raise ValueError(
+                "sampled and missing process IDs must partition discovered IDs"
+            )
+
+        object.__setattr__(self, "discovered_pids", discovered)
+        object.__setattr__(self, "sampled_pids", sampled)
+        object.__setattr__(self, "missing_pids", missing)
+
+    @property
+    def discovered_count(self) -> int:
+        return len(self.discovered_pids)
+
+    @property
+    def sampled_count(self) -> int:
+        return len(self.sampled_pids)
+
+    @property
+    def missing_count(self) -> int:
+        return len(self.missing_pids)
+
+    def to_dict(self) -> dict[str, list[int] | int]:
+        return {
+            "discovered_pids": list(self.discovered_pids),
+            "sampled_pids": list(self.sampled_pids),
+            "missing_pids": list(self.missing_pids),
+            "discovered_count": self.discovered_count,
+            "sampled_count": self.sampled_count,
+            "missing_count": self.missing_count,
+        }
+
+
+@dataclass(frozen=True)
+class ProcessTreeReport:
+    """Independent category subtotals and the unique app-tree aggregate."""
+
+    parent_direct: ProcessSubtotal
+    terminal: ProcessSubtotal
+    webkit: ProcessSubtotal
+    full_tree: ProcessSubtotal
+    coverage: ProcessCoverage
+
+    def to_dict(self) -> dict[str, dict[str, object]]:
+        return {
+            "parent_direct": self.parent_direct.to_dict(),
+            "terminal": self.terminal.to_dict(),
+            "webkit": self.webkit.to_dict(),
+            "full_tree": self.full_tree.to_dict(),
+            "coverage": self.coverage.to_dict(),
+        }
+
+
+def classify_webkit_role(record: ProcessRecord) -> WebKitRole | None:
+    """Classify a known WebKit service role from its command text."""
+
+    command = record.command.casefold()
+    if "webkit.networking" in command or "networkprocess" in command:
+        return "network"
+    if "webkit.gpu" in command or "gpuprocess" in command:
+        return "gpu"
+    if "webkit.webcontent" in command or "webcontentprocess" in command:
+        return "content"
+    return None
+
+
+def _index_records(
+    records: Iterable[ProcessRecord],
+) -> tuple[dict[int, ProcessRecord], dict[int, set[int]]]:
+    records_by_pid: dict[int, ProcessRecord] = {}
+    children_by_parent: dict[int, set[int]] = {}
+
+    for record in records:
+        previous = records_by_pid.get(record.pid)
+        if previous is not None:
+            if previous != record:
+                raise ValueError(f"conflicting records for PID {record.pid}")
+            continue
+        records_by_pid[record.pid] = record
+        children_by_parent.setdefault(record.parent_pid, set()).add(record.pid)
+
+    return records_by_pid, children_by_parent
+
+
+def _expand_from_roots(
+    records_by_pid: dict[int, ProcessRecord],
+    children_by_parent: dict[int, set[int]],
+    root_pids: Iterable[int],
+) -> frozenset[int]:
+    """Return recorded roots and all recorded transitive descendants."""
+
+    pending = list(set(root_pids))
+    visited: set[int] = set()
+    expanded: set[int] = set()
+
+    while pending:
+        pid = pending.pop()
+        if pid in visited:
+            continue
+        visited.add(pid)
+        if pid in records_by_pid:
+            expanded.add(pid)
+        pending.extend(children_by_parent.get(pid, ()))
+
+    return frozenset(expanded)
+
+
+def expand_descendants(
+    records: Iterable[ProcessRecord], root_pids: Iterable[int]
+) -> frozenset[int]:
+    """Expand roots transitively, returning only PIDs present in ``records``.
+
+    Roots are included when they have a record.  Descendants can still be
+    discovered beneath a root whose own sample is absent.
+    """
+
+    records_by_pid, children_by_parent = _index_records(records)
+    return _expand_from_roots(records_by_pid, children_by_parent, root_pids)
+
+
+def _subtotal(
+    records_by_pid: dict[int, ProcessRecord], pids: Iterable[int]
+) -> ProcessSubtotal:
+    unique_pids = tuple(sorted(set(pids) & records_by_pid.keys()))
+    unique_records = tuple(records_by_pid[pid] for pid in unique_pids)
+    return ProcessSubtotal(
+        pids=unique_pids,
+        cpu_percent=fsum(record.cpu_percent or 0.0 for record in unique_records),
+        resident_bytes=sum(record.resident_bytes for record in unique_records),
+        physical_footprint_bytes=sum(
+            record.physical_footprint_bytes for record in unique_records
+        ),
+    )
+
+
+def analyze_process_tree(
+    records: Iterable[ProcessRecord],
+    *,
+    app_pid: int,
+    terminal_root_pids: Iterable[int],
+    webkit_root_pids: Iterable[int],
+) -> ProcessTreeReport:
+    """Account for one app process tree without double-counting any subtotal.
+
+    Terminal and WebKit categories remain independent and may overlap.  Their
+    expanded roots are intersected with the app tree so unrelated supplied
+    roots cannot enter the report.  The full-tree subtotal is calculated
+    directly from its unique PID set rather than by adding category totals.
+    """
+
+    records_by_pid, children_by_parent = _index_records(records)
+    full_tree_pids = _expand_from_roots(
+        records_by_pid, children_by_parent, {app_pid}
+    )
+    terminal_pids = _expand_from_roots(
+        records_by_pid, children_by_parent, terminal_root_pids
+    ) & full_tree_pids
+    webkit_pids = _expand_from_roots(
+        records_by_pid, children_by_parent, webkit_root_pids
+    ) & full_tree_pids
+    parent_pids = {app_pid} & full_tree_pids
+
+    sampled_pids = {
+        pid
+        for pid in full_tree_pids
+        if records_by_pid[pid].cpu_percent is not None
+    }
+    missing_pids = set(full_tree_pids) - sampled_pids
+    coverage = ProcessCoverage(
+        discovered_pids=tuple(full_tree_pids),
+        sampled_pids=tuple(sampled_pids),
+        missing_pids=tuple(missing_pids),
+    )
+
+    return ProcessTreeReport(
+        parent_direct=_subtotal(records_by_pid, parent_pids),
+        terminal=_subtotal(records_by_pid, terminal_pids),
+        webkit=_subtotal(records_by_pid, webkit_pids),
+        full_tree=_subtotal(records_by_pid, full_tree_pids),
+        coverage=coverage,
+    )
+
+
+__all__ = [
+    "ProcessCoverage",
+    "ProcessRecord",
+    "ProcessSubtotal",
+    "ProcessTreeReport",
+    "WebKitRole",
+    "analyze_process_tree",
+    "classify_webkit_role",
+    "expand_descendants",
+]

--- a/scripts/perf_top_payload.py
+++ b/scripts/perf_top_payload.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Parse ``system.top`` payloads into benchmark process-accounting groups.
+
+The socket payload repeats process trees at several topology levels.  This
+module normalizes those repetitions into one immutable process snapshot, then
+uses :mod:`perf_process_tree` for the independent parent, terminal, and WebKit
+subtotals.  The payload's top-level totals remain authoritative for the full
+snapshot because the independent groups can intentionally overlap.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+from math import isfinite
+from pathlib import Path
+import sys
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+def _load_process_tree() -> Any:
+    existing = sys.modules.get("perf_process_tree")
+    if existing is not None:
+        return existing
+    path = Path(__file__).with_name("perf_process_tree.py")
+    spec = importlib.util.spec_from_file_location("perf_process_tree", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load perf_process_tree from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_process_tree = _load_process_tree()
+ProcessCoverage = _process_tree.ProcessCoverage
+ProcessRecord = _process_tree.ProcessRecord
+ProcessSubtotal = _process_tree.ProcessSubtotal
+analyze_process_tree = _process_tree.analyze_process_tree
+classify_webkit_role = _process_tree.classify_webkit_role
+expand_descendants = _process_tree.expand_descendants
+
+_WEBKIT_ROLES = ("content", "gpu", "network")
+_TOPOLOGY_CHILDREN = ("workspaces", "panes", "surfaces", "webviews")
+
+
+@dataclass(frozen=True)
+class TopPayloadAccounting:
+    """Immutable accounting derived from one complete ``system.top`` payload."""
+
+    app_pid: int
+    terminal_root_pids: tuple[int, ...]
+    webkit_root_pids: tuple[int, ...]
+    webkit_role_pids: Mapping[str, tuple[int, ...]]
+    parent_direct: Any
+    terminal: Any
+    webkit: Any
+    full_tree: Any
+    coverage: Any
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "terminal_root_pids", tuple(sorted(set(self.terminal_root_pids)))
+        )
+        object.__setattr__(
+            self, "webkit_root_pids", tuple(sorted(set(self.webkit_root_pids)))
+        )
+        canonical_roles = {
+            role: tuple(sorted(set(self.webkit_role_pids.get(role, ()))))
+            for role in _WEBKIT_ROLES
+        }
+        object.__setattr__(
+            self, "webkit_role_pids", MappingProxyType(canonical_roles)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "app_pid": self.app_pid,
+            "terminal_root_pids": list(self.terminal_root_pids),
+            "webkit_root_pids": list(self.webkit_root_pids),
+            "webkit_role_pids": {
+                role: list(self.webkit_role_pids[role]) for role in _WEBKIT_ROLES
+            },
+            "parent_direct": self.parent_direct.to_dict(),
+            "terminal": self.terminal.to_dict(),
+            "webkit": self.webkit.to_dict(),
+            "full_tree": self.full_tree.to_dict(),
+            "coverage": self.coverage.to_dict(),
+        }
+
+
+def _mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    return value
+
+
+def _array(value: Any, name: str) -> list[Any] | tuple[Any, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"{name} must be an array")
+    return value
+
+
+def _integer(value: Any, name: str, *, positive: bool = False) -> int:
+    minimum = 1 if positive else 0
+    if type(value) is not int or value < minimum:
+        qualifier = "positive" if positive else "nonnegative"
+        raise ValueError(f"{name} must be a {qualifier} integer")
+    return value
+
+
+def _pid_array(value: Any, name: str) -> tuple[int, ...]:
+    values = _array(value, name)
+    pids = tuple(
+        _integer(item, f"{name}[{index}]", positive=True)
+        for index, item in enumerate(values)
+    )
+    if len(pids) != len(set(pids)):
+        raise ValueError(f"{name} must not contain duplicate process IDs")
+    return pids
+
+
+def _resource_number(value: Any, name: str) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not isfinite(value)
+        or value < 0
+    ):
+        raise ValueError(f"{name} must be a nonnegative finite number")
+    return float(value)
+
+
+def _resource_bytes(value: Any, name: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{name} must be a nonnegative integer")
+    return value
+
+
+def _resource_fields(resources: Any, name: str) -> tuple[float, int, int]:
+    summary = _mapping(resources, name)
+    try:
+        cpu_raw = summary["cpu_percent"]
+        resident_raw = summary["resident_bytes"]
+        footprint_raw = summary["memory_bytes"]
+    except KeyError as error:
+        raise ValueError(f"{name} is missing {error.args[0]}") from None
+    return (
+        _resource_number(cpu_raw, f"{name}.cpu_percent"),
+        _resource_bytes(resident_raw, f"{name}.resident_bytes"),
+        _resource_bytes(footprint_raw, f"{name}.memory_bytes"),
+    )
+
+
+def _process_command(node: Mapping[str, Any], name: str) -> str:
+    process_name = node.get("name")
+    if not isinstance(process_name, str):
+        raise ValueError(f"{name}.name must be a string")
+    path = node.get("path")
+    if path is not None and not isinstance(path, str):
+        raise ValueError(f"{name}.path must be a string or null")
+    return process_name if not path else f"{process_name} {path}"
+
+
+def _walk_process_node(
+    raw_node: Any,
+    name: str,
+    records_by_pid: dict[int, Any],
+) -> None:
+    node = _mapping(raw_node, name)
+    try:
+        pid_raw = node["pid"]
+        parent_raw = node["ppid"]
+        resources_raw = node["resources"]
+        children_raw = node["children"]
+    except KeyError as error:
+        raise ValueError(f"{name} is missing {error.args[0]}") from None
+
+    pid = _integer(pid_raw, f"{name}.pid", positive=True)
+    parent_pid = _integer(parent_raw, f"{name}.ppid")
+    cpu_percent, resident_bytes, physical_footprint_bytes = _resource_fields(
+        resources_raw, f"{name}.resources"
+    )
+    record = ProcessRecord(
+        pid=pid,
+        parent_pid=parent_pid,
+        command=_process_command(node, name),
+        cpu_percent=cpu_percent,
+        resident_bytes=resident_bytes,
+        physical_footprint_bytes=physical_footprint_bytes,
+    )
+    previous = records_by_pid.get(pid)
+    if previous is not None and previous != record:
+        raise ValueError(f"conflicting records for PID {pid}")
+    records_by_pid[pid] = record
+
+    children = _array(children_raw, f"{name}.children")
+    for index, child in enumerate(children):
+        _walk_process_node(child, f"{name}.children[{index}]", records_by_pid)
+
+
+def _walk_topology_node(
+    raw_node: Any,
+    name: str,
+    *,
+    node_kind: str,
+    records_by_pid: dict[int, Any],
+    app_pid_candidates: set[int],
+    surface_root_pids: set[int],
+    webkit_root_pids: set[int],
+) -> None:
+    node = _mapping(raw_node, name)
+
+    if node_kind == "windows":
+        app_pids = _pid_array(
+            node.get("app_process_pids", []), f"{name}.app_process_pids"
+        )
+        app_pid_candidates.update(app_pids)
+    elif node_kind == "surfaces":
+        roots = _pid_array(node.get("root_pids", []), f"{name}.root_pids")
+        surface_root_pids.update(roots)
+    elif node_kind == "webviews":
+        roots = _pid_array(node.get("root_pids", []), f"{name}.root_pids")
+        webkit_root_pids.update(roots)
+
+    if "processes" in node:
+        processes = _array(node["processes"], f"{name}.processes")
+        for index, process in enumerate(processes):
+            _walk_process_node(
+                process, f"{name}.processes[{index}]", records_by_pid
+            )
+
+    for child_kind in _TOPOLOGY_CHILDREN:
+        if child_kind not in node:
+            continue
+        children = _array(node[child_kind], f"{name}.{child_kind}")
+        for index, child in enumerate(children):
+            _walk_topology_node(
+                child,
+                f"{name}.{child_kind}[{index}]",
+                node_kind=child_kind,
+                records_by_pid=records_by_pid,
+                app_pid_candidates=app_pid_candidates,
+                surface_root_pids=surface_root_pids,
+                webkit_root_pids=webkit_root_pids,
+            )
+
+
+def _authoritative_totals(totals_raw: Any) -> tuple[Any, Any]:
+    totals = _mapping(totals_raw, "payload.totals")
+    cpu_percent, resident_bytes, physical_footprint_bytes = _resource_fields(
+        totals, "payload.totals"
+    )
+    try:
+        pids = _pid_array(totals["pids"], "payload.totals.pids")
+        missing_pids = _pid_array(
+            totals["missing_pids"], "payload.totals.missing_pids"
+        )
+        process_count = _integer(
+            totals["process_count"], "payload.totals.process_count"
+        )
+    except KeyError as error:
+        raise ValueError(f"payload.totals is missing {error.args[0]}") from None
+
+    if process_count != len(pids):
+        raise ValueError("payload.totals.process_count must equal the number of pids")
+    if set(pids) & set(missing_pids):
+        raise ValueError("payload.totals.pids and missing_pids must be disjoint")
+
+    full_tree = ProcessSubtotal(
+        pids=pids,
+        cpu_percent=cpu_percent,
+        resident_bytes=resident_bytes,
+        physical_footprint_bytes=physical_footprint_bytes,
+    )
+    coverage = ProcessCoverage(
+        discovered_pids=tuple(set(pids) | set(missing_pids)),
+        sampled_pids=pids,
+        missing_pids=missing_pids,
+    )
+    return full_tree, coverage
+
+
+def _webkit_roles(
+    records: tuple[Any, ...], webkit_root_pids: set[int]
+) -> Mapping[str, tuple[int, ...]]:
+    records_by_pid = {record.pid: record for record in records}
+    role_pids: dict[str, set[int]] = {role: set() for role in _WEBKIT_ROLES}
+    assigned_roles: dict[int, str] = {}
+
+    for root_pid in sorted(webkit_root_pids):
+        descendants = set(expand_descendants(records, (root_pid,)))
+        classified = {
+            role
+            for pid in descendants
+            if (role := classify_webkit_role(records_by_pid[pid])) is not None
+        }
+        if not classified:
+            raise ValueError(f"cannot classify WebKit root PID {root_pid}")
+        if len(classified) != 1:
+            raise ValueError(f"ambiguous WebKit role for root PID {root_pid}")
+        role = classified.pop()
+        for pid in descendants:
+            previous = assigned_roles.get(pid)
+            if previous is not None and previous != role:
+                raise ValueError(f"ambiguous WebKit role for PID {pid}")
+            assigned_roles[pid] = role
+            role_pids[role].add(pid)
+
+    return MappingProxyType(
+        {role: tuple(sorted(role_pids[role])) for role in _WEBKIT_ROLES}
+    )
+
+
+def parse_system_top_payload(
+    payload: Mapping[str, Any], app_pid: int | None = None
+) -> TopPayloadAccounting:
+    """Normalize and account for one process-detailed ``system.top`` payload.
+
+    ``app_pid`` overrides window-derived application PID selection, which is
+    useful when a multi-window payload contains more than one application root.
+    All other roots and records are always derived from the payload itself.
+    """
+
+    top = _mapping(payload, "payload")
+    try:
+        windows = _array(top["windows"], "payload.windows")
+        totals_raw = top["totals"]
+    except KeyError as error:
+        raise ValueError(f"payload is missing {error.args[0]}") from None
+
+    records_by_pid: dict[int, Any] = {}
+    app_pid_candidates: set[int] = set()
+    surface_root_pids: set[int] = set()
+    webkit_root_pids: set[int] = set()
+    for index, window in enumerate(windows):
+        _walk_topology_node(
+            window,
+            f"payload.windows[{index}]",
+            node_kind="windows",
+            records_by_pid=records_by_pid,
+            app_pid_candidates=app_pid_candidates,
+            surface_root_pids=surface_root_pids,
+            webkit_root_pids=webkit_root_pids,
+        )
+
+    if app_pid is None:
+        if len(app_pid_candidates) != 1:
+            raise ValueError(
+                "payload must identify exactly one app PID in app_process_pids"
+            )
+        resolved_app_pid = next(iter(app_pid_candidates))
+    else:
+        resolved_app_pid = _integer(app_pid, "app_pid", positive=True)
+
+    records = tuple(records_by_pid[pid] for pid in sorted(records_by_pid))
+    if resolved_app_pid not in records_by_pid:
+        raise ValueError(f"app PID {resolved_app_pid} has no process record")
+    if not webkit_root_pids.issubset(surface_root_pids):
+        raise ValueError("WebKit root PIDs must also be surface root PIDs")
+
+    terminal_root_pids = surface_root_pids - webkit_root_pids
+    report = analyze_process_tree(
+        records,
+        app_pid=resolved_app_pid,
+        terminal_root_pids=terminal_root_pids,
+        webkit_root_pids=webkit_root_pids,
+    )
+    role_pids = _webkit_roles(records, webkit_root_pids)
+    full_tree, coverage = _authoritative_totals(totals_raw)
+
+    return TopPayloadAccounting(
+        app_pid=resolved_app_pid,
+        terminal_root_pids=tuple(terminal_root_pids),
+        webkit_root_pids=tuple(webkit_root_pids),
+        webkit_role_pids=role_pids,
+        parent_direct=report.parent_direct,
+        terminal=report.terminal,
+        webkit=report.webkit,
+        full_tree=full_tree,
+        coverage=coverage,
+    )
+
+
+__all__ = ["TopPayloadAccounting", "parse_system_top_payload"]

--- a/scripts/perf_top_payload.py
+++ b/scripts/perf_top_payload.py
@@ -247,15 +247,20 @@ def _walk_topology_node(
             )
 
 
-def _authoritative_totals(totals_raw: Any) -> tuple[Any, Any]:
+def _authoritative_totals(
+    totals_raw: Any,
+    *,
+    recorded_pids: set[int],
+    topology_pids: set[int],
+) -> tuple[Any, Any]:
     totals = _mapping(totals_raw, "payload.totals")
     cpu_percent, resident_bytes, physical_footprint_bytes = _resource_fields(
         totals, "payload.totals"
     )
     try:
-        pids = _pid_array(totals["pids"], "payload.totals.pids")
-        missing_pids = _pid_array(
-            totals["missing_pids"], "payload.totals.missing_pids"
+        requested_pids = set(_pid_array(totals["pids"], "payload.totals.pids"))
+        producer_missing_pids = set(
+            _pid_array(totals["missing_pids"], "payload.totals.missing_pids")
         )
         process_count = _integer(
             totals["process_count"], "payload.totals.process_count"
@@ -263,21 +268,26 @@ def _authoritative_totals(totals_raw: Any) -> tuple[Any, Any]:
     except KeyError as error:
         raise ValueError(f"payload.totals is missing {error.args[0]}") from None
 
-    if process_count != len(pids):
-        raise ValueError("payload.totals.process_count must equal the number of pids")
-    if set(pids) & set(missing_pids):
-        raise ValueError("payload.totals.pids and missing_pids must be disjoint")
+    sampled_pids = (requested_pids & recorded_pids) - producer_missing_pids
+    if process_count != len(sampled_pids):
+        raise ValueError(
+            "payload.totals.process_count must equal recorded sampled pids"
+        )
+    discovered_pids = (
+        requested_pids | producer_missing_pids | topology_pids | recorded_pids
+    )
+    missing_pids = discovered_pids - sampled_pids
 
     full_tree = ProcessSubtotal(
-        pids=pids,
+        pids=tuple(sampled_pids),
         cpu_percent=cpu_percent,
         resident_bytes=resident_bytes,
         physical_footprint_bytes=physical_footprint_bytes,
     )
     coverage = ProcessCoverage(
-        discovered_pids=tuple(set(pids) | set(missing_pids)),
-        sampled_pids=pids,
-        missing_pids=missing_pids,
+        discovered_pids=tuple(discovered_pids),
+        sampled_pids=tuple(sampled_pids),
+        missing_pids=tuple(missing_pids),
     )
     return full_tree, coverage
 
@@ -296,6 +306,8 @@ def _webkit_roles(
             for pid in descendants
             if (role := classify_webkit_role(records_by_pid[pid])) is not None
         }
+        if not descendants:
+            continue
         if not classified:
             raise ValueError(f"cannot classify WebKit root PID {root_pid}")
         if len(classified) != 1:
@@ -368,7 +380,11 @@ def parse_system_top_payload(
         webkit_root_pids=webkit_root_pids,
     )
     role_pids = _webkit_roles(records, webkit_root_pids)
-    full_tree, coverage = _authoritative_totals(totals_raw)
+    full_tree, coverage = _authoritative_totals(
+        totals_raw,
+        recorded_pids=set(records_by_pid),
+        topology_pids=app_pid_candidates | surface_root_pids,
+    )
 
     return TopPayloadAccounting(
         app_pid=resolved_app_pid,

--- a/tests/test_perf_activation_scrollback_sizing.py
+++ b/tests/test_perf_activation_scrollback_sizing.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import argparse
+import hashlib
 import importlib.util
 from pathlib import Path
 
@@ -63,6 +65,35 @@ def test_small_requested_fixture_is_not_scaled_up() -> None:
 
     assert summary["scrollback_target_applied"] is False
     assert set(plan.values()) == {1}
+
+
+def test_persisted_snapshot_fingerprint_uses_exact_tagged_primary_file(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    args = argparse.Namespace(
+        tag="Fingerprint Test",
+        app_path=str(tmp_path / "cmux.app"),
+        fixture_root=str(tmp_path / "fixture"),
+        launch_timeout=1.0,
+        snapshot_timeout=1.0,
+    )
+    runner = perf_activation_session.CmuxPerfRunner(args)
+    payload = b'{"owned":"snapshot"}'
+    snapshot_path = (
+        home
+        / "Library/Application Support/cmux"
+        / "session-com.cmuxterm.app.debug.fingerprint.test.json"
+    )
+    snapshot_path.parent.mkdir(parents=True)
+    snapshot_path.write_bytes(payload)
+
+    assert runner.persisted_snapshot_fingerprint() == {
+        "algorithm": "sha256",
+        "digest": hashlib.sha256(payload).hexdigest(),
+        "byte_count": len(payload),
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_perf_activation_scrollback_sizing.py
+++ b/tests/test_perf_activation_scrollback_sizing.py
@@ -87,6 +87,11 @@ def test_persisted_snapshot_fingerprint_uses_exact_tagged_primary_file(
         / "session-com.cmuxterm.app.debug.fingerprint.test.json"
     )
     snapshot_path.parent.mkdir(parents=True)
+    previous_payload = b'{"owned":"previous"}'
+    previous_path = snapshot_path.with_name(
+        "session-com.cmuxterm.app.debug.fingerprint.test-previous.json"
+    )
+    previous_path.write_bytes(previous_payload)
     snapshot_path.write_bytes(payload)
 
     assert runner.persisted_snapshot_fingerprint() == {
@@ -95,6 +100,11 @@ def test_persisted_snapshot_fingerprint_uses_exact_tagged_primary_file(
         "byte_count": len(payload),
     }
 
+    assert runner.persisted_snapshot_fingerprint(source="previous") == {
+        "algorithm": "sha256",
+        "digest": hashlib.sha256(previous_payload).hexdigest(),
+        "byte_count": len(previous_payload),
+    }
 
 if __name__ == "__main__":
     test_default_scrollback_seed_is_bounded_above_budget_floor()

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from concurrent.futures import Future, ThreadPoolExecutor as RealThreadPoolExecutor
 import importlib.util
 import json
 from pathlib import Path
@@ -59,6 +60,32 @@ class FakeClock:
         self.sleeps.append(duration)
         self.now += duration
         time.sleep(0.001)
+
+
+class InlineExecutor:
+    """Future-compatible executor for deterministic fake-clock behavior tests."""
+
+    def __init__(self, max_workers: int) -> None:
+        del max_workers
+
+    def __enter__(self) -> InlineExecutor:
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    def submit(self, function: Any, *args: Any, **kwargs: Any) -> Future[Any]:
+        future: Future[Any] = Future()
+        try:
+            future.set_result(function(*args, **kwargs))
+        except BaseException as error:
+            future.set_exception(error)
+        return future
+
+    def shutdown(
+        self, wait: bool = True, *, cancel_futures: bool = False
+    ) -> None:
+        del wait, cancel_futures
 
 
 class FakeRunner:
@@ -632,11 +659,15 @@ def test_steady_primes_system_top_and_parser_deduplicates_repeated_processes(tmp
     }
 
 
-def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Path) -> None:
+def test_churn_calls_every_planned_surface_and_records_real_metrics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     cfg = config(tmp_path)
     runner = FakeRunner()
     runner.top_payloads = [top_payload(), top_payload()]
     clock = FakeClock()
+    monkeypatch.setattr(adapter_module, "ThreadPoolExecutor", InlineExecutor)
     adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=clock)
     plan = prepare_fixture(adapter, runner, cfg)
 
@@ -711,6 +742,198 @@ def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Pa
         "present_rate" not in item for item in result["render_observations"]
     )
     assert result["failures"] == []
+
+
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, SystemExit])
+def test_profile_setup_control_flow_exceptions_propagate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[BaseException],
+) -> None:
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        config(tmp_path, profile_enabled=True),
+        runner=FakeRunner(),
+        clock=FakeClock(),
+    )
+
+    def interrupt_profile_setup(**_: Any) -> list[dict[str, Any]]:
+        raise error_type("profile setup interrupted")
+
+    monkeypatch.setattr(adapter, "_profile_metadata", interrupt_profile_setup)
+
+    with pytest.raises(error_type, match="profile setup interrupted"):
+        adapter.run_churn([])
+
+
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, SystemExit])
+def test_raw_churn_sampling_control_flow_exceptions_propagate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[BaseException],
+) -> None:
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        config(
+            tmp_path,
+            churn_duration_s=0.5,
+            churn_measurement_duration_s=0.5,
+        ),
+        runner=FakeRunner(),
+        clock=FakeClock(),
+    )
+
+    def interrupt_sampling() -> dict[str, Any]:
+        raise error_type("sampling interrupted")
+
+    monkeypatch.setattr(adapter, "_raw_top", interrupt_sampling)
+
+    with pytest.raises(error_type, match="sampling interrupted"):
+        adapter.run_churn([])
+
+
+@pytest.mark.parametrize(
+    "injection_point", ["raw_top", "pre_sampling_sleep", "future_aggregation"]
+)
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, SystemExit])
+def test_profile_pool_is_joined_before_process_control_propagates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[BaseException],
+    injection_point: str,
+) -> None:
+    class RecordingExecutor:
+        instances: list[Any] = []
+
+        def __init__(self, max_workers: int) -> None:
+            self.executor = RealThreadPoolExecutor(max_workers=max_workers)
+            self.futures: list[Future[Any]] = []
+            self.shutdown_calls: list[tuple[bool, bool]] = []
+            self.instances.append(self)
+
+        def __enter__(self) -> RecordingExecutor:
+            self.executor.__enter__()
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return self.executor.__exit__(*args)
+
+        def submit(self, function: Any, *args: Any, **kwargs: Any) -> Future[Any]:
+            future = self.executor.submit(function, *args, **kwargs)
+            self.futures.append(future)
+            return future
+
+        def shutdown(
+            self, wait: bool = True, *, cancel_futures: bool = False
+        ) -> None:
+            self.shutdown_calls.append((wait, cancel_futures))
+            self.executor.shutdown(wait=wait, cancel_futures=cancel_futures)
+
+    def profiler(**kwargs: Any) -> dict[str, Any]:
+        time.sleep(0.02)
+        Path(kwargs["path"]).write_text("profile evidence", encoding="utf-8")
+        return {"ok": True}
+
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload()]
+    clock = FakeClock()
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        config(
+            tmp_path,
+            profile_enabled=True,
+            churn_duration_s=0.5,
+            churn_measurement_duration_s=0.5,
+        ),
+        runner=runner,
+        clock=clock,
+        profiler=profiler,
+    )
+    adapter._last_accounting = (
+        adapter_module._top_payload.parse_system_top_payload(top_payload())
+    )
+
+    def interrupt() -> None:
+        raise error_type("profiled process control interrupted")
+
+    monkeypatch.setattr(adapter_module, "ThreadPoolExecutor", RecordingExecutor)
+    if injection_point == "raw_top":
+        monkeypatch.setattr(adapter, "_raw_top", interrupt)
+    elif injection_point == "pre_sampling_sleep":
+        monkeypatch.setattr(clock, "sleep", lambda _: interrupt())
+    else:
+        def interrupt_aggregation(_: Any) -> Any:
+            interrupt()
+            yield
+
+        monkeypatch.setattr(adapter_module, "as_completed", interrupt_aggregation)
+
+    with pytest.raises(error_type, match="profiled process control interrupted"):
+        adapter.run_churn([])
+
+    profile_executor = RecordingExecutor.instances[0]
+    assert profile_executor.shutdown_calls == [(True, True)]
+    assert profile_executor.futures
+    assert all(future.done() for future in profile_executor.futures)
+
+
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, SystemExit])
+def test_temporary_browser_cycle_control_flow_exceptions_propagate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[BaseException],
+) -> None:
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload()]
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        config(
+            tmp_path,
+            churn_duration_s=0.5,
+            churn_measurement_duration_s=0.5,
+        ),
+        runner=runner,
+        clock=FakeClock(),
+    )
+
+    def interrupt_temporary_browser() -> None:
+        raise error_type("temporary browser interrupted")
+
+    monkeypatch.setattr(
+        adapter, "_temporary_browser_cycle", interrupt_temporary_browser
+    )
+
+    with pytest.raises(error_type, match="temporary browser interrupted"):
+        adapter.run_churn([])
+
+
+def test_worker_future_base_exception_is_reported_as_churn_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload()]
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        config(
+            tmp_path,
+            churn_duration_s=0.5,
+            churn_measurement_duration_s=0.5,
+        ),
+        runner=runner,
+        clock=FakeClock(),
+    )
+    adapter._terminal_actual_ids = {"terminal-001": "surface:1"}
+
+    def interrupt_worker(*_: Any) -> dict[str, Any]:
+        raise KeyboardInterrupt("worker interrupted")
+
+    monkeypatch.setattr(adapter, "_terminal_churn", interrupt_worker)
+
+    result = adapter.run_churn([])
+
+    assert result["failures"] == [
+        {
+            "phase": "churn",
+            "surface_id": "terminal-001",
+            "message": "worker interrupted",
+        }
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -933,7 +933,7 @@ def test_cleanup_unlinks_exact_owned_screenshot_path(
     assert str(screenshot_path) in cleanup["owned_paths"]
 
 
-def test_browser_batch_parallelizes_hidden_safe_work_after_ordered_activation(
+def test_browser_batch_overlaps_hidden_safe_work_with_ordered_activation(
     tmp_path: Path,
 ) -> None:
     cfg = config(tmp_path, scenario=scenario(terminals=0, browsers=2, scrollback=0))
@@ -943,34 +943,40 @@ def test_browser_batch_parallelizes_hidden_safe_work_after_ordered_activation(
     )
     prepare_fixture(adapter, runner, cfg)
     original_rpc = runner.rpc
+    actual_ids = list(adapter._browser_actual_ids.values())
+    first_reload_started = threading.Event()
     entered_reload: set[str] = set()
     entered_lock = threading.Lock()
     both_reloading = threading.Event()
 
-    def rpc_with_reload_barrier(
+    def rpc_with_overlap_contract(
         method: str, params: dict[str, Any] | None = None, timeout: float = 60
     ) -> dict[str, Any]:
         if method == "browser.reload" and params is not None:
+            first_reload_started.set()
             with entered_lock:
                 entered_reload.add(params["surface_id"])
                 if len(entered_reload) == 2:
                     both_reloading.set()
             assert both_reloading.wait(timeout=1.0)
+        if method == "surface.focus" and params is not None:
+            if params["surface_id"] == actual_ids[1]:
+                assert first_reload_started.wait(timeout=1.0)
         return original_rpc(method, params, timeout)
 
-    runner.rpc = rpc_with_reload_barrier
+    runner.rpc = rpc_with_overlap_contract
     results = adapter._browser_churn_batch(1)
 
     assert [planned for planned, _result in results] == list(
         adapter._browser_actual_ids
     )
-    assert entered_reload == set(adapter._browser_actual_ids.values())
+    assert entered_reload == set(actual_ids)
     activations = [
         event[2]["surface_id"]
         for event in runner.events
         if event[:2] == ("rpc", "surface.focus")
     ]
-    assert activations == list(adapter._browser_actual_ids.values())
+    assert activations == actual_ids
 
 
 def test_churn_rejects_browser_work_that_outlives_fixed_measurement_window(

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -65,6 +65,7 @@ class FakeRunner:
     def __init__(self) -> None:
         self.events: list[Any] = []
         self.workspace = "workspace:9"
+        self.workspaces = [self.workspace]
         self.pane = "pane:4"
         self.initial_terminal = "surface:initial"
         self.surfaces: list[dict[str, Any]] = [
@@ -100,7 +101,11 @@ class FakeRunner:
     def json_cli(self, args: list[str], timeout: float = 60) -> dict[str, Any]:
         self.events.append(("json_cli", tuple(args), timeout))
         if args[0] == "list-workspaces":
-            return {"workspaces": [{"workspace_id": self.workspace}]}
+            return {
+                "workspaces": [
+                    {"workspace_id": workspace} for workspace in self.workspaces
+                ]
+            }
         if args[:2] == ["workspace", "create"]:
             return {"workspace_id": self.workspace}
         if args[0] == "list-panes":
@@ -349,9 +354,13 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
         for item in plan.browser_surfaces
     ]
     assert all(item.url.startswith("file://") for item in plan.browser_surfaces)
-    workspace_calls = [event for event in runner.events if event[0] == "json_cli" and event[1][:2] == ("workspace", "create")]
-    assert len(workspace_calls) == 1
-    assert workspace_calls[0][1] == ("workspace", "create", "--name", "cmux-perf-mixed-test", "--cwd", str(cfg.output_root))
+    workspace_calls = [
+        event
+        for event in runner.events
+        if event[0] == "json_cli" and event[1][:2] == ("workspace", "create")
+    ]
+    assert workspace_calls == []
+    assert adapter.raw_details["fixture"]["workspace_id"] == runner.workspace
     pane_calls = [event for event in runner.events if event[0] == "json_cli" and event[1][0] == "new-surface"]
     assert pane_calls and all("--pane" in event[1] and event[1][event[1].index("--pane") + 1] == runner.pane for event in pane_calls)
     seed = next(event for event in runner.events if event[:2] == ("rpc", "debug.session_snapshot_seed_scrollback"))
@@ -366,6 +375,21 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
         "browser-mixed-test-002": "surface:4",
     }
     json.dumps(adapter.raw_details)
+
+def test_fixture_rejects_nonunique_clean_startup_workspace(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    runner.workspaces.append("workspace:unexpected")
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+
+    with pytest.raises(ValueError, match="exactly one clean startup workspace"):
+        prepare_fixture(adapter, runner, cfg)
+
+    assert not any(
+        event[0] == "json_cli" and event[1][0] == "new-surface"
+        for event in runner.events
+    )
+
 
 def test_browser_only_closes_initial_terminal_and_does_not_seed_scrollback(tmp_path: Path) -> None:
     cfg = config(tmp_path, scenario=scenario(terminals=0, browsers=2, scrollback=0))

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -68,6 +68,7 @@ class FakeRunner:
         self.workspaces = [self.workspace]
         self.pane = "pane:4"
         self.initial_terminal = "surface:initial"
+        self.initial_terminal_id = "00000000-0000-0000-0000-000000000009"
         self.surfaces: list[dict[str, Any]] = [
             {"surface_id": self.initial_terminal, "type": "terminal", "title": "shell"}
         ]
@@ -100,15 +101,17 @@ class FakeRunner:
 
     def json_cli(self, args: list[str], timeout: float = 60) -> dict[str, Any]:
         self.events.append(("json_cli", tuple(args), timeout))
-        if args[0] == "list-workspaces":
+        both_ids = args[:2] == ["--id-format", "both"]
+        command_args = args[2:] if both_ids else args
+        if command_args[0] == "list-workspaces":
             return {
                 "workspaces": [
                     {"workspace_id": workspace} for workspace in self.workspaces
                 ]
             }
-        if args[:2] == ["workspace", "create"]:
+        if command_args[:2] == ["workspace", "create"]:
             return {"workspace_id": self.workspace}
-        if args[0] == "list-panes":
+        if command_args[0] == "list-panes":
             return {
                 "panes": [
                     {
@@ -118,19 +121,29 @@ class FakeRunner:
                     }
                 ]
             }
-        if args[0] == "list-pane-surfaces":
+        if command_args[0] == "list-pane-surfaces":
+            surfaces = deepcopy(self.surfaces)
+            if both_ids:
+                surfaces = [
+                    {
+                        **{key: value for key, value in surface.items() if key != "surface_id"},
+                        "id": self.initial_terminal_id,
+                        "ref": surface["surface_id"],
+                    }
+                    for surface in surfaces
+                ]
             return {
                 "workspace_id": self.workspace,
                 "pane_id": self.pane,
-                "surfaces": deepcopy(self.surfaces),
+                "surfaces": surfaces,
             }
-        if args[0] == "new-surface":
-            kind = args[args.index("--type") + 1]
+        if command_args[0] == "new-surface":
+            kind = command_args[command_args.index("--type") + 1]
             ref = f"surface:{len(self.surfaces) + 1}"
             item = {"surface_id": ref, "type": kind, "title": kind}
             self.surfaces.append(item)
             if kind == "browser":
-                url = args[args.index("--url") + 1]
+                url = command_args[command_args.index("--url") + 1]
                 self.browser_state[ref] = {"url": url, "title": "", "content_marker": ""}
             return {"surface_id": ref, "pane_id": self.pane, "workspace_id": self.workspace}
         raise AssertionError(f"unexpected JSON CLI call: {args}")
@@ -164,10 +177,8 @@ class FakeRunner:
         self.events.append(("rpc", method, params, timeout))
         if method == "surface.respawn":
             return {
-                "surface_id": "00000000-0000-0000-0000-000000000009",
-                "surface_ref": params["surface_id"],
-                "workspace_id": "00000000-0000-0000-0000-000000000008",
-                "workspace_ref": params["workspace_id"],
+                "surface_id": params["surface_id"],
+                "surface_ref": self.initial_terminal,
                 "type": "terminal",
             }
         if method == "debug.session_snapshot_seed_scrollback":
@@ -390,8 +401,7 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
     )
     respawn = next(event for event in runner.events if event[:2] == ("rpc", "surface.respawn"))
     assert respawn[2] == {
-        "workspace_id": runner.workspace,
-        "surface_id": runner.initial_terminal,
+        "surface_id": runner.initial_terminal_id,
         "working_directory": str(cfg.output_root),
         "focus": False,
     }

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -91,8 +91,14 @@ class FakeRunner:
             "digest": "a" * 64,
             "byte_count": 4096,
         }
+        self.previous_snapshot_fingerprint: dict[str, Any] | None = None
 
     def _restore_with_fresh_ids(self) -> None:
+        self.previous_snapshot_fingerprint = deepcopy(self.snapshot_fingerprint)
+        self.snapshot_fingerprint = {
+            **self.snapshot_fingerprint,
+            "digest": "b" * 64,
+        }
         self.restore_count += 1
         suffix = f"restored-{self.restore_count}"
         old_workspace = self.workspace
@@ -139,9 +145,13 @@ class FakeRunner:
     def clean_persisted_state(self) -> None:
         self.events.append("clean_persisted_state")
 
-    def persisted_snapshot_fingerprint(self) -> dict[str, Any]:
-        self.events.append("persisted_snapshot_fingerprint")
-        return deepcopy(self.snapshot_fingerprint)
+    def persisted_snapshot_fingerprint(self, source: str = "primary") -> dict[str, Any]:
+        self.events.append(("persisted_snapshot_fingerprint", source))
+        if source == "primary":
+            return deepcopy(self.snapshot_fingerprint)
+        if source == "previous" and self.previous_snapshot_fingerprint is not None:
+            return deepcopy(self.previous_snapshot_fingerprint)
+        raise ValueError(f"unavailable persisted snapshot source: {source}")
 
     def launch(self, label: str) -> float:
         self.events.append(("launch", label))
@@ -757,11 +767,12 @@ def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shap
     original_workspace = adapter._workspace_id
     original_pane = adapter._pane_id
     original_terminals = dict(adapter._terminal_actual_ids)
+    expected_persisted = deepcopy(runner.snapshot_fingerprint)
     original_browsers = dict(adapter._browser_actual_ids)
 
     captured = adapter.snapshot()
     assert captured["elapsed_ms"] == 4.5
-    assert runner.events[-1] == "persisted_snapshot_fingerprint"
+    assert runner.events[-1] == ("persisted_snapshot_fingerprint", "primary")
     before_restore = len(runner.events)
     adapter.restore(captured)
     restored_events = runner.events[before_restore:]
@@ -794,8 +805,9 @@ def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shap
         if event[:2] == ("rpc", "debug.session_snapshot_benchmark")
     ]
     assert len(benchmark_calls) == 1
-    assert adapter.raw_details["snapshot"]["persisted_before"] == runner.snapshot_fingerprint
-    assert adapter.raw_details["snapshot"]["persisted_after"] == runner.snapshot_fingerprint
+    assert adapter.raw_details["snapshot"]["persisted_before"] == expected_persisted
+    assert adapter.raw_details["snapshot"]["persisted_after"] == expected_persisted
+    assert runner.snapshot_fingerprint != expected_persisted
     assert adapter.observe_fixture()["browsers"][0]["content_marker"] == plan.browser_surfaces[0].content_marker
     runner.snapshot_fingerprint["digest"] = "0" * 64
     with pytest.raises(ValueError, match="persisted snapshot fingerprint"):

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+"""Focused behavioral contracts for the tagged cmux runtime adapter."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import importlib.util
+import json
+from pathlib import Path
+import re
+import sys
+import threading
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+SCRIPT = SCRIPTS / "perf_cmux_adapter.py"
+spec = importlib.util.spec_from_file_location("perf_cmux_adapter", SCRIPT)
+assert spec is not None and spec.loader is not None
+adapter_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = adapter_module
+spec.loader.exec_module(adapter_module)
+
+runtime_spec = importlib.util.spec_from_file_location(
+    "perf_mixed_workload", SCRIPTS / "perf_mixed_workload.py"
+)
+assert runtime_spec is not None and runtime_spec.loader is not None
+runtime = importlib.util.module_from_spec(runtime_spec)
+sys.modules[runtime_spec.name] = runtime
+runtime_spec.loader.exec_module(runtime)
+
+SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+def scenario(*, terminals: int = 2, browsers: int = 2, scrollback: int = 120) -> dict[str, Any]:
+    return {
+        "scenario_id": "mixed-test",
+        "kind": "mixed" if terminals and browsers else ("terminal" if terminals else "browser"),
+        "load": "light",
+        "terminal_surfaces": terminals,
+        "browser_surfaces": browsers,
+        "aggregate_scrollback_chars": scrollback,
+    }
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, duration: float) -> None:
+        self.sleeps.append(duration)
+        self.now += duration
+
+
+class FakeRunner:
+    """Stateful CmuxPerfRunner-shaped seam with no OS effects."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+        self.workspace = "workspace:9"
+        self.pane = "pane:4"
+        self.initial_terminal = "surface:initial"
+        self.surfaces: list[dict[str, Any]] = [
+            {"surface_id": self.initial_terminal, "type": "terminal", "title": "shell"}
+        ]
+        self.browser_state: dict[str, dict[str, str]] = {}
+        self.snapshot_payload: dict[str, Any] | None = None
+        self.top_payloads: list[dict[str, Any]] = []
+        self.terminal_markers: dict[str, str] = {}
+        self.stopped = False
+
+    def check_paths(self) -> None:
+        self.events.append("check_paths")
+
+    def clean_persisted_state(self) -> None:
+        self.events.append("clean_persisted_state")
+
+    def launch(self, label: str) -> float:
+        self.events.append(("launch", label))
+        self.stopped = False
+        return 12.5
+
+    def stop_app(self) -> None:
+        self.events.append("stop_app")
+        self.stopped = True
+
+    def cleanup_owned(self) -> dict[str, Any]:
+        self.events.append("cleanup_owned")
+        return {"owned_state_removed": True, "stopped": self.stopped}
+
+    def json_cli(self, args: list[str], timeout: float = 60) -> dict[str, Any]:
+        self.events.append(("json_cli", tuple(args), timeout))
+        if args[0] == "list-workspaces":
+            return {"workspaces": [{"workspace_id": self.workspace}]}
+        if args[:2] == ["workspace", "create"]:
+            return {"workspace_id": self.workspace}
+        if args[0] == "list-panes":
+            return {
+                "panes": [
+                    {
+                        "pane_id": self.pane,
+                        "workspace_id": self.workspace,
+                        "surface_ids": [surface["surface_id"] for surface in self.surfaces],
+                    }
+                ]
+            }
+        if args[0] == "list-pane-surfaces":
+            return {
+                "workspace_id": self.workspace,
+                "pane_id": self.pane,
+                "surfaces": deepcopy(self.surfaces),
+            }
+        if args[0] == "new-surface":
+            kind = args[args.index("--type") + 1]
+            ref = f"surface:{len(self.surfaces) + 1}"
+            item = {"surface_id": ref, "type": kind, "title": kind}
+            self.surfaces.append(item)
+            if kind == "browser":
+                url = args[args.index("--url") + 1]
+                self.browser_state[ref] = {"url": url, "title": "", "content_marker": ""}
+            return {"surface_id": ref, "pane_id": self.pane, "workspace_id": self.workspace}
+        raise AssertionError(f"unexpected JSON CLI call: {args}")
+
+    def run_cli(
+        self,
+        args: list[str],
+        input_text: str | None = None,
+        timeout: float = 60,
+        check: bool = True,
+    ) -> str:
+        self.events.append(("run_cli", tuple(args), input_text, timeout, check))
+        if args[0] == "close-surface":
+            surface = args[args.index("--surface") + 1]
+            self.surfaces = [item for item in self.surfaces if item["surface_id"] != surface]
+            self.browser_state.pop(surface, None)
+        if args[0] == "send":
+            surface = args[args.index("--surface") + 1]
+            match = re.search(r"CMUX_PERF_FINAL_COUNT=\d+:[A-Za-z0-9-]+", args[-1])
+            if match is not None:
+                self.terminal_markers[surface] = match.group(0)
+        if args[0] == "capture-pane":
+            surface = args[args.index("--surface") + 1]
+            return self.terminal_markers.get(surface, "")
+        return "OK"
+
+    def rpc(
+        self, method: str, params: dict[str, Any] | None = None, timeout: float = 60
+    ) -> dict[str, Any]:
+        params = deepcopy(params or {})
+        self.events.append(("rpc", method, params, timeout))
+        if method == "debug.session_snapshot_seed_scrollback":
+            chars = params["characters_per_terminal"]
+            terminals = sum(item["type"] == "terminal" for item in self.surfaces)
+            return {
+                "characters_per_terminal": chars,
+                "workspaces": 1,
+                "terminals": terminals,
+                "scrollback_chars": chars * terminals,
+            }
+        if method == "debug.session_snapshot_benchmark":
+            assert self.snapshot_payload is not None
+            return deepcopy(self.snapshot_payload)
+        if method == "debug.terminal.render_stats":
+            return {
+                "stats": {
+                    "drawCount": 10,
+                    "presentCount": 20,
+                    "metalDrawableCount": 20,
+                }
+            }
+        if method == "system.top":
+            if not self.top_payloads:
+                raise AssertionError("missing fake top payload")
+            return deepcopy(self.top_payloads.pop(0))
+        if method == "browser.wait":
+            return {"load_state": params["load_state"], "complete": True}
+        if method == "browser.url.get":
+            return {"url": self.browser_state[params["surface_id"]]["url"]}
+        if method == "browser.get.title":
+            return {"title": self.browser_state[params["surface_id"]]["title"]}
+        if method == "browser.eval":
+            return {"value": self.browser_state[params["surface_id"]]["content_marker"]}
+        if method in {"browser.focus_webview", "browser.reload", "browser.snapshot"}:
+            return {"ok": True, "surface_id": params["surface_id"]}
+        if method == "surface.create":
+            ref = "surface:temporary"
+            self.surfaces.append({"surface_id": ref, "type": "browser", "title": "temporary"})
+            return {"surface_id": ref, "pane_id": self.pane}
+        if method == "surface.close":
+            ref = params["surface_id"]
+            self.surfaces = [item for item in self.surfaces if item["surface_id"] != ref]
+            self.browser_state.pop(ref, None)
+            return {"ok": True}
+        raise AssertionError(f"unexpected RPC call: {method} {params}")
+
+def config(tmp_path: Path, **overrides: Any) -> Any:
+    values = {
+        "sha": SHA,
+        "tag": "cpu-adapter-test",
+        "app_path": "/owned/cmux DEV cpu-adapter-test.app",
+        "scenario": scenario(),
+        "output_root": tmp_path / "owned-output",
+        "warmup": False,
+        "profile_enabled": False,
+        "steady_duration_s": 1.0,
+        "steady_interval_s": 0.5,
+        "churn_duration_s": 1.0,
+        "churn_interval_s": 0.5,
+        "profile_duration_s": 1.0,
+    }
+    values.update(overrides)
+    return adapter_module.AdapterConfig(**values)
+
+
+def plan_for(cfg: Any) -> Any:
+    return runtime.build_browser_fixture_plan(
+        scenario_id=cfg.scenario["scenario_id"],
+        terminal_count=cfg.scenario["terminal_surfaces"],
+        browser_count=cfg.scenario["browser_surfaces"],
+        owned_root=cfg.output_root,
+    )
+
+
+def top_payload() -> dict[str, Any]:
+    def resources(pids: list[int], cpu: float) -> dict[str, Any]:
+        return {
+            "cpu_percent": cpu,
+            "memory_bytes": len(pids) * 1000,
+            "resident_bytes": len(pids) * 100,
+            "process_count": len(pids),
+            "pids": pids,
+            "missing_pids": [],
+        }
+
+    webkit = {
+        "pid": 300,
+        "ppid": 200,
+        "name": "com.apple.WebKit.WebContent",
+        "path": "/System/WebKit/WebContent",
+        "resources": resources([300], 3.0),
+        "children": [],
+    }
+    terminal = {
+        "pid": 200,
+        "ppid": 100,
+        "name": "zsh",
+        "path": "/bin/zsh",
+        "resources": resources([200], 2.0),
+        "children": [deepcopy(webkit)],
+    }
+    app = {
+        "pid": 100,
+        "ppid": 1,
+        "name": "cmux",
+        "path": "/owned/cmux",
+        "resources": resources([100], 1.0),
+        "children": [deepcopy(terminal)],
+    }
+    surface = {
+        "root_pids": [200, 300],
+        "resources": resources([200, 300], 5.0),
+        "processes": [deepcopy(terminal)],
+        "webviews": [
+            {
+                "pid": 300,
+                "root_pids": [300],
+                "resources": resources([300], 3.0),
+                "processes": [deepcopy(webkit)],
+            }
+        ],
+    }
+    return {
+        "windows": [
+            {
+                "app_process_pids": [100],
+                "resources": resources([100, 200, 300], 6.0),
+                "processes": [app],
+                "workspaces": [
+                    {
+                        "resources": resources([200, 300], 5.0),
+                        "panes": [
+                            {
+                                "resources": resources([200, 300], 5.0),
+                                "surfaces": [surface],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "totals": resources([100, 200, 300], 6.0),
+    }
+
+
+def prepare_fixture(adapter: Any, runner: FakeRunner, cfg: Any) -> Any:
+    plan = plan_for(cfg)
+    adapter.create_fixture(plan)
+    for planned, actual in zip(plan.browser_surfaces, adapter._browser_actual_ids.values(), strict=True):
+        runner.browser_state[actual].update(
+            url=planned.url, title=planned.title, content_marker=planned.content_marker
+        )
+    return plan
+
+
+def test_config_is_immutable_and_rejects_non_exact_identity_and_unbounded_times(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    with pytest.raises(Exception):
+        cfg.tag = "changed"
+    with pytest.raises(ValueError, match="40 hexadecimal"):
+        config(tmp_path, sha="abc")
+    with pytest.raises(ValueError, match="bounded"):
+        config(tmp_path, churn_duration_s=301.0)
+    assert cfg.scenario["terminal_surfaces"] == 2
+
+
+def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    plan = prepare_fixture(adapter, runner, cfg)
+
+    observation = adapter.observe_fixture()
+    assert observation["shape"] == {"terminal_surfaces": 2, "browser_surfaces": 2}
+    assert observation["browsers"] == [
+        {
+            "surface_id": item.surface_id,
+            "url": item.url,
+            "title": item.title,
+            "content_marker": item.content_marker,
+        }
+        for item in plan.browser_surfaces
+    ]
+    assert all(item.url.startswith("file://") for item in plan.browser_surfaces)
+    workspace_calls = [event for event in runner.events if event[0] == "json_cli" and event[1][:2] == ("workspace", "create")]
+    assert len(workspace_calls) == 1
+    assert workspace_calls[0][1] == ("workspace", "create", "--name", "cmux-perf-mixed-test", "--cwd", str(cfg.output_root))
+    pane_calls = [event for event in runner.events if event[0] == "json_cli" and event[1][0] == "new-surface"]
+    assert pane_calls and all("--pane" in event[1] and event[1][event[1].index("--pane") + 1] == runner.pane for event in pane_calls)
+    seed = next(event for event in runner.events if event[:2] == ("rpc", "debug.session_snapshot_seed_scrollback"))
+    assert seed[2] == {"characters_per_terminal": 60}
+    waits = [event for event in runner.events if event[:2] == ("rpc", "browser.wait")]
+    assert {event[2]["surface_id"] for event in waits} == set(adapter._browser_actual_ids.values())
+    assert all(event[2]["load_state"] == "complete" and event[2]["timeout_ms"] == 60_000 for event in waits)
+    assert adapter.raw_details["fixture"]["planned_to_actual"] == {
+        "terminal-001": "surface:initial",
+        "terminal-002": "surface:2",
+        "browser-mixed-test-001": "surface:3",
+        "browser-mixed-test-002": "surface:4",
+    }
+    json.dumps(adapter.raw_details)
+
+def test_browser_only_closes_initial_terminal_and_does_not_seed_scrollback(tmp_path: Path) -> None:
+    cfg = config(tmp_path, scenario=scenario(terminals=0, browsers=2, scrollback=0))
+    runner = FakeRunner()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    prepare_fixture(adapter, runner, cfg)
+
+    close = next(event for event in runner.events if event[0] == "run_cli" and event[1][0] == "close-surface")
+    assert runner.initial_terminal in close[1]
+    assert not any(event[:2] == ("rpc", "debug.session_snapshot_seed_scrollback") for event in runner.events)
+    assert [item["type"] for item in runner.surfaces] == ["browser", "browser"]
+
+
+def test_steady_primes_system_top_and_parser_deduplicates_repeated_processes(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload(), top_payload()]
+    clock = FakeClock()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=clock)
+
+    samples = adapter.sample_steady()
+
+    top_calls = [event for event in runner.events if event[:2] == ("rpc", "system.top")]
+    assert len(top_calls) == 3  # one prime plus two retained interval samples
+    assert all(event[2] == {"all_windows": True, "include_processes": True} for event in top_calls)
+    assert clock.sleeps == [0.5, 0.5]
+    assert len(samples) == 2
+    assert samples[0]["process_attribution"]["full_tree"]["cpu_percent"] == 6.0
+    assert samples[0]["process_attribution"]["webkit"]["cpu_percent"] == 3.0
+    assert samples[0]["process_attribution"]["terminal"]["pids"] == [200, 300]
+    assert samples[0]["coverage"] == {
+        "discovered_count": 3,
+        "sampled_count": 3,
+        "missing_count": 0,
+        "discovered_pids": [100, 200, 300],
+        "sampled_pids": [100, 200, 300],
+        "missing_pids": [],
+    }
+
+
+def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload()]
+    clock = FakeClock()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=clock)
+    plan = prepare_fixture(adapter, runner, cfg)
+
+    result = adapter.run_churn([])
+
+    terminal_sends = [event for event in runner.events if event[0] == "run_cli" and event[1][0] == "send"]
+    assert {event[1][event[1].index("--surface") + 1] for event in terminal_sends} == set(adapter._terminal_actual_ids.values())
+    assert all("\\033[" in event[1][-1] and "CMUX_PERF_FINAL_COUNT=" in event[1][-1] for event in terminal_sends)
+    assert all("time.sleep(" in event[1][-1] for event in terminal_sends)
+    capture_calls = [
+        event
+        for event in runner.events
+        if event[0] == "run_cli" and event[1][0] == "capture-pane"
+    ]
+    assert {
+        event[1][event[1].index("--surface") + 1] for event in capture_calls
+    } == set(adapter._terminal_actual_ids.values())
+    for method in ("browser.focus_webview", "browser.reload", "browser.snapshot"):
+        actual = {event[2]["surface_id"] for event in runner.events if event[:2] == ("rpc", method)}
+        assert actual == set(adapter._browser_actual_ids.values())
+    assert any(event[:2] == ("rpc", "surface.create") for event in runner.events)
+    assert any(event[:2] == ("rpc", "surface.close") for event in runner.events)
+    render_calls = [event for event in runner.events if event[:2] == ("rpc", "debug.terminal.render_stats")]
+    assert len(render_calls) == 2 * len(adapter._terminal_actual_ids)
+    assert {event[2]["surface_id"] for event in render_calls} == set(adapter._terminal_actual_ids.values())
+    assert result["latencies_ms"] and all(set(item) == {"label", "surface_id", "milliseconds"} for item in result["latencies_ms"])
+    assert result["throughput_ops_per_second"]["terminal"] > 0
+    assert result["throughput_ops_per_second"]["browser"] > 0
+    assert {item["measurement"] for item in result["presents"]} == {
+        "debug.terminal.render_stats",
+        "completed_local_reload_snapshot_operations_proxy",
+    }
+    assert all(item["present_delta"] >= 0 for item in result["presents"])
+    assert result["failures"] == []
+
+
+@pytest.mark.parametrize(
+    ("terminals", "browsers", "forbidden_prefixes"),
+    [(0, 2, ("terminal_",)), (2, 0, ("browser_",))],
+)
+def test_extract_metrics_omits_absent_kind_metrics(
+    tmp_path: Path, terminals: int, browsers: int, forbidden_prefixes: tuple[str, ...]
+) -> None:
+    result = {
+        "steady_samples": [
+            {
+                "process_attribution": {
+                    "parent_direct": {"cpu_percent": 1.0},
+                    "terminal": {"cpu_percent": 2.0},
+                    "webkit": {"cpu_percent": 3.0},
+                    "full_tree": {"cpu_percent": 4.0},
+                }
+            }
+        ],
+        "churn_samples": [
+            {
+                "process_attribution": {
+                    "parent_direct": {"cpu_percent": 5.0},
+                    "terminal": {"cpu_percent": 6.0},
+                    "webkit": {"cpu_percent": 7.0},
+                    "full_tree": {"cpu_percent": 8.0},
+                }
+            }
+        ],
+        "latencies_ms": [{"label": "browser_reload", "surface_id": "b", "milliseconds": 9.0}],
+        "throughput_ops_per_second": {"terminal": 10.0, "browser": 11.0},
+        "presents": [
+            {"surface_kind": "terminal", "present_rate": 12.0},
+            {"surface_kind": "browser", "present_rate": 13.0},
+        ],
+    }
+    details = {"scenario": scenario(terminals=terminals, browsers=browsers, scrollback=0)}
+    metrics = adapter_module.extract_metrics(result, details)
+    allowed = {
+        "steady_parent_cpu_percent", "steady_full_tree_cpu_percent",
+        "steady_terminal_cpu_percent", "steady_webkit_cpu_percent",
+        "churn_parent_cpu_percent", "churn_full_tree_cpu_percent",
+        "churn_terminal_cpu_percent", "churn_webkit_cpu_percent",
+        "browser_latency_ms", "terminal_throughput_per_second",
+        "browser_throughput_per_second", "terminal_present_rate", "browser_present_rate",
+    }
+    assert set(metrics) <= allowed
+    assert not any(name.startswith(forbidden_prefixes) for name in metrics)
+    if browsers == 0:
+        assert "steady_webkit_cpu_percent" not in metrics
+        assert "churn_webkit_cpu_percent" not in metrics
+
+
+def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shape_and_browser(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    plan = prepare_fixture(adapter, runner, cfg)
+    expected = {
+        "built": True,
+        "include_scrollback": True,
+        "persist": True,
+        "saved": True,
+        "elapsed_ms": 4.5,
+        "build_ms": 3.0,
+        "persist_ms": 1.5,
+        "shape": {
+            "windows": 1, "workspaces": 1, "panels": 4, "terminals": 2,
+            "browsers": 2, "markdown": 0, "scrollback_chars": 120,
+            "status_entries": 0, "log_entries": 0, "progress_entries": 0, "git_entries": 0,
+        },
+    }
+    runner.snapshot_payload = deepcopy(expected)
+
+    captured = adapter.snapshot()
+    assert captured["elapsed_ms"] == 4.5
+    before_restore = len(runner.events)
+    adapter.restore(captured)
+    restored_events = runner.events[before_restore:]
+
+    assert restored_events[:2] == ["stop_app", ("launch", "restore")]
+    assert "clean_persisted_state" not in restored_events
+    assert adapter.observe_fixture()["browsers"][0]["content_marker"] == plan.browser_surfaces[0].content_marker
+    runner.snapshot_payload["shape"]["browsers"] = 1
+    with pytest.raises(ValueError, match="snapshot"):
+        adapter.restore(captured)
+
+
+def test_runtime_failure_still_stops_and_cleanup_removes_only_owned_state(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    runner.top_payloads = [top_payload(), top_payload(), top_payload()]
+    runner.snapshot_payload = {
+        "built": True, "include_scrollback": True, "persist": True, "saved": True,
+        "shape": {"windows": 1, "workspaces": 1, "panels": 4, "terminals": 2, "browsers": 2,
+                  "markdown": 0, "scrollback_chars": 120, "status_entries": 0, "log_entries": 0,
+                  "progress_entries": 0, "git_entries": 0},
+    }
+    original_observe = adapter.observe_fixture
+    calls = 0
+
+    def fail_restored_observation() -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        value = original_observe()
+        if calls == 2:
+            value["browsers"][0]["title"] = "wrong"
+        return value
+
+    adapter.observe_fixture = fail_restored_observation
+    with pytest.raises(ValueError):
+        runtime.run_invocation(
+            scenario_id="mixed-test", sha=SHA, order="AB", repetition=1,
+            requested_shape={"terminal_surfaces": 2, "browser_surfaces": 2},
+            owned_root=cfg.output_root, adapter=adapter,
+        )
+    assert runner.stopped is True
+    assert runner.events[-2:] == ["stop_app", "cleanup_owned"]
+    cleanup = adapter.raw_details["cleanup"]
+    assert all(str(path).startswith(str(cfg.output_root)) or cfg.tag in str(path) for path in cleanup["owned_paths"])
+
+
+def test_enabled_profiles_overlap_churn_and_record_work_units(tmp_path: Path) -> None:
+    cfg = config(tmp_path, profile_enabled=True)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload(), top_payload()]
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        cfg, runner=runner, clock=FakeClock(), profiler=None
+    )
+    prepare_fixture(adapter, runner, cfg)
+    profile_started = threading.Event()
+    release_profiles = threading.Event()
+    profile_calls: list[dict[str, Any]] = []
+
+    def profiler(**kwargs: Any) -> dict[str, Any]:
+        profile_calls.append(deepcopy(kwargs))
+        profile_started.set()
+        assert release_profiles.wait(timeout=1.0)
+        Path(kwargs["path"]).write_text("overlapped", encoding="utf-8")
+        return {"ok": True}
+
+    adapter._profiler = profiler
+    original_run_cli = runner.run_cli
+
+    def run_cli_during_profile(*args: Any, **kwargs: Any) -> str:
+        command = args[0]
+        if command[0] == "send":
+            assert profile_started.wait(timeout=1.0)
+            release_profiles.set()
+        return original_run_cli(*args, **kwargs)
+
+    runner.run_cli = run_cli_during_profile
+    result = adapter.run_churn([])
+
+    assert result["failures"] == []
+    assert len(profile_calls) == 2
+    assert all(call["phase"] == "churn" for call in profile_calls)
+    assert all(
+        call["work_units"]
+        == {
+            "terminal_ansi_lines": 3_200,
+            "browser_reload_snapshot_operations": 8,
+            "temporary_browser_open_close_operations": 2,
+        }
+        for call in profile_calls
+    )
+    assert all(Path(call["path"]).read_text(encoding="utf-8") == "overlapped" for call in profile_calls)
+
+
+def test_profile_keeps_parent_and_each_discovered_webkit_role_separate(tmp_path: Path) -> None:
+    cfg = config(tmp_path, profile_enabled=True)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload()]
+    calls: list[dict[str, Any]] = []
+
+    def profiler(**kwargs: Any) -> dict[str, Any]:
+        calls.append(deepcopy(kwargs))
+        Path(kwargs["path"]).write_text("profile evidence", encoding="utf-8")
+        return {"path": kwargs["path"], "ok": True}
+
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        cfg, runner=runner, clock=FakeClock(), profiler=profiler
+    )
+    profiles = adapter.collect_profiles()
+
+    assert [(item["role"], item["pid"]) for item in calls] == [
+        ("parent", 100), ("webkit-content", 300)
+    ]
+    assert len({item["path"] for item in calls}) == len(calls)
+    assert all(item["duration_s"] == 1.0 and item["work_unit"] == "mixed-test" for item in calls)
+    assert adapter.raw_details["profiles"] == [
+        {**call, "result": {"path": call["path"], "ok": True}} for call in calls
+    ]
+    cleanup = adapter.cleanup_owned()
+    assert cleanup["owned_state_removed"] is True
+    assert cfg.output_root.is_dir()
+    assert all(Path(profile["path"]).read_text(encoding="utf-8") == "profile evidence" for profile in profiles)
+    assert not (cfg.output_root / "browser-fixtures").exists()
+
+
+assert adapter_module.__all__ == ["AdapterConfig", "CmuxRuntimeAdapter", "extract_metrics"]

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -78,6 +78,7 @@ class FakeRunner:
             {"surface_id": self.initial_terminal, "type": "terminal", "title": "shell"}
         ]
         self.browser_state: dict[str, dict[str, str]] = {}
+        self.focused_surface: str | None = None
         self.snapshot_payload: dict[str, Any] | None = None
         self.top_payloads: list[dict[str, Any]] = []
         self.terminal_markers: dict[str, str] = {}
@@ -295,7 +296,14 @@ class FakeRunner:
             return {"title": self.browser_state[params["surface_id"]]["title"]}
         if method == "browser.eval":
             return {"value": self.browser_state[params["surface_id"]]["content_marker"]}
-        if method in {"browser.focus_webview", "browser.reload", "browser.snapshot"}:
+        if method == "surface.focus":
+            self.focused_surface = params["surface_id"]
+            return {"ok": True, "surface_id": params["surface_id"]}
+        if method == "browser.focus_webview":
+            if self.focused_surface != params["surface_id"]:
+                raise RuntimeError("invalid_state: WebView is hidden")
+            return {"ok": True, "surface_id": params["surface_id"]}
+        if method in {"browser.reload", "browser.snapshot"}:
             return {"ok": True, "surface_id": params["surface_id"]}
         if method == "browser.screenshot":
             result = {
@@ -655,6 +663,12 @@ def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Pa
             if event[:2] == ("rpc", method)
         }
         assert actual == set(adapter._browser_actual_ids.values())
+    surface_focuses = [
+        event[2]["surface_id"]
+        for event in runner.events
+        if event[:2] == ("rpc", "surface.focus")
+    ]
+    assert surface_focuses == list(adapter._browser_actual_ids.values())
     screenshot_calls = [
         event for event in runner.events if event[:2] == ("rpc", "browser.screenshot")
     ]

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -86,6 +86,11 @@ class FakeRunner:
         self.screenshot_path: str | None = None
         self.restore_count = 0
         self.browser_wait_errors: list[BaseException] = []
+        self.snapshot_fingerprint = {
+            "algorithm": "sha256",
+            "digest": "a" * 64,
+            "byte_count": 4096,
+        }
 
     def _restore_with_fresh_ids(self) -> None:
         self.restore_count += 1
@@ -100,10 +105,17 @@ class FakeRunner:
         }
         self.workspace = f"workspace:{suffix}"
         self.pane = f"pane:{suffix}"
-        self.surfaces = [
+        restored_surfaces = [
             {**item, "surface_id": mapping[item["surface_id"]]}
             for item in old_surfaces
         ]
+        self.surfaces = [
+            item for item in restored_surfaces if item["type"] == "terminal"
+        ] + list(
+            reversed(
+                [item for item in restored_surfaces if item["type"] == "browser"]
+            )
+        )
         self.browser_state = {
             mapping[surface_id]: state
             for surface_id, state in old_browser_state.items()
@@ -126,6 +138,10 @@ class FakeRunner:
 
     def clean_persisted_state(self) -> None:
         self.events.append("clean_persisted_state")
+
+    def persisted_snapshot_fingerprint(self) -> dict[str, Any]:
+        self.events.append("persisted_snapshot_fingerprint")
+        return deepcopy(self.snapshot_fingerprint)
 
     def launch(self, label: str) -> float:
         self.events.append(("launch", label))
@@ -745,6 +761,7 @@ def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shap
 
     captured = adapter.snapshot()
     assert captured["elapsed_ms"] == 4.5
+    assert runner.events[-1] == "persisted_snapshot_fingerprint"
     before_restore = len(runner.events)
     adapter.restore(captured)
     restored_events = runner.events[before_restore:]
@@ -764,9 +781,24 @@ def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shap
     assert [item["type"] for item in runner.surfaces] == [
         "terminal", "terminal", "browser", "browser"
     ]
+    planned_browsers = {item.surface_id: item for item in plan.browser_surfaces}
+    assert {
+        planned_id: runner.browser_state[actual_id]["url"]
+        for planned_id, actual_id in adapter._browser_actual_ids.items()
+    } == {
+        planned_id: planned.url for planned_id, planned in planned_browsers.items()
+    }
+    benchmark_calls = [
+        event
+        for event in runner.events
+        if event[:2] == ("rpc", "debug.session_snapshot_benchmark")
+    ]
+    assert len(benchmark_calls) == 1
+    assert adapter.raw_details["snapshot"]["persisted_before"] == runner.snapshot_fingerprint
+    assert adapter.raw_details["snapshot"]["persisted_after"] == runner.snapshot_fingerprint
     assert adapter.observe_fixture()["browsers"][0]["content_marker"] == plan.browser_surfaces[0].content_marker
-    runner.snapshot_payload["shape"]["browsers"] = 1
-    with pytest.raises(ValueError, match="snapshot"):
+    runner.snapshot_fingerprint["digest"] = "0" * 64
+    with pytest.raises(ValueError, match="persisted snapshot fingerprint"):
         adapter.restore(captured)
 
 

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -164,8 +164,10 @@ class FakeRunner:
         self.events.append(("rpc", method, params, timeout))
         if method == "surface.respawn":
             return {
-                "surface_id": params["surface_id"],
-                "workspace_id": params["workspace_id"],
+                "surface_id": "00000000-0000-0000-0000-000000000009",
+                "surface_ref": params["surface_id"],
+                "workspace_id": "00000000-0000-0000-0000-000000000008",
+                "workspace_ref": params["workspace_id"],
                 "type": "terminal",
             }
         if method == "debug.session_snapshot_seed_scrollback":

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -934,6 +934,46 @@ def test_cleanup_unlinks_exact_owned_screenshot_path(
     assert str(screenshot_path) in cleanup["owned_paths"]
 
 
+def test_browser_batch_parallelizes_hidden_safe_work_after_ordered_activation(
+    tmp_path: Path,
+) -> None:
+    cfg = config(tmp_path, scenario=scenario(terminals=0, browsers=2, scrollback=0))
+    runner = FakeRunner()
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        cfg, runner=runner, clock=FakeClock()
+    )
+    prepare_fixture(adapter, runner, cfg)
+    original_rpc = runner.rpc
+    entered_reload: set[str] = set()
+    entered_lock = threading.Lock()
+    both_reloading = threading.Event()
+
+    def rpc_with_reload_barrier(
+        method: str, params: dict[str, Any] | None = None, timeout: float = 60
+    ) -> dict[str, Any]:
+        if method == "browser.reload" and params is not None:
+            with entered_lock:
+                entered_reload.add(params["surface_id"])
+                if len(entered_reload) == 2:
+                    both_reloading.set()
+            assert both_reloading.wait(timeout=1.0)
+        return original_rpc(method, params, timeout)
+
+    runner.rpc = rpc_with_reload_barrier
+    results = adapter._browser_churn_batch(1)
+
+    assert [planned for planned, _result in results] == list(
+        adapter._browser_actual_ids
+    )
+    assert entered_reload == set(adapter._browser_actual_ids.values())
+    activations = [
+        event[2]["surface_id"]
+        for event in runner.events
+        if event[:2] == ("rpc", "surface.focus")
+    ]
+    assert activations == list(adapter._browser_actual_ids.values())
+
+
 def test_churn_rejects_browser_work_that_outlives_fixed_measurement_window(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -162,6 +162,12 @@ class FakeRunner:
     ) -> dict[str, Any]:
         params = deepcopy(params or {})
         self.events.append(("rpc", method, params, timeout))
+        if method == "surface.respawn":
+            return {
+                "surface_id": params["surface_id"],
+                "workspace_id": params["workspace_id"],
+                "type": "terminal",
+            }
         if method == "debug.session_snapshot_seed_scrollback":
             chars = params["characters_per_terminal"]
             terminals = sum(item["type"] == "terminal" for item in self.surfaces)
@@ -371,28 +377,36 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
         and event[1][event[1].index("--pane") + 1] == runner.pane
         for event in pane_calls
     )
-    terminal_calls = [event for event in pane_calls if event[1][event[1].index("--type") + 1] == "terminal"]
-    assert len(terminal_calls) == 2
-    assert all(
-        event[1][event[1].index("--working-directory") + 1] == str(cfg.output_root)
-        for event in terminal_calls
-    )
-    close = next(
+    terminal_calls = [
         event
-        for event in runner.events
-        if event[0] == "run_cli" and event[1][0] == "close-surface"
+        for event in pane_calls
+        if event[1][event[1].index("--type") + 1] == "terminal"
+    ]
+    assert len(terminal_calls) == 1
+    assert terminal_calls[0][1][terminal_calls[0][1].index("--working-directory") + 1] == str(
+        cfg.output_root
     )
-    assert runner.initial_terminal in close[1]
+    respawn = next(event for event in runner.events if event[:2] == ("rpc", "surface.respawn"))
+    assert respawn[2] == {
+        "workspace_id": runner.workspace,
+        "surface_id": runner.initial_terminal,
+        "working_directory": str(cfg.output_root),
+        "focus": False,
+    }
+    assert not any(
+        event[0] == "run_cli" and event[1][0] == "close-surface"
+        for event in runner.events
+    )
     seed = next(event for event in runner.events if event[:2] == ("rpc", "debug.session_snapshot_seed_scrollback"))
     assert seed[2] == {"characters_per_terminal": 60}
     waits = [event for event in runner.events if event[:2] == ("rpc", "browser.wait")]
     assert {event[2]["surface_id"] for event in waits} == set(adapter._browser_actual_ids.values())
     assert all(event[2]["load_state"] == "complete" and event[2]["timeout_ms"] == 60_000 for event in waits)
     assert adapter.raw_details["fixture"]["planned_to_actual"] == {
-        "terminal-001": "surface:2",
-        "terminal-002": "surface:3",
-        "browser-mixed-test-001": "surface:4",
-        "browser-mixed-test-002": "surface:5",
+        "terminal-001": "surface:initial",
+        "terminal-002": "surface:2",
+        "browser-mixed-test-001": "surface:3",
+        "browser-mixed-test-002": "surface:4",
     }
     json.dumps(adapter.raw_details)
 
@@ -424,6 +438,7 @@ def test_fixture_rejects_nonterminal_startup_surface_before_mutation(tmp_path: P
     assert not any(
         (event[0] == "json_cli" and event[1][0] == "new-surface")
         or (event[0] == "run_cli" and event[1][0] == "close-surface")
+        or (event[0] == "rpc" and event[1] == "surface.respawn")
         for event in runner.events
     )
 
@@ -436,6 +451,7 @@ def test_browser_only_closes_initial_terminal_and_does_not_seed_scrollback(tmp_p
     close = next(event for event in runner.events if event[0] == "run_cli" and event[1][0] == "close-surface")
     assert runner.initial_terminal in close[1]
     assert not any(event[:2] == ("rpc", "debug.session_snapshot_seed_scrollback") for event in runner.events)
+    assert not any(event[:2] == ("rpc", "surface.respawn") for event in runner.events)
     assert [item["type"] for item in runner.surfaces] == ["browser", "browser"]
 
 

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -361,18 +361,38 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
     ]
     assert workspace_calls == []
     assert adapter.raw_details["fixture"]["workspace_id"] == runner.workspace
-    pane_calls = [event for event in runner.events if event[0] == "json_cli" and event[1][0] == "new-surface"]
-    assert pane_calls and all("--pane" in event[1] and event[1][event[1].index("--pane") + 1] == runner.pane for event in pane_calls)
+    pane_calls = [
+        event
+        for event in runner.events
+        if event[0] == "json_cli" and event[1][0] == "new-surface"
+    ]
+    assert pane_calls and all(
+        "--pane" in event[1]
+        and event[1][event[1].index("--pane") + 1] == runner.pane
+        for event in pane_calls
+    )
+    terminal_calls = [event for event in pane_calls if event[1][event[1].index("--type") + 1] == "terminal"]
+    assert len(terminal_calls) == 2
+    assert all(
+        event[1][event[1].index("--working-directory") + 1] == str(cfg.output_root)
+        for event in terminal_calls
+    )
+    close = next(
+        event
+        for event in runner.events
+        if event[0] == "run_cli" and event[1][0] == "close-surface"
+    )
+    assert runner.initial_terminal in close[1]
     seed = next(event for event in runner.events if event[:2] == ("rpc", "debug.session_snapshot_seed_scrollback"))
     assert seed[2] == {"characters_per_terminal": 60}
     waits = [event for event in runner.events if event[:2] == ("rpc", "browser.wait")]
     assert {event[2]["surface_id"] for event in waits} == set(adapter._browser_actual_ids.values())
     assert all(event[2]["load_state"] == "complete" and event[2]["timeout_ms"] == 60_000 for event in waits)
     assert adapter.raw_details["fixture"]["planned_to_actual"] == {
-        "terminal-001": "surface:initial",
-        "terminal-002": "surface:2",
-        "browser-mixed-test-001": "surface:3",
-        "browser-mixed-test-002": "surface:4",
+        "terminal-001": "surface:2",
+        "terminal-002": "surface:3",
+        "browser-mixed-test-001": "surface:4",
+        "browser-mixed-test-002": "surface:5",
     }
     json.dumps(adapter.raw_details)
 
@@ -390,6 +410,22 @@ def test_fixture_rejects_nonunique_clean_startup_workspace(tmp_path: Path) -> No
         for event in runner.events
     )
 
+
+
+def test_fixture_rejects_nonterminal_startup_surface_before_mutation(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    runner.surfaces[0]["type"] = "browser"
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+
+    with pytest.raises(ValueError, match="startup surface must be a terminal"):
+        prepare_fixture(adapter, runner, cfg)
+
+    assert not any(
+        (event[0] == "json_cli" and event[1][0] == "new-surface")
+        or (event[0] == "run_cli" and event[1][0] == "close-surface")
+        for event in runner.events
+    )
 
 def test_browser_only_closes_initial_terminal_and_does_not_seed_scrollback(tmp_path: Path) -> None:
     cfg = config(tmp_path, scenario=scenario(terminals=0, browsers=2, scrollback=0))

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -945,6 +945,7 @@ def test_browser_batch_overlaps_hidden_safe_work_with_ordered_activation(
     original_rpc = runner.rpc
     actual_ids = list(adapter._browser_actual_ids.values())
     first_reload_started = threading.Event()
+    second_focus_entered = threading.Event()
     entered_reload: set[str] = set()
     entered_lock = threading.Lock()
     both_reloading = threading.Event()
@@ -954,6 +955,7 @@ def test_browser_batch_overlaps_hidden_safe_work_with_ordered_activation(
     ) -> dict[str, Any]:
         if method == "browser.reload" and params is not None:
             first_reload_started.set()
+            assert second_focus_entered.wait(timeout=1.0)
             with entered_lock:
                 entered_reload.add(params["surface_id"])
                 if len(entered_reload) == 2:
@@ -962,6 +964,7 @@ def test_browser_batch_overlaps_hidden_safe_work_with_ordered_activation(
         if method == "surface.focus" and params is not None:
             if params["surface_id"] == actual_ids[1]:
                 assert first_reload_started.wait(timeout=1.0)
+                second_focus_entered.set()
         return original_rpc(method, params, timeout)
 
     runner.rpc = rpc_with_overlap_contract

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -69,7 +69,7 @@ class FakeRunner:
         self.workspaces = [self.startup_workspace]
         self.pane = "pane:4"
         self.initial_terminal = "surface:initial"
-        self.initial_terminal_id = "00000000-0000-0000-0000-000000000009"
+        self.initial_terminal_id = self.initial_terminal
         self.surfaces: list[dict[str, Any]] = [
             {"surface_id": self.initial_terminal, "type": "terminal", "title": "shell"}
         ]
@@ -131,7 +131,7 @@ class FakeRunner:
                 surfaces = [
                     {
                         **{key: value for key, value in surface.items() if key != "surface_id"},
-                        "id": self.initial_terminal_id,
+                        "id": surface["surface_id"],
                         "ref": surface["surface_id"],
                     }
                     for surface in surfaces
@@ -408,7 +408,7 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
     pane_calls = [
         event
         for event in runner.events
-        if event[0] == "json_cli" and event[1][0] == "new-surface"
+        if event[0] == "json_cli" and "new-surface" in event[1]
     ]
     assert pane_calls and all(
         "--pane" in event[1]
@@ -452,7 +452,7 @@ def test_fixture_rejects_nonunique_clean_startup_workspace(tmp_path: Path) -> No
         prepare_fixture(adapter, runner, cfg)
 
     assert not any(
-        event[0] == "json_cli" and event[1][0] == "new-surface"
+        event[0] == "json_cli" and "new-surface" in event[1]
         for event in runner.events
     )
 
@@ -464,11 +464,11 @@ def test_fixture_rejects_nonterminal_startup_surface_before_mutation(tmp_path: P
     runner.surfaces[0]["type"] = "browser"
     adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
 
-    with pytest.raises(ValueError, match="startup surface must be a terminal"):
+    with pytest.raises(ValueError, match="owned fixture workspace must start with one terminal"):
         prepare_fixture(adapter, runner, cfg)
 
     assert not any(
-        (event[0] == "json_cli" and event[1][0] == "new-surface")
+        (event[0] == "json_cli" and "new-surface" in event[1])
         or (event[0] == "run_cli" and event[1][0] == "close-surface")
         or (event[0] == "rpc" and event[1] == "surface.respawn")
         for event in runner.events

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -75,6 +75,8 @@ class FakeRunner:
         self.top_payloads: list[dict[str, Any]] = []
         self.terminal_markers: dict[str, str] = {}
         self.stopped = False
+        self.render_stats_calls = 0
+        self.screenshot_path: str | None = None
 
     def check_paths(self) -> None:
         self.events.append("check_paths")
@@ -168,11 +170,12 @@ class FakeRunner:
             assert self.snapshot_payload is not None
             return deepcopy(self.snapshot_payload)
         if method == "debug.terminal.render_stats":
+            self.render_stats_calls += 1
             return {
                 "stats": {
                     "drawCount": 10,
                     "presentCount": 20,
-                    "metalDrawableCount": 20,
+                    "metalDrawableCount": 20 + 5 * self.render_stats_calls,
                 }
             }
         if method == "system.top":
@@ -189,6 +192,14 @@ class FakeRunner:
             return {"value": self.browser_state[params["surface_id"]]["content_marker"]}
         if method in {"browser.focus_webview", "browser.reload", "browser.snapshot"}:
             return {"ok": True, "surface_id": params["surface_id"]}
+        if method == "browser.screenshot":
+            result = {
+                "surface_id": params["surface_id"],
+                "png_base64": "iVBORw0KGgo=",
+            }
+            if self.screenshot_path is not None:
+                result["path"] = self.screenshot_path
+            return result
         if method == "surface.create":
             ref = "surface:temporary"
             self.surfaces.append({"surface_id": ref, "type": "browser", "title": "temporary"})
@@ -417,9 +428,22 @@ def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Pa
     assert {
         event[1][event[1].index("--surface") + 1] for event in capture_calls
     } == set(adapter._terminal_actual_ids.values())
-    for method in ("browser.focus_webview", "browser.reload", "browser.snapshot"):
-        actual = {event[2]["surface_id"] for event in runner.events if event[:2] == ("rpc", method)}
+    for method in (
+        "browser.focus_webview",
+        "browser.reload",
+        "browser.snapshot",
+        "browser.screenshot",
+    ):
+        actual = {
+            event[2]["surface_id"]
+            for event in runner.events
+            if event[:2] == ("rpc", method)
+        }
         assert actual == set(adapter._browser_actual_ids.values())
+    screenshot_calls = [
+        event for event in runner.events if event[:2] == ("rpc", "browser.screenshot")
+    ]
+    assert len(screenshot_calls) == len(adapter._browser_actual_ids)
     assert any(event[:2] == ("rpc", "surface.create") for event in runner.events)
     assert any(event[:2] == ("rpc", "surface.close") for event in runner.events)
     render_calls = [event for event in runner.events if event[:2] == ("rpc", "debug.terminal.render_stats")]
@@ -428,11 +452,28 @@ def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Pa
     assert result["latencies_ms"] and all(set(item) == {"label", "surface_id", "milliseconds"} for item in result["latencies_ms"])
     assert result["throughput_ops_per_second"]["terminal"] > 0
     assert result["throughput_ops_per_second"]["browser"] > 0
-    assert {item["measurement"] for item in result["presents"]} == {
-        "debug.terminal.render_stats",
-        "completed_local_reload_snapshot_operations_proxy",
+    assert {item["measurement"] for item in result["render_observations"]} == {
+        "debug.terminal.render_stats.metalDrawableCount_render_proxy",
+        "completed_browser_screenshot_render_proxy",
     }
-    assert all(item["present_delta"] >= 0 for item in result["presents"])
+    assert all(
+        item["render_delta"] > 0 for item in result["render_observations"]
+    )
+    assert {
+        item["render_delta"]
+        for item in result["render_observations"]
+        if item["surface_kind"] == "browser"
+    } == {1}
+    browser_evidence = [
+        item
+        for item in adapter.raw_details["churn"]["surface_evidence"]
+        if item["surface_kind"] == "browser"
+    ]
+    assert all("png_base64" not in item["screenshot"] for item in browser_evidence)
+    assert {item["screenshot"]["png_base64_length"] for item in browser_evidence} == {12}
+    assert all(
+        "present_rate" not in item for item in result["render_observations"]
+    )
     assert result["failures"] == []
 
 
@@ -466,9 +507,9 @@ def test_extract_metrics_omits_absent_kind_metrics(
         ],
         "latencies_ms": [{"label": "browser_reload", "surface_id": "b", "milliseconds": 9.0}],
         "throughput_ops_per_second": {"terminal": 10.0, "browser": 11.0},
-        "presents": [
-            {"surface_kind": "terminal", "present_rate": 12.0},
-            {"surface_kind": "browser", "present_rate": 13.0},
+        "render_observations": [
+            {"surface_kind": "terminal", "render_rate": 12.0},
+            {"surface_kind": "browser", "render_rate": 13.0},
         ],
     }
     details = {"scenario": scenario(terminals=terminals, browsers=browsers, scrollback=0)}
@@ -479,7 +520,7 @@ def test_extract_metrics_omits_absent_kind_metrics(
         "churn_parent_cpu_percent", "churn_full_tree_cpu_percent",
         "churn_terminal_cpu_percent", "churn_webkit_cpu_percent",
         "browser_latency_ms", "terminal_throughput_per_second",
-        "browser_throughput_per_second", "terminal_present_rate", "browser_present_rate",
+        "browser_throughput_per_second", "terminal_render_rate", "browser_render_rate",
     }
     assert set(metrics) <= allowed
     assert not any(name.startswith(forbidden_prefixes) for name in metrics)
@@ -558,6 +599,70 @@ def test_runtime_failure_still_stops_and_cleanup_removes_only_owned_state(tmp_pa
     assert all(str(path).startswith(str(cfg.output_root)) or cfg.tag in str(path) for path in cleanup["owned_paths"])
 
 
+def test_churn_rejects_missing_terminal_drawable_counter(tmp_path: Path) -> None:
+    cfg = config(
+        tmp_path,
+        scenario=scenario(terminals=2, browsers=0, scrollback=120),
+    )
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload()]
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    prepare_fixture(adapter, runner, cfg)
+    original_rpc = runner.rpc
+
+    def rpc_without_drawables(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        payload = original_rpc(*args, **kwargs)
+        if args[0] == "debug.terminal.render_stats":
+            payload["stats"].pop("metalDrawableCount")
+        return payload
+
+    runner.rpc = rpc_without_drawables
+
+    with pytest.raises(ValueError, match="metalDrawableCount"):
+        adapter.run_churn([])
+
+
+def test_cleanup_never_unlinks_untrusted_screenshot_path(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload()]
+    untrusted_root = tmp_path / "outside" / "cmux-browser-screenshots"
+    untrusted_root.mkdir(parents=True)
+    untrusted_path = untrusted_root / "surface-untrusted.png"
+    untrusted_path.write_bytes(b"not owned")
+    runner.screenshot_path = str(untrusted_path)
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    prepare_fixture(adapter, runner, cfg)
+
+    adapter.run_churn([])
+    adapter.cleanup_owned()
+
+    assert untrusted_path.read_bytes() == b"not owned"
+
+
+def test_cleanup_unlinks_exact_owned_screenshot_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload()]
+    system_temp = tmp_path / "system-temp"
+    monkeypatch.setattr(adapter_module.tempfile, "gettempdir", lambda: str(system_temp))
+    screenshot_root = system_temp / "cmux-browser-screenshots"
+    screenshot_root.mkdir(parents=True)
+    screenshot_path = screenshot_root / "surface-owned.png"
+    screenshot_path.write_bytes(b"owned")
+    runner.screenshot_path = str(screenshot_path)
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    prepare_fixture(adapter, runner, cfg)
+
+    adapter.run_churn([])
+    cleanup = adapter.cleanup_owned()
+
+    assert not screenshot_path.exists()
+    assert str(screenshot_path) in cleanup["owned_paths"]
+
+
 def test_enabled_profiles_overlap_churn_and_record_work_units(tmp_path: Path) -> None:
     cfg = config(tmp_path, profile_enabled=True)
     runner = FakeRunner()
@@ -597,12 +702,81 @@ def test_enabled_profiles_overlap_churn_and_record_work_units(tmp_path: Path) ->
         call["work_units"]
         == {
             "terminal_ansi_lines": 3_200,
-            "browser_reload_snapshot_operations": 8,
+            "browser_churn_rpc_operations": 14,
             "temporary_browser_open_close_operations": 2,
         }
         for call in profile_calls
     )
     assert all(Path(call["path"]).read_text(encoding="utf-8") == "overlapped" for call in profile_calls)
+
+
+def test_profile_rejects_stale_output_not_recreated_by_current_sample(
+    tmp_path: Path,
+) -> None:
+    cfg = config(tmp_path, profile_enabled=True)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload()]
+
+    def profiler(**kwargs: Any) -> dict[str, Any]:
+        return {
+            "path": kwargs["path"],
+            "returncode": 0,
+            "stdout": "",
+            "stderr": "",
+        }
+
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        cfg, runner=runner, clock=FakeClock(), profiler=profiler
+    )
+    metadata = adapter._profile_metadata(phase="manual", work_units={})[0]
+    stale_path = Path(metadata["path"])
+    stale_path.write_text("stale profile", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="empty output") as captured:
+        adapter._run_profile(metadata)
+
+    assert not stale_path.exists()
+    assert captured.value.evidence["result"]["returncode"] == 0
+
+
+@pytest.mark.parametrize(
+    ("returncode", "profile_contents", "message"),
+    [
+        (1, "partial profile", "nonzero status"),
+        (0, "", "empty output"),
+    ],
+)
+def test_profile_failure_rejects_churn_and_retains_evidence(
+    tmp_path: Path,
+    returncode: int,
+    profile_contents: str,
+    message: str,
+) -> None:
+    cfg = config(tmp_path, profile_enabled=True)
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload(), top_payload()]
+
+    def profiler(**kwargs: Any) -> dict[str, Any]:
+        Path(kwargs["path"]).write_text(profile_contents, encoding="utf-8")
+        return {
+            "path": kwargs["path"],
+            "returncode": returncode,
+            "stdout": "profile stdout",
+            "stderr": "profile stderr",
+        }
+
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        cfg, runner=runner, clock=FakeClock(), profiler=profiler
+    )
+    prepare_fixture(adapter, runner, cfg)
+
+    result = adapter.run_churn([])
+
+    assert len(result["failures"]) == 2
+    assert all(item["phase"] == "profile_churn" for item in result["failures"])
+    assert all(message in item["message"] for item in result["failures"])
+    assert all(item["evidence"]["result"]["returncode"] == returncode for item in result["failures"])
+    assert all(item["evidence"]["result"]["stderr"] == "profile stderr" for item in result["failures"])
 
 
 def test_profile_keeps_parent_and_each_discovered_webkit_role_separate(tmp_path: Path) -> None:

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -64,8 +64,9 @@ class FakeRunner:
 
     def __init__(self) -> None:
         self.events: list[Any] = []
+        self.startup_workspace = "workspace:startup"
         self.workspace = "workspace:9"
-        self.workspaces = [self.workspace]
+        self.workspaces = [self.startup_workspace]
         self.pane = "pane:4"
         self.initial_terminal = "surface:initial"
         self.initial_terminal_id = "00000000-0000-0000-0000-000000000009"
@@ -89,6 +90,8 @@ class FakeRunner:
     def launch(self, label: str) -> float:
         self.events.append(("launch", label))
         self.stopped = False
+        if label == "restore":
+            self.workspaces = [self.startup_workspace, self.workspace]
         return 12.5
 
     def stop_app(self) -> None:
@@ -110,6 +113,7 @@ class FakeRunner:
                 ]
             }
         if command_args[:2] == ["workspace", "create"]:
+            self.workspaces.append(self.workspace)
             return {"workspace_id": self.workspace}
         if command_args[0] == "list-panes":
             return {
@@ -156,6 +160,9 @@ class FakeRunner:
         check: bool = True,
     ) -> str:
         self.events.append(("run_cli", tuple(args), input_text, timeout, check))
+        if args[0] == "close-workspace":
+            workspace = args[args.index("--workspace") + 1]
+            self.workspaces = [item for item in self.workspaces if item != workspace]
         if args[0] == "close-surface":
             surface = args[args.index("--surface") + 1]
             self.surfaces = [item for item in self.surfaces if item["surface_id"] != surface]
@@ -376,10 +383,28 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
     workspace_calls = [
         event
         for event in runner.events
-        if event[0] == "json_cli" and event[1][:2] == ("workspace", "create")
+        if event[0] == "json_cli" and "workspace" in event[1] and "create" in event[1]
     ]
-    assert workspace_calls == []
+    assert len(workspace_calls) == 1
     assert adapter.raw_details["fixture"]["workspace_id"] == runner.workspace
+    unpin = next(
+        event
+        for event in runner.events
+        if event[0] == "run_cli" and event[1][0] == "workspace-action"
+    )
+    assert unpin[1] == (
+        "workspace-action",
+        "--workspace",
+        runner.startup_workspace,
+        "--action",
+        "unpin",
+    )
+    closed_startup = next(
+        event
+        for event in runner.events
+        if event[0] == "run_cli" and event[1][0] == "close-workspace"
+    )
+    assert runner.startup_workspace in closed_startup[1]
     pane_calls = [
         event
         for event in runner.events
@@ -399,12 +424,7 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
     assert terminal_calls[0][1][terminal_calls[0][1].index("--working-directory") + 1] == str(
         cfg.output_root
     )
-    respawn = next(event for event in runner.events if event[:2] == ("rpc", "surface.respawn"))
-    assert respawn[2] == {
-        "surface_id": runner.initial_terminal_id,
-        "working_directory": str(cfg.output_root),
-        "focus": False,
-    }
+    assert not any(event[:2] == ("rpc", "surface.respawn") for event in runner.events)
     assert not any(
         event[0] == "run_cli" and event[1][0] == "close-surface"
         for event in runner.events
@@ -646,6 +666,12 @@ def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shap
 
     assert restored_events[:2] == ["stop_app", ("launch", "restore")]
     assert "clean_persisted_state" not in restored_events
+    assert any(
+        event[0] == "run_cli"
+        and event[1][0] == "close-workspace"
+        and runner.startup_workspace in event[1]
+        for event in restored_events
+    )
     assert adapter.observe_fixture()["browsers"][0]["content_marker"] == plan.browser_surfaces[0].content_marker
     runner.snapshot_payload["shape"]["browsers"] = 1
     with pytest.raises(ValueError, match="snapshot"):

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -58,6 +58,7 @@ class FakeClock:
     def sleep(self, duration: float) -> None:
         self.sleeps.append(duration)
         self.now += duration
+        time.sleep(0.001)
 
 
 class FakeRunner:

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -966,7 +966,7 @@ def test_enabled_profiles_overlap_churn_and_record_work_units(tmp_path: Path) ->
         call["work_units"]
         == {
             "terminal_ansi_lines": 3_200,
-            "browser_churn_rpc_operations": 14,
+            "browser_churn_rpc_operations": 16,
             "temporary_browser_open_close_operations": 2,
         }
         for call in profile_calls

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -934,6 +934,37 @@ def test_cleanup_unlinks_exact_owned_screenshot_path(
     assert str(screenshot_path) in cleanup["owned_paths"]
 
 
+def test_cleanup_removes_adapter_paths_when_runner_cleanup_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class CleanupFailingRunner(FakeRunner):
+        def cleanup_owned(self) -> dict[str, Any]:
+            super().cleanup_owned()
+            raise RuntimeError("runner cleanup failed")
+
+    cfg = config(tmp_path)
+    runner = CleanupFailingRunner()
+    runner.top_payloads = [top_payload(), top_payload()]
+    system_temp = tmp_path / "system-temp"
+    monkeypatch.setattr(adapter_module.tempfile, "gettempdir", lambda: str(system_temp))
+    screenshot_root = system_temp / "cmux-browser-screenshots"
+    screenshot_root.mkdir(parents=True)
+    screenshot_path = screenshot_root / "surface-owned.png"
+    screenshot_path.write_bytes(b"owned")
+    runner.screenshot_path = str(screenshot_path)
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    prepare_fixture(adapter, runner, cfg)
+    adapter.run_churn([])
+    browser_fixture_root = cfg.output_root / "browser-fixtures"
+    assert browser_fixture_root.is_dir()
+
+    with pytest.raises(RuntimeError, match="runner cleanup failed"):
+        adapter.cleanup_owned()
+
+    assert not browser_fixture_root.exists()
+    assert not screenshot_path.exists()
+
+
 def test_browser_batch_overlaps_hidden_safe_work_with_ordered_activation(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -67,6 +67,10 @@ class FakeRunner:
         self.startup_workspace = "workspace:startup"
         self.workspace = "workspace:9"
         self.workspaces = [self.startup_workspace]
+        self.workspace_titles = {
+            self.startup_workspace: "startup",
+            self.workspace: "cmux-perf-mixed-test",
+        }
         self.pane = "pane:4"
         self.initial_terminal = "surface:initial"
         self.initial_terminal_id = self.initial_terminal
@@ -80,6 +84,42 @@ class FakeRunner:
         self.stopped = False
         self.render_stats_calls = 0
         self.screenshot_path: str | None = None
+        self.restore_count = 0
+        self.browser_wait_errors: list[BaseException] = []
+
+    def _restore_with_fresh_ids(self) -> None:
+        self.restore_count += 1
+        suffix = f"restored-{self.restore_count}"
+        old_workspace = self.workspace
+        old_surfaces = self.surfaces
+        old_browser_state = self.browser_state
+        old_terminal_markers = self.terminal_markers
+        mapping = {
+            item["surface_id"]: f"surface:{suffix}-{index}"
+            for index, item in enumerate(old_surfaces, start=1)
+        }
+        self.workspace = f"workspace:{suffix}"
+        self.pane = f"pane:{suffix}"
+        self.surfaces = [
+            {**item, "surface_id": mapping[item["surface_id"]]}
+            for item in old_surfaces
+        ]
+        self.browser_state = {
+            mapping[surface_id]: state
+            for surface_id, state in old_browser_state.items()
+            if surface_id in mapping
+        }
+        self.terminal_markers = {
+            mapping[surface_id]: marker
+            for surface_id, marker in old_terminal_markers.items()
+            if surface_id in mapping
+        }
+        if self.initial_terminal in mapping:
+            self.initial_terminal = mapping[self.initial_terminal]
+        self.workspace_titles[self.startup_workspace] = "startup"
+        self.workspace_titles.pop(old_workspace, None)
+        self.workspace_titles[self.workspace] = "cmux-perf-mixed-test"
+        self.workspaces = [self.startup_workspace, self.workspace]
 
     def check_paths(self) -> None:
         self.events.append("check_paths")
@@ -91,7 +131,7 @@ class FakeRunner:
         self.events.append(("launch", label))
         self.stopped = False
         if label == "restore":
-            self.workspaces = [self.startup_workspace, self.workspace]
+            self._restore_with_fresh_ids()
         return 12.5
 
     def stop_app(self) -> None:
@@ -109,11 +149,16 @@ class FakeRunner:
         if command_args[0] == "list-workspaces":
             return {
                 "workspaces": [
-                    {"workspace_id": workspace} for workspace in self.workspaces
+                    {
+                        "workspace_id": workspace,
+                        "title": self.workspace_titles.get(workspace, "unexpected"),
+                    }
+                    for workspace in self.workspaces
                 ]
             }
         if command_args[:2] == ["workspace", "create"]:
             self.workspaces.append(self.workspace)
+            self.workspace_titles[self.workspace] = "cmux-perf-mixed-test"
             return {"workspace_id": self.workspace}
         if command_args[0] == "list-panes":
             return {
@@ -163,6 +208,7 @@ class FakeRunner:
         if args[0] == "close-workspace":
             workspace = args[args.index("--workspace") + 1]
             self.workspaces = [item for item in self.workspaces if item != workspace]
+            self.workspace_titles.pop(workspace, None)
         if args[0] == "close-surface":
             surface = args[args.index("--surface") + 1]
             self.surfaces = [item for item in self.surfaces if item["surface_id"] != surface]
@@ -214,6 +260,8 @@ class FakeRunner:
                 raise AssertionError("missing fake top payload")
             return deepcopy(self.top_payloads.pop(0))
         if method == "browser.wait":
+            if self.browser_wait_errors:
+                raise self.browser_wait_errors.pop(0)
             return {"load_state": params["load_state"], "complete": True}
         if method == "browser.url.get":
             return {"url": self.browser_state[params["surface_id"]]["url"]}
@@ -442,6 +490,39 @@ def test_fixture_uses_one_workspace_and_pane_exact_local_identity_and_scrollback
     }
     json.dumps(adapter.raw_details)
 
+
+def test_browser_wait_retries_once_only_after_explicit_recovery(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    prepare_fixture(adapter, runner, cfg)
+    runner.browser_wait_errors.append(
+        RuntimeError(
+            "browser surface stopped responding and was recovered. Retry the command."
+        )
+    )
+
+    adapter.observe_fixture()
+
+    waits = [event for event in runner.events if event[:2] == ("rpc", "browser.wait")]
+    first_browser = next(iter(adapter._browser_actual_ids.values()))
+    assert [event[2]["surface_id"] for event in waits].count(first_browser) == 2
+    assert len(waits) == len(adapter._browser_actual_ids) + 1
+
+
+def test_browser_wait_does_not_retry_unrelated_failures(tmp_path: Path) -> None:
+    cfg = config(tmp_path)
+    runner = FakeRunner()
+    adapter = adapter_module.CmuxRuntimeAdapter(cfg, runner=runner, clock=FakeClock())
+    prepare_fixture(adapter, runner, cfg)
+    runner.browser_wait_errors.append(RuntimeError("browser fixture is invalid"))
+
+    with pytest.raises(RuntimeError, match="fixture is invalid"):
+        adapter.observe_fixture()
+
+    waits = [event for event in runner.events if event[:2] == ("rpc", "browser.wait")]
+    assert len(waits) == 1
+
 def test_fixture_rejects_nonunique_clean_startup_workspace(tmp_path: Path) -> None:
     cfg = config(tmp_path)
     runner = FakeRunner()
@@ -657,6 +738,10 @@ def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shap
         },
     }
     runner.snapshot_payload = deepcopy(expected)
+    original_workspace = adapter._workspace_id
+    original_pane = adapter._pane_id
+    original_terminals = dict(adapter._terminal_actual_ids)
+    original_browsers = dict(adapter._browser_actual_ids)
 
     captured = adapter.snapshot()
     assert captured["elapsed_ms"] == 4.5
@@ -672,6 +757,13 @@ def test_snapshot_restore_relaunches_without_cleaning_and_strictly_verifies_shap
         and runner.startup_workspace in event[1]
         for event in restored_events
     )
+    assert adapter._workspace_id == runner.workspace != original_workspace
+    assert adapter._pane_id == runner.pane != original_pane
+    assert set(adapter._terminal_actual_ids.values()).isdisjoint(original_terminals.values())
+    assert set(adapter._browser_actual_ids.values()).isdisjoint(original_browsers.values())
+    assert [item["type"] for item in runner.surfaces] == [
+        "terminal", "terminal", "browser", "browser"
+    ]
     assert adapter.observe_fixture()["browsers"][0]["content_marker"] == plan.browser_surfaces[0].content_marker
     runner.snapshot_payload["shape"]["browsers"] = 1
     with pytest.raises(ValueError, match="snapshot"):

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -338,6 +338,7 @@ def config(tmp_path: Path, **overrides: Any) -> Any:
         "steady_duration_s": 1.0,
         "steady_interval_s": 0.5,
         "churn_duration_s": 1.0,
+        "churn_measurement_duration_s": 1.0,
         "churn_interval_s": 0.5,
         "profile_duration_s": 1.0,
     }

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import re
 import sys
 import threading
+import time
 from typing import Any
 
 import pytest
@@ -669,6 +670,12 @@ def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Pa
         if event[:2] == ("rpc", "surface.focus")
     ]
     assert surface_focuses == list(adapter._browser_actual_ids.values())
+    webview_focuses = [
+        event
+        for event in runner.events
+        if event[:2] == ("rpc", "browser.focus_webview")
+    ]
+    assert len(webview_focuses) == len(adapter._browser_actual_ids)
     screenshot_calls = [
         event for event in runner.events if event[:2] == ("rpc", "browser.screenshot")
     ]
@@ -927,6 +934,31 @@ def test_cleanup_unlinks_exact_owned_screenshot_path(
     assert str(screenshot_path) in cleanup["owned_paths"]
 
 
+def test_churn_rejects_browser_work_that_outlives_fixed_measurement_window(
+    tmp_path: Path,
+) -> None:
+    cfg = config(tmp_path, scenario=scenario(terminals=0, browsers=2, scrollback=0))
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload(), top_payload()]
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        cfg, runner=runner, clock=FakeClock()
+    )
+    prepare_fixture(adapter, runner, cfg)
+    original_batch = adapter._browser_churn_batch
+
+    def delayed_batch(cycles: int) -> list[tuple[str, dict[str, Any]]]:
+        time.sleep(0.05)
+        return original_batch(cycles)
+
+    adapter._browser_churn_batch = delayed_batch
+    result = adapter.run_churn([])
+
+    assert any(
+        failure["phase"] == "browser_measurement_window"
+        for failure in result["failures"]
+    )
+
+
 def test_enabled_profiles_overlap_churn_and_record_work_units(tmp_path: Path) -> None:
     cfg = config(tmp_path, profile_enabled=True)
     runner = FakeRunner()
@@ -966,7 +998,7 @@ def test_enabled_profiles_overlap_churn_and_record_work_units(tmp_path: Path) ->
         call["work_units"]
         == {
             "terminal_ansi_lines": 3_200,
-            "browser_churn_rpc_operations": 16,
+            "browser_churn_rpc_operations": 10,
             "temporary_browser_open_close_operations": 2,
         }
         for call in profile_calls

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -982,6 +982,49 @@ def test_browser_batch_overlaps_hidden_safe_work_with_ordered_activation(
     assert activations == actual_ids
 
 
+def test_churn_measurement_window_can_outlast_fixed_workload(tmp_path: Path) -> None:
+    cfg = config(
+        tmp_path,
+        scenario=scenario(terminals=0, browsers=2, scrollback=0),
+        churn_measurement_duration_s=2.0,
+    )
+    runner = FakeRunner()
+    runner.top_payloads = [top_payload() for _ in range(4)]
+    release_batch = threading.Event()
+    batch_done = threading.Event()
+
+    class ReleasingClock(FakeClock):
+        def sleep(self, duration: float) -> None:
+            super().sleep(duration)
+            if len(self.sleeps) == 3:
+                release_batch.set()
+            if len(self.sleeps) == 4:
+                assert batch_done.wait(timeout=1.0)
+
+    adapter = adapter_module.CmuxRuntimeAdapter(
+        cfg, runner=runner, clock=ReleasingClock()
+    )
+    prepare_fixture(adapter, runner, cfg)
+    original_batch = adapter._browser_churn_batch
+
+    def delayed_batch(cycles: int) -> list[tuple[str, dict[str, Any]]]:
+        assert release_batch.wait(timeout=1.0)
+        try:
+            return original_batch(cycles)
+        finally:
+            batch_done.set()
+
+    adapter._browser_churn_batch = delayed_batch
+    result = adapter.run_churn([])
+
+    assert result["failures"] == []
+    assert len(result["samples"]) == 4
+    assert adapter.raw_details["churn"]["fixed_duration_s"] == 2.0
+    assert adapter.raw_details["churn"]["workload_target_duration_s"] == 1.0
+
+
+
+
 def test_churn_rejects_browser_work_that_outlives_fixed_measurement_window(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_perf_cmux_adapter.py
+++ b/tests/test_perf_cmux_adapter.py
@@ -654,7 +654,6 @@ def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Pa
         event[1][event[1].index("--surface") + 1] for event in capture_calls
     } == set(adapter._terminal_actual_ids.values())
     for method in (
-        "browser.focus_webview",
         "browser.reload",
         "browser.snapshot",
         "browser.screenshot",
@@ -670,13 +669,12 @@ def test_churn_calls_every_planned_surface_and_records_real_metrics(tmp_path: Pa
         for event in runner.events
         if event[:2] == ("rpc", "surface.focus")
     ]
-    assert surface_focuses == list(adapter._browser_actual_ids.values())
     webview_focuses = [
         event
         for event in runner.events
         if event[:2] == ("rpc", "browser.focus_webview")
     ]
-    assert len(webview_focuses) == len(adapter._browser_actual_ids)
+    assert webview_focuses == []
     screenshot_calls = [
         event for event in runner.events if event[:2] == ("rpc", "browser.screenshot")
     ]
@@ -1039,7 +1037,7 @@ def test_enabled_profiles_overlap_churn_and_record_work_units(tmp_path: Path) ->
         call["work_units"]
         == {
             "terminal_ansi_lines": 3_200,
-            "browser_churn_rpc_operations": 10,
+            "browser_churn_rpc_operations": 8,
             "temporary_browser_open_close_operations": 2,
         }
         for call in profile_calls

--- a/tests/test_perf_mixed_workload_contract.py
+++ b/tests/test_perf_mixed_workload_contract.py
@@ -163,6 +163,63 @@ def _assert_snapshot_rejected(scenario: Any, snapshot: dict[str, Any]) -> None:
     raise AssertionError("validate_snapshot accepted an invalid snapshot")
 
 
+def _assert_runtime_snapshot_rejected(scenario: Any, snapshot: dict[str, Any]) -> None:
+    try:
+        perf_contract.validate_runtime_snapshot(scenario, snapshot)
+    except ValueError:
+        return
+    raise AssertionError("validate_runtime_snapshot accepted an invalid snapshot")
+
+
+def _assert_restore_snapshot_rejected(
+    captured: dict[str, Any], restored: dict[str, Any]
+) -> None:
+    try:
+        perf_contract.validate_restored_snapshot(captured, restored)
+    except ValueError:
+        return
+    raise AssertionError("validate_restored_snapshot accepted a changed snapshot")
+
+
+def test_runtime_snapshot_accepts_live_scrollback_but_keeps_exact_topology() -> None:
+    scenarios = _scenarios_by_id()
+    scenario = scenarios["mixed-realistic"]
+    snapshot = _expected_snapshot(EXPECTED_SCENARIOS["mixed-realistic"])
+    snapshot["shape"]["scrollback_chars"] = 1_234_567
+
+    assert perf_contract.validate_runtime_snapshot(scenario, snapshot) is None
+
+    wrong_topology = {
+        **snapshot,
+        "shape": {**snapshot["shape"], "browsers": 3},
+    }
+    _assert_runtime_snapshot_rejected(scenario, wrong_topology)
+
+
+def test_runtime_snapshot_rejects_invalid_live_scrollback_types_and_values() -> None:
+    scenarios = _scenarios_by_id()
+    scenario = scenarios["terminal-light"]
+
+    for invalid in (-1, True, 1.5, "100000"):
+        snapshot = _expected_snapshot(EXPECTED_SCENARIOS["terminal-light"])
+        snapshot["shape"]["scrollback_chars"] = invalid
+        _assert_runtime_snapshot_rejected(scenario, snapshot)
+
+
+def test_restored_snapshot_must_exactly_match_captured_live_shape() -> None:
+    captured = _expected_snapshot(EXPECTED_SCENARIOS["terminal-realistic"])
+    captured["shape"]["scrollback_chars"] = 2_345_678
+    restored = {
+        **captured,
+        "shape": dict(captured["shape"]),
+    }
+
+    assert perf_contract.validate_restored_snapshot(captured, restored) is None
+
+    restored["shape"]["scrollback_chars"] += 1
+    _assert_restore_snapshot_rejected(captured, restored)
+
+
 def test_scenario_matrix_has_exact_nine_ids_and_counts() -> None:
     scenarios = _scenarios_by_id()
 

--- a/tests/test_perf_mixed_workload_contract.py
+++ b/tests/test_perf_mixed_workload_contract.py
@@ -171,14 +171,6 @@ def _assert_runtime_snapshot_rejected(scenario: Any, snapshot: dict[str, Any]) -
     raise AssertionError("validate_runtime_snapshot accepted an invalid snapshot")
 
 
-def _assert_restore_snapshot_rejected(
-    captured: dict[str, Any], restored: dict[str, Any]
-) -> None:
-    try:
-        perf_contract.validate_restored_snapshot(captured, restored)
-    except ValueError:
-        return
-    raise AssertionError("validate_restored_snapshot accepted a changed snapshot")
 
 
 def test_runtime_snapshot_accepts_live_scrollback_but_keeps_exact_topology() -> None:
@@ -206,18 +198,6 @@ def test_runtime_snapshot_rejects_invalid_live_scrollback_types_and_values() -> 
         _assert_runtime_snapshot_rejected(scenario, snapshot)
 
 
-def test_restored_snapshot_must_exactly_match_captured_live_shape() -> None:
-    captured = _expected_snapshot(EXPECTED_SCENARIOS["terminal-realistic"])
-    captured["shape"]["scrollback_chars"] = 2_345_678
-    restored = {
-        **captured,
-        "shape": dict(captured["shape"]),
-    }
-
-    assert perf_contract.validate_restored_snapshot(captured, restored) is None
-
-    restored["shape"]["scrollback_chars"] += 1
-    _assert_restore_snapshot_rejected(captured, restored)
 
 
 def test_scenario_matrix_has_exact_nine_ids_and_counts() -> None:

--- a/tests/test_perf_mixed_workload_contract.py
+++ b/tests/test_perf_mixed_workload_contract.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for the mixed terminal/browser performance matrix."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "perf_mixed_workload_contract.py"
+spec = importlib.util.spec_from_file_location("perf_mixed_workload_contract", SCRIPT)
+assert spec is not None and spec.loader is not None
+perf_contract = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = perf_contract
+spec.loader.exec_module(perf_contract)
+
+BASELINE_SHA = "0123456789abcdef0123456789abcdef01234567"
+CANDIDATE_SHA = "fedcba9876543210fedcba9876543210fedcba98"
+
+EXPECTED_SCENARIOS = {
+    "terminal-light": {
+        "kind": "terminal",
+        "load": "light",
+        "terminal_surfaces": 4,
+        "browser_surfaces": 0,
+        "aggregate_scrollback_chars": 100_000,
+    },
+    "terminal-realistic": {
+        "kind": "terminal",
+        "load": "realistic",
+        "terminal_surfaces": 16,
+        "browser_surfaces": 0,
+        "aggregate_scrollback_chars": 1_000_000,
+    },
+    "terminal-heavy": {
+        "kind": "terminal",
+        "load": "heavy",
+        "terminal_surfaces": 40,
+        "browser_surfaces": 0,
+        "aggregate_scrollback_chars": 3_000_000,
+    },
+    "browser-light": {
+        "kind": "browser",
+        "load": "light",
+        "terminal_surfaces": 0,
+        "browser_surfaces": 1,
+        "aggregate_scrollback_chars": 0,
+    },
+    "browser-realistic": {
+        "kind": "browser",
+        "load": "realistic",
+        "terminal_surfaces": 0,
+        "browser_surfaces": 4,
+        "aggregate_scrollback_chars": 0,
+    },
+    "browser-heavy": {
+        "kind": "browser",
+        "load": "heavy",
+        "terminal_surfaces": 0,
+        "browser_surfaces": 12,
+        "aggregate_scrollback_chars": 0,
+    },
+    "mixed-light": {
+        "kind": "mixed",
+        "load": "light",
+        "terminal_surfaces": 2,
+        "browser_surfaces": 1,
+        "aggregate_scrollback_chars": 100_000,
+    },
+    "mixed-realistic": {
+        "kind": "mixed",
+        "load": "realistic",
+        "terminal_surfaces": 8,
+        "browser_surfaces": 4,
+        "aggregate_scrollback_chars": 1_000_000,
+    },
+    "mixed-heavy": {
+        "kind": "mixed",
+        "load": "heavy",
+        "terminal_surfaces": 20,
+        "browser_surfaces": 12,
+        "aggregate_scrollback_chars": 3_000_000,
+    },
+}
+
+
+def _field(record: Any, name: str) -> Any:
+    if isinstance(record, dict):
+        return record[name]
+    return getattr(record, name)
+
+
+def _scenarios_by_id() -> dict[str, Any]:
+    scenarios = perf_contract.scenario_matrix()
+    return {_field(scenario, "scenario_id"): scenario for scenario in scenarios}
+
+
+def _scenario_contract(scenario: Any) -> dict[str, Any]:
+    return {
+        "kind": _field(scenario, "kind"),
+        "load": _field(scenario, "load"),
+        "terminal_surfaces": _field(scenario, "terminal_surfaces"),
+        "browser_surfaces": _field(scenario, "browser_surfaces"),
+        "aggregate_scrollback_chars": _field(scenario, "aggregate_scrollback_chars"),
+    }
+
+
+def _expected_snapshot(scenario: dict[str, Any]) -> dict[str, Any]:
+    terminal_count = scenario["terminal_surfaces"]
+    browser_count = scenario["browser_surfaces"]
+    return {
+        "built": True,
+        "include_scrollback": True,
+        "persist": True,
+        "saved": True,
+        "shape": {
+            "windows": 1,
+            "workspaces": 1,
+            "panels": terminal_count + browser_count,
+            "terminals": terminal_count,
+            "browsers": browser_count,
+            "markdown": 0,
+            "scrollback_chars": scenario["aggregate_scrollback_chars"],
+            "status_entries": 0,
+            "log_entries": 0,
+            "progress_entries": 0,
+            "git_entries": 0,
+        },
+    }
+
+
+def _snapshot_contract(snapshot: Any) -> dict[str, Any]:
+    shape = _field(snapshot, "shape")
+    return {
+        "built": _field(snapshot, "built"),
+        "include_scrollback": _field(snapshot, "include_scrollback"),
+        "persist": _field(snapshot, "persist"),
+        "saved": _field(snapshot, "saved"),
+        "shape": {
+            "windows": _field(shape, "windows"),
+            "workspaces": _field(shape, "workspaces"),
+            "panels": _field(shape, "panels"),
+            "terminals": _field(shape, "terminals"),
+            "browsers": _field(shape, "browsers"),
+            "markdown": _field(shape, "markdown"),
+            "scrollback_chars": _field(shape, "scrollback_chars"),
+            "status_entries": _field(shape, "status_entries"),
+            "log_entries": _field(shape, "log_entries"),
+            "progress_entries": _field(shape, "progress_entries"),
+            "git_entries": _field(shape, "git_entries"),
+        },
+    }
+
+
+def _assert_snapshot_rejected(scenario: Any, snapshot: dict[str, Any]) -> None:
+    try:
+        perf_contract.validate_snapshot(scenario, snapshot)
+    except ValueError:
+        return
+    raise AssertionError("validate_snapshot accepted an invalid snapshot")
+
+
+def test_scenario_matrix_has_exact_nine_ids_and_counts() -> None:
+    scenarios = _scenarios_by_id()
+
+    assert set(scenarios) == set(EXPECTED_SCENARIOS)
+    assert len(scenarios) == 9
+    assert {
+        scenario_id: _scenario_contract(scenario)
+        for scenario_id, scenario in scenarios.items()
+    } == EXPECTED_SCENARIOS
+
+
+def test_experiment_plan_keeps_ab_and_ba_orders_separate() -> None:
+    plan = perf_contract.build_experiment_plan(
+        baseline_sha=BASELINE_SHA,
+        candidate_sha=CANDIDATE_SHA,
+    )
+
+    assert len(plan) == 9 * 2 * 4
+    for scenario_id in EXPECTED_SCENARIOS:
+        scenario_runs = [run for run in plan if _field(run, "scenario_id") == scenario_id]
+        assert {_field(run, "order") for run in scenario_runs} == {"AB", "BA"}
+
+        for order, expected_variants in (("AB", ["A", "B"]), ("BA", ["B", "A"])):
+            order_runs = [run for run in scenario_runs if _field(run, "order") == order]
+            assert len(order_runs) == 4
+            assert sum(_field(run, "warmup") is True for run in order_runs) == 1
+
+            warmups = [run for run in order_runs if _field(run, "warmup") is True]
+            measured = [run for run in order_runs if _field(run, "warmup") is False]
+            assert [_field(run, "repetition") for run in warmups] == [0]
+            assert [_field(run, "repetition") for run in measured] == [1, 2, 3]
+
+            for run in order_runs:
+                invocations = _field(run, "invocations")
+                assert [_field(invocation, "variant") for invocation in invocations] == expected_variants
+
+
+def test_every_planned_variant_uses_exact_sha_and_recreates_clean_state() -> None:
+    plan = perf_contract.build_experiment_plan(
+        baseline_sha=BASELINE_SHA,
+        candidate_sha=CANDIDATE_SHA,
+    )
+    expected_shas = {"A": BASELINE_SHA, "B": CANDIDATE_SHA}
+
+    assert len(BASELINE_SHA) == 40
+    assert len(CANDIDATE_SHA) == 40
+    for run in plan:
+        assert len(_field(run, "invocations")) == 2
+        for invocation in _field(run, "invocations"):
+            variant = _field(invocation, "variant")
+            sha = _field(invocation, "sha")
+            assert sha == expected_shas[variant]
+            assert len(sha) == 40
+            assert _field(invocation, "recreate_process") is True
+            assert _field(invocation, "recreate_fixture") is True
+
+
+def test_expected_snapshot_is_exact_for_every_terminal_browser_and_mixed_scenario() -> None:
+    scenarios = _scenarios_by_id()
+
+    assert set(scenarios) == set(EXPECTED_SCENARIOS)
+    for scenario_id, expected_scenario in EXPECTED_SCENARIOS.items():
+        expected = _expected_snapshot(expected_scenario)
+        actual = perf_contract.expected_snapshot(scenarios[scenario_id])
+        assert _snapshot_contract(actual) == expected
+        assert perf_contract.validate_snapshot(scenarios[scenario_id], expected) is None
+
+
+def test_snapshot_validation_rejects_mismatched_browser_count() -> None:
+    scenarios = _scenarios_by_id()
+    scenario = scenarios["mixed-realistic"]
+    snapshot = _expected_snapshot(EXPECTED_SCENARIOS["mixed-realistic"])
+    snapshot["shape"]["browsers"] = 3
+
+    _assert_snapshot_rejected(scenario, snapshot)
+
+
+def test_snapshot_validation_rejects_any_false_snapshot_flag() -> None:
+    scenarios = _scenarios_by_id()
+    scenario = scenarios["terminal-light"]
+
+    for flag in ("built", "include_scrollback", "persist", "saved"):
+        snapshot = _expected_snapshot(EXPECTED_SCENARIOS["terminal-light"])
+        snapshot[flag] = False
+        _assert_snapshot_rejected(scenario, snapshot)

--- a/tests/test_perf_mixed_workload_driver.py
+++ b/tests/test_perf_mixed_workload_driver.py
@@ -241,6 +241,100 @@ def test_failures_are_written_and_execution_continues(tmp_path: Path) -> None:
     assert manifest["failures"] == [failure]
 
 
+def test_cleanup_failures_are_structured_in_raw_and_manifest_outputs(
+    tmp_path: Path,
+) -> None:
+    baseline, candidate = _variants()
+    primary_cleanup = [
+        {
+            "phase": "adapter.stop()",
+            "type": "RuntimeError",
+            "message": "primary stop failure",
+            "traceback": "Traceback: primary stop failure",
+        },
+        {
+            "phase": "adapter.cleanup_owned()",
+            "type": "LookupError",
+            "message": "primary owned cleanup failure",
+            "traceback": "Traceback: primary owned cleanup failure",
+        },
+    ]
+    grouped_cleanup = [
+        {
+            "phase": "adapter.stop()",
+            "type": "RuntimeError",
+            "message": "grouped stop failure",
+            "traceback": "Traceback: grouped stop failure",
+        },
+        {
+            "phase": "adapter.cleanup_owned()",
+            "type": "LookupError",
+            "message": "grouped owned cleanup failure",
+            "traceback": "Traceback: grouped owned cleanup failure",
+        },
+    ]
+    call_count = 0
+
+    def run_variant(variant: Any, scenario: Any, run: Any) -> dict[str, Any]:
+        nonlocal call_count
+        del variant, scenario, run
+        call_count += 1
+        if call_count == 1:
+            error = ValueError("primary body failure")
+            error.cleanup_failures = primary_cleanup
+            raise error
+        if call_count == 2:
+            error = ExceptionGroup(
+                "multiple invocation cleanup failures",
+                [RuntimeError("stop"), LookupError("cleanup")],
+            )
+            error.cleanup_failures = grouped_cleanup
+            raise error
+        return {
+            "metrics": {"steady_full_tree_cpu_percent": 10.0},
+            "cleanup": {"owned_processes_removed": 1},
+        }
+
+    result = perf_driver.execute_experiment(
+        baseline=baseline,
+        candidate=candidate,
+        output_dir=tmp_path,
+        run_variant=run_variant,
+    )
+
+    assert [failure.error_type for failure in result.failures] == [
+        "ValueError",
+        "ExceptionGroup",
+    ]
+    assert [
+        failure.to_dict()["cleanup_failures"] for failure in result.failures
+    ] == [primary_cleanup, grouped_cleanup]
+    raw_failures = [
+        json.loads((tmp_path / failure.raw_path).read_text(encoding="utf-8"))[
+            "failure"
+        ]
+        for failure in result.failures
+    ]
+    assert [failure["cleanup_failures"] for failure in raw_failures] == [
+        primary_cleanup,
+        grouped_cleanup,
+    ]
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert [failure["cleanup_failures"] for failure in manifest["failures"]] == [
+        primary_cleanup,
+        grouped_cleanup,
+    ]
+    failed_cleanup_summaries = [
+        summary
+        for summary in manifest["cleanup_summaries"]
+        if summary["status"] == "failure"
+    ]
+    assert [summary["cleanup_failures"] for summary in failed_cleanup_summaries] == [
+        primary_cleanup,
+        grouped_cleanup,
+    ]
+
+
 def test_analysis_excludes_warmups_and_keeps_ab_ba_metric_strata_separate() -> None:
     records = [
         _record(
@@ -320,6 +414,40 @@ def test_predeclared_metric_directions_and_thresholds_are_complete() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("metric", "direction", "threshold", "candidate", "relative_regression"),
+    [
+        ("terminal_render_rate", "lower_is_better", 0.01, 95.0, -0.05),
+        ("browser_render_rate", "higher_is_better", 0.20, 90.0, 0.10),
+    ],
+)
+def test_render_gate_verdict_uses_driver_direction_and_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+    metric: str,
+    direction: str,
+    threshold: float,
+    candidate: float,
+    relative_regression: float,
+) -> None:
+    monkeypatch.setattr(
+        perf_driver,
+        "METRIC_GATES",
+        {metric: (direction, threshold)},
+    )
+
+    group = perf_driver._comparison_group(
+        "mixed-heavy", "AB", metric, [100.0], [candidate]
+    )
+
+    assert group["direction"] == direction
+    assert group["gate"]["direction"] == direction
+    assert group["gate"]["threshold"] == threshold
+    assert group["gate"]["relative_regression"] == pytest.approx(
+        relative_regression
+    )
+    assert group["gate"]["passed"] is True
+
+
 def test_scenario_conclusions_and_final_acceptance_do_not_pool_workloads() -> None:
     records: list[Any] = []
     terminal_metrics = {
@@ -355,6 +483,7 @@ def test_scenario_conclusions_and_final_acceptance_do_not_pool_workloads() -> No
     assert analysis["regressed"] == ["browser-heavy"]
     assert "mixed-heavy" in analysis["inconclusive"]
     assert analysis["final_acceptance"] is False
+    assert analysis["status"] == "rejected"
 
     no_browser_regression = [
         record
@@ -534,6 +663,8 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
 
     accepted = perf_driver.analyze_experiment(complete)
     assert accepted["final_acceptance"] is True
+    assert accepted["status"] == "accepted"
+    perf_driver.validate_accepted_analysis(accepted)
 
     one_group_missing = [
         record
@@ -546,11 +677,32 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
     ]
     rejected = perf_driver.analyze_experiment(one_group_missing)
     assert rejected["final_acceptance"] is False
+    assert rejected["status"] == "rejected"
+    with pytest.raises(ValueError, match="final_acceptance"):
+        perf_driver.validate_accepted_analysis(rejected)
     browser_light = next(
         item for item in rejected["scenarios"] if item["scenario_id"] == "browser-light"
     )
     assert browser_light["complete"] is False
     assert "BA:browser_render_rate" in browser_light["missing_groups"]
+
+
+@pytest.mark.parametrize(
+    "analysis",
+    [
+        {},
+        {"final_acceptance": 1, "status": "accepted"},
+        {"final_acceptance": False, "status": "accepted"},
+        {"final_acceptance": True},
+        {"final_acceptance": True, "status": "Accepted"},
+        {"final_acceptance": True, "status": "rejected"},
+    ],
+)
+def test_analysis_acceptance_validation_is_fail_closed(
+    analysis: dict[str, Any],
+) -> None:
+    with pytest.raises(ValueError):
+        perf_driver.validate_accepted_analysis(analysis)
 
 
 def test_scenario_timing_extends_heavy_browser_measurement_windows() -> None:

--- a/tests/test_perf_mixed_workload_driver.py
+++ b/tests/test_perf_mixed_workload_driver.py
@@ -553,7 +553,7 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
     assert "BA:browser_render_rate" in browser_light["missing_groups"]
 
 
-def test_scenario_timing_extends_only_mixed_heavy_measurement_window() -> None:
+def test_scenario_timing_extends_heavy_browser_measurement_windows() -> None:
     timings = {
         scenario.scenario_id: perf_driver._scenario_timing(scenario)
         for scenario in perf_driver._contract.scenario_matrix()
@@ -564,6 +564,11 @@ def test_scenario_timing_extends_only_mixed_heavy_measurement_window() -> None:
         "churn_measurement_duration_s": 5.0,
         "profile_duration_s": 5.0,
     }
+    assert timings["browser-heavy"] == {
+        "churn_duration_s": 5.0,
+        "churn_measurement_duration_s": 15.0,
+        "profile_duration_s": 15.0,
+    }
     assert timings["mixed-heavy"] == {
         "churn_duration_s": 5.0,
         "churn_measurement_duration_s": 12.0,
@@ -572,7 +577,7 @@ def test_scenario_timing_extends_only_mixed_heavy_measurement_window() -> None:
     assert all(
         timing == default
         for scenario_id, timing in timings.items()
-        if scenario_id != "mixed-heavy"
+        if scenario_id not in {"browser-heavy", "mixed-heavy"}
     )
 
 

--- a/tests/test_perf_mixed_workload_driver.py
+++ b/tests/test_perf_mixed_workload_driver.py
@@ -315,8 +315,8 @@ def test_predeclared_metric_directions_and_thresholds_are_complete() -> None:
         "browser_latency_ms": ("lower_is_better", 0.10),
         "terminal_throughput_per_second": ("higher_is_better", 0.05),
         "browser_throughput_per_second": ("higher_is_better", 0.05),
-        "terminal_present_rate": ("higher_is_better", 0.05),
-        "browser_present_rate": ("higher_is_better", 0.05),
+        "terminal_render_rate": ("higher_is_better", 0.05),
+        "browser_render_rate": ("higher_is_better", 0.05),
     }
 
 
@@ -450,6 +450,56 @@ def test_cli_contract_requires_exact_fixed_repetition_plan(tmp_path: Path) -> No
         perf_driver.parse_cli_args(bad_repetitions)
 
 
+def test_analysis_rejects_records_outside_fixed_measured_plan() -> None:
+    records = [
+        _record(
+            "terminal-light",
+            "AB",
+            4,
+            variant,
+            {"steady_full_tree_cpu_percent": 1.0},
+        )
+        for variant in "AB"
+    ]
+
+    with pytest.raises(ValueError, match="measured repetition"):
+        perf_driver.analyze_experiment(records)
+
+
+def test_analysis_rejects_inconsistent_build_and_scenario_identity() -> None:
+    baseline = _record(
+        "terminal-light",
+        "AB",
+        1,
+        "A",
+        {"steady_full_tree_cpu_percent": 1.0},
+    ).to_dict()
+    candidate = _record(
+        "terminal-light",
+        "AB",
+        1,
+        "B",
+        {"steady_full_tree_cpu_percent": 1.0},
+    ).to_dict()
+
+    wrong_scenario = dict(candidate)
+    wrong_scenario["kind"] = "browser"
+    with pytest.raises(ValueError, match="scenario metadata"):
+        perf_driver.analyze_experiment([baseline, wrong_scenario])
+
+    wrong_build = dict(candidate)
+    wrong_build["sha"] = BASELINE_SHA
+    with pytest.raises(ValueError, match="distinct build SHAs"):
+        perf_driver.analyze_experiment([baseline, wrong_build])
+
+    second_baseline = dict(baseline)
+    second_baseline["scenario_id"] = "terminal-realistic"
+    second_baseline["load"] = "realistic"
+    second_baseline["sha"] = "a" * 40
+    with pytest.raises(ValueError, match="one SHA"):
+        perf_driver.analyze_experiment([baseline, second_baseline, candidate])
+
+
 def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
     metrics_by_kind = {
         "terminal": (
@@ -460,7 +510,7 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
             "churn_full_tree_cpu_percent",
             "churn_terminal_cpu_percent",
             "terminal_throughput_per_second",
-            "terminal_present_rate",
+            "terminal_render_rate",
         ),
         "browser": (
             "steady_parent_cpu_percent",
@@ -471,7 +521,7 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
             "churn_webkit_cpu_percent",
             "browser_latency_ms",
             "browser_throughput_per_second",
-            "browser_present_rate",
+            "browser_render_rate",
         ),
         "mixed": tuple(perf_driver.METRIC_GATES),
     }
@@ -491,7 +541,7 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
         if not (
             record.scenario_id == "browser-light"
             and record.order == "BA"
-            and "browser_present_rate" in record.metrics
+            and "browser_render_rate" in record.metrics
         )
     ]
     rejected = perf_driver.analyze_experiment(one_group_missing)
@@ -500,7 +550,7 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
         item for item in rejected["scenarios"] if item["scenario_id"] == "browser-light"
     )
     assert browser_light["complete"] is False
-    assert "BA:browser_present_rate" in browser_light["missing_groups"]
+    assert "BA:browser_render_rate" in browser_light["missing_groups"]
 
 
 def test_platform_bridge_passes_exact_variant_scenario_and_profile_scope(
@@ -546,7 +596,7 @@ def test_platform_bridge_passes_exact_variant_scenario_and_profile_scope(
                     "churn_samples": [],
                     "latencies_ms": [],
                     "throughput_ops_per_second": {},
-                    "presents": [],
+                    "render_observations": [],
                     "failures": [],
                 },
             )()

--- a/tests/test_perf_mixed_workload_driver.py
+++ b/tests/test_perf_mixed_workload_driver.py
@@ -553,6 +553,29 @@ def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
     assert "BA:browser_render_rate" in browser_light["missing_groups"]
 
 
+def test_scenario_timing_extends_only_mixed_heavy_measurement_window() -> None:
+    timings = {
+        scenario.scenario_id: perf_driver._scenario_timing(scenario)
+        for scenario in perf_driver._contract.scenario_matrix()
+    }
+
+    default = {
+        "churn_duration_s": 5.0,
+        "churn_measurement_duration_s": 5.0,
+        "profile_duration_s": 5.0,
+    }
+    assert timings["mixed-heavy"] == {
+        "churn_duration_s": 5.0,
+        "churn_measurement_duration_s": 12.0,
+        "profile_duration_s": 12.0,
+    }
+    assert all(
+        timing == default
+        for scenario_id, timing in timings.items()
+        if scenario_id != "mixed-heavy"
+    )
+
+
 def test_platform_bridge_passes_exact_variant_scenario_and_profile_scope(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_perf_mixed_workload_driver.py
+++ b/tests/test_perf_mixed_workload_driver.py
@@ -642,6 +642,9 @@ def test_platform_bridge_passes_exact_variant_scenario_and_profile_scope(
             "output_root": tmp_path / "invocations" / "terminal-light-AB-r1-A",
             "warmup": False,
             "profile_enabled": True,
+            "churn_duration_s": 5.0,
+            "churn_measurement_duration_s": 5.0,
+            "profile_duration_s": 5.0,
         }
     ]
     assert calls[0]["scenario_id"] == "terminal-light"

--- a/tests/test_perf_mixed_workload_driver.py
+++ b/tests/test_perf_mixed_workload_driver.py
@@ -584,3 +584,46 @@ def test_platform_bridge_passes_exact_variant_scenario_and_profile_scope(
     assert outcome["metrics"] == {"steady_full_tree_cpu_percent": 4.0}
     assert outcome["cleanup"] == {"owned": True}
     assert outcome["evidence"]["profiles"] == [{"role": "parent", "pid": 100}]
+
+
+def test_platform_bridge_rejects_recorded_churn_failures(tmp_path: Path) -> None:
+    baseline, _ = _variants()
+
+    class FakeAdapter:
+        raw_details = {"churn": {"failures": [{"phase": "profile_churn"}]}}
+
+        def __init__(self, config: Any) -> None:
+            del config
+
+    class FakeAdapterModule:
+        AdapterConfig = lambda **values: values
+        CmuxRuntimeAdapter = FakeAdapter
+        extract_metrics = staticmethod(lambda result, details: {})
+
+    class FakeRuntimeModule:
+        @staticmethod
+        def run_invocation(**kwargs: Any) -> Any:
+            del kwargs
+            return type(
+                "Result",
+                (),
+                {
+                    "failures": [{"phase": "profile_churn"}],
+                    "cleanup": {"owned": True},
+                },
+            )()
+
+    bridge = perf_driver.build_platform_run_variant(
+        output_root=tmp_path,
+        adapter_module=FakeAdapterModule,
+        runtime_module=FakeRuntimeModule,
+    )
+    scenario_value = perf_driver._contract.scenario_matrix()[0]
+    run = perf_driver._contract.build_experiment_plan(BASELINE_SHA, CANDIDATE_SHA)[1]
+
+    with pytest.raises(RuntimeError, match="recorded workload failures") as caught:
+        bridge(baseline, scenario_value, run)
+    assert caught.value.cleanup == {"owned": True}
+    assert caught.value.evidence["churn"]["failures"] == [
+        {"phase": "profile_churn"}
+    ]

--- a/tests/test_perf_mixed_workload_driver.py
+++ b/tests/test_perf_mixed_workload_driver.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for the pure mixed-workload experiment driver."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "perf_mixed_workload_driver.py"
+spec = importlib.util.spec_from_file_location("perf_mixed_workload_driver", SCRIPT)
+assert spec is not None and spec.loader is not None
+perf_driver = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = perf_driver
+spec.loader.exec_module(perf_driver)
+
+BASELINE_SHA = "0123456789abcdef0123456789abcdef01234567"
+CANDIDATE_SHA = "fedcba9876543210fedcba9876543210fedcba98"
+BASELINE = None
+CANDIDATE = None
+
+
+def _variants() -> tuple[Any, Any]:
+    return (
+        perf_driver.VariantConfig(
+            variant="A",
+            sha=BASELINE_SHA,
+            tag="perf-baseline",
+            app_path="/apps/cmux DEV perf-baseline.app",
+        ),
+        perf_driver.VariantConfig(
+            variant="B",
+            sha=CANDIDATE_SHA,
+            tag="perf-candidate",
+            app_path="/apps/cmux DEV perf-candidate.app",
+        ),
+    )
+
+
+def _record(
+    scenario_id: str,
+    order: str,
+    repetition: int,
+    variant: str,
+    metrics: dict[str, float],
+    *,
+    warmup: bool = False,
+) -> Any:
+    scenario_kind, load = scenario_id.split("-", 1)
+    sha = BASELINE_SHA if variant == "A" else CANDIDATE_SHA
+    return perf_driver.ExperimentRecord(
+        scenario_id=scenario_id,
+        kind=scenario_kind,
+        load=load,
+        order=order,
+        repetition=repetition,
+        warmup=warmup,
+        variant=variant,
+        sha=sha,
+        metrics=metrics,
+        cleanup={"removed": 1},
+    )
+
+
+def _paired_records(
+    scenario_id: str,
+    metric_values: dict[str, tuple[float, float]],
+) -> list[Any]:
+    records = []
+    for order in ("AB", "BA"):
+        for repetition in range(1, 4):
+            for variant in order:
+                records.append(
+                    _record(
+                        scenario_id,
+                        order,
+                        repetition,
+                        variant,
+                        {
+                            metric: values[0 if variant == "A" else 1]
+                            for metric, values in metric_values.items()
+                        },
+                    )
+                )
+    return records
+
+
+def test_variant_and_experiment_records_are_immutable_and_json_friendly() -> None:
+    baseline, _ = _variants()
+    record = _record(
+        "terminal-heavy",
+        "AB",
+        1,
+        "A",
+        {"steady_full_tree_cpu_percent": 42.5},
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        baseline.tag = "changed"
+    with pytest.raises(TypeError):
+        record.metrics["steady_full_tree_cpu_percent"] = 1.0
+
+    assert json.loads(json.dumps(baseline.to_dict())) == {
+        "variant": "A",
+        "sha": BASELINE_SHA,
+        "tag": "perf-baseline",
+        "app_path": "/apps/cmux DEV perf-baseline.app",
+    }
+    assert json.loads(json.dumps(record.to_dict()))["metrics"] == {
+        "steady_full_tree_cpu_percent": 42.5
+    }
+
+
+def test_execute_experiment_runs_exact_fixed_plan_and_writes_deterministic_outputs(
+    tmp_path: Path,
+) -> None:
+    baseline, candidate = _variants()
+    calls: list[tuple[str, str, str, int, bool, str, str, str]] = []
+
+    def run_variant(variant: Any, scenario: Any, run: Any) -> dict[str, Any]:
+        calls.append(
+            (
+                scenario.scenario_id,
+                scenario.kind,
+                run.order,
+                run.repetition,
+                run.warmup,
+                variant.variant,
+                variant.tag,
+                variant.app_path,
+            )
+        )
+        value = 100.0 if variant.variant == "A" else 99.0
+        return {
+            "metrics": {
+                metric: value for metric in perf_driver.METRIC_GATES
+            },
+            "cleanup": {"owned_processes_removed": 1},
+        }
+
+    result = perf_driver.execute_experiment(
+        baseline=baseline,
+        candidate=candidate,
+        output_dir=tmp_path,
+        run_variant=run_variant,
+    )
+
+    assert len(calls) == 144
+    assert len(result.records) == 144
+    assert sum(not record.warmup for record in result.records) == 108
+    assert result.failures == ()
+    assert calls[:4] == [
+        ("terminal-light", "terminal", "AB", 0, True, "A", "perf-baseline", "/apps/cmux DEV perf-baseline.app"),
+        ("terminal-light", "terminal", "AB", 0, True, "B", "perf-candidate", "/apps/cmux DEV perf-candidate.app"),
+        ("terminal-light", "terminal", "AB", 1, False, "A", "perf-baseline", "/apps/cmux DEV perf-baseline.app"),
+        ("terminal-light", "terminal", "AB", 1, False, "B", "perf-candidate", "/apps/cmux DEV perf-candidate.app"),
+    ]
+    assert calls[8:12] == [
+        ("terminal-light", "terminal", "BA", 0, True, "B", "perf-candidate", "/apps/cmux DEV perf-candidate.app"),
+        ("terminal-light", "terminal", "BA", 0, True, "A", "perf-baseline", "/apps/cmux DEV perf-baseline.app"),
+        ("terminal-light", "terminal", "BA", 1, False, "B", "perf-candidate", "/apps/cmux DEV perf-candidate.app"),
+        ("terminal-light", "terminal", "BA", 1, False, "A", "perf-baseline", "/apps/cmux DEV perf-baseline.app"),
+    ]
+
+    assert result.manifest_path == tmp_path / "experiment-manifest.json"
+    assert result.analysis_path == tmp_path / "analysis.json"
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    analysis = json.loads(result.analysis_path.read_text(encoding="utf-8"))
+    assert manifest["schema"] == "cmux.perf.mixed-workload-experiment/v1"
+    assert manifest["variants"] == {"A": baseline.to_dict(), "B": candidate.to_dict()}
+    assert manifest["plan"] == {
+        "scenario_count": 9,
+        "order_count": 2,
+        "pairs_per_order": 4,
+        "warmup_pairs_per_order": 1,
+        "measured_pairs_per_order": 3,
+        "pair_count": 72,
+        "invocation_count": 144,
+        "warmup_invocation_count": 36,
+        "measured_invocation_count": 108,
+    }
+    assert len(manifest["raw_paths"]) == 144
+    assert manifest["raw_paths"][0] == "raw/001-terminal-light-AB-r0-A.json"
+    assert manifest["raw_paths"][-1] == "raw/144-mixed-heavy-BA-r3-A.json"
+    assert len(manifest["cleanup_summaries"]) == 144
+    assert manifest["failures"] == []
+    assert analysis == result.analysis
+    assert len(list((tmp_path / "raw").glob("*.json"))) == 144
+
+
+def test_failures_are_written_and_execution_continues(tmp_path: Path) -> None:
+    baseline, candidate = _variants()
+    attempted: list[tuple[str, str, int, str]] = []
+
+    def run_variant(variant: Any, scenario: Any, run: Any) -> dict[str, Any]:
+        key = (scenario.scenario_id, run.order, run.repetition, variant.variant)
+        attempted.append(key)
+        if key == ("terminal-light", "AB", 1, "B"):
+            error = RuntimeError("synthetic candidate failure")
+            error.cleanup = {"owned_processes_removed": 2}
+            error.evidence = {"last_process_sample": {"coverage": {"missing_pids": [99]}}}
+            raise error
+        return {
+            "metrics": {"steady_full_tree_cpu_percent": 10.0},
+            "cleanup": {"owned_processes_removed": 1},
+        }
+
+    result = perf_driver.execute_experiment(
+        baseline=baseline,
+        candidate=candidate,
+        output_dir=tmp_path,
+        run_variant=run_variant,
+    )
+
+    assert len(attempted) == 144
+    assert attempted[-1] == ("mixed-heavy", "BA", 3, "A")
+    assert len(result.records) == 143
+    assert len(result.failures) == 1
+    failure = result.failures[0].to_dict()
+    assert failure["scenario_id"] == "terminal-light"
+    assert failure["order"] == "AB"
+    assert failure["repetition"] == 1
+    assert failure["variant"] == "B"
+    assert failure["error_type"] == "RuntimeError"
+    assert failure["message"] == "synthetic candidate failure"
+    assert failure["cleanup"] == {"owned_processes_removed": 2}
+    failure_raw = json.loads((tmp_path / failure["raw_path"]).read_text(encoding="utf-8"))
+    assert failure_raw["status"] == "failure"
+    assert failure_raw["failure"]["message"] == "synthetic candidate failure"
+    assert failure_raw["evidence"]["last_process_sample"]["coverage"] == {
+        "missing_pids": [99]
+    }
+    manifest = json.loads((tmp_path / "experiment-manifest.json").read_text())
+    assert manifest["failures"] == [failure]
+
+
+def test_analysis_excludes_warmups_and_keeps_ab_ba_metric_strata_separate() -> None:
+    records = [
+        _record(
+            "terminal-heavy",
+            order,
+            0,
+            variant,
+            {"steady_full_tree_cpu_percent": 9999.0 if variant == "A" else 1.0},
+            warmup=True,
+        )
+        for order in ("AB", "BA")
+        for variant in order
+    ]
+    for order, baseline_values, candidate_values in (
+        ("AB", (10.0, 20.0, 30.0), (9.0, 18.0, 27.0)),
+        ("BA", (40.0, 50.0, 60.0), (38.0, 47.0, 55.0)),
+    ):
+        for repetition, (a_value, b_value) in enumerate(
+            zip(baseline_values, candidate_values, strict=True), start=1
+        ):
+            for variant in order:
+                records.append(
+                    _record(
+                        "terminal-heavy",
+                        order,
+                        repetition,
+                        variant,
+                        {
+                            "steady_full_tree_cpu_percent": (
+                                a_value if variant == "A" else b_value
+                            )
+                        },
+                    )
+                )
+
+    analysis = perf_driver.analyze_experiment(records)
+    groups = {
+        (group["scenario_id"], group["order"], group["metric"]): group
+        for group in analysis["groups"]
+    }
+    assert set(groups) == {
+        ("terminal-heavy", "AB", "steady_full_tree_cpu_percent"),
+        ("terminal-heavy", "BA", "steady_full_tree_cpu_percent"),
+    }
+    ab = groups[("terminal-heavy", "AB", "steady_full_tree_cpu_percent")]
+    ba = groups[("terminal-heavy", "BA", "steady_full_tree_cpu_percent")]
+    assert ab["comparison"]["baseline"]["raw_values"] == [10.0, 20.0, 30.0]
+    assert ab["comparison"]["candidate"]["raw_values"] == [9.0, 18.0, 27.0]
+    assert ba["comparison"]["baseline"]["raw_values"] == [40.0, 50.0, 60.0]
+    assert ba["comparison"]["candidate"]["raw_values"] == [38.0, 47.0, 55.0]
+    assert ab["comparison"]["baseline"]["median"] == 20.0
+    assert ab["comparison"]["baseline"]["iqr"] == 20.0
+    assert ab["comparison"]["baseline"]["mad"] == 10.0
+    assert ab["comparison"]["absolute_deltas"] == [-1.0, -2.0, -3.0]
+    assert ab["comparison"]["probability_candidate_better"] > 0.5
+    assert ab["comparison"]["oriented_effect_size"] > 0.0
+    assert ab["gate"]["direction"] == "lower_is_better"
+    assert ab["gate"]["threshold"] == 0.05
+    assert ab["gate"]["passed"] is True
+
+
+def test_predeclared_metric_directions_and_thresholds_are_complete() -> None:
+    assert dict(perf_driver.METRIC_GATES) == {
+        "steady_parent_cpu_percent": ("lower_is_better", 0.05),
+        "steady_full_tree_cpu_percent": ("lower_is_better", 0.05),
+        "steady_terminal_cpu_percent": ("lower_is_better", 0.05),
+        "steady_webkit_cpu_percent": ("lower_is_better", 0.05),
+        "churn_parent_cpu_percent": ("lower_is_better", 0.05),
+        "churn_full_tree_cpu_percent": ("lower_is_better", 0.05),
+        "churn_terminal_cpu_percent": ("lower_is_better", 0.05),
+        "churn_webkit_cpu_percent": ("lower_is_better", 0.05),
+        "browser_latency_ms": ("lower_is_better", 0.10),
+        "terminal_throughput_per_second": ("higher_is_better", 0.05),
+        "browser_throughput_per_second": ("higher_is_better", 0.05),
+        "terminal_present_rate": ("higher_is_better", 0.05),
+        "browser_present_rate": ("higher_is_better", 0.05),
+    }
+
+
+def test_scenario_conclusions_and_final_acceptance_do_not_pool_workloads() -> None:
+    records: list[Any] = []
+    terminal_metrics = {
+        metric: (100.0, 100.0)
+        for metric in perf_driver._REQUIRED_METRICS_BY_KIND["terminal"]
+    }
+    terminal_metrics["steady_full_tree_cpu_percent"] = (100.0, 90.0)
+    records.extend(_paired_records("terminal-heavy", terminal_metrics))
+
+    browser_metrics = {
+        metric: (100.0, 100.0)
+        for metric in perf_driver._REQUIRED_METRICS_BY_KIND["browser"]
+    }
+    browser_metrics["browser_latency_ms"] = (100.0, 111.0)
+    records.extend(_paired_records("browser-heavy", browser_metrics))
+
+    records.extend(
+        _paired_records(
+            "mixed-heavy",
+            {metric: (100.0, 100.0) for metric in perf_driver.METRIC_GATES},
+        )
+    )
+
+    analysis = perf_driver.analyze_experiment(records)
+    conclusions = {
+        item["scenario_id"]: item["conclusion"]
+        for item in analysis["scenarios"]
+    }
+    assert conclusions["terminal-heavy"] == "proven"
+    assert conclusions["browser-heavy"] == "regressed"
+    assert conclusions["mixed-heavy"] == "inconclusive"
+    assert analysis["proven"] == ["terminal-heavy"]
+    assert analysis["regressed"] == ["browser-heavy"]
+    assert "mixed-heavy" in analysis["inconclusive"]
+    assert analysis["final_acceptance"] is False
+
+    no_browser_regression = [
+        record
+        for record in records
+        if not (
+            record.scenario_id == "browser-heavy"
+            and "browser_latency_ms" in record.metrics
+        )
+    ]
+    passing = perf_driver.analyze_experiment(no_browser_regression)
+    passing_conclusions = {
+        item["scenario_id"]: item["conclusion"]
+        for item in passing["scenarios"]
+    }
+    assert passing_conclusions["browser-heavy"] == "inconclusive"
+    assert passing_conclusions["mixed-heavy"] == "inconclusive"
+    assert passing["final_acceptance"] is False
+    assert passing["proven"] == ["terminal-heavy"]
+
+
+def test_success_raw_file_retains_complete_adapter_evidence(tmp_path: Path) -> None:
+    baseline, candidate = _variants()
+
+    def run_variant(variant: Any, scenario: Any, run: Any) -> dict[str, Any]:
+        return {
+            "metrics": {"steady_full_tree_cpu_percent": 1.0},
+            "cleanup": {"removed": True},
+            "evidence": {
+                "requested_shape": {
+                    "terminal_surfaces": scenario.terminal_surfaces,
+                    "browser_surfaces": scenario.browser_surfaces,
+                },
+                "raw_samples": [{"full_tree": {"pids": [10, 11], "cpu_percent": 1.0}}],
+                "order": run.order,
+                "variant": variant.variant,
+            },
+        }
+
+    perf_driver.execute_experiment(
+        baseline=baseline,
+        candidate=candidate,
+        output_dir=tmp_path,
+        run_variant=run_variant,
+    )
+
+    first = json.loads(
+        (tmp_path / "raw" / "001-terminal-light-AB-r0-A.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert first["evidence"]["requested_shape"] == {
+        "terminal_surfaces": 4,
+        "browser_surfaces": 0,
+    }
+    assert first["evidence"]["raw_samples"][0]["full_tree"]["pids"] == [10, 11]
+
+
+def test_cli_contract_requires_exact_fixed_repetition_plan(tmp_path: Path) -> None:
+    required = [
+        "--baseline-sha",
+        BASELINE_SHA,
+        "--baseline-tag",
+        "perf-baseline",
+        "--baseline-app",
+        "/apps/baseline.app",
+        "--candidate-sha",
+        CANDIDATE_SHA,
+        "--candidate-tag",
+        "perf-candidate",
+        "--candidate-app",
+        "/apps/candidate.app",
+        "--output-dir",
+        str(tmp_path),
+        "--warmups",
+        "1",
+        "--repetitions",
+        "3",
+    ]
+
+    parsed = perf_driver.parse_cli_args(required)
+    assert parsed.baseline_sha == BASELINE_SHA
+    assert parsed.candidate_sha == CANDIDATE_SHA
+    assert parsed.output_dir == tmp_path
+
+    bad_warmups = required.copy()
+    bad_warmups[bad_warmups.index("1")] = "0"
+    with pytest.raises(ValueError, match="exactly one warmup"):
+        perf_driver.parse_cli_args(bad_warmups)
+
+    bad_repetitions = required.copy()
+    bad_repetitions[bad_repetitions.index("3")] = "2"
+    with pytest.raises(ValueError, match="exactly three measured"):
+        perf_driver.parse_cli_args(bad_repetitions)
+
+
+def test_final_acceptance_requires_every_scenario_metric_and_order() -> None:
+    metrics_by_kind = {
+        "terminal": (
+            "steady_parent_cpu_percent",
+            "steady_full_tree_cpu_percent",
+            "steady_terminal_cpu_percent",
+            "churn_parent_cpu_percent",
+            "churn_full_tree_cpu_percent",
+            "churn_terminal_cpu_percent",
+            "terminal_throughput_per_second",
+            "terminal_present_rate",
+        ),
+        "browser": (
+            "steady_parent_cpu_percent",
+            "steady_full_tree_cpu_percent",
+            "steady_webkit_cpu_percent",
+            "churn_parent_cpu_percent",
+            "churn_full_tree_cpu_percent",
+            "churn_webkit_cpu_percent",
+            "browser_latency_ms",
+            "browser_throughput_per_second",
+            "browser_present_rate",
+        ),
+        "mixed": tuple(perf_driver.METRIC_GATES),
+    }
+    complete: list[Any] = []
+    for scenario in perf_driver._contract.scenario_matrix():
+        values = {metric: (100.0, 100.0) for metric in metrics_by_kind[scenario.kind]}
+        if scenario.scenario_id == "terminal-heavy":
+            values["steady_full_tree_cpu_percent"] = (100.0, 90.0)
+        complete.extend(_paired_records(scenario.scenario_id, values))
+
+    accepted = perf_driver.analyze_experiment(complete)
+    assert accepted["final_acceptance"] is True
+
+    one_group_missing = [
+        record
+        for record in complete
+        if not (
+            record.scenario_id == "browser-light"
+            and record.order == "BA"
+            and "browser_present_rate" in record.metrics
+        )
+    ]
+    rejected = perf_driver.analyze_experiment(one_group_missing)
+    assert rejected["final_acceptance"] is False
+    browser_light = next(
+        item for item in rejected["scenarios"] if item["scenario_id"] == "browser-light"
+    )
+    assert browser_light["complete"] is False
+    assert "BA:browser_present_rate" in browser_light["missing_groups"]
+
+
+def test_platform_bridge_passes_exact_variant_scenario_and_profile_scope(
+    tmp_path: Path,
+) -> None:
+    baseline, _ = _variants()
+    captured_configs: list[dict[str, Any]] = []
+
+    class FakeConfig:
+        def __init__(self, **values: Any) -> None:
+            captured_configs.append(values)
+
+    class FakeAdapter:
+        def __init__(self, cfg: Any) -> None:
+            self.raw_details = {
+                "fixture": {"exact": True},
+                "profiles": [{"role": "parent", "pid": 100}],
+            }
+
+    class FakeAdapterModule:
+        AdapterConfig = FakeConfig
+        CmuxRuntimeAdapter = FakeAdapter
+
+        @staticmethod
+        def extract_metrics(result: Any, details: Any) -> dict[str, float]:
+            assert details["fixture"] == {"exact": True}
+            return {"steady_full_tree_cpu_percent": 4.0}
+
+    calls: list[dict[str, Any]] = []
+
+    class FakeRuntimeModule:
+        @staticmethod
+        def run_invocation(**kwargs: Any) -> Any:
+            calls.append(kwargs)
+            return type(
+                "Result",
+                (),
+                {
+                    "cleanup": {"owned": True},
+                    "requested_shape": kwargs["requested_shape"],
+                    "observed_shape": kwargs["requested_shape"],
+                    "steady_samples": [],
+                    "churn_samples": [],
+                    "latencies_ms": [],
+                    "throughput_ops_per_second": {},
+                    "presents": [],
+                    "failures": [],
+                },
+            )()
+
+    bridge = perf_driver.build_platform_run_variant(
+        output_root=tmp_path,
+        adapter_module=FakeAdapterModule,
+        runtime_module=FakeRuntimeModule,
+    )
+    scenario_value = perf_driver._contract.scenario_matrix()[0]
+    run = perf_driver._contract.build_experiment_plan(BASELINE_SHA, CANDIDATE_SHA)[1]
+    outcome = bridge(baseline, scenario_value, run)
+
+    assert captured_configs == [
+        {
+            "sha": BASELINE_SHA,
+            "tag": "perf-baseline",
+            "app_path": "/apps/cmux DEV perf-baseline.app",
+            "scenario": scenario_value,
+            "output_root": tmp_path / "invocations" / "terminal-light-AB-r1-A",
+            "warmup": False,
+            "profile_enabled": True,
+        }
+    ]
+    assert calls[0]["scenario_id"] == "terminal-light"
+    assert calls[0]["sha"] == BASELINE_SHA
+    assert calls[0]["order"] == "AB"
+    assert calls[0]["repetition"] == 1
+    assert calls[0]["requested_shape"] == {
+        "terminal_surfaces": 4,
+        "browser_surfaces": 0,
+    }
+    assert calls[0]["owned_root"] == captured_configs[0]["output_root"]
+    assert isinstance(calls[0]["adapter"], FakeAdapter)
+    assert outcome["metrics"] == {"steady_full_tree_cpu_percent": 4.0}
+    assert outcome["cleanup"] == {"owned": True}
+    assert outcome["evidence"]["profiles"] == [{"role": "parent", "pid": 100}]

--- a/tests/test_perf_mixed_workload_runtime.py
+++ b/tests/test_perf_mixed_workload_runtime.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for one mixed-workload benchmark invocation."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "perf_mixed_workload.py"
+spec = importlib.util.spec_from_file_location("perf_mixed_workload", SCRIPT)
+assert spec is not None and spec.loader is not None
+perf_runtime = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = perf_runtime
+spec.loader.exec_module(perf_runtime)
+
+SCENARIO_ID = "mixed-realistic"
+SHA = "fedcba9876543210fedcba9876543210fedcba98"
+REQUESTED_SHAPE = {"terminal_surfaces": 2, "browser_surfaces": 2}
+EXPECTED_PROCESS_GROUPS = {"parent_direct", "terminal", "webkit", "full_tree"}
+EXPECTED_STEADY_SAMPLES = [
+    {
+        "sample_index": 0,
+        "elapsed_seconds": 0.0,
+        "process_attribution": {
+            "parent_direct": {"pids": [700], "cpu_percent": 4.0},
+            "terminal": {"pids": [710, 711], "cpu_percent": 8.0},
+            "webkit": {"pids": [720, 721], "cpu_percent": 12.0},
+            "full_tree": {
+                "pids": [700, 710, 711, 720, 721],
+                "cpu_percent": 24.0,
+            },
+        },
+    },
+    {
+        "sample_index": 1,
+        "elapsed_seconds": 1.0,
+        "process_attribution": {
+            "parent_direct": {"pids": [700], "cpu_percent": 5.0},
+            "terminal": {"pids": [710, 711], "cpu_percent": 9.0},
+            "webkit": {"pids": [720, 721], "cpu_percent": 13.0},
+            "full_tree": {
+                "pids": [700, 710, 711, 720, 721],
+                "cpu_percent": 27.0,
+            },
+        },
+    },
+]
+EXPECTED_CHURN_SAMPLES = [
+    {
+        "sample_index": 0,
+        "elapsed_seconds": 0.25,
+        "process_attribution": {
+            "parent_direct": {"pids": [700], "cpu_percent": 6.0},
+            "terminal": {"pids": [710, 711], "cpu_percent": 14.0},
+            "webkit": {"pids": [720, 721], "cpu_percent": 18.0},
+            "full_tree": {
+                "pids": [700, 710, 711, 720, 721],
+                "cpu_percent": 38.0,
+            },
+        },
+    }
+]
+EXPECTED_LATENCIES_MS = [3.0, 5.0, 7.0, 11.0]
+EXPECTED_PRESENTS = [
+    {"surface_id": "terminal-001", "count": 6},
+    {"surface_id": "browser-mixed-realistic-001", "count": 9},
+]
+EXPECTED_FAILURES = [
+    {
+        "phase": "churn",
+        "operation_index": 3,
+        "message": "deterministic synthetic probe miss",
+    }
+]
+
+
+def _field(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value[name]
+    return getattr(value, name)
+
+
+def _browser_surfaces(plan: Any) -> list[Any]:
+    return list(_field(plan, "browser_surfaces"))
+
+
+def _observed_browsers(plan: Any) -> list[dict[str, str]]:
+    return [
+        {
+            "surface_id": _field(surface, "surface_id"),
+            "url": _field(surface, "url"),
+            "title": _field(surface, "title"),
+            "content_marker": _field(surface, "content_marker"),
+        }
+        for surface in _browser_surfaces(plan)
+    ]
+
+
+def _expected_churn_operations() -> list[dict[str, Any]]:
+    return [
+        {
+            "operation": "activate",
+            "surface_kind": "terminal",
+            "surface_id": "terminal-001",
+        },
+        {
+            "operation": "activate",
+            "surface_kind": "browser",
+            "surface_id": "browser-mixed-realistic-001",
+        },
+        {
+            "operation": "terminal_input",
+            "surface_id": "terminal-002",
+            "payload": "printf 'cmux-perf-churn:mixed-realistic:terminal-002\\n'",
+        },
+        {
+            "operation": "browser_reload",
+            "surface_id": "browser-mixed-realistic-002",
+        },
+    ]
+
+
+class FakeRuntimeAdapter:
+    """Small synchronous seam for process, fixture, sampling, and cleanup I/O."""
+
+    def __init__(self, owned_root: Path, *, invalid_observation: int | None = None):
+        self.owned_root = owned_root
+        self.invalid_observation = invalid_observation
+        self.events: list[Any] = []
+        self.plan: Any | None = None
+        self.observation_count = 0
+        self.stopped = False
+        self.cleaned = False
+
+    def clean_state(self) -> None:
+        self.events.append("clean_state")
+
+    def launch(self, sha: str) -> None:
+        self.events.append(("launch", sha))
+
+    def create_fixture(self, plan: Any) -> None:
+        self.events.append("create_fixture")
+        self.plan = plan
+
+    def observe_fixture(self) -> dict[str, Any]:
+        self.events.append("observe_fixture")
+        self.observation_count += 1
+        assert self.plan is not None
+        browsers = _observed_browsers(self.plan)
+        if self.observation_count == self.invalid_observation:
+            browsers[0]["title"] = "wrong restored title"
+        return {
+            "shape": copy.deepcopy(REQUESTED_SHAPE),
+            "browsers": browsers,
+        }
+
+    def sample_steady(self) -> list[dict[str, Any]]:
+        self.events.append("sample_steady")
+        return copy.deepcopy(EXPECTED_STEADY_SAMPLES)
+
+    def run_churn(self, operations: list[dict[str, Any]]) -> dict[str, Any]:
+        self.events.append(("run_churn", copy.deepcopy(operations)))
+        return {
+            "samples": copy.deepcopy(EXPECTED_CHURN_SAMPLES),
+            "latencies_ms": list(EXPECTED_LATENCIES_MS),
+            "throughput_ops_per_second": 16.0,
+            "presents": copy.deepcopy(EXPECTED_PRESENTS),
+            "failures": copy.deepcopy(EXPECTED_FAILURES),
+        }
+
+    def snapshot(self) -> dict[str, str]:
+        self.events.append("snapshot")
+        return {"snapshot_id": "owned-mixed-realistic-snapshot"}
+
+    def restore(self, snapshot: dict[str, str]) -> None:
+        self.events.append(("restore", copy.deepcopy(snapshot)))
+
+    def stop(self) -> None:
+        self.events.append("stop")
+        self.stopped = True
+
+    def cleanup_owned(self) -> dict[str, Any]:
+        self.events.append("cleanup_owned")
+        self.cleaned = True
+        return {
+            "stopped": self.stopped,
+            "owned_state_removed": True,
+            "owned_paths": [str(self.owned_root)],
+        }
+
+
+def _run(adapter: FakeRuntimeAdapter, owned_root: Path) -> Any:
+    return perf_runtime.run_invocation(
+        scenario_id=SCENARIO_ID,
+        sha=SHA,
+        order="BA",
+        repetition=2,
+        requested_shape=copy.deepcopy(REQUESTED_SHAPE),
+        owned_root=owned_root,
+        adapter=adapter,
+    )
+
+
+def test_browser_fixture_plan_is_local_owned_stable_and_exact(tmp_path: Path) -> None:
+    owned_root = tmp_path / "owned-fixtures"
+    kwargs = {
+        "scenario_id": SCENARIO_ID,
+        "terminal_count": 2,
+        "browser_count": 2,
+        "owned_root": owned_root,
+    }
+
+    first = perf_runtime.build_browser_fixture_plan(**kwargs)
+    second = perf_runtime.build_browser_fixture_plan(**kwargs)
+
+    assert _field(first, "scenario_id") == SCENARIO_ID
+    assert _field(first, "terminal_count") == 2
+    assert _field(first, "browser_count") == 2
+    assert _observed_browsers(first) == _observed_browsers(second)
+
+    surfaces = _browser_surfaces(first)
+    assert len(surfaces) == 2
+    assert [_field(surface, "surface_id") for surface in surfaces] == [
+        "browser-mixed-realistic-001",
+        "browser-mixed-realistic-002",
+    ]
+
+    for index, surface in enumerate(surfaces, start=1):
+        expected_marker = (
+            f"cmux-perf:scenario={SCENARIO_ID};surface=browser-{index:03d}"
+        )
+        expected_title = f"cmux perf {SCENARIO_ID} browser {index:03d}"
+        assert _field(surface, "content_marker") == expected_marker
+        assert _field(surface, "title") == expected_title
+
+        parsed = urlparse(_field(surface, "url"))
+        assert parsed.scheme == "file"
+        assert parsed.netloc == ""
+        assert parsed.query == ""
+        assert parsed.fragment == ""
+        fixture_path = Path(unquote(parsed.path)).resolve()
+        assert fixture_path.is_relative_to(owned_root.resolve())
+        assert fixture_path.is_file()
+        html = fixture_path.read_text(encoding="utf-8")
+        assert f"<title>{expected_title}</title>" in html
+        assert expected_marker in html
+
+
+@pytest.mark.parametrize("field", ["surface_id", "url", "title", "content_marker"])
+def test_browser_observations_must_match_every_planned_identity_field(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    plan = perf_runtime.build_browser_fixture_plan(
+        scenario_id=SCENARIO_ID,
+        terminal_count=2,
+        browser_count=2,
+        owned_root=tmp_path / "owned-fixtures",
+    )
+    observations = _observed_browsers(plan)
+
+    assert perf_runtime.validate_browser_observations(plan, observations) is None
+
+    mismatched = copy.deepcopy(observations)
+    mismatched[0][field] = f"wrong-{field}"
+    with pytest.raises(ValueError):
+        perf_runtime.validate_browser_observations(plan, mismatched)
+
+
+def test_one_invocation_orders_lifecycle_and_retains_raw_observations(
+    tmp_path: Path,
+) -> None:
+    owned_root = tmp_path / "owned-run"
+    adapter = FakeRuntimeAdapter(owned_root)
+
+    result = _run(adapter, owned_root)
+
+    expected_snapshot = {"snapshot_id": "owned-mixed-realistic-snapshot"}
+    assert adapter.events == [
+        "clean_state",
+        ("launch", SHA),
+        "create_fixture",
+        "observe_fixture",
+        "sample_steady",
+        ("run_churn", _expected_churn_operations()),
+        "snapshot",
+        ("restore", expected_snapshot),
+        "observe_fixture",
+        "stop",
+        "cleanup_owned",
+    ]
+    assert adapter.observation_count == 2
+
+    assert _field(result, "scenario_id") == SCENARIO_ID
+    assert _field(result, "sha") == SHA
+    assert _field(result, "order") == "BA"
+    assert _field(result, "repetition") == 2
+    assert _field(result, "requested_shape") == REQUESTED_SHAPE
+    assert _field(result, "observed_shape") == REQUESTED_SHAPE
+
+    steady_samples = _field(result, "steady_samples")
+    churn_samples = _field(result, "churn_samples")
+    assert steady_samples == EXPECTED_STEADY_SAMPLES
+    assert churn_samples == EXPECTED_CHURN_SAMPLES
+    for sample in [*steady_samples, *churn_samples]:
+        assert set(sample["process_attribution"]) == EXPECTED_PROCESS_GROUPS
+
+    assert _field(result, "latencies_ms") == EXPECTED_LATENCIES_MS
+    assert _field(result, "throughput_ops_per_second") == 16.0
+    assert _field(result, "presents") == EXPECTED_PRESENTS
+    assert _field(result, "failures") == EXPECTED_FAILURES
+    assert _field(result, "cleanup") == {
+        "stopped": True,
+        "owned_state_removed": True,
+        "owned_paths": [str(owned_root)],
+    }
+
+
+@pytest.mark.parametrize("invalid_observation", [1, 2])
+def test_fixture_validation_failure_still_stops_and_cleans_owned_state(
+    tmp_path: Path,
+    invalid_observation: int,
+) -> None:
+    owned_root = tmp_path / "owned-failing-run"
+    adapter = FakeRuntimeAdapter(
+        owned_root,
+        invalid_observation=invalid_observation,
+    )
+
+    with pytest.raises(ValueError):
+        _run(adapter, owned_root)
+
+    expected_events: list[Any] = [
+        "clean_state",
+        ("launch", SHA),
+        "create_fixture",
+        "observe_fixture",
+    ]
+    if invalid_observation == 2:
+        expected_events.extend(
+            [
+                "sample_steady",
+                ("run_churn", _expected_churn_operations()),
+                "snapshot",
+                ("restore", {"snapshot_id": "owned-mixed-realistic-snapshot"}),
+                "observe_fixture",
+            ]
+        )
+    expected_events.extend(["stop", "cleanup_owned"])
+
+    assert adapter.events == expected_events
+    assert adapter.stopped is True
+    assert adapter.cleaned is True

--- a/tests/test_perf_mixed_workload_runtime.py
+++ b/tests/test_perf_mixed_workload_runtime.py
@@ -209,6 +209,37 @@ def _run(adapter: FakeRuntimeAdapter, owned_root: Path) -> Any:
     )
 
 
+class CleanupFailingRuntimeAdapter(FakeRuntimeAdapter):
+    def __init__(
+        self,
+        owned_root: Path,
+        *,
+        body_error: BaseException | None = None,
+        stop_error: BaseException | None = None,
+        cleanup_error: BaseException | None = None,
+    ) -> None:
+        super().__init__(owned_root)
+        self.body_error = body_error
+        self.stop_error = stop_error
+        self.cleanup_error = cleanup_error
+
+    def clean_state(self) -> None:
+        super().clean_state()
+        if self.body_error is not None:
+            raise self.body_error
+
+    def stop(self) -> None:
+        super().stop()
+        if self.stop_error is not None:
+            raise self.stop_error
+
+    def cleanup_owned(self) -> dict[str, Any]:
+        result = super().cleanup_owned()
+        if self.cleanup_error is not None:
+            raise self.cleanup_error
+        return result
+
+
 def test_browser_fixture_plan_is_local_owned_stable_and_exact(tmp_path: Path) -> None:
     owned_root = tmp_path / "owned-fixtures"
     kwargs = {
@@ -359,3 +390,101 @@ def test_fixture_validation_failure_still_stops_and_cleans_owned_state(
     assert adapter.events == expected_events
     assert adapter.stopped is True
     assert adapter.cleaned is True
+
+
+def test_primary_failure_retains_every_cleanup_failure_as_traceback_notes(
+    tmp_path: Path,
+) -> None:
+    owned_root = tmp_path / "owned-primary-cleanup-failure"
+    primary_error = ValueError("primary body failure")
+    adapter = CleanupFailingRuntimeAdapter(
+        owned_root,
+        body_error=primary_error,
+        stop_error=RuntimeError("stop failure"),
+        cleanup_error=LookupError("owned cleanup failure"),
+    )
+
+    with pytest.raises(ValueError, match="primary body failure") as captured:
+        _run(adapter, owned_root)
+
+    assert captured.value is primary_error
+    notes = "\n".join(captured.value.__notes__)
+    assert adapter.events == ["clean_state", "stop", "cleanup_owned"]
+    assert "adapter.stop()" in notes
+    assert "stop failure" in notes
+    assert "adapter.cleanup_owned()" in notes
+    assert "owned cleanup failure" in notes
+    assert notes.count("Traceback (most recent call last)") == 2
+    assert [
+        {key: failure[key] for key in ("phase", "type", "message")}
+        for failure in captured.value.cleanup_failures
+    ] == [
+        {
+            "phase": "adapter.stop()",
+            "type": "RuntimeError",
+            "message": "stop failure",
+        },
+        {
+            "phase": "adapter.cleanup_owned()",
+            "type": "LookupError",
+            "message": "owned cleanup failure",
+        },
+    ]
+    assert all(
+        "Traceback (most recent call last)" in failure["traceback"]
+        for failure in captured.value.cleanup_failures
+    )
+
+
+def test_stop_and_owned_cleanup_failures_are_both_raised(tmp_path: Path) -> None:
+    owned_root = tmp_path / "owned-double-cleanup-failure"
+    adapter = CleanupFailingRuntimeAdapter(
+        owned_root,
+        stop_error=RuntimeError("stop failure"),
+        cleanup_error=LookupError("owned cleanup failure"),
+    )
+
+    with pytest.raises(ExceptionGroup) as captured:
+        _run(adapter, owned_root)
+
+    assert adapter.events[-2:] == ["stop", "cleanup_owned"]
+    assert [str(error) for error in captured.value.exceptions] == [
+        "stop failure",
+        "owned cleanup failure",
+    ]
+    assert captured.value.exceptions[0].__notes__ == [
+        "Invocation cleanup phase: adapter.stop()"
+    ]
+    assert captured.value.exceptions[1].__notes__ == [
+        "Invocation cleanup phase: adapter.cleanup_owned()"
+    ]
+    assert [failure["phase"] for failure in captured.value.cleanup_failures] == [
+        "adapter.stop()",
+        "adapter.cleanup_owned()",
+    ]
+    assert [failure["message"] for failure in captured.value.cleanup_failures] == [
+        "stop failure",
+        "owned cleanup failure",
+    ]
+    assert all(
+        "Traceback (most recent call last)" in failure["traceback"]
+        for failure in captured.value.cleanup_failures
+    )
+
+
+def test_owned_cleanup_only_failure_remains_directly_recognizable(
+    tmp_path: Path,
+) -> None:
+    owned_root = tmp_path / "owned-cleanup-only-failure"
+    adapter = CleanupFailingRuntimeAdapter(
+        owned_root,
+        cleanup_error=LookupError("owned cleanup failure"),
+    )
+
+    with pytest.raises(LookupError, match="owned cleanup failure") as captured:
+        _run(adapter, owned_root)
+
+    assert adapter.events[-2:] == ["stop", "cleanup_owned"]
+    assert captured.value.__notes__ == [
+        "Invocation cleanup phase: adapter.cleanup_owned()"
+    ]

--- a/tests/test_perf_mixed_workload_runtime.py
+++ b/tests/test_perf_mixed_workload_runtime.py
@@ -69,9 +69,9 @@ EXPECTED_CHURN_SAMPLES = [
     }
 ]
 EXPECTED_LATENCIES_MS = [3.0, 5.0, 7.0, 11.0]
-EXPECTED_PRESENTS = [
-    {"surface_id": "terminal-001", "count": 6},
-    {"surface_id": "browser-mixed-realistic-001", "count": 9},
+EXPECTED_RENDER_OBSERVATIONS = [
+    {"surface_id": "terminal-001", "render_delta": 6},
+    {"surface_id": "browser-mixed-realistic-001", "render_delta": 1},
 ]
 EXPECTED_FAILURES = [
     {
@@ -172,7 +172,7 @@ class FakeRuntimeAdapter:
             "samples": copy.deepcopy(EXPECTED_CHURN_SAMPLES),
             "latencies_ms": list(EXPECTED_LATENCIES_MS),
             "throughput_ops_per_second": 16.0,
-            "presents": copy.deepcopy(EXPECTED_PRESENTS),
+            "render_observations": copy.deepcopy(EXPECTED_RENDER_OBSERVATIONS),
             "failures": copy.deepcopy(EXPECTED_FAILURES),
         }
 
@@ -315,7 +315,7 @@ def test_one_invocation_orders_lifecycle_and_retains_raw_observations(
 
     assert _field(result, "latencies_ms") == EXPECTED_LATENCIES_MS
     assert _field(result, "throughput_ops_per_second") == 16.0
-    assert _field(result, "presents") == EXPECTED_PRESENTS
+    assert _field(result, "render_observations") == EXPECTED_RENDER_OBSERVATIONS
     assert _field(result, "failures") == EXPECTED_FAILURES
     assert _field(result, "cleanup") == {
         "stopped": True,

--- a/tests/test_perf_mixed_workload_statistics.py
+++ b/tests/test_perf_mixed_workload_statistics.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for mixed-workload benchmark statistics and gates."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "perf_mixed_workload_statistics.py"
+spec = importlib.util.spec_from_file_location("perf_mixed_workload_statistics", SCRIPT)
+assert spec is not None and spec.loader is not None
+perf_statistics = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = perf_statistics
+spec.loader.exec_module(perf_statistics)
+
+ABS_TOL = 1e-12
+REL_TOL = 1e-12
+
+
+def _field(record: Any, name: str) -> Any:
+    if isinstance(record, dict):
+        return record[name]
+    return getattr(record, name)
+
+
+def _assert_close(actual: float, expected: float) -> None:
+    assert abs(actual - expected) <= max(ABS_TOL, REL_TOL * abs(expected))
+
+
+def _assert_float_list(actual: Any, expected: list[float]) -> None:
+    assert len(actual) == len(expected)
+    for actual_value, expected_value in zip(actual, expected, strict=True):
+        _assert_close(actual_value, expected_value)
+
+
+def test_sample_summary_reports_deterministic_median_iqr_mad_count_and_raw_values() -> None:
+    # Repeated quartile values make the expected IQR independent of percentile
+    # interpolation conventions. MAD is the unscaled median absolute deviation.
+    samples = [9.0, 1.0, 9.0, 1.0, 5.0, 9.0, 1.0, 9.0, 1.0]
+
+    summary = perf_statistics.summarize_samples(samples)
+
+    assert _field(summary, "sample_count") == 9
+    assert list(_field(summary, "raw_values")) == samples
+    _assert_close(_field(summary, "median"), 5.0)
+    _assert_close(_field(summary, "iqr"), 8.0)
+    _assert_close(_field(summary, "mad"), 4.0)
+
+
+def test_lower_is_better_comparison_reports_paired_deltas_and_oriented_effect() -> None:
+    comparison = perf_statistics.compare_paired_samples(
+        baseline_values=[10.0, 20.0, 30.0],
+        candidate_values=[5.0, 15.0, 25.0],
+        direction="lower_is_better",
+    )
+
+    # Deltas retain candidate-minus-baseline sign regardless of metric direction.
+    _assert_float_list(_field(comparison, "absolute_deltas"), [-5.0, -5.0, -5.0])
+    _assert_float_list(
+        _field(comparison, "relative_deltas"),
+        [-0.5, -0.25, -1.0 / 6.0],
+    )
+    # Common-language probability compares every candidate value with every
+    # baseline value, counting a tie as half a win. The effect is oriented so
+    # positive always means the candidate is better: wins minus losses over all
+    # cross-sample pairs (equivalently 2 * probability - 1).
+    _assert_close(_field(comparison, "probability_candidate_better"), 2.0 / 3.0)
+    _assert_close(_field(comparison, "oriented_effect_size"), 1.0 / 3.0)
+
+
+def test_higher_is_better_comparison_reports_paired_deltas_and_oriented_effect() -> None:
+    comparison = perf_statistics.compare_paired_samples(
+        baseline_values=[100.0, 200.0, 300.0],
+        candidate_values=[150.0, 250.0, 350.0],
+        direction="higher_is_better",
+    )
+
+    _assert_float_list(_field(comparison, "absolute_deltas"), [50.0, 50.0, 50.0])
+    _assert_float_list(
+        _field(comparison, "relative_deltas"),
+        [0.5, 0.25, 1.0 / 6.0],
+    )
+    _assert_close(_field(comparison, "probability_candidate_better"), 2.0 / 3.0)
+    _assert_close(_field(comparison, "oriented_effect_size"), 1.0 / 3.0)
+
+
+def test_aggregation_never_pools_scenario_ids_or_ab_ba_orders() -> None:
+    records = [
+        {
+            "scenario_id": "terminal-heavy",
+            "order": "AB",
+            "metric": "cpu_percent",
+            "direction": "lower_is_better",
+            "baseline_value": 10.0,
+            "candidate_value": 9.0,
+        },
+        {
+            "scenario_id": "terminal-heavy",
+            "order": "BA",
+            "metric": "cpu_percent",
+            "direction": "lower_is_better",
+            "baseline_value": 30.0,
+            "candidate_value": 27.0,
+        },
+        {
+            "scenario_id": "browser-heavy",
+            "order": "AB",
+            "metric": "cpu_percent",
+            "direction": "lower_is_better",
+            "baseline_value": 50.0,
+            "candidate_value": 45.0,
+        },
+        {
+            "scenario_id": "terminal-heavy",
+            "order": "AB",
+            "metric": "cpu_percent",
+            "direction": "lower_is_better",
+            "baseline_value": 12.0,
+            "candidate_value": 11.0,
+        },
+        {
+            "scenario_id": "terminal-heavy",
+            "order": "BA",
+            "metric": "cpu_percent",
+            "direction": "lower_is_better",
+            "baseline_value": 32.0,
+            "candidate_value": 28.0,
+        },
+        {
+            "scenario_id": "browser-heavy",
+            "order": "AB",
+            "metric": "cpu_percent",
+            "direction": "lower_is_better",
+            "baseline_value": 52.0,
+            "candidate_value": 46.0,
+        },
+    ]
+
+    groups = perf_statistics.aggregate_paired_samples(records)
+    keyed = {
+        (
+            _field(group, "scenario_id"),
+            _field(group, "order"),
+            _field(group, "metric"),
+        ): group
+        for group in groups
+    }
+
+    assert set(keyed) == {
+        ("terminal-heavy", "AB", "cpu_percent"),
+        ("terminal-heavy", "BA", "cpu_percent"),
+        ("browser-heavy", "AB", "cpu_percent"),
+    }
+    expected_raw_values = {
+        ("terminal-heavy", "AB", "cpu_percent"): ([10.0, 12.0], [9.0, 11.0]),
+        ("terminal-heavy", "BA", "cpu_percent"): ([30.0, 32.0], [27.0, 28.0]),
+        ("browser-heavy", "AB", "cpu_percent"): ([50.0, 52.0], [45.0, 46.0]),
+    }
+    for key, (expected_baseline, expected_candidate) in expected_raw_values.items():
+        group = keyed[key]
+        assert _field(group, "sample_count") == 2
+        assert list(_field(group, "baseline_values")) == expected_baseline
+        assert list(_field(group, "candidate_values")) == expected_candidate
+
+
+def _assert_gate(
+    metric: str,
+    baseline_value: float,
+    candidate_value: float,
+    *,
+    expected_threshold: float,
+    expected_regression: float,
+    expected_passed: bool,
+) -> None:
+    result = perf_statistics.evaluate_metric_gate(
+        metric=metric,
+        baseline_value=baseline_value,
+        candidate_value=candidate_value,
+    )
+
+    assert _field(result, "passed") is expected_passed
+    _assert_close(_field(result, "threshold"), expected_threshold)
+    _assert_close(_field(result, "relative_regression"), expected_regression)
+
+
+def test_cpu_gate_passes_at_five_percent_and_fails_above_it() -> None:
+    _assert_gate(
+        "cpu_percent",
+        100.0,
+        105.0,
+        expected_threshold=0.05,
+        expected_regression=0.05,
+        expected_passed=True,
+    )
+    _assert_gate(
+        "cpu_percent",
+        100.0,
+        105.0001,
+        expected_threshold=0.05,
+        expected_regression=0.050001,
+        expected_passed=False,
+    )
+
+
+def test_latency_gate_passes_at_ten_percent_and_fails_above_it() -> None:
+    _assert_gate(
+        "latency_ms",
+        100.0,
+        110.0,
+        expected_threshold=0.10,
+        expected_regression=0.10,
+        expected_passed=True,
+    )
+    _assert_gate(
+        "latency_ms",
+        100.0,
+        110.0001,
+        expected_threshold=0.10,
+        expected_regression=0.100001,
+        expected_passed=False,
+    )
+
+
+def test_throughput_gate_passes_at_five_percent_drop_and_fails_above_it() -> None:
+    _assert_gate(
+        "throughput_per_second",
+        100.0,
+        95.0,
+        expected_threshold=0.05,
+        expected_regression=0.05,
+        expected_passed=True,
+    )
+    _assert_gate(
+        "throughput_per_second",
+        100.0,
+        94.9999,
+        expected_threshold=0.05,
+        expected_regression=0.050001,
+        expected_passed=False,
+    )
+
+
+def test_final_acceptance_requires_browser_heavy_and_mixed_heavy_to_pass() -> None:
+    terminal_improves = {
+        "passed": True,
+        "relative_change": -0.50,
+    }
+    passing = {
+        "passed": True,
+        "relative_change": 0.0,
+    }
+    failing = {
+        "passed": False,
+        "relative_change": 0.11,
+    }
+
+    assert perf_statistics.evaluate_final_acceptance(
+        {
+            "terminal-heavy": terminal_improves,
+            "browser-heavy": failing,
+            "mixed-heavy": passing,
+        }
+    ) is False
+    assert perf_statistics.evaluate_final_acceptance(
+        {
+            "terminal-heavy": terminal_improves,
+            "browser-heavy": passing,
+            "mixed-heavy": failing,
+        }
+    ) is False
+    assert perf_statistics.evaluate_final_acceptance(
+        {
+            "terminal-heavy": terminal_improves,
+            "browser-heavy": passing,
+            "mixed-heavy": passing,
+        }
+    ) is True
+
+
+def test_final_acceptance_requires_terminal_heavy_to_pass() -> None:
+    passing = {"passed": True, "relative_change": 0.0}
+    failing = {"passed": False, "relative_change": 0.06}
+
+    assert perf_statistics.evaluate_final_acceptance(
+        {
+            "terminal-heavy": failing,
+            "browser-heavy": passing,
+            "mixed-heavy": passing,
+        }
+    ) is False
+    assert perf_statistics.evaluate_final_acceptance(
+        {
+            "browser-heavy": passing,
+            "mixed-heavy": passing,
+        }
+    ) is False

--- a/tests/test_perf_mixed_workload_statistics.py
+++ b/tests/test_perf_mixed_workload_statistics.py
@@ -88,6 +88,23 @@ def test_higher_is_better_comparison_reports_paired_deltas_and_oriented_effect()
     _assert_close(_field(comparison, "oriented_effect_size"), 1.0 / 3.0)
 
 
+def test_comparison_accepts_zero_baselines_with_finite_directional_deltas() -> None:
+    comparison = perf_statistics.compare_paired_samples(
+        baseline_values=[0.0, 0.0, 2.0],
+        candidate_values=[0.0, 3.0, 1.0],
+        direction="lower_is_better",
+    )
+
+    _assert_float_list(
+        _field(comparison, "relative_deltas"),
+        [0.0, 1.0, -0.5],
+    )
+    assert all(
+        perf_statistics.math.isfinite(value)
+        for value in _field(comparison, "relative_deltas")
+    )
+
+
 def test_aggregation_never_pools_scenario_ids_or_ab_ba_orders() -> None:
     records = [
         {
@@ -241,6 +258,33 @@ def test_throughput_gate_passes_at_five_percent_drop_and_fails_above_it() -> Non
         expected_threshold=0.05,
         expected_regression=0.050001,
         expected_passed=False,
+    )
+
+
+def test_zero_baseline_gate_is_neutral_at_zero_and_decisive_above_zero() -> None:
+    _assert_gate(
+        "cpu_percent",
+        0.0,
+        0.0,
+        expected_threshold=0.05,
+        expected_regression=0.0,
+        expected_passed=True,
+    )
+    _assert_gate(
+        "cpu_percent",
+        0.0,
+        1.0,
+        expected_threshold=0.05,
+        expected_regression=1.0,
+        expected_passed=False,
+    )
+    _assert_gate(
+        "throughput_per_second",
+        0.0,
+        1.0,
+        expected_threshold=0.05,
+        expected_regression=-1.0,
+        expected_passed=True,
     )
 
 

--- a/tests/test_perf_process_tree_accounting.py
+++ b/tests/test_perf_process_tree_accounting.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for deterministic process-tree CPU accounting."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "perf_process_tree.py"
+spec = importlib.util.spec_from_file_location("perf_process_tree", SCRIPT)
+assert spec is not None
+perf_process_tree = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = perf_process_tree
+spec.loader.exec_module(perf_process_tree)
+
+
+def _field(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value[name]
+    return getattr(value, name)
+
+
+def _records() -> list[Any]:
+    record = perf_process_tree.ProcessRecord
+    # Deliberately unordered: discovery must follow parent relationships rather
+    # than rely on parents appearing before children in the input.
+    return [
+        record(pid=112, parent_pid=111, command="python benchmark.py", cpu_percent=30.0),
+        record(pid=121, parent_pid=120, command="com.apple.WebKit.GPU", cpu_percent=50.0),
+        record(pid=100, parent_pid=1, command="/Applications/cmux.app/Contents/MacOS/cmux", cpu_percent=10.0),
+        record(pid=131, parent_pid=130, command="cmux helper worker", cpu_percent=70.0),
+        record(pid=111, parent_pid=110, command="zsh", cpu_percent=None),
+        record(pid=122, parent_pid=100, command="com.apple.WebKit.Networking", cpu_percent=None),
+        record(pid=999, parent_pid=1, command="unrelated process", cpu_percent=999.0),
+        record(pid=110, parent_pid=100, command="cmux terminal host", cpu_percent=20.0),
+        record(pid=125, parent_pid=112, command="com.apple.WebKit.WebContent", cpu_percent=5.0),
+        record(pid=130, parent_pid=100, command="cmux helper", cpu_percent=60.0),
+        record(pid=120, parent_pid=100, command="com.apple.WebKit.WebContent", cpu_percent=40.0),
+    ]
+
+
+def _report(records: list[Any] | None = None) -> Any:
+    return perf_process_tree.analyze_process_tree(
+        records if records is not None else _records(),
+        app_pid=100,
+        # 111 is already below 110. Supplying both proves overlapping roots do
+        # not cause the shell or its descendants to be counted twice.
+        terminal_root_pids={110, 111},
+        # 121 is below 120, while 125 is also in the terminal tree. Both kinds
+        # of overlap are intentional.
+        webkit_root_pids={120, 121, 122, 125},
+    )
+
+
+def _pids(subtotal: Any) -> list[int] | set[int] | tuple[int, ...]:
+    return _field(subtotal, "pids")
+
+
+def _assert_unique_pids(subtotal: Any, expected: set[int]) -> None:
+    pids = _pids(subtotal)
+    assert set(pids) == expected
+    assert len(pids) == len(set(pids))
+
+
+def test_descendants_are_discovered_transitively_and_once_across_overlapping_roots() -> None:
+    report = _report()
+
+    _assert_unique_pids(_field(report, "terminal"), {110, 111, 112, 125})
+    _assert_unique_pids(_field(report, "webkit"), {120, 121, 122, 125})
+    _assert_unique_pids(
+        _field(report, "full_tree"),
+        {100, 110, 111, 112, 120, 121, 122, 125, 130, 131},
+    )
+
+    # These are several generations below their respective roots.
+    assert 112 in _pids(_field(report, "terminal"))
+    assert 131 in _pids(_field(report, "full_tree"))
+    # A process may belong to two useful subtotals, but remains one member of
+    # the unique full tree.
+    assert 125 in _pids(_field(report, "terminal"))
+    assert 125 in _pids(_field(report, "webkit"))
+
+
+def test_webkit_process_roles_are_classified_from_command_text() -> None:
+    record = perf_process_tree.ProcessRecord
+
+    assert perf_process_tree.classify_webkit_role(
+        record(
+            pid=201,
+            parent_pid=100,
+            command=(
+                "/System/Library/Frameworks/WebKit.framework/XPCServices/"
+                "com.apple.WebKit.WebContent.xpc/Contents/MacOS/com.apple.WebKit.WebContent"
+            ),
+            cpu_percent=1.0,
+        )
+    ) == "content"
+    assert perf_process_tree.classify_webkit_role(
+        record(
+            pid=202,
+            parent_pid=100,
+            command="/System/Library/Frameworks/WebKit.framework/com.apple.WebKit.GPU",
+            cpu_percent=2.0,
+        )
+    ) == "gpu"
+    assert perf_process_tree.classify_webkit_role(
+        record(
+            pid=203,
+            parent_pid=100,
+            command="/System/Library/Frameworks/WebKit.framework/com.apple.WebKit.Networking",
+            cpu_percent=3.0,
+        )
+    ) == "network"
+
+
+def test_report_has_independent_parent_terminal_webkit_and_unique_tree_totals() -> None:
+    report = _report()
+    parent = _field(report, "parent_direct")
+    terminal = _field(report, "terminal")
+    webkit = _field(report, "webkit")
+    full_tree = _field(report, "full_tree")
+
+    _assert_unique_pids(parent, {100})
+    assert _field(parent, "cpu_percent") == 10.0
+    assert _field(terminal, "cpu_percent") == 55.0
+    assert _field(webkit, "cpu_percent") == 95.0
+    # Assert the unique-tree aggregate independently. Summing the category
+    # subtotals would double count PID 125 and the app is not a category root.
+    assert _field(full_tree, "cpu_percent") == 285.0
+
+
+def test_coverage_names_every_discovered_sampled_and_missing_pid() -> None:
+    coverage = _field(_report(), "coverage")
+    discovered = {100, 110, 111, 112, 120, 121, 122, 125, 130, 131}
+    sampled = {100, 110, 112, 120, 121, 125, 130, 131}
+    missing = {111, 122}
+
+    assert set(_field(coverage, "discovered_pids")) == discovered
+    assert set(_field(coverage, "sampled_pids")) == sampled
+    assert set(_field(coverage, "missing_pids")) == missing
+    assert _field(coverage, "discovered_count") == len(discovered)
+    assert _field(coverage, "sampled_count") == len(sampled)
+    assert _field(coverage, "missing_count") == len(missing)
+
+
+def test_missing_samples_do_not_fabricate_cpu_usage() -> None:
+    record = perf_process_tree.ProcessRecord
+    report = perf_process_tree.analyze_process_tree(
+        [
+            record(pid=300, parent_pid=1, command="cmux", cpu_percent=None),
+            record(pid=301, parent_pid=300, command="zsh", cpu_percent=None),
+        ],
+        app_pid=300,
+        terminal_root_pids={301},
+        webkit_root_pids=set(),
+    )
+
+    assert _field(_field(report, "parent_direct"), "cpu_percent") == 0.0
+    assert _field(_field(report, "terminal"), "cpu_percent") == 0.0
+    assert _field(_field(report, "full_tree"), "cpu_percent") == 0.0
+
+    coverage = _field(report, "coverage")
+    assert set(_field(coverage, "discovered_pids")) == {300, 301}
+    assert set(_field(coverage, "sampled_pids")) == set()
+    assert set(_field(coverage, "missing_pids")) == {300, 301}
+    assert _field(coverage, "discovered_count") == 2
+    assert _field(coverage, "sampled_count") == 0
+    assert _field(coverage, "missing_count") == 2
+
+
+def test_report_sums_unique_memory_in_every_independent_subtotal() -> None:
+    record = perf_process_tree.ProcessRecord
+    report = perf_process_tree.analyze_process_tree(
+        [
+            record(
+                pid=600,
+                parent_pid=1,
+                command="cmux",
+                cpu_percent=1.0,
+                resident_bytes=100,
+                physical_footprint_bytes=1_000,
+            ),
+            record(
+                pid=610,
+                parent_pid=600,
+                command="cmux terminal host",
+                cpu_percent=2.0,
+                resident_bytes=200,
+                physical_footprint_bytes=2_000,
+            ),
+            record(
+                pid=611,
+                parent_pid=610,
+                command="com.apple.WebKit.WebContent",
+                cpu_percent=3.0,
+                resident_bytes=300,
+                physical_footprint_bytes=3_000,
+            ),
+            record(
+                pid=612,
+                parent_pid=611,
+                command="com.apple.WebKit.GPU",
+                cpu_percent=4.0,
+                resident_bytes=400,
+                physical_footprint_bytes=4_000,
+            ),
+            record(
+                pid=620,
+                parent_pid=600,
+                command="cmux helper outside named groups",
+                cpu_percent=5.0,
+                resident_bytes=500,
+                physical_footprint_bytes=5_000,
+            ),
+        ],
+        app_pid=600,
+        terminal_root_pids={610},
+        webkit_root_pids={611},
+    )
+
+    parent = _field(report, "parent_direct")
+    terminal = _field(report, "terminal")
+    webkit = _field(report, "webkit")
+    full_tree = _field(report, "full_tree")
+
+    _assert_unique_pids(parent, {600})
+    assert _field(parent, "resident_bytes") == 100
+    assert _field(parent, "physical_footprint_bytes") == 1_000
+
+    _assert_unique_pids(terminal, {610, 611, 612})
+    assert _field(terminal, "resident_bytes") == 900
+    assert _field(terminal, "physical_footprint_bytes") == 9_000
+
+    _assert_unique_pids(webkit, {611, 612})
+    assert _field(webkit, "resident_bytes") == 700
+    assert _field(webkit, "physical_footprint_bytes") == 7_000
+
+    _assert_unique_pids(full_tree, {600, 610, 611, 612, 620})
+    assert _field(full_tree, "resident_bytes") == 1_500
+    assert _field(full_tree, "physical_footprint_bytes") == 15_000

--- a/tests/test_perf_top_payload_accounting.py
+++ b/tests/test_perf_top_payload_accounting.py
@@ -392,3 +392,30 @@ def test_parser_reports_independent_resources_and_authoritative_full_totals() ->
     assert _field(coverage, "discovered_count") == len(discovered)
     assert _field(coverage, "sampled_count") == len(sampled)
     assert _field(coverage, "missing_count") == 1
+
+
+def test_parser_reports_disappeared_webkit_roots_as_missing_instead_of_aborting() -> None:
+    payload = _payload()
+
+    def remove_content_tree(process: dict[str, Any]) -> None:
+        process["children"] = [
+            child for child in process["children"] if child["pid"] != 300
+        ]
+        for child in process["children"]:
+            remove_content_tree(child)
+
+    remove_content_tree(payload["windows"][0]["processes"][0])
+    surface = payload["windows"][0]["workspaces"][0]["panes"][0]["surfaces"][0]
+    remove_content_tree(surface["processes"][0])
+    surface["webviews"][0]["processes"] = []
+    payload["totals"]["process_count"] = len(FULL_PIDS) - 2
+    payload["totals"]["missing_pids"] = []
+
+    accounting = perf_top_payload.parse_system_top_payload(payload)
+
+    assert set(accounting.webkit_root_pids) == {300, 400, 500}
+    assert accounting.webkit_role_pids["content"] == ()
+    assert set(accounting.full_tree.pids) == set(FULL_PIDS) - {300, 301}
+    assert set(accounting.coverage.discovered_pids) == set(FULL_PIDS)
+    assert set(accounting.coverage.sampled_pids) == set(FULL_PIDS) - {300, 301}
+    assert set(accounting.coverage.missing_pids) == {300, 301}

--- a/tests/test_perf_top_payload_accounting.py
+++ b/tests/test_perf_top_payload_accounting.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Behavioral contracts for accounting directly from ``system.top`` payloads."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "perf_top_payload.py"
+spec = importlib.util.spec_from_file_location("perf_top_payload", SCRIPT)
+assert spec is not None
+perf_top_payload = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = perf_top_payload
+spec.loader.exec_module(perf_top_payload)
+
+
+FULL_PIDS = (100, 200, 201, 300, 301, 400, 401, 500, 501)
+TERMINAL_PIDS = (200, 201, 300, 301, 400, 401, 500, 501)
+WEBKIT_PIDS = (300, 301, 400, 401, 500, 501)
+MISSING_PID = 999
+
+
+def _field(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value[name]
+    return getattr(value, name)
+
+
+def _summary(
+    pids: tuple[int, ...],
+    *,
+    cpu_percent: float,
+    resident_bytes: int,
+    physical_footprint_bytes: int,
+    missing_pids: tuple[int, ...] = (),
+) -> dict[str, Any]:
+    return {
+        "cpu_percent": cpu_percent,
+        # ``system.top`` calls physical footprint ``memory_bytes``.
+        "memory_bytes": physical_footprint_bytes,
+        "resident_bytes": resident_bytes,
+        "process_count": len(pids),
+        "pids": list(pids),
+        "missing_pids": list(missing_pids),
+    }
+
+
+def _process(
+    pid: int,
+    ppid: int,
+    name: str,
+    path: str,
+    *,
+    cpu_percent: float,
+    resident_bytes: int,
+    physical_footprint_bytes: int,
+    children: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "pid": pid,
+        "ppid": ppid,
+        "name": name,
+        "path": path,
+        "resources": _summary(
+            (pid,),
+            cpu_percent=cpu_percent,
+            resident_bytes=resident_bytes,
+            physical_footprint_bytes=physical_footprint_bytes,
+        ),
+        "children": children or [],
+    }
+
+
+def _webkit_content_tree() -> dict[str, Any]:
+    return _process(
+        300,
+        201,
+        "com.apple.WebKit.WebContent",
+        "/System/Library/Frameworks/WebKit.framework/com.apple.WebKit.WebContent",
+        cpu_percent=3.0,
+        resident_bytes=3_000,
+        physical_footprint_bytes=30_000,
+        children=[
+            _process(
+                301,
+                300,
+                "WebContent worker",
+                "/System/Library/Frameworks/WebKit.framework/WebContentProcess",
+                cpu_percent=3.1,
+                resident_bytes=3_100,
+                physical_footprint_bytes=31_000,
+            )
+        ],
+    )
+
+
+def _webkit_gpu_tree() -> dict[str, Any]:
+    return _process(
+        400,
+        201,
+        "com.apple.WebKit.GPU",
+        "/System/Library/Frameworks/WebKit.framework/com.apple.WebKit.GPU",
+        cpu_percent=4.0,
+        resident_bytes=4_000,
+        physical_footprint_bytes=40_000,
+        children=[
+            _process(
+                401,
+                400,
+                "GPUProcess worker",
+                "/System/Library/Frameworks/WebKit.framework/GPUProcess",
+                cpu_percent=4.1,
+                resident_bytes=4_100,
+                physical_footprint_bytes=41_000,
+            )
+        ],
+    )
+
+
+def _webkit_network_tree() -> dict[str, Any]:
+    return _process(
+        500,
+        201,
+        "com.apple.WebKit.Networking",
+        "/System/Library/Frameworks/WebKit.framework/com.apple.WebKit.Networking",
+        cpu_percent=5.0,
+        resident_bytes=5_000,
+        physical_footprint_bytes=50_000,
+        children=[
+            _process(
+                501,
+                500,
+                "NetworkProcess worker",
+                "/System/Library/Frameworks/WebKit.framework/NetworkProcess",
+                cpu_percent=5.1,
+                resident_bytes=5_100,
+                physical_footprint_bytes=51_000,
+            )
+        ],
+    )
+
+
+def _terminal_tree() -> dict[str, Any]:
+    return _process(
+        200,
+        100,
+        "cmux terminal host",
+        "/Applications/cmux.app/Contents/MacOS/cmux",
+        cpu_percent=2.0,
+        resident_bytes=2_000,
+        physical_footprint_bytes=20_000,
+        children=[
+            _process(
+                201,
+                200,
+                "zsh",
+                "/bin/zsh",
+                cpu_percent=2.1,
+                resident_bytes=2_100,
+                physical_footprint_bytes=21_000,
+                children=[
+                    _webkit_content_tree(),
+                    _webkit_gpu_tree(),
+                    _webkit_network_tree(),
+                ],
+            )
+        ],
+    )
+
+
+def _app_tree() -> dict[str, Any]:
+    return _process(
+        100,
+        1,
+        "cmux",
+        "/Applications/cmux.app/Contents/MacOS/cmux",
+        cpu_percent=1.0,
+        resident_bytes=1_000,
+        physical_footprint_bytes=10_000,
+        children=[_terminal_tree()],
+    )
+
+
+def _payload() -> dict[str, Any]:
+    """Return one realistic payload with intentional process-tree repetition."""
+
+    terminal_summary = _summary(
+        TERMINAL_PIDS,
+        cpu_percent=28.4,
+        resident_bytes=28_400,
+        physical_footprint_bytes=284_000,
+    )
+    content_summary = _summary(
+        (300, 301),
+        cpu_percent=6.1,
+        resident_bytes=6_100,
+        physical_footprint_bytes=61_000,
+    )
+    gpu_summary = _summary(
+        (400, 401),
+        cpu_percent=8.1,
+        resident_bytes=8_100,
+        physical_footprint_bytes=81_000,
+    )
+    network_summary = _summary(
+        (500, 501),
+        cpu_percent=10.1,
+        resident_bytes=10_100,
+        physical_footprint_bytes=101_000,
+    )
+    totals = _summary(
+        FULL_PIDS,
+        cpu_percent=29.4,
+        resident_bytes=29_400,
+        physical_footprint_bytes=294_000,
+        missing_pids=(MISSING_PID,),
+    )
+
+    surface = {
+        "root_pids": [200, 300, 400, 500],
+        "resources": deepcopy(terminal_summary),
+        "processes": [_terminal_tree()],
+        "webviews": [
+            {
+                "pid": 300,
+                "root_pids": [300],
+                "resources": content_summary,
+                "processes": [_webkit_content_tree()],
+            },
+            {
+                "pid": 400,
+                "root_pids": [400],
+                "resources": gpu_summary,
+                "processes": [_webkit_gpu_tree()],
+            },
+            {
+                "pid": 500,
+                "root_pids": [500],
+                "resources": network_summary,
+                "processes": [_webkit_network_tree()],
+            },
+        ],
+    }
+    pane = {
+        "resources": deepcopy(terminal_summary),
+        "surfaces": [surface],
+    }
+    workspace = {
+        "resources": deepcopy(terminal_summary),
+        "panes": [pane],
+    }
+    window = {
+        "app_process_pids": [100],
+        "resources": deepcopy(totals),
+        "processes": [_app_tree()],
+        "workspaces": [workspace],
+    }
+    return {"windows": [window], "totals": totals}
+
+
+def _pid_set(value: Any) -> set[int]:
+    return set(_field(value, "pids"))
+
+
+def _assert_resources(
+    subtotal: Any,
+    *,
+    pids: set[int],
+    cpu_percent: float,
+    resident_bytes: int,
+    physical_footprint_bytes: int,
+) -> None:
+    subtotal_pids = _field(subtotal, "pids")
+    assert set(subtotal_pids) == pids
+    assert len(subtotal_pids) == len(set(subtotal_pids))
+    assert _field(subtotal, "cpu_percent") == pytest.approx(cpu_percent)
+    assert _field(subtotal, "resident_bytes") == resident_bytes
+    assert _field(subtotal, "physical_footprint_bytes") == physical_footprint_bytes
+
+
+def test_parser_deduplicates_process_trees_and_derives_roots_and_webkit_roles() -> None:
+    accounting = perf_top_payload.parse_system_top_payload(_payload())
+
+    assert _field(accounting, "app_pid") == 100
+    assert set(_field(accounting, "terminal_root_pids")) == {200}
+    assert set(_field(accounting, "webkit_root_pids")) == {300, 400, 500}
+
+    roles = _field(accounting, "webkit_role_pids")
+    assert set(roles["content"]) == {300, 301}
+    assert set(roles["gpu"]) == {400, 401}
+    assert set(roles["network"]) == {500, 501}
+
+    # Every terminal/WebKit process occurs in multiple nested ``processes``
+    # arrays. Exact unique sums prove identical records were deduplicated.
+    _assert_resources(
+        _field(accounting, "terminal"),
+        pids=set(TERMINAL_PIDS),
+        cpu_percent=28.4,
+        resident_bytes=28_400,
+        physical_footprint_bytes=284_000,
+    )
+    _assert_resources(
+        _field(accounting, "webkit"),
+        pids=set(WEBKIT_PIDS),
+        cpu_percent=24.3,
+        resident_bytes=24_300,
+        physical_footprint_bytes=243_000,
+    )
+
+
+def test_parser_rejects_conflicting_records_for_a_repeated_pid() -> None:
+    payload = _payload()
+    repeated_terminal = payload["windows"][0]["workspaces"][0]["panes"][0][
+        "surfaces"
+    ][0]["processes"][0]
+    repeated_terminal["resources"]["resident_bytes"] = 999_999
+
+    with pytest.raises(ValueError, match=r"conflicting records for PID 200"):
+        perf_top_payload.parse_system_top_payload(payload)
+
+
+def test_parser_reports_independent_resources_and_authoritative_full_totals() -> None:
+    payload = _payload()
+    accounting = perf_top_payload.parse_system_top_payload(payload)
+
+    parent = _field(accounting, "parent_direct")
+    terminal = _field(accounting, "terminal")
+    webkit = _field(accounting, "webkit")
+    full_tree = _field(accounting, "full_tree")
+
+    _assert_resources(
+        parent,
+        pids={100},
+        cpu_percent=1.0,
+        resident_bytes=1_000,
+        physical_footprint_bytes=10_000,
+    )
+    _assert_resources(
+        terminal,
+        pids=set(TERMINAL_PIDS),
+        cpu_percent=28.4,
+        resident_bytes=28_400,
+        physical_footprint_bytes=284_000,
+    )
+    _assert_resources(
+        webkit,
+        pids=set(WEBKIT_PIDS),
+        cpu_percent=24.3,
+        resident_bytes=24_300,
+        physical_footprint_bytes=243_000,
+    )
+    _assert_resources(
+        full_tree,
+        pids=set(FULL_PIDS),
+        cpu_percent=payload["totals"]["cpu_percent"],
+        resident_bytes=payload["totals"]["resident_bytes"],
+        physical_footprint_bytes=payload["totals"]["memory_bytes"],
+    )
+
+    # Terminal contains the WebKit roots in this payload. Adding independently
+    # useful subtotals would count those PIDs twice; top-level totals are the
+    # sole authoritative full-tree aggregate.
+    assert _field(full_tree, "cpu_percent") != pytest.approx(
+        sum(_field(group, "cpu_percent") for group in (parent, terminal, webkit))
+    )
+    assert _field(full_tree, "resident_bytes") != sum(
+        _field(group, "resident_bytes") for group in (parent, terminal, webkit)
+    )
+    assert _field(full_tree, "physical_footprint_bytes") != sum(
+        _field(group, "physical_footprint_bytes")
+        for group in (parent, terminal, webkit)
+    )
+
+    full_pids = _field(full_tree, "pids")
+    assert list(full_pids) == list(FULL_PIDS)
+    assert len(full_pids) == len(set(full_pids))
+
+    coverage = _field(accounting, "coverage")
+    discovered = set(FULL_PIDS) | {MISSING_PID}
+    sampled = set(FULL_PIDS)
+    assert set(_field(coverage, "discovered_pids")) == discovered
+    assert set(_field(coverage, "sampled_pids")) == sampled
+    assert set(_field(coverage, "missing_pids")) == {MISSING_PID}
+    assert _field(coverage, "discovered_count") == len(discovered)
+    assert _field(coverage, "sampled_count") == len(sampled)
+    assert _field(coverage, "missing_count") == 1


### PR DESCRIPTION
## Summary
- add a deterministic nine-scenario terminal/browser/mixed workload matrix with both AB and BA execution orders
- measure direct-parent and unique full-process-tree CPU, terminal render/throughput counters, browser latency, and per-role sample profiles
- require complete raw evidence, fixture cleanup/restoration, process-attribution invariants, and predeclared scenario gates before accepting a candidate
- run only in `usr-bin-roygbiv/cmux` with exact 40-hex baseline/candidate commits and read-only workflow permissions

This PR is benchmark infrastructure only. The PromptLine candidate exercised during validation regressed the predeclared gates and is intentionally excluded from this branch.

## Validation
- `python3 -m pytest -q tests/test_perf_activation_scrollback_sizing.py tests/test_perf_cmux_adapter.py tests/test_perf_mixed_workload_contract.py tests/test_perf_mixed_workload_driver.py tests/test_perf_mixed_workload_runtime.py tests/test_perf_mixed_workload_statistics.py tests/test_perf_process_tree_accounting.py tests/test_perf_top_payload_accounting.py` — 105 passed
- [complete validation run 30036003776](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30036003776): 144 successful invocations (108 measured, 36 warmups), all nine scenarios in AB and BA order, 1,712 process-accounting samples, 172 nonempty profiles, no cleanup or attribution failures
- The validation run finished with `final_acceptance=false` because all nine scenarios rejected the measured candidate. That failure is the expected acceptance behavior, not an incomplete experiment.
- Regression proof: commit `8bd4fe5a1a` adds the runner-cleanup failure test; commit `2b57a7fc68` guarantees adapter-owned paths are still removed before propagating that failure.
- Review follow-up `1982d917ea` makes acceptance fail closed, keeps metric gate evaluation on one configuration path, preserves structured cleanup evidence, and guarantees profiler shutdown before process-control exceptions propagate.

## Evidence and privacy
The uploaded evidence contains synthetic workload plans/results, host controls, process metrics, profiles, and generated browser screenshots from the benchmark fixture. It does not read or archive developer browser history, local user sessions, or repository secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deterministic mixed terminal-and-browser performance workflow for comparing two exact builds (baseline vs candidate), including automated snapshot validation and profiling support.
  * Introduced an adapter-driven benchmarking runtime with strict planning/observation checks, paired AB/BA experiment execution, evidence collection, and statistically gated acceptance.
* **Bug Fixes**
  * Strengthened persisted snapshot fingerprint verification and improved safety/robustness of owned-state cleanup and failure handling.
* **Tests**
  * Added end-to-end, contract, and statistics test coverage for benchmarking execution, runtime behavior, snapshots, process accounting, profiling, and cleanup/failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
