### PR TITLE
Fix iOS task route picker colors

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerMachineMenu.swift
@@ -16,43 +16,34 @@ struct TaskComposerMachineMenu: View, Equatable {
     }
 
     var body: some View {
-        Menu {
-            ForEach(value.machines) { mac in
-                Button {
-                    actions.selectMachine(mac.macDeviceID)
-                } label: {
-                    Label(mac.resolvedName, systemImage: "desktopcomputer")
+        ZStack {
+            TaskComposerRouteLabel(
+                icon: selectedMachine.map(routeIconContent(for:)) ?? .symbol("desktopcomputer"),
+                title: L10n.string("mobile.taskComposer.machine", defaultValue: "Machine"),
+                value: selectedMachine?.resolvedName ?? value.selectedMacDeviceID,
+                valueFont: .caption.weight(.semibold),
+                valueTruncationMode: .tail,
+                chevronSystemName: "chevron.up.chevron.down"
+            )
+            .accessibilityHidden(true)
+
+            Menu {
+                ForEach(value.machines) { mac in
+                    Button {
+                        actions.selectMachine(mac.macDeviceID)
+                    } label: {
+                        Label(mac.resolvedName, systemImage: "desktopcomputer")
+                    }
+                    .accessibilityAddTraits(mac.macDeviceID == value.selectedMacDeviceID ? .isSelected : [])
                 }
-                .accessibilityAddTraits(mac.macDeviceID == value.selectedMacDeviceID ? .isSelected : [])
+            } label: {
+                Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
             }
-        } label: {
-            HStack(spacing: 8) {
-                if let selectedMachine {
-                    machineIcon(selectedMachine)
-                } else {
-                    contextSymbol("desktopcomputer", tint: .accentColor)
-                }
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(L10n.string("mobile.taskComposer.machine", defaultValue: "Machine"))
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.75)
-                    Text(selectedMachine?.resolvedName ?? value.selectedMacDeviceID)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
-                }
-                Spacer(minLength: 0)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(.tertiary)
-                    .accessibilityHidden(true)
-            }
-            .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
         }
+        .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
         .disabled(value.isDisabled)
         .accessibilityLabel(L10n.string("mobile.taskComposer.machine", defaultValue: "Machine"))
         .accessibilityValue(selectedMachine?.resolvedName ?? value.selectedMacDeviceID)
@@ -60,31 +51,13 @@ struct TaskComposerMachineMenu: View, Equatable {
         .accessibilityIdentifier("MobileTaskComposerMachineMenu")
     }
 
-    private func contextSymbol(_ name: String, tint: Color) -> some View {
-        Image(systemName: name)
-            .font(.system(size: 13, weight: .semibold))
-            .foregroundStyle(tint)
-            .frame(width: 28, height: 28)
-            .background(tint.opacity(0.12), in: Circle())
-            .accessibilityHidden(true)
-    }
-
-    private func machineIcon(_ mac: MobilePairedMac) -> some View {
-        ZStack {
-            Circle()
-                .fill(Color.accentColor)
-            switch MacAvatarIcon.resolve(custom: mac.customIcon, defaultSymbol: "desktopcomputer") {
-            case .symbol(let name):
-                Image(systemName: name)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.white)
-            case .emoji(let emoji):
-                Text(emoji)
-                    .font(.system(size: 17))
-            }
+    private func routeIconContent(for mac: MobilePairedMac) -> TaskComposerRouteIcon.Content {
+        switch MacAvatarIcon.resolve(custom: mac.customIcon, defaultSymbol: "desktopcomputer") {
+        case .symbol(let name):
+            .symbol(name)
+        case .emoji(let emoji):
+            .emoji(emoji)
         }
-        .frame(width: 28, height: 28)
-        .accessibilityHidden(true)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRouteIcon.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRouteIcon.swift
@@ -56,7 +56,7 @@ struct TaskComposerRouteLabel: View {
             Spacer(minLength: 0)
             Image(systemName: chevronSystemName)
                 .font(.caption2.weight(.bold))
-                .foregroundStyle(Color.secondary.opacity(0.55))
+                .foregroundStyle(.tertiary)
                 .accessibilityHidden(true)
         }
         .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRouteIcon.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRouteIcon.swift
@@ -1,0 +1,66 @@
+#if os(iOS)
+import SwiftUI
+
+struct TaskComposerRouteIcon: View {
+    enum Content {
+        case symbol(String)
+        case emoji(String)
+    }
+
+    let content: Content
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Color.accentColor.opacity(0.12))
+
+            switch content {
+            case .symbol(let name):
+                Image(systemName: name)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            case .emoji(let emoji):
+                Text(emoji)
+                    .font(.system(size: 17))
+            }
+        }
+        .frame(width: 28, height: 28)
+        .accessibilityHidden(true)
+    }
+}
+
+struct TaskComposerRouteLabel: View {
+    let icon: TaskComposerRouteIcon.Content
+    let title: String
+    let value: String
+    let valueFont: Font
+    let valueTruncationMode: Text.TruncationMode
+    let chevronSystemName: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            TaskComposerRouteIcon(content: icon)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(Color.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                Text(value)
+                    .font(valueFont)
+                    .foregroundStyle(Color.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                    .truncationMode(valueTruncationMode)
+            }
+            Spacer(minLength: 0)
+            Image(systemName: chevronSystemName)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(Color.secondary.opacity(0.55))
+                .accessibilityHidden(true)
+        }
+        .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+        .contentShape(Rectangle())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TaskComposer/TaskComposerRoutePicker.swift
@@ -16,29 +16,14 @@ struct TaskComposerRoutePicker: View {
             machinePicker
 
             Button(action: selectDirectory) {
-                HStack(spacing: 8) {
-                    contextSymbol("folder.fill", tint: .blue)
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(L10n.string("mobile.taskComposer.directory", defaultValue: "Directory"))
-                            .font(.caption2.weight(.medium))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                        Text(directory)
-                            .font(.system(.caption, design: .monospaced, weight: .semibold))
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.72)
-                            .truncationMode(.middle)
-                    }
-                    Spacer(minLength: 0)
-                    Image(systemName: "chevron.right")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(.tertiary)
-                        .accessibilityHidden(true)
-                }
-                .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
-                .contentShape(Rectangle())
+                TaskComposerRouteLabel(
+                    icon: .symbol("folder.fill"),
+                    title: L10n.string("mobile.taskComposer.directory", defaultValue: "Directory"),
+                    value: directory,
+                    valueFont: .system(.caption, design: .monospaced, weight: .semibold),
+                    valueTruncationMode: .middle,
+                    chevronSystemName: "chevron.right"
+                )
             }
             .buttonStyle(.plain)
             .disabled(isDisabled)
@@ -59,7 +44,7 @@ struct TaskComposerRoutePicker: View {
     private var machinePicker: some View {
         if machines.isEmpty {
             HStack(spacing: 8) {
-                contextSymbol("desktopcomputer.trianglebadge.exclamationmark", tint: .accentColor)
+                TaskComposerRouteIcon(content: .symbol("desktopcomputer.trianglebadge.exclamationmark"))
                 VStack(alignment: .leading, spacing: 2) {
                     Text(L10n.string("mobile.taskComposer.machine.none", defaultValue: "No paired Macs"))
                         .font(.caption.weight(.semibold))
@@ -81,15 +66,6 @@ struct TaskComposerRoutePicker: View {
             )
             .equatable()
         }
-    }
-
-    private func contextSymbol(_ name: String, tint: Color) -> some View {
-        Image(systemName: name)
-            .font(.system(size: 13, weight: .semibold))
-            .foregroundStyle(tint)
-            .frame(width: 28, height: 28)
-            .background(tint.opacity(0.12), in: Circle())
-            .accessibilityHidden(true)
     }
 }
 #endif


### PR DESCRIPTION
## Summary

- Give Machine and Directory one shared icon, subtitle, value, and chevron treatment.
- Render the Machine visuals independently from the native menu label so the Machine subtitle remains visible in dark mode.
- Preserve the full-row Machine menu interaction and accessibility metadata.

## Verification

- Built tagged macOS app rtclr from commit 7ce9ec6264.
- Built and installed tagged iOS app rtclr on isolated iOS 26.5 simulator.
- Opened New Task in dark mode and confirmed both subtitles are visible with matching colors.
- Opened the Machine menu through the full row.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787438019&installation_model_id=21920&pr_number=8767&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8767&signature=73941b5a254fb131062fa372eaa6611d343266fe8eea76e3b7af8059ccc9321c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark mode subtitle visibility and unifies colors/styling for the iOS Task route picker (Machine and Directory). Uses shared route icon/label views and semantic chevron color while preserving full-row menu behavior and accessibility.

- **Bug Fixes**
  - Unifies icon, subtitle, value, and chevron styling for Machine and Directory.
  - Keeps the Machine subtitle visible in dark mode by rendering visuals outside the native `Menu` label.
  - Uses a semantic tertiary color for chevrons to match light/dark mode.

- **Refactors**
  - Adds `TaskComposerRouteIcon` and `TaskComposerRouteLabel` for consistent route UI.
  - Simplifies `TaskComposerMachineMenu` and `TaskComposerRoutePicker` by replacing inline UI with shared components.

<sup>Written for commit da48199fa735113083388a403efb8e4fe17e51ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed Task Composer route and machine pickers with consistent icons, labels, and chevrons.
  * Updated the picker header and directory/empty states to use new shared iOS-only route icon/label components for a unified look.
  * Support machine icons as either symbols or emojis, with consistent accent-tinted styling.
  * Preserved existing selection behavior and retained the prior menu label accessibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->