### PR TITLE
Make CMUX_RELAY_TOKEN_RATE_LIMIT_ID optional so deploys survive unset rate-limit envs

### DIFF
--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -70,7 +70,6 @@ const privateRelayEnvNames = new Set([
   "CMUX_RELAY_JWT_PRIVATE_KEY_PEM",
   "CMUX_RELAY_POLICY_KEY_ID",
   "CMUX_RELAY_POLICY_PRIVATE_KEY_PEM",
-  "CMUX_RELAY_TOKEN_RATE_LIMIT_ID",
 ]);
 const publicEnvValidationIssues = (issues: readonly unknown[]): readonly unknown[] => {
   const publicIssues: unknown[] = [];
@@ -259,7 +258,10 @@ export const env = createEnv({
     CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: requireVercelRelayValue(
       z.string().min(64).max(16_384),
     ),
-    CMUX_RELAY_TOKEN_RATE_LIMIT_ID: requireVercelRelayValue(),
+    // Optional: leave unset to disable relay-token rate limiting entirely.
+    // When unset, enforceRelayRateLimit skips the firewall gate. Matches
+    // CMUX_IROH_RATE_LIMIT_ID and CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID.
+    CMUX_RELAY_TOKEN_RATE_LIMIT_ID: z.string().min(1).optional(),
     // Optional dedicated rule. Preferences deliberately fall back to the token
     // rule so existing deployments keep one shared account-scoped limiter.
     CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID: z.string().min(1).optional(),

--- a/web/services/relay/errors.ts
+++ b/web/services/relay/errors.ts
@@ -6,8 +6,7 @@ export class RelayConfigurationError extends Data.TaggedError("RelayConfiguratio
     | "catalog_invalid"
     | "signing_key_not_configured"
     | "signing_key_invalid"
-    | "credential_set_invalid"
-    | "rate_limit_not_configured";
+    | "credential_set_invalid";
 }> {}
 
 export class RelayCatalogRollbackError extends Data.TaggedError("RelayCatalogRollbackError")<{


### PR DESCRIPTION
## Problem

https://github.com/manaflow-ai/cmux/pull/8773 (merged + deployed) made `enforceRelayRateLimit` skip rate limiting when the rule id env is unset, and the rate-limit env vars have since been deleted from Vercel per the no-rate-limits decision. But `web/app/env.ts` still marks `CMUX_RELAY_TOKEN_RATE_LIMIT_ID` **required** on non-preview Vercel deployments (`requireVercelRelayValue`), and `onValidationError` throws — so the **next production deploy fails env validation at build** with the vars unset.

## Fix

- `CMUX_RELAY_TOKEN_RATE_LIMIT_ID` becomes `z.string().min(1).optional()`, matching what https://github.com/manaflow-ai/cmux/pull/8714 did for `CMUX_IROH_RATE_LIMIT_ID` and the already-optional `CMUX_RELAY_PREFERENCES_RATE_LIMIT_ID`.
- Dropped it from `privateRelayEnvNames` (it can no longer produce validation issues).
- Removed the `rate_limit_not_configured` error code that 8773 left unconstructable.

This PR originally duplicated 8773's runtime fail-open fix (written in parallel before 8773 merged); it is now reduced to the env-schema gap 8773 did not cover.

## Verification

`bun run typecheck` clean; `bun test tests/relay-token-route.test.ts tests/relay-preferences-route.test.ts` 15 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-hosted relay configuration validation by allowing the rate-limit identifier to be omitted when it is not configured.
  * Removed the obsolete “rate limit not configured” configuration error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->