### PR TITLE
Make relay rate limiter fail open on missing rule and skip when unconfigured

### DIFF
--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -38,9 +38,9 @@ export function enforceRelayRateLimit(input: {
   }
   const ruleId = input.ruleId?.trim();
   if (!ruleId) {
-    return Effect.fail(
-      new RelayConfigurationError({ code: "rate_limit_not_configured" }),
-    );
+    // No configured rule means the operator wants no rate limiting. Failing
+    // here would turn a deliberately-unset env var into a relay outage.
+    return Effect.void;
   }
   return Effect.tryPromise({
     try: () => input.check(ruleId, {
@@ -63,6 +63,14 @@ export function enforceRelayRateLimit(input: {
             ? { retryAfterSeconds }
             : {}),
         }));
+      }
+      if (error === "not-found") {
+        // The configured rule no longer exists (Vercel returns 404). That
+        // means the operator deleted the limit, so treat it as "no limit" and
+        // fail open rather than 503-ing every request. Genuine unavailability
+        // (a thrown check or an unexpected status) still fails closed below.
+        console.warn("relay rate-limit rule not found; failing open");
+        return Effect.void;
       }
       if (error) {
         return Effect.fail(

--- a/web/tests/relay-token-route.test.ts
+++ b/web/tests/relay-token-route.test.ts
@@ -344,10 +344,50 @@ describe("POST /api/relay/token", () => {
     expect(invalid.status).toBe(400);
     expect(checks).toBe(1);
 
+    const blocked = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-token",
+        checkRateLimit: async () => ({ rateLimited: false, error: "blocked" }),
+      }),
+    );
+    expect(blocked.status).toBe(429);
+
     const unavailable = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-token",
+        checkRateLimit: async () => {
+          throw new Error("firewall unreachable");
+        },
+      }),
+    );
+    expect(unavailable.status).toBe(503);
+  });
+
+  test("skips rate limiting when no rule is configured", async () => {
+    // An unset rule id env var means the operator wants no rate limiting.
+    // This must mint credentials, not 503 every device off the relay network.
+    const response = await handleRelayTokenRequest(
       request({ endpointId: ENDPOINT_ID }),
       deps({ isVercel: () => true, rateLimitRuleId: () => undefined }),
     );
-    expect(unavailable.status).toBe(503);
+    expect(response.status).toBe(200);
+  });
+
+  test("fails open when the configured rate-limit rule no longer exists", async () => {
+    // Vercel reports a deleted firewall rule as not-found. That is an operator
+    // action, not an outage, so the mint must proceed as if unlimited.
+    const response = await handleRelayTokenRequest(
+      request({ endpointId: ENDPOINT_ID }),
+      deps({
+        isVercel: () => true,
+        rateLimitRuleId: () => "relay-token",
+        checkRateLimit: async () => ({ rateLimited: false, error: "not-found" }),
+      }),
+    );
+    expect(response.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Problem

`enforceRelayRateLimit` in `web/services/relay/http.ts` (used by `/api/relay/token` and `/api/relay/preferences`) hard-fails on every non-success firewall outcome: an unset `CMUX_RELAY_TOKEN_RATE_LIMIT_ID` fails with `rate_limit_not_configured` and a deleted Vercel firewall rule (`not-found`) fails as `rate_limit_unavailable`, both returning 503 to every authenticated request. Since the Vercel rate-limit rules were removed, every device's relay policy fetch has been failing (`policyUnavailable` in the client diag rings), macOS hosts loop on `endpointStarting -> relayPolicyRefreshFailed -> endpointFailed` and never come up, and phones cannot discover or connect to Macs.

https://github.com/manaflow-ai/cmux/pull/8714 fixed this exact class in `web/services/iroh/routeHandler.ts` but did not cover this second limiter.

## Fix

- Unset/blank rule id: skip rate limiting entirely (operator wants no limits).
- Rule check returns `not-found` (rule deleted): warn and fail open, mirroring 8714.
- Unchanged: `rateLimited`/`blocked` still 429 with retry-after; thrown or unexpected check outcomes still fail closed with 503.

## Commits

Two-commit regression structure: commit 1 adds the failing tests (red), commit 2 the fix (green).

## Verification

- `bun test tests/relay-token-route.test.ts tests/relay-preferences-route.test.ts tests/iroh-route-handler.test.ts`: 29 pass.
- `bun run typecheck` clean.
- Live evidence of the outage: cmux NIGHTLY host diag ring shows the continuous `relayPolicyRefreshFailed(policyUnavailable)` loop while `CMUX_RELAY_TOKEN_RATE_LIMIT_ID` points at a deleted rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440035&installation_model_id=21920&pr_number=8773&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8773&signature=c1bd81486e3a60fe8268f36b99501d85bb4aa69f3b0c064708f7217c64645c8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail open in the relay rate limiter when the Vercel rule is missing or unconfigured to stop 503s on `/api/relay/token` and `/api/relay/preferences` and restore device connectivity. Matches the existing behavior in `services/iroh/routeHandler.ts`.

- **Bug Fixes**
  - Unset `CMUX_RELAY_TOKEN_RATE_LIMIT_ID`: skip rate limiting.
  - Vercel check returns `not-found`: warn and proceed (no limit).
  - Still return 429 for `rateLimited` and `blocked`; unexpected errors still 503.
  - Added tests for the skip and fail-open cases.

<sup>Written for commit 69c8cb315237da00b49802ea1ed76a3bf9dd7a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relay requests now proceed when no rate-limit rule is configured.
  * Requests also proceed when a configured rate-limit rule cannot be found.

* **Bug Fixes**
  * Rate-limit outages continue to return an appropriate service-unavailable response.
  * Active rate limits still block requests with a 429 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->