### PR TITLE
Show more notification rows in onboarding

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
@@ -32,6 +32,7 @@ struct OnboardingScreenshot: View {
         }
             .aspectRatio(contentMode: .fill)
             .frame(maxWidth: .infinity)
+            .offset(y: content.cropYOffset)
             .frame(height: 330, alignment: .top)
             .clipped()
             .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
@@ -110,6 +111,17 @@ struct OnboardingScreenshot: View {
         language: OnboardingScreenshotLanguage
     ) -> String {
         "Onboarding-\(content.rawValue)-\(language.rawValue)"
+    }
+}
+
+private extension OnboardingScreenshot.Content {
+    var cropYOffset: CGFloat {
+        switch self {
+        case .workspaces:
+            0
+        case .notifications:
+            -140
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- shifts only the Notifications onboarding screenshot crop upward so page two shows multiple feed rows
- leaves the real localized screenshot assets, page one, and page three unchanged

## Verification
- `git diff --check`
- `jq empty Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings`
- `./scripts/reload-cloud.sh --tag onfeed` via run https://github.com/manaflow-ai/cmux/actions/runs/30051583498, build succeeded; artifact installed locally from `reload-onfeed-macos`
- `CMUX_PORT=3777 CMUX_PORT_RANGE=1 CMUX_PORT_END=3777 ios/scripts/reload.sh --tag onfeed --simulator cmux-onfeed-root-0723 --no-setup`
- warmed `http://127.0.0.1:3777/`, `/handler/sign-in`, `/handler/after-sign-in`, all 200
- Computer Use verified page two in simulator `cmux-onfeed-root-0723` shows two full notification rows plus the start of a third row
- saved evidence screenshot: `/tmp/cmux-onfeed-evidence/onboarding-page-2-notifications-current-head.png`

## Notes
- `swift test --package-path Packages/iOS/CmuxMobileShellUI --filter OnboardingSceneChromeTests` is blocked by the package manifest's existing macOS deployment target mismatch with dependencies that require macOS 12 or 14.
- No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440132&installation_model_id=21920&pr_number=8774&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8774&signature=46dab8fcb015bc6bcffe6292bd9ce183d6407974126e48c4d2be3b576670084b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the Notifications onboarding screenshot to show more feed rows by shifting the crop upward. Other onboarding pages and localized assets are unchanged.

<sup>Written for commit 62c93142987f2543f3ac283d749180e5c756e17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the positioning of the notifications screenshot during onboarding for more accurate cropping.
  * Preserved the existing layout for workspace screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->