### PR TITLE
Name online-admission session closes and reject nearly expired leases at admission

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -63,6 +63,10 @@ public enum DiagnosticFailureKind: Int, Sendable, Codable, CaseIterable {
     case cancelled = 20
     /// The established transport exceeded its negotiated inactivity window.
     case transportIdleTimedOut = 21
+    /// Online admission closed the session because its signed lease expired.
+    case admissionLeaseExpired = 22
+    /// Online admission closed the session after broker revalidation failed.
+    case admissionRevalidationFailed = 23
     case unknown = 255
 
     /// Reduces a typed or system error to the bounded diagnostic vocabulary.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -239,6 +239,8 @@ import Testing
         #expect(CmxAttachTransportKind.iroh.diagnosticTransportKind.rawValue == 1)
         #expect(DiagnosticFailureKind.cancelled.rawValue == 20)
         #expect(DiagnosticFailureKind.transportIdleTimedOut.rawValue == 21)
+        #expect(DiagnosticFailureKind.admissionLeaseExpired.rawValue == 22)
+        #expect(DiagnosticFailureKind.admissionRevalidationFailed.rawValue == 23)
         #expect(DiagnosticFailureKind.unknown.rawValue == 255)
         #expect(DiagnosticSessionLifecycleKind.established.rawValue == 1)
         #expect(DiagnosticSessionLifecycleKind.controlOwnerReleased.rawValue == 2)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedServerSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedServerSession.swift
@@ -44,4 +44,21 @@ public struct CmxIrohAdmittedServerSession: Sendable {
     public func close() async {
         await session.close()
     }
+
+    /// Resolves an observed supervisor exit against a named host-side close cause.
+    ///
+    /// - Parameter observedExit: The first control or application-lane exit.
+    /// - Returns: The host invalidation exit when one initiated the close;
+    ///   otherwise, `observedExit`.
+    public func connectionExit(
+        resolving observedExit: CmxIrohAdmittedConnectionExit
+    ) async -> CmxIrohAdmittedConnectionExit {
+        guard let failure = await session.explicitCloseFailureKind() else {
+            return observedExit
+        }
+        return CmxIrohAdmittedConnectionExit(
+            lifecycle: .explicitlyInvalidated,
+            failure: failure
+        )
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -412,8 +412,16 @@ public actor CmxIrohHostRuntime {
             await onlineAdmissionRegistry.monitor(
                 onlineLease,
                 connection: connection
-            ) {
-                await session.close()
+            ) { reason in
+                let failure: DiagnosticFailureKind = switch reason {
+                case .leaseExpired:
+                    .admissionLeaseExpired
+                case .denied:
+                    .admissionDenied
+                case .revalidationFailed:
+                    .admissionRevalidationFailed
+                }
+                await session.close(failure: failure)
             }
         }
         let pathConnectionID = UUID()

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionInvalidationReason.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionInvalidationReason.swift
@@ -1,0 +1,11 @@
+/// Why an admitted online lease stopped authorizing its live host session.
+public enum CmxIrohOnlineAdmissionInvalidationReason: Sendable, Equatable {
+    /// The signed lease reached its expiration time.
+    case leaseExpired
+
+    /// Local or broker policy denied or revoked one of the lease bindings.
+    case denied
+
+    /// Online broker revalidation failed for a non-connectivity reason.
+    case revalidationFailed
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionRegistry.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohOnlineAdmissionRegistry.swift
@@ -3,7 +3,10 @@ public import Foundation
 
 /// Locally authenticates pair grants, then enforces current broker revocation policy.
 public actor CmxIrohOnlineAdmissionRegistry {
-    public typealias InvalidationHandler = @Sendable () async -> Void
+    /// Receives the concrete policy reason that invalidated one admitted lease.
+    public typealias InvalidationHandler = @Sendable (
+        CmxIrohOnlineAdmissionInvalidationReason
+    ) async -> Void
 
     private struct Snapshot: Sendable {
         let id: UUID
@@ -31,11 +34,14 @@ public actor CmxIrohOnlineAdmissionRegistry {
     private enum Revalidation {
         case active(Date)
         case connectivity
-        case terminal
+        case terminal(CmxIrohOnlineAdmissionInvalidationReason)
     }
 
     /// A successful broker snapshot is reused for no more than 30 seconds.
     public static let maximumOnlineSnapshotAge: TimeInterval = 30
+
+    /// The minimum unexpired lease duration required to admit a new session.
+    public static let minimumAdmissionLeaseRemaining: TimeInterval = 30
 
     private let broker: any CmxIrohDiscoveryServing
     private var managedRelayURLs: Set<String>
@@ -138,6 +144,7 @@ public actor CmxIrohOnlineAdmissionRegistry {
     ) async -> CmxIrohOnlineAdmissionAuthorization {
         guard !isDenied(lease), !isExpired(lease) else { return .denied }
         let revision = policyRevision
+        let acceptedLease: CmxIrohOnlineAdmissionLease
         do {
             guard let online = try await validatedSnapshot(
                 for: lease,
@@ -149,7 +156,7 @@ public actor CmxIrohOnlineAdmissionRegistry {
             guard !isExpired(lease) else {
                 return .denied
             }
-            return .accepted(lease.validatedOnline(at: online.fetchedAt))
+            acceptedLease = lease.validatedOnline(at: online.fetchedAt)
         } catch {
             guard Self.isConnectivity(error),
                   policyRevision == revision,
@@ -157,8 +164,13 @@ public actor CmxIrohOnlineAdmissionRegistry {
                   !isExpired(lease) else {
                 return .denied
             }
-            return .accepted(lease)
+            acceptedLease = lease
         }
+        guard acceptedLease.expiresAt.timeIntervalSince(clock.now())
+                >= Self.minimumAdmissionLeaseRemaining else {
+            return .denied
+        }
+        return .accepted(acceptedLease)
     }
 
     /// Starts an idle-safe lease monitor owned by the exact live connection.
@@ -235,8 +247,20 @@ public actor CmxIrohOnlineAdmissionRegistry {
                 return
             }
             guard monitors[id] != nil else { return }
-            if clock.now() >= lease.expiresAt || isDenied(lease) {
-                await invalidate(id: id, onInvalidated: onInvalidated)
+            if clock.now() >= lease.expiresAt {
+                await invalidate(
+                    id: id,
+                    reason: .leaseExpired,
+                    onInvalidated: onInvalidated
+                )
+                return
+            }
+            if isDenied(lease) {
+                await invalidate(
+                    id: id,
+                    reason: .denied,
+                    onInvalidated: onInvalidated
+                )
                 return
             }
 
@@ -249,17 +273,20 @@ public actor CmxIrohOnlineAdmissionRegistry {
                 nextOnlineCheck = clock.now().addingTimeInterval(
                     Self.maximumOnlineSnapshotAge
                 )
-            case .terminal:
-                await invalidate(id: id, onInvalidated: onInvalidated)
+            case let .terminal(reason):
+                await invalidate(
+                    id: id,
+                    reason: reason,
+                    onInvalidated: onInvalidated
+                )
                 return
             }
         }
     }
 
     private func revalidate(_ lease: CmxIrohOnlineAdmissionLease) async -> Revalidation {
-        guard !isDenied(lease), clock.now() < lease.expiresAt else {
-            return .terminal
-        }
+        guard !isDenied(lease) else { return .terminal(.denied) }
+        guard clock.now() < lease.expiresAt else { return .terminal(.leaseExpired) }
         let revision = policyRevision
         do {
             guard let online = try await validatedSnapshot(
@@ -267,18 +294,22 @@ public actor CmxIrohOnlineAdmissionRegistry {
                 policyRevision: revision
             ) else {
                 await invalidateDeniedMonitors()
-                return .terminal
+                return isDenied(lease)
+                    ? .terminal(.denied)
+                    : .terminal(.revalidationFailed)
             }
             guard clock.now() < lease.expiresAt else {
-                return .terminal
+                return .terminal(.leaseExpired)
             }
             return .active(online.fetchedAt)
         } catch {
-            return Self.isConnectivity(error)
-                && policyRevision == revision
-                && !isDenied(lease)
+            guard !isDenied(lease) else { return .terminal(.denied) }
+            guard clock.now() < lease.expiresAt else {
+                return .terminal(.leaseExpired)
+            }
+            return Self.isConnectivity(error) && policyRevision == revision
                 ? .connectivity
-                : .terminal
+                : .terminal(.revalidationFailed)
         }
     }
 
@@ -473,11 +504,12 @@ public actor CmxIrohOnlineAdmissionRegistry {
 
     private func invalidate(
         id: UUID,
+        reason: CmxIrohOnlineAdmissionInvalidationReason,
         onInvalidated: @escaping InvalidationHandler
     ) async {
         guard let monitor = monitors.removeValue(forKey: id) else { return }
         monitor.connectionLifetimeTask?.cancel()
-        await onInvalidated()
+        await onInvalidated(reason)
     }
 
     private func connectionClosed(id: UUID) {
@@ -492,7 +524,7 @@ public actor CmxIrohOnlineAdmissionRegistry {
             monitor.task?.cancel()
             monitor.connectionLifetimeTask?.cancel()
         }
-        for monitor in denied.values { await monitor.onInvalidated() }
+        for monitor in denied.values { await monitor.onInvalidated(.denied) }
     }
 
     private static func isConnectivity(_ error: any Error) -> Bool {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohServerSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohServerSession.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 public import Foundation
 
 /// An admitted Mac-side multistream session over one TLS-authenticated Iroh connection.
@@ -21,6 +22,7 @@ public actor CmxIrohServerSession {
     private var admissionInProgress = false
     private var admitted = false
     private var closed = false
+    private var explicitCloseFailure: DiagnosticFailureKind?
 
     public init(
         connection: any CmxIrohConnection,
@@ -248,6 +250,24 @@ public actor CmxIrohServerSession {
     }
 
     public func close() async {
+        await closeConnection()
+    }
+
+    /// Closes the session while retaining the host-side failure that initiated the close.
+    func close(failure: DiagnosticFailureKind) async {
+        guard !closed else { return }
+        if explicitCloseFailure == nil {
+            explicitCloseFailure = failure
+        }
+        await closeConnection()
+    }
+
+    /// Returns a named host-side close cause after an explicit policy invalidation.
+    func explicitCloseFailureKind() -> DiagnosticFailureKind? {
+        explicitCloseFailure
+    }
+
+    private func closeConnection() async {
         guard !closed else { return }
         closed = true
         if let controlStream {

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
@@ -172,8 +172,8 @@ extension CmxIrohOnlineAdmissionRegistryTests {
             ).lease
         )
         let closeRecorder = OnlineAdmissionCloseRecorder()
-        await registry.monitor(lease, connection: fixture.connection()) {
-            await closeRecorder.close()
+        await registry.monitor(lease, connection: fixture.connection()) { reason in
+            await closeRecorder.close(reason: reason)
         }
         await clock.waitUntilSleeping()
 
@@ -194,6 +194,33 @@ extension CmxIrohOnlineAdmissionRegistryTests {
     }
 
     @Test
+    func relayFleetMismatchInvalidatesLeaseAsRevalidationFailure() async throws {
+        let fixture = try OnlineAdmissionFixture()
+        let clock = OnlineAdmissionManualClock(now: fixture.now)
+        let broker = OnlineAdmissionBroker(responses: [
+            .success(try fixture.discovery()),
+            .success(try fixture.discovery(relayFleet: [fixture.otherRelayURL])),
+        ])
+        let registry = fixture.registry(broker: broker, clock: clock)
+        let lease = try #require(
+            await registry.authorizePairGrant(
+                fixture.grant(),
+                authenticatedPeerID: fixture.initiator.endpointID
+            ).lease
+        )
+        let closeRecorder = OnlineAdmissionCloseRecorder()
+        await registry.monitor(lease, connection: fixture.connection()) { reason in
+            await closeRecorder.close(reason: reason)
+        }
+        await clock.waitUntilSleeping()
+
+        clock.advance(by: 30)
+        await closeRecorder.waitUntilClosed()
+
+        #expect(await closeRecorder.observedReasons() == [.revalidationFailed])
+    }
+
+    @Test
     func connectivityDoesNotCloseActiveLease() async throws {
         let fixture = try OnlineAdmissionFixture()
         let clock = OnlineAdmissionManualClock(now: fixture.now)
@@ -209,8 +236,8 @@ extension CmxIrohOnlineAdmissionRegistryTests {
             ).lease
         )
         let closeRecorder = OnlineAdmissionCloseRecorder()
-        await registry.monitor(lease, connection: fixture.connection()) {
-            await closeRecorder.close()
+        await registry.monitor(lease, connection: fixture.connection()) { reason in
+            await closeRecorder.close(reason: reason)
         }
         await clock.waitUntilSleeping()
 
@@ -240,8 +267,8 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         )
         let closeRecorder = OnlineAdmissionCloseRecorder()
 
-        await registry.monitor(lease, connection: connection) {
-            await closeRecorder.close()
+        await registry.monitor(lease, connection: connection) { reason in
+            await closeRecorder.close(reason: reason)
             await connection.close(errorCode: 1, reason: "lease_invalidated")
         }
 
@@ -268,14 +295,15 @@ extension CmxIrohOnlineAdmissionRegistryTests {
             ).lease
         )
         let closeRecorder = OnlineAdmissionCloseRecorder()
-        await registry.monitor(lease, connection: fixture.connection()) {
-            await closeRecorder.close()
+        await registry.monitor(lease, connection: fixture.connection()) { reason in
+            await closeRecorder.close(reason: reason)
         }
 
         await registry.revoke(bindingID: fixture.initiator.bindingID)
         await closeRecorder.waitUntilClosed()
 
         #expect(await closeRecorder.count() == 1)
+        #expect(await closeRecorder.observedReasons() == [.denied])
         #expect(
             await registry.authorizePairGrant(
                 fixture.grant(),
@@ -287,9 +315,12 @@ extension CmxIrohOnlineAdmissionRegistryTests {
 
     @Test
     func grantExpiryClosesLeaseAndDeniesNewAdmission() async throws {
-        let fixture = try OnlineAdmissionFixture(grantLifetime: 20)
+        let fixture = try OnlineAdmissionFixture(grantLifetime: 31)
         let clock = OnlineAdmissionManualClock(now: fixture.now)
-        let broker = OnlineAdmissionBroker(responses: [.failure(.connectivity)])
+        let broker = OnlineAdmissionBroker(responses: [
+            .failure(.connectivity),
+            .failure(.connectivity),
+        ])
         let registry = fixture.registry(broker: broker, clock: clock)
         let lease = try #require(
             await registry.authorizePairGrant(
@@ -298,14 +329,18 @@ extension CmxIrohOnlineAdmissionRegistryTests {
             ).lease
         )
         let closeRecorder = OnlineAdmissionCloseRecorder()
-        await registry.monitor(lease, connection: fixture.connection()) {
-            await closeRecorder.close()
+        await registry.monitor(lease, connection: fixture.connection()) { reason in
+            await closeRecorder.close(reason: reason)
         }
         await clock.waitUntilSleeping()
 
-        clock.advance(by: 20)
+        clock.advance(by: 30)
+        await broker.waitForCallCount(2)
+        await clock.waitUntilSleeping()
+        clock.advance(by: 1)
         await closeRecorder.waitUntilClosed()
 
+        #expect(await closeRecorder.observedReasons() == [.leaseExpired])
         #expect(
             await registry.authorizePairGrant(
                 fixture.grant(),

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryLeaseTests.swift
@@ -7,6 +7,35 @@ import Testing
 
 extension CmxIrohOnlineAdmissionRegistryTests {
     @Test
+    func pairGrantRequiresThirtySecondsOfLeaseRemainingAtAdmission() async throws {
+        let nearlyExpiredFixture = try OnlineAdmissionFixture(grantLifetime: 29)
+        let nearlyExpiredBroker = OnlineAdmissionBroker(
+            responses: [.success(try nearlyExpiredFixture.discovery())]
+        )
+        let viableFixture = try OnlineAdmissionFixture(grantLifetime: 31)
+        let viableBroker = OnlineAdmissionBroker(
+            responses: [.success(try viableFixture.discovery())]
+        )
+
+        #expect(
+            await nearlyExpiredFixture.registry(
+                broker: nearlyExpiredBroker
+            ).authorizePairGrant(
+                nearlyExpiredFixture.grant(),
+                authenticatedPeerID: nearlyExpiredFixture.initiator.endpointID
+            ) == .denied
+        )
+        #expect(
+            await viableFixture.registry(
+                broker: viableBroker
+            ).authorizePairGrant(
+                viableFixture.grant(),
+                authenticatedPeerID: viableFixture.initiator.endpointID
+            ).isAccepted
+        )
+    }
+
+    @Test
     func connectivityAllowsLocallyValidGrantOffline() async throws {
         let fixture = try OnlineAdmissionFixture()
         let broker = OnlineAdmissionBroker(responses: [.failure(.connectivity)])

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryOfflineTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryOfflineTests.swift
@@ -7,6 +7,38 @@ import Testing
 
 extension CmxIrohOnlineAdmissionRegistryTests {
     @Test
+    func offlinePairRequiresThirtySecondsOfLeaseRemainingAtAdmission() async throws {
+        let fixture = try OnlineAdmissionFixture()
+        let nearlyExpiredBroker = OnlineAdmissionBroker(
+            responses: [.success(try fixture.discovery())]
+        )
+        let viableBroker = OnlineAdmissionBroker(
+            responses: [.success(try fixture.discovery())]
+        )
+
+        #expect(
+            await fixture.registry(
+                broker: nearlyExpiredBroker
+            ).authorizeOfflinePair(
+                try fixture.offlinePair(
+                    initiatorLifetime: 29,
+                    acceptorLifetime: 29
+                )
+            ) == .denied
+        )
+        #expect(
+            await fixture.registry(
+                broker: viableBroker
+            ).authorizeOfflinePair(
+                try fixture.offlinePair(
+                    initiatorLifetime: 31,
+                    acceptorLifetime: 31
+                )
+            ).isAccepted
+        )
+    }
+
+    @Test
     func activeOfflinePairAcceptsUntilEarlierAttestationExpiry() async throws {
         let fixture = try OnlineAdmissionFixture()
         let broker = OnlineAdmissionBroker(responses: [.success(try fixture.discovery())])

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryOfflineTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryOfflineTests.swift
@@ -58,9 +58,12 @@ extension CmxIrohOnlineAdmissionRegistryTests {
     func connectivityAllowsVerifiedOfflinePairUntilEarlierExpiry() async throws {
         let fixture = try OnlineAdmissionFixture()
         let clock = OnlineAdmissionManualClock(now: fixture.now)
-        let broker = OnlineAdmissionBroker(responses: [.failure(.connectivity)])
+        let broker = OnlineAdmissionBroker(responses: [
+            .failure(.connectivity),
+            .failure(.connectivity),
+        ])
         let registry = fixture.registry(broker: broker, clock: clock)
-        let pair = try fixture.offlinePair(initiatorLifetime: 90, acceptorLifetime: 20)
+        let pair = try fixture.offlinePair(initiatorLifetime: 90, acceptorLifetime: 31)
         let lease = try #require(
             await registry.authorizeOfflinePair(pair).lease
         )
@@ -68,16 +71,21 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         await registry.monitor(
             lease,
             connection: fixture.connection()
-        ) { await closeRecorder.close() }
+        ) { reason in await closeRecorder.close(reason: reason) }
         await clock.waitUntilSleeping()
 
-        #expect(clock.sleepingDeadlines() == [fixture.now.addingTimeInterval(20)])
-        clock.advance(by: 20)
+        #expect(clock.sleepingDeadlines() == [fixture.now.addingTimeInterval(30)])
+        clock.advance(by: 30)
+        await broker.waitForCallCount(2)
+        await clock.waitUntilSleeping()
+        #expect(clock.sleepingDeadlines() == [fixture.now.addingTimeInterval(31)])
+        clock.advance(by: 1)
         await closeRecorder.waitUntilClosed()
 
         #expect(await closeRecorder.count() == 1)
+        #expect(await closeRecorder.observedReasons() == [.leaseExpired])
         #expect(await registry.authorizeOfflinePair(pair) == .denied)
-        #expect(await broker.callCount() == 1)
+        #expect(await broker.callCount() == 2)
     }
 
     @Test(arguments: [
@@ -180,7 +188,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         await registry.monitor(
             lease,
             connection: fixture.connection()
-        ) { await closeRecorder.close() }
+        ) { reason in await closeRecorder.close(reason: reason) }
         await clock.waitUntilSleeping()
 
         #expect(clock.sleepingDeadlines() == [fixture.now.addingTimeInterval(30)])
@@ -348,7 +356,7 @@ extension CmxIrohOnlineAdmissionRegistryTests {
         await registry.monitor(
             lease,
             connection: fixture.connection()
-        ) { await closeRecorder.close() }
+        ) { reason in await closeRecorder.close(reason: reason) }
         await clock.waitUntilSleeping()
         await broker.suspend()
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohOnlineAdmissionRegistryTests.swift
@@ -185,20 +185,24 @@ final class OnlineAdmissionManualClock: CmxIrohRelayClock, @unchecked Sendable {
 }
 
 actor OnlineAdmissionCloseRecorder {
-    private var closes = 0
+    private var reasons: [CmxIrohOnlineAdmissionInvalidationReason] = []
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
-    func close() {
-        closes += 1
+    func close(reason: CmxIrohOnlineAdmissionInvalidationReason) {
+        reasons.append(reason)
         let current = waiters
         waiters.removeAll()
         for waiter in current { waiter.resume() }
     }
 
-    func count() -> Int { closes }
+    func count() -> Int { reasons.count }
+
+    func observedReasons() -> [CmxIrohOnlineAdmissionInvalidationReason] {
+        reasons
+    }
 
     func waitUntilClosed() async {
-        if closes > 0 { return }
+        if !reasons.isEmpty { return }
         await withCheckedContinuation { waiters.append($0) }
     }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
@@ -5,6 +5,44 @@ import Testing
 
 @Suite
 struct CmxIrohServerSessionTests {
+    @Test(arguments: [
+        DiagnosticFailureKind.admissionLeaseExpired,
+        .admissionDenied,
+        .admissionRevalidationFailed,
+    ])
+    func namedHostCloseOverridesTheObservedSupervisorExit(
+        failure: DiagnosticFailureKind
+    ) async throws {
+        let fixture = try ServerFixture(decision: .accepted)
+        let connection = TestIrohConnection(
+            remoteIdentity: fixture.peerID,
+            bidirectionalStreams: [fixture.controlStream]
+        )
+        let serverSession = try CmxIrohServerSession(
+            connection: connection,
+            authorizer: fixture.authorizer
+        )
+        let peer = try await serverSession.admit()
+        let session = CmxIrohAdmittedServerSession(
+            peer: peer,
+            session: serverSession
+        )
+        let observedExit = CmxIrohAdmittedConnectionExit(
+            lifecycle: .controlReadFailed,
+            failure: .connectionClosed
+        )
+
+        await serverSession.close(failure: failure)
+
+        #expect(
+            await session.connectionExit(resolving: observedExit)
+                == CmxIrohAdmittedConnectionExit(
+                    lifecycle: .explicitlyInvalidated,
+                    failure: failure
+                )
+        )
+    }
+
     @Test
     func acceptedControlPreservesPayloadAndUnlocksIndependentLanes() async throws {
         let events = TestIrohEventRecorder()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -370,6 +370,16 @@ private extension MobileIrohSettingsView {
                 "mobile.iroh.diagnostics.failure.admissionDenied",
                 defaultValue: "Connection Admission Denied"
             )
+        case .some(.admissionLeaseExpired):
+            L10n.string(
+                "mobile.iroh.diagnostics.failure.admissionLeaseExpired",
+                defaultValue: "Admission Lease Expired"
+            )
+        case .some(.admissionRevalidationFailed):
+            L10n.string(
+                "mobile.iroh.diagnostics.failure.admissionRevalidationFailed",
+                defaultValue: "Admission Revalidation Failed"
+            )
         case .some(.authorizationFailed):
             L10n.string(
                 "mobile.iroh.diagnostics.failure.authorizationFailed",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -977,6 +977,40 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "接続の受け入れが拒否されました" } }
       }
     },
+    "mobile.iroh.diagnostics.failure.admissionLeaseExpired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Admission Lease Expired"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受け入れリースの期限切れ"
+          }
+        }
+      }
+    },
+    "mobile.iroh.diagnostics.failure.admissionRevalidationFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Admission Revalidation Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受け入れの再検証に失敗しました"
+          }
+        }
+      }
+    },
     "mobile.iroh.diagnostics.failure.authorizationFailed" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -562,6 +562,16 @@ private struct IrohDiagnosticsReportRows: View {
                 localized: "settings.networking.diagnostics.failure.admissionDenied",
                 defaultValue: "Connection Admission Denied"
             )
+        case .some(.admissionLeaseExpired):
+            String(
+                localized: "settings.networking.diagnostics.failure.admissionLeaseExpired",
+                defaultValue: "Admission Lease Expired"
+            )
+        case .some(.admissionRevalidationFailed):
+            String(
+                localized: "settings.networking.diagnostics.failure.admissionRevalidationFailed",
+                defaultValue: "Admission Revalidation Failed"
+            )
         case .some(.authorizationFailed):
             String(
                 localized: "settings.networking.diagnostics.failure.authorizationFailed",

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -258,7 +258,8 @@ extension MobileHostIrohRuntime {
                         await laneRouter.stop()
                     }
                 )
-                let exit = await connectionSupervisor.run()
+                let observedExit = await connectionSupervisor.run()
+                let exit = await session.connectionExit(resolving: observedExit)
                 diagnosticLog.record(DiagnosticEvent(
                     .transportSessionLifecycle,
                     a: exit.lifecycle.rawValue,

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -14723,6 +14723,40 @@
         }
       }
     },
+    "mobile.iroh.diagnostics.failure.admissionLeaseExpired": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Admission Lease Expired"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受け入れリースの期限切れ"
+          }
+        }
+      }
+    },
+    "mobile.iroh.diagnostics.failure.admissionRevalidationFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Admission Revalidation Failed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "受け入れの再検証に失敗しました"
+          }
+        }
+      }
+    },
     "mobile.iroh.diagnostics.failure.authorizationFailed": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Problem

When the Mac host's online admission layer kills a live phone session (lease expiry, revocation, or failed broker revalidation), it calls a bare `session.close()`. The phone can only classify this as `controlReadFailed/connectionClosed`, and the host's own `sessionClosed` diagnostic (from https://github.com/manaflow-ai/cmux/pull/8716) records a generic exit — so field rings cannot distinguish these policy closes from network failures. Field evidence in https://github.com/manaflow-ai/cmux/issues/8531: a phone admitted (pairOk + rpcReady) then closed by the host ~2s later, every ~4s, with no named cause on either end.

Additionally, `authorize()` happily admits a lease that is seconds from expiry, then the monitor kills the connection moments later — an accept-then-kill loop that reads as network flapping.

## Fix

- `CmxIrohOnlineAdmissionRegistry.InvalidationHandler` now carries a concrete `CmxIrohOnlineAdmissionInvalidationReason` (`leaseExpired` / `denied` / `revalidationFailed`), plumbed from every invalidation site including the revalidation terminal paths.
- The host runtime maps those to new append-only `DiagnosticFailureKind` cases `admissionLeaseExpired = 22` and `admissionRevalidationFailed = 23` (`denied` → existing `admissionDenied`), records the cause on the session, and resolves the supervisor exit through it — so the host `sessionClosed` event now names exactly why admission closed the session.
- Admission floor: `authorize()` denies any lease with less than 30s remaining (`minimumAdmissionLeaseRemaining`), for both pair-grant and offline-pair authorities, converting the accept-then-kill churn into a clean, named denial.

Two-commit structure: commit 1 adds the failing admission-floor regression test (red), commit 2 the fix (green).

## Verification

- `Packages/Shared/CmuxIrohTransport`: `swift test` — 465 tests / 56 suites passed (re-run after rebase onto current main).
- `Packages/Shared/CMUXMobileCore`: `swift test` — 277 tests / 23 suites passed.
- New behavior tests: expiry → `.leaseExpired`, revoke → `.denied`, fleet-mismatch revalidation → `.revalidationFailed`, sub-30s lease denied at admission, supervisor-exit resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787440514&installation_model_id=21920&pr_number=8775&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8775&signature=ec2f889a52375edbf51be68e9a39b39f9096272ba1637899c66629c69542f595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Online admission now names policy-driven session closes and blocks leases with less than 30s remaining. Diagnostics on iOS and macOS now display these reasons.

- New Features
  - Added `CmxIrohOnlineAdmissionInvalidationReason` (`leaseExpired`, `denied`, `revalidationFailed`) and plumbed it through the monitor callback.
  - Mapped reasons to `DiagnosticFailureKind`: `admissionLeaseExpired` and `admissionRevalidationFailed` (keeps `admissionDenied`).
  - Persist explicit close failure in `CmxIrohServerSession` and resolve it via `CmxIrohAdmittedServerSession.connectionExit`.
  - Enforced a 30s minimum lease remaining for `authorizePairGrant` and `authorizeOfflinePair`.
  - Added iOS and macOS UI strings (en + ja) for `admissionLeaseExpired` and `admissionRevalidationFailed`.

- Bug Fixes
  - Prevents admitting near-expiry leases that would be closed moments later.
  - `sessionClosed` now reports the exact admission cause instead of generic network failures.

<sup>Written for commit 2674c65cb7fc985c9508456cef33b70af652c4c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new admission diagnostics for expired leases and admission revalidation failures (including localized UI text).
  * Introduced a stricter minimum remaining lease requirement before accepting admissions.
  * Improved tracking of specific invalidation/close reasons during online admission handling.

* **Bug Fixes**
  * Corrected admission monitoring behavior to map failure causes to the appropriate diagnostics and invalidation outcomes.
  * Ensured host-side close failures correctly override and preserve the reported reason.

* **Tests**
  * Expanded async test coverage for lease thresholds, invalidation reasons, and stable diagnostic raw values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->