### PR TITLE
Route agent-team respawns in remote SSH workspaces onto remote pty sessions

### DIFF
--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -249,15 +249,25 @@ extension TerminalController {
         let focus: Bool? = inputs.hasFocusParam
             ? v2FocusAllowed(requested: inputs.requestedFocus)
             : nil
+        var effectiveCommand = inputs.command
+        var shimRewrite: RemoteShimRespawnRewrite?
+        if let rewrite = ws.remoteShimRespawnRewrite(panelId: surfaceId, rawCommand: inputs.command) {
+            effectiveCommand = rewrite.command
+            shimRewrite = rewrite
+        }
         guard let replacementPanel = ws.respawnTerminalSurface(
             panelId: surfaceId,
-            command: inputs.command,
+            command: effectiveCommand,
             workingDirectory: inputs.workingDirectory,
-            tmuxStartCommand: inputs.tmuxStartCommand,
+            tmuxStartCommand: shimRewrite != nil ? effectiveCommand : inputs.tmuxStartCommand,
             focus: focus,
+            waitAfterCommand: shimRewrite != nil ? true : nil,
             allowTextBoxFocusDefault: focus == true
         ) else {
             return .respawnFailed(surfaceId)
+        }
+        if let shimRewrite {
+            ws.applyRemoteShimRespawnBookkeeping(panelId: surfaceId, sessionID: shimRewrite.sessionID)
         }
         return .respawned(
             windowID: v2ResolveWindowId(tabManager: tabManager),

--- a/Sources/Workspace+RemoteShimSurfaceRouting.swift
+++ b/Sources/Workspace+RemoteShimSurfaceRouting.swift
@@ -10,6 +10,32 @@ extension Workspace {
     /// daemon-owned pty session on the remote host. nil = surface is local;
     /// caller proceeds with the ordinary local respawn.
     func remoteShimRespawnRewrite(panelId: UUID, rawCommand: String) -> RemoteShimRespawnRewrite? {
-        nil // red commit: not implemented
+        guard remoteConfiguration != nil else { return nil }
+        guard isRemoteTerminalSurface(panelId)
+            || activeRemoteTerminalSurfaceIds.contains(panelId)
+            || remoteDisconnectPlaceholderPanelIds.contains(panelId) else { return nil }
+        let trimmed = rawCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        // Fresh ID per respawn: reusing the deterministic reattach ID would
+        // join the pane's previous session instead of starting this command.
+        let sessionID = "shim-\(id.uuidString)-\(panelId.uuidString)-\(UUID().uuidString)"
+        let command = remotePTYAttachStartupCommand(
+            sessionID: sessionID,
+            remoteCommand: trimmed,
+            requireExisting: false
+        )
+        return RemoteShimRespawnRewrite(command: command, sessionID: sessionID)
+    }
+
+    /// Same post-respawn bookkeeping the persistent-PTY reattach path does
+    /// (Workspace+PersistentRemotePTYReattach.swift:86-95).
+    func applyRemoteShimRespawnBookkeeping(panelId: UUID, sessionID: String) {
+        remotePTYSessionIDsByPanelId[panelId] = sessionID
+        registerRemoteRelayIDAliases(remotePTYSessionID: sessionID, restoredPanelId: panelId)
+        remoteDisconnectPlaceholderPanelIds.remove(panelId)
+        pendingRemoteTerminalChildExitSurfaceIds.remove(panelId)
+        pendingRemoteDisconnectReplacementsBySurfaceId.removeValue(forKey: panelId)
+        endedPersistentRemotePTYAttachSurfaceIds.remove(panelId)
+        trackRemoteTerminalSurface(panelId)
     }
 }

--- a/Sources/Workspace+RemoteShimSurfaceRouting.swift
+++ b/Sources/Workspace+RemoteShimSurfaceRouting.swift
@@ -34,6 +34,37 @@ extension Workspace {
     /// this respawn replaced it, or nil if the pane had no prior remote session.
     @discardableResult
     func applyRemoteShimRespawnBookkeeping(panelId: UUID, sessionID: String) -> String? {
+        // If a previous remote session was tracked for this pane, end it before
+        // registering the replacement.  Persistent daemon sessions survive detach
+        // for up to 24 hours by design; without an explicit close the replaced
+        // session would linger as an orphan until the idle-reap TTL fires.
+        let previousSessionID = remotePTYSessionIDsByPanelId[panelId]
+        let isReplacing = previousSessionID != nil && previousSessionID != sessionID
+        if let previousSessionID, isReplacing {
+            // Clear relay aliases for the old session.  We do NOT call
+            // markRemotePTYAttachEnded here because that function calls
+            // untrackRemoteTerminalSurface, which would transiently empty
+            // activeRemoteTerminalSurfaceIds and cascade to
+            // maybeDemoteRemoteWorkspaceAfterSSHSessionEnded →
+            // disconnectRemoteConnection(clearConfiguration: true), killing the
+            // workspace mid-respawn.  The guard in markRemotePTYAttachEnded also
+            // fires on the old session ID only when it still equals the map entry,
+            // so reordering (registering the new ID first) would silently no-op it.
+            // The two pieces of markRemotePTYAttachEnded the replaced-session case
+            // genuinely needs are:
+            //   1. removeRemoteRelaySurfaceAliases — clears stale relay routing
+            //      entries for the old session so the new one is unambiguous.
+            //   2. closeRemotePTYSession — daemon-side kill of the orphaned session.
+            // The third piece (untrackRemoteTerminalSurface) must be skipped: the
+            // pane stays tracked because it is being immediately re-registered.
+            // The endedPersistentRemotePTYAttachSurfaceIds bookkeeping is also
+            // skipped: that flag marks a *terminated* pane; respawn is the opposite.
+            removeRemoteRelaySurfaceAliases(targeting: panelId)
+            // Best-effort daemon-side kill.  closeRemotePTYSession throws when
+            // the remote connection is not active (e.g. in unit tests or after
+            // disconnect); swallow those errors silently.
+            try? closeRemotePTYSession(sessionID: previousSessionID)
+        }
         remotePTYSessionIDsByPanelId[panelId] = sessionID
         registerRemoteRelayIDAliases(remotePTYSessionID: sessionID, restoredPanelId: panelId)
         remoteDisconnectPlaceholderPanelIds.remove(panelId)
@@ -41,6 +72,6 @@ extension Workspace {
         pendingRemoteDisconnectReplacementsBySurfaceId.removeValue(forKey: panelId)
         endedPersistentRemotePTYAttachSurfaceIds.remove(panelId)
         trackRemoteTerminalSurface(panelId)
-        return nil
+        return isReplacing ? previousSessionID : nil
     }
 }

--- a/Sources/Workspace+RemoteShimSurfaceRouting.swift
+++ b/Sources/Workspace+RemoteShimSurfaceRouting.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct RemoteShimRespawnRewrite: Equatable {
+    let command: String
+    let sessionID: String
+}
+
+extension Workspace {
+    /// Reroutes shim/relay respawns of remote-tracked surfaces onto a fresh
+    /// daemon-owned pty session on the remote host. nil = surface is local;
+    /// caller proceeds with the ordinary local respawn.
+    func remoteShimRespawnRewrite(panelId: UUID, rawCommand: String) -> RemoteShimRespawnRewrite? {
+        nil // red commit: not implemented
+    }
+}

--- a/Sources/Workspace+RemoteShimSurfaceRouting.swift
+++ b/Sources/Workspace+RemoteShimSurfaceRouting.swift
@@ -29,7 +29,11 @@ extension Workspace {
 
     /// Same post-respawn bookkeeping the persistent-PTY reattach path does
     /// (Workspace+PersistentRemotePTYReattach.swift:86-95).
-    func applyRemoteShimRespawnBookkeeping(panelId: UUID, sessionID: String) {
+    ///
+    /// Returns the previous session ID for the pane, if one was tracked before
+    /// this respawn replaced it, or nil if the pane had no prior remote session.
+    @discardableResult
+    func applyRemoteShimRespawnBookkeeping(panelId: UUID, sessionID: String) -> String? {
         remotePTYSessionIDsByPanelId[panelId] = sessionID
         registerRemoteRelayIDAliases(remotePTYSessionID: sessionID, restoredPanelId: panelId)
         remoteDisconnectPlaceholderPanelIds.remove(panelId)
@@ -37,5 +41,6 @@ extension Workspace {
         pendingRemoteDisconnectReplacementsBySurfaceId.removeValue(forKey: panelId)
         endedPersistentRemotePTYAttachSurfaceIds.remove(panelId)
         trackRemoteTerminalSurface(panelId)
+        return nil
     }
 }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5811,7 +5811,7 @@ final class Workspace: Identifiable, ObservableObject {
         syncRemoteRelayIDAliasesToController()
     }
 
-    private func removeRemoteRelaySurfaceAliases(targeting panelId: UUID) {
+    func removeRemoteRelaySurfaceAliases(targeting panelId: UUID) {
         let nextAliases = remoteRelaySurfaceIDAliases.filter { $0.value != panelId }
         guard nextAliases != remoteRelaySurfaceIDAliases else { return }
         remoteRelaySurfaceIDAliases = nextAliases

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1795,6 +1795,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */; };
 		C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
+		63A6792ED28244D28F5E9A83 /* RemoteShimSurfaceRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95FA2E4CBC042628EE67957 /* RemoteShimSurfaceRoutingTests.swift */; };
 		A71100000000000000000001 /* TailscaleStatusProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71100000000000000000002 /* TailscaleStatusProviding.swift */; };
 		C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000000001 /* TaskManagerResourcesTests.swift */; };
 		C7A503000000000000000002 /* TaskManagerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A503000000000000000001 /* TaskManagerSnapshot.swift */; };
@@ -2073,6 +2074,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */; };
 		791100010000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */; };
 		7989B0057989B0057989B005 /* Workspace+RemoteRelayCommandRewrite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1057989B1057989B105 /* Workspace+RemoteRelayCommandRewrite.swift */; };
+		51A3E82C604B4E8CB2E62730 /* Workspace+RemoteShimSurfaceRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37996A7C5AD2472083D94F54 /* Workspace+RemoteShimSurfaceRouting.swift */; };
 		806100010000000000000001 /* Workspace+RemoteSessionLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806100010000000000000002 /* Workspace+RemoteSessionLifecycle.swift */; };
 		7989B0047989B0047989B004 /* Workspace+RemoteSurfaceResumeBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7989B1047989B1047989B104 /* Workspace+RemoteSurfaceResumeBinding.swift */; };
 		7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */; };
@@ -3954,6 +3956,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateStalenessTests.swift; sourceTree = "<group>"; };
 		C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
+		C95FA2E4CBC042628EE67957 /* RemoteShimSurfaceRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShimSurfaceRoutingTests.swift; sourceTree = "<group>"; };
 		A71100000000000000000002 /* TailscaleStatusProviding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TailscaleStatusProviding.swift; sourceTree = "<group>"; };
 		C7A507000000000000000001 /* TaskManagerResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerResourcesTests.swift; sourceTree = "<group>"; };
 		C7A503000000000000000001 /* TaskManagerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerSnapshot.swift; sourceTree = "<group>"; };
@@ -4232,6 +4235,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PersistentRemotePTYReattach.swift"; sourceTree = "<group>"; };
 		791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteDisconnectPlaceholder.swift"; sourceTree = "<group>"; };
 		7989B1057989B1057989B105 /* Workspace+RemoteRelayCommandRewrite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteRelayCommandRewrite.swift"; sourceTree = "<group>"; };
+		37996A7C5AD2472083D94F54 /* Workspace+RemoteShimSurfaceRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteShimSurfaceRouting.swift"; sourceTree = "<group>"; };
 		806100010000000000000002 /* Workspace+RemoteSessionLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteSessionLifecycle.swift"; sourceTree = "<group>"; };
 		7989B1047989B1047989B104 /* Workspace+RemoteSurfaceResumeBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteSurfaceResumeBinding.swift"; sourceTree = "<group>"; };
 		7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTmuxControlTopology.swift"; sourceTree = "<group>"; };
@@ -5059,6 +5063,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */,
 				806100010000000000000002 /* Workspace+RemoteSessionLifecycle.swift */,
 				7989B1057989B1057989B105 /* Workspace+RemoteRelayCommandRewrite.swift */,
+				37996A7C5AD2472083D94F54 /* Workspace+RemoteShimSurfaceRouting.swift */,
 				7989B1047989B1047989B104 /* Workspace+RemoteSurfaceResumeBinding.swift */,
 				8300A0030000000000000003 /* Workspace+SSHConnectionBroker.swift */,
 				791102020000000000000001 /* RemoteDisconnectPreparationService.swift */,
@@ -6429,6 +6434,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */,
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				C95FA2E4CBC042628EE67957 /* RemoteShimSurfaceRoutingTests.swift */,
 				AB12CD340000000000000002 /* WorkspaceTodoNotificationRegressionTests.swift */,
 				DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */,
 				9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */,
@@ -8405,6 +8411,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				797800030000000000000001 /* Workspace+PersistentRemotePTYReattach.swift in Sources */,
 				791100010000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift in Sources */,
 				7989B0057989B0057989B005 /* Workspace+RemoteRelayCommandRewrite.swift in Sources */,
+				51A3E82C604B4E8CB2E62730 /* Workspace+RemoteShimSurfaceRouting.swift in Sources */,
 				806100010000000000000001 /* Workspace+RemoteSessionLifecycle.swift in Sources */,
 				7989B0047989B0047989B004 /* Workspace+RemoteSurfaceResumeBinding.swift in Sources */,
 				7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */,
@@ -9123,6 +9130,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */,
 				C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
+				63A6792ED28244D28F5E9A83 /* RemoteShimSurfaceRoutingTests.swift in Sources */,
 				C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */,
 				C7A507000000000000004529 /* TaskManagerViewSnapshotBoundaryTests.swift in Sources */,
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,

--- a/cmuxTests/RemoteShimSurfaceRoutingTests.swift
+++ b/cmuxTests/RemoteShimSurfaceRoutingTests.swift
@@ -11,11 +11,6 @@ import CmuxCore
 
 @MainActor
 struct RemoteShimSurfaceRoutingTests {
-    // Helper: build a workspace with a remote configuration and one tracked
-    // remote terminal panel. Follow the construction pattern used by the
-    // nearest existing Workspace unit test (grep: "remoteConfiguration ="
-    // in cmuxTests/ and Packages/*/Tests for a factory/stub; reuse it).
-
     private func makeRemoteWorkspaceWithTrackedPanel() throws -> Workspace {
         let workspace = Workspace()
         let config = WorkspaceRemoteConfiguration(
@@ -63,7 +58,7 @@ struct RemoteShimSurfaceRoutingTests {
 
     @Test func respawnRewriteReroutesTrackedRemoteSurface() throws {
         let ws = try makeRemoteWorkspaceWithTrackedPanel()
-        let panelId = ws.activeRemoteTerminalSurfaceIds.first!
+        let panelId = try #require(ws.activeRemoteTerminalSurfaceIds.first)
         let raw = "cd /Users/bencollins/Development/Braid && env CLAUDECODE=1 claude --agent-id x"
 
         let rewrite = ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: raw)
@@ -81,7 +76,7 @@ struct RemoteShimSurfaceRoutingTests {
 
     @Test func respawnRewriteMintsFreshSessionIDs() throws {
         let ws = try makeRemoteWorkspaceWithTrackedPanel()
-        let panelId = ws.activeRemoteTerminalSurfaceIds.first!
+        let panelId = try #require(ws.activeRemoteTerminalSurfaceIds.first)
         let a = ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: "echo a")
         let b = ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: "echo b")
         #expect(try #require(a).sessionID != (try #require(b).sessionID))
@@ -91,7 +86,7 @@ struct RemoteShimSurfaceRoutingTests {
 
     @Test func respawnRewriteLeavesLocalWorkspacesAlone() throws {
         let ws = try makeLocalWorkspaceWithTerminalPanel()
-        let panelId = ws.panels.keys.first!
+        let panelId = try #require(ws.panels.keys.first)
         #expect(ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: "echo x") == nil)
     }
 

--- a/cmuxTests/RemoteShimSurfaceRoutingTests.swift
+++ b/cmuxTests/RemoteShimSurfaceRoutingTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+import Bonsplit
+import CmuxCore
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+struct RemoteShimSurfaceRoutingTests {
+    // Helper: build a workspace with a remote configuration and one tracked
+    // remote terminal panel. Follow the construction pattern used by the
+    // nearest existing Workspace unit test (grep: "remoteConfiguration ="
+    // in cmuxTests/ and Packages/*/Tests for a factory/stub; reuse it).
+
+    private func makeRemoteWorkspaceWithTrackedPanel() throws -> Workspace {
+        let workspace = Workspace()
+        let config = WorkspaceRemoteConfiguration(
+            destination: "cmux-test-remote",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: nil,
+            relayID: nil,
+            relayToken: nil,
+            localSocketPath: nil,
+            terminalStartupCommand: "ssh cmux-test-remote"
+        )
+        workspace.configureRemoteConnection(config, autoConnect: false)
+        _ = try #require(workspace.focusedTerminalPanel)
+        return workspace
+    }
+
+    private func makeLocalWorkspaceWithTerminalPanel() throws -> Workspace {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        _ = try #require(workspace.focusedTerminalPanel)
+        return workspace
+    }
+
+    // Add a terminal panel to a remote workspace that is NOT tracked as a
+    // remote surface. suppressWorkspaceRemoteStartupCommand: true skips the
+    // remote startup command so the panel does not enter
+    // activeRemoteTerminalSurfaceIds.
+    @discardableResult
+    private func addLocalUntrackedTerminalPanel(to workspace: Workspace) throws -> UUID {
+        let paneId = try #require(
+            workspace.bonsplitController.focusedPaneId ?? workspace.bonsplitController.allPaneIds.first
+        )
+        let panel = try #require(
+            workspace.newTerminalSurface(
+                inPane: paneId,
+                focus: false,
+                suppressWorkspaceRemoteStartupCommand: true
+            )
+        )
+        return panel.id
+    }
+
+    @Test func respawnRewriteReroutesTrackedRemoteSurface() throws {
+        let ws = try makeRemoteWorkspaceWithTrackedPanel()
+        let panelId = ws.activeRemoteTerminalSurfaceIds.first!
+        let raw = "cd /Users/bencollins/Development/Braid && env CLAUDECODE=1 claude --agent-id x"
+
+        let rewrite = ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: raw)
+
+        let r = try #require(rewrite)
+        // Must NOT exec the raw command locally:
+        #expect(!r.command.contains("Development/Braid"))
+        // Must be the ssh-pty-attach bridge carrying the command as base64:
+        #expect(r.command.contains("ssh-pty-attach"))
+        #expect(r.command.contains(Data(raw.utf8).base64EncodedString()))
+        // Must create the session (no --require-existing):
+        #expect(!r.command.contains("--require-existing"))
+        #expect(r.command.contains(r.sessionID))
+    }
+
+    @Test func respawnRewriteMintsFreshSessionIDs() throws {
+        let ws = try makeRemoteWorkspaceWithTrackedPanel()
+        let panelId = ws.activeRemoteTerminalSurfaceIds.first!
+        let a = ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: "echo a")
+        let b = ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: "echo b")
+        #expect(try #require(a).sessionID != (try #require(b).sessionID))
+        // Never the deterministic reattach ID — that would join a stale session:
+        #expect(try #require(a).sessionID != Workspace.defaultSSHPTYSessionID(workspaceId: ws.id, panelId: panelId))
+    }
+
+    @Test func respawnRewriteLeavesLocalWorkspacesAlone() throws {
+        let ws = try makeLocalWorkspaceWithTerminalPanel()
+        let panelId = ws.panels.keys.first!
+        #expect(ws.remoteShimRespawnRewrite(panelId: panelId, rawCommand: "echo x") == nil)
+    }
+
+    @Test func respawnRewriteLeavesUntrackedLocalPanesInRemoteWorkspaceAlone() throws {
+        let ws = try makeRemoteWorkspaceWithTrackedPanel()
+        let localPanelId = try addLocalUntrackedTerminalPanel(to: ws)
+        #expect(ws.remoteShimRespawnRewrite(panelId: localPanelId, rawCommand: "echo x") == nil)
+    }
+}

--- a/cmuxTests/RemoteShimSurfaceRoutingTests.swift
+++ b/cmuxTests/RemoteShimSurfaceRoutingTests.swift
@@ -100,4 +100,40 @@ struct RemoteShimSurfaceRoutingTests {
         let localPanelId = try addLocalUntrackedTerminalPanel(to: ws)
         #expect(ws.remoteShimRespawnRewrite(panelId: localPanelId, rawCommand: "echo x") == nil)
     }
+
+    /// A respawn that replaces an existing remote session must surface the old
+    /// session ID so callers can end it on the daemon.  Without this, the
+    /// replaced persistent session lingers for its full 24-hour idle TTL.
+    @Test func respawnBookkeepingEndsTrackedPreviousSession() throws {
+        let ws = try makeRemoteWorkspaceWithTrackedPanel()
+        let panelId = try #require(ws.activeRemoteTerminalSurfaceIds.first)
+        let oldSessionID = "shim-old-\(ws.id.uuidString)-\(panelId.uuidString)-\(UUID().uuidString)"
+        let newSessionID = "shim-new-\(ws.id.uuidString)-\(panelId.uuidString)-\(UUID().uuidString)"
+        // Simulate the pane already having a tracked remote session from a prior respawn.
+        ws.remotePTYSessionIDsByPanelId[panelId] = oldSessionID
+
+        let endedSessionID = ws.applyRemoteShimRespawnBookkeeping(panelId: panelId, sessionID: newSessionID)
+
+        // The old session ID must be returned so the caller can end it daemon-side.
+        #expect(endedSessionID == oldSessionID)
+        // The new session must be registered in its place.
+        #expect(ws.remotePTYSessionIDsByPanelId[panelId] == newSessionID)
+        // The panel must remain tracked as an active remote terminal.
+        #expect(ws.activeRemoteTerminalSurfaceIds.contains(panelId))
+    }
+
+    /// A respawn on a pane with no prior remote session returns nil (nothing to end).
+    @Test func respawnBookkeepingWithNoPreviousSessionReturnsNil() throws {
+        let ws = try makeRemoteWorkspaceWithTrackedPanel()
+        let panelId = try #require(ws.activeRemoteTerminalSurfaceIds.first)
+        // Ensure no prior session is tracked for this panel.
+        ws.remotePTYSessionIDsByPanelId.removeValue(forKey: panelId)
+        let newSessionID = "shim-\(ws.id.uuidString)-\(panelId.uuidString)-\(UUID().uuidString)"
+
+        let endedSessionID = ws.applyRemoteShimRespawnBookkeeping(panelId: panelId, sessionID: newSessionID)
+
+        #expect(endedSessionID == nil)
+        #expect(ws.remotePTYSessionIDsByPanelId[panelId] == newSessionID)
+        #expect(ws.activeRemoteTerminalSurfaceIds.contains(panelId))
+    }
 }

--- a/cmuxTests/RemoteShimSurfaceRoutingTests.swift
+++ b/cmuxTests/RemoteShimSurfaceRoutingTests.swift
@@ -136,4 +136,20 @@ struct RemoteShimSurfaceRoutingTests {
         #expect(ws.remotePTYSessionIDsByPanelId[panelId] == newSessionID)
         #expect(ws.activeRemoteTerminalSurfaceIds.contains(panelId))
     }
+
+    /// A respawn that receives the same session ID the pane already tracks is a
+    /// no-op: the session must not be torn down and then immediately re-registered
+    /// (which would kill a session that is being reattached after a reconnect).
+    @Test func respawnBookkeepingWithSameSessionIDIsNoOp() throws {
+        let ws = try makeRemoteWorkspaceWithTrackedPanel()
+        let panelId = try #require(ws.activeRemoteTerminalSurfaceIds.first)
+        let sessionID = "shim-same-\(ws.id.uuidString)-\(panelId.uuidString)-\(UUID().uuidString)"
+        ws.remotePTYSessionIDsByPanelId[panelId] = sessionID
+
+        let endedSessionID = ws.applyRemoteShimRespawnBookkeeping(panelId: panelId, sessionID: sessionID)
+
+        #expect(endedSessionID == nil)
+        #expect(ws.remotePTYSessionIDsByPanelId[panelId] == sessionID)
+        #expect(ws.activeRemoteTerminalSurfaceIds.contains(panelId))
+    }
 }


### PR DESCRIPTION
Follow-up to #8660. That PR made the Go relay's `__tmux-compat` accept `respawn-pane`, so Claude Code agent teams over SSH got panes — but the GUI-side `surface.respawn` handler execs the (remote-host) command strings in LOCAL Ghostty surfaces. On a real two-machine pair the teammate tabs die instantly: `cd <remote cwd>: No such file or directory`. (#8660's verification was loopback SSH on one Mac, where remote and local paths coincide — this failure mode is structurally invisible there.)

## Fix (Swift-only; no daemon changes)

When the target surface of a `surface.respawn` is a remote-tracked surface in a relay workspace, the handler rewrites the exec into the existing `ssh-pty-attach` bridge (the `reattachPersistentRemotePTYPanels` pattern) with `requireExisting: false` and the raw command delivered via `--command-b64`. The teammate process runs in a daemon-owned pty session on the remote host; the local surface is just the attached viewer, with the bridge's existing reconnect retry. A fresh session ID is minted per respawn, and the pane's previous pty session is explicitly closed (`respawn-pane -k` semantics) so replaced sessions don't linger as daemon-side orphans until the 24h idle reap.

Teammate pane *creation* (`split-window` → `surface.split`) needs no change: the existing split path already gives panes in remote workspaces the workspace remote startup command and remote tracking — that tracking is what arms this fix's respawn gate.

## Commit structure

Two red/green regression pairs per repo policy (respawn rewrite; previous-session cleanup), one characterization test, one test-tidy commit. Honest caveat: the characterization test (same-session-ID no-op guard) locks in behavior that was never broken — it has no red phase, unlike the two regression pairs.

## Notes / caveats

- `tmux_start_command` for rewritten respawns stores the bridge command rather than the shim's raw command (reattach precedent; restoring the raw remote command locally on session restore would resurrect the original bug). This deviates from the shim's raw-command contract: command-less `respawn-pane -k` replay of such a pane is unsupported.
- Session cleanup is best-effort: a respawn issued while the workspace is disconnected orphans the replaced daemon session until the idle-reap TTL (acknowledged in code comments).
- Unit tests (7, `cmuxTests/RemoteShimSurfaceRoutingTests`) cover the Workspace-level rewrite/bookkeeping helpers; the controller wiring and live daemon kill are being proven by a real two-machine dogfood run (laptop GUI → Mac mini over Tailscale SSH) — draft until that passes.
- Localization audit: no user-facing strings changed (diff adds code and comments only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787442269&installation_model_id=21920&pr_number=8780&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8780&signature=d331fa260cacf5e5424591221e9ebee22f7bf8819d532be396fa9e2c3004450d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route respawns of remote-tracked panes in SSH/relay workspaces through the remote PTY bridge so commands run on the remote host, fixing agent-team tabs that crashed from local path execution. Each respawn creates a fresh remote session and cleans up the previous one to avoid orphaned sessions.

- **Bug Fixes**
  - Rewrite `surface.respawn` for remote-tracked surfaces to use the existing `ssh-pty-attach` bridge with `--command-b64` and `requireExisting: false`, so the process runs on the remote host while the local pane is just a viewer.
  - Store the bridge command in `tmuxStartCommand`, set `waitAfterCommand`, and mint per-respawn session IDs; best-effort close of the replaced session and relay-alias cleanup without untracking the pane.
  - Add tests for reroute behavior, fresh session IDs, previous-session cleanup, same-session no-op, and ensuring local/untracked panes are unaffected.

<sup>Written for commit 9d17d31125a7864a7fa2e09106aabd0b7ad8f87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

