### PR TITLE
Keep Iroh reconnects alive through control-plane outages

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -80,7 +80,17 @@ extension CmxIrohHostRuntime {
         // Discovery follows registration in one trust round. Honor a restored
         // discovery floor first so activation cannot spend a registration call
         // that is guaranteed to stop at the next broker operation.
-        try await broker.preflight(operation: .discovery)
+        do {
+            try await broker.preflight(operation: .discovery)
+        } catch {
+            return try cachedPolicy(
+                after: error,
+                expectedEndpointID: expectedEndpointID,
+                confirmedBinding: nil,
+                relayBootstrap: nil,
+                allowFallback: allowCachedFallback
+            )
+        }
         try requireCurrent(revision)
         let publicHints = Array(address.pathHints.compactMap {
             $0.publicDisclosure(at: now())
@@ -174,7 +184,9 @@ extension CmxIrohHostRuntime {
            CmxIrohBrokerBindingMetadata(binding: confirmedBinding) != localBinding {
             throw CmxIrohHostRuntimeError.invalidLocalBinding
         }
-        guard allowFallback, Self.isConnectivityFailure(error),
+        guard allowFallback,
+              CmxIrohTrustBrokerClientError
+                .preservesVerifiedPolicyDuringRefresh(error),
               let cached = configuration.cachedHostPolicy else {
             throw error
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -604,10 +604,4 @@ public actor CmxIrohHostRuntime {
         )
     }
 
-    static func isConnectivityFailure(_ error: any Error) -> Bool {
-        guard let brokerError = error as? CmxIrohTrustBrokerClientError else {
-            return false
-        }
-        return brokerError == .connectivity
-    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -433,6 +433,38 @@ extension CmxIrohHostRuntimeTests {
     }
 
     @Test
+    func restoredBrokerCooldownUsesVerifiedCacheBeforeRegistration() async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let cachedPolicy = try cachedFixture.policy()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            preflightErrors: [
+                CmxIrohBrokerCooldownError(retryAfterSeconds: 600),
+            ]
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
+            ),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            handleTransport: { session, _ in await session.close() }
+        )
+
+        try await runtime.start()
+
+        #expect(await broker.observedRegistrationCount() == 0)
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
+        await runtime.stop()
+    }
+
+    @Test
     func endpointNetworkChangeRequestsImmediateLANRefresh() async throws {
         let fixture = try HostRuntimeFixture()
         let endpoint = TestIrohEndpoint(identity: fixture.endpointID)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeLifecycleTests.swift
@@ -393,6 +393,45 @@ extension CmxIrohHostRuntimeTests {
         await runtime.stop()
     }
 
+    @Test(arguments: [
+        CmxIrohTrustBrokerClientError.rateLimited(
+            code: "rate_limited",
+            retryAfterSeconds: 600
+        ),
+        .rejected(statusCode: 503, code: "relay_policy_unavailable"),
+    ])
+    func transientBrokerFailureUsesVerifiedCacheWithoutWaitingForRetry(
+        _ failure: CmxIrohTrustBrokerClientError
+    ) async throws {
+        let fixture = try HostRuntimeFixture()
+        let cachedFixture = try fixture.cachedPolicyFixture()
+        let now = cachedFixture.now
+        let cachedPolicy = try cachedFixture.policy()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: failure
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
+            ),
+            broker: broker,
+            configuration: fixture.configuration(cachedHostPolicy: cachedPolicy),
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { now },
+            registrationClock: ImmediateHostActivationClock(),
+            handleTransport: { session, _ in await session.close() }
+        )
+
+        try await runtime.start()
+
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .active)
+        #expect(await runtime.snapshot().bindingID == cachedPolicy.binding.bindingID)
+        await runtime.stop()
+    }
+
     @Test
     func endpointNetworkChangeRequestsImmediateLANRefresh() async throws {
         let fixture = try HostRuntimeFixture()

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/RPCTaskTimeout.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/RPCTaskTimeout.swift
@@ -1,7 +1,14 @@
 import Foundation
 
-struct RPCTaskTimeout: Sendable {
-    func value<T: Sendable>(
+/// Races asynchronous work against the mobile RPC deadline scheduler.
+///
+/// The scheduler owns settlement through an actor, so callers do not need
+/// timing tasks, polling, or manual synchronization.
+public struct RPCTaskTimeout: Sendable {
+    public init() {}
+
+    /// Returns a task's value or throws when its deadline expires.
+    public func value<T: Sendable>(
         _ task: Task<T, any Error>,
         timeoutNanoseconds: UInt64
     ) async throws -> T {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -907,53 +907,27 @@ extension MobileShellComposite {
         _ operation: @escaping @Sendable () async -> Value
     ) async -> DeadlineRaceOutcome<Value> {
         let operationTask = Task { await operation() }
-        // The operation runs unstructured (so a cancellation-ignoring dial
-        // cannot park the race past its deadline), which severs implicit
-        // cancellation inheritance — forward the caller's cancellation
-        // explicitly so a superseded recovery attempt still aborts a
-        // well-behaved dial immediately.
-        let value: Value? = await withTaskCancellationHandler {
-            await withCheckedContinuation { (continuation: CheckedContinuation<Value?, Never>) in
-                let once = RaceContinuationOnce(continuation)
-                Task {
-                    once.finish(await operationTask.value)
-                }
-                Task {
-                    // Intentional bounded deadline timer (not a polling wait);
-                    // cancellation of the race cancels the operation via the
-                    // handler above, and this timer resolves the race at the
-                    // bound either way.
-                    try? await ContinuousClock().sleep(for: .nanoseconds(Int64(nanoseconds)))
-                    operationTask.cancel()
-                    once.finish(nil)
-                }
-            }
-        } onCancel: {
+        // RPCTaskTimeout owns the deadline race through an actor. Keep the
+        // operation itself separate so a cancellation-ignoring FFI dial does
+        // not park the timeout scheduler; the returned handle accounts for
+        // that abandoned work until it eventually resolves.
+        let deadlineWaiter = Task<Value, any Error> {
+            await operationTask.value
+        }
+        let value: Value?
+        do {
+            value = try await RPCTaskTimeout().value(
+                deadlineWaiter,
+                timeoutNanoseconds: nanoseconds
+            )
+        } catch {
+            deadlineWaiter.cancel()
             operationTask.cancel()
+            value = nil
         }
         return DeadlineRaceOutcome(
             value: value,
             abandoned: value == nil ? operationTask : nil
         )
-    }
-}
-
-/// Resumes a race continuation exactly once, whichever side finishes first.
-/// Lock-based rather than actor-based so both racing tasks can call it
-/// without an isolation hop.
-private final class RaceContinuationOnce<Value: Sendable>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<Value?, Never>?
-
-    init(_ continuation: CheckedContinuation<Value?, Never>) {
-        self.continuation = continuation
-    }
-
-    func finish(_ value: Value?) {
-        lock.lock()
-        let continuation = self.continuation
-        self.continuation = nil
-        lock.unlock()
-        continuation?.resume(returning: value)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -238,56 +238,16 @@ extension MobileShellComposite {
 
                 // Recovery uses authenticated local Iroh state first. A stuck
                 // account-backup fetch must not block a known EndpointID from
-                // dialing; normal launch reconnect still refreshes first.
-                //
-                // The redial runs under a hard deadline: while an attempt is
-                // in flight the recovery owner defers every other trigger, so
-                // one hung dial would otherwise freeze the recovery machine
-                // (https://github.com/manaflow-ai/cmux/issues/8531). The
-                // deadline is applied HERE, not inside the shared reconnect
-                // entry, because a blanket detached wrapper severs the dial's
-                // synchronous prefix and breaks reconnect serialization for
-                // lifecycle callers; bounding those callers is tracked as a
-                // follow-up.
-                let deadlineNanoseconds = self.runtime?.reconnectAttemptDeadlineNanoseconds
-                    ?? 30_000_000_000
-                let race = await Self.raceAgainstDeadline(
-                    nanoseconds: deadlineNanoseconds
-                ) { [weak self] in
-                    await self?.reconnectActiveMacOutcome(
-                        stackUserID: stackUserID,
-                        refreshBackupBeforeDial: false
-                    ) ?? .superseded
-                }
-                // Account for a wedged dial BEFORE any currency guard: a
-                // cancelled or superseded attempt whose race still hit the
-                // deadline would otherwise drop the only handle to a task
-                // that keeps retaining the client and transport, bypassing
-                // the abandoned-dial ceiling.
-                self.registerAbandonedReconnectDial(race.abandoned)
+                // dialing; normal launch reconnect still refreshes first. The
+                // shared reconnect entry owns the hard deadline after claiming
+                // its generation synchronously, so every lifecycle caller gets
+                // the same wedge protection without a second race here.
+                let reconnectOutcome = await self.reconnectActiveMacOutcome(
+                    stackUserID: stackUserID,
+                    refreshBackupBeforeDial: false
+                )
                 guard !Task.isCancelled,
                       self.connectionRecoveryOwner.isCurrent(attempt) else { return }
-                guard let reconnectOutcome = race.value else {
-                    MobileDebugLog.anchormux(
-                        "connection.recovery redial deadline expired; abandoning attempt \(attempt.id.uuidString)"
-                    )
-                    guard self.failConnectionRecovery(attempt, failure: .timedOut) else { return }
-                    if self.connectionState == .connected {
-                        self.connectionState = .disconnected
-                        self.macConnectionStatus = .unavailable
-                        self.clearRemoteConnectionContext()
-                    }
-                    // Schedule the next automatic try only while the number of
-                    // still-wedged abandoned dials is bounded; each dial that
-                    // eventually resolves re-arms the retry itself. Manual,
-                    // foreground, and network-change triggers are never gated.
-                    if self.abandonedReconnectDialCount <= Self.maximumAbandonedReconnectDials,
-                       let accountID = stackUserID ?? self.identityProvider?.currentUserID {
-                        self.recordTransientAutomaticReconnectBackoff(accountID: accountID)
-                    }
-                    self.applyConnectionRecoveryOwnerState()
-                    return
-                }
                 guard self.settleConnectionRecovery(
                     attempt,
                     outcome: reconnectOutcome,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1814,6 +1814,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         stackUserID: String?
     ) async -> Bool {
         guard !isReconnectingStoredMac else { return false }
+        if let accountID = stackUserID ?? identityProvider?.currentUserID {
+            clearTransientAutomaticReconnectBackoff(accountID: accountID)
+        }
         isReconnectingStoredMac = true
         return await reconnectActiveMacIfAvailable(stackUserID: stackUserID)
     }
@@ -1853,6 +1856,49 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             self.didFinishStoredMacReconnectAttempt = true
         }
         defer { restoringDeadline.cancel() }
+        // Run the awaited restore/dial phase under the same hard ceiling for
+        // startup, team changes, manual fallback, and automatic recovery. The
+        // generation claim above remains synchronous, preserving serialization
+        // while the unstructured operation can be abandoned if an FFI dial
+        // ignores cancellation.
+        let deadlineNanoseconds = runtime?.reconnectAttemptDeadlineNanoseconds
+            ?? 30_000_000_000
+        let race = await Self.raceAgainstDeadline(
+            nanoseconds: deadlineNanoseconds
+        ) { [weak self] in
+            await self?.performReconnectActiveMacAttempt(
+                stackUserID: stackUserID,
+                refreshBackupBeforeDial: refreshBackupBeforeDial,
+                generation: generation
+            ) ?? .superseded
+        }
+        registerAbandonedReconnectDial(race.abandoned)
+        if let outcome = race.value {
+            if outcome.didConnect, multiMacAggregationEnabled {
+                // Start secondary dials only after the bounded foreground
+                // operation has handed ownership back to this shared entry.
+                // This preserves foreground-first ordering even though the
+                // deadline race executes the awaited phase in a child task.
+                scheduleSecondaryAggregation()
+            }
+            return outcome
+        }
+        MobileDebugLog.anchormux(
+            "storedMacReconnect deadline expired generation=\(generation)"
+        )
+        finishStoredMacReconnectAttempt(generation: generation)
+        if abandonedReconnectDialCount <= Self.maximumAbandonedReconnectDials,
+           let accountID = stackUserID ?? identityProvider?.currentUserID {
+            recordTransientAutomaticReconnectBackoff(accountID: accountID)
+        }
+        return .failed(.timedOut)
+    }
+
+    private func performReconnectActiveMacAttempt(
+        stackUserID: String?,
+        refreshBackupBeforeDial: Bool,
+        generation: Int
+    ) async -> StoredMacReconnectOutcome {
         // No store / not signed in: can't determine a stored Mac here. Resolve the
         // restoring gate (so a returning user doesn't spin on RestoringSessionView)
         // but leave the persisted hint intact for a future attempt.
@@ -5521,7 +5567,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     }
                     // Aggregate the user's other Macs' workspaces in the background.
                     // Best-effort; never blocks the foreground connect.
-                    if multiMacAggregationEnabled {
+                    if multiMacAggregationEnabled, !isReconnectingStoredMac {
                         self.scheduleSecondaryAggregation()
                     }
                     diagnosticLog?.record(DiagnosticEvent(.pairOk))

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectAttemptDeadlineTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectAttemptDeadlineTests.swift
@@ -147,6 +147,28 @@ extension ReconnectRouteSelectionTests {
         }
     }
 
+    @Test func explicitRootRetryBypassesAutomaticIrohBackoff() async throws {
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(router: router, box: box)
+        let runtime = LivenessTestRuntime(
+            transportFactory: factory,
+            now: Date.init,
+            supportedRouteKinds: [.iroh]
+        )
+        let store = try await makeReconnectStore(
+            routes: [try iroh()],
+            runtime: runtime
+        )
+        store.recordTransientAutomaticReconnectBackoff(accountID: "user-1")
+        #expect(store.automaticIrohReconnectIsBlocked(accountID: "user-1"))
+
+        #expect(await store.retryActiveMacReconnect(stackUserID: "user-1"))
+
+        #expect(store.connectionState == .connected)
+        #expect(factory.attemptedKinds() == [.iroh])
+    }
+
     @Test func hungRedialSettlesAtDeadlineAndUnfreezesRecovery() async throws {
         let clock = TestClock()
         let router = LivenessHostRouter()
@@ -157,8 +179,9 @@ extension ReconnectRouteSelectionTests {
             now: { clock.now },
             supportedRouteKinds: [.iroh]
         )
-        // Small enough that the test settles fast; the production default is 30s.
-        runtime.reconnectAttemptDeadlineNanoseconds = 150_000_000
+        // Keep the initial healthy dial stable under full-suite contention while
+        // remaining far below the production default of 30 seconds.
+        runtime.reconnectAttemptDeadlineNanoseconds = 1_000_000_000
         let store = try await makeReconnectStore(
             routes: [try iroh()],
             runtime: runtime

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectAttemptDeadlineTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectAttemptDeadlineTests.swift
@@ -13,18 +13,22 @@ import Testing
 @MainActor
 extension ReconnectRouteSelectionTests {
     @Test func deadlineRaceReturnsNilWhenOperationIgnoresCancellation() async {
+        let gate = ReconnectDeadlineTestGate()
         // The race must not structurally await the losing side: an operation
         // that never completes AND ignores cancellation (the wedged-FFI-dial
         // shape) must still let the deadline resolve the race.
         let outcome = await MobileShellComposite.raceAgainstDeadline(
             nanoseconds: 50_000_000
         ) {
-            await withCheckedContinuation { (_: CheckedContinuation<Int, Never>) in
-                // Parked forever; no cancellation handler on purpose.
-            }
+            await gate.wait()
+            return 1
         }
         #expect(outcome.value == nil)
         #expect(outcome.abandoned != nil, "the wedged operation is handed back for bounded tracking")
+        await gate.release()
+        if let abandoned = outcome.abandoned {
+            _ = await abandoned.value
+        }
     }
 
     @Test func deadlineRaceReturnsOperationValueWhenItWins() async {
@@ -96,6 +100,53 @@ extension ReconnectRouteSelectionTests {
         #expect(!store.isReconnectingStoredMac)
     }
 
+    @Test func lifecycleReconnectReturnsAtHardDeadlineWhenStoreRestoreHangs() async throws {
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(router: router, box: box)
+        var runtime = LivenessTestRuntime(
+            transportFactory: factory,
+            now: Date.init,
+            supportedRouteKinds: [.iroh]
+        )
+        runtime.reconnectAttemptDeadlineNanoseconds = 100_000_000
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: ["": []],
+            blockedTeams: [""]
+        )
+        let store = MobileShellComposite(
+            runtime: runtime,
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "reconnect-lifecycle-deadline-\(UUID().uuidString)"
+            )!,
+            storedMacReconnectRestoringDeadlineSeconds: 5
+        )
+
+        let reconnect = Task {
+            await store.reconnectActiveMacIfAvailable(stackUserID: "user-1")
+        }
+        await pairedStore.waitUntilLoadStarted(teamID: nil)
+        let returned = await MobileShellComposite.raceAgainstDeadline(
+            nanoseconds: 1_000_000_000
+        ) {
+            await reconnect.value
+        }
+
+        #expect(returned.value == false, "lifecycle callers must return at the shared hard deadline")
+        #expect(store.didFinishStoredMacReconnectAttempt)
+        #expect(!store.isReconnectingStoredMac)
+
+        await pairedStore.release(teamID: nil)
+        _ = await reconnect.value
+        if let abandoned = returned.abandoned {
+            _ = await abandoned.value
+        }
+    }
+
     @Test func hungRedialSettlesAtDeadlineAndUnfreezesRecovery() async throws {
         let clock = TestClock()
         let router = LivenessHostRouter()
@@ -161,5 +212,27 @@ extension ReconnectRouteSelectionTests {
         }
         #expect(reconnected, "manual retry after a settled deadline must reconnect")
         #expect(factory.attemptedKinds().count > dialsBeforeManual)
+    }
+}
+
+private actor ReconnectDeadlineTestGate {
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var isReleased = false
+
+    func wait() async {
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            if isReleased {
+                continuation.resume()
+            } else {
+                releaseContinuation = continuation
+            }
+        }
+    }
+
+    func release() {
+        isReleased = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
     }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/8531

Related lifecycle context: https://github.com/manaflow-ai/cmux/issues/8573

## Summary

- Keep the last verified signed relay policy active through broker connectivity failures, cooldowns, rate limits, and transient server failures.
- Give every stored-Mac reconnect caller one actor-owned 30-second hard deadline, cap abandoned Iroh dials at three, and let explicit Retry bypass automatic cooldown.
- The optional relay limiter infrastructure decision is already on main via https://github.com/manaflow-ai/cmux/pull/8771.

## Testing

- Shared Iroh transport: 467 tests in 56 suites passed.
- Mobile reconnect selection: 64 tests passed.
- Tagged macOS build and isolated iOS simulator build passed.
- Stored-pair startup reached `sync.subscribe_ok`.
- Restarting the tagged Mac recovered the iOS subscription and workspace, followed by repeated successful liveness probes.
- `/`, `/handler/sign-in`, and `/handler/after-sign-in` returned 200 from the local API.

## Demo Video

- No video. Exact-head behavior was verified on the isolated `Codex-irrel-49440` simulator and tagged `irrel` Mac app.

## Review Trigger

Automatic repository reviews run on push. No manual Codex review was requested.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] Docs and changelog are not needed for this internal reliability change
- [x] Automatic review bots were triggered by the latest push
- [ ] All code review bot comments are resolved
- [x] There are no human review comments