### PR TITLE
Dock surface runtime parity

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4583,7 +4583,8 @@ struct CMUXCLI {
                         let count = pane["surface_count"] as? Int ?? 0
                         let prefix = focused ? "* " : "  "
                         let focusTag = focused ? "  [focused]" : ""
-                        print("\(prefix)\(handle)  [\(count) surface\(count == 1 ? "" : "s")]\(focusTag)")
+                        let dockTag = dockScopeTag(pane)
+                        print("\(prefix)\(handle)  [\(count) surface\(count == 1 ? "" : "s")]\(dockTag)\(focusTag)")
                     }
                 }
             }
@@ -4606,13 +4607,14 @@ struct CMUXCLI {
                 if surfaces.isEmpty {
                     print("No surfaces in pane")
                 } else {
+                    let dockTag = dockScopeTag(payload)
                     for surface in surfaces {
                         let selected = (surface["selected"] as? Bool) == true
                         let handle = textHandle(surface, idFormat: idFormat)
                         let title = (surface["title"] as? String) ?? ""
                         let prefix = selected ? "* " : "  "
                         let selTag = selected ? "  [selected]" : ""
-                        print("\(prefix)\(handle)  \(title)\(selTag)")
+                        print("\(prefix)\(handle)  \(title)\(dockTag)\(selTag)")
                     }
                 }
             }
@@ -4853,7 +4855,8 @@ struct CMUXCLI {
                         let prefix = focused ? "* " : "  "
                         let focusTag = focused ? "  [focused]" : ""
                         let titlePart = title.isEmpty ? "" : "  \"\(title)\""
-                        print("\(prefix)\(handle)  \(sType)\(focusTag)\(titlePart)")
+                        let dockTag = dockScopeTag(surface)
+                        print("\(prefix)\(handle)  \(sType)\(dockTag)\(focusTag)\(titlePart)")
                     }
                 }
             }
@@ -17933,7 +17936,14 @@ struct CMUXCLI {
             if workspaces.isEmpty {
                 throw CLIError(message: "Workspace not found")
             }
-            let workspaceNodes = try workspaces.map { try buildTreeWorkspaceNode(workspace: $0, activePath: activePath, client: client) }
+            let workspaceNodes = try workspaces.map {
+                try buildTreeWorkspaceNode(
+                    workspace: $0,
+                    activePath: activePath,
+                    includeGlobalDock: true,
+                    client: client
+                )
+            }
             var node = window
             let isActiveWindow = treeItemMatchesHandle(node, handle: activePath.windowHandle)
             node["current"] = isActiveWindow
@@ -17993,7 +18003,14 @@ struct CMUXCLI {
         }
         let workspacePayload = try client.sendV2(method: "workspace.list", params: workspaceParams)
         let workspaces = workspacePayload["workspaces"] as? [[String: Any]] ?? []
-        let workspaceNodes = try workspaces.map { try buildTreeWorkspaceNode(workspace: $0, activePath: activePath, client: client) }
+        let workspaceNodes = try workspaces.map {
+            try buildTreeWorkspaceNode(
+                workspace: $0,
+                activePath: activePath,
+                includeGlobalDock: ($0["selected"] as? Bool) == true,
+                client: client
+            )
+        }
         var windowNode = window
         let isActiveWindow = treeItemMatchesHandle(windowNode, handle: activePath.windowHandle)
         windowNode["current"] = isActiveWindow
@@ -18006,6 +18023,7 @@ struct CMUXCLI {
     private func buildTreeWorkspaceNode(
         workspace: [String: Any],
         activePath: TreePath,
+        includeGlobalDock: Bool,
         client: SocketClient
     ) throws -> [String: Any] {
         var workspaceNode = workspace
@@ -18016,8 +18034,12 @@ struct CMUXCLI {
 
         let panePayload = try client.sendV2(method: "pane.list", params: ["workspace_id": workspaceHandle])
         let surfacePayload = try client.sendV2(method: "surface.list", params: ["workspace_id": workspaceHandle])
-        let panes = panePayload["panes"] as? [[String: Any]] ?? []
-        let surfaces = surfacePayload["surfaces"] as? [[String: Any]] ?? []
+        let panes = (panePayload["panes"] as? [[String: Any]] ?? []).filter {
+            includeGlobalDock || ($0["dock_scope"] as? String) != "global"
+        }
+        let surfaces = (surfacePayload["surfaces"] as? [[String: Any]] ?? []).filter {
+            includeGlobalDock || ($0["dock_scope"] as? String) != "global"
+        }
         let browserURLsByHandle = fetchTreeBrowserURLs(
             workspaceHandle: workspaceHandle,
             surfaces: surfaces,
@@ -18305,6 +18327,9 @@ struct CMUXCLI {
 
     private func treePaneLabel(_ pane: [String: Any], idFormat: CLIIDFormat) -> String {
         var parts = ["pane \(textHandle(pane, idFormat: idFormat))"]
+        if let dockScope = pane["dock_scope"] as? String {
+            parts.append("[dock:\(dockScope)]")
+        }
         if (pane["focused"] as? Bool) == true {
             parts.append("[focused]")
         }
@@ -18318,6 +18343,9 @@ struct CMUXCLI {
         let rawType = ((surface["type"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let surfaceType = rawType.isEmpty ? "unknown" : rawType
         var parts = ["surface \(textHandle(surface, idFormat: idFormat))", "[\(surfaceType)]"]
+        if let dockScope = surface["dock_scope"] as? String {
+            parts.append("[dock:\(dockScope)]")
+        }
         let title = (surface["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !title.isEmpty {
             parts.append("\"\(title)\"")
@@ -18340,6 +18368,11 @@ struct CMUXCLI {
             parts.append(url)
         }
         return parts.joined(separator: " ")
+    }
+
+    private func dockScopeTag(_ item: [String: Any]) -> String {
+        guard let scope = item["dock_scope"] as? String else { return "" }
+        return "  [dock:\(scope)]"
     }
 
     private func renderTopText(

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
@@ -159,6 +159,9 @@ extension ControlCommandCoordinator {
                     dict["cell_height_points"] = .double(height)
                 }
             }
+            if let dockScope = pane.dockScopeRawValue {
+                dict["dock_scope"] = .string(dockScope)
+            }
             return .object(dict)
         }
 
@@ -264,17 +267,21 @@ extension ControlCommandCoordinator {
             return .err(code: "not_found", message: "Pane or workspace not found", data: nil)
         case let .resolved(snapshot, surfaceRefs, workspaceRef, paneRef, windowRef):
             let surfaces: [JSONValue] = snapshot.surfaces.enumerated().map { index, surface in
-                .object([
+                var item: [String: JSONValue] = [
                     "id": orNull(surface.surfaceID?.uuidString),
                     "ref": surfaceRefs[index],
                     "index": .int(Int64(index)),
                     "title": .string(surface.title),
                     "type": orNull(surface.typeRawValue),
                     "selected": .bool(surface.isSelected),
-                ])
+                ]
+                if let dockScope = surface.dockScopeRawValue {
+                    item["dock_scope"] = .string(dockScope)
+                }
+                return .object(item)
             }
 
-            return .ok(.object([
+            var payload: [String: JSONValue] = [
                 "workspace_id": .string(snapshot.workspaceID.uuidString),
                 "workspace_ref": workspaceRef,
                 "pane_id": .string(snapshot.paneID.uuidString),
@@ -282,7 +289,11 @@ extension ControlCommandCoordinator {
                 "surfaces": .array(surfaces),
                 "window_id": orNull(snapshot.windowID?.uuidString),
                 "window_ref": windowRef,
-            ]))
+            ]
+            if let dockScope = snapshot.dockScopeRawValue {
+                payload["dock_scope"] = .string(dockScope)
+            }
+            return .ok(.object(payload))
         }
     }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneSummary.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneSummary.swift
@@ -20,6 +20,8 @@ public struct ControlPaneSummary: Sendable, Equatable {
     public let pixelFrame: ControlPanePixelFrame?
     /// The selected surface's terminal grid size, if it is live and reporting.
     public let gridSize: ControlPaneGridSize?
+    /// The Dock container scope for Dock-hosted panes, else `nil`.
+    public let dockScopeRawValue: String?
 
     /// Creates a pane summary.
     ///
@@ -30,13 +32,15 @@ public struct ControlPaneSummary: Sendable, Equatable {
     ///   - selectedSurfaceID: The selected surface, if any.
     ///   - pixelFrame: The pane's pixel frame, if known.
     ///   - gridSize: The selected surface's grid size, if available.
+    ///   - dockScopeRawValue: The Dock scope for a Dock-hosted pane.
     public init(
         paneID: UUID,
         isFocused: Bool,
         surfaceIDs: [UUID],
         selectedSurfaceID: UUID?,
         pixelFrame: ControlPanePixelFrame?,
-        gridSize: ControlPaneGridSize?
+        gridSize: ControlPaneGridSize?,
+        dockScopeRawValue: String? = nil
     ) {
         self.paneID = paneID
         self.isFocused = isFocused
@@ -44,5 +48,6 @@ public struct ControlPaneSummary: Sendable, Equatable {
         self.selectedSurfaceID = selectedSurfaceID
         self.pixelFrame = pixelFrame
         self.gridSize = gridSize
+        self.dockScopeRawValue = dockScopeRawValue
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneSurfaceSummary.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneSurfaceSummary.swift
@@ -17,6 +17,8 @@ public struct ControlPaneSurfaceSummary: Sendable, Equatable {
     public let typeRawValue: String?
     /// Whether this surface is the selected tab in its pane.
     public let isSelected: Bool
+    /// The Dock container scope for a Dock-hosted surface, else `nil`.
+    public let dockScopeRawValue: String?
 
     /// Creates a pane-surface summary.
     ///
@@ -25,15 +27,18 @@ public struct ControlPaneSurfaceSummary: Sendable, Equatable {
     ///   - title: The tab's title.
     ///   - typeRawValue: The panel type's raw value, if resolved.
     ///   - isSelected: Whether this surface is selected.
+    ///   - dockScopeRawValue: The Dock scope for a Dock-hosted surface.
     public init(
         surfaceID: UUID?,
         title: String,
         typeRawValue: String?,
-        isSelected: Bool
+        isSelected: Bool,
+        dockScopeRawValue: String? = nil
     ) {
         self.surfaceID = surfaceID
         self.title = title
         self.typeRawValue = typeRawValue
         self.isSelected = isSelected
+        self.dockScopeRawValue = dockScopeRawValue
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneSurfacesSnapshot.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneSurfacesSnapshot.swift
@@ -15,6 +15,8 @@ public struct ControlPaneSurfacesSnapshot: Sendable, Equatable {
     public let windowID: UUID?
     /// The surfaces in the pane, in tab order.
     public let surfaces: [ControlPaneSurfaceSummary]
+    /// The Dock container scope for a Dock-hosted pane, else `nil`.
+    public let dockScopeRawValue: String?
 
     /// Creates a pane-surfaces snapshot.
     ///
@@ -23,15 +25,18 @@ public struct ControlPaneSurfacesSnapshot: Sendable, Equatable {
     ///   - paneID: The pane the surfaces belong to.
     ///   - windowID: The window the workspace belongs to, if resolved.
     ///   - surfaces: The surfaces in the pane, in order.
+    ///   - dockScopeRawValue: The Dock scope for a Dock-hosted pane.
     public init(
         workspaceID: UUID,
         paneID: UUID,
         windowID: UUID?,
-        surfaces: [ControlPaneSurfaceSummary]
+        surfaces: [ControlPaneSurfaceSummary],
+        dockScopeRawValue: String? = nil
     ) {
         self.workspaceID = workspaceID
         self.paneID = paneID
         self.windowID = windowID
         self.surfaces = surfaces
+        self.dockScopeRawValue = dockScopeRawValue
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -170,6 +170,9 @@ extension ControlCommandCoordinator {
                     item["tmux_start_command"] = orNull(surface.tmuxStartCommand)
                     item["resume_binding"] = surfaceResumeBindingPayload(surface.resumeBinding)
                 }
+                if let dockScope = surface.dockScopeRawValue {
+                    item["dock_scope"] = .string(dockScope)
+                }
                 return .object(item)
             }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceSummary.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceSummary.swift
@@ -40,6 +40,8 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
     /// For terminal surfaces, the resume binding, else `nil`. Emitted as the
     /// `resume_binding` value (a `null` binding still emits the key).
     public let resumeBinding: ControlSurfaceResumeBinding?
+    /// The Dock container scope for Dock-hosted surfaces, else `nil`.
+    public let dockScopeRawValue: String?
 
     /// Creates a surface summary.
     ///
@@ -57,6 +59,7 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
     ///   - tmuxStartCommand: For terminals, the tmux start command.
     ///   - isTerminal: Whether this is a terminal surface.
     ///   - resumeBinding: For terminals, the resume binding.
+    ///   - dockScopeRawValue: The Dock scope for a Dock-hosted surface.
     public init(
         surfaceID: UUID,
         typeRawValue: String,
@@ -70,7 +73,8 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
         initialCommand: String?,
         tmuxStartCommand: String?,
         isTerminal: Bool,
-        resumeBinding: ControlSurfaceResumeBinding?
+        resumeBinding: ControlSurfaceResumeBinding?,
+        dockScopeRawValue: String? = nil
     ) {
         self.surfaceID = surfaceID
         self.typeRawValue = typeRawValue
@@ -85,5 +89,6 @@ public struct ControlSurfaceSummary: Sendable, Equatable {
         self.tmuxStartCommand = tmuxStartCommand
         self.isTerminal = isTerminal
         self.resumeBinding = resumeBinding
+        self.dockScopeRawValue = dockScopeRawValue
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+System.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+System.swift
@@ -288,7 +288,7 @@ extension ControlCommandCoordinator {
         _ node: ControlSystemTreePaneNode,
         refs: SystemTreePaneRefs
     ) -> JSONValue {
-        .object([
+        var item: [String: JSONValue] = [
             "id": .string(node.paneID.uuidString),
             "ref": refs.paneRef,
             "index": .int(Int64(node.index)),
@@ -299,7 +299,11 @@ extension ControlCommandCoordinator {
             "selected_surface_ref": refs.selectedSurfaceRef,
             "surface_count": .int(Int64(node.surfaceIDs.count)),
             "surfaces": .array(zip(node.surfaces, refs.surfaces).map { pair in systemTreeSurfacePayload(pair.0, refs: pair.1) }),
-        ])
+        ]
+        if let dockScope = node.dockScopeRawValue {
+            item["dock_scope"] = .string(dockScope)
+        }
+        return .object(item)
     }
 
     /// The `system.tree` surface node payload (browser surfaces emit their URL
@@ -323,6 +327,9 @@ extension ControlCommandCoordinator {
             "tty": orNull(node.tty),
         ]
         item["url"] = node.isBrowser ? .string(node.url ?? "") : .null
+        if let dockScope = node.dockScopeRawValue {
+            item["dock_scope"] = .string(dockScope)
+        }
         return .object(item)
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreePaneNode.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreePaneNode.swift
@@ -15,6 +15,8 @@ public struct ControlSystemTreePaneNode: Sendable, Equatable {
     public let selectedSurfaceID: UUID?
     /// The pane's surface nodes, pre-sorted by `indexInPane ?? index`.
     public let surfaces: [ControlSystemTreeSurfaceNode]
+    /// The Dock container scope for Dock-hosted panes, else `nil`.
+    public let dockScopeRawValue: String?
 
     /// Creates a pane node.
     ///
@@ -25,13 +27,15 @@ public struct ControlSystemTreePaneNode: Sendable, Equatable {
     ///   - surfaceIDs: The pane's surfaces in tab order.
     ///   - selectedSurfaceID: The selected tab's panel identifier.
     ///   - surfaces: The pane's surface nodes.
+    ///   - dockScopeRawValue: The Dock scope for a Dock-hosted pane.
     public init(
         paneID: UUID,
         index: Int,
         isFocused: Bool,
         surfaceIDs: [UUID],
         selectedSurfaceID: UUID?,
-        surfaces: [ControlSystemTreeSurfaceNode]
+        surfaces: [ControlSystemTreeSurfaceNode],
+        dockScopeRawValue: String? = nil
     ) {
         self.paneID = paneID
         self.index = index
@@ -39,5 +43,6 @@ public struct ControlSystemTreePaneNode: Sendable, Equatable {
         self.surfaceIDs = surfaceIDs
         self.selectedSurfaceID = selectedSurfaceID
         self.surfaces = surfaces
+        self.dockScopeRawValue = dockScopeRawValue
     }
 }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreeSurfaceNode.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreeSurfaceNode.swift
@@ -36,6 +36,8 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
     /// For browser surfaces, the current URL string (`nil` encodes as the
     /// legacy empty string).
     public let url: String?
+    /// The Dock container scope for Dock-hosted surfaces, else `nil`.
+    public let dockScopeRawValue: String?
 
     /// Creates a surface node.
     ///
@@ -52,6 +54,7 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
     ///   - tty: The terminal's tty name, if known.
     ///   - isBrowser: Whether this is a browser surface.
     ///   - url: For browsers, the current URL string.
+    ///   - dockScopeRawValue: The Dock scope for a Dock-hosted surface.
     public init(
         surfaceID: UUID,
         index: Int,
@@ -64,7 +67,8 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
         indexInPane: Int?,
         tty: String?,
         isBrowser: Bool,
-        url: String?
+        url: String?,
+        dockScopeRawValue: String? = nil
     ) {
         self.surfaceID = surfaceID
         self.index = index
@@ -78,5 +82,6 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
         self.tty = tty
         self.isBrowser = isBrowser
         self.url = url
+        self.dockScopeRawValue = dockScopeRawValue
     }
 }

--- a/Sources/AgentDeliveryTargetResolution.swift
+++ b/Sources/AgentDeliveryTargetResolution.swift
@@ -17,8 +17,9 @@ import Foundation
 ///   tty. A pane's pty device is fixed for the pane's lifetime and the
 ///   process's controlling terminal is a live kernel fact, so a unique match
 ///   is authoritative regardless of where the pane has been moved.
-/// - surface → workspace: `AppDelegate.workspaceContainingPanel`, which finds
-///   the workspace that CURRENTLY owns the panel (issue #5781 pane moves).
+/// - surface → notification owner: `AppDelegate.notificationSurfaceOwner`,
+///   which finds the workspace or Dock that CURRENTLY owns the panel (issue
+///   #5781 pane moves and Dock transfers).
 ///
 /// The CLI reaches this through the `agent.resolve_delivery_target` control
 /// method; in-app notification delivery reaches it through
@@ -107,7 +108,7 @@ extension AppDelegate {
     /// process's controlling tty matched against every surface's pty device
     /// (unique-match only), with the exact live process's start-time-keyed
     /// `CMUX_SURFACE_ID` environment re-homed through
-    /// `workspaceContainingPanel` as a nested-PTY fallback. Disagreement fails
+    /// `notificationSurfaceOwner` as a nested-PTY fallback. Disagreement fails
     /// closed.
     func liveAgentDeliveryTarget(forAgentPID pid: pid_t) -> AgentDeliveryTargetCandidate? {
         guard let identity = agentLiveProcessIdentity(pid: pid) else { return nil }
@@ -138,8 +139,11 @@ extension AppDelegate {
         }
         var envTarget: AgentDeliveryTargetCandidate?
         if let envSurfaceId = processScope?.surfaceID,
-           let owner = workspaceContainingPanel(panelId: envSurfaceId) {
-            envTarget = AgentDeliveryTargetCandidate(workspaceId: owner.workspace.id, surfaceId: envSurfaceId)
+           let owner = notificationSurfaceOwner(
+               surfaceID: envSurfaceId,
+               preferredTabID: processScope?.workspaceID
+           ) {
+            envTarget = AgentDeliveryTargetCandidate(workspaceId: owner.tabID, surfaceId: envSurfaceId)
         }
 
         return agentDeliveryTargetCombining(ttyTarget: ttyTarget, envTarget: envTarget)
@@ -160,13 +164,13 @@ extension AppDelegate {
             guard manager?.tabs.contains(where: { $0.id == claimedTabId }) == true else { return nil }
             return (claimedTabId, nil)
         }
-        guard let owner = workspaceContainingPanel(
-            panelId: surfaceId,
-            preferredWorkspaceId: claimedTabId
+        guard let owner = notificationSurfaceOwner(
+            surfaceID: surfaceId,
+            preferredTabID: claimedTabId
         ) else {
             return nil
         }
-        return (owner.workspace.id, surfaceId)
+        return (owner.tabID, surfaceId)
     }
 
     private func agentDeliveryTabManagers() -> [TabManager] {
@@ -237,12 +241,12 @@ extension TerminalController {
             )
         }
         if let claimedSurfaceId,
-           let owner = appDelegate.workspaceContainingPanel(
-               panelId: claimedSurfaceId,
-               preferredWorkspaceId: claimedWorkspaceId
+           let owner = appDelegate.notificationSurfaceOwner(
+               surfaceID: claimedSurfaceId,
+               preferredTabID: claimedWorkspaceId
            ) {
             return .ok([
-                "workspace_id": owner.workspace.id.uuidString,
+                "workspace_id": owner.tabID.uuidString,
                 "surface_id": claimedSurfaceId.uuidString,
                 "source": "surface",
             ])

--- a/Sources/AppDelegate+DockAttentionRouting.swift
+++ b/Sources/AppDelegate+DockAttentionRouting.swift
@@ -3,6 +3,30 @@ import Foundation
 
 @MainActor
 extension AppDelegate {
+    /// Resolves the current notification owner for a surface across every
+    /// container. Dock IDs are stable notification namespaces (`workspaceId`
+    /// is the workspace ID for a workspace Dock and the window ID for a global
+    /// Dock); main-tree surfaces keep the existing workspace owner.
+    func notificationSurfaceOwner(
+        surfaceID: UUID,
+        preferredTabID: UUID? = nil
+    ) -> (tabID: UUID, surfaceID: UUID, tabManager: TabManager)? {
+        if let dock = DockSplitStore.liveStores.first(where: { $0.containsPanel(surfaceID) }) {
+            let manager = dock.scope == .global
+                ? tabManagerFor(windowId: dock.workspaceId)
+                : tabManagerFor(tabId: dock.workspaceId)
+            guard let manager else { return nil }
+            return (dock.workspaceId, surfaceID, manager)
+        }
+        guard let owner = workspaceContainingPanel(
+            panelId: surfaceID,
+            preferredWorkspaceId: preferredTabID
+        ) else {
+            return nil
+        }
+        return (owner.workspace.id, surfaceID, owner.tabManager)
+    }
+
     /// Shared notification-attention route for every surface container. Dock
     /// stores resolve first through their live registry; workspace panels use
     /// the existing attention coordinator and pane-overlay path.

--- a/Sources/AppDelegate+DockAttentionRouting.swift
+++ b/Sources/AppDelegate+DockAttentionRouting.swift
@@ -1,0 +1,61 @@
+import AppKit
+import Foundation
+
+@MainActor
+extension AppDelegate {
+    /// Shared notification-attention route for every surface container. Dock
+    /// stores resolve first through their live registry; workspace panels use
+    /// the existing attention coordinator and pane-overlay path.
+    @discardableResult
+    func routeNotificationAttentionFlash(
+        workspaceID: UUID,
+        panelID: UUID,
+        reason: WorkspaceAttentionFlashReason,
+        requiresSplit: Bool = false,
+        shouldFocus: Bool = false
+    ) -> Bool {
+        if DockSplitStore.routeAttentionFlash(
+            panelID: panelID,
+            reason: reason,
+            requiresSplit: requiresSplit,
+            shouldFocus: shouldFocus
+        ) {
+            return true
+        }
+
+        guard let workspace = workspaceFor(tabId: workspaceID) ??
+                tabManager?.tabs.first(where: { $0.id == workspaceID }),
+              let panel = workspace.panels[panelID],
+              panel.panelType == .terminal else {
+            return false
+        }
+        if shouldFocus {
+            workspace.focusPanel(panelID)
+        }
+        if requiresSplit,
+           workspace.bonsplitController.allPaneIds.count <= 1,
+           workspace.panels.count <= 1 {
+            return true
+        }
+        workspace.requestAttentionFlash(panelId: panelID, reason: reason)
+        return true
+    }
+
+    /// Resolves the surface whose unread notification becomes visible when the
+    /// app activates. The key window's focused global Dock wins when the Dock
+    /// owns input focus; otherwise the selected workspace keeps the existing
+    /// focused-main-surface behavior.
+    func notificationAttentionTargetOnActivation(
+        tabManager: TabManager
+    ) -> (workspaceID: UUID, surfaceID: UUID)? {
+        if let dock = focusedDockStoreForShortcut(preferredWindow: NSApp.keyWindow),
+           let surfaceID = dock.focusedPanelId {
+            return (dock.workspaceId, surfaceID)
+        }
+        guard let workspaceID = tabManager.selectedTabId,
+              let surfaceID = tabManager.focusedSurfaceId(for: workspaceID) else {
+            return nil
+        }
+        return (workspaceID, surfaceID)
+    }
+}

--- a/Sources/AppDelegate+DockSurfaceMove.swift
+++ b/Sources/AppDelegate+DockSurfaceMove.swift
@@ -136,6 +136,11 @@ extension AppDelegate {
             reattachSurfaceToContainer(detached, source)
             return false
         }
+        notificationStore?.rebindSurfaceNotifications(
+            fromTabId: detached.sourceWorkspaceId,
+            toTabId: destinationDock.workspaceId,
+            surfaceId: detached.panelId
+        )
         destinationDock.scheduleDockPortalReconcile(reason: "dock.moveSurfaceIntoDock")
 
         // The surface was attached into the Dock with focus, so record Dock focus

--- a/Sources/AppDelegate+NotificationNavSeams.swift
+++ b/Sources/AppDelegate+NotificationNavSeams.swift
@@ -351,7 +351,15 @@ extension AppDelegate {
     }
 
     func triggerUnreadIndicatorDismissFlash(workspaceId: UUID, panelId: UUID) {
-        unreadJumpWorkspace(forTabId: workspaceId)?.triggerUnreadIndicatorDismissFlash(panelId: panelId)
+        if routeNotificationAttentionFlash(
+            workspaceID: workspaceId,
+            panelID: panelId,
+            reason: .unreadIndicatorDismiss
+        ) {
+            return
+        }
+        unreadJumpWorkspace(forTabId: workspaceId)?
+            .triggerUnreadIndicatorDismissFlash(panelId: panelId)
     }
 
     func clearUnreadAfterJump(workspaceId: UUID, panelId: UUID?) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1806,16 +1806,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let notificationStore else { return }
         notificationStore.handleApplicationDidBecomeActive()
         guard let tabManager else { return }
-        guard let tabId = tabManager.selectedTabId else { return }
-        let surfaceId = tabManager.focusedSurfaceId(for: tabId)
-        guard notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId) else { return }
+        guard let target = notificationAttentionTargetOnActivation(tabManager: tabManager) else { return }
+        guard notificationStore.hasUnreadNotification(
+            forTabId: target.workspaceID,
+            surfaceId: target.surfaceID
+        ) else { return }
 
-        if let surfaceId,
-           let tab = tabManager.tabs.first(where: { $0.id == tabId }),
-           notificationStore.hasUnreadNotificationRequiringPaneFlash(forTabId: tabId, surfaceId: surfaceId) {
-            tab.triggerNotificationFocusFlash(panelId: surfaceId, requiresSplit: false, shouldFocus: false)
+        if notificationStore.hasUnreadNotificationRequiringPaneFlash(
+            forTabId: target.workspaceID,
+            surfaceId: target.surfaceID
+        ) {
+            routeNotificationAttentionFlash(
+                workspaceID: target.workspaceID,
+                panelID: target.surfaceID,
+                reason: .notificationArrival
+            )
         }
-        notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
+        notificationStore.markRead(forTabId: target.workspaceID, surfaceId: target.surfaceID)
     }
 
     /// Sole caller of `NSApp.reply(toApplicationShouldTerminate:)`.

--- a/Sources/DockSplitStore+AttentionRouting.swift
+++ b/Sources/DockSplitStore+AttentionRouting.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@MainActor
+extension DockSplitStore {
+    /// Routes a panel attention request through the shared live-container
+    /// registry. This is the Dock equivalent of Workspace's panel lookup and is
+    /// intentionally container-agnostic: both workspace and global Docks
+    /// register in `liveStores`.
+    @discardableResult
+    static func routeAttentionFlash(
+        panelID: UUID,
+        reason: WorkspaceAttentionFlashReason,
+        requiresSplit: Bool = false,
+        shouldFocus: Bool = false
+    ) -> Bool {
+        guard let dock = liveStores.first(where: { $0.containsPanel(panelID) }),
+              let panel = dock.panels[panelID],
+              panel.panelType == .terminal else {
+            return false
+        }
+        if shouldFocus {
+            dock.focusPanel(panelID)
+        }
+        if requiresSplit,
+           dock.bonsplitController.allPaneIds.count <= 1,
+           dock.panels.count <= 1 {
+            return true
+        }
+        panel.triggerFlash(reason: reason)
+        return true
+    }
+
+    /// Gives a Dock-owned terminal a Dock-owned pane-flash callback. A terminal
+    /// moved out of a workspace can otherwise retain the workspace closure and
+    /// send its flash into the old pane overlay.
+    func installAttentionFlashRouting(for panel: any Panel) {
+        guard let terminal = panel as? TerminalPanel else { return }
+        terminal.onRequestWorkspacePaneFlash = { [weak self, weak terminal] reason in
+            guard let self, let terminal,
+                  let mountedTerminal = self.panels[terminal.id] as? TerminalPanel,
+                  mountedTerminal === terminal else {
+                return
+            }
+            mountedTerminal.hostedView.triggerFlash(
+                style: GhosttySurfaceScrollView.flashStyle(for: reason)
+            )
+        }
+    }
+}

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -528,6 +528,7 @@ final class DockSplitStore: BonsplitDelegate {
     // MARK: - Tab metadata subscriptions
 
     func installSubscription(for panel: any Panel, tracksTerminalTitle: Bool) {
+        installAttentionFlashRouting(for: panel)
         if let browser = panel as? BrowserPanel {
             let cancellable = Publishers.CombineLatest4(
                 browser.$pageTitle.removeDuplicates(),

--- a/Sources/TabManager+NotificationDismissalHosting.swift
+++ b/Sources/TabManager+NotificationDismissalHosting.swift
@@ -131,10 +131,26 @@ extension TabManager: NotificationDismissalHosting {
     }
 
     func workspaceTriggerNotificationDismissFlash(workspaceId: UUID, panelId: UUID) {
-        tabs.first(where: { $0.id == workspaceId })?.triggerNotificationDismissFlash(panelId: panelId)
+        if AppDelegate.shared?.routeNotificationAttentionFlash(
+            workspaceID: workspaceId,
+            panelID: panelId,
+            reason: .notificationDismiss
+        ) == true {
+            return
+        }
+        tabs.first(where: { $0.id == workspaceId })?
+            .triggerNotificationDismissFlash(panelId: panelId)
     }
 
     func workspaceTriggerUnreadIndicatorDismissFlash(workspaceId: UUID, panelId: UUID) {
-        tabs.first(where: { $0.id == workspaceId })?.triggerUnreadIndicatorDismissFlash(panelId: panelId)
+        if AppDelegate.shared?.routeNotificationAttentionFlash(
+            workspaceID: workspaceId,
+            panelID: panelId,
+            reason: .unreadIndicatorDismiss
+        ) == true {
+            return
+        }
+        tabs.first(where: { $0.id == workspaceId })?
+            .triggerUnreadIndicatorDismissFlash(panelId: panelId)
     }
 }

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -74,7 +74,7 @@ extension TerminalController: ControlPaneContext {
             windowID: v2ResolveWindowId(tabManager: tabManager),
             panes: controlPaneSummaries(workspace: ws, snapshot: snapshot) +
                 controlTopologyDocks(workspace: ws, tabManager: tabManager)
-                .flatMap { controlDockPaneSummaries(dock: $0) },
+                .flatMap { controlDockPaneSummaries(dock: $0, includePixelFrames: false) },
             containerWidth: snapshot.containerFrame.width,
             containerHeight: snapshot.containerFrame.height
         )

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -68,63 +68,13 @@ extension TerminalController: ControlPaneContext {
         }
         guard let ws = resolveWorkspace(routing: routing, tabManager: tabManager) else { return nil }
 
-        return controlPaneList(workspace: ws, tabManager: tabManager)
-    }
-
-    private func controlDockPaneList(
-        dock: DockSplitStore,
-        tabManager: TabManager
-    ) -> ControlPaneListSnapshot {
-        let focusedPaneId = dock.bonsplitController.focusedPaneId
-        let snapshot = dock.bonsplitController.layoutSnapshot()
-        let geometryByPaneId = Dictionary(
-            snapshot.panes.map { ($0.paneId, $0.frame) },
-            uniquingKeysWith: { first, _ in first }
-        )
-
-        let panes: [ControlPaneSummary] = dock.bonsplitController.allPaneIds.map { paneId in
-            let tabs = dock.bonsplitController.tabs(inPane: paneId)
-            let surfaceUUIDs: [UUID] = tabs.compactMap { dock.panel(for: $0.id)?.id }
-            let selectedTab = dock.bonsplitController.selectedTab(inPane: paneId)
-            let selectedSurfaceUUID = selectedTab.flatMap { dock.panel(for: $0.id)?.id }
-
-            let pixelFrame: ControlPanePixelFrame? = geometryByPaneId[paneId.id.uuidString].map { frame in
-                ControlPanePixelFrame(x: frame.x, y: frame.y, width: frame.width, height: frame.height)
-            }
-
-            var gridSize: ControlPaneGridSize?
-            if let panelUUID = selectedSurfaceUUID,
-               let panel = dock.panels[panelUUID] as? TerminalPanel,
-               panel.surface.hasLiveSurface,
-               let ghosttySurface = panel.surface.surface {
-                let size = ghostty_surface_size(ghosttySurface)
-                if size.columns > 0 && size.rows > 0 {
-                    let cellPoints = panel.surface.cellSizePoints()
-                    gridSize = ControlPaneGridSize(
-                        columns: Int(size.columns),
-                        rows: Int(size.rows),
-                        cellWidthPx: Int(size.cell_width_px),
-                        cellHeightPx: Int(size.cell_height_px),
-                        cellWidthPoints: cellPoints.map { Double($0.width) },
-                        cellHeightPoints: cellPoints.map { Double($0.height) }
-                    )
-                }
-            }
-
-            return ControlPaneSummary(
-                paneID: paneId.id,
-                isFocused: paneId == focusedPaneId,
-                surfaceIDs: surfaceUUIDs,
-                selectedSurfaceID: selectedSurfaceUUID,
-                pixelFrame: pixelFrame,
-                gridSize: gridSize
-            )
-        }
-
+        let snapshot = ws.bonsplitController.layoutSnapshot()
         return ControlPaneListSnapshot(
-            workspaceID: dock.workspaceId,
-            windowID: dockResultWindowId(for: dock, tabManager: tabManager),
-            panes: panes,
+            workspaceID: ws.id,
+            windowID: v2ResolveWindowId(tabManager: tabManager),
+            panes: controlPaneSummaries(workspace: ws, snapshot: snapshot) +
+                controlTopologyDocks(workspace: ws, tabManager: tabManager)
+                .flatMap { controlDockPaneSummaries(dock: $0) },
             containerWidth: snapshot.containerFrame.width,
             containerHeight: snapshot.containerFrame.height
         )
@@ -163,35 +113,22 @@ extension TerminalController: ControlPaneContext {
             return nil
         }
         if let dock = windowDockForRouting(routing, tabManager: tabManager) {
-            let paneId: PaneID? = {
-                if let paneID {
-                    return dock.bonsplitController.allPaneIds.first(where: { $0.id == paneID })
-                }
-                return dock.bonsplitController.focusedPaneId
-            }()
-            guard let paneId else { return nil }
-
-            let selectedTab = dock.bonsplitController.selectedTab(inPane: paneId)
-            let tabs = dock.bonsplitController.tabs(inPane: paneId)
-
-            let surfaces: [ControlPaneSurfaceSummary] = tabs.map { tab in
-                let panel = dock.panel(for: tab.id)
-                return ControlPaneSurfaceSummary(
-                    surfaceID: panel?.id,
-                    title: tab.title,
-                    typeRawValue: panel?.panelType.rawValue,
-                    isSelected: tab.id == selectedTab?.id
-                )
-            }
-
-            return ControlPaneSurfacesSnapshot(
-                workspaceID: dock.workspaceId,
-                paneID: paneId.id,
-                windowID: dockResultWindowId(for: dock, tabManager: tabManager),
-                surfaces: surfaces
+            return controlDockPaneSurfaces(
+                dock: dock,
+                paneID: paneID,
+                tabManager: tabManager
             )
         }
         guard let ws = resolveWorkspace(routing: routing, tabManager: tabManager) else { return nil }
+        if let paneID,
+           let dock = ws._dockSplit,
+           dock.containsPane(paneID) {
+            return controlDockPaneSurfaces(
+                dock: dock,
+                paneID: paneID,
+                tabManager: tabManager
+            )
+        }
 
         return controlPaneSurfaces(workspace: ws, paneID: paneID, tabManager: tabManager)
     }

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -114,58 +114,9 @@ extension TerminalController: ControlSurfaceContext {
         return ControlSurfaceListSnapshot(
             workspaceID: ws.id,
             windowID: v2ResolveWindowId(tabManager: tabManager),
-            surfaces: controlSurfaceSummaries(workspace: ws)
-        )
-    }
-
-    private func controlDockSurfaceList(
-        dock: DockSplitStore,
-        tabManager: TabManager
-    ) -> ControlSurfaceListSnapshot {
-        var paneByPanelId: [UUID: UUID] = [:]
-        var indexInPaneByPanelId: [UUID: Int] = [:]
-        var selectedInPaneByPanelId: [UUID: Bool] = [:]
-        for paneId in dock.bonsplitController.allPaneIds {
-            let tabs = dock.bonsplitController.tabs(inPane: paneId)
-            let selected = dock.bonsplitController.selectedTab(inPane: paneId)
-            for (idx, tab) in tabs.enumerated() {
-                guard let panel = dock.panel(for: tab.id) else { continue }
-                paneByPanelId[panel.id] = paneId.id
-                indexInPaneByPanelId[panel.id] = idx
-                selectedInPaneByPanelId[panel.id] = (tab.id == selected?.id)
-            }
-        }
-
-        let focusedSurfaceId = dock.focusedPanelId
-        let surfaces: [ControlSurfaceSummary] = orderedPanels(in: dock).map { panel in
-            let terminalPanel = panel as? TerminalPanel
-            return ControlSurfaceSummary(
-                surfaceID: panel.id,
-                typeRawValue: panel.panelType.rawValue,
-                title: dockPanelTitle(panel, in: dock),
-                isFocused: panel.id == focusedSurfaceId,
-                paneID: paneByPanelId[panel.id],
-                indexInPane: indexInPaneByPanelId[panel.id],
-                selectedInPane: selectedInPaneByPanelId[panel.id],
-                developerToolsVisible: (panel as? BrowserPanel)?.isDeveloperToolsVisible(),
-                requestedWorkingDirectory: terminalPanel.flatMap {
-                    v2NonEmptyString($0.requestedWorkingDirectory)
-                },
-                initialCommand: terminalPanel.flatMap {
-                    v2NonEmptyString($0.surface.debugInitialCommand())
-                },
-                tmuxStartCommand: terminalPanel.flatMap {
-                    v2NonEmptyString($0.surface.debugTmuxStartCommand())
-                },
-                isTerminal: terminalPanel != nil,
-                resumeBinding: nil
-            )
-        }
-
-        return ControlSurfaceListSnapshot(
-            workspaceID: dock.workspaceId,
-            windowID: dockResultWindowId(for: dock, tabManager: tabManager),
-            surfaces: surfaces
+            surfaces: controlSurfaceSummaries(workspace: ws) +
+                controlTopologyDocks(workspace: ws, tabManager: tabManager)
+                .flatMap { controlDockSurfaceSummaries(dock: $0) }
         )
     }
 

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -116,13 +116,15 @@ extension TerminalController: ControlSystemContext {
         )
     }
 
-    /// Projects the authoritative control-plane workspace topology shared by
-    /// `system.tree`, `system.top`, and the task-manager snapshot.
+    /// Projects the requested control-plane workspace containers. Tree callers
+    /// include Dock stores; legacy top/task-manager callers explicitly pass
+    /// none because Dock process attribution is outside the list/tree parity
+    /// scope.
     func controlSystemTreeWorkspaceNode(
         workspace: Workspace,
         index: Int,
         selected: Bool,
-        dockStores: [DockSplitStore] = []
+        dockStores: [DockSplitStore]
     ) -> ControlSystemTreeWorkspaceNode {
         var surfacesByPane: [UUID: [ControlSystemTreeSurfaceNode]] = [:]
         let surfaceSummaries = controlSurfaceSummaries(workspace: workspace) +

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -54,7 +54,11 @@ extension TerminalController: ControlSystemContext {
                     let workspaceNode = controlSystemTreeWorkspaceNode(
                         workspace: workspace,
                         index: workspaceIndex,
-                        selected: workspace.id == manager.selectedTabId
+                        selected: workspace.id == manager.selectedTabId,
+                        dockStores: controlTopologyDocks(
+                            workspace: workspace,
+                            tabManager: manager
+                        )
                     )
                     windows = [
                         ControlSystemTreeWindowNode(
@@ -72,10 +76,16 @@ extension TerminalController: ControlSystemContext {
                 }
 
                 let workspaceNodesForWindow = manager.tabs.enumerated().map { workspaceIndex, workspace in
-                    controlSystemTreeWorkspaceNode(
+                    let selected = workspace.id == manager.selectedTabId
+                    return controlSystemTreeWorkspaceNode(
                         workspace: workspace,
                         index: workspaceIndex,
-                        selected: workspace.id == manager.selectedTabId
+                        selected: selected,
+                        dockStores: controlTopologyDocks(
+                            workspace: workspace,
+                            tabManager: manager,
+                            includeGlobalDock: selected
+                        )
                     )
                 }
 
@@ -111,11 +121,15 @@ extension TerminalController: ControlSystemContext {
     func controlSystemTreeWorkspaceNode(
         workspace: Workspace,
         index: Int,
-        selected: Bool
+        selected: Bool,
+        dockStores: [DockSplitStore] = []
     ) -> ControlSystemTreeWorkspaceNode {
         var surfacesByPane: [UUID: [ControlSystemTreeSurfaceNode]] = [:]
-        for (surfaceIndex, surface) in controlSurfaceSummaries(workspace: workspace).enumerated() {
-            let panel = workspace.controlSurfaceTarget(for: surface.surfaceID)?.panel
+        let surfaceSummaries = controlSurfaceSummaries(workspace: workspace) +
+            dockStores.flatMap { controlDockSurfaceSummaries(dock: $0) }
+        for (surfaceIndex, surface) in surfaceSummaries.enumerated() {
+            let panel = workspace.controlSurfaceTarget(for: surface.surfaceID)?.panel ??
+                dockStores.lazy.compactMap { $0.panels[surface.surfaceID] }.first
             let browserPanel = panel as? BrowserPanel
             let node = ControlSystemTreeSurfaceNode(
                 surfaceID: surface.surfaceID,
@@ -129,7 +143,8 @@ extension TerminalController: ControlSystemContext {
                 indexInPane: surface.indexInPane,
                 tty: workspace.surfaceTTYNames[surface.surfaceID],
                 isBrowser: browserPanel != nil,
-                url: browserPanel?.currentURL?.absoluteString
+                url: browserPanel?.currentURL?.absoluteString,
+                dockScopeRawValue: surface.dockScopeRawValue
             )
             if let paneUUID = surface.paneID {
                 surfacesByPane[paneUUID, default: []].append(node)
@@ -145,7 +160,7 @@ extension TerminalController: ControlSystemContext {
         let paneSummaries = controlPaneSummaries(
             workspace: workspace,
             snapshot: workspace.bonsplitController.layoutSnapshot()
-        )
+        ) + dockStores.flatMap { controlDockPaneSummaries(dock: $0) }
         let panes: [ControlSystemTreePaneNode] = paneSummaries.enumerated().map { paneIndex, pane in
             ControlSystemTreePaneNode(
                 paneID: pane.paneID,
@@ -153,7 +168,8 @@ extension TerminalController: ControlSystemContext {
                 isFocused: pane.isFocused,
                 surfaceIDs: pane.surfaceIDs,
                 selectedSurfaceID: pane.selectedSurfaceID,
-                surfaces: surfacesByPane[pane.paneID] ?? []
+                surfaces: surfacesByPane[pane.paneID] ?? [],
+                dockScopeRawValue: pane.dockScopeRawValue
             )
         }
 

--- a/Sources/TerminalController+DockControlTopology.swift
+++ b/Sources/TerminalController+DockControlTopology.swift
@@ -40,6 +40,7 @@ extension TerminalController {
         var paneByPanelID: [UUID: UUID] = [:]
         var indexInPaneByPanelID: [UUID: Int] = [:]
         var selectedInPaneByPanelID: [UUID: Bool] = [:]
+        var titleByPanelID: [UUID: String] = [:]
         for paneID in dock.bonsplitController.allPaneIds {
             let tabs = dock.bonsplitController.tabs(inPane: paneID)
             let selected = dock.bonsplitController.selectedTab(inPane: paneID)
@@ -48,6 +49,7 @@ extension TerminalController {
                 paneByPanelID[panel.id] = paneID.id
                 indexInPaneByPanelID[panel.id] = index
                 selectedInPaneByPanelID[panel.id] = tab.id == selected?.id
+                titleByPanelID[panel.id] = tab.title
             }
         }
 
@@ -56,7 +58,7 @@ extension TerminalController {
             return ControlSurfaceSummary(
                 surfaceID: panel.id,
                 typeRawValue: panel.panelType.rawValue,
-                title: dockPanelTitle(panel, in: dock),
+                title: titleByPanelID[panel.id] ?? panel.displayTitle,
                 isFocused: panel.id == dock.focusedPanelId,
                 paneID: paneByPanelID[panel.id],
                 indexInPane: indexInPaneByPanelID[panel.id],

--- a/Sources/TerminalController+DockControlTopology.swift
+++ b/Sources/TerminalController+DockControlTopology.swift
@@ -1,0 +1,182 @@
+import Bonsplit
+import CmuxControlSocket
+import Foundation
+import GhosttyKit
+
+@MainActor
+extension TerminalController {
+    /// Returns the Dock containers that contribute to a workspace-scoped
+    /// topology snapshot. The workspace Dock is owned by the workspace; the
+    /// global Dock is owned by the workspace's window. Neither lookup creates a
+    /// Dock merely because a read-only list command ran.
+    func controlTopologyDocks(
+        workspace: Workspace,
+        tabManager: TabManager,
+        includeGlobalDock: Bool = true
+    ) -> [DockSplitStore] {
+        var docks: [DockSplitStore] = []
+        if let workspaceDock = workspace._dockSplit {
+            docks.append(workspaceDock)
+        }
+        if includeGlobalDock,
+           let globalDock = AppDelegate.shared?.existingWindowDock(for: tabManager) {
+            docks.append(globalDock)
+        }
+        return docks
+    }
+
+    func controlDockSurfaceList(
+        dock: DockSplitStore,
+        tabManager: TabManager
+    ) -> ControlSurfaceListSnapshot {
+        ControlSurfaceListSnapshot(
+            workspaceID: dock.workspaceId,
+            windowID: dockResultWindowId(for: dock, tabManager: tabManager),
+            surfaces: controlDockSurfaceSummaries(dock: dock)
+        )
+    }
+
+    func controlDockSurfaceSummaries(dock: DockSplitStore) -> [ControlSurfaceSummary] {
+        var paneByPanelID: [UUID: UUID] = [:]
+        var indexInPaneByPanelID: [UUID: Int] = [:]
+        var selectedInPaneByPanelID: [UUID: Bool] = [:]
+        for paneID in dock.bonsplitController.allPaneIds {
+            let tabs = dock.bonsplitController.tabs(inPane: paneID)
+            let selected = dock.bonsplitController.selectedTab(inPane: paneID)
+            for (index, tab) in tabs.enumerated() {
+                guard let panel = dock.panel(for: tab.id) else { continue }
+                paneByPanelID[panel.id] = paneID.id
+                indexInPaneByPanelID[panel.id] = index
+                selectedInPaneByPanelID[panel.id] = tab.id == selected?.id
+            }
+        }
+
+        return orderedPanels(in: dock).map { panel in
+            let terminal = panel as? TerminalPanel
+            return ControlSurfaceSummary(
+                surfaceID: panel.id,
+                typeRawValue: panel.panelType.rawValue,
+                title: dockPanelTitle(panel, in: dock),
+                isFocused: panel.id == dock.focusedPanelId,
+                paneID: paneByPanelID[panel.id],
+                indexInPane: indexInPaneByPanelID[panel.id],
+                selectedInPane: selectedInPaneByPanelID[panel.id],
+                developerToolsVisible: (panel as? BrowserPanel)?.isDeveloperToolsVisible(),
+                requestedWorkingDirectory: terminal.flatMap {
+                    v2NonEmptyString($0.requestedWorkingDirectory)
+                },
+                initialCommand: terminal.flatMap {
+                    v2NonEmptyString($0.surface.debugInitialCommand())
+                },
+                tmuxStartCommand: terminal.flatMap {
+                    v2NonEmptyString($0.surface.debugTmuxStartCommand())
+                },
+                isTerminal: terminal != nil,
+                resumeBinding: nil,
+                dockScopeRawValue: dock.scope.rawValue
+            )
+        }
+    }
+
+    func controlDockPaneList(
+        dock: DockSplitStore,
+        tabManager: TabManager
+    ) -> ControlPaneListSnapshot {
+        let snapshot = dock.bonsplitController.layoutSnapshot()
+        return ControlPaneListSnapshot(
+            workspaceID: dock.workspaceId,
+            windowID: dockResultWindowId(for: dock, tabManager: tabManager),
+            panes: controlDockPaneSummaries(dock: dock, snapshot: snapshot),
+            containerWidth: snapshot.containerFrame.width,
+            containerHeight: snapshot.containerFrame.height
+        )
+    }
+
+    func controlDockPaneSummaries(
+        dock: DockSplitStore,
+        snapshot: LayoutSnapshot? = nil
+    ) -> [ControlPaneSummary] {
+        let snapshot = snapshot ?? dock.bonsplitController.layoutSnapshot()
+        let focusedPaneID = dock.bonsplitController.focusedPaneId
+        let geometryByPaneID = Dictionary(
+            snapshot.panes.map { ($0.paneId, $0.frame) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        return dock.bonsplitController.allPaneIds.map { paneID in
+            let tabs = dock.bonsplitController.tabs(inPane: paneID)
+            let surfaceIDs = tabs.compactMap { dock.panel(for: $0.id)?.id }
+            let selectedSurfaceID = dock.bonsplitController
+                .selectedTab(inPane: paneID)
+                .flatMap { dock.panel(for: $0.id)?.id }
+            let pixelFrame = geometryByPaneID[paneID.id.uuidString].map {
+                ControlPanePixelFrame(x: $0.x, y: $0.y, width: $0.width, height: $0.height)
+            }
+            let gridSize = selectedSurfaceID
+                .flatMap { dock.panels[$0] as? TerminalPanel }
+                .flatMap { controlDockGridSize(panel: $0) }
+
+            return ControlPaneSummary(
+                paneID: paneID.id,
+                isFocused: paneID == focusedPaneID,
+                surfaceIDs: surfaceIDs,
+                selectedSurfaceID: selectedSurfaceID,
+                pixelFrame: pixelFrame,
+                gridSize: gridSize,
+                dockScopeRawValue: dock.scope.rawValue
+            )
+        }
+    }
+
+    func controlDockPaneSurfaces(
+        dock: DockSplitStore,
+        paneID requestedPaneID: UUID?,
+        tabManager: TabManager
+    ) -> ControlPaneSurfacesSnapshot? {
+        let paneID: PaneID?
+        if let requestedPaneID {
+            paneID = dock.bonsplitController.allPaneIds.first { $0.id == requestedPaneID }
+        } else {
+            paneID = dock.bonsplitController.focusedPaneId
+        }
+        guard let paneID else { return nil }
+
+        let selectedTab = dock.bonsplitController.selectedTab(inPane: paneID)
+        let surfaces = dock.bonsplitController.tabs(inPane: paneID).map { tab in
+            let panel = dock.panel(for: tab.id)
+            return ControlPaneSurfaceSummary(
+                surfaceID: panel?.id,
+                title: tab.title,
+                typeRawValue: panel?.panelType.rawValue,
+                isSelected: tab.id == selectedTab?.id,
+                dockScopeRawValue: dock.scope.rawValue
+            )
+        }
+
+        return ControlPaneSurfacesSnapshot(
+            workspaceID: dock.workspaceId,
+            paneID: paneID.id,
+            windowID: dockResultWindowId(for: dock, tabManager: tabManager),
+            surfaces: surfaces,
+            dockScopeRawValue: dock.scope.rawValue
+        )
+    }
+
+    private func controlDockGridSize(panel: TerminalPanel) -> ControlPaneGridSize? {
+        guard panel.surface.hasLiveSurface,
+              let ghosttySurface = panel.surface.surface else {
+            return nil
+        }
+        let size = ghostty_surface_size(ghosttySurface)
+        guard size.columns > 0, size.rows > 0 else { return nil }
+        let cellPoints = panel.surface.cellSizePoints()
+        return ControlPaneGridSize(
+            columns: Int(size.columns),
+            rows: Int(size.rows),
+            cellWidthPx: Int(size.cell_width_px),
+            cellHeightPx: Int(size.cell_height_px),
+            cellWidthPoints: cellPoints.map { Double($0.width) },
+            cellHeightPoints: cellPoints.map { Double($0.height) }
+        )
+    }
+}

--- a/Sources/TerminalController+DockControlTopology.swift
+++ b/Sources/TerminalController+DockControlTopology.swift
@@ -94,7 +94,8 @@ extension TerminalController {
 
     func controlDockPaneSummaries(
         dock: DockSplitStore,
-        snapshot: LayoutSnapshot? = nil
+        snapshot: LayoutSnapshot? = nil,
+        includePixelFrames: Bool = true
     ) -> [ControlPaneSummary] {
         let snapshot = snapshot ?? dock.bonsplitController.layoutSnapshot()
         let focusedPaneID = dock.bonsplitController.focusedPaneId
@@ -109,9 +110,9 @@ extension TerminalController {
             let selectedSurfaceID = dock.bonsplitController
                 .selectedTab(inPane: paneID)
                 .flatMap { dock.panel(for: $0.id)?.id }
-            let pixelFrame = geometryByPaneID[paneID.id.uuidString].map {
+            let pixelFrame = includePixelFrames ? geometryByPaneID[paneID.id.uuidString].map {
                 ControlPanePixelFrame(x: $0.x, y: $0.y, width: $0.width, height: $0.height)
-            }
+            } : nil
             let gridSize = selectedSurfaceID
                 .flatMap { dock.panels[$0] as? TerminalPanel }
                 .flatMap { controlDockGridSize(panel: $0) }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3049,9 +3049,7 @@ class TerminalController {
         selected: Bool
     ) -> [String: Any] {
         let topology = controlSystemTreeWorkspaceNode(
-            workspace: workspace,
-            index: index,
-            selected: selected
+            workspace: workspace, index: index, selected: selected, dockStores: []
         )
         let panes = topology.panes.map { pane in
             return [

--- a/Sources/TerminalNotificationStore+HookResolution.swift
+++ b/Sources/TerminalNotificationStore+HookResolution.swift
@@ -19,8 +19,17 @@ extension TerminalNotificationStore {
               ) else {
             return
         }
-        let globalConfigPath = appDelegate.contextContainingTabId(initialTarget.tabId)?
-            .cmuxConfigStore?.globalConfigPath
+        let initialManager = initialTarget.surfaceId.flatMap {
+            appDelegate.notificationSurfaceOwner(
+                surfaceID: $0,
+                preferredTabID: initialTarget.tabId
+            )?.tabManager
+        }
+            ?? appDelegate.tabManagerFor(tabId: initialTarget.tabId)
+            ?? appDelegate.tabManager
+        let globalConfigPath = initialManager.flatMap {
+            appDelegate.mainWindowContext(for: $0)?.cmuxConfigStore?.globalConfigPath
+        }
             ?? CmuxConfigStore.defaultGlobalConfigPath()
         let policyRequestId = beginDesktopNotificationHookResolution(
             tabId: initialTarget.tabId,
@@ -42,8 +51,18 @@ extension TerminalNotificationStore {
         guard let target = appDelegate.agentNotificationDeliveryTarget(
                 claimedTabId: tabId,
                 surfaceId: surfaceId
-              ),
-              let owningManager = appDelegate.tabManagerFor(tabId: target.tabId) ?? appDelegate.tabManager else {
+              ) else {
+            return
+        }
+        let owningManager = target.surfaceId.flatMap {
+            appDelegate.notificationSurfaceOwner(
+                surfaceID: $0,
+                preferredTabID: target.tabId
+            )?.tabManager
+        }
+            ?? appDelegate.tabManagerFor(tabId: target.tabId)
+            ?? appDelegate.tabManager
+        guard let owningManager else {
             return
         }
         let workspace = owningManager.workspacesById[target.tabId]

--- a/Sources/Workspace+AttentionFlashRouting.swift
+++ b/Sources/Workspace+AttentionFlashRouting.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+@MainActor
+extension Workspace {
+    func triggerFocusFlash(panelId: UUID) {
+        requestAttentionFlash(panelId: panelId, reason: .navigation)
+    }
+
+    func triggerNotificationFocusFlash(
+        panelId: UUID,
+        requiresSplit: Bool = false,
+        shouldFocus: Bool = true
+    ) {
+        if AppDelegate.shared?.routeNotificationAttentionFlash(
+            workspaceID: id,
+            panelID: panelId,
+            reason: .notificationArrival,
+            requiresSplit: requiresSplit,
+            shouldFocus: shouldFocus
+        ) == true {
+            return
+        }
+        guard terminalPanel(for: panelId) != nil else { return }
+        if shouldFocus {
+            focusPanel(panelId)
+        }
+        let isSplit = bonsplitController.allPaneIds.count > 1 || panels.count > 1
+        if requiresSplit && !isSplit {
+            return
+        }
+        requestAttentionFlash(panelId: panelId, reason: .notificationArrival)
+    }
+
+    func triggerNotificationDismissFlash(panelId: UUID) {
+        if AppDelegate.shared?.routeNotificationAttentionFlash(
+            workspaceID: id,
+            panelID: panelId,
+            reason: .notificationDismiss
+        ) == true {
+            return
+        }
+        guard terminalPanel(for: panelId) != nil else { return }
+        requestAttentionFlash(panelId: panelId, reason: .notificationDismiss)
+    }
+
+    func triggerUnreadIndicatorDismissFlash(panelId: UUID) {
+        if AppDelegate.shared?.routeNotificationAttentionFlash(
+            workspaceID: id,
+            panelID: panelId,
+            reason: .unreadIndicatorDismiss
+        ) == true {
+            return
+        }
+        guard terminalPanel(for: panelId) != nil else { return }
+        requestAttentionFlash(panelId: panelId, reason: .unreadIndicatorDismiss)
+    }
+
+    func triggerDebugFlash(panelId: UUID) {
+        guard panels[panelId] != nil else { return }
+        focusPanel(panelId)
+        requestAttentionFlash(panelId: panelId, reason: .debug)
+    }
+}

--- a/Sources/Workspace+RemoteTmuxControlTopology.swift
+++ b/Sources/Workspace+RemoteTmuxControlTopology.swift
@@ -162,8 +162,14 @@ extension Workspace {
         case .unresolvedMirror:
             return nil
         case .notRemote:
-            guard let panel = panels[surfaceID] else { return nil }
-            return (surfaceID, paneId(forPanelId: surfaceID)?.id, panel)
+            if let panel = panels[surfaceID] {
+                return (surfaceID, paneId(forPanelId: surfaceID)?.id, panel)
+            }
+            guard let dock = _dockSplit,
+                  let panel = dock.panels[surfaceID] else {
+                return nil
+            }
+            return (surfaceID, dock.paneId(forPanelId: surfaceID)?.id, panel)
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4129,7 +4129,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
-    private func requestAttentionFlash(panelId: UUID, reason: WorkspaceAttentionFlashReason) {
+    func requestAttentionFlash(panelId: UUID, reason: WorkspaceAttentionFlashReason) {
         let decision = WorkspaceAttentionCoordinator.decideFlash(
             targetPanelID: panelId,
             reason: reason,
@@ -9592,44 +9592,6 @@ final class Workspace: Identifiable, ObservableObject {
                 includeRefs: true
             )
         )
-    }
-
-    // MARK: - Flash/Notification Support
-
-    func triggerFocusFlash(panelId: UUID) {
-        requestAttentionFlash(panelId: panelId, reason: .navigation)
-    }
-
-    func triggerNotificationFocusFlash(
-        panelId: UUID,
-        requiresSplit: Bool = false,
-        shouldFocus: Bool = true
-    ) {
-        guard terminalPanel(for: panelId) != nil else { return }
-        if shouldFocus {
-            focusPanel(panelId)
-        }
-        let isSplit = bonsplitController.allPaneIds.count > 1 || panels.count > 1
-        if requiresSplit && !isSplit {
-            return
-        }
-        requestAttentionFlash(panelId: panelId, reason: .notificationArrival)
-    }
-
-    func triggerNotificationDismissFlash(panelId: UUID) {
-        guard terminalPanel(for: panelId) != nil else { return }
-        requestAttentionFlash(panelId: panelId, reason: .notificationDismiss)
-    }
-
-    func triggerUnreadIndicatorDismissFlash(panelId: UUID) {
-        guard terminalPanel(for: panelId) != nil else { return }
-        requestAttentionFlash(panelId: panelId, reason: .unreadIndicatorDismiss)
-    }
-
-    func triggerDebugFlash(panelId: UUID) {
-        guard panels[panelId] != nil else { return }
-        focusPanel(panelId)
-        requestAttentionFlash(panelId: panelId, reason: .debug)
     }
 
     // MARK: - Portal Lifecycle

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */; };
 		C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */; };
 		C65930010000000000000003 /* AppDelegate+CrashSessionSnapshotRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65930010000000000000004 /* AppDelegate+CrashSessionSnapshotRemoval.swift */; };
+		8777A0018777A0018777A001 /* AppDelegate+DockAttentionRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777A0028777A0028777A002 /* AppDelegate+DockAttentionRouting.swift */; };
 		DCDC3000000000000000E001 /* AppDelegate+DockShortcutRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC3000000000000000E002 /* AppDelegate+DockShortcutRouting.swift */; };
 		DCDC1000000000000000C000 /* AppDelegate+DockSurfaceMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C001 /* AppDelegate+DockSurfaceMove.swift */; };
 		E3309A01 /* AppDelegate+EqualizeSplitsShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */; };
@@ -794,6 +795,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81390010000000000000002 /* DockShortcutRoutingTests.swift */; };
 		D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */; };
 		DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */; };
+		8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */; };
 		DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */; };
 		DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000A004 /* DockSplitStore+Config.swift */; };
 		DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */; };
@@ -1864,6 +1866,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C57B00040000000000000001 /* TerminalController+CustomSidebarCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57B00040000000000000002 /* TerminalController+CustomSidebarCommands.swift */; };
 		C0DEBEEF0000000000000002 /* TerminalController+DebugMethodNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEBEEF0000000000000001 /* TerminalController+DebugMethodNames.swift */; };
 		A28B087F000000000000000B /* TerminalController+DiffViewerTrust.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F000000000000000C /* TerminalController+DiffViewerTrust.swift */; };
+		8777C0018777C0018777C001 /* TerminalController+DockControlTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777C0028777C0028777C002 /* TerminalController+DockControlTopology.swift */; };
 		A7C0F0020000000000000002 /* TerminalController+MobileAttachTicket.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C0F0020000000000000001 /* TerminalController+MobileAttachTicket.swift */; };
 		ACA7C4A7000000000000000D /* TerminalController+MobileChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000E /* TerminalController+MobileChat.swift */; };
 		C7AF10000000000000000003 /* TerminalController+MobileChatArtifacts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF10000000000000000004 /* TerminalController+MobileChatArtifacts.swift */; };
@@ -2076,6 +2079,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */; };
 		C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE43000000000000000008 /* Workspace+AgentChat.swift */; };
 		A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */; };
+		8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
 		A5FB120D /* Workspace+CustomLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB120E /* Workspace+CustomLayout.swift */; };
@@ -2403,6 +2407,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxNavigationDeepLinks.swift"; sourceTree = "<group>"; };
 		C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxSSHURL.swift"; sourceTree = "<group>"; };
 		C65930010000000000000004 /* AppDelegate+CrashSessionSnapshotRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CrashSessionSnapshotRemoval.swift"; sourceTree = "<group>"; };
+		8777A0028777A0028777A002 /* AppDelegate+DockAttentionRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+DockAttentionRouting.swift"; sourceTree = "<group>"; };
 		DCDC3000000000000000E002 /* AppDelegate+DockShortcutRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+DockShortcutRouting.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000C001 /* AppDelegate+DockSurfaceMove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+DockSurfaceMove.swift"; sourceTree = "<group>"; };
 		E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+EqualizeSplitsShortcut.swift"; sourceTree = "<group>"; };
@@ -2993,6 +2998,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D81390010000000000000002 /* DockShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSocketLifecycleTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Appearance.swift"; sourceTree = "<group>"; };
+		8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+AttentionRouting.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+CloseConfirmation.swift"; sourceTree = "<group>"; };
 		DCDC0000000000000000A004 /* DockSplitStore+Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Config.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PaneFocus.swift"; sourceTree = "<group>"; };
@@ -4043,6 +4049,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C57B00040000000000000002 /* TerminalController+CustomSidebarCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+CustomSidebarCommands.swift"; sourceTree = "<group>"; };
 		C0DEBEEF0000000000000001 /* TerminalController+DebugMethodNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+DebugMethodNames.swift"; sourceTree = "<group>"; };
 		A28B087F000000000000000C /* TerminalController+DiffViewerTrust.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+DiffViewerTrust.swift"; sourceTree = "<group>"; };
+		8777C0028777C0028777C002 /* TerminalController+DockControlTopology.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+DockControlTopology.swift"; sourceTree = "<group>"; };
 		A7C0F0020000000000000001 /* TerminalController+MobileAttachTicket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileAttachTicket.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000E /* TerminalController+MobileChat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileChat.swift"; sourceTree = "<group>"; };
 		C7AF10000000000000000004 /* TerminalController+MobileChatArtifacts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileChatArtifacts.swift"; sourceTree = "<group>"; };
@@ -4255,6 +4262,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7632B14A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/WKWebView+CmuxPrintOperation.swift"; sourceTree = "<group>"; };
 		C0DE43000000000000000008 /* Workspace+AgentChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentChat.swift"; sourceTree = "<group>"; };
 		A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AgentLifecycle.swift"; sourceTree = "<group>"; };
+		8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AttentionFlashRouting.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
 		A5FB120E /* Workspace+CustomLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomLayout.swift"; sourceTree = "<group>"; };
@@ -5095,6 +5103,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001511 /* UITestRecorder.swift */,
 				A5001520 /* PostHogAnalytics.swift */,
 				A5001416 /* Workspace.swift */,
+				8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */,
 				791100020000000000000001 /* Workspace+RemoteDisconnectPlaceholder.swift */,
 				797800030000000000000002 /* Workspace+PersistentRemotePTYReattach.swift */,
 				806100010000000000000002 /* Workspace+RemoteSessionLifecycle.swift */,
@@ -5318,6 +5327,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE00000000000000000C8A /* TerminalController+WorkspaceGroupAction.swift */,
 				C0DE00000000000000000C88 /* TerminalController+WorkspaceMove.swift */,
 				C0DE00000000000000000C55 /* TerminalController+ControlPaneContext.swift */,
+				8777C0028777C0028777C002 /* TerminalController+DockControlTopology.swift */,
 				C7A50B000000000000000001 /* TerminalControllerV2ParamParsingSupport.swift */,
 				C7A50B000000000000000011 /* TerminalController+MobileWorkspaceList.swift */,
 				C7A505000000000000000001 /* TerminalControllerTopSupport.swift */,
@@ -5961,6 +5971,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B00A /* DockControlDefinition.swift */,
 				D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */,
 				DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */,
+				8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */,
 				DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */,
 				DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */,
 				DCDC0000000000000000A004 /* DockSplitStore+Config.swift */,
@@ -5979,6 +5990,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B00E /* DockSurfaceKind.swift */,
 				DCDC1000000000000000B010 /* DockTrustRequest.swift */,
 				D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */,
+				8777A0028777A0028777A002 /* AppDelegate+DockAttentionRouting.swift */,
 				DCDC3000000000000000E002 /* AppDelegate+DockShortcutRouting.swift */,
 				CA52D0010000000000000000 /* Canvas */,
 				CA52F0020000000000000000 /* TerminalController+ControlCanvasContext.swift */,
@@ -7267,6 +7279,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */,
 				C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */,
 				C65930010000000000000003 /* AppDelegate+CrashSessionSnapshotRemoval.swift in Sources */,
+				8777A0018777A0018777A001 /* AppDelegate+DockAttentionRouting.swift in Sources */,
 				DCDC3000000000000000E001 /* AppDelegate+DockShortcutRouting.swift in Sources */,
 				DCDC1000000000000000C000 /* AppDelegate+DockSurfaceMove.swift in Sources */,
 				E3309A01 /* AppDelegate+EqualizeSplitsShortcut.swift in Sources */,
@@ -7578,6 +7591,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */,
 				DCDC1000000000000000C020 /* DockScope.swift in Sources */,
 				DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */,
+				8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */,
 				DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */,
 				DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */,
 				DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */,
@@ -8298,6 +8312,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C57B00040000000000000001 /* TerminalController+CustomSidebarCommands.swift in Sources */,
 				C0DEBEEF0000000000000002 /* TerminalController+DebugMethodNames.swift in Sources */,
 				A28B087F000000000000000B /* TerminalController+DiffViewerTrust.swift in Sources */,
+				8777C0018777C0018777C001 /* TerminalController+DockControlTopology.swift in Sources */,
 				A7C0F0020000000000000002 /* TerminalController+MobileAttachTicket.swift in Sources */,
 				ACA7C4A7000000000000000D /* TerminalController+MobileChat.swift in Sources */,
 				C7AF10000000000000000003 /* TerminalController+MobileChatArtifacts.swift in Sources */,
@@ -8463,6 +8478,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7632B13A1B2C3D4E5F60718 /* WKWebView+CmuxPrintOperation.swift in Sources */,
 				C0DE43000000000000000007 /* Workspace+AgentChat.swift in Sources */,
 				A6AC73020000000000000001 /* Workspace+AgentLifecycle.swift in Sources */,
+				8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,
 				A5FB120D /* Workspace+CustomLayout.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -789,6 +789,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */; };
 		D77800010000000000000001 /* DockPortalReconcileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77800010000000000000002 /* DockPortalReconcileTests.swift */; };
 		DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */; };
+		8777D0018777D0018777D001 /* DockRuntimeParityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777D0028777D0028777D002 /* DockRuntimeParityTests.swift */; };
 		DCDC1000000000000000C020 /* DockScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C021 /* DockScope.swift */; };
 		D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81390010000000000000002 /* DockShortcutRoutingTests.swift */; };
 		D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */; };
@@ -2987,6 +2988,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPanelView.swift; sourceTree = "<group>"; };
 		D77800010000000000000002 /* DockPortalReconcileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPortalReconcileTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockRemoteBrowserSettings.swift; sourceTree = "<group>"; };
+		8777D0028777D0028777D002 /* DockRuntimeParityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockRuntimeParityTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000C021 /* DockScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockScope.swift; sourceTree = "<group>"; };
 		D81390010000000000000002 /* DockShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSocketLifecycleTests.swift; sourceTree = "<group>"; };
@@ -6197,6 +6199,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				859100000000000000000002 /* TerminalLinkOpenCoordinatorTests.swift */,
 				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
 				D77800010000000000000002 /* DockPortalReconcileTests.swift */,
+				8777D0028777D0028777D002 /* DockRuntimeParityTests.swift */,
 				D81390010000000000000002 /* DockShortcutRoutingTests.swift */,
 				D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */,
 				D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */,
@@ -8913,6 +8916,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC0000000000000000B001 /* DockControlDefinitionDecodingTests.swift in Sources */,
 				D7529001A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift in Sources */,
 				D77800010000000000000001 /* DockPortalReconcileTests.swift in Sources */,
+				8777D0018777D0018777D001 /* DockRuntimeParityTests.swift in Sources */,
 				D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */,
 				D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */,
 				D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */,

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Bonsplit
 import Combine
 import CmuxControlSocket
@@ -108,9 +109,11 @@ struct DockRuntimeParityTests {
 
     private func waitForLiveSurface(_ surface: TerminalSurface) async {
         guard !surface.hasLiveSurface else { return }
-        defer { surface.onRuntimeReady = nil }
+        let previousOnRuntimeReady = surface.onRuntimeReady
+        defer { surface.onRuntimeReady = previousOnRuntimeReady }
         let readiness = AsyncStream<Void> { continuation in
             surface.onRuntimeReady = {
+                previousOnRuntimeReady?()
                 continuation.yield()
                 continuation.finish()
             }
@@ -129,11 +132,28 @@ struct DockRuntimeParityTests {
             AppDelegate.shared = appDelegate
             appDelegate.tabManager = manager
             TerminalController.shared.setActiveTabManager(manager)
-            let windowID = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            let windowID = UUID()
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowID.uuidString)")
+            appDelegate.registerMainWindow(
+                window,
+                windowId: windowID,
+                tabManager: manager,
+                sidebarState: SidebarState(),
+                sidebarSelectionState: SidebarSelectionState()
+            )
             defer {
                 TerminalController.shared.setActiveTabManager(previousManager)
                 appDelegate.unregisterMainWindowContextForTesting(windowId: windowID)
                 manager.tabs.forEach { $0.teardownAllPanels() }
+                window.orderOut(nil)
+                window.close()
                 AppDelegate.shared = previousAppDelegate
             }
 
@@ -266,6 +286,15 @@ struct DockRuntimeParityTests {
             })
             #expect(treePanes.contains {
                 $0["id"] as? String == globalPane.id.uuidString &&
+                    $0["dock_scope"] as? String == "global"
+            })
+            let treeSurfaces = treePanes.flatMap { $0["surfaces"] as? [[String: Any]] ?? [] }
+            #expect(treeSurfaces.contains {
+                $0["id"] as? String == workspaceTerminal.id.uuidString &&
+                    $0["dock_scope"] as? String == "workspace"
+            })
+            #expect(treeSurfaces.contains {
+                $0["id"] as? String == globalPanel.id.uuidString &&
                     $0["dock_scope"] as? String == "global"
             })
 

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -101,12 +101,12 @@ struct DockRuntimeParityTests {
         params: [String: Any] = [:]
     ) throws -> [String: Any] {
         let envelope = try socketEnvelope(method: method, params: params)
-        #expect(envelope["ok"] as? Bool == true, "\(envelope)")
+        try #require(envelope["ok"] as? Bool == true, "\(envelope)")
         return try #require(envelope["result"] as? [String: Any])
     }
 
     private func withAppContext(
-        _ body: (AppDelegate, TabManager, Workspace, UUID) async throws -> Void
+        _ body: @MainActor (AppDelegate, TabManager, Workspace, UUID) async throws -> Void
     ) async throws {
         try await AppContextSerialGate.withExclusiveAppContext {
             let previousAppDelegate = AppDelegate.shared
@@ -242,7 +242,7 @@ struct DockRuntimeParityTests {
                 hasWindowIDParam: false,
                 windowID: nil,
                 groupID: nil,
-                workspaceID: workspace.id,
+                workspaceID: nil,
                 surfaceID: workspaceTerminal.id,
                 paneID: nil
             )
@@ -265,14 +265,12 @@ struct DockRuntimeParityTests {
             let readEnvelope = try await socketEnvelopeOnWorker(
                 method: "surface.read_text",
                 params: [
-                    "workspace_id": workspace.id.uuidString,
                     "surface_id": workspaceTerminal.id.uuidString,
                 ]
             )
-            if readEnvelope["ok"] as? Bool != true {
-                let error = try #require(readEnvelope["error"] as? [String: Any])
-                #expect(error["message"] as? String != "Surface is not a terminal")
-            }
+            try #require(readEnvelope["ok"] as? Bool == true, "\(readEnvelope)")
+            let readResult = try #require(readEnvelope["result"] as? [String: Any])
+            #expect(readResult["surface_id"] as? String == workspaceTerminal.id.uuidString)
         }
     }
 }

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -1,0 +1,277 @@
+import Bonsplit
+import Combine
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+private final class DockRuntimeParityPanel: Panel, ObservableObject {
+    let id = UUID()
+    let stableSurfaceIdentity = PanelStableSurfaceIdentity()
+    let panelType: PanelType = .terminal
+    let displayTitle: String
+    let displayIcon: String? = "terminal.fill"
+    var isDirty = false
+
+    private(set) var flashReasons: [WorkspaceAttentionFlashReason] = []
+
+    init(title: String) {
+        displayTitle = title
+    }
+
+    func close() {}
+    func focus() {}
+    func unfocus() {}
+
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) {
+        flashReasons.append(reason)
+    }
+}
+
+@MainActor
+private extension DockSplitStore {
+    @discardableResult
+    func seedRuntimeParityPanel(_ panel: any Panel) throws -> PaneID {
+        let pane = try #require(bonsplitController.allPaneIds.first)
+        panels[panel.id] = panel
+        let tabID = try #require(
+            bonsplitController.createTab(
+                title: panel.displayTitle,
+                icon: panel.displayIcon,
+                kind: panel.panelType.rawValue,
+                isDirty: panel.isDirty,
+                inPane: pane
+            )
+        )
+        surfaceIdToPanelId[tabID] = panel.id
+        return pane
+    }
+}
+
+@MainActor
+@Suite("Dock runtime parity", .serialized)
+struct DockRuntimeParityTests {
+    private static let socketWorker = DispatchQueue(label: "DockRuntimeParityTests.socketWorker")
+
+    private func socketEnvelope(
+        method: String,
+        params: [String: Any] = [:]
+    ) throws -> [String: Any] {
+        let request: [String: Any] = [
+            "id": method,
+            "method": method,
+            "params": params,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: request)
+        let line = try #require(String(data: data, encoding: .utf8))
+        let raw = TerminalController.shared.handleSocketLine(line)
+        let responseData = try #require(raw.data(using: .utf8))
+        return try #require(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+    }
+
+    private func socketEnvelopeOnWorker(
+        method: String,
+        params: [String: Any] = [:]
+    ) async throws -> [String: Any] {
+        let request: [String: Any] = [
+            "id": method,
+            "method": method,
+            "params": params,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: request)
+        let line = try #require(String(data: data, encoding: .utf8))
+        let controller = TerminalController.shared
+        let raw = await withCheckedContinuation { continuation in
+            Self.socketWorker.async {
+                continuation.resume(returning: controller.handleSocketLine(line))
+            }
+        }
+        let responseData = try #require(raw.data(using: .utf8))
+        return try #require(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+    }
+
+    private func socketResult(
+        method: String,
+        params: [String: Any] = [:]
+    ) throws -> [String: Any] {
+        let envelope = try socketEnvelope(method: method, params: params)
+        #expect(envelope["ok"] as? Bool == true, "\(envelope)")
+        return try #require(envelope["result"] as? [String: Any])
+    }
+
+    private func withAppContext(
+        _ body: (AppDelegate, TabManager, Workspace, UUID) async throws -> Void
+    ) async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            TerminalController.shared.setActiveTabManager(manager)
+            let windowID = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                TerminalController.shared.setActiveTabManager(previousManager)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowID)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let workspace = try #require(manager.tabs.first)
+            try await body(appDelegate, manager, workspace, windowID)
+        }
+    }
+
+    @Test("Notification attention routes to both Dock scopes")
+    func notificationAttentionRoutesToBothDockScopes() async throws {
+        try await withAppContext { appDelegate, manager, workspace, windowID in
+            let workspaceDock = workspace.dockSplit
+            let globalDock = appDelegate.windowDock(forWindowId: windowID)
+            let workspacePanel = DockRuntimeParityPanel(title: "Workspace Dock")
+            let globalPanel = DockRuntimeParityPanel(title: "Global Dock")
+            try workspaceDock.seedRuntimeParityPanel(workspacePanel)
+            try globalDock.seedRuntimeParityPanel(globalPanel)
+
+            workspace.triggerNotificationFocusFlash(
+                panelId: workspacePanel.id,
+                requiresSplit: false,
+                shouldFocus: false
+            )
+            workspace.triggerNotificationFocusFlash(
+                panelId: globalPanel.id,
+                requiresSplit: false,
+                shouldFocus: false
+            )
+            manager.workspaceTriggerNotificationDismissFlash(
+                workspaceId: workspace.id,
+                panelId: workspacePanel.id
+            )
+            manager.workspaceTriggerNotificationDismissFlash(
+                workspaceId: globalDock.workspaceId,
+                panelId: globalPanel.id
+            )
+            manager.workspaceTriggerUnreadIndicatorDismissFlash(
+                workspaceId: workspace.id,
+                panelId: workspacePanel.id
+            )
+            manager.workspaceTriggerUnreadIndicatorDismissFlash(
+                workspaceId: globalDock.workspaceId,
+                panelId: globalPanel.id
+            )
+
+            let expected: [WorkspaceAttentionFlashReason] = [
+                .notificationArrival,
+                .notificationDismiss,
+                .unreadIndicatorDismiss,
+            ]
+            #expect(workspacePanel.flashReasons == expected)
+            #expect(globalPanel.flashReasons == expected)
+        }
+    }
+
+    @Test("Dock surfaces are discoverable and workspace Dock terminals resolve by bare ID")
+    func topologyAndBareIDRoutingIncludeBothDockScopes() async throws {
+        try await withAppContext { appDelegate, _, workspace, windowID in
+            let workspaceDock = workspace.dockSplit
+            let globalDock = appDelegate.windowDock(forWindowId: windowID)
+            let workspaceTerminal = TerminalPanel(
+                workspaceId: workspace.id,
+                runtimeSpawnPolicy: .deferredUntilVisible
+            )
+            let globalPanel = DockRuntimeParityPanel(title: "Global Dock")
+            let workspacePane = try workspaceDock.seedRuntimeParityPanel(workspaceTerminal)
+            let globalPane = try globalDock.seedRuntimeParityPanel(globalPanel)
+            let params = ["workspace_id": workspace.id.uuidString]
+
+            let surfaceList = try socketResult(method: "surface.list", params: params)
+            let surfaces = try #require(surfaceList["surfaces"] as? [[String: Any]])
+            let workspaceSurface = try #require(surfaces.first {
+                $0["id"] as? String == workspaceTerminal.id.uuidString
+            })
+            let globalSurface = try #require(surfaces.first {
+                $0["id"] as? String == globalPanel.id.uuidString
+            })
+            #expect(workspaceSurface["dock_scope"] as? String == "workspace")
+            #expect(globalSurface["dock_scope"] as? String == "global")
+
+            let paneList = try socketResult(method: "pane.list", params: params)
+            let panes = try #require(paneList["panes"] as? [[String: Any]])
+            let workspacePaneRow = try #require(panes.first {
+                $0["id"] as? String == workspacePane.id.uuidString
+            })
+            let globalPaneRow = try #require(panes.first {
+                $0["id"] as? String == globalPane.id.uuidString
+            })
+            #expect(workspacePaneRow["dock_scope"] as? String == "workspace")
+            #expect(globalPaneRow["dock_scope"] as? String == "global")
+
+            for (paneID, surfaceID, scope) in [
+                (workspacePane.id, workspaceTerminal.id, "workspace"),
+                (globalPane.id, globalPanel.id, "global"),
+            ] {
+                let result = try socketResult(
+                    method: "pane.surfaces",
+                    params: ["pane_id": paneID.uuidString]
+                )
+                #expect(result["dock_scope"] as? String == scope)
+                let paneSurfaces = try #require(result["surfaces"] as? [[String: Any]])
+                #expect(paneSurfaces.contains { $0["id"] as? String == surfaceID.uuidString })
+            }
+
+            let tree = try socketResult(method: "system.tree")
+            let windows = try #require(tree["windows"] as? [[String: Any]])
+            let treeWorkspaces = windows.flatMap { $0["workspaces"] as? [[String: Any]] ?? [] }
+            let treePanes = treeWorkspaces.flatMap { $0["panes"] as? [[String: Any]] ?? [] }
+            #expect(treePanes.contains {
+                $0["id"] as? String == workspacePane.id.uuidString &&
+                    $0["dock_scope"] as? String == "workspace"
+            })
+            #expect(treePanes.contains {
+                $0["id"] as? String == globalPane.id.uuidString &&
+                    $0["dock_scope"] as? String == "global"
+            })
+
+            let routing = ControlRoutingSelectors(
+                hasWindowIDParam: false,
+                windowID: nil,
+                groupID: nil,
+                workspaceID: workspace.id,
+                surfaceID: workspaceTerminal.id,
+                paneID: nil
+            )
+            let send = TerminalController.shared.controlSurfaceSendText(
+                routing: routing,
+                surfaceID: workspaceTerminal.id,
+                hasSurfaceIDParam: true,
+                text: "dock input"
+            )
+            switch send {
+            case .sent(_, _, let surfaceID, _),
+                 .surfaceUnavailable(let surfaceID),
+                 .processExited(let surfaceID),
+                 .inputQueueFull(let surfaceID):
+                #expect(surfaceID == workspaceTerminal.id)
+            default:
+                Issue.record("Workspace Dock send did not resolve its terminal: \(send)")
+            }
+
+            let readEnvelope = try await socketEnvelopeOnWorker(
+                method: "surface.read_text",
+                params: [
+                    "workspace_id": workspace.id.uuidString,
+                    "surface_id": workspaceTerminal.id.uuidString,
+                ]
+            )
+            if readEnvelope["ok"] as? Bool != true {
+                let error = try #require(readEnvelope["error"] as? [String: Any])
+                #expect(error["message"] as? String != "Surface is not a terminal")
+            }
+        }
+    }
+}

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -1,5 +1,6 @@
 import Bonsplit
 import Combine
+import CmuxControlSocket
 import Foundation
 import Testing
 
@@ -182,7 +183,7 @@ struct DockRuntimeParityTests {
             let globalDock = appDelegate.windowDock(forWindowId: windowID)
             let workspaceTerminal = TerminalPanel(
                 workspaceId: workspace.id,
-                runtimeSpawnPolicy: .deferredUntilVisible
+                runtimeSpawnPolicy: .pacedSessionRestore
             )
             let globalPanel = DockRuntimeParityPanel(title: "Global Dock")
             let workspacePane = try workspaceDock.seedRuntimeParityPanel(workspaceTerminal)

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -1,6 +1,7 @@
 import Bonsplit
 import Combine
 import CmuxControlSocket
+import CmuxTerminal
 import Foundation
 import Testing
 
@@ -107,6 +108,7 @@ struct DockRuntimeParityTests {
 
     private func waitForLiveSurface(_ surface: TerminalSurface) async {
         guard !surface.hasLiveSurface else { return }
+        defer { surface.onRuntimeReady = nil }
         let readiness = AsyncStream<Void> { continuation in
             surface.onRuntimeReady = {
                 continuation.yield()
@@ -114,7 +116,6 @@ struct DockRuntimeParityTests {
             }
         }
         for await _ in readiness { break }
-        surface.onRuntimeReady = nil
     }
 
     private func withAppContext(
@@ -150,6 +151,19 @@ struct DockRuntimeParityTests {
             let globalPanel = DockRuntimeParityPanel(title: "Global Dock")
             try workspaceDock.seedRuntimeParityPanel(workspacePanel)
             try globalDock.seedRuntimeParityPanel(globalPanel)
+
+            let workspaceDelivery = appDelegate.agentNotificationDeliveryTarget(
+                claimedTabId: workspace.id,
+                surfaceId: workspacePanel.id
+            )
+            #expect(workspaceDelivery?.tabId == workspace.id)
+            #expect(workspaceDelivery?.surfaceId == workspacePanel.id)
+            let globalDelivery = appDelegate.agentNotificationDeliveryTarget(
+                claimedTabId: workspace.id,
+                surfaceId: globalPanel.id
+            )
+            #expect(globalDelivery?.tabId == globalDock.workspaceId)
+            #expect(globalDelivery?.surfaceId == globalPanel.id)
 
             workspace.triggerNotificationFocusFlash(
                 panelId: workspacePanel.id,
@@ -188,7 +202,10 @@ struct DockRuntimeParityTests {
         }
     }
 
-    @Test("Dock surfaces are discoverable and workspace Dock terminals resolve by bare ID")
+    @Test(
+        "Dock surfaces are discoverable and workspace Dock terminals resolve by bare ID",
+        .timeLimit(.minutes(1))
+    )
     func topologyAndBareIDRoutingIncludeBothDockScopes() async throws {
         try await withAppContext { appDelegate, _, workspace, windowID in
             let workspaceDock = workspace.dockSplit
@@ -266,15 +283,11 @@ struct DockRuntimeParityTests {
                 hasSurfaceIDParam: true,
                 text: "dock input"
             )
-            switch send {
-            case .sent(_, _, let surfaceID, _),
-                 .surfaceUnavailable(let surfaceID),
-                 .processExited(let surfaceID),
-                 .inputQueueFull(let surfaceID):
-                #expect(surfaceID == workspaceTerminal.id)
-            default:
+            guard case .sent(_, _, let sentSurfaceID, _) = send else {
                 Issue.record("Workspace Dock send did not resolve its terminal: \(send)")
+                return
             }
+            #expect(sentSurfaceID == workspaceTerminal.id)
 
             await waitForLiveSurface(workspaceTerminal.surface)
             try #require(workspaceTerminal.surface.hasLiveSurface)

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -105,6 +105,18 @@ struct DockRuntimeParityTests {
         return try #require(envelope["result"] as? [String: Any])
     }
 
+    private func waitForLiveSurface(_ surface: TerminalSurface) async {
+        guard !surface.hasLiveSurface else { return }
+        let readiness = AsyncStream<Void> { continuation in
+            surface.onRuntimeReady = {
+                continuation.yield()
+                continuation.finish()
+            }
+        }
+        for await _ in readiness { break }
+        surface.onRuntimeReady = nil
+    }
+
     private func withAppContext(
         _ body: @MainActor (AppDelegate, TabManager, Workspace, UUID) async throws -> Void
     ) async throws {
@@ -211,6 +223,8 @@ struct DockRuntimeParityTests {
             })
             #expect(workspacePaneRow["dock_scope"] as? String == "workspace")
             #expect(globalPaneRow["dock_scope"] as? String == "global")
+            #expect(workspacePaneRow["pixel_frame"] == nil)
+            #expect(globalPaneRow["pixel_frame"] == nil)
 
             for (paneID, surfaceID, scope) in [
                 (workspacePane.id, workspaceTerminal.id, "workspace"),
@@ -225,7 +239,7 @@ struct DockRuntimeParityTests {
                 #expect(paneSurfaces.contains { $0["id"] as? String == surfaceID.uuidString })
             }
 
-            let tree = try socketResult(method: "system.tree")
+            let tree = try socketResult(method: "system.tree", params: params)
             let windows = try #require(tree["windows"] as? [[String: Any]])
             let treeWorkspaces = windows.flatMap { $0["workspaces"] as? [[String: Any]] ?? [] }
             let treePanes = treeWorkspaces.flatMap { $0["panes"] as? [[String: Any]] ?? [] }
@@ -262,6 +276,8 @@ struct DockRuntimeParityTests {
                 Issue.record("Workspace Dock send did not resolve its terminal: \(send)")
             }
 
+            await waitForLiveSurface(workspaceTerminal.surface)
+            try #require(workspaceTerminal.surface.hasLiveSurface)
             let readEnvelope = try await socketEnvelopeOnWorker(
                 method: "surface.read_text",
                 params: [

--- a/docs/dock.md
+++ b/docs/dock.md
@@ -32,7 +32,19 @@ cmux new-surface --type browser --placement dock --url https://example.com   # a
 
 `--placement` accepts `workspace` (default) or `dock`. The Dock hosts terminal and browser panes only.
 
-Dock-created handles are returned as Dock-scoped response fields: `dock_surface_id` and `dock_pane_id`. The ordinary workspace fields `surface_id` and `pane_id` are `null` for Dock placement, because existing workspace surface and pane RPCs route through the main content split tree.
+Dock-created handles are returned as Dock-scoped response fields: `dock_surface_id` and `dock_pane_id`. The ordinary workspace fields `surface_id` and `pane_id` remain `null` in creation responses for backwards compatibility.
+
+Dock panes and surfaces also appear in the ordinary discovery commands:
+
+```sh
+cmux tree
+cmux list-panes
+cmux list-pane-surfaces --pane <dock-pane-id>
+```
+
+Text output marks them as `[dock:workspace]` or `[dock:global]`. JSON and socket rows carry the additive `dock_scope` field with the stable value `workspace` or `global`; existing non-Dock rows are unchanged. Pane and surface IDs remain stable for the lifetime of their Dock items.
+
+Existing surface and pane verbs accept these Dock IDs directly. In particular, `send`, `send-key`, `read-screen`, `capture-pane`, `focus`, and `close` can target a Dock terminal by its bare surface ID in either Dock scope. No Dock-specific addressing syntax is required.
 
 ## Configuration
 

--- a/docs/dock.md
+++ b/docs/dock.md
@@ -44,7 +44,7 @@ cmux list-pane-surfaces --pane <dock-pane-id>
 
 Text output marks them as `[dock:workspace]` or `[dock:global]`. JSON and socket rows carry the additive `dock_scope` field with the stable value `workspace` or `global`; existing non-Dock rows are unchanged. Pane and surface IDs remain stable for the lifetime of their Dock items.
 
-Existing surface and pane verbs accept these Dock IDs directly. In particular, `send`, `send-key`, `read-screen`, `capture-pane`, `focus`, and `close` can target a Dock terminal by its bare surface ID in either Dock scope. No Dock-specific addressing syntax is required.
+Existing surface-addressed terminal verbs accept these Dock surface IDs directly. In particular, `send`, `send-key`, `read-screen`, `capture-pane`, `focus`, and `close` can target a Dock terminal by its bare surface ID in either Dock scope. No Dock-specific addressing syntax is required.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Route notification arrival, dismissal, and unread-indicator flashes through the shared live Dock registry for both workspace and per-window/global Dock scopes.
- Make Dock panes and surfaces additive members of `surface.list`, `pane.list`, `pane.surfaces`, and `system.tree`, tagged with `dock_scope: workspace|global` while preserving existing non-Dock fields and IDs.
- Resolve per-workspace Dock terminals through the same bare surface-ID path used by existing send/read/capture verbs, and document the discovery/addressing contract.

## Design

Dock stores participate through `DockSplitStore.liveStores`, so attention routing, ID resolution, and topology enumeration share a container registry instead of adding verb-specific special cases. Global Dock rows are attached once to the selected workspace in whole-window tree snapshots to avoid duplication; explicit workspace tree queries and ordinary workspace-scoped list queries include both applicable Dock scopes. Notification delivery resolves the current surface owner through that same registry, and successful cross-container moves rebind existing notifications to the destination owner so later dismiss/unread flashes follow the stable surface ID.

## Testing

- First commit adds behavior coverage alone so CI demonstrates both gaps before the fix.
- Targeted test-only CI [run 30056685303](https://github.com/manaflow-ai/cmux/actions/runs/30056685303) executed both tests at `21c18a40f0` and failed on the intended attention and topology assertions before the fix.
- Swift test target wiring and pbxproj normalization checks pass locally.
- Targeted test-only CI [run 30059284182](https://github.com/manaflow-ai/cmux/actions/runs/30059284182) checked out exact HEAD `4d20fdde9157f3ed27061cb012046d466ba9b3e5` and passed both Dock runtime parity tests.
- Per task instructions, no local build or Xcode test run was performed; CI is the build/test authority.

## Demo Video

- Video URL or attachment: Not applicable; this is control-plane routing and the existing flash renderer.

## Checklist

- [ ] I tested the change locally (CI only per task instructions)
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

Closes #8777

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787443202&installation_model_id=21920&pr_number=8782&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8782&signature=c3f1e2e682c7daf8f26570aed84d223d5fe88b74bddb7ef82fb1661b3c6c9ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Dock runtime parity across workspace and global scopes. Adds `dock_scope` to discovery APIs, enables bare-ID control of Dock terminals, and routes notification flashes through a shared Dock registry; CLI output and docs updated (closes #8777).

- **New Features**
  - Add `dock_scope` to `surface.list`, `pane.list`, `pane.surfaces`, and `system.tree`; include both Dock scopes. The global Dock attaches to the selected workspace in `system.tree`.
  - Target Dock terminals by bare surface ID with `send`, `send-key`, `read-screen`, `capture-pane`, `focus`, and `close`.
  - Show `[dock:workspace|global]` tags in `tree`, `list-panes`, and `list-pane-surfaces`; text and JSON match.

- **Bug Fixes**
  - Route notification arrival/dismiss/unread flashes via a shared Dock registry; activation uses the key window’s focused Dock when active.
  - Rebind notifications when moving surfaces into a Dock.
  - Ensure Dock terminal flashes render in the Dock pane overlay, not the previous workspace pane.

<sup>Written for commit 4d20fdde9157f3ed27061cb012046d466ba9b3e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dock-scoped discovery now appears across CLI and control/socket responses via a `dock_scope` tag, including updated pane, surface, and system tree rows/labels.
  * Workspace topology can optionally include the global dock.
  * Notification-driven attention/flash routing now properly targets the correct Dock scope.
* **Bug Fixes**
  * Improved attention routing for unread-indicator dismiss and notification dismiss to behave consistently across workspace and global Dock scopes.
* **Tests**
  * Added “dock runtime parity” test coverage for ordered attention reasons and routing/topology/discovery correctness.
* **Documentation**
  * Updated Dock docs to describe Dock-scoped identifiers and the new `dock_scope` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
