### PR TITLE
Fail closed when CLI forwarding loops back to the GUI binary

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CLIForwardingLaunchPolicy.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/CLIForwardingLaunchPolicy.swift
@@ -1,0 +1,49 @@
+/// How a launch of the cmux GUI binary should be routed when its argv may
+/// belong to the bundled command-line tool.
+public enum CLIForwardingDecision: Equatable, Sendable {
+    /// GUI-style argv (no subcommand, `-psn_...`/`-` flags, `cmux://` URLs,
+    /// launch sentinels): proceed with the normal app launch.
+    case launchGUI
+    /// CLI-style argv on a first pass: exec the bundled CLI.
+    case forwardToBundledCLI
+    /// CLI-style argv but the forwarding guard is already set: forwarding
+    /// resolved back to the GUI binary (mispackaged bundle, or the guard
+    /// leaked into the caller's environment). Booting the GUI here leaves a
+    /// faceless app instance in the event loop forever — agent hook
+    /// invocations (`cmux claude-hook …`) then pile up one idle GUI process
+    /// per hook event — so the launch must fail closed instead.
+    case failForwardingLoop
+}
+
+/// Pure argv/guard classification for launches of the GUI binary. The app
+/// target owns the glue that acts on the decision (reading the guard
+/// environment variable, exec'ing the bundled CLI, writing errors, exiting).
+public enum CLIForwardingLaunchPolicy {
+    /// Launch sentinels passed by tagged GUI builds; never CLI subcommands.
+    private static let guiLaunchSentinels: Set<String> = ["DEV", "STAGING", "NIGHTLY"]
+
+    /// True when `argv` looks like an invocation of the bundled CLI.
+    /// macOS-launch arguments (`-psn_...`, other `-` flags), `cmux://` URLs,
+    /// and launch sentinels stay with the GUI.
+    public static func shouldForwardToBundledCLI(arguments argv: [String]) -> Bool {
+        guard argv.count > 1 else { return false }
+
+        let first = argv[1]
+        if first.isEmpty || first.hasPrefix("-") { return false }
+        if first.contains("://") { return false }
+        if guiLaunchSentinels.contains(first) { return false }
+
+        return true
+    }
+
+    /// Classifies a launch of the GUI binary: GUI-style argv launches the
+    /// app, first-pass CLI argv forwards to the bundled CLI, and CLI argv
+    /// with the forwarding guard already set is a forwarding loop.
+    public static func decision(
+        arguments argv: [String],
+        forwardingGuardIsSet: Bool
+    ) -> CLIForwardingDecision {
+        guard shouldForwardToBundledCLI(arguments: argv) else { return .launchGUI }
+        return forwardingGuardIsSet ? .failForwardingLoop : .forwardToBundledCLI
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CLIForwardingLaunchPolicyTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/CLIForwardingLaunchPolicyTests.swift
@@ -1,0 +1,61 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("CLIForwardingLaunchPolicy")
+struct CLIForwardingLaunchPolicyTests {
+    /// A CLI invocation that reaches the GUI binary with the forwarding
+    /// guard already set must not fall through to a GUI launch: hook
+    /// commands (`cmux claude-hook …`) would each leave a faceless app
+    /// instance running forever.
+    @Test("CLI argv with the guard set fails closed")
+    func cliArgvWithGuardSetFailsClosed() {
+        #expect(
+            CLIForwardingLaunchPolicy.decision(
+                arguments: ["cmux", "claude-hook", "pre-tool-use"],
+                forwardingGuardIsSet: true
+            ) == .failForwardingLoop
+        )
+        #expect(
+            CLIForwardingLaunchPolicy.decision(
+                arguments: ["cmux", "claude-hook", "pre-tool-use"],
+                forwardingGuardIsSet: false
+            ) == .forwardToBundledCLI
+        )
+    }
+
+    /// GUI-style launches (no subcommand, `-psn_...` flags, `cmux://` URLs,
+    /// launch sentinels) stay in the app regardless of the forwarding guard.
+    @Test("GUI argv launches the app even with the guard set")
+    func guiArgvLaunchesAppEvenWithGuardSet() {
+        #expect(
+            CLIForwardingLaunchPolicy.decision(arguments: ["cmux"], forwardingGuardIsSet: true) == .launchGUI
+        )
+        #expect(
+            CLIForwardingLaunchPolicy.decision(
+                arguments: ["cmux", "-psn_0_12345"],
+                forwardingGuardIsSet: true
+            ) == .launchGUI
+        )
+        #expect(
+            CLIForwardingLaunchPolicy.decision(
+                arguments: ["cmux", "cmux://workspace/foo"],
+                forwardingGuardIsSet: true
+            ) == .launchGUI
+        )
+        #expect(
+            CLIForwardingLaunchPolicy.decision(
+                arguments: ["cmux DEV", "DEV"],
+                forwardingGuardIsSet: true
+            ) == .launchGUI
+        )
+    }
+
+    /// CLI-style subcommands forward to the bundled CLI on the first pass.
+    @Test("CLI subcommands forward to the bundled CLI")
+    func cliSubcommandsForward() {
+        #expect(CLIForwardingLaunchPolicy.shouldForwardToBundledCLI(arguments: ["cmux", "wait-for", "workspace:1"]))
+        #expect(CLIForwardingLaunchPolicy.shouldForwardToBundledCLI(arguments: ["cmux", "hooks", "setup"]))
+        #expect(!CLIForwardingLaunchPolicy.shouldForwardToBundledCLI(arguments: ["cmux", "-psn_0_12345"]))
+        #expect(!CLIForwardingLaunchPolicy.shouldForwardToBundledCLI(arguments: ["cmux", "cmux://workspace/foo"]))
+    }
+}

--- a/Sources/App/CLIForwardingLaunchRouter.swift
+++ b/Sources/App/CLIForwardingLaunchRouter.swift
@@ -23,6 +23,9 @@ enum CLIForwardingLaunchRouter {
         case failForwardingLoop
     }
 
+    /// Classifies a launch of the GUI binary: GUI-style argv launches the
+    /// app, first-pass CLI argv forwards to the bundled CLI, and CLI argv
+    /// with the forwarding guard already set is a forwarding loop.
     static func forwardingDecision(
         arguments argv: [String],
         forwardingGuardIsSet: Bool
@@ -170,6 +173,8 @@ enum CLIForwardingLaunchRouter {
         )
     }
 
+    /// User-facing message for a detected forwarding loop: the bundled CLI
+    /// resolved back to the GUI binary, so the command cannot be handed off.
     private static func localizedForwardingLoopError() -> String {
         String(
             localized: "cli.forwarding.error.forwardingLoop",

--- a/Sources/App/CLIForwardingLaunchRouter.swift
+++ b/Sources/App/CLIForwardingLaunchRouter.swift
@@ -7,16 +7,49 @@ nonisolated private let cliForwardingLogger = Logger(subsystem: "com.cmuxterm.ap
 enum CLIForwardingLaunchRouter {
     private static let guardKey = "CMUX_CLI_FORWARDED"
 
+    /// How a launch of the GUI binary should be routed.
+    enum ForwardingDecision: Equatable {
+        /// GUI-style argv (no subcommand, `-psn_...`/`-` flags, `cmux://`
+        /// URLs, launch sentinels): proceed with the normal app launch.
+        case launchGUI
+        /// CLI-style argv on a first pass: exec the bundled CLI.
+        case forwardToBundledCLI
+        /// CLI-style argv but the forwarding guard is already set: forwarding
+        /// resolved back to this GUI binary (mispackaged bundle, or the guard
+        /// leaked into the caller's environment). Booting the GUI here leaves
+        /// a faceless app instance in the event loop forever — agent hook
+        /// invocations (`cmux claude-hook …`) then pile up one idle GUI
+        /// process per hook event — so fail closed with an error instead.
+        case failForwardingLoop
+    }
+
+    static func forwardingDecision(
+        arguments argv: [String],
+        forwardingGuardIsSet: Bool
+    ) -> ForwardingDecision {
+        guard shouldForwardToBundledCLI(arguments: argv) else { return .launchGUI }
+        return forwardingGuardIsSet ? .failForwardingLoop : .forwardToBundledCLI
+    }
+
     /// If `argv` looks like a CLI invocation, exec the bundled CLI at
     /// `Contents/Resources/bin/cmux` and never return. macOS-launch arguments
     /// (`-psn_...`, other `-` flags) and `cmux://` URLs are left to the GUI.
+    /// A CLI invocation that cannot be forwarded (the forwarding guard is
+    /// already set) exits with an error instead of falling through to the GUI.
     static func forwardToBundledCLIIfNeeded(
         arguments argv: [String] = CommandLine.arguments,
         bundle: Bundle = .main,
         fileManager: FileManager = .default
     ) {
-        if getenv(guardKey) != nil { return }
-        guard shouldForwardToBundledCLI(arguments: argv) else { return }
+        switch forwardingDecision(arguments: argv, forwardingGuardIsSet: getenv(guardKey) != nil) {
+        case .launchGUI:
+            return
+        case .failForwardingLoop:
+            writeStderr(localizedForwardingLoopError())
+            Darwin.exit(127)
+        case .forwardToBundledCLI:
+            break
+        }
 
         guard let cliURL = bundledCLIURL(bundle: bundle, fileManager: fileManager) else {
             #if DEBUG
@@ -134,6 +167,13 @@ enum CLIForwardingLaunchRouter {
         String(
             localized: "cli.forwarding.error.execFailed",
             defaultValue: "cmux could not start the command-line tool from the app bundle. Reinstall cmux or run the command from a standard cmux CLI installation."
+        )
+    }
+
+    private static func localizedForwardingLoopError() -> String {
+        String(
+            localized: "cli.forwarding.error.forwardingLoop",
+            defaultValue: "cmux could not hand this command to its bundled command-line tool because forwarding resolved back to the app itself. Reinstall cmux or run the command from a standard cmux CLI installation."
         )
     }
 

--- a/Sources/App/CLIForwardingLaunchRouter.swift
+++ b/Sources/App/CLIForwardingLaunchRouter.swift
@@ -1,3 +1,4 @@
+import CMUXAgentLaunch
 import Darwin
 import Foundation
 import os
@@ -7,31 +8,13 @@ nonisolated private let cliForwardingLogger = Logger(subsystem: "com.cmuxterm.ap
 enum CLIForwardingLaunchRouter {
     private static let guardKey = "CMUX_CLI_FORWARDED"
 
-    /// How a launch of the GUI binary should be routed.
-    enum ForwardingDecision: Equatable {
-        /// GUI-style argv (no subcommand, `-psn_...`/`-` flags, `cmux://`
-        /// URLs, launch sentinels): proceed with the normal app launch.
-        case launchGUI
-        /// CLI-style argv on a first pass: exec the bundled CLI.
-        case forwardToBundledCLI
-        /// CLI-style argv but the forwarding guard is already set: forwarding
-        /// resolved back to this GUI binary (mispackaged bundle, or the guard
-        /// leaked into the caller's environment). Booting the GUI here leaves
-        /// a faceless app instance in the event loop forever — agent hook
-        /// invocations (`cmux claude-hook …`) then pile up one idle GUI
-        /// process per hook event — so fail closed with an error instead.
-        case failForwardingLoop
-    }
-
-    /// Classifies a launch of the GUI binary: GUI-style argv launches the
-    /// app, first-pass CLI argv forwards to the bundled CLI, and CLI argv
-    /// with the forwarding guard already set is a forwarding loop.
+    /// Classifies a launch of the GUI binary via the pure policy in
+    /// CMUXAgentLaunch; this router keeps only the exec/exit glue.
     static func forwardingDecision(
         arguments argv: [String],
         forwardingGuardIsSet: Bool
-    ) -> ForwardingDecision {
-        guard shouldForwardToBundledCLI(arguments: argv) else { return .launchGUI }
-        return forwardingGuardIsSet ? .failForwardingLoop : .forwardToBundledCLI
+    ) -> CLIForwardingDecision {
+        CLIForwardingLaunchPolicy.decision(arguments: argv, forwardingGuardIsSet: forwardingGuardIsSet)
     }
 
     /// If `argv` looks like a CLI invocation, exec the bundled CLI at
@@ -90,17 +73,9 @@ enum CLIForwardingLaunchRouter {
         Darwin.exit(127)
     }
 
+    /// Delegates the pure argv classification to CMUXAgentLaunch.
     static func shouldForwardToBundledCLI(arguments argv: [String]) -> Bool {
-        guard argv.count > 1 else { return false }
-
-        let first = argv[1]
-        if first.isEmpty || first.hasPrefix("-") { return false }
-        if first.contains("://") { return false }
-
-        let guiLaunchSentinels: Set<String> = ["DEV", "STAGING", "NIGHTLY"]
-        if guiLaunchSentinels.contains(first) { return false }
-
-        return true
+        CLIForwardingLaunchPolicy.shouldForwardToBundledCLI(arguments: argv)
     }
 
     static func bundledCLIURL(

--- a/cmuxTests/CLIForwardingLaunchArgumentTests.swift
+++ b/cmuxTests/CLIForwardingLaunchArgumentTests.swift
@@ -9,44 +9,6 @@ final class CLIForwardingLaunchArgumentTests: XCTestCase {
         XCTAssertTrue(CLIForwardingLaunchRouter.shouldForwardToBundledCLI(arguments: ["cmux", "hooks", "setup"]))
     }
 
-    /// A CLI invocation that reaches the GUI binary with the forwarding
-    /// guard already set must not fall through to a GUI launch: hook
-    /// commands (`cmux claude-hook …`) would each leave a faceless app
-    /// instance running forever.
-    func testForwardingDecisionFailsClosedWhenGuardIsAlreadySet() {
-        XCTAssertEqual(
-            CLIForwardingLaunchRouter.forwardingDecision(
-                arguments: ["cmux", "claude-hook", "pre-tool-use"],
-                forwardingGuardIsSet: true
-            ),
-            .failForwardingLoop
-        )
-        XCTAssertEqual(
-            CLIForwardingLaunchRouter.forwardingDecision(
-                arguments: ["cmux", "claude-hook", "pre-tool-use"],
-                forwardingGuardIsSet: false
-            ),
-            .forwardToBundledCLI
-        )
-    }
-
-    /// GUI-style launches (no subcommand, `-psn_...` flags, `cmux://` URLs)
-    /// stay in the app regardless of the forwarding guard.
-    func testForwardingDecisionKeepsGuiLaunchesInAppEvenWithGuardSet() {
-        XCTAssertEqual(
-            CLIForwardingLaunchRouter.forwardingDecision(arguments: ["cmux"], forwardingGuardIsSet: true),
-            .launchGUI
-        )
-        XCTAssertEqual(
-            CLIForwardingLaunchRouter.forwardingDecision(arguments: ["cmux", "-psn_0_12345"], forwardingGuardIsSet: true),
-            .launchGUI
-        )
-        XCTAssertEqual(
-            CLIForwardingLaunchRouter.forwardingDecision(arguments: ["cmux", "cmux://workspace/foo"], forwardingGuardIsSet: true),
-            .launchGUI
-        )
-    }
-
     func testGuiLaunchArgumentsStayInApp() {
         XCTAssertFalse(CLIForwardingLaunchRouter.shouldForwardToBundledCLI(arguments: ["cmux DEV", "DEV"]))
         XCTAssertFalse(CLIForwardingLaunchRouter.shouldForwardToBundledCLI(arguments: ["cmux STAGING", "STAGING"]))

--- a/cmuxTests/CLIForwardingLaunchArgumentTests.swift
+++ b/cmuxTests/CLIForwardingLaunchArgumentTests.swift
@@ -9,11 +9,11 @@ final class CLIForwardingLaunchArgumentTests: XCTestCase {
         XCTAssertTrue(CLIForwardingLaunchRouter.shouldForwardToBundledCLI(arguments: ["cmux", "hooks", "setup"]))
     }
 
+    /// A CLI invocation that reaches the GUI binary with the forwarding
+    /// guard already set must not fall through to a GUI launch: hook
+    /// commands (`cmux claude-hook …`) would each leave a faceless app
+    /// instance running forever.
     func testForwardingDecisionFailsClosedWhenGuardIsAlreadySet() {
-        // A CLI invocation that reaches the GUI binary with the forwarding
-        // guard already set must not fall through to a GUI launch: hook
-        // commands (`cmux claude-hook …`) would each leave a faceless app
-        // instance running forever.
         XCTAssertEqual(
             CLIForwardingLaunchRouter.forwardingDecision(
                 arguments: ["cmux", "claude-hook", "pre-tool-use"],
@@ -30,6 +30,8 @@ final class CLIForwardingLaunchArgumentTests: XCTestCase {
         )
     }
 
+    /// GUI-style launches (no subcommand, `-psn_...` flags, `cmux://` URLs)
+    /// stay in the app regardless of the forwarding guard.
     func testForwardingDecisionKeepsGuiLaunchesInAppEvenWithGuardSet() {
         XCTAssertEqual(
             CLIForwardingLaunchRouter.forwardingDecision(arguments: ["cmux"], forwardingGuardIsSet: true),

--- a/cmuxTests/CLIForwardingLaunchArgumentTests.swift
+++ b/cmuxTests/CLIForwardingLaunchArgumentTests.swift
@@ -9,6 +9,42 @@ final class CLIForwardingLaunchArgumentTests: XCTestCase {
         XCTAssertTrue(CLIForwardingLaunchRouter.shouldForwardToBundledCLI(arguments: ["cmux", "hooks", "setup"]))
     }
 
+    func testForwardingDecisionFailsClosedWhenGuardIsAlreadySet() {
+        // A CLI invocation that reaches the GUI binary with the forwarding
+        // guard already set must not fall through to a GUI launch: hook
+        // commands (`cmux claude-hook …`) would each leave a faceless app
+        // instance running forever.
+        XCTAssertEqual(
+            CLIForwardingLaunchRouter.forwardingDecision(
+                arguments: ["cmux", "claude-hook", "pre-tool-use"],
+                forwardingGuardIsSet: true
+            ),
+            .failForwardingLoop
+        )
+        XCTAssertEqual(
+            CLIForwardingLaunchRouter.forwardingDecision(
+                arguments: ["cmux", "claude-hook", "pre-tool-use"],
+                forwardingGuardIsSet: false
+            ),
+            .forwardToBundledCLI
+        )
+    }
+
+    func testForwardingDecisionKeepsGuiLaunchesInAppEvenWithGuardSet() {
+        XCTAssertEqual(
+            CLIForwardingLaunchRouter.forwardingDecision(arguments: ["cmux"], forwardingGuardIsSet: true),
+            .launchGUI
+        )
+        XCTAssertEqual(
+            CLIForwardingLaunchRouter.forwardingDecision(arguments: ["cmux", "-psn_0_12345"], forwardingGuardIsSet: true),
+            .launchGUI
+        )
+        XCTAssertEqual(
+            CLIForwardingLaunchRouter.forwardingDecision(arguments: ["cmux", "cmux://workspace/foo"], forwardingGuardIsSet: true),
+            .launchGUI
+        )
+    }
+
     func testGuiLaunchArgumentsStayInApp() {
         XCTAssertFalse(CLIForwardingLaunchRouter.shouldForwardToBundledCLI(arguments: ["cmux DEV", "DEV"]))
         XCTAssertFalse(CLIForwardingLaunchRouter.shouldForwardToBundledCLI(arguments: ["cmux STAGING", "STAGING"]))


### PR DESCRIPTION
## Problem

When a CLI-style invocation reaches the GUI binary while `CMUX_CLI_FORWARDED` is already set, `CLIForwardingLaunchRouter.forwardToBundledCLIIfNeeded()` returns early and the process falls through into the normal SwiftUI app launch. The process then sits in the AppKit event loop indefinitely as a faceless GUI instance.

This is worst for agent hook commands (`cmux claude-hook pre-tool-use` etc.): each hook event leaves one idle full GUI app process (Sparkle, Sentry, event loop and all) behind, and they accumulate into dozens of lingering `cmux claude-hook …` processes under headless agent sessions. Field forensics from an affected machine: `sample` of a lingering hook process showed the main thread parked in `NSApplicationMain` → `-[NSApplication run]` with no CLI work on any thread, 11+ minutes after launch, parented to a headless `claude` worker.

#4678 / #4679 fixed the primary path (forwarding CLI argv to the bundled CLI), but the guard fall-through remains: if forwarding ever resolves back to the GUI binary (mispackaged bundle, or the guard value leaking into a caller's environment), the second pass silently boots the GUI instead of failing.

## Fix

Route the launch through an explicit `ForwardingDecision`:

- GUI-style argv (no subcommand, `-psn_...`/`-` flags, `cmux://` URLs, launch sentinels) still launches the app, guard set or not.
- First-pass CLI argv still execs the bundled CLI.
- CLI argv with the guard already set now writes a localized error to stderr and exits 127 instead of booting the GUI. The exec loop stays broken, and hook invocations can never linger as faceless GUI instances.

## Verification

- `swiftc -typecheck` passes on the modified router file.
- Added unit tests for the new decision function (fail-closed with guard set, forwarding without it, GUI launches unaffected either way) in `CLIForwardingLaunchArgumentTests`.
- New `cli.forwarding.error.forwardingLoop` string seeded across locales in `Localizable.xcstrings` following the existing `cli.forwarding.error.*` entries.
- I could not run the full app build locally (no GhosttyKit toolchain set up), so CI should be the authority on the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787444227&installation_model_id=21920&pr_number=8788&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8788&signature=9f4e81ab69f9f0832608fc7a6300c3cffce1058925cb42f48e8ee67cc436535c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed when CLI forwarding resolves back to the GUI binary to stop lingering faceless app processes from agent hooks. Adds an explicit routing decision and exits with a localized error (code 127) when `CMUX_CLI_FORWARDED` is already set.

- **Bug Fixes**
  - When the guard is set, print a localized error to stderr and exit 127 instead of launching the GUI.
  - GUI-style launches unchanged; first-pass CLI still execs the bundled CLI.
  - Added tests for the decision policy; added `cli.forwarding.error.forwardingLoop` with real translations across 20 locales (including `km`).

- **Refactors**
  - Moved pure argv/guard classification into `CMUXAgentLaunch` as `CLIForwardingLaunchPolicy`/`CLIForwardingDecision`; the app router now delegates and keeps only the exec/exit and stderr glue.

<sup>Written for commit 2ff6c2bc3ff7edbd442401e4f14bcd4964525626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line launching to distinguish CLI commands from normal graphical launches.
  - Added protection against forwarding loops, with a clear localized error message and a controlled failure status.
  - Preserved expected handling for macOS launch arguments, URLs, and other GUI-style invocations.

- **Localization**
  - Added translated forwarding-loop error messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->