### PR TITLE
Guard main-window focus after context teardown

### DIFF
--- a/Sources/App/MainWindowVisibilityController.swift
+++ b/Sources/App/MainWindowVisibilityController.swift
@@ -33,6 +33,19 @@ final class MainWindowVisibilityController {
         case afterWindowOrdering
     }
 
+    /// Snapshot of the owning main-window context at focus time.
+    struct WindowAvailability {
+        let isAvailable: Bool
+        let windowId: UUID?
+        let workspaceId: UUID?
+
+        static let unidentifiedAvailable = WindowAvailability(
+            isAvailable: true,
+            windowId: nil,
+            workspaceId: nil
+        )
+    }
+
     @MainActor
     struct WindowOperations {
         var isVisible: @MainActor (NSWindow) -> Bool
@@ -84,6 +97,7 @@ final class MainWindowVisibilityController {
     @MainActor
     struct Dependencies {
         var isActivationSuppressed: @MainActor () -> Bool
+        var windowAvailability: @MainActor (NSWindow) -> WindowAvailability
         var setActiveMainWindow: @MainActor (NSWindow) -> Void
         var isApplicationActive: @MainActor () -> Bool
         var isApplicationHidden: @MainActor () -> Bool
@@ -92,10 +106,14 @@ final class MainWindowVisibilityController {
         var hideApplication: @MainActor () -> Void
         var unhideApplication: @MainActor () -> Void
         var activateRunningApplication: @MainActor (NSApplication.ActivationOptions) -> Void
+        var recordBreadcrumb: @MainActor (String, [String: Any]) -> Void
         var windowOperations: WindowOperations
 
         init(
             isActivationSuppressed: @escaping @MainActor () -> Bool,
+            windowAvailability: @escaping @MainActor (NSWindow) -> WindowAvailability = { _ in
+                .unidentifiedAvailable
+            },
             setActiveMainWindow: @escaping @MainActor (NSWindow) -> Void,
             isApplicationActive: @escaping @MainActor () -> Bool = { NSApp.isActive },
             isApplicationHidden: @escaping @MainActor () -> Bool = { NSApp.isHidden },
@@ -106,9 +124,13 @@ final class MainWindowVisibilityController {
             activateRunningApplication: @escaping @MainActor (NSApplication.ActivationOptions) -> Void = {
                 NSRunningApplication.current.activate(options: $0)
             },
+            recordBreadcrumb: @escaping @MainActor (String, [String: Any]) -> Void = { message, data in
+                sentryBreadcrumb(message, category: "window", data: data)
+            },
             windowOperations: WindowOperations? = nil
         ) {
             self.isActivationSuppressed = isActivationSuppressed
+            self.windowAvailability = windowAvailability
             self.setActiveMainWindow = setActiveMainWindow
             self.isApplicationActive = isApplicationActive
             self.isApplicationHidden = isApplicationHidden
@@ -117,6 +139,7 @@ final class MainWindowVisibilityController {
             self.hideApplication = hideApplication
             self.unhideApplication = unhideApplication
             self.activateRunningApplication = activateRunningApplication
+            self.recordBreadcrumb = recordBreadcrumb
             self.windowOperations = windowOperations ?? WindowOperations.live
         }
     }
@@ -141,7 +164,25 @@ final class MainWindowVisibilityController {
         unhide: Bool = true,
         respectActivationSuppression: Bool = true
     ) -> Bool {
-        if respectActivationSuppression, dependencies.isActivationSuppressed() {
+        let suppressed = respectActivationSuppression && dependencies.isActivationSuppressed()
+        let availability = dependencies.windowAvailability(window)
+        let breadcrumbData = focusBreadcrumbData(
+            window,
+            reason: reason,
+            suppressed: suppressed,
+            availability: availability
+        )
+        dependencies.recordBreadcrumb("mainWindow.focus", breadcrumbData)
+
+        guard availability.isAvailable else {
+            var unavailableData = breadcrumbData
+            unavailableData["cause"] = "missing-context"
+            dependencies.recordBreadcrumb("mainWindow.focus.unavailable", unavailableData)
+            log("focus.unavailable", reason: reason, windows: [window])
+            return false
+        }
+
+        if suppressed {
             dependencies.setActiveMainWindow(window)
             log("focus.suppressed", reason: reason, windows: [window])
             return true
@@ -466,6 +507,32 @@ final class MainWindowVisibilityController {
 
     private func activationRequiringKeyTransfer(_ activation: Activation, makeKey: Bool) -> Activation {
         makeKey ? activation : .none
+    }
+
+    private func focusBreadcrumbData(
+        _ window: NSWindow,
+        reason: Reason,
+        suppressed: Bool,
+        availability: WindowAvailability
+    ) -> [String: Any] {
+        var data: [String: Any] = [
+            "reason": reason.rawValue,
+            "windowNumber": window.windowNumber,
+            "windowIdentifier": window.identifier?.rawValue ?? "<nil>",
+            "isVisible": window.isVisible,
+            "isMiniaturized": window.isMiniaturized,
+            "appActive": dependencies.isApplicationActive(),
+            "appHidden": dependencies.isApplicationHidden(),
+            "suppressed": suppressed,
+            "contextAvailable": availability.isAvailable
+        ]
+        if let windowId = availability.windowId {
+            data["windowId"] = windowId.uuidString
+        }
+        if let workspaceId = availability.workspaceId {
+            data["workspaceId"] = workspaceId.uuidString
+        }
+        return data
     }
 
     private func uniqueWindows(_ windows: [NSWindow]) -> [NSWindow] {

--- a/Sources/App/MainWindowVisibilityController.swift
+++ b/Sources/App/MainWindowVisibilityController.swift
@@ -172,7 +172,7 @@ final class MainWindowVisibilityController {
             suppressed: suppressed,
             availability: availability
         )
-        dependencies.recordBreadcrumb("mainWindow.focus", breadcrumbData)
+        dependencies.recordBreadcrumb("mainWindow.focus.attempt", breadcrumbData)
 
         guard availability.isAvailable else {
             var unavailableData = breadcrumbData

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -879,6 +879,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 TerminalController.shouldSuppressSocketCommandActivation()
                     && !TerminalController.socketCommandAllowsInAppFocusMutations()
             },
+            windowAvailability: { [weak self] window in
+                guard let self else {
+                    return .init(isAvailable: false, windowId: nil, workspaceId: nil)
+                }
+                guard let context = self.contextForMainTerminalWindow(window, reindex: false) else {
+                    return .init(
+                        isAvailable: false,
+                        windowId: self.mainWindowId(from: window),
+                        workspaceId: nil
+                    )
+                }
+                return .init(
+                    isAvailable: true,
+                    windowId: context.windowId,
+                    workspaceId: context.tabManager.selectedTabId ?? context.tabManager.tabs.first?.id
+                )
+            },
             setActiveMainWindow: { [weak self] window in
                 self?.setActiveMainWindow(window)
             }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -893,7 +893,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return .init(
                     isAvailable: true,
                     windowId: context.windowId,
-                    workspaceId: context.tabManager.selectedTabId ?? context.tabManager.tabs.first?.id
+                    workspaceId: context.tabManager.selectedTabId
                 )
             },
             setActiveMainWindow: { [weak self] window in

--- a/cmuxTests/MainWindowVisibilityControllerTests.swift
+++ b/cmuxTests/MainWindowVisibilityControllerTests.swift
@@ -81,6 +81,88 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
         XCTAssertEqual(activationCount, 0)
     }
 
+    func testFocusUnavailableWindowReturnsFalseBeforeWindowOperations() {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        let windowId = UUID()
+        let workspaceId = UUID()
+        var activeCount = 0
+        var operationCount = 0
+        var activationCount = 0
+        var breadcrumbs: [String: [String: Any]] = [:]
+
+        let controller = MainWindowVisibilityController(
+            dependencies: .init(
+                isActivationSuppressed: { false },
+                windowAvailability: { _ in
+                    .init(
+                        isAvailable: false,
+                        windowId: windowId,
+                        workspaceId: workspaceId
+                    )
+                },
+                setActiveMainWindow: { _ in activeCount += 1 },
+                isApplicationHidden: { false },
+                activateRunningApplication: { _ in activationCount += 1 },
+                recordBreadcrumb: { message, data in
+                    breadcrumbs[message] = data
+                },
+                windowOperations: makeWindowOperations(
+                    isMiniaturized: { _ in operationCount += 1; return false },
+                    deminiaturize: { _ in operationCount += 1 },
+                    makeKeyAndOrderFront: { _ in operationCount += 1 },
+                    orderFront: { _ in operationCount += 1 },
+                    softShow: { _ in operationCount += 1 }
+                )
+            )
+        )
+
+        XCTAssertFalse(controller.focus(window, reason: .focusMainWindow))
+        XCTAssertEqual(activeCount, 0)
+        XCTAssertEqual(operationCount, 0)
+        XCTAssertEqual(activationCount, 0)
+        XCTAssertEqual(
+            breadcrumbs["mainWindow.focus.unavailable"]?["reason"] as? String,
+            "focusMainWindow"
+        )
+        XCTAssertEqual(
+            breadcrumbs["mainWindow.focus.unavailable"]?["windowId"] as? String,
+            windowId.uuidString
+        )
+        XCTAssertEqual(
+            breadcrumbs["mainWindow.focus.unavailable"]?["workspaceId"] as? String,
+            workspaceId.uuidString
+        )
+        XCTAssertEqual(
+            breadcrumbs["mainWindow.focus.unavailable"]?["contextAvailable"] as? Bool,
+            false
+        )
+    }
+
+    func testFocusUnavailableWindowDoesNotUseSuppressedActiveContextShortcut() {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        var activeCount = 0
+        let controller = MainWindowVisibilityController(
+            dependencies: .init(
+                isActivationSuppressed: { true },
+                windowAvailability: { _ in
+                    .init(isAvailable: false, windowId: nil, workspaceId: nil)
+                },
+                setActiveMainWindow: { _ in activeCount += 1 },
+                isApplicationHidden: { false },
+                windowOperations: makeWindowOperations(
+                    makeKeyAndOrderFront: { _ in XCTFail("Unavailable windows must not be ordered") }
+                )
+            )
+        )
+
+        XCTAssertFalse(controller.focus(window, reason: .socketActivate))
+        XCTAssertEqual(activeCount, 0)
+    }
+
     func testHotkeyRestoreUsesCapturedVisibleTargetsWithoutDeminiaturizingMiniaturizedWindows() {
         let visibleWindow = makeWindow()
         let miniaturizedWindow = makeWindow()

--- a/cmuxTests/MainWindowVisibilityControllerTests.swift
+++ b/cmuxTests/MainWindowVisibilityControllerTests.swift
@@ -88,7 +88,7 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
         let windowId = UUID()
         let workspaceId = UUID()
         var activeCount = 0
-        var operationCount = 0
+        var mutationCount = 0
         var activationCount = 0
         var breadcrumbs: [String: [String: Any]] = [:]
 
@@ -109,18 +109,18 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
                     breadcrumbs[message] = data
                 },
                 windowOperations: makeWindowOperations(
-                    isMiniaturized: { _ in operationCount += 1; return false },
-                    deminiaturize: { _ in operationCount += 1 },
-                    makeKeyAndOrderFront: { _ in operationCount += 1 },
-                    orderFront: { _ in operationCount += 1 },
-                    softShow: { _ in operationCount += 1 }
+                    isMiniaturized: { _ in false },
+                    deminiaturize: { _ in mutationCount += 1 },
+                    makeKeyAndOrderFront: { _ in mutationCount += 1 },
+                    orderFront: { _ in mutationCount += 1 },
+                    softShow: { _ in mutationCount += 1 }
                 )
             )
         )
 
         XCTAssertFalse(controller.focus(window, reason: .focusMainWindow))
         XCTAssertEqual(activeCount, 0)
-        XCTAssertEqual(operationCount, 0)
+        XCTAssertEqual(mutationCount, 0)
         XCTAssertEqual(activationCount, 0)
         XCTAssertEqual(
             breadcrumbs["mainWindow.focus.unavailable"]?["reason"] as? String,
@@ -138,6 +138,11 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
             breadcrumbs["mainWindow.focus.unavailable"]?["contextAvailable"] as? Bool,
             false
         )
+        XCTAssertEqual(
+            breadcrumbs["mainWindow.focus.attempt"]?["contextAvailable"] as? Bool,
+            false
+        )
+        XCTAssertNil(breadcrumbs["mainWindow.focus"])
     }
 
     func testFocusUnavailableWindowDoesNotUseSuppressedActiveContextShortcut() {


### PR DESCRIPTION
## Summary

- Resolve main-window ownership at the shared focus entrypoint.
- Return `false` before active-context or AppKit operations when teardown removed the owning context.
- Record caller reason, window/workspace identity, app activation state, and context availability in Sentry breadcrumbs.

Fixes https://github.com/manaflow-ai/cmux/issues/7313

## Testing

- Red regression commit: `6ae8684272`.
- Red proof: focused `cmux-unit` build failed because `windowAvailability` and breadcrumb injection were absent.
- Green: focused `cmux-unit` build-for-testing succeeded for `MainWindowVisibilityControllerTests`.
- Tagged preflight: `foc13` created and focused two windows, closed one, then retried its immutable UUID. The shared focus guard logged `mainWindow.visibility.focus.unavailable`, returned `Window not found`, and the socket returned `PONG`.
- Debug-socket screenshot: `foc13-unavailable-guard_2026-07-24T01-32-15Z_2CED96B2`.
- Localization: no user-facing strings changed.

## Demo Video

No UI changed. The tagged debug-socket screenshot shows the surviving window after the guarded stale-focus request.

## Review Trigger

Not posted. Codex review requires explicit opt-in. Automatic review bots may inspect the ready PR.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit, not authorized for Codex review
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

Split replacement for the focus portion of https://github.com/manaflow-ai/cmux/pull/7331.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented main-window focus and activation when the target window’s required context is unavailable.
  * Improved behavior when terminal/workspace context can’t be determined, avoiding partial/incorrect activation flows.

* **Diagnostics**
  * Added enriched diagnostics for focus attempts, including context availability details and improved breadcrumbs for unavailable focus cases (with activation/suppression and app visibility state).

* **Tests**
  * Added coverage verifying unavailable windows don’t trigger activation, reordering, or active-context updates, and that the correct diagnostics are recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->