### PR TITLE
Pin four unread session-restore tests to the model the product implements

### DIFF
--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -1738,10 +1738,14 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
         let restoredTabId = try XCTUnwrap(restored.surfaceIdFromPanelId(restoredPanelId))
         XCTAssertFalse(restored.manualUnreadPanelIds.contains(restoredPanelId))
-        XCTAssertTrue(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        // The snapshot carries the notification, so restore puts it back still unread and
+        // leaves the restored-unread indicator off. The notification drives the badge, and
+        // setting the indicator as well would count the same notification twice.
+        XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: restored.id, surfaceId: restoredPanelId))
         XCTAssertTrue(restored.bonsplitController.tab(restoredTabId)?.showsNotificationBadge ?? false)
         XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
-        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
 
         restored.markPanelRead(restoredPanelId)
 
@@ -1788,12 +1792,16 @@ final class WorkspaceManualUnreadTests: XCTestCase {
 
         let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
         XCTAssertTrue(restored.manualUnreadPanelIds.contains(restoredPanelId))
-        XCTAssertTrue(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        // Manual panel unread survives restore on its own. The restored-unread indicator
+        // stays off because the snapshot's unread notification comes back instead.
+        XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: restored.id, surfaceId: restoredPanelId))
 
         restored.markPanelRead(restoredPanelId)
 
         XCTAssertFalse(restored.manualUnreadPanelIds.contains(restoredPanelId))
         XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: restored.id, surfaceId: restoredPanelId))
     }
 
     func testSessionRestorePreservesFocusedReadIndicator() throws {
@@ -1961,7 +1969,10 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         restored.restoreSessionSnapshot(snapshot)
 
         XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
-        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        // The workspace-level notification is restored unread, so it carries the unread
+        // state and the restored-unread indicator is not set on top of it.
+        XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: restored.id, surfaceId: nil))
         XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
 
         store.markRead(forTabId: restored.id)
@@ -2004,14 +2015,19 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         let restored = Workspace()
         restored.restoreSessionSnapshot(snapshot)
 
+        // Manual workspace unread and the restored workspace notification are independent,
+        // so the count is the notification (1) plus the manual indicator (1). unreadCount
+        // adds one for any workspace-level indicator on top of the per-notification count.
         XCTAssertTrue(store.hasManualUnread(forTabId: restored.id))
-        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: restored.id))
-        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+        XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: restored.id, surfaceId: nil))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 2)
 
         store.clearManualUnread(forTabId: restored.id)
 
         XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
-        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: restored.id, surfaceId: nil))
         XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
 
         store.markRead(forTabId: restored.id)

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -1796,12 +1796,16 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         // stays off because the snapshot's unread notification comes back instead.
         XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
         XCTAssertTrue(store.hasUnreadNotification(forTabId: restored.id, surfaceId: restoredPanelId))
+        // One notification plus the manual workspace indicator: the combined badge count
+        // must be 2, or a regression in either contribution passes unnoticed.
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 2)
 
         restored.markPanelRead(restoredPanelId)
 
         XCTAssertFalse(restored.manualUnreadPanelIds.contains(restoredPanelId))
         XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
         XCTAssertFalse(store.hasUnreadNotification(forTabId: restored.id, surfaceId: restoredPanelId))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
     }
 
     func testSessionRestorePreservesFocusedReadIndicator() throws {


### PR DESCRIPTION
Four session-restore tests in `WorkspaceManualUnreadTests` still describe the restore model the product
had before `e4856922b0`, so they assert an indicator the product deliberately no longer sets and a count
of zero for a notification the product deliberately keeps unread.

## What changed in the product, and why

In the old model an unread notification present at snapshot time was dropped on restore and came back as
a purely visual "restored unread indicator", with an unread count of zero. `e4856922b0` ("fix: persist
restored pane notifications") changed that on purpose: snapshots now carry the notifications themselves,
restore re-inserts them still unread, and the restored-unread indicator is set **only** when a snapshot
claims unread with no unread notification to back it.

Both gates are live. At workspace level the restore path computes
`snapshot.notifications?.contains { !$0.isRead }` and skips the indicator when that is true; the panel
level does the same. Setting both would count one notification twice, which is exactly what the
indicator exists to avoid.

So these four tests were asserting the double-counted state:

- `testSessionRestorePreservesNotificationUnreadIndicator`
- `testSessionRestorePreservesManualAndNotificationPanelUnreadIndependently`
- `testSessionRestorePreservesWorkspaceNotificationUnreadIndicatorWithoutManualState`
- `testSessionRestorePreservesManualAndNotificationWorkspaceUnreadIndependently`

## The change

Each test now asserts the restored notification directly, through
`store.hasUnreadNotification(forTabId:surfaceId:)`, and expects the restored-unread indicator to be
false — which is what the product implements. The independence the last two tests are named for still
holds and is still checked: manual unread and a restored notification each contribute to the count, so
it reads 2 until the manual half is cleared, then 1.

That 2 is not a guess. `unreadCount(forTabId:)` returns the per-notification count plus one if any
workspace-level indicator is set, and manual unread is one of those indicators.

The assertions after `markPanelRead` and `markRead` are untouched: marking read clears the notification,
so the existing indicator-false, badge-false and count-zero expectations there were already correct.
Test names are unchanged, because the CI shard timings key on them.

## Test plan

```
xcodebuild test -scheme cmux-unit -configuration Debug -destination 'platform=macOS' \
  -only-testing:cmuxTests/WorkspaceManualUnreadTests
```

Measured on `5dc99c6da5`, same checkout and DerivedData for both arms, one GUI test host at a time:

| arm | XCTest failures across a 60-test run | distinct tests red |
|---|---|---|
| `main` unchanged | 7 | 4 |
| this branch | **0** | **0** |

The four tests that flip are exactly the four named above, and no host restarts occurred in either arm.

Pull-request CI on this repo runs review bots and security scanners rather than the test suite, so the
arms above are the only test evidence this carries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787452140&installation_model_id=21920&pr_number=8798&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8798&signature=2876c147106813c754cf0b8c98b890feb1eb678907c6e8387285459ccdd34ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins four session-restore unread tests to the current model that persists notifications across restore and adds explicit combined-count checks to prevent double-counting.

- **Bug Fixes**
  - Updated tests: `testSessionRestorePreservesNotificationUnreadIndicator`, `testSessionRestorePreservesManualAndNotificationPanelUnreadIndependently`, `testSessionRestorePreservesWorkspaceNotificationUnreadIndicatorWithoutManualState`, `testSessionRestorePreservesManualAndNotificationWorkspaceUnreadIndependently`.
  - Assertions now check: restored notification present (`store.hasUnreadNotification(...)` true) with the restored-unread indicator off; unreadCount is 1 for a restored notification, 2 when combined with manual unread, drops to 1 after clearing manual, and 0 after `markPanelRead`/`markRead`.

<sup>Written for commit 61f8a225fe1865e93bb3e94ea4738f2ee243e0d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-restore unread-state handling for panels and workspaces.
  * Restored notification-based unread indicators now remain distinct from manually marked unread states.
  * Unread counts accurately reflect combined manual and notification sources.
  * Clearing manual unread status now preserves notification-driven unread status while removing the manual contribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->