### PR TITLE
Launch workspace initial commands via the user's login shell

### DIFF
--- a/Sources/TerminalController+WorkspaceCreateExecutionPreparation.swift
+++ b/Sources/TerminalController+WorkspaceCreateExecutionPreparation.swift
@@ -43,7 +43,9 @@ extension TerminalController {
     ) -> WorkspaceCreateExecutionPreparationOutcome {
         let requestedInitialCommand = v2RawString(params, "initial_command")
         let initialCommand = requestedInitialCommand.flatMap {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0
+            $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? nil
+                : WorkspaceInitialCommandLoginShell.wrap($0)
         }
         let initialEnvironment = sanitizedInitialEnvironment(v2StringMap(params, "initial_env") ?? [:])
         let workspaceEnvironment = Workspace.sanitizedWorkspaceEnvironment(

--- a/Sources/WorkspaceInitialCommandLoginShell.swift
+++ b/Sources/WorkspaceInitialCommandLoginShell.swift
@@ -1,0 +1,68 @@
+import Darwin
+import Foundation
+
+enum WorkspaceInitialCommandLoginShell {
+    /// Resolves the user's login shell and wraps an externally supplied workspace command.
+    ///
+    /// Ghostty otherwise launches string commands through Bash with `--noprofile --norc`,
+    /// so the user's profile cannot contribute tools such as Homebrew-installed agents.
+    /// Ghostty prepends `exec -l`, so the returned command starts with the quoted shell path.
+    static func wrap(_ command: String) -> String {
+        let databaseShell: String?
+        if let record = getpwuid(getuid()),
+           let shell = record.pointee.pw_shell {
+            let copiedShell = String(cString: shell)
+            databaseShell = copiedShell.isEmpty ? nil : copiedShell
+        } else {
+            databaseShell = nil
+        }
+
+        let userShell = databaseShell
+            ?? ProcessInfo.processInfo.environment["SHELL"]
+            ?? "/bin/zsh"
+        return wrap(command, userShell: userShell)
+    }
+
+    /// Wraps a command in a supported login shell while preserving the command verbatim.
+    ///
+    /// Login profiles can prepend other tool directories (Homebrew's `shellenv` puts
+    /// `/opt/homebrew/bin` first) ahead of the per-surface shim directory that cmux
+    /// seeds into the spawned PATH, which would route `claude`/`codex` around cmux's
+    /// wrapper hooks. The payload therefore re-prepends the shim directory
+    /// unconditionally after profiles run; a duplicate PATH entry is harmless and
+    /// matches what interactive shell integration already produces.
+    static func wrap(_ command: String, userShell: String?) -> String {
+        var shellPath: String
+        if let userShell, userShell.hasPrefix("/") {
+            shellPath = userShell
+        } else {
+            shellPath = "/bin/zsh"
+        }
+        let payload: String
+
+        switch (shellPath as NSString).lastPathComponent {
+        case "fish":
+            payload = """
+            if test -n "$CMUX_CLAUDE_WRAPPER_SHIM_ROOT"; and test -d "$CMUX_CLAUDE_WRAPPER_SHIM_ROOT"; set -gx PATH "$CMUX_CLAUDE_WRAPPER_SHIM_ROOT" $PATH; end
+            \(command)
+            """
+        case "zsh", "bash", "sh", "ksh", "dash":
+            payload = """
+            if [ -n "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}" ] && [ -d "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}" ]; then PATH="${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}${PATH:+:$PATH}"; export PATH; fi
+            \(command)
+            """
+        default:
+            shellPath = "/bin/zsh"
+            payload = """
+            if [ -n "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}" ] && [ -d "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}" ]; then PATH="${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}${PATH:+:$PATH}"; export PATH; fi
+            \(command)
+            """
+        }
+
+        return "\(shellSingleQuoted(shellPath)) -lc \(shellSingleQuoted(payload))"
+    }
+
+    private static func shellSingleQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2143,6 +2143,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C9A57401C9A57401C9A57401 /* WorkspaceGroupMoveToMenuStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57402C9A57402C9A57402 /* WorkspaceGroupMoveToMenuStateTests.swift */; };
 		C9A57001C9A57001C9A57001 /* WorkspaceGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */; };
 		E3B7A4000000000000000007 /* WorkspaceIndicatorStyle+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B7A4000000000000000008 /* WorkspaceIndicatorStyle+Display.swift */; };
+		A17C0A110000000000000001 /* WorkspaceInitialCommandLoginShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17C0A110000000000000002 /* WorkspaceInitialCommandLoginShell.swift */; };
 		B63E1257BB174740A44F458C /* WorkspaceIsStaleAgentHookBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B714B27E46014592B9CB2D3A /* WorkspaceIsStaleAgentHookBindingTests.swift */; };
 		CA52B0180000000000000000 /* WorkspaceLayoutMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0180000000000000000 /* WorkspaceLayoutMode.swift */; };
 		A6AC720A0000000000000001 /* WorkspaceLoadingArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC720A0000000000000002 /* WorkspaceLoadingArguments.swift */; };
@@ -4322,6 +4323,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C9A57402C9A57402C9A57402 /* WorkspaceGroupMoveToMenuStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupMoveToMenuStateTests.swift; sourceTree = "<group>"; };
 		C9A57002C9A57002C9A57002 /* WorkspaceGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupTests.swift; sourceTree = "<group>"; };
 		E3B7A4000000000000000008 /* WorkspaceIndicatorStyle+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceIndicatorStyle+Display.swift"; sourceTree = "<group>"; };
+		A17C0A110000000000000002 /* WorkspaceInitialCommandLoginShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceInitialCommandLoginShell.swift; sourceTree = "<group>"; };
 		B714B27E46014592B9CB2D3A /* WorkspaceIsStaleAgentHookBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIsStaleAgentHookBindingTests.swift; sourceTree = "<group>"; };
 		CA52C0180000000000000000 /* WorkspaceLayoutMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkspaceLayoutMode.swift"; sourceTree = "<group>"; };
 		A6AC720A0000000000000002 /* WorkspaceLoadingArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLoadingArguments.swift; sourceTree = "<group>"; };
@@ -5317,6 +5319,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE00000000000000000E92 /* TerminalController+WorkspaceCreateWorkingDirectoryValidationService.swift */,
 				C0DE00000000000000000D35 /* TerminalController+WorkspaceCreatePreparation.swift */,
 				C0DE00000000000000000C8A /* TerminalController+WorkspaceGroupAction.swift */,
+				A17C0A110000000000000002 /* WorkspaceInitialCommandLoginShell.swift */,
 				C0DE00000000000000000C88 /* TerminalController+WorkspaceMove.swift */,
 				C0DE00000000000000000C55 /* TerminalController+ControlPaneContext.swift */,
 				C7A50B000000000000000001 /* TerminalControllerV2ParamParsingSupport.swift */,
@@ -8513,6 +8516,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57203C9A57203C9A57203 /* WorkspaceGroupMenuSnapshot.swift in Sources */,
 				C9A57206C9A57206C9A57206 /* WorkspaceGroupMoveToMenuState.swift in Sources */,
 				E3B7A4000000000000000007 /* WorkspaceIndicatorStyle+Display.swift in Sources */,
+				A17C0A110000000000000001 /* WorkspaceInitialCommandLoginShell.swift in Sources */,
 				CA52B0180000000000000000 /* WorkspaceLayoutMode.swift in Sources */,
 				E3B7A4000000000000000005 /* WorkspacePlacement+Resolution.swift in Sources */,
 				D0B10004A1B2C3D4E5F60001 /* WorkspacePortalPaneDrop.swift in Sources */,

--- a/cmuxTests/WorkspaceCreateWorkingDirectoryTests.swift
+++ b/cmuxTests/WorkspaceCreateWorkingDirectoryTests.swift
@@ -30,10 +30,11 @@ import Testing
         let manager = TabManager()
         let initialWorkspaceIDs = Set(manager.tabs.map(\.id))
         let operationID = UUID()
+        let initialCommand = "codex \"${CMUX_TASK_PROMPT}\""
         let params: [String: Any] = [
             "operation_id": operationID.uuidString,
             "title": "Idempotent Task",
-            "initial_command": "codex \"${CMUX_TASK_PROMPT}\"",
+            "initial_command": initialCommand,
             "initial_env": ["CMUX_TASK_PROMPT": "Fix the composer"],
         ]
         let cache = Self.makeCache()
@@ -53,7 +54,9 @@ import Testing
 
         #expect(manager.tabs.count == initialWorkspaceIDs.count + 1)
         #expect(createdPanels.count == 1)
-        #expect(createdPanels.first?.surface.debugInitialCommand() == "codex \"${CMUX_TASK_PROMPT}\"")
+        let launchedCommand = try #require(createdPanels.first?.surface.debugInitialCommand())
+        #expect(launchedCommand == WorkspaceInitialCommandLoginShell.wrap(initialCommand))
+        #expect(launchedCommand.contains(initialCommand))
         #expect(Self.workspaceID(from: first) == created.id)
         #expect(Self.workspaceID(from: retry) == created.id)
     }
@@ -89,7 +92,13 @@ import Testing
 
         let created = try #require(manager.tabs.first { !initialWorkspaceIDs.contains($0.id) })
         let panel = try #require(created.panels.values.compactMap { $0 as? TerminalPanel }.first)
-        #expect(panel.surface.debugInitialCommand() == initialCommand)
+        let launchedCommand = try #require(panel.surface.debugInitialCommand())
+        #expect(launchedCommand == WorkspaceInitialCommandLoginShell.wrap(initialCommand))
+        #expect(
+            launchedCommand
+                .replacingOccurrences(of: "'\"'\"'", with: "'")
+                .contains(initialCommand)
+        )
     }
 
     @Test func whitespaceOnlyInitialAgentCommandStartsPlainShell() throws {
@@ -103,6 +112,68 @@ import Testing
         let created = try #require(manager.tabs.first { !initialWorkspaceIDs.contains($0.id) })
         let panel = try #require(created.panels.values.compactMap { $0 as? TerminalPanel }.first)
         #expect(panel.surface.debugInitialCommand() == nil)
+    }
+
+    @Test func workspaceInitialCommandWrapsZshExactly() {
+        let actual = WorkspaceInitialCommandLoginShell.wrap("echo zsh", userShell: "/bin/zsh")
+        let expected = """
+        '/bin/zsh' -lc 'if [ -n "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}" ] && [ -d "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}" ]; then PATH="${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}${PATH:+:$PATH}"; export PATH; fi
+        echo zsh'
+        """
+
+        #expect(actual == expected)
+    }
+
+    @Test func workspaceInitialCommandWrapsBashExactly() {
+        let actual = WorkspaceInitialCommandLoginShell.wrap("echo bash", userShell: "/bin/bash")
+        let expected = """
+        '/bin/bash' -lc 'if [ -n "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}" ] && [ -d "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}" ]; then PATH="${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}${PATH:+:$PATH}"; export PATH; fi
+        echo bash'
+        """
+
+        #expect(actual == expected)
+    }
+
+    @Test func workspaceInitialCommandWrapsFishExactly() {
+        let actual = WorkspaceInitialCommandLoginShell.wrap("echo fish", userShell: "/usr/local/bin/fish")
+        let expected = """
+        '/usr/local/bin/fish' -lc 'if test -n "$CMUX_CLAUDE_WRAPPER_SHIM_ROOT"; and test -d "$CMUX_CLAUDE_WRAPPER_SHIM_ROOT"; set -gx PATH "$CMUX_CLAUDE_WRAPPER_SHIM_ROOT" $PATH; end
+        echo fish'
+        """
+
+        #expect(actual == expected)
+    }
+
+    @Test func workspaceInitialCommandFallsBackToZshForNilShell() {
+        let actual = WorkspaceInitialCommandLoginShell.wrap("echo nil", userShell: nil)
+        let expected = """
+        '/bin/zsh' -lc 'if [ -n "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}" ] && [ -d "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}" ]; then PATH="${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}${PATH:+:$PATH}"; export PATH; fi
+        echo nil'
+        """
+
+        #expect(actual == expected)
+    }
+
+    @Test func workspaceInitialCommandFallsBackToZshForUnknownShell() {
+        let actual = WorkspaceInitialCommandLoginShell.wrap("echo unknown", userShell: "/opt/weird/nu")
+        let expected = """
+        '/bin/zsh' -lc 'if [ -n "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}" ] && [ -d "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}" ]; then PATH="${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}${PATH:+:$PATH}"; export PATH; fi
+        echo unknown'
+        """
+
+        #expect(actual == expected)
+    }
+
+    @Test func workspaceInitialCommandEscapesSingleQuotesAndPreservesNewlines() {
+        let command = "printf 'hello'\necho done"
+        let actual = WorkspaceInitialCommandLoginShell.wrap(command, userShell: "/bin/zsh")
+        let expected = """
+        '/bin/zsh' -lc 'if [ -n "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT:-}" ] && [ -d "${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}" ]; then PATH="${CMUX_CLAUDE_WRAPPER_SHIM_ROOT}${PATH:+:$PATH}"; export PATH; fi
+        printf '"'"'hello'"'"'
+        echo done'
+        """
+
+        #expect(actual == expected)
     }
 
     @Test func initialEnvironmentRejectsCStringTruncationAndPreservesEmptyPrompt() throws {
@@ -378,7 +449,11 @@ import Testing
         let attemptsAfterCreation = taskPanel.surface.debugRuntimeSurfaceCreateAttemptCountForTesting()
 
         #expect(Set(manager.tabs.map(\.id)).subtracting(baselineIDs).count == 1)
-        #expect(initialCommands.filter { $0 == "must-run-once" }.count == 1)
+        #expect(
+            initialCommands.filter {
+                $0 == WorkspaceInitialCommandLoginShell.wrap("must-run-once")
+            }.count == 1
+        )
         #expect(attemptsAfterCreation > 0)
         #expect(!successfulResponses.isEmpty)
         #expect(successfulResponses.count + completedErrors.count == concurrentResults.count)

--- a/cmuxTests/WorkspaceCreateWorkingDirectoryTests.swift
+++ b/cmuxTests/WorkspaceCreateWorkingDirectoryTests.swift
@@ -58,6 +58,26 @@ import Testing
         #expect(Self.workspaceID(from: retry) == created.id)
     }
 
+    @Test func initialAgentCommandLaunchesThroughLoginShellWithShimPath() throws {
+        let manager = TabManager()
+        let initialWorkspaceIDs = Set(manager.tabs.map(\.id))
+        let initialCommand = "claude -- \"$CMUX_TASK_PROMPT\""
+
+        _ = TerminalController.shared.v2WorkspaceCreate(params: [
+            "initial_command": initialCommand,
+            "initial_env": ["CMUX_TASK_PROMPT": "Fix the composer"],
+        ], tabManager: manager)
+
+        let created = try #require(manager.tabs.first { !initialWorkspaceIDs.contains($0.id) })
+        let panel = try #require(created.panels.values.compactMap { $0 as? TerminalPanel }.first)
+        let launchedCommand = try #require(panel.surface.debugInitialCommand())
+
+        #expect(launchedCommand != initialCommand)
+        #expect(launchedCommand.contains("-lc"))
+        #expect(launchedCommand.contains(initialCommand))
+        #expect(launchedCommand.contains("CMUX_CLAUDE_WRAPPER_SHIM_ROOT"))
+    }
+
     @Test func initialAgentCommandPreservesSurroundingWhitespaceThroughTerminalStartup() throws {
         let manager = TabManager()
         let initialWorkspaceIDs = Set(manager.tabs.map(\.id))


### PR DESCRIPTION
Fixes the iOS "New Task" failure where every template command died with `Error: claude not found in PATH`.

**Bug.** Workspace-create `initial_command` (iOS task composer, CLI `cmux workspace create --command`) was passed verbatim to Ghostty, which launches string commands as `/usr/bin/login -flp <user> /bin/bash --noprofile --norc -c "exec -l <cmd>"`. No shell profile runs, so PATH is the app-inherited launchd default plus the per-surface `cmux-cli-shims` dir. The claude shim is found and runs, but its `find_real_claude` scans that same bare PATH, misses `/opt/homebrew/bin/claude`, prints the error, and exits 127.

**Fix.** `v2PrepareWorkspaceCreateExecution` now wraps a non-blank `initial_command` via the new `WorkspaceInitialCommandLoginShell` helper into `'<usershell>' -lc '<payload>'`. The payload re-prepends `$CMUX_CLAUDE_WRAPPER_SHIM_ROOT` to PATH (login profiles prepend `/opt/homebrew/bin`, which would otherwise shadow the cmux claude/codex wrapper hooks) and then runs the original command verbatim. fish gets fish syntax; unknown shells fall back to `/bin/zsh` with the POSIX payload. This matches the login-shell wrapping that session restore (`SessionRestoredTerminalCommandStore`) and the right-dock (`DockSplitStore+TerminalStartup`) already do; first launch was the only path executing user commands with a bare environment.

Commit 1 adds the regression test only (CI red), commit 2 adds the fix (CI green). Pure string transform: no temp files, respawn-safe, nothing user-facing to localize.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787453873&installation_model_id=21920&pr_number=8801&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8801&signature=030fd6df04963d45016e1c833b67898d84efc002167deb7c5baa52d13cece53f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run workspace initial commands through the user’s login shell so PATH and profiles load correctly. Fixes the iOS “New Task” failure where commands like claude were not found.

- **Bug Fixes**
  - Wrap non-empty `initial_command` via the user’s shell with `-lc`, preserving the original command, whitespace, and newlines.
  - Re-prepend `$CMUX_CLAUDE_WRAPPER_SHIM_ROOT` to PATH so cmux Claude/Codex wrapper hooks stay active.
  - Use fish-specific syntax when the shell is fish; otherwise use POSIX syntax, falling back to `/bin/zsh`.
  - Align first-launch behavior with session restore and right-dock startup.
  - Added tests for shell selection/fallback, PATH shim injection, single-quote escaping, whitespace/newline preservation, and blank-command handling.

<sup>Written for commit d506ed04a9e15a1fa59bb20a54bd3c2a942d5370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace startup commands now run through the system’s configured login shell.
  * Supports common shells (zsh, bash, fish, sh, ksh, dash) with a safe fallback.
  * Preserves original command content, including whitespace and newlines, with robust escaping.
  * Ensures required command-line integration hooks remain available after shell startup.

* **Bug Fixes**
  * Improved consistency for workspace creation with initial commands across repeated and concurrent scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->