### PR TITLE
Limit CMUX INTERNAL builds to iOS changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Validate TestFlight notes generator
         run: python3 tests/test_ios_testflight_notes.py
 
+      - name: Validate CMUX INTERNAL main-push path filter
+        run: python3 tests/test_ios_testflight_main_push_filter.py
+
       - name: Validate external TestFlight group assignment helper
         run: python3 tests/test_ios_testflight_external_distribution.py
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,12 +1,24 @@
 name: iOS TestFlight (CMUX INTERNAL)
 
 on:
-  # Every main commit gets its own cmux INTERNAL build. Do not add a path filter:
-  # the contract is one TestFlight upload for every main change, regardless of
-  # which part of the repository changed.
+  # Automatically upload only when main changes the iOS app or a direct archive
+  # input. Manual dispatch remains available for intentional rebuilds.
   push:
     branches:
       - main
+    paths:
+      - "ios/**"
+      - "Packages/iOS/**"
+      - "Packages/Shared/**"
+      - "Sources/Mobile/**"
+      - "vendor/stack-auth-swift-sdk-prerelease/**"
+      - "ghostty"
+      - "ghostty.h"
+      - "scripts/ensure-ghosttykit.sh"
+      - "scripts/ghosttykit-checksums.txt"
+      - "scripts/install-zig-ci.sh"
+      - "scripts/validate-xcframework-archive.py"
+      - ".github/workflows/ios-testflight.yml"
   workflow_dispatch:
     inputs:
       build_number:
@@ -20,8 +32,8 @@ on:
 
 concurrency:
   # A shared group keeps only one pending run and silently replaces older pending
-  # SHAs during merge bursts. Key push runs by SHA so every main commit survives.
-  # Manual runs use run_id because an operator may intentionally rebuild a SHA.
+  # SHAs during merge bursts. Key qualifying push runs by SHA so every iOS change
+  # survives. Manual runs use run_id because an operator may intentionally rebuild.
   group: ios-testflight-${{ github.event_name == 'push' && github.sha || github.run_id }}
   cancel-in-progress: false
 
@@ -181,8 +193,9 @@ jobs:
               core.warning(`could not resolve last uploaded sha: ${e.message}`);
             }
 
-            // Push and manual runs always build. There is deliberately no SHA or
-            // path gate: every main push owns one CMUX INTERNAL upload.
+            // Push runs have already passed the workflow's iOS path filter.
+            // Manual runs are intentional rebuilds, so every event that reaches
+            // this workflow should build.
             const shouldBuild =
               context.eventName === 'push' || context.eventName === 'workflow_dispatch';
             core.setOutput('should_build', shouldBuild ? 'true' : 'false');

--- a/ios/scripts/generate-testflight-notes.sh
+++ b/ios/scripts/generate-testflight-notes.sh
@@ -63,7 +63,7 @@ fi
 
 # iOS-affecting paths: mirror the push-trigger filter in ios-testflight.yml so the
 # notes only mention changes that could be in this build.
-PATHS="ios Packages/iOS Packages/Shared Sources/Mobile vendor/stack-auth-swift-sdk-prerelease scripts/ghosttykit-checksums.txt"
+PATHS="ios Packages/iOS Packages/Shared Sources/Mobile vendor/stack-auth-swift-sdk-prerelease ghostty ghostty.h scripts/ensure-ghosttykit.sh scripts/ghosttykit-checksums.txt scripts/install-zig-ci.sh scripts/validate-xcframework-archive.py .github/workflows/ios-testflight.yml"
 
 # First-line subjects of non-merge commits in range touching those paths. Squash
 # merges carry the PR title + "(#N)" as the subject, which is exactly what we want.

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -29,23 +29,46 @@ def trigger_block(text: str) -> str:
     return text[text.index("on:\n") : text.index("\nconcurrency:\n")]
 
 
-def trigger_paths(triggers: str) -> tuple[str, ...]:
-    lines = triggers[triggers.index("    paths:\n") :].splitlines()[1:]
-    return tuple(
-        line.removeprefix('      - "').removesuffix('"')
-        for line in lines
-        if line.startswith('      - "')
-    )
+def mapping_block(text: str, key: str, indent: int) -> str:
+    marker = f"{' ' * indent}{key}:\n"
+    assert marker in text, f"missing {key} mapping"
+    lines = text[text.index(marker) + len(marker) :].splitlines()
+    block = []
+    for line in lines:
+        if line.strip() and len(line) - len(line.lstrip()) <= indent:
+            break
+        block.append(line)
+    return "\n".join(block)
+
+
+def sequence_values(text: str, key: str, indent: int) -> tuple[str, ...]:
+    marker = f"{' ' * indent}{key}:\n"
+    assert marker in text, f"missing {key} sequence"
+    lines = text[text.index(marker) + len(marker) :].splitlines()
+    item_prefix = f"{' ' * (indent + 2)}- "
+    values = []
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        line_indent = len(line) - len(line.lstrip())
+        if line_indent <= indent:
+            break
+        assert line.startswith(item_prefix), f"invalid {key} item: {line}"
+        parsed = shlex.split(line.removeprefix(item_prefix), comments=True)
+        assert len(parsed) == 1, f"invalid {key} value: {line}"
+        values.append(parsed[0])
+    return tuple(values)
 
 
 def test_main_push_triggers_only_for_ios_affecting_paths() -> None:
     text = workflow_text()
     triggers = trigger_block(text)
+    push = mapping_block(triggers, "push", indent=2)
 
-    assert "  push:\n    branches:\n      - main\n" in triggers
+    assert sequence_values(push, "branches", indent=4) == ("main",)
+    assert sequence_values(push, "paths", indent=4) == IOS_PATHS
     assert "  workflow_dispatch:\n" in triggers
     assert "schedule:" not in triggers
-    assert trigger_paths(triggers) == IOS_PATHS
     assert "'schedule'" not in text
     assert "context.eventName === 'push' || context.eventName === 'workflow_dispatch'" in text
 
@@ -53,8 +76,10 @@ def test_main_push_triggers_only_for_ios_affecting_paths() -> None:
 def test_testflight_notes_use_the_same_ios_path_contract() -> None:
     generator = NOTES_GENERATOR.read_text(encoding="utf-8")
     path_assignment = next(
-        line for line in generator.splitlines() if line.startswith("PATHS=")
+        (line for line in generator.splitlines() if line.startswith("PATHS=")),
+        None,
     )
+    assert path_assignment is not None, "missing PATHS assignment"
     notes_paths = tuple(
         shlex.split(path_assignment.removeprefix("PATHS="))[0].split()
     )

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -1,8 +1,24 @@
+import shlex
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "ios-testflight.yml"
+NOTES_GENERATOR = ROOT / "ios" / "scripts" / "generate-testflight-notes.sh"
+IOS_PATHS = (
+    "ios/**",
+    "Packages/iOS/**",
+    "Packages/Shared/**",
+    "Sources/Mobile/**",
+    "vendor/stack-auth-swift-sdk-prerelease/**",
+    "ghostty",
+    "ghostty.h",
+    "scripts/ensure-ghosttykit.sh",
+    "scripts/ghosttykit-checksums.txt",
+    "scripts/install-zig-ci.sh",
+    "scripts/validate-xcframework-archive.py",
+    ".github/workflows/ios-testflight.yml",
+)
 
 
 def workflow_text() -> str:
@@ -13,16 +29,40 @@ def trigger_block(text: str) -> str:
     return text[text.index("on:\n") : text.index("\nconcurrency:\n")]
 
 
-def test_every_main_push_triggers_without_path_or_schedule_gates() -> None:
+def trigger_paths(triggers: str) -> tuple[str, ...]:
+    lines = triggers[triggers.index("    paths:\n") :].splitlines()[1:]
+    return tuple(
+        line.removeprefix('      - "').removesuffix('"')
+        for line in lines
+        if line.startswith('      - "')
+    )
+
+
+def test_main_push_triggers_only_for_ios_affecting_paths() -> None:
     text = workflow_text()
     triggers = trigger_block(text)
 
     assert "  push:\n    branches:\n      - main\n" in triggers
     assert "  workflow_dispatch:\n" in triggers
     assert "schedule:" not in triggers
-    assert "paths:" not in triggers
+    assert trigger_paths(triggers) == IOS_PATHS
     assert "'schedule'" not in text
     assert "context.eventName === 'push' || context.eventName === 'workflow_dispatch'" in text
+
+
+def test_testflight_notes_use_the_same_ios_path_contract() -> None:
+    generator = NOTES_GENERATOR.read_text(encoding="utf-8")
+    path_assignment = next(
+        line for line in generator.splitlines() if line.startswith("PATHS=")
+    )
+    notes_paths = tuple(
+        shlex.split(path_assignment.removeprefix("PATHS="))[0].split()
+    )
+    expected_notes_paths = tuple(
+        path.removesuffix("/**") for path in IOS_PATHS
+    )
+
+    assert notes_paths == expected_notes_paths
 
 
 def test_main_push_runs_are_preserved_and_uploaded_in_order() -> None:
@@ -50,7 +90,8 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
 
 
 if __name__ == "__main__":
-    test_every_main_push_triggers_without_path_or_schedule_gates()
+    test_main_push_triggers_only_for_ios_affecting_paths()
+    test_testflight_notes_use_the_same_ios_path_contract()
     test_main_push_runs_are_preserved_and_uploaded_in_order()
     test_automatic_lane_stays_on_cmux_internal_identity()
-    print("all iOS TestFlight main-push workflow tests passed")
+    print("all iOS TestFlight main-push filter tests passed")

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -41,6 +41,21 @@ def mapping_block(text: str, key: str, indent: int) -> str:
     return "\n".join(block)
 
 
+def mapping_keys(text: str, indent: int) -> tuple[str, ...]:
+    keys = []
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if len(line) - len(line.lstrip()) != indent:
+            continue
+        key, separator, _ = line.strip().partition(":")
+        assert separator, f"invalid mapping entry: {line}"
+        parsed = shlex.split(key, comments=True)
+        assert len(parsed) == 1, f"invalid mapping key: {line}"
+        keys.append(parsed[0])
+    return tuple(keys)
+
+
 def sequence_values(text: str, key: str, indent: int) -> tuple[str, ...]:
     marker = f"{' ' * indent}{key}:\n"
     assert marker in text, f"missing {key} sequence"
@@ -65,12 +80,20 @@ def test_main_push_triggers_only_for_ios_affecting_paths() -> None:
     triggers = trigger_block(text)
     push = mapping_block(triggers, "push", indent=2)
 
+    assert mapping_keys(triggers, indent=2) == ("push", "workflow_dispatch")
     assert sequence_values(push, "branches", indent=4) == ("main",)
     assert sequence_values(push, "paths", indent=4) == IOS_PATHS
-    assert "  workflow_dispatch:\n" in triggers
-    assert "schedule:" not in triggers
-    assert "'schedule'" not in text
     assert "context.eventName === 'push' || context.eventName === 'workflow_dispatch'" in text
+
+
+def test_mapping_keys_normalizes_quoted_yaml_keys() -> None:
+    triggers = "  push:\n  'schedule':\n  \"workflow_dispatch\":\n"
+
+    assert mapping_keys(triggers, indent=2) == (
+        "push",
+        "schedule",
+        "workflow_dispatch",
+    )
 
 
 def test_testflight_notes_use_the_same_ios_path_contract() -> None:
@@ -116,6 +139,7 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
 
 if __name__ == "__main__":
     test_main_push_triggers_only_for_ios_affecting_paths()
+    test_mapping_keys_normalizes_quoted_yaml_keys()
     test_testflight_notes_use_the_same_ios_path_contract()
     test_main_push_runs_are_preserved_and_uploaded_in_order()
     test_automatic_lane_stays_on_cmux_internal_identity()


### PR DESCRIPTION
Summary:
- trigger automatic CMUX INTERNAL uploads only for iOS source and direct archive-input changes
- preserve manual workflow dispatch for intentional rebuilds
- keep TestFlight notes paths aligned and enforce the contract in static CI

Tests:
- `python3 tests/test_ios_testflight_main_push_filter.py`
- `python3 tests/test_ios_testflight_notes.py`
- parsed `.github/workflows/ios-testflight.yml` and `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787460160&installation_model_id=21920&pr_number=8812&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8812&signature=aecbf3d5858ee351d6f2563d20857f3865be8c45917168306a9cb9fdf8865be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit automatic CMUX INTERNAL TestFlight uploads to iOS-affecting changes only. Manual dispatch remains, and TestFlight notes mirror the same path contract with CI checks.

- **Refactors**
  - Added a `paths` filter in `.github/workflows/ios-testflight.yml` for `ios/**`, `Packages/iOS/**`, `Packages/Shared/**`, `Sources/Mobile/**`, GhosttyKit inputs (`ghostty`, `ghostty.h`), related scripts, and the workflow file.
  - Synced paths in `ios/scripts/generate-testflight-notes.sh`; added tests to verify exact trigger keys and that workflow and notes paths match; enforced via a new CI step.
  - Preserved concurrency: push runs keyed by SHA; manual runs keyed by `run_id`.

<sup>Written for commit 7c09399d32315fa53cbe96230032962f33e38a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS TestFlight builds now trigger automatically only when iOS-related files change.
  * TestFlight “What to Test” notes now include a broader set of iOS-related updates.
* **Bug Fixes**
  * Improved automated checks to ensure iOS TestFlight workflow trigger rules and the notes path contract stay aligned.
  * Added an extra CI guard step to strengthen TestFlight-related validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->