### PR TITLE
Route Get Pro directly to Stripe checkout

### DIFF
--- a/docs/pro-badge-options.html
+++ b/docs/pro-badge-options.html
@@ -189,9 +189,8 @@
     <div class="row">
       <span class="flag"><span class="dot on"></span> <code>pro-upgrade-ui-enabled-release</code> — badge + all Pro entrypoints · ON</span>
       <span class="flag"><span class="dot on"></span> <code>mobile-connect-button-enabled-release</code> — titlebar iPhone button · ON</span>
-      <span class="flag"><span class="dot off"></span> <code>pro-checkout-enabled-release</code> — pricing CTA → checkout · OFF</span>
     </div>
-    <p style="margin-top:12px">Each is registered in code (owner + review date + safe default), gated live from the PostHog dashboard, and enforced by <code>scripts/lint-feature-flags.py</code> in CI against the posthog.com feature-flag-mistakes rules.</p>
+    <p style="margin-top:12px">Each is registered in code (owner + review date + safe default), gated live from the PostHog dashboard, and enforced by <code>scripts/lint-feature-flags.py</code> in CI against the posthog.com feature-flag-mistakes rules. Pricing checkout is launched and no longer feature-gated.</p>
   </div>
 
   <h2>In-app pricing screen (native)</h2>

--- a/scripts/retired-feature-flags.txt
+++ b/scripts/retired-feature-flags.txt
@@ -2,3 +2,4 @@
 # from code. Keys listed here must NEVER be reused for new functionality —
 # reusing a stale key is how Knight Capital lost $440M in 45 minutes.
 # scripts/lint-feature-flags.py fails CI if any of these reappear.
+pro-checkout-enabled-release

--- a/skills/cmux-billing/SKILL.md
+++ b/skills/cmux-billing/SKILL.md
@@ -40,7 +40,7 @@ Use this skill before changing billing, pricing, Stripe, Pro entitlement, checko
 ## Feature Flags
 
 - `pro-upgrade-ui-enabled-release` (PostHog id `741838`) gates all Pro UI and stays OFF in release until launch. DEBUG builds default the UI on.
-- `pro-checkout-enabled-release` (PostHog id `741839`) routes the public pricing CTA.
+- Public Pro and Team pricing CTAs always route through `/api/billing/checkout`; do not fall back to the download confirmation page.
 - `cmux __internal_flags`, once merged, inspects and overrides flags locally.
 
 ## Prod Runbook

--- a/web/app/[locale]/components/pro-cta-link.tsx
+++ b/web/app/[locale]/components/pro-cta-link.tsx
@@ -9,51 +9,28 @@ import {
   CheckoutPendingContent,
   useCheckoutRedirect,
 } from "../../components/checkout-navigation";
-import {
-  isClientConfigFlagEnabled,
-  useClientConfigFlag,
-} from "../../lib/client-config-flags";
-import { FEATURE_FLAGS } from "../../lib/feature-flags";
-
-// Single evaluation site for the pro-checkout flag (lint-enforced).
-// Resolution: build-time env force (local dev / previews), then the PostHog
-// flag, then the registry's safe default (the download link always works,
-// including while flags are still loading — no checkout flicker).
-const FORCE = process.env.NEXT_PUBLIC_CMUX_CHECKOUT_ENABLED;
-const FORCED_ON = FORCE === "1" || (FORCE === undefined && process.env.NODE_ENV === "development");
-const FORCED_OFF = FORCE === "0";
 
 export function ProCtaLink({
   checkoutHref,
-  fallbackHref,
   children,
   size = "default",
   location = "pricing_page",
 }: {
   checkoutHref: string;
-  fallbackHref: string;
   children: React.ReactNode;
   size?: PricingActionSize;
   location?: string;
 }) {
-  const flagEnabled = useClientConfigFlag(FEATURE_FLAGS.proCheckout.key);
-  const checkout =
-    !FORCED_OFF &&
-    (FORCED_ON ||
-      isClientConfigFlagEnabled(
-        flagEnabled,
-        FEATURE_FLAGS.proCheckout.defaultWhenUnavailable,
-      ));
-  const href = checkout ? checkoutHref : fallbackHref;
   const { pending, start } = useCheckoutRedirect();
   return (
     <a
-      href={href}
+      href={checkoutHref}
       onClick={(event) => {
-        posthog.capture("cmuxterm_pro_cta_clicked", { location, checkout });
-        // Only the checkout href is intercepted for the spinner; the download
-        // fallback navigates normally.
-        start(href, event);
+        posthog.capture("cmuxterm_pro_cta_clicked", {
+          location,
+          checkout: true,
+        });
+        start(checkoutHref, event);
       }}
       aria-busy={pending}
       className={`${pricingActionClassName("primary", size)} relative`}

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -36,9 +36,6 @@ import {
 } from "../../components/pricing-shared";
 import { CheckoutButton } from "../../components/checkout-navigation";
 
-// The Pro CTA destination is decided at runtime by the proCheckout PostHog
-// flag inside <ProCtaLink> (see app/lib/feature-flags.ts); the download
-// link is the safe fallback.
 const ENTERPRISE_CTA_URL = "/enterprise";
 const ANONYMOUS_IF_EXISTS = "anonymous-if-exists[deprecated]" as const;
 
@@ -152,7 +149,7 @@ export default async function PricingPage({
                 </SecondaryLink>
               </div>
             ) : (
-              <ProCtaLink checkoutHref={PRO_CHECKOUT_URL} fallbackHref={DOWNLOAD_CONFIRMATION_HREF}>
+              <ProCtaLink checkoutHref={PRO_CHECKOUT_URL}>
                 {t("pro.cta")}
               </ProCtaLink>
             )}
@@ -216,7 +213,6 @@ export default async function PricingPage({
                 ) : (
                   <ProCtaLink
                     checkoutHref={PRO_CHECKOUT_URL}
-                    fallbackHref={DOWNLOAD_CONFIRMATION_HREF}
                     size="compact"
                     location="pricing_compare_header"
                   >

--- a/web/app/lib/feature-flags.ts
+++ b/web/app/lib/feature-flags.ts
@@ -32,12 +32,4 @@ export const FEATURE_FLAGS = {
     reviewBy: "2026-10-01",
     defaultWhenUnavailable: false,
   },
-  proCheckout: {
-    key: "pro-checkout-enabled-release",
-    owner: "lawrencecchen",
-    description:
-      "Points the pricing page Pro CTA at /api/billing/checkout instead of the download link. Off until prod Stripe is live.",
-    reviewBy: "2026-10-01",
-    defaultWhenUnavailable: false,
-  },
 } as const satisfies Record<string, FeatureFlagDefinition>;

--- a/web/tests/pro-cta-link.test.tsx
+++ b/web/tests/pro-cta-link.test.tsx
@@ -16,7 +16,6 @@ describe("Pro pricing CTA", () => {
     const html = renderToStaticMarkup(
       <ProCtaLink
         checkoutHref="/api/billing/checkout?plan=pro"
-        fallbackHref="/download/confirmation?dl=1"
       >
         Get Pro
       </ProCtaLink>,

--- a/web/tests/pro-cta-link.test.tsx
+++ b/web/tests/pro-cta-link.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, mock, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const capture = mock(() => undefined);
+
+mock.module("posthog-js", () => ({
+  default: { capture },
+}));
+
+const { ProCtaLink } = await import(
+  "../app/[locale]/components/pro-cta-link"
+);
+
+describe("Pro pricing CTA", () => {
+  test("routes the initial click to Stripe checkout", () => {
+    const html = renderToStaticMarkup(
+      <ProCtaLink
+        checkoutHref="/api/billing/checkout?plan=pro"
+        fallbackHref="/download/confirmation?dl=1"
+      >
+        Get Pro
+      </ProCtaLink>,
+    );
+
+    expect(html).toContain(
+      'href="/api/billing/checkout?plan=pro"',
+    );
+    expect(html).not.toContain('href="/download/confirmation?dl=1"');
+  });
+});


### PR DESCRIPTION
## Summary
- route every public Get Pro CTA directly through Stripe checkout
- retire the completed checkout rollout flag and remove its download fallback
- cover the pre-client-config destination with a red/green regression test

## Testing
- `cd web && bun test tests/pro-cta-link.test.tsx tests/checkout-navigation.test.tsx tests/pricing-page.test.tsx tests/app-pricing-page.test.tsx tests/billing-checkout-route.test.ts`
- `cd web && bun run typecheck`
- focused ESLint
- `python3 scripts/lint-feature-flags.py`
- browser-verified pre-hydration and hydrated clicks with client config unavailable

## Issues
- Follow-up to https://github.com/manaflow-ai/cmux/pull/8806

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787461423&installation_model_id=21920&pr_number=8813&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8813&signature=36bed7e031075bfd660fa6ef2d58569c1df8adedbd9a00ad4213de3586d9bf49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all public Get Pro CTAs directly to Stripe Checkout and remove the rollout flag and download fallback for a consistent upgrade flow. Adds a server-rendered regression test to cover pre-hydration clicks.

- **Refactors**
  - Always link Pro and Team pricing CTAs to `/api/billing/checkout`; remove the download confirmation fallback.
  - Remove the `pro-checkout-enabled-release` flag and add it to `scripts/retired-feature-flags.txt`.
  - Simplify `ProCtaLink` to always start the checkout redirect and capture `checkout: true`.
  - Update docs and billing skill notes to reflect the launched checkout path.
  - Add a regression test validating the initial link renders to checkout before client config loads.

<sup>Written for commit ef420168e1c53d06352ba94b54d100cfaec57991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pro and Team pricing calls to action now always open the pricing checkout flow.
  * Checkout links consistently use the billing checkout destination.

* **Bug Fixes**
  * Removed fallback navigation to the download confirmation page from pricing CTAs.

* **Documentation**
  * Updated pricing guidance to reflect that checkout is launched and no longer feature-gated.
  * Retired the obsolete checkout release flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->