### PR TITLE
Attribute iroh connection closes and log per-path lifecycle events

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -180,6 +180,17 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// Device reachability changed. `a` is 1 when a usable network path
     /// exists, else 0. Correlates drops with WiFi/cellular transitions.
     case reachabilityChanged = 53
+    /// The Iroh boundary reported why a shared QUIC connection closed. `a` is
+    /// the stable close-initiator kind (0 unknown, 1 local, 2 remote, 3 timed
+    /// out), `b` is ``DiagnosticFailureKind``, `ms` is the application error
+    /// code clamped to the nonnegative `Int32` range when parseable, and `c` is
+    /// the matching positive, process-local session correlation ID.
+    case transportCloseAttribution = 54
+    /// One Iroh path opened, closed, became selected, or reported lag. `a` is
+    /// the stable path-event kind (1 opened, 2 closed, 3 selected, 4 lagged),
+    /// `b` is ``DiagnosticPathKind`` for the affected path, and `c` is the
+    /// matching positive, process-local session correlation ID.
+    case transportPathEvent = 55
 }
 
 /// Scene phase carried by ``DiagnosticEventCode/appLifecycleChanged``.

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -256,12 +256,13 @@ public extension DiagnosticEvent {
         return c
     }
 
-    /// Redacted path class carried by ``DiagnosticEventCode/selectedPathChanged``.
+    /// Redacted path class carried by a selected-path or path-lifecycle event.
     var diagnosticPathKind: DiagnosticPathKind? {
-        guard code == .selectedPathChanged, let a else {
+        guard code == .selectedPathChanged || code == .transportPathEvent,
+              let rawValue = code == .transportPathEvent ? b : a else {
             return nil
         }
-        return DiagnosticPathKind(rawValue: a)
+        return DiagnosticPathKind(rawValue: rawValue)
     }
 
     /// Privacy-safe pool transition carried by
@@ -282,7 +283,10 @@ public extension DiagnosticEvent {
     /// Positive process-local session correlation ID. This value is not stable
     /// across app launches or devices.
     var diagnosticSessionID: Int? {
-        guard code == .transportSessionLifecycle || code == .sessionClosed,
+        guard code == .transportSessionLifecycle
+                || code == .sessionClosed
+                || code == .transportCloseAttribution
+                || code == .transportPathEvent,
               let c,
               c > 0 else { return nil }
         return c
@@ -344,6 +348,7 @@ public extension DiagnosticEventCode {
              .endpointFailed,
              .relayPolicyRefreshFailed,
              .sessionClosed,
+             .transportCloseAttribution,
              .routeUnavailable,
              .discoveryFailed,
              .admissionFailed,

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -228,7 +228,32 @@ import Testing
         #expect(DiagnosticEventCode.hostAuthenticationFailed.rawValue == 49)
         #expect(DiagnosticEventCode.rpcFailed.rawValue == 50)
         #expect(DiagnosticEventCode.transportSessionLifecycle.rawValue == 51)
+        #expect(DiagnosticEventCode.transportCloseAttribution.rawValue == 54)
+        #expect(DiagnosticEventCode.transportPathEvent.rawValue == 55)
         #expect(Set(DiagnosticEventCode.allCases.map(\.rawValue)).count == DiagnosticEventCode.allCases.count)
+    }
+
+    @Test func closeAttributionAndPathEventsExposeTypedPayloads() {
+        let close = DiagnosticEvent(
+            code: .transportCloseAttribution,
+            tNanos: 10,
+            ms: 42,
+            a: 2,
+            b: DiagnosticFailureKind.connectionClosed.rawValue,
+            c: 7
+        )
+        let path = DiagnosticEvent(
+            code: .transportPathEvent,
+            tNanos: 11,
+            a: 3,
+            b: DiagnosticPathKind.privateNetwork.rawValue,
+            c: 7
+        )
+
+        #expect(close.diagnosticFailureKind == .connectionClosed)
+        #expect(close.diagnosticSessionID == 7)
+        #expect(path.diagnosticPathKind == .privateNetwork)
+        #expect(path.diagnosticSessionID == 7)
     }
 
     @Test func diagnosticTaxonomyHasStableRawValuesAndRedactedMappings() {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedServerSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohAdmittedServerSession.swift
@@ -61,4 +61,14 @@ public struct CmxIrohAdmittedServerSession: Sendable {
             failure: failure
         )
     }
+
+    /// Returns the classified terminal cause for the shared QUIC connection.
+    public func closeAttribution() async -> CmxIrohConnectionCloseAttribution {
+        await session.closeAttribution()
+    }
+
+    /// Observes redacted lifecycle events for paths on the shared connection.
+    public func observedPathEvents() async -> AsyncStream<CmxIrohConnectionPathEvent> {
+        await session.observedPathEvents()
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSession.swift
@@ -20,6 +20,7 @@ public actor CmxIrohClientSession {
     private var controlStream: CmxIrohBidirectionalStream?
     private var serverEventReceiver: CmxIrohClientServerEventReceiver?
     private var controlReceiveBuffer = Data()
+    private var terminalCloseAttribution: CmxIrohConnectionCloseAttribution?
     private var closed = false
 
     /// Creates a disconnected session with an explicit two-phase dial plan.
@@ -187,6 +188,24 @@ public actor CmxIrohClientSession {
     public func waitUntilClosed() async {
         guard let connection else { return }
         await connection.waitUntilClosed()
+        terminalCloseAttribution = await connection.closeAttribution()
+    }
+
+    /// Returns the classified terminal cause for the admitted connection.
+    func closeAttribution() async -> CmxIrohConnectionCloseAttribution {
+        if let terminalCloseAttribution {
+            return terminalCloseAttribution
+        }
+        guard let connection else {
+            return CmxIrohConnectionCloseAttribution(
+                initiator: .unknown,
+                applicationErrorCode: nil,
+                failureKind: .unknown
+            )
+        }
+        let attribution = await connection.closeAttribution()
+        terminalCloseAttribution = attribution
+        return attribution
     }
 
     /// Returns whether the admitted QUIC connection already closed.
@@ -230,6 +249,14 @@ public actor CmxIrohClientSession {
         return await connection.observedSelectedPathChanges()
     }
 
+    /// Observes redacted path lifecycle events on the admitted connection.
+    func observedPathEvents() async -> AsyncStream<CmxIrohConnectionPathEvent> {
+        guard let connection else {
+            return AsyncStream { continuation in continuation.finish() }
+        }
+        return await connection.observedPathEvents()
+    }
+
     /// Closes the control stream and complete QUIC connection.
     public func close() async {
         guard !closed else { return }
@@ -244,6 +271,7 @@ public actor CmxIrohClientSession {
         }
         if let connection {
             await connection.close(errorCode: 0, reason: "client_closed")
+            terminalCloseAttribution = await connection.closeAttribution()
         }
         controlStream = nil
         self.connection = nil

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
@@ -21,6 +21,7 @@ actor CmxIrohClientSessionPool {
         let session: CmxIrohClientSession
         let closureTask: Task<Void, Never>
         let pathObservationTask: Task<Void, Never>
+        let pathEventObservationTask: Task<Void, Never>?
     }
 
     private struct ControlWaiter {
@@ -163,13 +164,30 @@ actor CmxIrohClientSessionPool {
                     )
                 }
             }
+            let pathEventObservationTask: Task<Void, Never>?
+            if let diagnosticLog {
+                let recorder = CmxIrohConnectionDiagnosticRecorder(
+                    diagnosticLog: diagnosticLog,
+                    sessionID: diagnosticID
+                )
+                let pathEvents = await connected.observedPathEvents()
+                pathEventObservationTask = Task {
+                    for await event in pathEvents {
+                        guard !Task.isCancelled else { return }
+                        recorder.record(event)
+                    }
+                }
+            } else {
+                pathEventObservationTask = nil
+            }
             sessions[key] = PooledSession(
                 id: sessionID,
                 diagnosticID: diagnosticID,
                 initialPurpose: request.sessionPurpose,
                 session: connected,
                 closureTask: closureTask,
-                pathObservationTask: pathObservationTask
+                pathObservationTask: pathObservationTask,
+                pathEventObservationTask: pathEventObservationTask
             )
             sessionOrder.removeAll { $0 == key }
             sessionOrder.append(key)
@@ -297,13 +315,14 @@ actor CmxIrohClientSessionPool {
         for (key, pooled) in closing {
             pooled.closureTask.cancel()
             pooled.pathObservationTask.cancel()
-            recordSessionClosure(
+            await pooled.session.close()
+            await pooled.pathEventObservationTask?.value
+            await recordSessionClosure(
                 reason,
                 pooled: pooled,
                 purpose: closingOwners[key]?.purpose ?? pooled.initialPurpose,
                 failure: .none
             )
-            await pooled.session.close()
         }
         publishSelectedPathChange()
     }
@@ -343,7 +362,8 @@ actor CmxIrohClientSessionPool {
         sessions[key] = nil
         sessionOrder.removeAll { $0 == key }
         pooled.pathObservationTask.cancel()
-        recordSessionClosure(
+        await pooled.pathEventObservationTask?.value
+        await recordSessionClosure(
             .remoteClosed,
             pooled: pooled,
             purpose: owner?.purpose ?? pooled.initialPurpose,
@@ -388,14 +408,15 @@ actor CmxIrohClientSessionPool {
         pooled?.closureTask.cancel()
         pooled?.pathObservationTask.cancel()
         if let pooled {
-            recordSessionClosure(
+            await pooled.session.close()
+            await pooled.pathEventObservationTask?.value
+            await recordSessionClosure(
                 reason,
                 pooled: pooled,
                 purpose: currentOwner?.purpose ?? pooled.initialPurpose,
                 failure: failure
             )
         }
-        await pooled?.session.close()
         if let owner {
             releaseControlOwner(for: key, ownerID: owner.id)
         }
@@ -523,7 +544,14 @@ actor CmxIrohClientSessionPool {
         pooled: PooledSession,
         purpose: CmxTransportSessionPurpose,
         failure: DiagnosticFailureKind
-    ) {
+    ) async {
+        if let diagnosticLog {
+            let recorder = CmxIrohConnectionDiagnosticRecorder(
+                diagnosticLog: diagnosticLog,
+                sessionID: pooled.diagnosticID
+            )
+            recorder.record(await pooled.session.closeAttribution())
+        }
         recordSessionLifecycle(
             kind,
             sessionID: pooled.diagnosticID,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnection.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnection.swift
@@ -50,6 +50,15 @@ public protocol CmxIrohConnection: Sendable {
     /// enforcement for the complete connection lifetime.
     func waitUntilClosed() async
 
+    /// Returns the classified terminal cause for this connection.
+    ///
+    /// Implementations consume any raw transport text at their boundary and
+    /// retain only this privacy-safe value.
+    func closeAttribution() async -> CmxIrohConnectionCloseAttribution
+
+    /// Observes redacted per-path lifecycle events for this connection.
+    func observedPathEvents() async -> AsyncStream<CmxIrohConnectionPathEvent>
+
     /// Returns whether this connection already has a terminal close reason.
     ///
     /// Callers use this nonblocking snapshot to reject a cached connection

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
@@ -1,0 +1,174 @@
+public import CMUXMobileCore
+import Foundation
+
+/// A privacy-safe classification of one terminal Iroh connection cause.
+///
+/// This value retains only bounded enums and an optional numeric QUIC
+/// application error code. The raw FFI cause string is consumed only by
+/// ``classify(_:)`` and is never stored.
+public struct CmxIrohConnectionCloseAttribution: Sendable, Equatable {
+    /// Which endpoint or transport condition initiated the close.
+    public let initiator: CmxIrohConnectionCloseInitiator
+    /// The QUIC application error code when the cause exposed one.
+    public let applicationErrorCode: Int64?
+    /// The bounded failure category derived from the cause.
+    public let failureKind: DiagnosticFailureKind
+
+    /// Creates a classified connection-close attribution.
+    ///
+    /// - Parameters:
+    ///   - initiator: Which endpoint or condition initiated the close.
+    ///   - applicationErrorCode: The optional QUIC application error code.
+    ///   - failureKind: The bounded diagnostic failure category.
+    public init(
+        initiator: CmxIrohConnectionCloseInitiator,
+        applicationErrorCode: Int64?,
+        failureKind: DiagnosticFailureKind
+    ) {
+        self.initiator = initiator
+        self.applicationErrorCode = applicationErrorCode
+        self.failureKind = failureKind
+    }
+
+    /// Classifies an opaque iroh-ffi close cause without retaining its text.
+    ///
+    /// iroh-ffi 1.0.2-cmux.4 exposes the terminal cause as a string. These
+    /// tokens mirror the package's pinned `IrohError` classification until the
+    /// binding exports a structured close-reason taxonomy.
+    ///
+    /// - Parameter cause: The ephemeral close-cause string from IrohLib.
+    /// - Returns: A bounded attribution containing no raw cause text.
+    public static func classify(_ cause: String) -> Self {
+        Self(
+            initiator: initiator(in: cause),
+            applicationErrorCode: applicationErrorCode(in: cause),
+            failureKind: failureKind(in: cause)
+        )
+    }
+
+    private static func initiator(
+        in cause: String
+    ) -> CmxIrohConnectionCloseInitiator {
+        let normalized = cause.lowercased()
+        if normalized.contains("peer") || normalized.contains("remote") {
+            return .remote
+        }
+        if normalized.contains("local") {
+            return .local
+        }
+        if normalized.contains("timed out")
+            || normalized.contains("timeout")
+            || normalized.contains("timedout") {
+            return .timedOut
+        }
+        return .unknown
+    }
+
+    private static func applicationErrorCode(in cause: String) -> Int64? {
+        for label in ["application error code", "application_error_code", "error code", "error_code", "code"] {
+            guard let range = cause.range(
+                of: label,
+                options: [.caseInsensitive]
+            ) else {
+                continue
+            }
+            if let value = firstInteger(in: cause[range.upperBound...]) {
+                return value
+            }
+        }
+        return lastInteger(in: cause[...])
+    }
+
+    private static func firstInteger(
+        in text: Substring
+    ) -> Int64? {
+        var token = ""
+        for character in text {
+            if character.isNumber || (character == "-" && token.isEmpty) {
+                token.append(character)
+            } else if !token.isEmpty {
+                if token != "-", let value = Int64(token) {
+                    return value
+                }
+                token.removeAll(keepingCapacity: true)
+            }
+        }
+        guard token != "-" else { return nil }
+        return Int64(token)
+    }
+
+    private static func lastInteger(
+        in text: Substring
+    ) -> Int64? {
+        var last: Int64?
+        var token = ""
+        for character in text {
+            if character.isNumber || (character == "-" && token.isEmpty) {
+                token.append(character)
+            } else if !token.isEmpty {
+                if token != "-", let value = Int64(token) {
+                    last = value
+                }
+                token.removeAll(keepingCapacity: true)
+            }
+        }
+        if token != "-", let value = Int64(token) {
+            last = value
+        }
+        return last
+    }
+
+    private static func failureKind(in cause: String) -> DiagnosticFailureKind {
+        if cause.contains("ConnectionLost(TimedOut)") {
+            return .transportIdleTimedOut
+        }
+        if cause.contains("ConnectionLost(LocallyClosed)") {
+            return .cancelled
+        }
+        if cause.contains("ConnectionLost(TransportError(")
+            && (cause.contains("Code::crypto(")
+                || cause.contains("TLS error:")) {
+            return .secureChannelFailed
+        }
+        if cause.contains("ConnectionLost(Reset)")
+            || cause.contains("ConnectionLost(TransportError(")
+            || cause.contains("ConnectionLost(ApplicationClosed(")
+            || cause.contains("ConnectionLost(ConnectionClosed(") {
+            return .connectionClosed
+        }
+        if cause.contains("AddressLookupFailed")
+            || cause.contains("DnsLookup")
+            || cause.contains("DNS lookup")
+            || cause.contains("No addressing information available")
+            || cause.contains("No address lookup configured")
+            || cause.contains("All address lookup services failed or produced no results")
+            || cause.contains("Failed to resolve TXT record")
+            || cause.contains("Resolve failed, IPv4:")
+            || cause.contains("Failed to resolve") {
+            return .dnsFailed
+        }
+        if cause.localizedCaseInsensitiveContains("timed out")
+            || cause.localizedCaseInsensitiveContains("timeout") {
+            return .timedOut
+        }
+        if cause.contains("Tls")
+            || cause.contains("TLS")
+            || cause.contains("CryptoError")
+            || cause.contains("Code::crypto(")
+            || cause.contains("Certificate")
+            || cause.contains("certificate")
+            || cause.contains("Handshake")
+            || cause.contains("handshake")
+            || cause.contains("crypto provider") {
+            return .secureChannelFailed
+        }
+        if cause.contains("ConnectionLost(")
+            || cause.contains("ClosedStream")
+            || cause.contains("Reset(")
+            || cause.contains("Stopped(")
+            || cause.localizedCaseInsensitiveContains("closed") {
+            return .connectionClosed
+        }
+        return .unknown
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttributionStore.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttributionStore.swift
@@ -1,0 +1,24 @@
+/// Retains only the classified terminal cause shared by connection observers.
+actor CmxIrohConnectionCloseAttributionStore {
+    private var attribution: CmxIrohConnectionCloseAttribution?
+
+    func record(
+        cause: String
+    ) -> CmxIrohConnectionCloseAttribution {
+        record(CmxIrohConnectionCloseAttribution.classify(cause))
+    }
+
+    func record(
+        _ classified: CmxIrohConnectionCloseAttribution
+    ) -> CmxIrohConnectionCloseAttribution {
+        if let attribution {
+            return attribution
+        }
+        attribution = classified
+        return classified
+    }
+
+    func current() -> CmxIrohConnectionCloseAttribution? {
+        attribution
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseInitiator.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseInitiator.swift
@@ -1,0 +1,14 @@
+/// The bounded origin of an Iroh connection close.
+///
+/// Raw values are stable diagnostic payload vocabulary. Append new cases;
+/// never renumber an existing case.
+public enum CmxIrohConnectionCloseInitiator: Int, Sendable, Equatable {
+    /// The cause did not contain a recognized ownership token.
+    case unknown = 0
+    /// The local endpoint initiated the close.
+    case local = 1
+    /// The peer or remote endpoint initiated the close.
+    case remote = 2
+    /// The transport closed after a timeout.
+    case timedOut = 3
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionDiagnosticRecorder.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionDiagnosticRecorder.swift
@@ -1,0 +1,57 @@
+public import CMUXMobileCore
+
+/// Records classified connection-boundary events with one session correlation ID.
+public struct CmxIrohConnectionDiagnosticRecorder: Sendable {
+    private let diagnosticLog: DiagnosticLog
+    private let sessionID: Int
+
+    /// Creates a recorder for one process-local session.
+    ///
+    /// - Parameters:
+    ///   - diagnosticLog: The bounded destination diagnostic ring.
+    ///   - sessionID: The positive ID shared with session lifecycle events.
+    public init(
+        diagnosticLog: DiagnosticLog,
+        sessionID: Int
+    ) {
+        precondition(sessionID > 0)
+        self.diagnosticLog = diagnosticLog
+        self.sessionID = sessionID
+    }
+
+    /// Records one classified terminal connection cause.
+    ///
+    /// - Parameter attribution: The privacy-safe close attribution.
+    public func record(
+        _ attribution: CmxIrohConnectionCloseAttribution
+    ) {
+        diagnosticLog.record(DiagnosticEvent(
+            .transportCloseAttribution,
+            ms: Self.diagnosticApplicationErrorCode(
+                attribution.applicationErrorCode
+            ),
+            a: attribution.initiator.rawValue,
+            b: attribution.failureKind.rawValue,
+            c: sessionID
+        ))
+    }
+
+    /// Records one redacted path lifecycle event.
+    ///
+    /// - Parameter event: The bounded path operation and path category.
+    public func record(_ event: CmxIrohConnectionPathEvent) {
+        diagnosticLog.record(DiagnosticEvent(
+            .transportPathEvent,
+            a: event.kind.rawValue,
+            b: event.pathKind.rawValue,
+            c: sessionID
+        ))
+    }
+
+    private static func diagnosticApplicationErrorCode(
+        _ code: Int64?
+    ) -> UInt32? {
+        guard let code else { return nil }
+        return UInt32(max(0, min(code, Int64(Int32.max))))
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionPathEvent.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionPathEvent.swift
@@ -1,0 +1,57 @@
+public import CMUXMobileCore
+import IrohLib
+
+/// A redacted lifecycle event for one Iroh connection path.
+public struct CmxIrohConnectionPathEvent: Sendable, Equatable {
+    /// The operation Iroh reported for the path.
+    public let kind: CmxIrohConnectionPathEventKind
+    /// The privacy-safe class of the affected path.
+    public let pathKind: DiagnosticPathKind
+
+    /// Creates a redacted path event.
+    ///
+    /// - Parameters:
+    ///   - kind: The path lifecycle operation.
+    ///   - pathKind: The privacy-safe path category.
+    public init(
+        kind: CmxIrohConnectionPathEventKind,
+        pathKind: DiagnosticPathKind
+    ) {
+        self.kind = kind
+        self.pathKind = pathKind
+    }
+
+    init(_ event: PathEvent) {
+        switch event {
+        case let .opened(_, remoteAddress, _):
+            self.init(
+                kind: .opened,
+                pathKind: Self.pathKind(remoteAddress: remoteAddress)
+            )
+        case let .closed(_, remoteAddress, _, _):
+            self.init(
+                kind: .closed,
+                pathKind: Self.pathKind(remoteAddress: remoteAddress)
+            )
+        case let .selected(_, remoteAddress, _):
+            self.init(
+                kind: .selected,
+                pathKind: Self.pathKind(remoteAddress: remoteAddress)
+            )
+        case .lagged:
+            self.init(kind: .lagged, pathKind: .unknown)
+        }
+    }
+
+    private static func pathKind(remoteAddress: String) -> DiagnosticPathKind {
+        if remoteAddress.contains("://") {
+            return .relay
+        }
+        guard remoteAddress.contains(":") else {
+            return .unknown
+        }
+        return CmxIrohIPAddressScope(socketAddress: remoteAddress).isPrivate
+            ? .privateNetwork
+            : .direct
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionPathEventKind.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionPathEventKind.swift
@@ -1,0 +1,14 @@
+/// The bounded lifecycle operation reported for one Iroh connection path.
+///
+/// Raw values are stable diagnostic payload vocabulary. Append new cases;
+/// never renumber an existing case.
+public enum CmxIrohConnectionPathEventKind: Int, Sendable, Equatable {
+    /// A new path opened.
+    case opened = 1
+    /// An existing path closed.
+    case closed = 2
+    /// A path became selected for application data.
+    case selected = 3
+    /// The watcher dropped one or more path events.
+    case lagged = 4
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLibConnection.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLibConnection.swift
@@ -9,6 +9,7 @@ struct CmxIrohLibConnection:
 {
     let driver: Connection
     let peerIdentity: CmxIrohPeerIdentity
+    let closeAttributionStore = CmxIrohConnectionCloseAttributionStore()
 
     init(driver: Connection) throws {
         self.driver = driver
@@ -39,6 +40,22 @@ struct CmxIrohLibConnection:
                 )
             )
             continuation.onTermination = { @Sendable _ in
+                Task { await handle.stop() }
+            }
+        }
+    }
+
+    func observedPathEvents() async -> AsyncStream<CmxIrohConnectionPathEvent> {
+        AsyncStream { continuation in
+            let callback = CmxIrohLibPathEventCallback(continuation: continuation)
+            let handle = driver.watchPathEvents(callback: callback)
+            let closeTask = Task {
+                let cause = await driver.closed()
+                _ = await closeAttributionStore.record(cause: cause)
+                continuation.finish()
+            }
+            continuation.onTermination = { @Sendable _ in
+                closeTask.cancel()
                 Task { await handle.stop() }
             }
         }
@@ -77,15 +94,37 @@ struct CmxIrohLibConnection:
     }
 
     func waitUntilClosed() async {
-        _ = await driver.closed()
+        let cause = await driver.closed()
+        _ = await closeAttributionStore.record(cause: cause)
+    }
+
+    func closeAttribution() async -> CmxIrohConnectionCloseAttribution {
+        if let attribution = await closeAttributionStore.current() {
+            return attribution
+        }
+        guard let cause = driver.closeReason() else {
+            return CmxIrohConnectionCloseAttribution(
+                initiator: .unknown,
+                applicationErrorCode: nil,
+                failureKind: .unknown
+            )
+        }
+        return await closeAttributionStore.record(cause: cause)
     }
 
     func isClosed() async -> Bool {
-        driver.closeReason() != nil
+        guard let cause = driver.closeReason() else { return false }
+        _ = await closeAttributionStore.record(cause: cause)
+        return true
     }
 
     func close(errorCode: UInt64, reason: String) async {
         let code = Int64(exactly: errorCode) ?? Int64.max
+        _ = await closeAttributionStore.record(CmxIrohConnectionCloseAttribution(
+            initiator: .local,
+            applicationErrorCode: code,
+            failureKind: .cancelled
+        ))
         try? driver.close(
             errorCode: code,
             reason: Data(reason.utf8.prefix(1_024))

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLibPathEventCallback.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLibPathEventCallback.swift
@@ -1,0 +1,16 @@
+import IrohLib
+
+/// Bridges Iroh's individual path watcher into a redacted async stream.
+final class CmxIrohLibPathEventCallback: PathEventCallback, Sendable {
+    private let continuation: AsyncStream<CmxIrohConnectionPathEvent>.Continuation
+
+    init(
+        continuation: AsyncStream<CmxIrohConnectionPathEvent>.Continuation
+    ) {
+        self.continuation = continuation
+    }
+
+    func onEvent(event: PathEvent) async {
+        continuation.yield(CmxIrohConnectionPathEvent(event))
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohServerSession.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohServerSession.swift
@@ -267,6 +267,14 @@ public actor CmxIrohServerSession {
         explicitCloseFailure
     }
 
+    func closeAttribution() async -> CmxIrohConnectionCloseAttribution {
+        await connection.closeAttribution()
+    }
+
+    func observedPathEvents() async -> AsyncStream<CmxIrohConnectionPathEvent> {
+        await connection.observedPathEvents()
+    }
+
     private func closeConnection() async {
         guard !closed else { return }
         closed = true

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
@@ -282,6 +282,64 @@ struct CmxIrohClientSessionPoolTests {
     }
 
     @Test
+    func remoteCloseEmitsAttributionAndPathEventsWithSessionCorrelation() async throws {
+        let fixture = try PoolFixture()
+        let connection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()],
+            closeAttribution: .init(
+                initiator: .remote,
+                applicationErrorCode: 71,
+                failureKind: .connectionClosed
+            )
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [.connection(connection)]
+        )
+        let diagnosticLog = DiagnosticLog(capacity: 8)
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            diagnosticLog: diagnosticLog
+        )
+        let transport = try CmxIrohByteTransportFactory(sessionPool: pool)
+            .makeTransport(for: fixture.request)
+        try await transport.connect()
+
+        await connection.emitPathEvent(.init(
+            kind: .opened,
+            pathKind: .privateNetwork
+        ))
+        await connection.emitPathEvent(.init(
+            kind: .selected,
+            pathKind: .privateNetwork
+        ))
+        await connection.close(errorCode: 71, reason: "peer_closed")
+
+        for _ in 0 ..< 1_000 {
+            if await diagnosticLog.processedCount() >= 6 { break }
+            await Task.yield()
+        }
+        let events = await diagnosticLog.snapshot().events
+        #expect(events.map(\.code) == [
+            .transportSessionLifecycle,
+            .transportPathEvent,
+            .transportPathEvent,
+            .transportCloseAttribution,
+            .transportSessionLifecycle,
+            .sessionClosed,
+        ])
+        let sessionID = try #require(events.first?.diagnosticSessionID)
+        #expect(events.dropFirst().allSatisfy { $0.diagnosticSessionID == sessionID })
+        #expect(events[1].diagnosticPathKind == .privateNetwork)
+        #expect(events[2].a == CmxIrohConnectionPathEventKind.selected.rawValue)
+        #expect(events[3].a == CmxIrohConnectionCloseInitiator.remote.rawValue)
+        #expect(events[3].b == DiagnosticFailureKind.connectionClosed.rawValue)
+        #expect(events[3].ms == 71)
+    }
+
+    @Test
     func knownClosedCachedSessionRedialsWithoutWaitingForClosureWatcher() async throws {
         let fixture = try PoolFixture()
         let firstConnection = TestIrohConnection(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
@@ -264,20 +264,22 @@ struct CmxIrohClientSessionPoolTests {
         #expect(await secondConnection.observedCloseCallCount() == 0)
 
         for _ in 0 ..< 1_000 {
-            if await diagnosticLog.processedCount() >= 4 { break }
+            if await diagnosticLog.processedCount() >= 5 { break }
             await Task.yield()
         }
         let events = await diagnosticLog.snapshot().events
         #expect(events.map(\.code) == [
             .transportSessionLifecycle,
+            .transportCloseAttribution,
             .transportSessionLifecycle,
             .sessionClosed,
             .transportSessionLifecycle,
         ])
-        #expect(events[1].diagnosticSessionLifecycleKind == .remoteClosed)
-        #expect(events[1].diagnosticSessionPurpose == .foregroundControl)
+        #expect(events[2].diagnosticSessionLifecycleKind == .remoteClosed)
+        #expect(events[2].diagnosticSessionPurpose == .foregroundControl)
         #expect(events[1].diagnosticSessionID == events[2].diagnosticSessionID)
-        #expect(events[3].diagnosticSessionID != events[2].diagnosticSessionID)
+        #expect(events[2].diagnosticSessionID == events[3].diagnosticSessionID)
+        #expect(events[4].diagnosticSessionID != events[3].diagnosticSessionID)
         await replacement.close()
     }
 
@@ -308,23 +310,23 @@ struct CmxIrohClientSessionPoolTests {
         try await transport.connect()
 
         await connection.emitPathEvent(.init(
-            kind: .opened,
-            pathKind: .privateNetwork
-        ))
-        await connection.emitPathEvent(.init(
             kind: .selected,
             pathKind: .privateNetwork
         ))
+        for _ in 0 ..< 10_000 {
+            if await diagnosticLog.processedCount() >= 2 { break }
+            await Task.yield()
+        }
+        #expect(await diagnosticLog.processedCount() >= 2)
         await connection.close(errorCode: 71, reason: "peer_closed")
 
-        for _ in 0 ..< 1_000 {
-            if await diagnosticLog.processedCount() >= 6 { break }
+        for _ in 0 ..< 10_000 {
+            if await diagnosticLog.processedCount() >= 5 { break }
             await Task.yield()
         }
         let events = await diagnosticLog.snapshot().events
         #expect(events.map(\.code) == [
             .transportSessionLifecycle,
-            .transportPathEvent,
             .transportPathEvent,
             .transportCloseAttribution,
             .transportSessionLifecycle,
@@ -333,10 +335,10 @@ struct CmxIrohClientSessionPoolTests {
         let sessionID = try #require(events.first?.diagnosticSessionID)
         #expect(events.dropFirst().allSatisfy { $0.diagnosticSessionID == sessionID })
         #expect(events[1].diagnosticPathKind == .privateNetwork)
-        #expect(events[2].a == CmxIrohConnectionPathEventKind.selected.rawValue)
-        #expect(events[3].a == CmxIrohConnectionCloseInitiator.remote.rawValue)
-        #expect(events[3].b == DiagnosticFailureKind.connectionClosed.rawValue)
-        #expect(events[3].ms == 71)
+        #expect(events[1].a == CmxIrohConnectionPathEventKind.selected.rawValue)
+        #expect(events[2].a == CmxIrohConnectionCloseInitiator.remote.rawValue)
+        #expect(events[2].b == DiagnosticFailureKind.connectionClosed.rawValue)
+        #expect(events[2].ms == 71)
     }
 
     @Test
@@ -828,28 +830,32 @@ struct CmxIrohClientSessionPoolTests {
         ])
 
         for _ in 0 ..< 1_000 {
-            if await diagnosticLog.processedCount() >= 4 { break }
+            if await diagnosticLog.processedCount() >= 5 { break }
             await Task.yield()
         }
         let events = await diagnosticLog.snapshot().events
         #expect(events.map(\.code) == [
             .transportSessionLifecycle,
+            .transportCloseAttribution,
             .transportSessionLifecycle,
             .sessionClosed,
             .transportSessionLifecycle,
         ])
         #expect(events.map(\.a) == [
             DiagnosticSessionLifecycleKind.established.rawValue,
+            CmxIrohConnectionCloseInitiator.local.rawValue,
             DiagnosticSessionLifecycleKind.controlOwnerReleased.rawValue,
             DiagnosticTransportKind.iroh.rawValue,
             DiagnosticSessionLifecycleKind.established.rawValue,
         ])
         #expect(events[0].b == Int(CmxTransportSessionPurpose.foregroundControl.rawValue))
-        #expect(events[1].b == Int(CmxTransportSessionPurpose.foregroundControl.rawValue))
-        #expect(events[2].b == DiagnosticFailureKind.none.rawValue)
+        #expect(events[1].b == DiagnosticFailureKind.cancelled.rawValue)
+        #expect(events[2].b == Int(CmxTransportSessionPurpose.foregroundControl.rawValue))
+        #expect(events[3].b == DiagnosticFailureKind.none.rawValue)
         #expect(events[0].c == events[1].c)
         #expect(events[1].c == events[2].c)
-        #expect(events[3].c != events[2].c)
+        #expect(events[2].c == events[3].c)
+        #expect(events[4].c != events[3].c)
 
         await replacement.close()
     }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionCloseAttributionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionCloseAttributionTests.swift
@@ -1,0 +1,59 @@
+import CMUXMobileCore
+import Testing
+
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohConnectionCloseAttributionTests {
+    @Test
+    func classifiesRemoteApplicationCloseWithCode() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "ConnectionLost(ApplicationClosed(ApplicationClose { error_code: 42, reason: \"closed by remote peer\" }))"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .remote,
+                applicationErrorCode: 42,
+                failureKind: .connectionClosed
+            )
+        )
+    }
+
+    @Test
+    func classifiesLocalClose() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "ConnectionLost(LocallyClosed)"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .local,
+                applicationErrorCode: nil,
+                failureKind: .cancelled
+            )
+        )
+    }
+
+    @Test
+    func classifiesTransportIdleTimeout() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "ConnectionLost(TimedOut)"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .timedOut,
+                applicationErrorCode: nil,
+                failureKind: .transportIdleTimedOut
+            )
+        )
+    }
+
+    @Test
+    func leavesUnrecognizedCauseBoundedAndUnknown() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "opaque bridge failure without stable tokens"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .unknown,
+                applicationErrorCode: nil,
+                failureKind: .unknown
+            )
+        )
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionDiagnosticRecorderTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionDiagnosticRecorderTests.swift
@@ -1,10 +1,53 @@
 import CMUXMobileCore
+import IrohLib
 import Testing
 
 @testable import CmuxIrohTransport
 
 @Suite
 struct CmxIrohConnectionDiagnosticRecorderTests {
+    @Test
+    func mapsIrohPathEventsToRedactedKinds() {
+        let events = [
+            CmxIrohConnectionPathEvent(.opened(
+                id: "private",
+                remoteAddr: "192.168.1.10:443",
+                localAddr: "192.168.1.2:5000"
+            )),
+            CmxIrohConnectionPathEvent(.closed(
+                id: "direct",
+                remoteAddr: "8.8.8.8:443",
+                localAddr: "192.168.1.2:5001",
+                lastStats: PathStatsRecord(
+                    rttMs: 0,
+                    udpTxDatagrams: 0,
+                    udpTxBytes: 0,
+                    udpRxDatagrams: 0,
+                    udpRxBytes: 0,
+                    cwnd: 0,
+                    congestionEvents: 0,
+                    lostPackets: 0,
+                    lostBytes: 0,
+                    currentMtu: 0
+                )
+            )),
+            CmxIrohConnectionPathEvent(.selected(
+                id: "relay",
+                remoteAddr: "https://relay.example",
+                localAddr: "https://relay.example"
+            )),
+            CmxIrohConnectionPathEvent(.lagged(missed: 3)),
+        ]
+
+        #expect(events.map(\.kind) == [.opened, .closed, .selected, .lagged])
+        #expect(events.map(\.pathKind) == [
+            .privateNetwork,
+            .direct,
+            .relay,
+            .unknown,
+        ])
+    }
+
     @Test
     func mapsPathEventsAndClampsApplicationErrorCode() async {
         let log = DiagnosticLog(capacity: 8)

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionDiagnosticRecorderTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionDiagnosticRecorderTests.swift
@@ -1,0 +1,61 @@
+import CMUXMobileCore
+import Testing
+
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohConnectionDiagnosticRecorderTests {
+    @Test
+    func mapsPathEventsAndClampsApplicationErrorCode() async {
+        let log = DiagnosticLog(capacity: 8)
+        let recorder = CmxIrohConnectionDiagnosticRecorder(
+            diagnosticLog: log,
+            sessionID: 23
+        )
+
+        recorder.record(CmxIrohConnectionPathEvent(
+            kind: .opened,
+            pathKind: .privateNetwork
+        ))
+        recorder.record(CmxIrohConnectionPathEvent(
+            kind: .closed,
+            pathKind: .direct
+        ))
+        recorder.record(CmxIrohConnectionPathEvent(
+            kind: .selected,
+            pathKind: .relay
+        ))
+        recorder.record(CmxIrohConnectionPathEvent(
+            kind: .lagged,
+            pathKind: .unknown
+        ))
+        recorder.record(CmxIrohConnectionCloseAttribution(
+            initiator: .remote,
+            applicationErrorCode: Int64.max,
+            failureKind: .connectionClosed
+        ))
+
+        for _ in 0 ..< 1_000 {
+            if await log.processedCount() >= 5 { break }
+            await Task.yield()
+        }
+        let events = await log.snapshot().events
+        #expect(events.map(\.code) == [
+            .transportPathEvent,
+            .transportPathEvent,
+            .transportPathEvent,
+            .transportPathEvent,
+            .transportCloseAttribution,
+        ])
+        #expect(events.map(\.a) == [1, 2, 3, 4, 2])
+        #expect(events.map(\.b) == [
+            DiagnosticPathKind.privateNetwork.rawValue,
+            DiagnosticPathKind.direct.rawValue,
+            DiagnosticPathKind.relay.rawValue,
+            DiagnosticPathKind.unknown.rawValue,
+            DiagnosticFailureKind.connectionClosed.rawValue,
+        ])
+        #expect(events.allSatisfy { $0.c == 23 })
+        #expect(events.last?.ms == UInt32(Int32.max))
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
@@ -39,6 +39,10 @@ struct CmxIrohServerSessionTests {
             kind: .selected,
             pathKind: .direct
         ))
+        for _ in 0 ..< 1_000 {
+            if await log.processedCount() >= 1 { break }
+            await Task.yield()
+        }
         await connection.close(errorCode: 93, reason: "remote_peer_closed")
         recorder.record(await admitted.closeAttribution())
 
@@ -46,7 +50,7 @@ struct CmxIrohServerSessionTests {
             if await log.processedCount() >= 2 { break }
             await Task.yield()
         }
-        pathTask.cancel()
+        await pathTask.value
         let events = await log.snapshot().events
         #expect(events.map(\.code) == [
             .transportPathEvent,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohServerSessionTests.swift
@@ -5,6 +5,61 @@ import Testing
 
 @Suite
 struct CmxIrohServerSessionTests {
+    @Test
+    func admittedHostSessionEmitsAttributedCloseAndPathEvents() async throws {
+        let fixture = try ServerFixture(decision: .accepted)
+        let connection = TestIrohConnection(
+            remoteIdentity: fixture.peerID,
+            bidirectionalStreams: [fixture.controlStream],
+            closeAttribution: .init(
+                initiator: .remote,
+                applicationErrorCode: 93,
+                failureKind: .connectionClosed
+            )
+        )
+        let server = try CmxIrohServerSession(
+            connection: connection,
+            authorizer: fixture.authorizer
+        )
+        let peer = try await server.admit()
+        let admitted = CmxIrohAdmittedServerSession(peer: peer, session: server)
+        let log = DiagnosticLog(capacity: 4)
+        let recorder = CmxIrohConnectionDiagnosticRecorder(
+            diagnosticLog: log,
+            sessionID: 31
+        )
+        let pathTask = Task {
+            let events = await admitted.observedPathEvents()
+            for await event in events {
+                recorder.record(event)
+            }
+        }
+
+        await connection.emitPathEvent(.init(
+            kind: .selected,
+            pathKind: .direct
+        ))
+        await connection.close(errorCode: 93, reason: "remote_peer_closed")
+        recorder.record(await admitted.closeAttribution())
+
+        for _ in 0 ..< 1_000 {
+            if await log.processedCount() >= 2 { break }
+            await Task.yield()
+        }
+        pathTask.cancel()
+        let events = await log.snapshot().events
+        #expect(events.map(\.code) == [
+            .transportPathEvent,
+            .transportCloseAttribution,
+        ])
+        #expect(events.allSatisfy { $0.c == 31 })
+        #expect(events[0].a == CmxIrohConnectionPathEventKind.selected.rawValue)
+        #expect(events[0].b == DiagnosticPathKind.direct.rawValue)
+        #expect(events[1].a == CmxIrohConnectionCloseInitiator.remote.rawValue)
+        #expect(events[1].b == DiagnosticFailureKind.connectionClosed.rawValue)
+        #expect(events[1].ms == 93)
+    }
+
     @Test(arguments: [
         DiagnosticFailureKind.admissionLeaseExpired,
         .admissionDenied,

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohConnection.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohConnection.swift
@@ -25,9 +25,12 @@ actor TestIrohConnection: CmxIrohConnection,
     private let eventRecorder: TestIrohEventRecorder?
     private let bidirectionalStreamFailureNumber: Int?
     private let reportsClosureToWaiters: Bool
+    private let reportedCloseAttribution: CmxIrohConnectionCloseAttribution
     private var selectedPath: CmxIrohObservedConnectionPath
     private let selectedPathStream: AsyncStream<CmxIrohObservedConnectionPath>
     private let selectedPathContinuation: AsyncStream<CmxIrohObservedConnectionPath>.Continuation
+    private let pathEventStream: AsyncStream<CmxIrohConnectionPathEvent>
+    private let pathEventContinuation: AsyncStream<CmxIrohConnectionPathEvent>.Continuation
     private var incomingStreamLimits: [(
         maximumBidirectionalStreamCount: UInt64,
         maximumUnidirectionalStreamCount: UInt64
@@ -51,7 +54,12 @@ actor TestIrohConnection: CmxIrohConnection,
         eventRecorder: TestIrohEventRecorder? = nil,
         selectedPath: CmxIrohObservedConnectionPath = .unavailable,
         bidirectionalStreamFailureNumber: Int? = nil,
-        reportsClosureToWaiters: Bool = true
+        reportsClosureToWaiters: Bool = true,
+        closeAttribution: CmxIrohConnectionCloseAttribution = .init(
+            initiator: .local,
+            applicationErrorCode: 0,
+            failureKind: .cancelled
+        )
     ) {
         peerIdentity = remoteIdentity
         self.continuityID = continuityID
@@ -61,6 +69,7 @@ actor TestIrohConnection: CmxIrohConnection,
         self.eventRecorder = eventRecorder
         self.bidirectionalStreamFailureNumber = bidirectionalStreamFailureNumber
         self.reportsClosureToWaiters = reportsClosureToWaiters
+        reportedCloseAttribution = closeAttribution
         self.selectedPath = selectedPath
         let pathChanges = AsyncStream<CmxIrohObservedConnectionPath>.makeStream(
             bufferingPolicy: .bufferingNewest(1)
@@ -68,6 +77,9 @@ actor TestIrohConnection: CmxIrohConnection,
         selectedPathStream = pathChanges.stream
         selectedPathContinuation = pathChanges.continuation
         selectedPathContinuation.yield(selectedPath)
+        let pathEvents = AsyncStream<CmxIrohConnectionPathEvent>.makeStream()
+        pathEventStream = pathEvents.stream
+        pathEventContinuation = pathEvents.continuation
         let closes = AsyncStream<(code: UInt64, reason: String)>.makeStream()
         closeStream = closes.stream
         closeContinuation = closes.continuation
@@ -92,6 +104,14 @@ actor TestIrohConnection: CmxIrohConnection,
     func setObservedSelectedPath(_ path: CmxIrohObservedConnectionPath) {
         selectedPath = path
         selectedPathContinuation.yield(path)
+    }
+
+    func observedPathEvents() -> AsyncStream<CmxIrohConnectionPathEvent> {
+        pathEventStream
+    }
+
+    func emitPathEvent(_ event: CmxIrohConnectionPathEvent) {
+        pathEventContinuation.yield(event)
     }
 
     func setIncomingStreamLimits(
@@ -145,6 +165,10 @@ actor TestIrohConnection: CmxIrohConnection,
 
     func isClosed() -> Bool {
         !closeCalls.isEmpty
+    }
+
+    func closeAttribution() -> CmxIrohConnectionCloseAttribution {
+        reportedCloseAttribution
     }
 
     private func recordClose(errorCode: UInt64, reason: String) {

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohConnection.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohConnection.swift
@@ -175,6 +175,9 @@ actor TestIrohConnection: CmxIrohConnection,
         let firstClose = closeCalls.isEmpty
         closeCalls.append((errorCode, reason))
         closeContinuation.yield((errorCode, reason))
+        if firstClose {
+            pathEventContinuation.finish()
+        }
         if firstClose, reportsClosureToWaiters {
             let waiters = closeWaiters
             closeWaiters.removeAll()

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -228,6 +228,17 @@ extension MobileHostIrohRuntime {
                     b: Int(CmxTransportSessionPurpose.foregroundControl.rawValue),
                     c: diagnosticSessionID
                 ))
+                let connectionDiagnostics = CmxIrohConnectionDiagnosticRecorder(
+                    diagnosticLog: diagnosticLog,
+                    sessionID: diagnosticSessionID
+                )
+                let pathEvents = await session.observedPathEvents()
+                let pathEventTask = Task {
+                    for await event in pathEvents {
+                        guard !Task.isCancelled else { return }
+                        connectionDiagnostics.record(event)
+                    }
+                }
                 let eventWriter = MobileHostIrohServerEventWriter(
                     session: session
                 )
@@ -260,6 +271,8 @@ extension MobileHostIrohRuntime {
                 )
                 let observedExit = await connectionSupervisor.run()
                 let exit = await session.connectionExit(resolving: observedExit)
+                await pathEventTask.value
+                connectionDiagnostics.record(await session.closeAttribution())
                 diagnosticLog.record(DiagnosticEvent(
                     .transportSessionLifecycle,
                     a: exit.lifecycle.rawValue,


### PR DESCRIPTION
## Problem

Sessions on Wi-Fi die ~2s after the connection selects the privateNetwork path (https://github.com/manaflow-ai/cmux/issues/8531 family; field-confirmed: cellular-only never flaps). The phone ring can only say `controlReadFailed/connectionClosed` because we discard the close cause iroh-ffi already reports (`_ = await driver.closed()`) and never subscribe to per-path events.

## Change

- New `CmxIrohConnectionCloseAttribution`: classifies the ffi close-cause string into initiator (local / remote / timedOut / unknown), optional QUIC application error code, and a bounded `DiagnosticFailureKind` — the raw string is never stored.
- New append-only diagnostic codes: `transportCloseAttribution = 54` (a=initiator, b=failure kind, ms=error code, c=session correlation id) and `transportPathEvent = 55` (a=opened/closed/selected/lagged, b=path kind, c=correlation id).
- Both roles emit them: mobile client session pool and Mac host activation, correlated with the existing sessionClosed/lifecycle ids. `watchPathEvents` handles are lifecycle-bound to the connection.

With this, the next flap ring shows exactly what happens to the privateNetwork path in the 2 seconds before death and which side closes — discriminating path-migration failure from everything else.

Two-commit structure: tests (red) then implementation (green).

## Verification

`CmuxIrohTransport` swift test: 473/58 suites pass (re-run after rebase). `CMUXMobileCore`: 281/24 pass. UI audit: only `DiagnosticFailureKind` switches exist, so no UI/localization changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787462753&installation_model_id=21920&pr_number=8819&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8819&signature=652e099970008737f4d55e3963a2f1b5a301decec0abd126307cda444982f50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attributes Iroh QUIC connection closes and logs redacted per‑path lifecycle events to diagnose privateNetwork flaps. Adds bounded diagnostics (codes 54 and 55) with session correlation across client and host.

- **New Features**
  - Added `CmxIrohConnectionCloseAttribution` and `CmxIrohConnectionCloseInitiator` to classify iroh‑ffi close causes (initiator, optional QUIC app error code, `DiagnosticFailureKind`).
  - Added per‑path event model `CmxIrohConnectionPathEvent` and kinds; emits opened/closed/selected/lagged with redacted `DiagnosticPathKind`.
  - Introduced `CmxIrohConnectionDiagnosticRecorder` to write `transportCloseAttribution` (54) and `transportPathEvent` (55); clamps app error code and correlates via session ID.
  - Exposed `closeAttribution()` and `observedPathEvents()` on `CmxIrohConnection` and threaded through `CmxIrohClientSession`, `CmxIrohServerSession`, `CmxIrohClientSessionPool`, and `MobileHostIrohRuntime+Activation`.
  - Updated `CMUXMobileCore` diagnostics to carry these events and typed payloads; raw iroh cause strings are not stored.

<sup>Written for commit 2d570d90f47ce024be13c9e8a6a9304fd819b63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy-safe connection close attribution diagnostics, including initiator, failure category, and application error information.
  * Added redacted connection path lifecycle diagnostics for opened, closed, selected, and lagged paths.
  * Added session correlation across transport lifecycle, path, and close events.
* **Bug Fixes**
  * Improved diagnostic payload decoding for path and session information.
* **Tests**
  * Expanded coverage for attribution classification, path events, payload mapping, and diagnostic event correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->