### PR TITLE
fix stable workspace restore test

### DIFF
--- a/cmuxTests/WorkspaceCreateWorkingDirectoryTests.swift
+++ b/cmuxTests/WorkspaceCreateWorkingDirectoryTests.swift
@@ -230,7 +230,7 @@ import Testing
         ], tabManager: manager, idempotencyCache: cache)
 
         #expect(Set(manager.tabs.map(\.id)) == initialIDs)
-        #expect(restored.id != sourceWorkspace.id)
+        #expect(restored.id == sourceWorkspace.id)
         #expect(restored.taskCreateOperationID == operationID)
         #expect(restored.panels.values.compactMap { $0 as? TerminalPanel }
             .allSatisfy { $0.surface.debugInitialCommand() != "must-not-launch" })


### PR DESCRIPTION
## summary

ordinary session restore now preserves an unreserved persisted workspace id. `retryFindsRestoredWorkspaceBeforeFreshCacheWithoutLaunchingCommand` still expected the old runtime id to be replaced, which left #8807 as the only failure in its 27 test suite.

this changes the stale `!=` expectation to `==`. the rest of the test still proves that an idempotent retry returns the restored workspace without creating another workspace or launching `must-not-launch`.

closes #8807

## testing

- on unmodified `main`, `WorkspaceCreateWorkingDirectoryTests` ran 27 tests and failed only at the stale id expectation
- after the change, the same 27 tests passed
- `./scripts/reload.sh --tag stable-restore-id` completed successfully
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-test-determinism.py --strict --roots cmuxTests/WorkspaceCreateWorkingDirectoryTests.swift`

## demo video

not applicable. this changes a test assertion and has no ui or runtime behavior change.

## review trigger

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## checklist

- [x] i tested the change locally
- [x] i added or updated tests for behavior changes
- [x] i updated docs/changelog if needed
- [x] i requested bot reviews after my latest commit
- [ ] all code review bot comments are resolved
- [ ] all human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787463520&installation_model_id=21920&pr_number=8820&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8820&signature=38d9fd809be80421b472c027da8caad37c4fa13e49ad2b3bacca432c7dec8b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the stable workspace restore test to expect that ordinary session restore preserves the persisted workspace id, aligning with durable workspace behavior; changes the assertion from "!=" to "==" and verifies the retry returns the same workspace without launching "must-not-launch". Closes #8807.

<sup>Written for commit 0203e7ca3efba78e62a47bf7c6913ea180320d69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workspace restoration coverage to verify that restored workspaces retain their original identifiers.
  * Confirmed restored workspaces are found correctly before creating a new workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->