### PR TITLE
iOS: stop the terminal files chip from flickering

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -45,17 +45,27 @@ extension GhosttySurfaceRepresentable.Coordinator {
             case .none:
                 break
             case .report(let report):
-                guard surfaceView.reportArtifactCount(
-                    report.count,
-                    generation: report.surfaceGeneration
-                ) else { return }
-                onArtifactGalleryRefreshSignal(TerminalArtifactGalleryRefreshSignal(
-                    count: report.count,
-                    surfaceGeneration: report.surfaceGeneration
-                ))
+                deliverArtifactCountReport(report, surfaceView: surfaceView)
             case .request(let request):
                 startArtifactCountRequest(request, surfaceView: surfaceView)
+            case .reportAndRequest(let report, let request):
+                deliverArtifactCountReport(report, surfaceView: surfaceView)
+                startArtifactCountRequest(request, surfaceView: surfaceView)
             }
+        }
+
+        private func deliverArtifactCountReport(
+            _ report: TerminalArtifactChipCountState.Report,
+            surfaceView: GhosttySurfaceView
+        ) {
+            guard surfaceView.reportArtifactCount(
+                report.count,
+                generation: report.surfaceGeneration
+            ) else { return }
+            onArtifactGalleryRefreshSignal(TerminalArtifactGalleryRefreshSignal(
+                count: report.count,
+                surfaceGeneration: report.surfaceGeneration
+            ))
         }
 
         private func startArtifactCountRequest(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -121,8 +121,10 @@ extension GhosttySurfaceRepresentable.Coordinator {
 
         /// How long a zero count must persist before the chip fades out.
         /// Streaming output re-scans the viewport on every settle, so counts
-        /// dip to zero for well under this window while paths scroll.
-        static let artifactChipHideGracePeriod: Duration = .seconds(2)
+        /// dip to zero while paths scroll; the rescan that restores a positive
+        /// count can itself be delayed past 2.5s when output keeps re-arming
+        /// the settle window, so the grace has margin over that.
+        static let artifactChipHideGracePeriod: Duration = .seconds(3.5)
 
         /// Projects the workspace's value count into a small SwiftUI chip hosted
         /// by the terminal surface, preserving the dock's keyboard geometry.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -109,23 +109,41 @@ extension GhosttySurfaceRepresentable.Coordinator {
             }
         }
 
+        /// How long a zero count must persist before the chip fades out.
+        /// Streaming output re-scans the viewport on every settle, so counts
+        /// dip to zero for well under this window while paths scroll.
+        static let artifactChipHideGracePeriod: Duration = .seconds(2)
+
         /// Projects the workspace's value count into a small SwiftUI chip hosted
         /// by the terminal surface, preserving the dock's keyboard geometry.
+        ///
+        /// Shows are immediate; hides wait out ``artifactChipHideGracePeriod``
+        /// so the transient zeros produced by streaming output and reconnect
+        /// resets do not flicker the chip. Disabling the chip and dismantling
+        /// the surface still unmount immediately.
         @MainActor
         func updateArtifactChip(count: Int) {
             visibleArtifactCount = count
             guard let surfaceView else { return }
-            let enabled = artifactChipGate.isEnabled
-            let renderState = (count: count, enabled: enabled)
-            if let lastArtifactChipRender, lastArtifactChipRender == renderState {
-                return
-            }
-            lastArtifactChipRender = renderState
-            guard enabled, count > 0 else {
+            switch artifactChipVisibility.update(
+                count: count,
+                enabled: artifactChipGate.isEnabled
+            ) {
+            case .none:
+                break
+            case .hideNow:
+                cancelArtifactChipHide()
                 surfaceView.mountArtifactChipView(nil, animated: true)
-                return
+            case .scheduleHide:
+                scheduleArtifactChipHide()
+            case .mount(let count):
+                cancelArtifactChipHide()
+                mountArtifactChip(count: count, on: surfaceView)
             }
+        }
 
+        @MainActor
+        private func mountArtifactChip(count: Int, on surfaceView: GhosttySurfaceView) {
             let chip = TerminalArtifactChipView(count: count) { [weak self] in
                 self?.requestArtifactFilesFromChip()
             }
@@ -144,6 +162,28 @@ extension GhosttySurfaceRepresentable.Coordinator {
         }
 
         @MainActor
+        private func scheduleArtifactChipHide() {
+            guard artifactChipHideTask == nil else { return }
+            artifactChipHideTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                try? await self.artifactChipHideClock.sleep(
+                    for: Self.artifactChipHideGracePeriod,
+                    tolerance: nil
+                )
+                guard !Task.isCancelled else { return }
+                self.artifactChipHideTask = nil
+                self.artifactChipVisibility.hideCompleted()
+                self.surfaceView?.mountArtifactChipView(nil, animated: true)
+            }
+        }
+
+        @MainActor
+        private func cancelArtifactChipHide() {
+            artifactChipHideTask?.cancel()
+            artifactChipHideTask = nil
+        }
+
+        @MainActor
         private func requestArtifactFilesFromChip() {
             guard artifactChipGate.isEnabled else { return }
             guard let surfaceView, let chipView = artifactChipController?.view else { return }
@@ -158,6 +198,8 @@ extension GhosttySurfaceRepresentable.Coordinator {
 
         @MainActor
         func tearDownArtifactChip() {
+            cancelArtifactChipHide()
+            artifactChipVisibility.reset()
             surfaceView?.mountArtifactChipView(nil, animated: false)
             artifactChipController = nil
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -46,14 +46,18 @@ extension GhosttySurfaceRepresentable.Coordinator {
                 break
             case .report(let report):
                 deliverArtifactCountReport(report, surfaceView: surfaceView)
+            case .provisionalReport(let report):
+                deliverProvisionalArtifactCountReport(report, surfaceView: surfaceView)
             case .request(let request):
                 startArtifactCountRequest(request, surfaceView: surfaceView)
             case .reportAndRequest(let report, let request):
-                deliverArtifactCountReport(report, surfaceView: surfaceView)
+                deliverProvisionalArtifactCountReport(report, surfaceView: surfaceView)
                 startArtifactCountRequest(request, surfaceView: surfaceView)
             }
         }
 
+        /// Authoritative delivery: updates the chip and notifies gallery
+        /// refresh listeners (an open Files sheet re-queries on this signal).
         private func deliverArtifactCountReport(
             _ report: TerminalArtifactChipCountState.Report,
             surfaceView: GhosttySurfaceView
@@ -66,6 +70,20 @@ extension GhosttySurfaceRepresentable.Coordinator {
                 count: report.count,
                 surfaceGeneration: report.surfaceGeneration
             ))
+        }
+
+        /// Provisional delivery: chip-only. These fire on every settled
+        /// viewport change during streaming, and each gallery refresh signal
+        /// makes an open Files sheet run a session transcript query — so only
+        /// authoritative scan completions may fan out.
+        private func deliverProvisionalArtifactCountReport(
+            _ report: TerminalArtifactChipCountState.Report,
+            surfaceView: GhosttySurfaceView
+        ) {
+            _ = surfaceView.reportArtifactCount(
+                report.count,
+                generation: report.surfaceGeneration
+            )
         }
 
         private func startArtifactCountRequest(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -95,25 +95,26 @@ extension GhosttySurfaceRepresentable.Coordinator {
             let artifactChipGate = artifactChipGate
             artifactCountTaskRequest = request
             artifactCountTask = Task { @MainActor [weak self, weak surfaceView] in
-                let sessionTotal: Int?
+                let scan: (sessionTotal: Int?, sessionID: String?)?
                 do {
-                    sessionTotal = try await artifactChipGate.performScan { [weak self] in
+                    scan = try await artifactChipGate.performScan { [weak self] in
                         guard let source = self?.store?.makeChatEventSource() else { return nil }
                         let response = try await source.terminalArtifactScan(
                             workspaceID: workspaceID,
                             surfaceID: surfaceID,
                             countOnly: true
                         )
-                        return response.sessionArtifactTotal
+                        return (response.sessionArtifactTotal, response.sessionID)
                     }
                 } catch {
-                    sessionTotal = nil
+                    scan = nil
                 }
 
                 guard let self, let surfaceView else { return }
                 let completion = self.artifactCountState.complete(
                     request,
-                    sessionTotal: sessionTotal,
+                    sessionTotal: scan?.sessionTotal,
+                    sessionID: scan?.sessionID,
                     currentSurfaceGeneration: surfaceView.visibleArtifactCountGeneration,
                     freshestLocalCount: self.freshestLocalArtifactCount
                 )
@@ -202,6 +203,16 @@ extension GhosttySurfaceRepresentable.Coordinator {
                 )
                 guard !Task.isCancelled else { return }
                 self.artifactChipHideTask = nil
+                // A positive report can land in the delegate just before this
+                // deadline and only cancel the hide after its SwiftUI round
+                // trip; hiding then would remount moments later — the exact
+                // flicker this grace exists to remove. Re-drive the state
+                // machine with the fresh count instead: it remounts and
+                // clears the pending-hide state in one step.
+                guard self.visibleArtifactCount <= 0 else {
+                    self.updateArtifactChip(count: self.visibleArtifactCount)
+                    return
+                }
                 self.artifactChipVisibility.hideCompleted()
                 self.surfaceView?.mountArtifactChipView(nil, animated: true)
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -115,6 +115,7 @@ extension GhosttySurfaceRepresentable.Coordinator {
                     request,
                     sessionTotal: scan?.sessionTotal,
                     sessionID: scan?.sessionID,
+                    scanSucceeded: scan != nil,
                     currentSurfaceGeneration: surfaceView.visibleArtifactCountGeneration,
                     freshestLocalCount: self.freshestLocalArtifactCount
                 )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -191,7 +191,13 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         /// dismantle; mounted/unmounted by ``setComposerMounted(_:)``.
         private var composerController: UIHostingController<TerminalComposerView>?
         var artifactChipController: UIHostingController<TerminalArtifactChipView>?
-        var lastArtifactChipRender: (count: Int, enabled: Bool)?
+        var artifactChipVisibility = TerminalArtifactChipVisibilityState()
+        /// Pending debounced chip unmount; cancelled whenever a positive count
+        /// arrives so transient zero counts cannot flicker the chip.
+        var artifactChipHideTask: Task<Void, Never>?
+        /// Injected so the hide grace period is testable and cancellable
+        /// (`DispatchQueue.asyncAfter` is banned for intentional delays).
+        let artifactChipHideClock: any Clock<Duration>
         private var composerMounted = false
         private var activeViewportPolicy: MobileTerminalOutputViewportPolicy = .natural
         private let verifiedReplayState = VerifiedTerminalReplayStateMachine()
@@ -221,7 +227,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             onArtifactFilesRequested: @escaping @MainActor (_ anchor: UnitPoint) -> Void,
             onArtifactPathTapped: @escaping @MainActor (_ path: String) -> Void,
             onVisibleArtifactCountChanged: @escaping @MainActor (_ count: Int) -> Void,
-            onArtifactGalleryRefreshSignal: @escaping @MainActor (TerminalArtifactGalleryRefreshSignal) -> Void
+            onArtifactGalleryRefreshSignal: @escaping @MainActor (TerminalArtifactGalleryRefreshSignal) -> Void,
+            artifactChipHideClock: any Clock<Duration> = ContinuousClock()
         ) {
             self.workspaceID = workspaceID
             self.surfaceID = surfaceID
@@ -239,6 +246,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             self.onArtifactPathTapped = onArtifactPathTapped
             self.onVisibleArtifactCountChanged = onVisibleArtifactCountChanged
             self.onArtifactGalleryRefreshSignal = onArtifactGalleryRefreshSignal
+            self.artifactChipHideClock = artifactChipHideClock
             super.init()
         }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -17,6 +17,15 @@ struct TerminalArtifactChipCountState: Sendable {
         case none
         case report(Report)
         case request(Request)
+        /// Report a provisional count now and refine it with a session scan.
+        ///
+        /// The provisional report is what keeps the chip honest on a busy
+        /// terminal: a session scan only survives if no output arrives while
+        /// its RPC is in flight, so waiting for it systematically drops the
+        /// positive counts (scanned right before the next output burst) while
+        /// zero counts (scanned in quiet pauses) get through, parking the
+        /// chip on zero and flickering it. The local count needs no RPC.
+        case reportAndRequest(Report, Request)
     }
 
     enum CompletionOutcome: Sendable, Equatable {
@@ -65,14 +74,28 @@ struct TerminalArtifactChipCountState: Sendable {
         guard supportsSessionCount else {
             return .report(Report(count: localCount, surfaceGeneration: surfaceGeneration))
         }
+        let provisional = Report(
+            count: displayCount(forLocalCount: localCount),
+            surfaceGeneration: surfaceGeneration
+        )
         let pending = Pending(surfaceGeneration: surfaceGeneration, localCount: localCount)
         guard inFlight == nil else {
             trailing = pending
-            return .none
+            return .report(provisional)
         }
         let request = makeRequest(pending)
         inFlight = request
-        return .request(request)
+        return .reportAndRequest(provisional, request)
+    }
+
+    /// The count the chip should show for a fresh local scan: the last known
+    /// session total wins while the session has artifacts, the viewport-only
+    /// count otherwise.
+    private func displayCount(forLocalCount localCount: Int) -> Int {
+        if let lastSessionTotal, lastSessionTotal > 0 {
+            return lastSessionTotal
+        }
+        return localCount
     }
 
     mutating func complete(
@@ -92,16 +115,8 @@ struct TerminalArtifactChipCountState: Sendable {
 
         let outcome: CompletionOutcome
         if request.surfaceGeneration == currentSurfaceGeneration {
-            let count: Int
-            if let sessionTotal {
-                count = sessionTotal > 0 ? sessionTotal : request.localCount
-            } else if let lastSessionTotal, lastSessionTotal > 0 {
-                count = lastSessionTotal
-            } else {
-                count = request.localCount
-            }
             outcome = .reported(Report(
-                count: count,
+                count: displayCount(forLocalCount: request.localCount),
                 surfaceGeneration: request.surfaceGeneration
             ))
             consecutiveRearmCount = 0

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -41,6 +41,10 @@ struct TerminalArtifactChipCountState: Sendable {
     private var inFlight: Request?
     private var trailing: Pending?
     private var consecutiveRearmCount = 0
+    /// Last successful session total, held across transient scan failures so
+    /// the chip does not regress to the viewport-only count (which oscillates
+    /// while output streams) whenever one RPC drops.
+    private var lastSessionTotal: Int?
 
     static let maxConsecutiveRearms = 3
 
@@ -49,6 +53,7 @@ struct TerminalArtifactChipCountState: Sendable {
         inFlight = nil
         trailing = nil
         consecutiveRearmCount = 0
+        lastSessionTotal = nil
     }
 
     mutating func trigger(
@@ -81,11 +86,20 @@ struct TerminalArtifactChipCountState: Sendable {
             return .stale
         }
         inFlight = nil
+        if let sessionTotal {
+            lastSessionTotal = sessionTotal
+        }
 
         let outcome: CompletionOutcome
         if request.surfaceGeneration == currentSurfaceGeneration {
-            let count = sessionTotal.map { $0 > 0 ? $0 : request.localCount }
-                ?? request.localCount
+            let count: Int
+            if let sessionTotal {
+                count = sessionTotal > 0 ? sessionTotal : request.localCount
+            } else if let lastSessionTotal, lastSessionTotal > 0 {
+                count = lastSessionTotal
+            } else {
+                count = request.localCount
+            }
             outcome = .reported(Report(
                 count: count,
                 surfaceGeneration: request.surfaceGeneration

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -17,6 +17,12 @@ struct TerminalArtifactChipCountState: Sendable {
         case none
         case report(Report)
         case request(Request)
+        /// A chip-only report while a session scan is already in flight.
+        ///
+        /// Provisional reports fire on every settled viewport change during
+        /// streaming, so they must not fan out to gallery refresh listeners;
+        /// only authoritative scan completions (and legacy `.report`) do.
+        case provisionalReport(Report)
         /// Report a provisional count now and refine it with a session scan.
         ///
         /// The provisional report is what keeps the chip honest on a busy
@@ -81,7 +87,7 @@ struct TerminalArtifactChipCountState: Sendable {
         let pending = Pending(surfaceGeneration: surfaceGeneration, localCount: localCount)
         guard inFlight == nil else {
             trailing = pending
-            return .report(provisional)
+            return .provisionalReport(provisional)
         }
         let request = makeRequest(pending)
         inFlight = request
@@ -109,12 +115,17 @@ struct TerminalArtifactChipCountState: Sendable {
             return .stale
         }
         inFlight = nil
-        if let sessionTotal {
-            lastSessionTotal = sessionTotal
-        }
 
         let outcome: CompletionOutcome
         if request.surfaceGeneration == currentSurfaceGeneration {
+            // Cache only accepted, current-generation responses: a dropped
+            // response may belong to a superseded surface state (a generation
+            // bump can coincide with a new agent session binding), and its
+            // total must not seed provisional reports for the new one. The
+            // re-armed request re-fetches under the current generation.
+            if let sessionTotal {
+                lastSessionTotal = sessionTotal
+            }
             outcome = .reported(Report(
                 count: displayCount(forLocalCount: request.localCount),
                 surfaceGeneration: request.surfaceGeneration

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -114,6 +114,7 @@ struct TerminalArtifactChipCountState: Sendable {
         _ request: Request,
         sessionTotal: Int?,
         sessionID: String? = nil,
+        scanSucceeded: Bool = true,
         currentSurfaceGeneration: UInt64,
         freshestLocalCount: Int
     ) -> Completion {
@@ -130,6 +131,12 @@ struct TerminalArtifactChipCountState: Sendable {
             // themselves are cached only from accepted responses below.
             lastSessionTotal = nil
             lastSessionTotalSessionID = sessionID
+        } else if scanSucceeded, sessionID == nil, lastSessionTotalSessionID != nil {
+            // A SUCCESSFUL response with no session means the binding is gone
+            // (e.g. the session moved to another surface) — unlike a transport
+            // failure, which proves nothing and holds. Clear the stale total.
+            lastSessionTotal = nil
+            lastSessionTotalSessionID = nil
         }
 
         let outcome: CompletionOutcome

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -122,21 +122,22 @@ struct TerminalArtifactChipCountState: Sendable {
             return .stale
         }
         inFlight = nil
+        if let sessionID, sessionID != lastSessionTotalSessionID {
+            // Session identity is generation-independent: any response naming
+            // a different session proves the binding changed, even when its
+            // count is stale for the current viewport (during streaming most
+            // responses are). Invalidate the old session's total here; totals
+            // themselves are cached only from accepted responses below.
+            lastSessionTotal = nil
+            lastSessionTotalSessionID = sessionID
+        }
 
         let outcome: CompletionOutcome
         if request.surfaceGeneration == currentSurfaceGeneration {
             // Cache only accepted, current-generation responses: a dropped
-            // response may belong to a superseded surface state (a generation
-            // bump can coincide with a new agent session binding), and its
-            // total must not seed provisional reports for the new one. The
-            // re-armed request re-fetches under the current generation.
-            if let sessionID, sessionID != lastSessionTotalSessionID {
-                // The surface is bound to a different session now; the held
-                // total belongs to the old one and must not keep the chip
-                // mounted for the new session while its index warms up.
-                lastSessionTotal = nil
-                lastSessionTotalSessionID = sessionID
-            }
+            // response's total may be stale for the superseded surface state
+            // and must not seed provisional reports. The re-armed request
+            // re-fetches under the current generation.
             if let sessionTotal {
                 lastSessionTotal = sessionTotal
                 lastSessionTotalSessionID = sessionID ?? lastSessionTotalSessionID

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -60,6 +60,11 @@ struct TerminalArtifactChipCountState: Sendable {
     /// the chip does not regress to the viewport-only count (which oscillates
     /// while output streams) whenever one RPC drops.
     private var lastSessionTotal: Int?
+    /// Session the held total belongs to. A terminal can bind a new agent
+    /// session without remounting the coordinator, and its first count-only
+    /// responses can carry the new session's ID with no total yet — the held
+    /// total from the previous session must be invalidated then, not shown.
+    private var lastSessionTotalSessionID: String?
 
     static let maxConsecutiveRearms = 3
 
@@ -69,6 +74,7 @@ struct TerminalArtifactChipCountState: Sendable {
         trailing = nil
         consecutiveRearmCount = 0
         lastSessionTotal = nil
+        lastSessionTotalSessionID = nil
     }
 
     mutating func trigger(
@@ -107,6 +113,7 @@ struct TerminalArtifactChipCountState: Sendable {
     mutating func complete(
         _ request: Request,
         sessionTotal: Int?,
+        sessionID: String? = nil,
         currentSurfaceGeneration: UInt64,
         freshestLocalCount: Int
     ) -> Completion {
@@ -123,8 +130,16 @@ struct TerminalArtifactChipCountState: Sendable {
             // bump can coincide with a new agent session binding), and its
             // total must not seed provisional reports for the new one. The
             // re-armed request re-fetches under the current generation.
+            if let sessionID, sessionID != lastSessionTotalSessionID {
+                // The surface is bound to a different session now; the held
+                // total belongs to the old one and must not keep the chip
+                // mounted for the new session while its index warms up.
+                lastSessionTotal = nil
+                lastSessionTotalSessionID = sessionID
+            }
             if let sessionTotal {
                 lastSessionTotal = sessionTotal
+                lastSessionTotalSessionID = sessionID ?? lastSessionTotalSessionID
             }
             outcome = .reported(Report(
                 count: displayCount(forLocalCount: request.localCount),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipVisibilityState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipVisibilityState.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Tracks the terminal files chip's mount state and turns raw count updates
+/// into mount transitions.
+///
+/// Shows are immediate; a zero count only *schedules* a hide so the caller can
+/// wait out a grace period before unmounting. The visible count dips to zero
+/// transiently all the time — streaming output scrolls paths out of the
+/// viewport between scans, and reconnects reset the artifact capabilities —
+/// and unmounting on every dip flickers the chip. Disabling the chip still
+/// hides immediately.
+struct TerminalArtifactChipVisibilityState: Sendable, Equatable {
+    enum Transition: Sendable, Equatable {
+        /// Nothing to do; the mounted state already matches.
+        case none
+        /// Mount or refresh the chip with this count and cancel any pending hide.
+        case mount(count: Int)
+        /// Start the hide grace period; unmount only if no positive count
+        /// arrives before it elapses.
+        case scheduleHide
+        /// Unmount immediately (the chip was disabled).
+        case hideNow
+    }
+
+    private enum Mount: Sendable, Equatable {
+        case unmounted
+        case mounted(count: Int)
+        /// Still mounted, showing the last count, waiting out the hide grace.
+        case hidePending
+    }
+
+    private var mount: Mount = .unmounted
+
+    mutating func update(count: Int, enabled: Bool) -> Transition {
+        guard enabled else {
+            guard mount != .unmounted else { return .none }
+            mount = .unmounted
+            return .hideNow
+        }
+        guard count > 0 else {
+            switch mount {
+            case .unmounted, .hidePending:
+                return .none
+            case .mounted:
+                mount = .hidePending
+                return .scheduleHide
+            }
+        }
+        if case .mounted(let mountedCount) = mount, mountedCount == count {
+            return .none
+        }
+        mount = .mounted(count: count)
+        return .mount(count: count)
+    }
+
+    /// The hide grace period elapsed and the chip was unmounted.
+    mutating func hideCompleted() {
+        guard mount == .hidePending else { return }
+        mount = .unmounted
+    }
+
+    /// The chip was torn down outside the update flow (dismantle).
+    mutating func reset() {
+        mount = .unmounted
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -40,6 +40,34 @@ struct TerminalArtifactChipCountStateTests {
         #expect(zeroCompletion.outcome == .reported(.init(count: 6, surfaceGeneration: 3)))
     }
 
+    @Test("a failed scan holds the last session total instead of regressing to the local count")
+    func failedScanHoldsLastSessionTotal() throws {
+        var state = TerminalArtifactChipCountState()
+        let first = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            first,
+            sessionTotal: 12,
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 3
+        ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+
+        let second = try request(from: state.trigger(
+            localCount: 1,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            second,
+            sessionTotal: nil,
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 1
+        ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+    }
+
     @Test("responses from an old state or surface generation are dropped")
     func staleResponses() throws {
         var resetState = TerminalArtifactChipCountState()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -68,6 +68,38 @@ struct TerminalArtifactChipCountStateTests {
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
     }
 
+    @Test("session-count triggers report the local count immediately and refine async")
+    func sessionTriggersReportProvisionally() throws {
+        var state = TerminalArtifactChipCountState()
+        guard case .reportAndRequest(let provisional, let request) = state.trigger(
+            localCount: 3,
+            surfaceGeneration: 5,
+            supportsSessionCount: true
+        ) else {
+            Issue.record("Expected a provisional report plus a session request")
+            throw UnexpectedAction()
+        }
+        #expect(provisional == .init(count: 3, surfaceGeneration: 5))
+        #expect(state.complete(
+            request,
+            sessionTotal: 12,
+            currentSurfaceGeneration: 5,
+            freshestLocalCount: 3
+        ).outcome == .reported(.init(count: 12, surfaceGeneration: 5)))
+
+        // Once a session total is known, provisional reports hold it instead
+        // of regressing to the smaller viewport-only count.
+        guard case .reportAndRequest(let upgraded, _) = state.trigger(
+            localCount: 1,
+            surfaceGeneration: 5,
+            supportsSessionCount: true
+        ) else {
+            Issue.record("Expected a provisional report plus a session request")
+            throw UnexpectedAction()
+        }
+        #expect(upgraded == .init(count: 12, surfaceGeneration: 5))
+    }
+
     @Test("reset forgets the remembered session total")
     func resetForgetsSessionTotal() throws {
         var state = TerminalArtifactChipCountState()
@@ -228,12 +260,12 @@ struct TerminalArtifactChipCountStateTests {
             localCount: 2,
             surfaceGeneration: 21,
             supportsSessionCount: true
-        ) == .none)
+        ) == .report(.init(count: 2, surfaceGeneration: 21)))
         #expect(state.trigger(
             localCount: 3,
             surfaceGeneration: 22,
             supportsSessionCount: true
-        ) == .none)
+        ) == .report(.init(count: 3, surfaceGeneration: 22)))
 
         let completion = state.complete(
             first,
@@ -249,11 +281,13 @@ struct TerminalArtifactChipCountStateTests {
     private func request(
         from action: TerminalArtifactChipCountState.TriggerAction
     ) throws -> TerminalArtifactChipCountState.Request {
-        guard case .request(let request) = action else {
+        switch action {
+        case .request(let request), .reportAndRequest(_, let request):
+            return request
+        case .none, .report:
             Issue.record("Expected a session-count request")
             throw UnexpectedAction()
         }
-        return request
     }
 
     private struct UnexpectedAction: Error {}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -68,6 +68,35 @@ struct TerminalArtifactChipCountStateTests {
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
     }
 
+    @Test("reset forgets the remembered session total")
+    func resetForgetsSessionTotal() throws {
+        var state = TerminalArtifactChipCountState()
+        let seeded = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        _ = state.complete(
+            seeded,
+            sessionTotal: 12,
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 3
+        )
+        state.reset()
+
+        let fresh = try request(from: state.trigger(
+            localCount: 2,
+            surfaceGeneration: 8,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            fresh,
+            sessionTotal: nil,
+            currentSurfaceGeneration: 8,
+            freshestLocalCount: 2
+        ).outcome == .reported(.init(count: 2, surfaceGeneration: 8)))
+    }
+
     @Test("responses from an old state or surface generation are dropped")
     func staleResponses() throws {
         var resetState = TerminalArtifactChipCountState()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -223,6 +223,50 @@ struct TerminalArtifactChipCountStateTests {
         ).outcome == .reported(.init(count: 2, surfaceGeneration: 7)))
     }
 
+    @Test("a dropped response naming a new session still invalidates the held total")
+    func droppedResponseWithNewSessionInvalidates() throws {
+        var state = TerminalArtifactChipCountState()
+        let first = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        _ = state.complete(
+            first,
+            sessionTotal: 12,
+            sessionID: "session-a",
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 3
+        )
+
+        // Session B starts streaming: its response arrives after the viewport
+        // generation advanced, so the count is dropped — but the session
+        // identity is generation-independent and must clear A's total.
+        let second = try request(from: state.trigger(
+            localCount: 2,
+            surfaceGeneration: 8,
+            supportsSessionCount: true
+        ))
+        let dropped = state.complete(
+            second,
+            sessionTotal: nil,
+            sessionID: "session-b",
+            currentSurfaceGeneration: 9,
+            freshestLocalCount: 2
+        )
+        #expect(dropped.outcome == .droppedForSurfaceGenerationMismatch)
+
+        guard case .provisionalReport(let provisional) = state.trigger(
+            localCount: 2,
+            surfaceGeneration: 9,
+            supportsSessionCount: true
+        ) else {
+            Issue.record("Expected a provisional report while the re-arm is in flight")
+            throw UnexpectedAction()
+        }
+        #expect(provisional == .init(count: 2, surfaceGeneration: 9))
+    }
+
     @Test("a dropped response's total does not seed provisional reports")
     func droppedResponseDoesNotSeedProvisional() throws {
         var state = TerminalArtifactChipCountState()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -190,6 +190,31 @@ struct TerminalArtifactChipCountStateTests {
         #expect(reported.nextRequest == nil)
     }
 
+    @Test("a dropped response's total does not seed provisional reports")
+    func droppedResponseDoesNotSeedProvisional() throws {
+        var state = TerminalArtifactChipCountState()
+        let request = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 11,
+            supportsSessionCount: true
+        ))
+        let dropped = state.complete(
+            request,
+            sessionTotal: 30,
+            currentSurfaceGeneration: 12,
+            freshestLocalCount: 8
+        )
+        #expect(dropped.outcome == .droppedForSurfaceGenerationMismatch)
+
+        // The re-armed request is in flight; a fresh viewport trigger must
+        // report the local count, not the dropped response's stale total.
+        #expect(state.trigger(
+            localCount: 8,
+            surfaceGeneration: 12,
+            supportsSessionCount: true
+        ) == .provisionalReport(.init(count: 8, surfaceGeneration: 12)))
+    }
+
     @Test("surface-generation re-arms stop after the bounded retry count")
     func rearmBound() throws {
         var state = TerminalArtifactChipCountState()
@@ -260,12 +285,12 @@ struct TerminalArtifactChipCountStateTests {
             localCount: 2,
             surfaceGeneration: 21,
             supportsSessionCount: true
-        ) == .report(.init(count: 2, surfaceGeneration: 21)))
+        ) == .provisionalReport(.init(count: 2, surfaceGeneration: 21)))
         #expect(state.trigger(
             localCount: 3,
             surfaceGeneration: 22,
             supportsSessionCount: true
-        ) == .report(.init(count: 3, surfaceGeneration: 22)))
+        ) == .provisionalReport(.init(count: 3, surfaceGeneration: 22)))
 
         let completion = state.complete(
             first,
@@ -284,7 +309,7 @@ struct TerminalArtifactChipCountStateTests {
         switch action {
         case .request(let request), .reportAndRequest(_, let request):
             return request
-        case .none, .report:
+        case .none, .report, .provisionalReport:
             Issue.record("Expected a session-count request")
             throw UnexpectedAction()
         }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -190,6 +190,39 @@ struct TerminalArtifactChipCountStateTests {
         #expect(reported.nextRequest == nil)
     }
 
+    @Test("a new session binding invalidates the held total from the old session")
+    func sessionSwitchInvalidatesHeldTotal() throws {
+        var state = TerminalArtifactChipCountState()
+        let first = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            first,
+            sessionTotal: 12,
+            sessionID: "session-a",
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 3
+        ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+
+        // The terminal binds a new session whose transcript is not indexed
+        // yet: the response carries the new session's ID with no total. The
+        // old session's 12 must not be shown for it.
+        let second = try request(from: state.trigger(
+            localCount: 2,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            second,
+            sessionTotal: nil,
+            sessionID: "session-b",
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 2
+        ).outcome == .reported(.init(count: 2, surfaceGeneration: 7)))
+    }
+
     @Test("a dropped response's total does not seed provisional reports")
     func droppedResponseDoesNotSeedProvisional() throws {
         var state = TerminalArtifactChipCountState()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -51,10 +51,13 @@ struct TerminalArtifactChipCountStateTests {
         #expect(state.complete(
             first,
             sessionTotal: 12,
+            sessionID: "session-a",
             currentSurfaceGeneration: 7,
             freshestLocalCount: 3
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
 
+        // Production-shaped failure: the scan explicitly did NOT succeed, so
+        // neither the no-session clearing branch nor the success path runs.
         let second = try request(from: state.trigger(
             localCount: 1,
             surfaceGeneration: 7,
@@ -63,9 +66,45 @@ struct TerminalArtifactChipCountStateTests {
         #expect(state.complete(
             second,
             sessionTotal: nil,
+            sessionID: nil,
+            scanSucceeded: false,
             currentSurfaceGeneration: 7,
             freshestLocalCount: 1
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+    }
+
+    @Test("a successful response with no session clears the held total")
+    func successfulNoSessionResponseClearsHeldTotal() throws {
+        var state = TerminalArtifactChipCountState()
+        let first = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            first,
+            sessionTotal: 12,
+            sessionID: "session-a",
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 3
+        ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+
+        // The session moved off this surface: the scan SUCCEEDS but resolves
+        // no session. Unlike a transport failure, this proves the binding is
+        // gone, so the held 12 must yield to the local count.
+        let second = try request(from: state.trigger(
+            localCount: 2,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            second,
+            sessionTotal: nil,
+            sessionID: nil,
+            scanSucceeded: true,
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 2
+        ).outcome == .reported(.init(count: 2, surfaceGeneration: 7)))
     }
 
     @Test("session-count triggers report the local count immediately and refine async")

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipVisibilityStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipVisibilityStateTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import CmuxMobileShellUI
+
+@Suite("Terminal artifact chip visibility")
+struct TerminalArtifactChipVisibilityStateTests {
+    @Test("positive counts mount immediately and dedupe repeats")
+    func mounts() {
+        var state = TerminalArtifactChipVisibilityState()
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+        #expect(state.update(count: 3, enabled: true) == .none)
+        #expect(state.update(count: 4, enabled: true) == .mount(count: 4))
+    }
+
+    @Test("a zero count schedules a hide instead of unmounting")
+    func zeroSchedulesHide() {
+        var state = TerminalArtifactChipVisibilityState()
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+        #expect(state.update(count: 0, enabled: true) == .scheduleHide)
+        #expect(state.update(count: 0, enabled: true) == .none)
+    }
+
+    @Test("a positive count during the hide grace remounts, even at the same value")
+    func positiveCountCancelsPendingHide() {
+        var state = TerminalArtifactChipVisibilityState()
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+        #expect(state.update(count: 0, enabled: true) == .scheduleHide)
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+        #expect(state.update(count: 0, enabled: true) == .scheduleHide)
+    }
+
+    @Test("zero counts while unmounted do nothing")
+    func zeroWhileUnmounted() {
+        var state = TerminalArtifactChipVisibilityState()
+        #expect(state.update(count: 0, enabled: true) == .none)
+        #expect(state.update(count: 0, enabled: false) == .none)
+    }
+
+    @Test("disabling hides immediately from mounted and hide-pending states")
+    func disableHidesNow() {
+        var state = TerminalArtifactChipVisibilityState()
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+        #expect(state.update(count: 3, enabled: false) == .hideNow)
+        #expect(state.update(count: 3, enabled: false) == .none)
+
+        var pending = TerminalArtifactChipVisibilityState()
+        #expect(pending.update(count: 3, enabled: true) == .mount(count: 3))
+        #expect(pending.update(count: 0, enabled: true) == .scheduleHide)
+        #expect(pending.update(count: 0, enabled: false) == .hideNow)
+    }
+
+    @Test("a completed hide unmounts, so the next positive count mounts again")
+    func hideCompletionUnmounts() {
+        var state = TerminalArtifactChipVisibilityState()
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+        #expect(state.update(count: 0, enabled: true) == .scheduleHide)
+        state.hideCompleted()
+        #expect(state.update(count: 0, enabled: true) == .none)
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+    }
+
+    @Test("reset returns to unmounted without a transition")
+    func resetUnmounts() {
+        var state = TerminalArtifactChipVisibilityState()
+        #expect(state.update(count: 3, enabled: true) == .mount(count: 3))
+        state.reset()
+        #expect(state.update(count: 0, enabled: true) == .none)
+        #expect(state.update(count: 2, enabled: true) == .mount(count: 2))
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1012,8 +1012,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// above the Ghostty renderer's sublayer so a lifted Liquid-Glass button is not
     /// clipped by the terminal render bounds (item 6). Below the zoom HUD (1100).
     private static let bottomChromeZPosition: CGFloat = 1000
-    /// Floats above dock chrome and terminal content while yielding to the zoom HUD.
-    private static let artifactChipZPosition: CGFloat = 1050
+    /// Floats above dock chrome, terminal content, AND the verified-replay
+    /// frozen presentation (zPosition 2000). The freeze copies only renderer
+    /// pixels, so anything below it blinks out for the length of every
+    /// freeze/reveal transaction — one ~40-90ms chip blink per output burst
+    /// while an agent streams. Zoom-HUD conflicts are handled by the
+    /// `zoomOverlayShown` visibility gate, not by z-order.
+    private static let artifactChipZPosition: CGFloat = 2050
 
     /// Whether the always-visible bottom chrome (the docked accessory toolbar and,
     /// when open, the composer band) is currently on screen.


### PR DESCRIPTION
The iOS terminal files chip ("N files" over the terminal) flickered constantly while an agent streamed output. Live sim reproduction (path burst, pause, 70 filler lines, pause, repeat) plus frame-by-frame video analysis found three stacked mechanisms:

1. **Covered by the verified-replay freeze (the dominant, per-burst blink).** The frozen presentation mounts a full-bounds snapshot layer at zPosition 2000 for every freeze/reveal output transaction (~40-90ms), and the chip sat at zPosition 1050, so it blinked fully off once per output burst, metronomically. Fix: raise the chip to 2050; the zoom-HUD conflict that motivated 1050 is already handled by the `zoomOverlayShown` visibility gate, not z-order.
2. **Unmount on every transient zero count.** The chip unmounted (0.18s fade) the moment the visible-viewport count hit 0 and remounted on the next positive scan; streaming output scrolls paths off the grid and reconnects reset the capabilities, so zeros happen every few seconds. Fix: `TerminalArtifactChipVisibilityState` + a 2s hide grace at the coordinator seam (cancellable Task with injected `Clock` sleep). Shows stay immediate; disable/dismantle still hide immediately.
3. **Session-count RPC starvation parking the count at zero.** With session counts enabled every report waited on the `terminalArtifactScan` RPC, whose completion is dropped if any output bumped the surface generation while it was in flight. Positive counts are scanned right before the next burst (dropped); zero counts are scanned in quiet pauses (land). Fix: report the local count synchronously as a provisional value (holding the last known session total so the number never regresses), and let the async session scan only refine the number. A failed scan also holds the last session total instead of regressing to the viewport-only count.

Verified live on an isolated simulator paired to a tagged Mac build, driving the count 0↔3 every ~0.9s for 22 cycles: before the z-order fix the chip blinked off once per output burst (frame analysis, PTS-exact); after it the chip stays continuously mounted for the whole run and fades out once, ~2s after the final output settles.

Commits follow the red/green regression policy: the first commit adds the failing count-state test, the rest add the fixes with state-machine tests. The CmuxMobileShellUI package tests are not wired into CI, so red/green was verified locally (standalone swiftc harness of the pure structs) plus `swift build --build-tests` for the iOS simulator triple.

No user-facing strings changed (localization audit: no new strings; existing chip strings untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Artifact chip counts now appear immediately, then refine using the latest remembered session total when available.
  * The files (artifact) chip remains visible briefly when counts drop to zero to reduce flicker.
  * Artifact gallery refreshes more reliably after count updates.
  * The files chip overlay layer now floats above frozen terminal content for improved accessibility.
* **Bug Fixes**
  * More consistent retention of known totals across transient scan/RPC failures and session identity changes.
* **Tests**
  * Added/expanded unit tests covering session retention and chip visibility transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->