### PR TITLE
Batch CMUX INTERNAL uploads every 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,8 @@ jobs:
       - name: Validate TestFlight notes generator
         run: python3 tests/test_ios_testflight_notes.py
 
-      - name: Validate CMUX INTERNAL main-push path filter
-        run: python3 tests/test_ios_testflight_main_push_filter.py
+      - name: Validate CMUX INTERNAL scheduled upload gate
+        run: python3 tests/test_ios_testflight_schedule.py
 
       - name: Validate external TestFlight group assignment helper
         run: python3 tests/test_ios_testflight_external_distribution.py

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,24 +1,10 @@
 name: iOS TestFlight (CMUX INTERNAL)
 
 on:
-  # Automatically upload only when main changes the iOS app or a direct archive
-  # input. Manual dispatch remains available for intentional rebuilds.
-  push:
-    branches:
-      - main
-    paths:
-      - "ios/**"
-      - "Packages/iOS/**"
-      - "Packages/Shared/**"
-      - "Sources/Mobile/**"
-      - "vendor/stack-auth-swift-sdk-prerelease/**"
-      - "ghostty"
-      - "ghostty.h"
-      - "scripts/ensure-ghosttykit.sh"
-      - "scripts/ghosttykit-checksums.txt"
-      - "scripts/install-zig-ci.sh"
-      - "scripts/validate-xcframework-archive.py"
-      - ".github/workflows/ios-testflight.yml"
+  # Batch automatic uploads into one check every 30 minutes. Minutes 7 and 37
+  # avoid GitHub's top-of-hour scheduling rush.
+  schedule:
+    - cron: "7,37 * * * *"
   workflow_dispatch:
     inputs:
       build_number:
@@ -31,10 +17,10 @@ on:
         default: ""
 
 concurrency:
-  # A shared group keeps only one pending run and silently replaces older pending
-  # SHAs during merge bursts. Key qualifying push runs by SHA so every iOS change
-  # survives. Manual runs use run_id because an operator may intentionally rebuild.
-  group: ios-testflight-${{ github.event_name == 'push' && github.sha || github.run_id }}
+  # Keep at most one running and one pending automatic batch. A newer scheduled
+  # run replaces an older pending run, so a slow upload cannot create a backlog
+  # of stale main SHAs. Manual uploads keep their own group.
+  group: ios-testflight-${{ github.event_name == 'schedule' && 'scheduled' || github.run_id }}
   cancel-in-progress: false
 
 permissions:
@@ -58,11 +44,10 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
 
-            // Per-SHA workflow concurrency preserves every push, but it also lets
-            // several runs reach App Store Connect at once. Build numbers must be
-            // uploaded monotonically, so wait on a cheap Linux runner until every
-            // earlier main-push run has finished its upload job. Assignment can
-            // continue independently after the upload completes.
+            // Scheduled and manual runs use separate concurrency groups. Build
+            // numbers must still be uploaded monotonically, so wait on a cheap
+            // Linux runner until every earlier main run has finished its upload
+            // job. Assignment can continue after the upload completes.
             if (context.ref === 'refs/heads/main') {
               const currentRunId = Number(context.runId);
               const maxWaits = 300;
@@ -80,7 +65,7 @@ jobs:
                     (run) =>
                       Number(run.id) < currentRunId &&
                       run.status !== 'completed' &&
-                      ['push', 'workflow_dispatch'].includes(run.event)
+                      ['schedule', 'workflow_dispatch'].includes(run.event)
                   );
                   for (const run of earlierActiveRuns) {
                     const jobs = await github.rest.actions.listJobsForWorkflowRun({
@@ -148,6 +133,7 @@ jobs:
             // is necessarily a normal immediate beta cut and SHOULD count as the
             // last canonical upload.
             let lastUploadedSha = null;
+            let lookupFailed = false;
             try {
               for (let page = 1; page <= 20 && !lastUploadedSha; page += 1) {
                 const runs = await github.rest.actions.listWorkflowRuns({
@@ -190,14 +176,75 @@ jobs:
                 if (runs.data.workflow_runs.length < 100) break;
               }
             } catch (e) {
+              lookupFailed = true;
               core.warning(`could not resolve last uploaded sha: ${e.message}`);
             }
 
-            // Push runs have already passed the workflow's iOS path filter.
-            // Manual runs are intentional rebuilds, so every event that reaches
-            // this workflow should build.
-            const shouldBuild =
-              context.eventName === 'push' || context.eventName === 'workflow_dispatch';
+            // Automatic uploads fail closed when history cannot be inspected.
+            // Treating an unknown prior SHA as "never uploaded" would create a
+            // duplicate build every 30 minutes during a GitHub API outage.
+            if (context.eventName === 'schedule' && lookupFailed) {
+              core.setFailed(
+                'could not resolve the last uploaded beta SHA; refusing to auto-upload'
+              );
+              return;
+            }
+
+            // Manual dispatch is an intentional rebuild. A scheduled run uploads
+            // only when main advanced past the last successful canonical upload
+            // and that range includes an input that can change the iOS archive.
+            const iosPathPattern = /^(ios\/|Packages\/iOS\/|Packages\/Shared\/|Sources\/Mobile\/|vendor\/stack-auth-swift-sdk-prerelease\/|ghostty$|ghostty\.h$|scripts\/ensure-ghosttykit\.sh$|scripts\/ghosttykit-checksums\.txt$|scripts\/install-zig-ci\.sh$|scripts\/validate-xcframework-archive\.py$|\.github\/workflows\/ios-testflight\.yml$)/;
+            let iosPathsChanged = 'not evaluated';
+            let shouldBuild = context.eventName === 'workflow_dispatch';
+            if (context.eventName === 'schedule') {
+              if (!lastUploadedSha) {
+                shouldBuild = true;
+                iosPathsChanged = 'first canonical upload';
+              } else if (lastUploadedSha === context.sha) {
+                core.notice(`skipping TestFlight upload: ${context.sha} was already uploaded`);
+                iosPathsChanged = 'not evaluated (HEAD already uploaded)';
+              } else {
+                try {
+                  const compare = await github.rest.repos.compareCommitsWithBasehead({
+                    owner,
+                    repo,
+                    basehead: `${lastUploadedSha}...${context.sha}`,
+                  });
+                  const files = compare.data.files || [];
+                  if (compare.data.status !== 'ahead') {
+                    core.setFailed(
+                      `cannot safely path-gate non-linear range ${lastUploadedSha}...${context.sha} (status: ${compare.data.status})`
+                    );
+                    return;
+                  }
+                  if (files.length >= 300) {
+                    core.setFailed(
+                      `cannot safely path-gate ${lastUploadedSha}...${context.sha}: GitHub truncated the changed-file list`
+                    );
+                    return;
+                  }
+                  const changed = files.some(
+                    (file) =>
+                      iosPathPattern.test(file.filename) ||
+                      (file.previous_filename &&
+                        iosPathPattern.test(file.previous_filename))
+                  );
+                  iosPathsChanged = String(changed);
+                  shouldBuild = changed;
+                  if (!changed) {
+                    core.notice(
+                      `skipping TestFlight upload: ${files.length} changed file(s) since ${lastUploadedSha} touch no iOS-affecting path`
+                    );
+                  }
+                } catch (e) {
+                  core.setFailed(
+                    `could not compare ${lastUploadedSha}...${context.sha}; refusing to auto-upload: ${e.message}`
+                  );
+                  return;
+                }
+              }
+            }
+
             core.setOutput('should_build', shouldBuild ? 'true' : 'false');
             core.setOutput('last_uploaded_sha', lastUploadedSha || '');
             core.summary
@@ -206,6 +253,7 @@ jobs:
                 [{ data: 'event', header: true }, context.eventName],
                 [{ data: 'head sha', header: true }, context.sha],
                 [{ data: 'last uploaded sha (notes base)', header: true }, String(lastUploadedSha)],
+                [{ data: 'iOS paths changed since last upload', header: true }, iosPathsChanged],
                 [{ data: 'should build', header: true }, String(shouldBuild)],
               ])
               .write();
@@ -213,7 +261,7 @@ jobs:
   upload:
     name: Upload to TestFlight
     needs: decide
-    # Only ever publish from main. Push runs always use main; this also
+    # Only ever publish from main. Scheduled runs always use main; this also
     # blocks publishing arbitrary code by dispatching the workflow against a
     # feature branch (the ASC secrets are only meant to ship reviewed main).
     if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
@@ -382,7 +430,7 @@ jobs:
         id: upload
         env:
           # Only set for manual workflow_dispatch with an explicit build number.
-          # For push this is empty and the script generates a monotonic
+          # For scheduled runs this is empty and the script generates a monotonic
           # 14-digit UTC timestamp itself (single source of the numbering scheme,
           # so the workflow can't drift from it the way it did before). An empty
           # value here means "let the script decide", which also keeps the guard's
@@ -425,7 +473,7 @@ jobs:
               --skip-notes
           else
             # Reuse the checked-in CMUX_IOS_BETA_MARKETING_VERSION for automatic betas.
-            # Main-push builds use:
+            # Scheduled main builds use:
             # - "cmux INTERNAL" display name
             # - dev.cmux.app.internal bundle ID (separate app, can coexist with external)
             # - assigned to internal TestFlight group for dogfooding within the team

--- a/ios/scripts/generate-testflight-notes.sh
+++ b/ios/scripts/generate-testflight-notes.sh
@@ -61,8 +61,8 @@ if ! git merge-base --is-ancestor "$BASE" HEAD 2>/dev/null; then
   exit 0
 fi
 
-# iOS-affecting paths: mirror the push-trigger filter in ios-testflight.yml so the
-# notes only mention changes that could be in this build.
+# iOS-affecting paths: mirror the scheduled path gate in ios-testflight.yml so
+# the notes only mention changes that could be in this build.
 PATHS="ios Packages/iOS Packages/Shared Sources/Mobile vendor/stack-auth-swift-sdk-prerelease ghostty ghostty.h scripts/ensure-ghosttykit.sh scripts/ghosttykit-checksums.txt scripts/install-zig-ci.sh scripts/validate-xcframework-archive.py .github/workflows/ios-testflight.yml"
 
 # First-line subjects of non-merge commits in range touching those paths. Squash

--- a/tests/test_ios_testflight_schedule.py
+++ b/tests/test_ios_testflight_schedule.py
@@ -29,18 +29,6 @@ def trigger_block(text: str) -> str:
     return text[text.index("on:\n") : text.index("\nconcurrency:\n")]
 
 
-def mapping_block(text: str, key: str, indent: int) -> str:
-    marker = f"{' ' * indent}{key}:\n"
-    assert marker in text, f"missing {key} mapping"
-    lines = text[text.index(marker) + len(marker) :].splitlines()
-    block = []
-    for line in lines:
-        if line.strip() and len(line) - len(line.lstrip()) <= indent:
-            break
-        block.append(line)
-    return "\n".join(block)
-
-
 def mapping_keys(text: str, indent: int) -> tuple[str, ...]:
     keys = []
     for line in text.splitlines():
@@ -56,34 +44,14 @@ def mapping_keys(text: str, indent: int) -> tuple[str, ...]:
     return tuple(keys)
 
 
-def sequence_values(text: str, key: str, indent: int) -> tuple[str, ...]:
-    marker = f"{' ' * indent}{key}:\n"
-    assert marker in text, f"missing {key} sequence"
-    lines = text[text.index(marker) + len(marker) :].splitlines()
-    item_prefix = f"{' ' * (indent + 2)}- "
-    values = []
-    for line in lines:
-        if not line.strip() or line.lstrip().startswith("#"):
-            continue
-        line_indent = len(line) - len(line.lstrip())
-        if line_indent <= indent:
-            break
-        assert line.startswith(item_prefix), f"invalid {key} item: {line}"
-        parsed = shlex.split(line.removeprefix(item_prefix), comments=True)
-        assert len(parsed) == 1, f"invalid {key} value: {line}"
-        values.append(parsed[0])
-    return tuple(values)
-
-
-def test_main_push_triggers_only_for_ios_affecting_paths() -> None:
+def test_automatic_upload_runs_every_thirty_minutes() -> None:
     text = workflow_text()
     triggers = trigger_block(text)
-    push = mapping_block(triggers, "push", indent=2)
 
-    assert mapping_keys(triggers, indent=2) == ("push", "workflow_dispatch")
-    assert sequence_values(push, "branches", indent=4) == ("main",)
-    assert sequence_values(push, "paths", indent=4) == IOS_PATHS
-    assert "context.eventName === 'push' || context.eventName === 'workflow_dispatch'" in text
+    assert mapping_keys(triggers, indent=2) == ("schedule", "workflow_dispatch")
+    assert '    - cron: "7,37 * * * *"' in triggers
+    assert "\n  push:" not in triggers
+    assert "context.eventName === 'workflow_dispatch'" in text
 
 
 def test_mapping_keys_normalizes_quoted_yaml_keys() -> None:
@@ -113,20 +81,39 @@ def test_testflight_notes_use_the_same_ios_path_contract() -> None:
     assert notes_paths == expected_notes_paths
 
 
-def test_main_push_runs_are_preserved_and_uploaded_in_order() -> None:
+def test_scheduled_runs_are_batched_and_uploaded_in_order() -> None:
     text = workflow_text()
 
     assert (
-        "group: ios-testflight-${{ github.event_name == 'push' && github.sha || github.run_id }}"
+        "group: ios-testflight-${{ github.event_name == 'schedule' && 'scheduled' || github.run_id }}"
         in text
     )
-    assert "group: ios-testflight-${{ github.ref_name }}" not in text
     assert "cancel-in-progress: false" in text
     assert "Number(run.id) < currentRunId" in text
+    assert "['schedule', 'workflow_dispatch'].includes(run.event)" in text
     assert "uploadJob.status !== 'completed'" in text
     assert "could not inspect earlier TestFlight runs; retrying" in text
     assert "ios-testflight-assignment-state-complete" not in text
     assert "CMUX_TESTFLIGHT_ASSIGN_STATE_OUT_FILE" not in text
+
+
+def test_scheduled_run_skips_uploaded_or_non_ios_main() -> None:
+    text = workflow_text()
+
+    assert "lastUploadedSha === context.sha" in text
+    assert "github.rest.repos.compareCommitsWithBasehead" in text
+    assert "iosPathPattern.test(file.filename)" in text
+    assert "iosPathPattern.test(file.previous_filename)" in text
+    assert "context.eventName === 'schedule' && lookupFailed" in text
+    assert "refusing to auto-upload" in text
+    for path in IOS_PATHS:
+        escaped = (
+            path.removesuffix("/**")
+            .replace(".", r"\.")
+            .replace("/", r"\/")
+        )
+        suffix = r"\/" if path.endswith("/**") else r"$"
+        assert f"{escaped}{suffix}" in text, f"missing scheduled path gate for {path}"
 
 
 def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
@@ -138,9 +125,10 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
 
 
 if __name__ == "__main__":
-    test_main_push_triggers_only_for_ios_affecting_paths()
+    test_automatic_upload_runs_every_thirty_minutes()
     test_mapping_keys_normalizes_quoted_yaml_keys()
     test_testflight_notes_use_the_same_ios_path_contract()
-    test_main_push_runs_are_preserved_and_uploaded_in_order()
+    test_scheduled_runs_are_batched_and_uploaded_in_order()
+    test_scheduled_run_skips_uploaded_or_non_ios_main()
     test_automatic_lane_stays_on_cmux_internal_identity()
-    print("all iOS TestFlight main-push filter tests passed")
+    print("all iOS TestFlight schedule tests passed")


### PR DESCRIPTION
## Summary
- replace per-push CMUX INTERNAL uploads with a 30-minute schedule
- batch overlapping scheduled runs and skip already-uploaded or non-iOS main changes
- fail closed when upload history or path comparison cannot be verified

## Verification
- `python3 tests/test_ios_testflight_schedule.py`
- `python3 tests/test_ios_testflight_notes.py`
- embedded `actions/github-script` JavaScript syntax check with `node --check`
- Ruby YAML parse for `.github/workflows/ios-testflight.yml` and `.github/workflows/ci.yml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787463929&installation_model_id=21920&pr_number=8823&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8823&signature=52c8a58dbf8915b4c9e095581b373ae383351bf6fd9541f746e8119f733c6a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CMUX INTERNAL TestFlight uploads from per-push to a 30-minute schedule, batching overlapping runs and only uploading when iOS-affecting changes landed on main since the last canonical upload. Skips already-uploaded SHAs and fails closed when history or file comparisons can’t be verified.

- **Refactors**
  - Replaced push trigger with cron at minutes 7 and 37; scheduled and manual runs use separate concurrency groups, and a wait step enforces monotonic build numbers.
  - Scheduled runs upload only if main advanced and iOS paths changed since the last successful upload; fail closed on API errors, non-linear ranges, or truncated file lists.
  - Aligned TestFlight notes path filter with the new gate and updated CI to use `tests/test_ios_testflight_schedule.py`.

<sup>Written for commit 35eebbde40c7d41b6140cfb57772c63556f15105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

