### PR TITLE
Promote the Iroh relay-only override to a real cross-platform setting

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohPathPreference.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohPathPreference.swift
@@ -1,0 +1,30 @@
+public import Foundation
+
+/// Release-safe, device-local Iroh path constraint chosen in Settings.
+public enum CmxIrohPathPreference: String, CaseIterable, Equatable, Sendable {
+    /// Allows Iroh to select automatic, direct, private-network, or relay paths.
+    case automatic = "auto"
+
+    /// Keeps Iroh connections on relay paths.
+    case relayOnly
+
+    /// Shared defaults key used independently by the macOS and iOS apps.
+    public static let defaultsKey = "cmux.iroh.pathPreference"
+
+    /// The transport constraint this preference imposes on the runtime.
+    public var transportVerificationMode: CmxIrohTransportVerificationMode {
+        switch self {
+        case .automatic: .automatic
+        case .relayOnly: .relayOnly
+        }
+    }
+
+    /// Reads the persisted preference; absent or unknown values are automatic.
+    ///
+    /// - Parameter defaults: The device-local defaults domain to read.
+    /// - Returns: The stored preference, or ``automatic`` when no known value exists.
+    public static func stored(in defaults: UserDefaults) -> CmxIrohPathPreference {
+        guard let rawValue = defaults.string(forKey: defaultsKey) else { return .automatic }
+        return CmxIrohPathPreference(rawValue: rawValue) ?? .automatic
+    }
+}

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsControlling.swift
@@ -12,6 +12,9 @@ public protocol CmxIrohSettingsControlling: AnyObject {
     /// Persists the account-level relay preference and safely rebuilds the endpoint.
     func setIrohRelayPreference(_ preference: CmxIrohRelayPreferenceDraft) async throws
 
+    /// Persists the device-local path preference and restarts the active runtime.
+    func setIrohPathPreference(_ preference: CmxIrohPathPreference) async throws
+
     /// Creates or updates account-visible custom relay metadata and a device-local secret.
     func upsertIrohCustomRelay(
         _ relay: CmxIrohCustomRelayDraft,
@@ -48,6 +51,10 @@ public protocol CmxIrohSettingsControlling: AnyObject {
 }
 
 public extension CmxIrohSettingsControlling {
+    func setIrohPathPreference(_ preference: CmxIrohPathPreference) async throws {
+        throw CmxIrohSettingsControlError.unsupported
+    }
+
     func upsertIrohCustomPrivatePath(_ path: CmxIrohCustomPrivatePathDraft) async throws {
         throw CmxIrohSettingsControlError.unsupported
     }

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsSnapshot.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxIrohSettingsSnapshot.swift
@@ -124,6 +124,8 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
     /// Redacted selected-path attribution, independent from lifecycle status.
     public let selectedTransportPath: CmxIrohSelectedTransportPath
     public let preference: CmxIrohRelayPreferenceDraft
+    /// Device-local path constraint selected in Settings.
+    public let pathPreference: CmxIrohPathPreference
     public let managedRelays: [ManagedRelay]
     public let customRelays: [CustomRelay]
     public let privateNetworkMacs: [PrivateNetworkMac]
@@ -145,6 +147,7 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
         runtimeStatus: RuntimeStatus,
         selectedTransportPath: CmxIrohSelectedTransportPath = .unavailable,
         preference: CmxIrohRelayPreferenceDraft,
+        pathPreference: CmxIrohPathPreference = .automatic,
         managedRelays: [ManagedRelay],
         customRelays: [CustomRelay],
         privateNetworkMacs: [PrivateNetworkMac] = [],
@@ -159,6 +162,7 @@ public struct CmxIrohSettingsSnapshot: Equatable, Sendable {
         self.runtimeStatus = runtimeStatus
         self.selectedTransportPath = selectedTransportPath
         self.preference = preference
+        self.pathPreference = pathPreference
         self.managedRelays = managedRelays
         self.customRelays = customRelays
         self.privateNetworkMacs = privateNetworkMacs

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohSettingsSnapshotTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxIrohSettingsSnapshotTests.swift
@@ -5,6 +5,53 @@ import Testing
 
 @Suite
 struct CmxIrohSettingsSnapshotTests {
+    @Test func pathPreferenceReadsKnownValuesAndDefaultsUnknownValues() throws {
+        let suiteName = "CmxIrohSettingsSnapshotTests.path-preference.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(CmxIrohPathPreference.stored(in: defaults) == .automatic)
+
+        defaults.set("auto", forKey: CmxIrohPathPreference.defaultsKey)
+        #expect(CmxIrohPathPreference.stored(in: defaults) == .automatic)
+
+        defaults.set("relayOnly", forKey: CmxIrohPathPreference.defaultsKey)
+        #expect(CmxIrohPathPreference.stored(in: defaults) == .relayOnly)
+
+        defaults.set("unknown", forKey: CmxIrohPathPreference.defaultsKey)
+        #expect(CmxIrohPathPreference.stored(in: defaults) == .automatic)
+    }
+
+    @Test func pathPreferenceMapsToTransportVerificationMode() {
+        #expect(
+            CmxIrohPathPreference.automatic.transportVerificationMode == .automatic
+        )
+        #expect(
+            CmxIrohPathPreference.relayOnly.transportVerificationMode == .relayOnly
+        )
+    }
+
+    @Test func snapshotDefaultsAndRoundTripsPathPreference() {
+        let automatic = CmxIrohSettingsSnapshot(
+            runtimeStatus: .inactive,
+            preference: .automatic,
+            managedRelays: [],
+            customRelays: [],
+            policySource: .unavailable
+        )
+        let relayOnly = CmxIrohSettingsSnapshot(
+            runtimeStatus: .active,
+            preference: .automatic,
+            pathPreference: .relayOnly,
+            managedRelays: [],
+            customRelays: [],
+            policySource: .server
+        )
+
+        #expect(automatic.pathPreference == .automatic)
+        #expect(relayOnly.pathPreference == .relayOnly)
+    }
+
     @Test
     func activeRuntimeStatusPreservesOnlyRedactedPathLabels() {
         #expect(CmxIrohSettingsSnapshot.RuntimeStatus(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsModel.swift
@@ -70,6 +70,10 @@ final class MobileIrohSettingsModel {
         mutate { try await self.controller.setIrohRelayPreference(try preference.validated()) }
     }
 
+    func setPathPreference(_ preference: CmxIrohPathPreference) {
+        mutate { try await self.controller.setIrohPathPreference(preference) }
+    }
+
     #if DEBUG
     func setDebugTransportVerificationMode(
         _ mode: CmxIrohTransportVerificationMode

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -54,6 +54,22 @@ struct MobileIrohSettingsView: View {
             }
 
             Section {
+                Toggle(isOn: Binding(
+                    get: { model.snapshot.pathPreference == .relayOnly },
+                    set: { model.setPathPreference($0 ? .relayOnly : .automatic) }
+                )) {
+                    Text(L10n.string("mobile.iroh.relayOnly", defaultValue: "Relay Only"))
+                }
+                .disabled(model.isMutating)
+                .accessibilityIdentifier("MobileIrohRelayOnly")
+            } footer: {
+                Text(L10n.string(
+                    "mobile.iroh.relayOnly.footer",
+                    defaultValue: "Keeps this device's Iroh connections on cmux relays instead of direct or local-network paths. Applies on the next reconnect."
+                ))
+            }
+
+            Section {
                 ForEach(model.snapshot.customRelays) { relay in
                     HStack {
                         VStack(alignment: .leading) {

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileIrohSettingsModelTests.swift
@@ -89,6 +89,16 @@ struct MobileIrohSettingsModelTests {
         #expect(model.snapshot == .unavailable)
     }
 
+    @Test func relayOnlyMutationForwardsThePathPreference() async {
+        let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
+        let model = MobileIrohSettingsModel(controller: controller)
+
+        model.setPathPreference(.relayOnly)
+        await waitUntil { controller.pathPreferenceMutations == [.relayOnly] }
+
+        #expect(!model.showsSaveError)
+    }
+
     @Test func customPrivatePathMutationsForwardExactMacScopedDraft() async {
         let controller = MobileIrohSettingsControllerDouble(snapshot: .unavailable)
         let model = MobileIrohSettingsModel(controller: controller)
@@ -243,6 +253,7 @@ private final class MobileIrohSettingsControllerDouble:
 {
     var snapshot: CmxIrohSettingsSnapshot
     var preferenceMutations: [CmxIrohRelayPreferenceDraft] = []
+    var pathPreferenceMutations: [CmxIrohPathPreference] = []
     var upsertError: Error?
     var snapshotAfterUpsertError: CmxIrohSettingsSnapshot?
     var streamCreations = 0
@@ -278,6 +289,9 @@ private final class MobileIrohSettingsControllerDouble:
 
     func setIrohRelayPreference(_ preference: CmxIrohRelayPreferenceDraft) async throws {
         preferenceMutations.append(preference)
+    }
+    func setIrohPathPreference(_ preference: CmxIrohPathPreference) async throws {
+        pathPreferenceMutations.append(preference)
     }
     func upsertIrohCustomRelay(_ relay: CmxIrohCustomRelayDraft, deviceSecret: String?) async throws {
         if let upsertError {
@@ -335,6 +349,7 @@ private final class MobileIrohSettingsControllerDouble:
             runtimeStatus: snapshot.runtimeStatus,
             selectedTransportPath: snapshot.selectedTransportPath,
             preference: snapshot.preference,
+            pathPreference: snapshot.pathPreference,
             managedRelays: snapshot.managedRelays,
             customRelays: snapshot.customRelays,
             privateNetworkMacs: snapshot.privateNetworkMacs,

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Models/IrohSettingsModel.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Models/IrohSettingsModel.swift
@@ -54,16 +54,11 @@ final class IrohSettingsModel {
         }
     }
 
-    #if DEBUG
-    func setDebugRelayOnly(_ enabled: Bool) {
+    func setPathPreference(_ preference: CmxIrohPathPreference) {
         mutate { controller in
-            guard let debugController = controller as? any CmxIrohDebugSettingsControlling else {
-                return
-            }
-            try await debugController.setIrohDebugRelayOnly(enabled)
+            try await controller.setIrohPathPreference(preference)
         }
     }
-    #endif
 
     func upsertCustomRelay(_ relay: CmxIrohCustomRelayDraft, deviceSecret: String?) async -> Bool {
         await mutateAndWait { controller in

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -224,16 +224,12 @@ public struct IrohNetworkingSection: View {
                 Image(systemName: policySymbol)
                     .foregroundStyle(model.snapshot.policySource == .unavailable ? .orange : .secondary)
             }
-            #if DEBUG
-            if let debugRelayOnlyEnabled = model.snapshot.debugRelayOnlyEnabled {
-                SettingsCardDivider()
-                IrohDebugRelayOnlyRow(
-                    isEnabled: debugRelayOnlyEnabled,
-                    isMutating: model.isMutating,
-                    setEnabled: { model.setDebugRelayOnly($0) }
-                )
-            }
-            #endif
+            SettingsCardDivider()
+            IrohRelayOnlyRow(
+                isEnabled: model.snapshot.pathPreference == .relayOnly,
+                isMutating: model.isMutating,
+                setEnabled: { model.setPathPreference($0 ? .relayOnly : .automatic) }
+            )
             IrohDiagnosticsReportRows(
                 report: model.diagnosticReport,
                 exportText: model.diagnosticExportText,
@@ -605,8 +601,7 @@ private struct IrohDiagnosticsReportRows: View {
     }
 }
 
-#if DEBUG
-private struct IrohDebugRelayOnlyRow: View {
+private struct IrohRelayOnlyRow: View {
     let isEnabled: Bool
     let isMutating: Bool
     let setEnabled: @MainActor @Sendable (Bool) -> Void
@@ -614,14 +609,14 @@ private struct IrohDebugRelayOnlyRow: View {
     var body: some View {
         SettingsCardRow(
             configurationReview: .settingsOnly,
-            searchAnchorID: "setting:networking:debugRelayOnly",
+            searchAnchorID: "setting:networking:relayOnly",
             String(
-                localized: "settings.networking.debug.relayOnly",
-                defaultValue: "Relay-Only Verification"
+                localized: "settings.networking.relayOnly",
+                defaultValue: "Relay Only"
             ),
             subtitle: String(
-                localized: "settings.networking.debug.relayOnly.subtitle",
-                defaultValue: "Debug builds only. Keeps authenticated Iroh sessions on relays so the relay path can be verified."
+                localized: "settings.networking.relayOnly.subtitle",
+                defaultValue: "Keeps Iroh connections to this Mac on cmux relays instead of direct or local-network paths. Applies on the next reconnect."
             )
         ) {
             Toggle(
@@ -633,8 +628,7 @@ private struct IrohDebugRelayOnlyRow: View {
             )
             .labelsHidden()
             .disabled(isMutating)
-            .accessibilityIdentifier("SettingsIrohDebugRelayOnly")
+            .accessibilityIdentifier("SettingsIrohRelayOnly")
         }
     }
 }
-#endif

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/IrohSettingsModelTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/IrohSettingsModelTests.swift
@@ -176,17 +176,15 @@ struct IrohSettingsModelTests {
         await observation.value
     }
 
-    #if DEBUG
-    @Test func relayOnlyMutationUsesTheDebugControllerBoundary() async {
+    @Test func relayOnlyMutationForwardsThePathPreference() async {
         let controller = IrohSettingsControllerDouble(snapshot: .unavailable)
         let model = IrohSettingsModel(controller: controller)
 
-        model.setDebugRelayOnly(true)
-        await waitUntil { controller.debugRelayOnlyMutations == [true] }
+        model.setPathPreference(.relayOnly)
+        await waitUntil { controller.pathPreferenceMutations == [.relayOnly] }
 
         #expect(!model.showsSaveError)
     }
-    #endif
 
     private func waitUntil(_ predicate: () -> Bool) async {
         var spins = 0
@@ -247,8 +245,7 @@ struct IrohSettingsModelTests {
 
 @MainActor
 private final class IrohSettingsControllerDouble:
-    CmxIrohSettingsControlling,
-    CmxIrohDebugSettingsControlling
+    CmxIrohSettingsControlling
 {
     struct CustomRelayMutation: Equatable {
         let relay: CmxIrohCustomRelayDraft
@@ -257,10 +254,10 @@ private final class IrohSettingsControllerDouble:
 
     var snapshot: CmxIrohSettingsSnapshot
     var preferenceMutations: [CmxIrohRelayPreferenceDraft] = []
+    var pathPreferenceMutations: [CmxIrohPathPreference] = []
     var customRelayMutations: [CustomRelayMutation] = []
     var customRelayError: Error?
     var snapshotAfterCustomRelayError: CmxIrohSettingsSnapshot?
-    var debugRelayOnlyMutations: [Bool] = []
     var streamCreations = 0
     var streamTerminated = false
     var report = DiagnosticReport.empty
@@ -291,6 +288,10 @@ private final class IrohSettingsControllerDouble:
 
     func setIrohRelayPreference(_ preference: CmxIrohRelayPreferenceDraft) async throws {
         preferenceMutations.append(preference)
+    }
+
+    func setIrohPathPreference(_ preference: CmxIrohPathPreference) async throws {
+        pathPreferenceMutations.append(preference)
     }
 
     func upsertIrohCustomRelay(
@@ -335,15 +336,6 @@ private final class IrohSettingsControllerDouble:
         exportData = Data()
     }
 
-    func setIrohDebugRelayOnly(_ enabled: Bool) async throws {
-        debugRelayOnlyMutations.append(enabled)
-    }
-
-    func setIrohDebugTransportVerificationMode(
-        _ mode: CmxIrohTransportVerificationMode
-    ) async throws {
-        debugRelayOnlyMutations.append(mode == .relayOnly)
-    }
 }
 
 private enum TestFailure: Error {

--- a/Sources/Mobile/MobileHostIrohRuntime+Lifecycle.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Lifecycle.swift
@@ -8,7 +8,7 @@ extension MobileHostIrohRuntime {
         #if DEBUG
         Self.debugTransportVerificationMode(defaults: .standard)
         #else
-        .automatic
+        CmxIrohPathPreference.stored(in: .standard).transportVerificationMode
         #endif
     }
 
@@ -29,6 +29,7 @@ extension MobileHostIrohRuntime {
     }
 
     #if DEBUG
+    /// Resolves DEBUG overrides before the release-safe path preference.
     static func debugTransportVerificationMode(
         defaults: UserDefaults
     ) -> CmxIrohTransportVerificationMode {
@@ -37,9 +38,10 @@ extension MobileHostIrohRuntime {
         ), let mode = CmxIrohTransportVerificationMode(rawValue: rawValue) {
             return mode
         }
-        return defaults.bool(forKey: debugRelayOnlyDefaultsKey)
-            ? .relayOnly
-            : .automatic
+        if defaults.bool(forKey: debugRelayOnlyDefaultsKey) {
+            return .relayOnly
+        }
+        return CmxIrohPathPreference.stored(in: defaults).transportVerificationMode
     }
 
     static var isDebugRelayOnlyEnabled: Bool {

--- a/Sources/Mobile/MobileHostIrohRuntime+SettingsControl.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+SettingsControl.swift
@@ -4,6 +4,27 @@ import Foundation
 
 @MainActor
 extension MobileHostIrohRuntime: CmxIrohSettingsControlling {
+    func setIrohPathPreference(_ preference: CmxIrohPathPreference) async throws {
+        let hadStoredChange = CmxIrohPathPreference.stored(in: .standard) != preference
+        let hadEffectiveChange = transportVerificationMode != preference.transportVerificationMode
+        UserDefaults.standard.set(
+            preference.rawValue,
+            forKey: CmxIrohPathPreference.defaultsKey
+        )
+        #if DEBUG
+        UserDefaults.standard.removeObject(
+            forKey: CmxIrohTransportVerificationMode.debugDefaultsKey
+        )
+        UserDefaults.standard.removeObject(forKey: Self.debugRelayOnlyDefaultsKey)
+        #endif
+        guard hadStoredChange || hadEffectiveChange else { return }
+        publishIrohSettingsUpdate()
+        await scheduleReconcile(
+            eraseAccountState: false,
+            restartActiveRuntime: true
+        ).value
+    }
+
     func irohSettingsUpdates() -> AsyncStream<CmxIrohSettingsSnapshot> {
         let id = UUID()
         return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in

--- a/Sources/Mobile/MobileHostIrohRuntime+SettingsSnapshot.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+SettingsSnapshot.swift
@@ -38,6 +38,7 @@ extension MobileHostIrohRuntime {
             ),
             selectedTransportPath: selectedPath,
             preference: Self.settingsPreference(requested),
+            pathPreference: CmxIrohPathPreference.stored(in: .standard),
             managedRelays: managedPolicy?.relays.map { relay in
                 CmxIrohSettingsSnapshot.ManagedRelay(
                     id: relay.id,

--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -175,8 +175,8 @@ extension MobileHostAuthorizationTests {
 
         #expect(MobileHostIrohRuntime.debugTransportVerificationMode(defaults: defaults) == .automatic)
         defaults.set(
-            CmxIrohTransportVerificationMode.relayOnly.rawValue,
-            forKey: CmxIrohTransportVerificationMode.debugDefaultsKey
+            CmxIrohPathPreference.relayOnly.rawValue,
+            forKey: CmxIrohPathPreference.defaultsKey
         )
         #expect(MobileHostIrohRuntime.debugTransportVerificationMode(defaults: defaults) == .relayOnly)
         defaults.set(
@@ -184,6 +184,13 @@ extension MobileHostAuthorizationTests {
             forKey: CmxIrohTransportVerificationMode.debugDefaultsKey
         )
         #expect(MobileHostIrohRuntime.debugTransportVerificationMode(defaults: defaults) == .directOnly)
+        defaults.removeObject(forKey: CmxIrohTransportVerificationMode.debugDefaultsKey)
+        defaults.set(
+            CmxIrohPathPreference.automatic.rawValue,
+            forKey: CmxIrohPathPreference.defaultsKey
+        )
+        defaults.set(true, forKey: MobileHostIrohRuntime.debugRelayOnlyDefaultsKey)
+        #expect(MobileHostIrohRuntime.debugTransportVerificationMode(defaults: defaults) == .relayOnly)
     }
     #endif
 

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -15607,6 +15607,40 @@
         }
       }
     },
+    "mobile.iroh.relayOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relay Only"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リレーのみ"
+          }
+        }
+      }
+    },
+    "mobile.iroh.relayOnly.footer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keeps this device's Iroh connections on cmux relays instead of direct or local-network paths. Applies on the next reconnect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このデバイスの Iroh 接続を、直接経路やローカルネットワーク経路ではなく cmux リレー経由に固定します。次回の再接続時に適用されます。"
+          }
+        }
+      }
+    },
     "mobile.iroh.relays": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -121,6 +121,7 @@ public final class MobileIrohRuntimeComposition:
         @MainActor (CmxIrohTransportVerificationMode) -> any CmxIrohEndpointFactory
     private var transportVerificationMode: CmxIrohTransportVerificationMode
     private let automaticRelayCredentialRefreshEnabled: Bool
+    /// The app defaults handle, retained under its existing DEBUG-era name.
     private let debugDefaults: UserDefaults?
     private let brokerFactory: BrokerFactory
     private let brokerBackpressureGate: CmxIrohBrokerBackpressureGate
@@ -186,14 +187,15 @@ public final class MobileIrohRuntimeComposition:
         diagnosticLog: DiagnosticLog? = nil
     ) {
         #if DEBUG
-        let transportVerificationMode = Self.debugTransportVerificationMode(
+        let transportVerificationMode = Self.initialTransportVerificationMode(
             defaults: defaults
         )
         let automaticRelayCredentialRefreshEnabled = ProcessInfo.processInfo.environment[
             "CMUX_IROH_DISABLE_RELAY_CREDENTIAL_REFRESH"
         ] != "1"
         #else
-        let transportVerificationMode = CmxIrohTransportVerificationMode.automatic
+        let transportVerificationMode =
+            CmxIrohPathPreference.stored(in: defaults).transportVerificationMode
         let automaticRelayCredentialRefreshEnabled = true
         #endif
         let installState = CmxIrohUserDefaultsInstallStateStore(defaults: defaults)
@@ -1733,14 +1735,24 @@ public final class MobileIrohRuntimeComposition:
         #endif
     }
 
+    static func initialTransportVerificationMode(
+        defaults: UserDefaults
+    ) -> CmxIrohTransportVerificationMode {
+        #if DEBUG
+        if let rawValue = defaults.string(
+            forKey: CmxIrohTransportVerificationMode.debugDefaultsKey
+        ), let mode = CmxIrohTransportVerificationMode(rawValue: rawValue) {
+            return mode
+        }
+        #endif
+        return CmxIrohPathPreference.stored(in: defaults).transportVerificationMode
+    }
+
     #if DEBUG
     static func debugTransportVerificationMode(
         defaults: UserDefaults
     ) -> CmxIrohTransportVerificationMode {
-        guard let rawValue = defaults.string(
-            forKey: CmxIrohTransportVerificationMode.debugDefaultsKey
-        ) else { return .automatic }
-        return CmxIrohTransportVerificationMode(rawValue: rawValue) ?? .automatic
+        initialTransportVerificationMode(defaults: defaults)
     }
 
     private static func developmentStoreDirectory(
@@ -1914,6 +1926,9 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
             ),
             selectedTransportPath: selectedPath,
             preference: Self.settingsPreference(requested),
+            pathPreference: debugDefaults.map {
+                CmxIrohPathPreference.stored(in: $0)
+            } ?? .automatic,
             managedRelays: managedPolicy?.relays.map { relay in
                 CmxIrohSettingsSnapshot.ManagedRelay(
                     id: relay.id,
@@ -2484,6 +2499,36 @@ extension MobileIrohRuntimeComposition: CmxIrohSettingsControlling {
         infoDictionary: [String: Any]?
     ) -> CmxIrohRelayPolicyTrustRoot? {
         CmxIrohRelayPolicyTrustRoot.appPinned(infoDictionary: infoDictionary)
+    }
+}
+
+extension MobileIrohRuntimeComposition {
+    public func setIrohPathPreference(
+        _ preference: CmxIrohPathPreference
+    ) async throws {
+        guard let defaults = debugDefaults else { throw SettingsError.unavailable }
+        defaults.set(
+            preference.rawValue,
+            forKey: CmxIrohPathPreference.defaultsKey
+        )
+        #if DEBUG
+        defaults.removeObject(
+            forKey: CmxIrohTransportVerificationMode.debugDefaultsKey
+        )
+        #endif
+        let mode = preference.transportVerificationMode
+        guard transportVerificationMode != mode else {
+            publishIrohSettingsUpdate()
+            return
+        }
+        transportVerificationMode = mode
+        publishIrohSettingsUpdate()
+        guard let accountID = observedAccountID ?? activeAccountID else { return }
+        await scheduleReconcile(
+            targetAccountID: accountID,
+            eraseAccountState: false,
+            restartActiveRuntime: true
+        ).value
     }
 }
 

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohTransportVerificationModeTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohTransportVerificationModeTests.swift
@@ -7,6 +7,44 @@ import Testing
 @MainActor
 @Suite
 struct MobileIrohTransportVerificationModeTests {
+    @Test
+    func iosCompositionResolvesTheReleasePathPreferenceAndDebugOverride() throws {
+        let suiteName = "MobileIrohTransportVerificationModeTests.path-preference.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let automatic = MobileIrohRuntimeComposition.initialTransportVerificationMode(
+            defaults: defaults
+        )
+        #expect(automatic == .automatic)
+
+        defaults.set(
+            CmxIrohPathPreference.relayOnly.rawValue,
+            forKey: CmxIrohPathPreference.defaultsKey
+        )
+        let relayOnly = MobileIrohRuntimeComposition.initialTransportVerificationMode(
+            defaults: defaults
+        )
+        #expect(relayOnly == .relayOnly)
+        #expect(
+            !MobileIrohRuntimeComposition.protocolConfiguration(
+                for: relayOnly
+            ).allowsNATTraversalAfterAdmission
+        )
+
+        #if DEBUG
+        defaults.set(
+            CmxIrohTransportVerificationMode.directOnly.rawValue,
+            forKey: CmxIrohTransportVerificationMode.debugDefaultsKey
+        )
+        #expect(
+            MobileIrohRuntimeComposition.initialTransportVerificationMode(
+                defaults: defaults
+            ) == .directOnly
+        )
+        #endif
+    }
+
     #if DEBUG
     @Test
     func iosCompositionUsesTheSharedVerificationMode() throws {


### PR DESCRIPTION
Stopgap kill-switch for the WiFi path-flap reconnect loop: phone+Mac Iroh sessions die seconds after `privateNetwork` path selection, and relay-only avoids the bad path (field-verified by WiFi-off experiments on 2026-07-23). Until now that constraint only existed in DEBUG builds via `cmux.iroh.debug.transport-mode`, so nightly/TestFlight users had no way to force it.

**What this wires**

- New shared, release-safe, device-local setting `cmux.iroh.pathPreference` (`auto` default, `relayOnly`) as `CmxIrohPathPreference` in CMUXMobileCore, with `setIrohPathPreference` on `CmxIrohSettingsControlling` (defaulted to `unsupported` for wrappers/doubles) and a `pathPreference` field on `CmxIrohSettingsSnapshot`.
- macOS host runtime (`MobileHostIrohRuntime`) honors it in RELEASE: `transportVerificationMode` now resolves from the stored preference instead of hardcoding `.automatic`. The DEBUG defaults keys (`cmux.iroh.debug.transport-mode`, legacy `cmux.iroh.debug.relay-only`) keep working in DEBUG as an override; explicitly changing the setting clears them. The setter persists, publishes a settings update, and restarts the active runtime in place.
- iOS client runtime (`MobileIrohRuntimeComposition`) honors it in RELEASE the same way via a new `initialTransportVerificationMode(defaults:)` resolver (DEBUG key overrides, path preference otherwise) and an equivalent release setter that reconciles with a runtime restart.
- Settings UI on both platforms: a "Relay Only" toggle in macOS Iroh networking settings (replacing the DEBUG-only "Relay-Only Verification" row; the Debug menu keeps the full transport-mode picker) and a new toggle section in iOS Iroh settings (the DEBUG transport picker stays). Subtitles note it applies on the next reconnect. All strings localized in English and Japanese (`settings.networking.relayOnly*` in `Resources/Localizable.xcstrings`, `mobile.iroh.relayOnly*` in `ios/cmux/Resources/Localizable.xcstrings`); the two now-unused debug keys were removed.

**Tested**

- `swift test --package-path Packages/Shared/CMUXMobileCore`: 283 tests passed (new coverage: `CmxIrohPathPreference.stored(in:)` decoding incl. unknown values, mode mapping, snapshot default + round-trip).
- `swift test --package-path Packages/macOS/CmuxSettingsUI`: 115 tests passed (relay-only mutation now forwards `.relayOnly` through the release controller boundary).
- New CI-run coverage: `MobileIrohSettingsModelTests` (iOS package, `#if os(iOS)`), `MobileIrohTransportVerificationModeTests` (release resolver + DEBUG override precedence), and the host defaults-resolution test in `cmuxTests/MobileHostIrohAdmissionTests.swift` (path preference fallback, debug-key override, legacy bool).
- macOS app compile verified with a tagged cloud build (`rlpref`).

**Residual gaps**

- iOS-side compile/tests rely on the `test-ios` workflow; `swift build` of `CmuxMobileShellUI` on a macOS host fails on pre-existing platform manifests (iOS-only packages), unrelated to this change.
- The setting is device-local (UserDefaults), matching the neighboring iroh settings; it is deliberately not in `~/.config/cmux/cmux.json` (the row is marked `settingsOnly` like its neighbors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787464230&installation_model_id=21920&pr_number=8824&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8824&signature=7894996adab15bc31d795e7140caf065b9a1a66f29e101966a8d6386b0a65f31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a release-safe, cross-platform Iroh path setting to force relay-only connections when needed. This gives macOS and iOS users a “Relay Only” toggle to avoid the WiFi path‑flap reconnect loop.

- **New Features**
  - Added device-local setting `cmux.iroh.pathPreference` (`auto` default, `relayOnly`) honored by macOS and iOS runtimes in RELEASE builds.
  - DEBUG overrides still work; changing this setting clears `cmux.iroh.debug.transport-mode` and the legacy relay-only key.
  - Changes persist to `UserDefaults`, publish a settings update, and restart the active runtime in place.
  - New “Relay Only” toggle in macOS Iroh Networking and iOS Iroh settings; localized (en, ja).
  - Tests added for defaults resolution, mode mapping, DEBUG precedence, and settings model forwarding.

- **Migration**
  - Defaults to `auto`; behavior is unchanged unless toggled.
  - Takes effect on the next reconnect; the app restarts the runtime automatically when changed.
  - Device-local only; not stored in `~/.config/cmux/cmux.json` and not account-scoped.
  - In DEBUG builds, manual transport-mode picks still override until a user changes this setting.

<sup>Written for commit 9d6028a9a02308fe2d52f0f4571d0d13f6e81f6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Relay Only” networking setting for iOS and macOS.
  * Users can keep Iroh connections on cmux relays, with the preference applied on the next reconnect.
  * The setting is saved locally and reflected in networking status and behavior.

* **Bug Fixes**
  * Updated connection setup to consistently honor the selected path preference across supported builds.
  * Improved preference handling when values are missing or unrecognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->