### PR TITLE
iOS: keep healthy connections across foreground, stop quick-cycle reconnect stalls

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionRecoveryOwner.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionRecoveryOwner.swift
@@ -93,6 +93,21 @@ final class MobileConnectionRecoveryOwner {
         return attempt
     }
 
+    /// Cancels an in-flight health probe and returns the owner to idle.
+    /// Used when the app leaves the foreground: a suspended probe burns its
+    /// wall-clock deadline while the process is frozen, so its timeout on
+    /// resume is not evidence the connection died. Redialing/validating
+    /// attempts are left alone — they own teardown side effects and settle
+    /// through their own deadline.
+    @discardableResult
+    func cancelProbing() -> Bool {
+        guard case .probing = phase else { return false }
+        task?.cancel()
+        task = nil
+        phase = .idle
+        return true
+    }
+
     func install(_ task: Task<Void, Never>, for attempt: Attempt) {
         guard isCurrent(attempt) else {
             task.cancel()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -70,15 +70,14 @@ extension MobileShellComposite {
         guard remoteClient != nil || pairedMacStore != nil else { return }
         if let accountID = identityProvider?.currentUserID {
             switch trigger {
-            case .manual, .networkChange:
+            case .manual, .networkChange, .foreground:
                 clearTransientAutomaticReconnectBackoff(accountID: accountID)
             case .presencePush:
                 guard !automaticIrohReconnectIsBlocked(accountID: accountID) else {
                     return
                 }
-            case .foreground, .liveness, .eventStreamEnded,
-                 .subscriptionStartFailed, .transportWriteTimedOut,
-                 .automaticBackoffExpired:
+            case .liveness, .eventStreamEnded, .subscriptionStartFailed,
+                 .transportWriteTimedOut, .automaticBackoffExpired:
                 break
             }
         }
@@ -189,6 +188,7 @@ extension MobileShellComposite {
                 guard self.connectionRecoveryOwner.isCurrent(attempt) else { return }
 
                 if probeCurrentConnection, let expectedClient {
+                    let epochAtProbeStart = self.foregroundResumeEpoch
                     let healthy = await self.reloadWorkspaceListFromMac(
                         timeoutNanoseconds: self.runtime?.livenessProbeTimeoutNanoseconds
                     )
@@ -208,6 +208,25 @@ extension MobileShellComposite {
                             )
                         }
                         self.applyConnectionRecoveryOwnerState()
+                        return
+                    }
+                    if self.lastBackgroundedAt != nil
+                        || self.foregroundResumeEpoch != epochAtProbeStart {
+                        // The probe spanned a background window: its wall-clock
+                        // deadline burned while the process was suspended, so
+                        // the timeout is not evidence of a dead connection.
+                        // Abandon this attempt without teardown; if we are
+                        // foreground again, probe once more with a fresh deadline.
+                        MobileDebugLog.anchormux(
+                            "connection.recovery probe abandoned: spanned background window"
+                        )
+                        _ = self.connectionRecoveryOwner.complete(attempt)
+                        self.applyConnectionRecoveryOwnerState()
+                        if self.lastBackgroundedAt == nil {
+                            self.recoverForegroundConnectionIfNeeded(
+                                resyncAfterHealthy: resyncAfterHealthy
+                            )
+                        }
                         return
                     }
                 }
@@ -394,7 +413,15 @@ extension MobileShellComposite {
         case .idle:
             isRecoveringConnection = false
             connectionRecoveryFailed = false
-        case .probing, .redialing, .validatingReplacement:
+        case .probing:
+            // A probe is a background health check on a connection still
+            // believed healthy: the terminal stays interactive and the visible
+            // status untouched. Only an actual redial may surface reconnecting
+            // UI (TerminalDisconnectedOverlay covers the whole terminal on
+            // `.reconnecting`).
+            isRecoveringConnection = false
+            connectionRecoveryFailed = false
+        case .redialing, .validatingReplacement:
             isRecoveringConnection = true
             connectionRecoveryFailed = false
             if connectionState == .connected { markMacConnectionReconnecting() }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -227,6 +227,7 @@ extension MobileShellComposite {
 
     /// Resume foreground-only refresh loops after the app becomes active.
     public func resumeForegroundRefresh() {
+        foregroundResumeEpoch &+= 1
         startObservingNetworkPathChanges()
         // Covers stores constructed already-signed-in (no isSignedIn edge) and
         // restarts a subscription torn down while backgrounded.
@@ -242,6 +243,7 @@ extension MobileShellComposite {
             resyncTerminalOutput(reason: "foreground", restartEventStream: true)
         }
         recoverForegroundConnectionIfNeeded(resyncAfterHealthy: shouldResync)
+        recoverDisconnectedOnForegroundIfNeeded()
         // The foreground Mac's workspace list updates live over the sync stream,
         // but the other Macs are a read-only snapshot. Re-aggregate them on
         // foreground so workspaces created on another Mac while backgrounded
@@ -253,8 +255,31 @@ extension MobileShellComposite {
 
     /// Record that the app left the active scene phase.
     public func suspendForegroundRefresh() {
+        if connectionRecoveryOwner.cancelProbing() {
+            applyConnectionRecoveryOwnerState()
+        }
         guard lastBackgroundedAt == nil else { return }
         lastBackgroundedAt = runtime?.now() ?? Date()
+    }
+
+    /// A foreground return while disconnected redials the stored Mac
+    /// immediately. Covers a recovery that failed while the app was
+    /// backgrounded (its deadline burns during suspension): without this
+    /// the user sits on "Connection lost" until a network change, presence
+    /// push, or backoff timer fires. Gated on a finished startup reconnect
+    /// so it cannot race the launch path, and excluded for reauth-required
+    /// states where a redial cannot help.
+    func recoverDisconnectedOnForegroundIfNeeded() {
+        guard connectionState != .connected,
+              isSignedIn,
+              pairedMacStore != nil,
+              !connectionRequiresReauth,
+              !isReconnectingStoredMac,
+              didFinishStoredMacReconnectAttempt,
+              !connectionRecoveryOwner.isActive else {
+            return
+        }
+        recoverMobileConnection(trigger: .foreground)
     }
 
     func loadReconnectRefreshSnapshot(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -759,6 +759,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var renderGridLivenessConsecutiveProbeFailures = 0
     var lastTerminalEventAt: Date?
     var lastBackgroundedAt: Date?
+    var foregroundResumeEpoch: UInt64 = 0
     private var terminalSubscriptionRefreshTask: Task<Void, Never>?
     var notificationReconcileTask: Task<Void, Never>?
     var createWorkspaceTask: Task<Result<Void, MobileWorkspaceMutationFailure>, Never>?

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -81,6 +81,65 @@ extension ReconnectRouteSelectionTests {
         #expect(owner.isCurrent(replacementAttempt))
     }
 
+    @Test func cancelProbingReturnsOwnerToIdle() throws {
+        let owner = MobileConnectionRecoveryOwner()
+        defer { owner.cancel() }
+        let attempt = try #require(owner.begin(
+            trigger: "foreground",
+            sourceConnectionGeneration: UUID(),
+            probing: true
+        ))
+        owner.install(Task {}, for: attempt)
+
+        #expect(owner.cancelProbing())
+        #expect(owner.phase == .idle)
+        #expect(owner.task == nil)
+    }
+
+    @Test func cancelProbingLeavesNonProbePhasesUnchanged() throws {
+        let generation = UUID()
+
+        let idleOwner = MobileConnectionRecoveryOwner()
+        #expect(!idleOwner.cancelProbing())
+        #expect(idleOwner.phase == .idle)
+
+        let redialingOwner = MobileConnectionRecoveryOwner()
+        let redialingAttempt = try #require(redialingOwner.begin(
+            trigger: "networkChange",
+            sourceConnectionGeneration: generation,
+            probing: false
+        ))
+        #expect(!redialingOwner.cancelProbing())
+        #expect(redialingOwner.phase == .redialing(redialingAttempt))
+
+        let validatingOwner = MobileConnectionRecoveryOwner()
+        let validatingAttempt = try #require(validatingOwner.begin(
+            trigger: "networkChange",
+            sourceConnectionGeneration: generation,
+            probing: false
+        ))
+        let replacementGeneration = UUID()
+        #expect(validatingOwner.transitionToValidation(
+            validatingAttempt,
+            connectionGeneration: replacementGeneration
+        ))
+        #expect(!validatingOwner.cancelProbing())
+        #expect(validatingOwner.phase == .validatingReplacement(
+            validatingAttempt,
+            connectionGeneration: replacementGeneration
+        ))
+
+        let failedOwner = MobileConnectionRecoveryOwner()
+        let failedAttempt = try #require(failedOwner.begin(
+            trigger: "networkChange",
+            sourceConnectionGeneration: generation,
+            probing: false
+        ))
+        #expect(failedOwner.fail(failedAttempt))
+        #expect(!failedOwner.cancelProbing())
+        #expect(failedOwner.phase == .failed(failedAttempt))
+    }
+
     @Test func localPinnedIrohRecoveryDoesNotWaitForBackupRefresh() async throws {
         let backup = BlockingSecondFetchBackup()
         let fixture = try await makeRecoveryOwnerFixture(backup: backup)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileAutomaticReconnectBackoffOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileAutomaticReconnectBackoffOwnerTests.swift
@@ -130,4 +130,28 @@ struct MobileAutomaticReconnectBackoffOwnerTests {
         #expect(owner.retryAt == nil)
         #expect(owner.transientFailureCount == 0)
     }
+
+    @MainActor
+    @Test
+    func foregroundRecoveryClearsTransientCooldown() async throws {
+        let (pairedStore, directory) = try ReconnectRouteSelectionTests()
+            .makePairedMacStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "account-a"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "foreground-backoff-\(UUID().uuidString)"
+            )!
+        )
+        store.recordTransientAutomaticReconnectBackoff(accountID: "account-a")
+        #expect(store.automaticReconnectBackoffOwner.transientRetryAt != nil)
+
+        store.recoverMobileConnection(trigger: .foreground)
+
+        #expect(store.automaticReconnectBackoffOwner.transientRetryAt == nil)
+        store.connectionRecoveryOwner.cancel()
+    }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellForegroundResumeTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellForegroundResumeTests.swift
@@ -1,3 +1,5 @@
+import CmuxMobilePairedMac
+import CmuxMobileRPC
 import Foundation
 import Testing
 @testable import CmuxMobileShell
@@ -90,4 +92,258 @@ import Testing
 
     await router.waitForCount(of: "mobile.events.subscribe", atLeast: subscribeCount + 1)
     collector.unmount()
+}
+
+@Suite(.serialized)
+struct MobileShellForegroundConnectionRecoveryTests {
+@MainActor
+@Test func foregroundProbeKeepsHealthyConnectionVisiblyConnected() async throws {
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let clock = TestClock()
+    let (store, directory) = try await makeForegroundRecoveryStore(
+        router: router,
+        box: box,
+        clock: clock
+    )
+    defer {
+        Task { await router.releaseAllHeld() }
+        try? FileManager.default.removeItem(at: directory)
+    }
+    await router.holdNextWorkspaceListRequests()
+    let probeCount = await router.count(of: "mobile.workspace.list")
+
+    store.resumeForegroundRefresh()
+
+    #expect(await router.waitForCount(
+        of: "mobile.workspace.list",
+        atLeast: probeCount + 1
+    ))
+    #expect(store.macConnectionStatus == .connected)
+    #expect(!store.isRecoveringConnection)
+
+    await router.releaseAllHeld()
+    #expect(try await pollUntil {
+        store.connectionRecoveryOwner.phase == .idle
+    })
+    #expect(store.connectionState == .connected)
+    #expect(store.macConnectionStatus == .connected)
+}
+
+@MainActor
+@Test func failedForegroundProbeStillSurfacesRedialRecoveryState() async throws {
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let clock = TestClock()
+    let (store, directory) = try await makeForegroundRecoveryStore(
+        router: router,
+        box: box,
+        clock: clock,
+        probeTimeoutNanoseconds: 50_000_000
+    )
+    defer {
+        Task { await router.releaseAllHeld() }
+        try? FileManager.default.removeItem(at: directory)
+    }
+    await router.holdNextWorkspaceListRequests(count: 2)
+
+    store.resumeForegroundRefresh()
+
+    #expect(try await pollUntil {
+        if case .redialing = store.connectionRecoveryOwner.phase {
+            return store.isRecoveringConnection
+        }
+        return false
+    })
+    await router.releaseAllHeld()
+}
+
+@MainActor
+@Test func suspendingForegroundRefreshCancelsInFlightProbeWithoutRedial() async throws {
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let clock = TestClock()
+    let (store, directory) = try await makeForegroundRecoveryStore(
+        router: router,
+        box: box,
+        clock: clock,
+        probeTimeoutNanoseconds: 1_000_000_000
+    )
+    defer {
+        Task { await router.releaseAllHeld() }
+        try? FileManager.default.removeItem(at: directory)
+    }
+    let originalTransport = try #require(box.get())
+    await router.holdNextWorkspaceListRequests()
+    let probeCount = await router.count(of: "mobile.workspace.list")
+
+    store.resumeForegroundRefresh()
+    #expect(await router.waitForCount(
+        of: "mobile.workspace.list",
+        atLeast: probeCount + 1
+    ))
+    store.suspendForegroundRefresh()
+
+    #expect(store.connectionRecoveryOwner.phase == .idle)
+    #expect(store.connectionState == .connected)
+    #expect(store.macConnectionStatus == .connected)
+    await router.releaseAllHeld()
+    let redialed = await router.waitForCount(
+        of: "workspace.list",
+        atLeast: 2,
+        timeoutNanoseconds: 200_000_000,
+        recordIssueOnTimeout: false
+    )
+    #expect(!redialed)
+    #expect(box.get() === originalTransport)
+}
+
+@MainActor
+@Test func foregroundResumeAbandonsProbeStartedDuringBackgroundAndProbesAgain() async throws {
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let clock = TestClock()
+    let (store, directory) = try await makeForegroundRecoveryStore(
+        router: router,
+        box: box,
+        clock: clock,
+        probeTimeoutNanoseconds: 50_000_000
+    )
+    defer {
+        Task { await router.releaseAllHeld() }
+        try? FileManager.default.removeItem(at: directory)
+    }
+    let originalClient = try #require(store.remoteClient)
+    await router.holdNextWorkspaceListRequests()
+    let probeCount = await router.count(of: "mobile.workspace.list")
+
+    store.suspendForegroundRefresh()
+    store.recoverForegroundConnectionIfNeeded(resyncAfterHealthy: false)
+    #expect(await router.waitForCount(
+        of: "mobile.workspace.list",
+        atLeast: probeCount + 1
+    ))
+    store.resumeForegroundRefresh()
+
+    #expect(await router.waitForCount(
+        of: "mobile.workspace.list",
+        atLeast: probeCount + 2
+    ))
+    #expect(try await pollUntil {
+        store.connectionRecoveryOwner.phase == .idle
+    })
+    #expect(store.remoteClient === originalClient)
+    #expect(store.connectionState == .connected)
+    #expect(store.macConnectionStatus == .connected)
+}
+
+@MainActor
+@Test func foregroundResumeRedialsFinishedDisconnectedRecovery() async throws {
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let clock = TestClock()
+    let (store, directory) = try await makeForegroundRecoveryStore(
+        router: router,
+        box: box,
+        clock: clock
+    )
+    defer {
+        Task { await router.releaseAllHeld() }
+        try? FileManager.default.removeItem(at: directory)
+    }
+    store.connectionState = .disconnected
+    store.clearRemoteConnectionContext()
+    let failedAttempt = try #require(store.connectionRecoveryOwner.begin(
+        trigger: "background-failure",
+        sourceConnectionGeneration: store.connectionGeneration,
+        probing: false
+    ))
+    #expect(store.connectionRecoveryOwner.fail(failedAttempt))
+    store.applyConnectionRecoveryOwnerState()
+    store.didFinishStoredMacReconnectAttempt = true
+    let workspaceListCount = await router.count(of: "workspace.list")
+
+    store.resumeForegroundRefresh()
+
+    #expect(await router.waitForCount(
+        of: "workspace.list",
+        atLeast: workspaceListCount + 1
+    ))
+    #expect(try await pollUntil {
+        store.connectionState == .connected
+            && store.macConnectionStatus == .connected
+    })
+}
+
+@MainActor
+@Test func foregroundResumeDoesNotRedialWhenReauthenticationIsRequired() async throws {
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let clock = TestClock()
+    let (store, directory) = try await makeForegroundRecoveryStore(
+        router: router,
+        box: box,
+        clock: clock
+    )
+    defer {
+        Task { await router.releaseAllHeld() }
+        try? FileManager.default.removeItem(at: directory)
+    }
+    #expect(store.disconnectForAuthorizationFailureIfNeeded(
+        MobileShellConnectionError.authorizationFailed("test reauthentication")
+    ))
+    store.didFinishStoredMacReconnectAttempt = true
+    let workspaceListCount = await router.count(of: "workspace.list")
+
+    store.resumeForegroundRefresh()
+
+    let redialed = await router.waitForCount(
+        of: "workspace.list",
+        atLeast: workspaceListCount + 1,
+        timeoutNanoseconds: 200_000_000,
+        recordIssueOnTimeout: false
+    )
+    #expect(!redialed)
+    #expect(store.connectionRequiresReauth)
+    #expect(store.connectionState == .disconnected)
+}
+}
+
+@MainActor
+private func makeForegroundRecoveryStore(
+    router: LivenessHostRouter,
+    box: TransportBox,
+    clock: TestClock,
+    probeTimeoutNanoseconds: UInt64 = 200_000_000
+) async throws -> (store: MobileShellComposite, directory: URL) {
+    let (pairedStore, directory) = try ReconnectRouteSelectionTests()
+        .makePairedMacStore()
+    let route = try #require(makeTicket(clock: clock).routes.first)
+    try await pairedStore.upsert(
+        macDeviceID: "test-mac",
+        displayName: "Test Mac",
+        routes: [route],
+        instanceTag: "default",
+        markActive: true,
+        stackUserID: "user-1",
+        teamID: nil,
+        now: clock.now
+    )
+    let store = MobileShellComposite(
+        runtime: LivenessTestRuntime(
+            transportFactory: LivenessTransportFactory(router: router, box: box),
+            now: { clock.now },
+            livenessProbeTimeoutNanoseconds: probeTimeoutNanoseconds
+        ),
+        isSignedIn: true,
+        pairedMacStore: pairedStore,
+        identityProvider: StaticIdentityProvider(userID: "user-1"),
+        reachability: AlwaysOnlineReachability(),
+        pairingHintDefaults: UserDefaults(
+            suiteName: "foreground-recovery-\(UUID().uuidString)"
+        )!
+    )
+    #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+    #expect(await router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
+    return (store, directory)
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -237,6 +237,14 @@ actor LivenessHostRouter {
         heldWorkspaceListRequestNumbers.insert(number)
     }
 
+    /// Hold the next workspace-list responses relative to requests already seen.
+    func holdNextWorkspaceListRequests(count: Int = 1) {
+        guard count > 0 else { return }
+        for offset in 1 ... count {
+            heldWorkspaceListRequestNumbers.insert(workspaceListRequestCount + offset)
+        }
+    }
+
     /// Hold the Nth `mobile.events.subscribe` request (1-based) forever,
     /// modeling a dead push path whose probe never completes.
     func holdSubscribeRequest(number: Int) {


### PR DESCRIPTION
Every app foreground ran a connection health probe that immediately set `macConnectionStatus = .reconnecting`, so `TerminalDisconnectedOverlay` covered the terminal with a full-screen spinner while the probe round-tripped, even when the connection was perfectly healthy. Worse, the probe's RPC deadline is wall-clock based (`DispatchTime.uptimeNanoseconds`), which keeps ticking while iOS suspends the process: a quick background/foreground around an in-flight probe made the probe "time out" on resume, and that spurious timeout tore down the healthy RPC client and its pooled QUIC session (one control stream per connection, so teardown means a full redial: store reads, discovery, QUIC dial, admission, resubscribe, replay). The fresh foreground trigger was meanwhile dropped because the recovery owner defers triggers while an attempt is active. A redial that failed while backgrounded (same burned-deadline problem, 30s race deadline) stranded the user on "Connection lost / Retry": `recoverForegroundConnectionIfNeeded` only acts when `connectionState == .connected`, so foregrounding never healed a disconnected shell.

Fix, all in `Packages/iOS/CmuxMobileShell`, no transport/protocol changes:

- `MobileConnectionRecoveryOwner.cancelProbing()`: `suspendForegroundRefresh()` cancels an in-flight probe back to idle. A suspended probe's timeout is not evidence of death; the next foreground probes fresh with a full deadline. Redialing/validating attempts are left alone since they own teardown side effects.
- Stale-probe abandonment: `startConnectionRecovery` captures a `foregroundResumeEpoch` before probing. A failed probe that spanned a background window (epoch moved or currently backgrounded) is abandoned without teardown, then re-probed once with a fresh deadline instead of redialing.
- Probing no longer surfaces reconnecting UI: `applyConnectionRecoveryOwnerState()` keeps `isRecoveringConnection` false and leaves `macConnectionStatus` untouched during `.probing`. The terminal stays interactive; only an actual redial (`.redialing`/`.validatingReplacement`) shows the overlay/banner.
- Foreground heals a disconnected shell: `resumeForegroundRefresh()` now redials the stored Mac when disconnected (gated on a finished startup reconnect, signed-in, paired store present, no reauth-required state, no active attempt), and the `.foreground` trigger clears transient automatic-reconnect backoff like a manual retry.

Two-commit structure: commit 1 adds the regression tests (red: `cancelProbing` absent), commit 2 adds the fix (green). `swift test --package-path Packages/iOS/CmuxMobileShell`: 731 tests, the only 6 issues are in 3 pre-existing terminal-replay/viewport tests (`terminalViewportDetachKeepsGenerationTombstoneForStaleAcks`, `terminalReplayInFlightClearsWhenOutputStreamUnmountsBeforeResponse`, `staleReplayResponseAfterRemountDoesNotDeliverIntoCurrentStream`) that fail identically on clean `main` (verified in an untouched checkout).

Related but distinct from the mid-session iroh flap in https://github.com/manaflow-ai/cmux/issues/8531 (this PR is about the shell recovery state machine on scene-phase transitions, not transport keepalive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787464384&installation_model_id=21920&pr_number=8825&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8825&signature=c8edf680e2f72961079fd1868131228d072c62140384bb46789b697f21c43059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unnecessary reconnects when returning to foreground and fixes stalls from quick background/foreground cycles. The terminal stays interactive during health probes, and foreground now heals a disconnected shell.

- **Bug Fixes**
  - Added `cancelProbing()` to stop in-flight probes on background; suspended deadlines no longer trigger teardown.
  - Abandon stale probes that span a background window; re-probe once on resume without redialing a healthy connection.
  - Kept reconnect UI hidden during `.probing`; overlay shows only for real redials (`.redialing`/`.validatingReplacement`).
  - On foreground, clear transient reconnect backoff and redial if disconnected (after startup, signed-in, paired store present, no reauth, no active attempt).
  - Tracked `foregroundResumeEpoch` to detect stale probes; added regression tests for probe cancelation, stale-probe abandon, UI behavior, and foreground redial.

<sup>Written for commit f2ebdbc38a6edecd233b30460de8a00e5e9a59db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

