### PR TITLE
Fail a unit shard that loses verdicts to a dead app host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,6 @@ jobs:
       - name: Validate TestFlight notes generator
         run: python3 tests/test_ios_testflight_notes.py
 
-      - name: Validate CMUX INTERNAL main-push path filter
-        run: python3 tests/test_ios_testflight_main_push_filter.py
-
       - name: Validate external TestFlight group assignment helper
         run: python3 tests/test_ios_testflight_external_distribution.py
 
@@ -254,6 +251,9 @@ jobs:
 
       - name: Validate test determinism gate
         run: python3 scripts/check-test-determinism.py --strict
+
+      - name: Validate the crash-report scan
+        run: python3 scripts/crash-reports-since.py --self-test
 
   remote-daemon-tests:
     needs: changes
@@ -857,6 +857,12 @@ jobs:
           # Stream output via tee so CI logs are visible in real time, while still
           # capturing for post-run analysis of expected vs unexpected failures.
           TEST_OUTPUT="$RUNNER_TEMP/cmux-unit-output-shard-${{ matrix.shard }}.txt"
+          # macOS writes crash reports to one fixed directory, so this shard cannot have its own.
+          # Recording what is already there gives the same thing by subtraction: anything
+          # cmux-named that appears later belongs to this run.
+          CRASH_SNAPSHOT="$RUNNER_TEMP/cmux-crash-snapshot-shard-${{ matrix.shard }}.txt"
+          CRASH_KEPT="$RUNNER_TEMP/cmux-crashes-shard-${{ matrix.shard }}"
+          python3 scripts/crash-reports-since.py --snapshot "$CRASH_SNAPSHOT"
           set +e
           run_unit_tests | tee "$TEST_OUTPUT"
           EXIT_CODE=${PIPESTATUS[0]}
@@ -879,6 +885,76 @@ jobs:
             set -e
           fi
 
+          # A dead app host is never a pass, whatever the summary says. When the host dies the
+          # runner relaunches it and the summary line then describes only the tests the LAST
+          # launch managed. Measured on this repo: a shard printing "Test run with 0 tests in 1
+          # suite passed" while two hosts had died, and job logs carrying 24 restarts. Those
+          # verdicts are not green, they are absent.
+          HOST_DEATHS=$(grep -c "Restarting after unexpected exit, crash, or test timeout" "$TEST_OUTPUT" || true)
+          if [ "${HOST_DEATHS:-0}" -ne 0 ]; then
+            echo "::error::app host died ${HOST_DEATHS} time(s); every verdict pending in those launches is lost"
+            echo "Tests that started but never reported (the last one named is where a host died):"
+            # Both harnesses, because they announce tests in different shapes and this shard may be
+            # either. swift-testing prints "Test foo() started"; XCTest prints
+            # "Test Case '-[Suite testFoo]' started". Matching only the first form made this list
+            # empty for a shard of XCTest suites — which is most of them — and an empty list reads
+            # as "nothing was lost" at the exact moment something was.
+            comm -23 \
+              <({ grep -oE "Test [A-Za-z0-9_]+\(\)" "$TEST_OUTPUT" | sed 's/^Test //'
+                  grep -oE "Test Case '-\[[A-Za-z0-9_.]+ [A-Za-z0-9_]+\]' started" "$TEST_OUTPUT" \
+                    | sed -E "s/^Test Case '-\[//; s/\]' started$//"
+                } | sort -u) \
+              <({ grep -oE "(✔|✘) Test [A-Za-z0-9_]+\(\)" "$TEST_OUTPUT" | sed -E 's/^(✔|✘) Test //'
+                  grep -oE "Test Case '-\[[A-Za-z0-9_.]+ [A-Za-z0-9_]+\]' (passed|failed)" "$TEST_OUTPUT" \
+                    | sed -E "s/^Test Case '-\[//; s/\]' (passed|failed)$//"
+                } | sort -u) \
+              | head -20 || true
+            exit 1
+          fi
+
+          # The restart line above is the runner noticing a host it has to replace, so it misses a
+          # crash with nothing left to restart — one during teardown, after the last verdict is
+          # already printed. That crash is still an over-release, and it reads as a clean shard.
+          # The process's own crash report is the evidence. Reports that appeared since the
+          # snapshot belong to this run, and each is copied out because macOS prunes that
+          # directory and the copy is what survives into the artifact.
+          #
+          # A report above zero proves a crash; zero does not prove none, because ReportCrash
+          # writes asynchronously and can land after this runs. So this backs the restart check
+          # up instead of replacing it.
+          #
+          # The scan's own failure is a failure. Swallowing its exit status would turn a renamed
+          # script or a missing interpreter into empty output, which reads as "nothing crashed".
+          set +e
+          CRASHES=$(python3 scripts/crash-reports-since.py --new-since "$CRASH_SNAPSHOT" --copy-to "$CRASH_KEPT")
+          CRASH_SCAN_RC=$?
+          set -e
+          if [ "$CRASH_SCAN_RC" -ne 0 ]; then
+            echo "::error::the crash-report scan failed (exit ${CRASH_SCAN_RC}); refusing to read that as a clean shard"
+            exit 1
+          fi
+          if [ -n "$CRASHES" ]; then
+            echo "::error::a cmux process crashed during this shard, even if every verdict printed"
+            echo "$CRASHES" | sed 's/^/  /'
+            exit 1
+          fi
+
+          # A run that executed nothing is not a pass either. A selector naming a file rather than
+          # a suite, or a suite that no longer exists, leaves xcodebuild reporting success having
+          # done no work at all.
+          #
+          # Both harnesses have to be counted. swift-testing prints a line per test; XCTest prints
+          # none of those and only reports "Executed N tests" — a shard of XCTest suites therefore
+          # looks empty if you count swift-testing lines alone.
+          SWIFT_TESTS=$(grep -c "✔ Test \|✘ Test " "$TEST_OUTPUT" || true)
+          XCTESTS=$(grep -oE "Executed [0-9]+ test" "$TEST_OUTPUT" | grep -oE "[0-9]+" | sort -rn | head -1)
+          TESTS_SEEN=$(( ${SWIFT_TESTS:-0} + ${XCTESTS:-0} ))
+          if [ "$TESTS_SEEN" -eq 0 ]; then
+            echo "::error::no tests executed for this shard; its selectors matched nothing"
+            exit 1
+          fi
+          echo "shard executed ${TESTS_SEEN} tests with no host deaths"
+
           if [ "$EXIT_CODE" -ne 0 ]; then
             SUMMARY=$(echo "$OUTPUT" | grep "Executed.*tests.*with.*failures" | tail -1)
             if echo "$SUMMARY" | grep -q "(0 unexpected)"; then
@@ -888,6 +964,20 @@ jobs:
               exit 1
             fi
           fi
+
+      - name: Keep the unit test evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cmux-unit-shard-${{ matrix.shard }}-output
+          # Without this, "which test failed on CI" is unanswerable after the fact: the job log is a
+          # filtered excerpt, and neither the xcodebuild output nor an xcresult was kept.
+          path: |
+            ${{ runner.temp }}/cmux-unit-output-shard-${{ matrix.shard }}.txt
+            ${{ runner.temp }}/cmux-unit-shard-${{ matrix.shard }}.args
+            ${{ runner.temp }}/cmux-crashes-shard-${{ matrix.shard }}/
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Run bundled Ghostty theme picker helper regression
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,6 +923,12 @@ jobs:
           # writes asynchronously and can land after this runs. So this backs the restart check
           # up instead of replacing it.
           #
+          # Attribution assumes this job has the crash directory to itself, which holds because
+          # the macOS runners are ephemeral per-job Tart VMs (docs/ci-runners.md). On a shared,
+          # persistent runner another job's cmux crash could land in the window and fail this
+          # shard too — a false failure, never a false pass, since a report that predates the
+          # snapshot is excluded and one that appears during the run is always attributed.
+          #
           # The scan's own failure is a failure. Swallowing its exit status would turn a renamed
           # script or a missing interpreter into empty output, which reads as "nothing crashed".
           set +e

--- a/cmuxTests/RemoteTmuxRectPublicationTests.swift
+++ b/cmuxTests/RemoteTmuxRectPublicationTests.swift
@@ -94,7 +94,12 @@ import Testing
             "%2 61 0 59 40 0 off :1 \"right\"",
         ])
         #expect(notifies == 1)
-        #expect(paneRect(in: connection.windowsByID[1]!.layout, id: 2)! == (61, 0, 59, 40))
+        if let layout = connection.windowsByID[1]?.layout,
+           let rect = paneRect(in: layout, id: 2) {
+            #expect(rect == (61, 0, 59, 40))
+        } else {
+            Issue.record("no rect for pane %2 in window @1")
+        }
         #expect(connection.paneHeaderLabels[0] == "0 \"left pane\"")
         #expect(connection.paneHeaderLabels[2] == "1 \"right\"")
         #expect(connection.windowTitleRowPlacements[1] == nil)
@@ -277,12 +282,22 @@ import Testing
         // the owed fetch for the newer generation goes out.
         reply(connection, lines: ["%0 0 0 60 40 1 off :stale", "%2 61 0 59 40 0 off :stale"])
         #expect(notifies == 1)
-        #expect(paneRect(in: connection.windowsByID[1]!.layout, id: 2)! == (61, 0, 59, 40))
+        if let layout = connection.windowsByID[1]?.layout,
+           let rect = paneRect(in: layout, id: 2) {
+            #expect(rect == (61, 0, 59, 40))
+        } else {
+            Issue.record("no rect for pane %2 in window @1")
+        }
         #expect(paneRectsFIFOCount(connection) == 1)
 
         reply(connection, lines: ["%0 0 0 80 40 1 off :wide", "%2 81 0 39 40 0 off :narrow"])
         #expect(notifies == 2)
-        #expect(paneRect(in: connection.windowsByID[1]!.layout, id: 2)! == (81, 0, 39, 40))
+        if let layout = connection.windowsByID[1]?.layout,
+           let rect = paneRect(in: layout, id: 2) {
+            #expect(rect == (81, 0, 39, 40))
+        } else {
+            Issue.record("no rect for pane %2 in window @1")
+        }
         #expect(connection.hasPendingLayout(windowId: 1) == false)
     }
 
@@ -311,12 +326,14 @@ import Testing
         reply(connection, lines: ["%0 0 0 60 40 0 off :left", "%2 61 0 59 40 1 off :right"])
         // The fetch's #{pane_active} seeds the initial active pane…
         #expect(connection.activePaneByWindow[1] == 2)
-        #expect(observed! == (1, 2))
+        #expect(observed?.0 == 1)
+        #expect(observed?.1 == 2)
 
         // …and live %window-pane-changed remains the authority afterwards.
         connection.handleMessageForTesting(.windowPaneChanged(windowId: 1, paneId: 0))
         #expect(connection.activePaneByWindow[1] == 0)
-        #expect(observed! == (1, 0))
+        #expect(observed?.0 == 1)
+        #expect(observed?.1 == 0)
     }
 
     @Test func mirrorAdoptsRemoteActivePaneAndCopiesLabelsOnReconcile() {
@@ -325,7 +342,10 @@ import Testing
         reply(connection, lines: ["@1 abcd,120x40,0,0{60x40,0,0,0,59x40,61,0,2} abcd,120x40,0,0{60x40,0,0,0,59x40,61,0,2} [] main"])
         reply(connection, lines: ["%0 0 1 60 39 1 top :0 \"left\"", "%2 61 1 59 39 0 top :1 \"right\""])
 
-        let published = connection.windowsByID[1]!.layout
+        guard let published = connection.windowsByID[1]?.layout else {
+            Issue.record("window @1 published no layout")
+            return
+        }
         let mirror = RemoteTmuxWindowMirror(
             windowId: 1,
             panelId: UUID(),
@@ -475,7 +495,8 @@ import Testing
         ))
         reply(connection, lines: ["%0 0 0 60 40 0 off :left", "%2 61 0 59 40 1 off :right"])
         #expect(connection.activePaneByWindow[1] == 2)
-        #expect(observed! == (1, 2))
+        #expect(observed?.0 == 1)
+        #expect(observed?.1 == 2)
     }
 
     @Test func rectsVerifiedPublishPrunesRemovedPaneDiagnosticState() {
@@ -539,13 +560,23 @@ import Testing
         reply(connection, lines: ["%0 0 0 90 24 1 off :zsh"])
         #expect(notifies == 1)
         #expect(connection.windowsByID[1]?.width == 100)
-        #expect(paneRect(in: connection.windowsByID[1]!.layout, id: 0)! == (0, 0, 90, 24))
+        if let layout = connection.windowsByID[1]?.layout,
+           let rect = paneRect(in: layout, id: 0) {
+            #expect(rect == (0, 0, 90, 24))
+        } else {
+            Issue.record("no rect for pane %0 in window @1")
+        }
         #expect(paneRectsFIFOCount(connection) == 1)
 
         // The owed follow-up lands with exact rects: quarantine drains.
         reply(connection, lines: ["%0 0 0 100 24 1 off :zsh"])
         #expect(notifies == 2)
-        #expect(paneRect(in: connection.windowsByID[1]!.layout, id: 0)! == (0, 0, 100, 24))
+        if let layout = connection.windowsByID[1]?.layout,
+           let rect = paneRect(in: layout, id: 0) {
+            #expect(rect == (0, 0, 100, 24))
+        } else {
+            Issue.record("no rect for pane %0 in window @1")
+        }
         #expect(connection.hasPendingLayout(windowId: 1) == false)
         #expect(paneRectsFIFOCount(connection) == 0)
     }

--- a/scripts/ci/cmux_unit_test_shard.py
+++ b/scripts/ci/cmux_unit_test_shard.py
@@ -43,8 +43,9 @@ FOCUSED_GATE_SELECTORS = {
 # BrowserDeveloperToolsVisibilityPersistenceTests used to crash-restart the app host, and the
 # "Restarting after unexpected exit" storms it produced timed out any live-WKWebView navigation
 # test packed behind it — which is how both attempts of
-# https://github.com/manaflow-ai/cmux/pull/7687 failed shard 3. The crash itself is fixed: its
-# windows now clear isReleasedWhenClosed, and a local run of the suite reports no restarts.
+# https://github.com/manaflow-ai/cmux/pull/7687 failed shard 3. The crash is addressed separately,
+# in https://github.com/manaflow-ai/cmux/pull/8832, which stops test windows releasing themselves
+# on close.
 #
 # The separation stays because the crash was not the only reason for it. That suite drives real
 # WebKit inspector attach/detach and is slow enough on its own to starve a live-navigation suite

--- a/scripts/ci/cmux_unit_test_shard.py
+++ b/scripts/ci/cmux_unit_test_shard.py
@@ -40,15 +40,16 @@ FOCUSED_GATE_SELECTORS = {
     "cmuxTests/GhosttyOptionAsAltModsTests",
     "cmuxTests/RemoteTmuxMirrorLayoutIdentityTests",
 }
-# BrowserDeveloperToolsVisibilityPersistenceTests reliably crash-restarts the
-# app host on CI runners (its detached-inspector tests kill the host mid-run;
-# see the "Restarting after unexpected exit" storms in app-host shard logs on
-# main and PR runs alike). Live-WKWebView navigation tests that run behind
-# that storm in the same shard time out with thrown errors, which count as
-# unexpected failures and fail the shard. Count-based packing happened to
-# keep the pair below apart; time-weighted packing co-located them and both
-# attempts of https://github.com/manaflow-ai/cmux/pull/7687 failed shard 3
-# the same way. Keep each group's suites on different shards.
+# BrowserDeveloperToolsVisibilityPersistenceTests used to crash-restart the app host, and the
+# "Restarting after unexpected exit" storms it produced timed out any live-WKWebView navigation
+# test packed behind it — which is how both attempts of
+# https://github.com/manaflow-ai/cmux/pull/7687 failed shard 3. The crash itself is fixed: its
+# windows now clear isReleasedWhenClosed, and a local run of the suite reports no restarts.
+#
+# The separation stays because the crash was not the only reason for it. That suite drives real
+# WebKit inspector attach/detach and is slow enough on its own to starve a live-navigation suite
+# sharing its shard. Removing this needs a timing measurement, not an assumption that fixing the
+# crash was sufficient.
 SEPARATED_SUITES: tuple[frozenset[str], ...] = (
     frozenset(
         {

--- a/scripts/crash-reports-since.py
+++ b/scripts/crash-reports-since.py
@@ -36,6 +36,7 @@ import io
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 
@@ -51,12 +52,24 @@ def header_of(path: str) -> dict:
             return {}
 
 
+def names_a_cmux_process(header: dict) -> bool:
+    """Whether a report header identifies a cmux process.
+
+    Both fields are checked independently. `app_name or procName` only reads procName when
+    app_name is empty, so a report whose app_name is some host process and whose procName is cmux
+    would be skipped.
+    """
+    return any(
+        "cmux" in str(header.get(field, "")).lower()
+        for field in ("app_name", "procName")
+    )
+
+
 def crashes_since(since: str, directory: str = REPORT_DIR) -> list[str]:
     hits = []
     for path in sorted(glob.glob(os.path.join(os.path.expanduser(directory), "*.ips"))):
         header = header_of(path)
-        name = str(header.get("app_name") or header.get("procName") or "")
-        if "cmux" not in name.lower():
+        if not names_a_cmux_process(header):
             continue
         # Header timestamps look like "2026-07-23 17:44:22.00 -0700"; compare the
         # second-resolution prefix, which sorts correctly as text in local time.
@@ -69,9 +82,7 @@ def cmux_reports(directory: str = REPORT_DIR) -> list[str]:
     """Every cmux-named report currently in the directory."""
     hits = []
     for path in sorted(glob.glob(os.path.join(os.path.expanduser(directory), "*.ips"))):
-        header = header_of(path)
-        name = str(header.get("app_name") or header.get("procName") or "")
-        if "cmux" in name.lower():
+        if names_a_cmux_process(header_of(path)):
             hits.append(os.path.basename(path))
     return hits
 
@@ -124,6 +135,12 @@ def self_test() -> int:
             with io.open(os.path.join(directory, name), "w", encoding="utf-8") as handle:
                 handle.write(json.dumps({"app_name": app, "timestamp": stamp}) + "\n")
                 handle.write(json.dumps(body))
+        # A report whose app_name is a host process but whose procName is cmux still belongs to us.
+        with io.open(os.path.join(directory, "helper-2026-07-22-120000.ips"), "w") as handle:
+            handle.write(json.dumps({"app_name": "SomeHost", "procName": "cmux DEV Helper",
+                                     "timestamp": "2026-07-22 12:00:00.00 -0700"}) + "\n")
+            handle.write("{}")
+
         # A junk file must not crash the scan.
         with io.open(os.path.join(directory, "truncated.ips"), "w", encoding="utf-8") as handle:
             handle.write("not json at all\n")
@@ -144,6 +161,12 @@ def self_test() -> int:
             print(f"  {'ok  ' if ok else 'FAIL'} since {since} -> {got}")
             if not ok:
                 print(f"       expected {expected}")
+        if "helper-2026-07-22-120000.ips" in cmux_reports(directory):
+            print("  ok   a report named by procName rather than app_name is found")
+        else:
+            print("  FAIL a procName-only cmux report was skipped")
+            failures += 1
+
         # Safari must never appear, at any window.
         if any("Safari" in name for name in crashes_since("2026-01-01 00:00:00", directory)):
             print("  FAIL a non-cmux crash was counted")
@@ -186,6 +209,20 @@ def self_test() -> int:
                 print("  FAIL a missing snapshot did not fail loudly enough")
                 failures += 1
 
+    # The CLI must refuse a missing snapshot rather than report an empty, successful scan.
+    absent = os.path.join(tempfile.gettempdir(), "crash-reports-since-absent-snapshot.txt")
+    if os.path.exists(absent):
+        os.remove(absent)
+    probe = subprocess.run(
+        [sys.executable, os.path.abspath(__file__), "--new-since", absent],
+        capture_output=True,
+    )
+    if probe.returncode != 0:
+        print("  ok   a missing snapshot fails the command instead of reading as clean")
+    else:
+        print(f"  FAIL a missing snapshot exited {probe.returncode}")
+        failures += 1
+
     print("self-test passed" if not failures else f"self-test FAILED ({failures})")
     return 1 if failures else 0
 
@@ -210,6 +247,16 @@ def main() -> int:
 
     new_since = arg_after("--new-since")
     if new_since:
+        # A missing snapshot is a broken scan, not a clean run. The caller writes it before the
+        # tests, so its absence means that write failed — and if the directory also happens to hold
+        # no reports, an empty list plus exit 0 would read as "nothing crashed".
+        if not os.path.exists(new_since):
+            print(
+                f"crash-reports-since: no snapshot at {new_since};"
+                " it is written before the run, so this means the scan is broken",
+                file=sys.stderr,
+            )
+            return 1
         for name in new_since_snapshot(new_since, copy_to=arg_after("--copy-to")):
             print(name)
         return 0

--- a/scripts/crash-reports-since.py
+++ b/scripts/crash-reports-since.py
@@ -69,7 +69,8 @@ def cmux_reports(directory: str = REPORT_DIR) -> list[str]:
     """Every cmux-named report currently in the directory."""
     hits = []
     for path in sorted(glob.glob(os.path.join(os.path.expanduser(directory), "*.ips"))):
-        name = str(header_of(path).get("app_name") or header_of(path).get("procName") or "")
+        header = header_of(path)
+        name = str(header.get("app_name") or header.get("procName") or "")
         if "cmux" in name.lower():
             hits.append(os.path.basename(path))
     return hits
@@ -85,7 +86,12 @@ def write_snapshot(snapshot: str, directory: str = REPORT_DIR) -> list[str]:
 def new_since_snapshot(
     snapshot: str, directory: str = REPORT_DIR, copy_to: str | None = None
 ) -> list[str]:
-    """Reports that appeared after the snapshot. A missing snapshot means none are attributable."""
+    """Reports that appeared after the snapshot.
+
+    A missing snapshot returns every cmux report in the directory rather than none. The shard
+    writes the snapshot before the run, so its absence means something went wrong with the scan
+    rather than that the run was clean, and the caller should see the reports and decide.
+    """
     before: set[str] = set()
     if os.path.exists(snapshot):
         before = {

--- a/scripts/crash-reports-since.py
+++ b/scripts/crash-reports-since.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Print the cmux crash reports a run produced, and keep a copy of them.
+
+macOS writes crash reports to one fixed per-user directory and gives no way to redirect it, so
+a run cannot have its own. What a run can have is a snapshot taken before it starts: anything
+cmux-named that appears afterwards belongs to it. That is a set difference, which beats
+comparing timestamps — it survives a clock that jumped, a report written in another timezone,
+and macOS rewriting mtimes when it prunes. Copying the matches into a per-run directory is what
+makes the evidence outlive both the pruner and the job.
+
+The test runner's "Restarting after unexpected exit, crash, or test timeout" line is the
+event to grade a run on, because it is the runner noticing a host it has to replace. It
+misses a crash with nothing left to restart — one during teardown, after the last verdict
+has already printed. That crash is still an over-release, and without this the shard reads
+clean.
+
+A count of zero still is not proof that nothing crashed: ReportCrash writes the file
+asynchronously, so a report can land after the scan. This backs the restart check up rather
+than replacing it.
+
+Usage:
+  scripts/crash-reports-since.py --snapshot FILE               # before the run
+  scripts/crash-reports-since.py --new-since FILE [--copy-to DIR]
+  scripts/crash-reports-since.py '2026-07-23 17:40:00'         # timestamp fallback
+  scripts/crash-reports-since.py --self-test
+
+Prints one filename per line. Exit 0 whether or not anything is found; the caller decides what
+a hit means. Exits non-zero only when the scan itself could not run, so a caller must not
+swallow the status.
+"""
+
+from __future__ import annotations
+
+import glob
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+REPORT_DIR = "~/Library/Logs/DiagnosticReports"
+
+
+def header_of(path: str) -> dict:
+    """An .ips file is a JSON header line followed by a separate JSON body."""
+    with io.open(path, encoding="utf-8", errors="replace") as handle:
+        try:
+            return json.loads(handle.readline())
+        except json.JSONDecodeError:
+            return {}
+
+
+def crashes_since(since: str, directory: str = REPORT_DIR) -> list[str]:
+    hits = []
+    for path in sorted(glob.glob(os.path.join(os.path.expanduser(directory), "*.ips"))):
+        header = header_of(path)
+        name = str(header.get("app_name") or header.get("procName") or "")
+        if "cmux" not in name.lower():
+            continue
+        # Header timestamps look like "2026-07-23 17:44:22.00 -0700"; compare the
+        # second-resolution prefix, which sorts correctly as text in local time.
+        if str(header.get("timestamp", ""))[:19] >= since:
+            hits.append(os.path.basename(path))
+    return hits
+
+
+def cmux_reports(directory: str = REPORT_DIR) -> list[str]:
+    """Every cmux-named report currently in the directory."""
+    hits = []
+    for path in sorted(glob.glob(os.path.join(os.path.expanduser(directory), "*.ips"))):
+        name = str(header_of(path).get("app_name") or header_of(path).get("procName") or "")
+        if "cmux" in name.lower():
+            hits.append(os.path.basename(path))
+    return hits
+
+
+def write_snapshot(snapshot: str, directory: str = REPORT_DIR) -> list[str]:
+    names = cmux_reports(directory)
+    with io.open(snapshot, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(names) + ("\n" if names else ""))
+    return names
+
+
+def new_since_snapshot(
+    snapshot: str, directory: str = REPORT_DIR, copy_to: str | None = None
+) -> list[str]:
+    """Reports that appeared after the snapshot. A missing snapshot means none are attributable."""
+    before: set[str] = set()
+    if os.path.exists(snapshot):
+        before = {
+            line.strip()
+            for line in io.open(snapshot, encoding="utf-8").read().splitlines()
+            if line.strip()
+        }
+    fresh = [name for name in cmux_reports(directory) if name not in before]
+    if copy_to and fresh:
+        os.makedirs(copy_to, exist_ok=True)
+        for name in fresh:
+            src = os.path.join(os.path.expanduser(directory), name)
+            try:
+                shutil.copy2(src, os.path.join(copy_to, name))
+            except OSError as error:
+                print(f"warning: could not keep {name}: {error}", file=sys.stderr)
+    return fresh
+
+
+def self_test() -> int:
+    """Check the filter against reports whose answers are known by construction."""
+    fixtures = {
+        "cmux DEV-2026-07-23-174422.ips": ("cmux DEV", "2026-07-23 17:44:22.00 -0700"),
+        "cmux DEV-2026-07-23-100000.ips": ("cmux DEV", "2026-07-23 10:00:00.00 -0700"),
+        "Safari-2026-07-23-180000.ips": ("Safari", "2026-07-23 18:00:00.00 -0700"),
+    }
+    with tempfile.TemporaryDirectory() as directory:
+        for name, (app, stamp) in fixtures.items():
+            body = {"faultingThread": 0, "threads": []}
+            with io.open(os.path.join(directory, name), "w", encoding="utf-8") as handle:
+                handle.write(json.dumps({"app_name": app, "timestamp": stamp}) + "\n")
+                handle.write(json.dumps(body))
+        # A junk file must not crash the scan.
+        with io.open(os.path.join(directory, "truncated.ips"), "w", encoding="utf-8") as handle:
+            handle.write("not json at all\n")
+
+        cases = [
+            ("2026-07-23 17:00:00", ["cmux DEV-2026-07-23-174422.ips"]),
+            ("2026-07-23 09:00:00", [
+                "cmux DEV-2026-07-23-100000.ips",
+                "cmux DEV-2026-07-23-174422.ips",
+            ]),
+            ("2026-07-23 19:00:00", []),
+        ]
+        failures = 0
+        for since, expected in cases:
+            got = crashes_since(since, directory)
+            ok = got == expected
+            failures += 0 if ok else 1
+            print(f"  {'ok  ' if ok else 'FAIL'} since {since} -> {got}")
+            if not ok:
+                print(f"       expected {expected}")
+        # Safari must never appear, at any window.
+        if any("Safari" in name for name in crashes_since("2026-01-01 00:00:00", directory)):
+            print("  FAIL a non-cmux crash was counted")
+            failures += 1
+        else:
+            print("  ok   a non-cmux crash is ignored")
+
+        # The snapshot path: what existed before a run must not be blamed on it, and what
+        # appears during it must be kept somewhere the pruner cannot reach.
+        with tempfile.TemporaryDirectory() as scratch:
+            snapshot = os.path.join(scratch, "before.txt")
+            write_snapshot(snapshot, directory)
+            if new_since_snapshot(snapshot, directory) == []:
+                print("  ok   a pre-existing crash is not blamed on the run")
+            else:
+                print("  FAIL a pre-existing crash was blamed on the run")
+                failures += 1
+
+            with io.open(os.path.join(directory, "cmux DEV-2026-07-23-235959.ips"), "w") as h:
+                h.write(json.dumps({"app_name": "cmux DEV", "timestamp": "2026-07-23 23:59:59.00 -0700"}) + "\n")
+                h.write("{}")
+            kept = os.path.join(scratch, "kept")
+            fresh = new_since_snapshot(snapshot, directory, copy_to=kept)
+            if fresh == ["cmux DEV-2026-07-23-235959.ips"]:
+                print("  ok   a crash during the run is attributed to it")
+            else:
+                print(f"  FAIL attribution returned {fresh}")
+                failures += 1
+            if os.path.isdir(kept) and os.listdir(kept) == fresh:
+                print("  ok   the report is copied into the per-run directory")
+            else:
+                print("  FAIL the per-run copy is missing")
+                failures += 1
+
+            # A snapshot that was never written must not silently blame the run for history.
+            missing = os.path.join(scratch, "never-written.txt")
+            if new_since_snapshot(missing, directory) == cmux_reports(directory):
+                print("  ok   a missing snapshot reports everything rather than nothing")
+            else:
+                print("  FAIL a missing snapshot did not fail loudly enough")
+                failures += 1
+
+    print("self-test passed" if not failures else f"self-test FAILED ({failures})")
+    return 1 if failures else 0
+
+
+def arg_after(flag: str) -> str | None:
+    if flag in sys.argv:
+        index = sys.argv.index(flag)
+        if index + 1 < len(sys.argv):
+            return sys.argv[index + 1]
+    return None
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    snapshot = arg_after("--snapshot")
+    if snapshot:
+        kept = write_snapshot(snapshot)
+        print(f"recorded {len(kept)} pre-existing cmux crash reports", file=sys.stderr)
+        return 0
+
+    new_since = arg_after("--new-since")
+    if new_since:
+        for name in new_since_snapshot(new_since, copy_to=arg_after("--copy-to")):
+            print(name)
+        return 0
+
+    if len(sys.argv) < 2 or sys.argv[1].startswith("--"):
+        print("usage: crash-reports-since.py --snapshot FILE | --new-since FILE | '<local time>'", file=sys.stderr)
+        return 2
+    for name in crashes_since(sys.argv[1]):
+        print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/crash-reports-since.py
+++ b/scripts/crash-reports-since.py
@@ -210,13 +210,15 @@ def self_test() -> int:
                 failures += 1
 
     # The CLI must refuse a missing snapshot rather than report an empty, successful scan.
-    absent = os.path.join(tempfile.gettempdir(), "crash-reports-since-absent-snapshot.txt")
-    if os.path.exists(absent):
-        os.remove(absent)
-    probe = subprocess.run(
-        [sys.executable, os.path.abspath(__file__), "--new-since", absent],
-        capture_output=True,
-    )
+    # The path lives inside a fresh directory and is never created, so "absent" is guaranteed
+    # rather than assumed — a fixed name in the shared temp directory could be left behind by an
+    # earlier run or created by a concurrent one, and then this checks nothing.
+    with tempfile.TemporaryDirectory() as scratch:
+        absent = os.path.join(scratch, "snapshot-that-was-never-written.txt")
+        probe = subprocess.run(
+            [sys.executable, os.path.abspath(__file__), "--new-since", absent],
+            capture_output=True,
+        )
     if probe.returncode != 0:
         print("  ok   a missing snapshot fails the command instead of reading as clean")
     else:


### PR DESCRIPTION
When the app host dies mid-run, xcodebuild relaunches it and the summary then covers only the last launch. Verdicts pending in the dead host are absent from the totals rather than failed, so the shard reports success. Run 29684286662 on `main` concluded `success` with 35 of those deaths across its four app-host jobs (24, 2, 4 and 5 restart lines).

The unit shard now fails on four conditions: the runner's restart line, a shard that executed no tests, a crash report that appeared during the run, and a failure of the crash scan itself.

The restart line misses a crash with nothing left to relaunch — one during teardown, after the last verdict has printed. `scripts/crash-reports-since.py` covers that by listing the crash directory before the run and subtracting afterwards, because macOS gives no way to redirect that directory per run. Each match is copied into a per-run directory that gets uploaded, since macOS prunes the original. Zero reports is not proof that nothing crashed, because `ReportCrash` writes asynchronously, so this backs the restart check up rather than replacing it.

The list of tests that started and never reported matched only swift-testing's output shape, so it printed nothing for a shard of XCTest suites — which is most of them. An empty list reads as "nothing was lost" at the moment something was. It now matches both shapes. Measured against a real log whose host died: the old form printed nothing, the new one names `MarkdownPanelTests.testOpenMarkdownPanelReloadsWhenFileChangesOnDisk`.

`RemoteTmuxRectPublicationTests` force-unwrapped the published layout and the observed pane in nine places. Each traps exactly when the expectation around it is already failing, turning a reportable failure into a dead process. They record the nil and continue.

The shard-packing comment in `scripts/ci/cmux_unit_test_shard.py` said `BrowserDeveloperToolsVisibilityPersistenceTests` reliably crash-restarts the host. That is fixed in #8832, so the comment says so now, but the separation stays — that suite drives real WebKit inspector attach and detach and may still starve a live-navigation suite sharing its shard. Removing it needs a timing measurement.

## Testing

The crash scan self-tests against fixtures whose answers are known in advance: eight cases covering a non-cmux crash in the same directory, a truncated report, a pre-existing crash that must not be attributed to the run, and a missing snapshot. That self-test runs in CI.

The never-reported fix was checked against a real log from a run whose host died, in both directions. The gate's shell parses under `bash -n`, and the workflow parses as YAML.

## Related

#8832 fixes the window over-release that causes most of these host deaths, at every site, with one hook. This PR is about the grading: a dead host should never read as a pass, whatever killed it. It replaces #8755, whose per-site window edits are redundant against #8832.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787466788&installation_model_id=21920&pr_number=8833&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8833&signature=295efbbe51b56732c79f8e4b61dc55b08539b1188ec57ab6c4d01a9ef7785fb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails unit test shards that lose verdicts to a dead app host. Previously, xcodebuild relaunched a dead host and the shard read green from a summary covering only the last launch; now shards fail on host restarts, empty runs, crash reports during the run, or a broken crash scan.

- Adds `scripts/crash-reports-since.py` to snapshot the crash directory pre-run, diff it post-run, and copy new cmux `.ips` reports; matches by `app_name` or `procName`; exits non-zero on a missing snapshot; self-test wired into CI.
- CI prints "started but never reported" for both swift-testing and XCTest output shapes; uploads shard output, args, and copied reports as 14-day artifacts; restores the "Validate CMUX INTERNAL main-push path filter"; pins `actions/upload-artifact@v7.0.1`. Attribution assumes ephemeral per-job macOS VMs.
- Makes `RemoteTmuxRectPublicationTests` nil-safe and records issues instead of trapping to avoid process deaths.
- Updates the shard-packing rationale to reference #8832; the separation remains pending a timing measurement.
- Stubs the crash scan in the CI step harness so existing step tests don't read the runner's own crash reports.

<sup>Written for commit 321d0648a89a18d15fb8b003b704cd5fb3aac09f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test stability by handling missing optional state without crashing.
  * Strengthened CI shard failure detection for host restarts, crashes, timeouts, and zero-test runs.
* **Tests**
  * Added crash-report scanning with snapshot-based filtering, optional copying, and a built-in self-test.
  * Preserved geometry, notification, and reconciliation coverage while improving diagnostic handling.
* **CI**
  * Added workflow validation for crash-report scanning.
  * Uploads per-shard test evidence and crash reports, retained for 14 days.
* **Documentation**
  * Clarified why certain test suites remain separated to avoid timing-related interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI pass/fail semantics for macOS app-host shards (new failure modes and artifact uploads); low product risk but can increase flaky or false failures on shared crash-report directories. Test-only Swift changes reduce crash risk during failures.
> 
> **Overview**
> **CI grading** for sharded app-host unit tests no longer treats a dead or absent run as green. After `xcodebuild`, each shard now **fails** if the log contains the runner’s **host-restart** line, if **no tests** ran (swift-testing lines plus XCTest’s `Executed N tests`), if **`crash-reports-since.py`** finds new cmux `.ips` reports since a pre-run snapshot (with copies kept for artifacts), or if that scan itself errors. The “started but never reported” diagnostic now matches **both** swift-testing and XCTest log shapes. Per-shard **artifacts** retain output, shard args, and copied crash reports for 14 days.
> 
> Adds **`scripts/crash-reports-since.py`** (snapshot/diff, optional copy, self-test) and wires the self-test into **workflow-guard-tests**.
> 
> **`RemoteTmuxRectPublicationTests`** replaces force-unwraps on layout/observed pane with nil checks and `Issue.record` so expectation failures don’t kill the host.
> 
> **`cmux_unit_test_shard.py`** comment updates: WebKit inspector crash fixed in #8832; suite separation kept for timing until measured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768e2acd1db9c203736fe447e5bdf892bdc79d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

The step harness in `tests/test_ci_change_areas.py` runs the Run unit tests step from a temporary root and never supplied `scripts/crash-reports-since.py`. So the step exited 2 before the runner started, and `test_app_host_multi_batch_failure_cannot_reuse_prior_expected_summary` failed. The harness now writes a stub that records an empty snapshot and reports no new crashes. The real scan is covered by its own `--self-test`.
