### PR TITLE
Name lane-failure and send-queue-overflow iroh session close reasons

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -67,6 +67,10 @@ public enum DiagnosticFailureKind: Int, Sendable, Codable, CaseIterable {
     case admissionLeaseExpired = 22
     /// Online admission closed the session after broker revalidation failed.
     case admissionRevalidationFailed = 23
+    /// The local side closed an admitted session because its bounded outbound
+    /// event queue overflowed while the transport stopped draining (for
+    /// example the peer's network path died mid-write).
+    case sendQueueOverflow = 24
     case unknown = 255
 
     /// Reduces a typed or system error to the bounded diagnostic vocabulary.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -241,6 +241,11 @@ import Testing
         #expect(DiagnosticFailureKind.transportIdleTimedOut.rawValue == 21)
         #expect(DiagnosticFailureKind.admissionLeaseExpired.rawValue == 22)
         #expect(DiagnosticFailureKind.admissionRevalidationFailed.rawValue == 23)
+        #expect(DiagnosticFailureKind.sendQueueOverflow.rawValue == 24)
+        #expect(
+            Set(DiagnosticFailureKind.allCases.map(\.rawValue)).count
+                == DiagnosticFailureKind.allCases.count
+        )
         #expect(DiagnosticFailureKind.unknown.rawValue == 255)
         #expect(DiagnosticSessionLifecycleKind.established.rawValue == 1)
         #expect(DiagnosticSessionLifecycleKind.controlOwnerReleased.rawValue == 2)

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
@@ -23,7 +23,7 @@ extension IrohError: @retroactive DiagnosticFailureProviding {
         if message.contains("ConnectionLost(LocallyClosed)") {
             return .cancelled
         }
-        if message.contains("ConnectionLost(TransportError(")
+        if message.contains("TransportError(")
             && (message.contains("Code::crypto(")
                 || message.contains("TLS error:")) {
             return .secureChannelFailed
@@ -44,6 +44,31 @@ extension IrohError: @retroactive DiagnosticFailureProviding {
             || message.contains("Resolve failed, IPv4:")
             || message.contains("Failed to resolve") {
             return .dnsFailed
+        }
+        // Connection-level operations (`accept_bi`, `open_bi`, `accept_uni`,
+        // `open_uni`) surface `iroh::endpoint::ConnectionError` Debug-formatted
+        // WITHOUT the `ConnectionLost(...)` wrapper that stream read/write
+        // errors carry (noq `ConnectionError` at manaflow-ai/noq@2271bbc, via
+        // iroh-ffi 1.0.2-cmux.4). Host rings from the 2026-07-23 WiFi
+        // path-flap loop showed admitted sessions dying `applicationLaneFailed`
+        // with these bare tokens classified `unknown`.
+        if message.contains("TimedOut") {
+            return .transportIdleTimedOut
+        }
+        if message.contains("LocallyClosed") {
+            return .cancelled
+        }
+        if message.contains("VersionMismatch") {
+            return .protocolViolation
+        }
+        if message.contains("CidsExhausted") {
+            return .endpointUnavailable
+        }
+        if message.contains("ApplicationClosed(")
+            || message.contains("ConnectionClosed(")
+            || message.contains("TransportError(")
+            || message.contains("Reset") {
+            return .connectionClosed
         }
         if message.contains("timed out")
             || message.contains("Timed out")

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
@@ -67,6 +67,27 @@ import Testing
             "ConnectionLost(TransportError(Error { code: Code::crypto(2a), reason: \"TLS error\" }))",
             DiagnosticFailureKind.secureChannelFailed
         ),
+        ("TimedOut", DiagnosticFailureKind.transportIdleTimedOut),
+        ("LocallyClosed", DiagnosticFailureKind.cancelled),
+        ("Reset", DiagnosticFailureKind.connectionClosed),
+        (
+            "ApplicationClosed(ApplicationClose { error_code: 0, reason: b\"server_closed\" })",
+            DiagnosticFailureKind.connectionClosed
+        ),
+        (
+            "ConnectionClosed(ConnectionClose { error_code: Code(10), frame_type: None, reason: b\"\" })",
+            DiagnosticFailureKind.connectionClosed
+        ),
+        (
+            "TransportError(Error { code: Code(1), frame: None, reason: \"internal\", crypto: None })",
+            DiagnosticFailureKind.connectionClosed
+        ),
+        (
+            "TransportError(Error { code: Code::crypto(2a), frame: None, reason: \"TLS error\" })",
+            DiagnosticFailureKind.secureChannelFailed
+        ),
+        ("VersionMismatch", DiagnosticFailureKind.protocolViolation),
+        ("CidsExhausted", DiagnosticFailureKind.endpointUnavailable),
         ("ReadError(ClosedStream)", DiagnosticFailureKind.connectionClosed),
         ("opaque unclassified bridge failure", DiagnosticFailureKind.unknown),
     ])

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -410,6 +410,11 @@ private extension MobileIrohSettingsView {
                 "mobile.iroh.diagnostics.failure.connectionClosed",
                 defaultValue: "Connection Closed"
             )
+        case .some(.sendQueueOverflow):
+            L10n.string(
+                "mobile.iroh.diagnostics.failure.sendQueueOverflow",
+                defaultValue: "Send Queue Overflow"
+            )
         case .some(.superseded):
             L10n.string(
                 "mobile.iroh.diagnostics.failure.superseded",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -979,6 +979,13 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "安全なチャネルの確立に失敗" } }
       }
     },
+    "mobile.iroh.diagnostics.failure.sendQueueOverflow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Send Queue Overflow" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "送信キューオーバーフロー" } }
+      }
+    },
     "mobile.iroh.diagnostics.failure.unsupportedRoute" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -588,6 +588,11 @@ private struct IrohDiagnosticsReportRows: View {
                 localized: "settings.networking.diagnostics.failure.connectionClosed",
                 defaultValue: "Connection Closed"
             )
+        case .some(.sendQueueOverflow):
+            String(
+                localized: "settings.networking.diagnostics.failure.sendQueueOverflow",
+                defaultValue: "Send Queue Overflow"
+            )
         case .some(.superseded):
             String(
                 localized: "settings.networking.diagnostics.failure.superseded",

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -2222,6 +2222,8 @@ actor MobileHostConnection {
         do {
             frame = try MobileSyncFrameCodec.encodeFrame(data)
         } catch {
+            // MobileSyncFrameCodec.encodeFrame only throws frameTooLarge: a
+            // local wire-limit violation, so protocolViolation is honest here.
             await close(
                 reason: "event frame encode failed",
                 exit: CmxIrohAdmittedConnectionExit(
@@ -2233,11 +2235,16 @@ actor MobileHostConnection {
         }
         guard queuedEvents.count < Self.maximumQueuedEventCount,
               frame.count <= Self.maximumQueuedEventByteCount - queuedEventByteCount else {
+            // The bounded queue fills when the control stream stops draining
+            // (e.g. the peer's network path died mid-write) while terminal
+            // events keep arriving. The peer violated nothing; field host
+            // rings (2026-07-23 WiFi path flap) showed this close mislabeled
+            // protocolViolation seconds after admission.
             await close(
                 reason: "event queue exceeded bounded capacity",
                 exit: CmxIrohAdmittedConnectionExit(
                     lifecycle: .controlWriteFailed,
-                    failure: .protocolViolation
+                    failure: .sendQueueOverflow
                 )
             )
             return false
@@ -2349,6 +2356,8 @@ actor MobileHostConnection {
         do {
             frame = try MobileSyncFrameCodec.encodeFrame(response)
         } catch {
+            // MobileSyncFrameCodec.encodeFrame only throws frameTooLarge: a
+            // local wire-limit violation, so protocolViolation is honest here.
             await close(
                 reason: "response frame encode failed",
                 exit: CmxIrohAdmittedConnectionExit(

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -14978,6 +14978,23 @@
         }
       }
     },
+    "mobile.iroh.diagnostics.failure.sendQueueOverflow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Queue Overflow"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信キューオーバーフロー"
+          }
+        }
+      }
+    },
     "mobile.iroh.diagnostics.failure.superseded": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Field evidence (2026-07-23, host ring captured on a MacBook during the WiFi path-flap reconnect loop): dozens of admitted iroh session deaths logged `transportSessionLifecycle a=7 (applicationLaneFailed)` with `sessionClosed b=255 (unknown)`, plus `a=4 (controlWriteFailed)` with `b=17 (protocolViolation)` 2-5 seconds after admission. Neither label names the kill mechanism, so cmuxdiag rings stayed indecisive.

https://github.com/manaflow-ai/cmux/pull/8716 pinned `IrohError.message()` tokens for stream read/write errors, which arrive wrapped as `ConnectionLost(...)`. Connection-level operations (`accept_bi`, `open_bi`, `accept_uni`, `open_uni`) throw the bare `iroh::endpoint::ConnectionError` instead: iroh-ffi 1.0.2-cmux.4 formats it with `anyhow!("{:?}")`, so the host lane-accept loop sees `TimedOut`, `LocallyClosed`, `Reset`, `ApplicationClosed(..)`, `ConnectionClosed(..)`, `TransportError(..)`, `VersionMismatch`, or `CidsExhausted` with no wrapper (noq `ConnectionError` at manaflow-ai/noq@2271bbc, via the manaflow-ai/iroh fork). None matched, so every lane-failure exit classified `unknown`. New bare-token mappings, mirroring the wrapped forms:

| bare token | DiagnosticFailureKind |
|---|---|
| `TimedOut` | transportIdleTimedOut (21) |
| `LocallyClosed` | cancelled (20) |
| `Reset` | connectionClosed (18) |
| `ApplicationClosed(` / `ConnectionClosed(` / `TransportError(` | connectionClosed (18) |
| `TransportError(` + `Code::crypto(` or `TLS error:` | secureChannelFailed (7) |
| `VersionMismatch` | protocolViolation (17) |
| `CidsExhausted` | endpointUnavailable (12) |

The `a=4/b=17` deaths were not write errors at all: no error thrown on the control write path can classify to protocolViolation. They came from `MobileHostConnection.sendEvent`'s bounded event-queue overflow close, which hardcoded `.protocolViolation`. During a path flap the drain task blocks inside the QUIC write while terminal deltas keep queueing; 256 events fill within seconds and the host kills the session, which matches the observed 2-5s timing. That close now uses the new appended `DiagnosticFailureKind.sendQueueOverflow = 24` (no existing case renumbered). Both Connection Report UIs (macOS Settings > Networking, iOS Iroh settings) render the new kind, localized en+ja across all three string catalogs. The two frame-encode closes keep protocolViolation with comments: `MobileSyncFrameCodec.encodeFrame` only throws `frameTooLarge`, a genuine local wire-limit violation.

Not done: recording a raw or hashed unknown-error string into the event payload. `sessionClosed` has a/b/c taken (transport, failure, session ID), `ms` is documented as a millisecond magnitude, and the diagnostics design deliberately excludes string payloads; hashes of full Debug messages also would not match precomputed candidates because they embed dynamic codes and reasons. With the noq error vocabulary now enumerated, residual unknowns should be structurally rare, and host os_log retains the raw string privately at each classify site.

Commit 1 adds the failing token table only (8 of 9 new rows red); commit 2 adds the fix. `swift test` passes for CmuxIrohTransport (465 tests) and CMUXMobileCore (283 tests); CmuxSettingsUI builds. Localization audit: the only new user-facing string is the failure label, added with en+ja entries to `Resources/Localizable.xcstrings`, the CmuxMobileShellUI package catalog, and `ios/cmux/Resources/Localizable.xcstrings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787467331&installation_model_id=21920&pr_number=8834&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8834&signature=b31d20775eccbdb995b49ee0da9dfafadd94b0764b802725d855a72d46cc95b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves iroh session diagnostics by mapping previously “unknown” lane failures and introducing a clear reason for send-queue overflow. This makes rings and Settings UIs show accurate close causes, especially during path flaps.

- **Bug Fixes**
  - Map bare iroh `ConnectionError` tokens to `DiagnosticFailureKind`: `TimedOut`, `LocallyClosed`, `Reset`, `ApplicationClosed(...)`, `ConnectionClosed(...)`, `TransportError(...)`, `VersionMismatch`, `CidsExhausted` (no more `unknown`).
  - Tests in `CmuxIrohTransport` and `CMUXMobileCore` pin the new classifications.

- **New Features**
  - Add `sendQueueOverflow = 24` and use it for the host’s bounded control send-queue close (was `protocolViolation`).
  - Render “Send Queue Overflow” in macOS and iOS settings (`CmuxSettingsUI`, `CmuxMobileShellUI`), localized in en and ja.

<sup>Written for commit 532ca81ade863df4e2d3b4fc387b830e9843de3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Send Queue Overflow” diagnostic reason for clearer connection failure reporting.
  * Added English and Japanese translations across mobile and desktop settings.
  * Expanded diagnostic classification for additional timeout, closure, reset, protocol, and transport error formats.

* **Bug Fixes**
  * Improved accuracy when identifying connection failures from transport errors.
  * Queue capacity failures are now reported with their specific diagnostic reason instead of a generic protocol error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->