### PR TITLE
cmuxTests: repair three red suites, one of which was killing its own test host

### DIFF
--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -72,11 +72,14 @@ import Testing
         // exited on its own terms rather than dying from a signal.
         XCTAssertFalse(result.timedOut, result.diagnostics)
         XCTAssertFalse(result.diedFromSignal, result.diagnostics)
-        // 2 is the unknown-command exit and it is deterministic now the socket is pinned. Asserting
-        // the exact code rather than merely non-zero keeps this from passing when the CLI fails for
-        // some unrelated reason. Nothing is asserted about stdout: the message goes to stderr, which
-        // this test deliberately closes.
-        XCTAssertEqual(result.status, 2, result.diagnostics)
+        // 1, measured, and deterministic for this fixture: the pinned socket has no listener, so the
+        // CLI fails at connect and the top-level handler exits 1 before the unknown-command arm (which
+        // would exit 2) is ever reached. That ordering is what makes this a good exercise of the guard
+        // rather than a weaker one — the connect error is written to the stderr this test has closed.
+        // Asserting the exact code rather than merely non-zero keeps the test from passing when the CLI
+        // fails for some unrelated reason. Nothing is asserted about stdout: every message on this path
+        // goes to the closed stderr.
+        XCTAssertEqual(result.status, 1, result.diagnostics)
     }
 
     @Test func testAgentTeamsHelpDoesNotLaunchExternalAgentCLI() throws {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -695,9 +695,15 @@ import Testing
         try fileManager.createDirectory(at: themesURL, withIntermediateDirectories: true)
         try writeTheme(named: "Theme A", background: "#101010", to: themesURL)
 
-        let socketPath = "/tmp/cmux-debug-active-theme-\(UUID().uuidString).sock"
+        // The reload target is derived from the socket file name, not from CMUX_BUNDLE_ID:
+        // `cmux-debug-<slug>.sock` becomes `com.cmuxterm.app.debug.<slug>`, where every run of
+        // non-alphanumerics in the slug collapses to a dot. A raw UUID here would put its dashes
+        // into the identifier as dots, so keep the unique part hex-only and the expected
+        // identifier stays a plain template rather than a call into the CLI's own helper.
+        let uniqueSuffix = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        let socketPath = "/tmp/cmux-debug-active-theme-\(uniqueSuffix).sock"
         let staleBundleIdentifier = "com.cmuxterm.app.debug.stale.theme"
-        let targetBundleIdentifier = "com.cmuxterm.app.debug.active.theme"
+        let targetBundleIdentifier = "com.cmuxterm.app.debug.active.theme.\(uniqueSuffix)"
         let reloadExpectation = expectation(description: "cmux themes set targets the resolved socket bundle")
         let notificationQueue = OperationQueue()
         notificationQueue.maxConcurrentOperationCount = 1

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -14,18 +14,53 @@ import Testing
         let status: Int32
         let stdout: String
         let timedOut: Bool
+        /// Defaulted so existing call sites are unaffected. A process killed by a signal reports
+        /// `.uncaughtSignal`, and its `terminationStatus` is the signal number — indistinguishable
+        /// from an ordinary non-zero exit if you only look at the status.
+        var terminationReason: Process.TerminationReason = .exit
+
+        var diedFromSignal: Bool { terminationReason == .uncaughtSignal }
+
+        var diagnostics: String {
+            "status=\(status) reason=\(diedFromSignal ? "uncaughtSignal" : "exit") "
+                + "timedOut=\(timedOut) stdout=\(stdout.isEmpty ? "<empty>" : stdout)"
+        }
     }
 
     @Test func testCLIErrorPathDoesNotCrashWhenStderrIsClosed() throws {
         let cliPath = try bundledCLIPath()
+        // Pin the socket and the home directory. Without CMUX_SOCKET_PATH the CLI's resolution can
+        // fall back to a machine-global marker file and reach whatever app happens to be running,
+        // which would make this test's exit code depend on the machine rather than on the CLI.
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-stderr-closed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let socketPath = home.appendingPathComponent("cmux.sock").path
+
+        // `exec` so the process we wait on is the CLI itself. Without it the shell is the child, and
+        // a shell reports a signalled child as an ordinary exit with status 128+signal — which would
+        // hide the very crash this test exists to catch.
         let result = runShell(
-            "CMUX_CLI_SENTRY_DISABLED=1 \(shellSingleQuote(cliPath)) definitely-not-a-command 2>&-",
+            "CMUX_CLI_SENTRY_DISABLED=1 "
+                + "CMUX_SOCKET_PATH=\(shellSingleQuote(socketPath)) "
+                + "CFFIXED_USER_HOME=\(shellSingleQuote(home.path)) "
+                + "HOME=\(shellSingleQuote(home.path)) "
+                + "exec \(shellSingleQuote(cliPath)) definitely-not-a-command 2>&-",
             timeout: 5
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 1, result.stdout)
-        XCTAssertTrue(result.stdout.contains("Usage:"), result.stdout)
+        // What is guarded here is a crash, not an exit code. cc4a6109d8 replaced
+        // FileHandle.standardError.write — which raises, and aborts the process, when stderr is
+        // closed — with a raw Darwin.write that returns -1 on EBADF. So the oracle is that the CLI
+        // exited on its own terms rather than dying from a signal.
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertFalse(result.diedFromSignal, result.diagnostics)
+        // 2 is the unknown-command exit and it is deterministic now the socket is pinned. Asserting
+        // the exact code rather than merely non-zero keeps this from passing when the CLI fails for
+        // some unrelated reason. Nothing is asserted about stdout: the message goes to stderr, which
+        // this test deliberately closes.
+        XCTAssertEqual(result.status, 2, result.diagnostics)
     }
 
     @Test func testAgentTeamsHelpDoesNotLaunchExternalAgentCLI() throws {
@@ -1478,7 +1513,8 @@ import Testing
         return ProcessRunResult(
             status: process.terminationStatus,
             stdout: String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
-            timedOut: timedOut
+            timedOut: timedOut,
+            terminationReason: process.terminationReason
         )
     }
 
@@ -1524,7 +1560,8 @@ import Testing
         return ProcessRunResult(
             status: process.terminationStatus,
             stdout: String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
-            timedOut: timedOut
+            timedOut: timedOut,
+            terminationReason: process.terminationReason
         )
     }
 

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -98,9 +98,13 @@ import Testing
         defer { try? FileManager.default.removeItem(at: home) }
         let stableSocketURL = try stableSocketURL(home: home)
 
-        let stableResponder = try UnixSocketResponder(path: stableSocketURL.path, response: "STABLE")
+        // The CLI only accepts OK / OK … / PONG / ERROR: … / JSON as a complete single-line
+        // reply. A bareword sends it into the multiline drain pass, where reconfiguring the
+        // receive timeout on an already-closed socket fails with EINVAL and the CLI reports
+        // "Invalid argument" instead of the reply it already has.
+        let stableResponder = try UnixSocketResponder(path: stableSocketURL.path, response: "OK STABLE")
         defer { stableResponder.stop() }
-        let taggedResponder = try UnixSocketResponder(path: taggedSocketPath, response: "TAGGED")
+        let taggedResponder = try UnixSocketResponder(path: taggedSocketPath, response: "OK TAGGED")
         defer { taggedResponder.stop() }
 
         let fakeCLIPath = try fakeTaggedBundledCLIPath(
@@ -127,9 +131,13 @@ import Testing
         XCTAssertEqual(result.status, 0, result.stdout)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
-            "TAGGED",
+            "OK TAGGED",
             result.stdout
         )
+        // The point of this test: the tagged socket was chosen and the stable one was not. These
+        // hold whatever framing the reply uses, so a future reply change cannot make it vacuous.
+        XCTAssertEqual(taggedResponder.receivedRequests, ["ping"], result.stdout)
+        XCTAssertEqual(stableResponder.receivedRequests, [], result.stdout)
     }
 
     @Test func testBundledCLIInTaggedDebugAppTreatsCaseVariantStableEnvSocketAsImplicitDefault() throws {
@@ -561,9 +569,13 @@ import Testing
         defer { try? FileManager.default.removeItem(at: home) }
         let stableSocketURL = try stableSocketURL(home: home)
 
-        let stableResponder = try UnixSocketResponder(path: stableSocketURL.path, response: "STABLE")
+        // The CLI only accepts OK / OK … / PONG / ERROR: … / JSON as a complete single-line
+        // reply. A bareword sends it into the multiline drain pass, where reconfiguring the
+        // receive timeout on an already-closed socket fails with EINVAL and the CLI reports
+        // "Invalid argument" instead of the reply it already has.
+        let stableResponder = try UnixSocketResponder(path: stableSocketURL.path, response: "OK STABLE")
         defer { stableResponder.stop() }
-        let taggedResponder = try UnixSocketResponder(path: taggedSocketPath, response: "TAGGED")
+        let taggedResponder = try UnixSocketResponder(path: taggedSocketPath, response: "OK TAGGED")
         defer { taggedResponder.stop() }
 
         let fakeCLIPath = try fakeTaggedBundledCLIPath(
@@ -590,9 +602,13 @@ import Testing
         XCTAssertEqual(result.status, 0, result.stdout)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
-            "TAGGED",
+            "OK TAGGED",
             result.stdout
         )
+        // The point of this test: the tagged socket was chosen and the stable one was not. These
+        // hold whatever framing the reply uses, so a future reply change cannot make it vacuous.
+        XCTAssertEqual(taggedResponder.receivedRequests, ["ping"], result.stdout)
+        XCTAssertEqual(stableResponder.receivedRequests, [], result.stdout)
     }
 
     @Test func testThemesSetReloadsRunningAppAfterEveryThemeWrite() throws {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -13,6 +13,13 @@ import Testing
     struct ProcessRunResult {
         let status: Int32
         let stdout: String
+        /// Captured on its own pipe, not merged into `stdout`.
+        ///
+        /// Roughly thirty tests here parse stdout as JSON or compare it to an exact
+        /// reply. While both streams shared one pipe, a single unrelated diagnostic line
+        /// from the runtime landed in the middle of that payload and failed the content
+        /// check instead of naming itself.
+        let stderr: String
         let timedOut: Bool
         /// Defaulted so existing call sites are unaffected. A process killed by a signal reports
         /// `.uncaughtSignal`, and its `terminationStatus` is the signal number — indistinguishable
@@ -21,9 +28,14 @@ import Testing
 
         var diedFromSignal: Bool { terminationReason == .uncaughtSignal }
 
+        /// Both streams together, for a check that cares whether the CLI said something
+        /// at all rather than which stream carried it.
+        var combinedOutput: String { stdout + stderr }
+
         var diagnostics: String {
             "status=\(status) reason=\(diedFromSignal ? "uncaughtSignal" : "exit") "
-                + "timedOut=\(timedOut) stdout=\(stdout.isEmpty ? "<empty>" : stdout)"
+                + "timedOut=\(timedOut) stdout=\(stdout.isEmpty ? "<empty>" : stdout) "
+                + "stderr=\(stderr.isEmpty ? "<empty>" : stderr)"
         }
     }
 
@@ -47,6 +59,10 @@ import Testing
                 + "CFFIXED_USER_HOME=\(shellSingleQuote(home.path)) "
                 + "HOME=\(shellSingleQuote(home.path)) "
                 + "exec \(shellSingleQuote(cliPath)) definitely-not-a-command 2>&-",
+            // The assignments above are what the CLI sees; this is the shell's own
+            // environment, kept bare so no `CMUX_*` the test host was launched with
+            // leaks through to the child.
+            environment: ["PATH": "/usr/bin:/bin"],
             timeout: 5
         )
 
@@ -65,25 +81,37 @@ import Testing
 
     @Test func testAgentTeamsHelpDoesNotLaunchExternalAgentCLI() throws {
         let cliPath = try bundledCLIPath()
+        let home = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
         var environment = ProcessInfo.processInfo.environment
         for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
             environment.removeValue(forKey: key)
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["PATH"] = "/usr/bin:/bin"
+        environment["HOME"] = home.path
+        environment["CFFIXED_USER_HOME"] = home.path
+        // The CLI resolves its socket before it dispatches the command, so even a
+        // `--help` run walks the candidate list — which means reading the machine-wide
+        // marker file and connecting to any `cmux-debug-*.sock` it finds in /tmp. A
+        // per-run path nothing listens on is not one of the implicit defaults, so the
+        // CLI takes it as given and never goes looking.
+        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-agent-teams-help-\(UUID().uuidString.prefix(8)).sock"
 
         for command in ["claude-teams", "codex-teams"] {
             let result = runProcess(
                 executablePath: cliPath,
                 arguments: [command, "--help"],
-                environment: environment,
-                timeout: 5
+                environment: environment
             )
 
-            XCTAssertFalse(result.timedOut, result.stdout)
-            XCTAssertEqual(result.status, 0, result.stdout)
-            XCTAssertTrue(result.stdout.contains("Usage: cmux \(command)"), result.stdout)
-            XCTAssertFalse(result.stdout.contains("Failed to launch"), result.stdout)
+            XCTAssertFalse(result.timedOut, result.diagnostics)
+            XCTAssertEqual(result.status, 0, result.diagnostics)
+            XCTAssertTrue(result.stdout.contains("Usage: cmux \(command)"), result.diagnostics)
+            // The CLI reports a failed exec by throwing, and the top-level handler prints
+            // that on stderr, so this has to read both streams. On one shared pipe it
+            // used to cover either by accident.
+            XCTAssertFalse(result.combinedOutput.contains("Failed to launch"), result.diagnostics)
         }
     }
 
@@ -151,28 +179,30 @@ import Testing
             environment.removeValue(forKey: key)
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
-        // Redirect the CLI's stable-socket resolution to the temp home so this
-        // test is hermetic (CFFIXED_USER_HOME overrides homeDirectoryForCurrentUser).
+        // No CMUX_SOCKET_PATH on purpose: where the CLI lands with no override is the
+        // whole subject. That stays inside the test because the tag slug is unique per
+        // run, so the tagged default socket and the marker file the CLI consults are both
+        // named after this run. CFFIXED_USER_HOME moves the stable socket into the temp
+        // home (it overrides homeDirectoryForCurrentUser).
         environment["CFFIXED_USER_HOME"] = home.path
 
         let result = runProcess(
             executablePath: fakeCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
             "OK TAGGED",
-            result.stdout
+            result.diagnostics
         )
         // The point of this test: the tagged socket was chosen and the stable one was not. These
         // hold whatever framing the reply uses, so a future reply change cannot make it vacuous.
-        XCTAssertEqual(taggedResponder.receivedRequests, ["ping"], result.stdout)
-        XCTAssertEqual(stableResponder.receivedRequests, [], result.stdout)
+        XCTAssertEqual(taggedResponder.receivedRequests, ["ping"], result.diagnostics)
+        XCTAssertEqual(stableResponder.receivedRequests, [], result.diagnostics)
     }
 
     @Test func testBundledCLIInTaggedDebugAppTreatsCaseVariantStableEnvSocketAsImplicitDefault() throws {
@@ -203,26 +233,26 @@ import Testing
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
+        // The env socket here is deliberately one of the stable implicit defaults, since
+        // looking past it is what a tagged build has to do, so it cannot be pinned to a
+        // per-run path. The temp home keeps that default inside the test.
         environment["CMUX_SOCKET_PATH"] = caseVariantStablePath
-        // Resolve the stable path under the temp home so the case-variant env
-        // socket is recognized as the implicit default hermetically.
         environment["CFFIXED_USER_HOME"] = home.path
 
         let result = runProcess(
             executablePath: fakeCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
             "PONG",
-            result.stdout
+            result.diagnostics
         )
-        XCTAssertEqual(stableResponder.receivedRequests, [])
+        XCTAssertEqual(stableResponder.receivedRequests, [], result.diagnostics)
     }
 
     @Test func testBundledCLIInTaggedDebugAppDoesNotFallBackToStableEnvSocketWhenTaggedSocketIsMissing() throws {
@@ -254,21 +284,24 @@ import Testing
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "0.1"
+        // Another deliberate stable-default env socket: pinning it to a per-run path would
+        // remove the fallback decision this test is about.
         environment["CMUX_SOCKET_PATH"] = stableSocketURL.path
         environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
 
         let result = runProcess(
             executablePath: fakeCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertNotEqual(result.status, 0, result.stdout)
-        XCTAssertTrue(result.stdout.contains(taggedSocketPath), result.stdout)
-        XCTAssertFalse(result.stdout.contains("OK STABLE"), result.stdout)
-        XCTAssertEqual(stableResponder.receivedRequests, [])
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertNotEqual(result.status, 0, result.diagnostics)
+        // The connect failure is thrown, and the top-level handler prints a thrown error
+        // on stderr, so that is where the socket it gave up on is named.
+        XCTAssertTrue(result.stderr.contains(taggedSocketPath), result.diagnostics)
+        XCTAssertFalse(result.combinedOutput.contains("OK STABLE"), result.diagnostics)
+        XCTAssertEqual(stableResponder.receivedRequests, [], result.diagnostics)
     }
 
     @Test func testBundledCLIInTaggedDebugAppTreatsUserScopedStableEnvSocketAsImplicitDefault() throws {
@@ -291,10 +324,6 @@ import Testing
                 .path,
         ]
 
-        if FileManager.default.fileExists(atPath: stableSocketPath) {
-            return
-        }
-
         for alias in aliases {
             try autoreleasepool {
                 let tagSlug = "cli-user-\(UUID().uuidString.lowercased())"
@@ -314,24 +343,25 @@ import Testing
                 }
                 environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
                 environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
+                // Each alias is a user-scoped stable default that a tagged build has to
+                // look past, so the env socket stays as spelled rather than pinned.
                 environment["CMUX_SOCKET_PATH"] = alias
                 environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
 
                 let result = runProcess(
                     executablePath: fakeCLIPath,
                     arguments: ["ping"],
-                    environment: environment,
-                    timeout: 5
+                    environment: environment
                 )
 
-                XCTAssertFalse(result.timedOut, result.stdout)
-                XCTAssertEqual(result.status, 0, result.stdout)
+                XCTAssertFalse(result.timedOut, result.diagnostics)
+                XCTAssertEqual(result.status, 0, result.diagnostics)
                 XCTAssertEqual(
                     result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
                     "PONG",
-                    result.stdout
+                    result.diagnostics
                 )
-                XCTAssertEqual(stableResponder.receivedRequests, [], alias)
+                XCTAssertEqual(stableResponder.receivedRequests, [], "\(alias)\n\(result.diagnostics)")
             }
         }
     }
@@ -352,9 +382,7 @@ import Testing
         let userScopedStableSocketPath = socketDirectoryURL
             .appendingPathComponent("cmux-\(getuid()).sock", isDirectory: false)
             .path
-        if FileManager.default.fileExists(atPath: userScopedStableSocketPath) {
-            return
-        }
+        try writeStableSocketMarker(home: fixedHomeURL)
 
         let fakeStableCLIPath = try fakeTaggedBundledCLIPath(
             sourceCLIPath: cliPath,
@@ -373,32 +401,33 @@ import Testing
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
+        // A stable implicit default on purpose: keeping this one rather than resolving on
+        // to another candidate is the behavior under test, so it is not pinned.
         environment["CMUX_SOCKET_PATH"] = userScopedStableSocketPath
         environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
 
         let result = runProcess(
             executablePath: fakeStableCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
             "OK USER",
-            result.stdout
+            result.diagnostics
         )
-        XCTAssertEqual(defaultResponder.receivedRequests, [])
+        XCTAssertEqual(defaultResponder.receivedRequests, [], result.diagnostics)
         XCTAssertEqual(
             userScopedResponder.receivedRequests.count,
             1,
-            userScopedResponder.receivedRequests.joined(separator: "\n")
+            "\(userScopedResponder.receivedRequests.joined(separator: "\n"))\n\(result.diagnostics)"
         )
         XCTAssertTrue(
             userScopedResponder.receivedRequests.contains { $0.contains("ping") },
-            userScopedResponder.receivedRequests.joined(separator: "\n")
+            "\(userScopedResponder.receivedRequests.joined(separator: "\n"))\n\(result.diagnostics)"
         )
     }
 
@@ -418,9 +447,7 @@ import Testing
         let userScopedStableSocketPath = socketDirectoryURL
             .appendingPathComponent("cmux-\(getuid()).sock", isDirectory: false)
             .path
-        if FileManager.default.fileExists(atPath: userScopedStableSocketPath) {
-            return
-        }
+        try writeStableSocketMarker(home: fixedHomeURL)
 
         let fakeStableCLIPath = try fakeTaggedBundledCLIPath(
             sourceCLIPath: cliPath,
@@ -437,35 +464,45 @@ import Testing
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
+        // Nothing listens on this stable default, and finding the next candidate is the
+        // behavior under test, so the env socket stays as spelled.
         environment["CMUX_SOCKET_PATH"] = userScopedStableSocketPath
         environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
 
         let result = runProcess(
             executablePath: fakeStableCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
             "OK DEFAULT",
-            result.stdout
+            result.diagnostics
         )
         XCTAssertEqual(
             defaultResponder.receivedRequests.count,
             1,
-            defaultResponder.receivedRequests.joined(separator: "\n")
+            "\(defaultResponder.receivedRequests.joined(separator: "\n"))\n\(result.diagnostics)"
         )
         XCTAssertTrue(
             defaultResponder.receivedRequests.contains { $0.contains("ping") },
-            defaultResponder.receivedRequests.joined(separator: "\n")
+            "\(defaultResponder.receivedRequests.joined(separator: "\n"))\n\(result.diagnostics)"
         )
     }
 
-    @Test func testBundledStableCLIFallsBackFromSymlinkedLegacyStableEnvSocket() throws {
+    /// A symlink standing where a stable socket belongs is not a socket, and the CLI has
+    /// to resolve past it.
+    ///
+    /// The env socket is the user-scoped stable default inside this test's temp home. It
+    /// used to be `/tmp/cmux.sock`, the release app's own socket path, which the responder
+    /// unlinks before it binds — that takes the control socket away from a release app the
+    /// developer is running. The early return that was supposed to prevent it both raced
+    /// the app and, because it used `lstat` where the sibling test followed symlinks,
+    /// disagreed with itself about what counts as present.
+    @Test func testBundledStableCLIFallsBackFromSymlinkedStableEnvSocket() throws {
         let cliPath = try bundledCLIPath()
         let fixedHomeURL = URL(fileURLWithPath: "/tmp/cmxh-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: fixedHomeURL) }
@@ -478,11 +515,11 @@ import Testing
         let defaultStableSocketPath = socketDirectoryURL
             .appendingPathComponent("cmux.sock", isDirectory: false)
             .path
-        let legacyStableSocketPath = "/tmp/cmux.sock"
+        let symlinkedStableSocketPath = socketDirectoryURL
+            .appendingPathComponent("cmux-\(getuid()).sock", isDirectory: false)
+            .path
         let symlinkTargetSocketPath = "/tmp/cmux-symlink-target-\(UUID().uuidString).sock"
-        if lstatPathExists(legacyStableSocketPath) {
-            return
-        }
+        try writeStableSocketMarker(home: fixedHomeURL)
 
         let fakeStableCLIPath = try fakeTaggedBundledCLIPath(
             sourceCLIPath: cliPath,
@@ -494,8 +531,7 @@ import Testing
         defer { defaultResponder.stop() }
         let targetResponder = try UnixSocketResponder(path: symlinkTargetSocketPath, response: "OK TARGET")
         defer { targetResponder.stop() }
-        XCTAssertEqual(symlink(symlinkTargetSocketPath, legacyStableSocketPath), 0)
-        defer { unlink(legacyStableSocketPath) }
+        XCTAssertEqual(symlink(symlinkTargetSocketPath, symlinkedStableSocketPath), 0)
 
         var environment = ProcessInfo.processInfo.environment
         for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
@@ -503,97 +539,86 @@ import Testing
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
-        environment["CMUX_SOCKET_PATH"] = legacyStableSocketPath
+        // The symlinked stable default is the input to the fallback under test, so it is
+        // not pinned to a per-run path.
+        environment["CMUX_SOCKET_PATH"] = symlinkedStableSocketPath
         environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
 
         let result = runProcess(
             executablePath: fakeStableCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
             "OK DEFAULT",
-            result.stdout
+            result.diagnostics
         )
         XCTAssertEqual(
             defaultResponder.receivedRequests.count,
             1,
-            defaultResponder.receivedRequests.joined(separator: "\n")
+            "\(defaultResponder.receivedRequests.joined(separator: "\n"))\n\(result.diagnostics)"
         )
         XCTAssertTrue(
             defaultResponder.receivedRequests.contains { $0.contains("ping") },
-            defaultResponder.receivedRequests.joined(separator: "\n")
+            "\(defaultResponder.receivedRequests.joined(separator: "\n"))\n\(result.diagnostics)"
         )
-        XCTAssertEqual(targetResponder.receivedRequests, [])
+        XCTAssertEqual(targetResponder.receivedRequests, [], result.diagnostics)
     }
 
-    @Test func testBundledStableCLIPreservesLiveLegacyStableEnvSocket() throws {
+    /// `/tmp/cmux.sock`, the release app's socket path, counts as a stable implicit
+    /// default: a tagged build handed it in the environment still talks to its own socket.
+    ///
+    /// Nothing here creates, binds, or removes that path — a release app may be using it
+    /// right now, and the responder unlinks whatever it finds before it binds. Only the
+    /// classification needs testing, and that is readable from which responder saw the
+    /// ping, with or without a release app running. The other half of the old test, that a
+    /// live stable env socket is kept rather than resolved away, is covered under a temp
+    /// home by ``testBundledStableCLIPreservesLiveUserScopedStableEnvSocket``.
+    @Test func testBundledCLIInTaggedDebugAppTreatsLegacyStableEnvSocketAsImplicitDefault() throws {
         let cliPath = try bundledCLIPath()
-        let fixedHomeURL = URL(fileURLWithPath: "/tmp/cmxh-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: fixedHomeURL) }
-        let socketDirectoryURL = fixedHomeURL
-            .appendingPathComponent(".local/state/cmux", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: socketDirectoryURL,
-            withIntermediateDirectories: true
-        )
-        let defaultStableSocketPath = socketDirectoryURL
-            .appendingPathComponent("cmux.sock", isDirectory: false)
-            .path
-        let legacyStableSocketPath = "/tmp/cmux.sock"
-        if FileManager.default.fileExists(atPath: legacyStableSocketPath) {
-            return
-        }
+        let tagSlug = "cli-legacy-\(UUID().uuidString.lowercased())"
+        let taggedSocketPath = "/tmp/cmux-debug-\(tagSlug).sock"
+        let home = try makeTemporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let stableSocketURL = try stableSocketURL(home: home)
 
-        let fakeStableCLIPath = try fakeTaggedBundledCLIPath(
+        let stableResponder = try UnixSocketResponder(path: stableSocketURL.path, response: "OK STABLE")
+        defer { stableResponder.stop() }
+        let taggedResponder = try UnixSocketResponder(path: taggedSocketPath, response: "PONG")
+        defer { taggedResponder.stop() }
+
+        let fakeCLIPath = try fakeTaggedBundledCLIPath(
             sourceCLIPath: cliPath,
-            tagSlug: "stable-\(UUID().uuidString.lowercased())",
-            bundleIdentifier: "com.cmuxterm.app",
-            bundleName: "cmux"
+            tagSlug: tagSlug
         )
-        let defaultResponder = try UnixSocketResponder(path: defaultStableSocketPath, response: "OK DEFAULT")
-        defer { defaultResponder.stop() }
-        let legacyResponder = try UnixSocketResponder(path: legacyStableSocketPath, response: "OK LEGACY")
-        defer { legacyResponder.stop() }
-
         var environment = ProcessInfo.processInfo.environment
         for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
             environment.removeValue(forKey: key)
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "5"
-        environment["CMUX_SOCKET_PATH"] = legacyStableSocketPath
-        environment["CFFIXED_USER_HOME"] = fixedHomeURL.path
+        environment["CMUX_SOCKET_PATH"] = SocketControlSettings.legacyStableDefaultSocketPath
+        environment["CFFIXED_USER_HOME"] = home.path
 
         let result = runProcess(
-            executablePath: fakeStableCLIPath,
+            executablePath: fakeCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
-            "OK LEGACY",
-            result.stdout
+            "PONG",
+            result.diagnostics
         )
-        XCTAssertEqual(defaultResponder.receivedRequests, [])
-        XCTAssertEqual(
-            legacyResponder.receivedRequests.count,
-            1,
-            legacyResponder.receivedRequests.joined(separator: "\n")
-        )
-        XCTAssertTrue(
-            legacyResponder.receivedRequests.contains { $0.contains("ping") },
-            legacyResponder.receivedRequests.joined(separator: "\n")
-        )
+        XCTAssertEqual(taggedResponder.receivedRequests, ["ping"], result.diagnostics)
+        XCTAssertEqual(stableResponder.receivedRequests, [], result.diagnostics)
     }
 
     @Test func testBundledCLISkipsIdentifierlessNestedAppWhenResolvingTaggedSocket() throws {
@@ -623,27 +648,27 @@ import Testing
             environment.removeValue(forKey: key)
         }
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
-        // Redirect the CLI's stable-socket resolution to the temp home (hermetic).
+        // No CMUX_SOCKET_PATH again: resolution from the bundle layout is the subject. The
+        // temp home and the unique tag slug keep that resolution inside the test.
         environment["CFFIXED_USER_HOME"] = home.path
 
         let result = runProcess(
             executablePath: fakeCLIPath,
             arguments: ["ping"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         XCTAssertEqual(
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
             "OK TAGGED",
-            result.stdout
+            result.diagnostics
         )
         // The point of this test: the tagged socket was chosen and the stable one was not. These
         // hold whatever framing the reply uses, so a future reply change cannot make it vacuous.
-        XCTAssertEqual(taggedResponder.receivedRequests, ["ping"], result.stdout)
-        XCTAssertEqual(stableResponder.receivedRequests, [], result.stdout)
+        XCTAssertEqual(taggedResponder.receivedRequests, ["ping"], result.diagnostics)
+        XCTAssertEqual(stableResponder.receivedRequests, [], result.diagnostics)
     }
 
     @Test func testThemesSetReloadsRunningAppAfterEveryThemeWrite() throws {
@@ -664,7 +689,14 @@ import Testing
         let socketPath = "/tmp/cmux-theme-\(UUID().uuidString.prefix(8)).sock"
         let responder = try UnixSocketResponder(path: socketPath, response: "OK")
         defer { responder.stop() }
-        let bundleIdentifier = "com.cmuxterm.app.debug.issue-4355-test"
+        // The reload notification travels over DistributedNotificationCenter, which is
+        // machine-wide, and the observer below filters only on the bundle identifier. With
+        // a fixed identifier a second run of this test on the same machine fulfills this
+        // run's expectation and appends to its list, so the identifier carries a per-run
+        // suffix. The CLI takes the identifier from CMUX_BUNDLE_ID here because this
+        // socket file name has no channel prefix to derive one from.
+        let bundleIdentifier = "com.cmuxterm.app.debug.issue-4355-test."
+            + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
         let reloadExpectation = expectation(description: "cmux themes set posts final reload notifications")
         reloadExpectation.expectedFulfillmentCount = 3
         let notificationQueue = OperationQueue()
@@ -710,12 +742,11 @@ import Testing
             let result = runProcess(
                 executablePath: cliPath,
                 arguments: ["themes", "set", themeName],
-                environment: environment,
-                timeout: 5
+                environment: environment
             )
 
-            XCTAssertFalse(result.timedOut, result.stdout)
-            XCTAssertEqual(result.status, 0, result.stdout)
+            XCTAssertFalse(result.timedOut, result.diagnostics)
+            XCTAssertEqual(result.status, 0, result.diagnostics)
             observedThemeValues.append(try managedThemeValue(in: configURL))
         }
         wait(for: [reloadExpectation], timeout: 5)
@@ -796,12 +827,11 @@ import Testing
         let result = runProcess(
             executablePath: cliPath,
             arguments: ["--json", "themes", "set", "Theme A"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         wait(for: [reloadExpectation], timeout: 5)
 
         notificationLock.lock()
@@ -810,8 +840,11 @@ import Testing
         XCTAssertEqual(reloads.map { $0.bundleIdentifier }, [targetBundleIdentifier])
         XCTAssertEqual(reloads.map { $0.phase }, ["final"])
         XCTAssertEqual(reloads.map { $0.socketPath }, [socketPath])
-        XCTAssertFalse(result.stdout.contains(staleBundleIdentifier), result.stdout)
-        XCTAssertTrue(result.stdout.contains(targetBundleIdentifier), result.stdout)
+        // The stale identifier must not show up anywhere the CLI writes, which is why this
+        // one reads both streams: the JSON payload is on stdout, and a leak through an
+        // error message would land on stderr.
+        XCTAssertFalse(result.combinedOutput.contains(staleBundleIdentifier), result.diagnostics)
+        XCTAssertTrue(result.stdout.contains(targetBundleIdentifier), result.diagnostics)
     }
 
     @Test func testThemesSetNightlyOverridePathIsReadableByNightlyAppConfigResolution() throws {
@@ -827,7 +860,16 @@ import Testing
         try fileManager.createDirectory(at: themesURL, withIntermediateDirectories: true)
         try writeTheme(named: "Theme A", background: "#101010", to: themesURL)
 
-        let bundleIdentifier = "com.cmuxterm.app.nightly"
+        // The reload target comes from the socket file name before CMUX_BUNDLE_ID is even
+        // consulted: `cmux-nightly-<slug>.sock` becomes `com.cmuxterm.app.nightly.<slug>`.
+        // So scoping the identifier means scoping the socket name it is read from, and both
+        // take the same hex-only suffix — a raw UUID's dashes would turn into dots in the
+        // identifier. Scoping matters because the reload goes out machine-wide: on the
+        // plain nightly socket name this test told a real nightly build to re-read its
+        // config, and two runs at once shared one identifier.
+        let uniqueSuffix = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        let socketPath = "/tmp/cmux-nightly-\(uniqueSuffix).sock"
+        let bundleIdentifier = "com.cmuxterm.app.nightly.\(uniqueSuffix)"
         var environment = ProcessInfo.processInfo.environment
         for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
             environment.removeValue(forKey: key)
@@ -835,25 +877,26 @@ import Testing
         environment["CFFIXED_USER_HOME"] = root.path
         environment["HOME"] = root.path
         environment["GHOSTTY_RESOURCES_DIR"] = resourcesURL.path
-        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-nightly.sock"
+        environment["CMUX_SOCKET_PATH"] = socketPath
         environment["CMUX_BUNDLE_ID"] = bundleIdentifier
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
 
         let result = runProcess(
             executablePath: cliPath,
             arguments: ["--json", "themes", "set", "Theme A"],
-            environment: environment,
-            timeout: 5
+            environment: environment
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
 
+        // Parsed from stdout alone. This is the check that used to break when a stray
+        // diagnostic line from the runtime shared the pipe with the payload.
         let payload = try XCTUnwrap(
             JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any],
-            result.stdout
+            result.diagnostics
         )
-        let configPath = try XCTUnwrap(payload["config_path"] as? String, result.stdout)
+        let configPath = try XCTUnwrap(payload["config_path"] as? String, result.diagnostics)
         XCTAssertEqual(payload["reload_target_bundle_id"] as? String, bundleIdentifier)
 
         let appSupportDirectory = root
@@ -952,17 +995,20 @@ import Testing
             shellSingleQuote(fakeCLIPath),
             "themes",
         ].joined(separator: " ")
-        let result = runShell(command, timeout: 5)
+        // `env -i` builds the CLI's environment from scratch, so the shell needs only a
+        // PATH of its own to find `env` — and nothing the test host was launched with
+        // reaches the CLI.
+        let result = runShell(command, environment: ["PATH": "/usr/bin:/bin"])
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
         wait(for: [reloadExpectation], timeout: 5)
         notificationLock.lock()
         let reloads = observedReloads
         notificationLock.unlock()
         XCTAssertEqual(reloads.map { $0.bundleIdentifier }, [bundleIdentifier])
         XCTAssertEqual(reloads.map { $0.phase }, ["final"])
-        XCTAssertEqual(responder.receivedRequests, [])
+        XCTAssertEqual(responder.receivedRequests, [], result.diagnostics)
     }
 
     @Test func testBareInteractiveThemesTreatsSigintAsSilentCancel() throws {
@@ -1018,12 +1064,18 @@ import Testing
             shellSingleQuote(fakeCLIPath),
             "themes",
         ].joined(separator: " ")
-        let result = runShell(command, timeout: 5)
+        let result = runShell(command, environment: ["PATH": "/usr/bin:/bin"])
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertFalse(result.stdout.contains("Interactive theme picker exited"), result.stdout)
-        XCTAssertEqual(responder.receivedRequests, [])
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        // `script` hands the CLI a pty for both streams, so a cancel notice arrives on
+        // stdout today. Reading both keeps this from going quiet if that changes — the
+        // notice is a thrown error, and thrown errors print on stderr.
+        XCTAssertFalse(
+            result.combinedOutput.contains("Interactive theme picker exited"),
+            result.diagnostics
+        )
+        XCTAssertEqual(responder.receivedRequests, [], result.diagnostics)
     }
 
     @Test func testBrowserDownloadWaitUsesRequestedTimeoutForSocketResponse() throws {
@@ -1052,12 +1104,19 @@ import Testing
                 "1000",
             ],
             environment: environment,
+            // A deliberate cap, not a hang guard: the responder answers after 0.4s and the
+            // request asks for 1000ms, so this run has to finish well inside 3s. Raising it
+            // to the suite default would let a CLI that ignored --timeout-ms still pass.
             timeout: 3
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "OK")
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK",
+            result.diagnostics
+        )
     }
 
     @Test func testBrowserDownloadWaitDefaultTimeoutMatchesServerDefaultWindow() throws {
@@ -1084,12 +1143,21 @@ import Testing
                 "wait",
             ],
             environment: environment,
+            // A deliberate cap, and the only upper bound that gives this test meaning: the
+            // responder answers after 10.5s, so waiting the server's default window has to
+            // land between there and 16s. Under the suite default a CLI that waited a full
+            // minute would still pass, and "matches the server default window" would stop
+            // being a claim about anything.
             timeout: 16
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "OK")
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK",
+            result.diagnostics
+        )
     }
 
     @Test func testDotPathOpenBypassesProtectedSocketForExternalCLI() throws {
@@ -1137,14 +1205,17 @@ import Testing
             executablePath: cliPath,
             arguments: ["."],
             environment: environment,
-            currentDirectoryURL: workingDirectory,
-            timeout: 5
+            currentDirectoryURL: workingDirectory
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "OK")
-        XCTAssertEqual(responder.receivedRequests, [])
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK",
+            result.diagnostics
+        )
+        XCTAssertEqual(responder.receivedRequests, [], result.diagnostics)
 
         let openArguments = try readFakeOpenArguments(from: openLogURL)
         XCTAssertEqual(openArguments.first, "-a")
@@ -1205,14 +1276,17 @@ import Testing
             executablePath: cliPath,
             arguments: ["project"],
             environment: environment,
-            currentDirectoryURL: root,
-            timeout: 5
+            currentDirectoryURL: root
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "OK")
-        XCTAssertEqual(responder.receivedRequests, [])
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK",
+            result.diagnostics
+        )
+        XCTAssertEqual(responder.receivedRequests, [], result.diagnostics)
 
         let openArguments = try readFakeOpenArguments(from: openLogURL)
         XCTAssertEqual(openArguments.last, workingDirectory.standardizedFileURL.path)
@@ -1250,15 +1324,18 @@ import Testing
             executablePath: cliPath,
             arguments: ["ping"],
             environment: environment,
-            currentDirectoryURL: root,
-            timeout: 5
+            currentDirectoryURL: root
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "PONG")
-        XCTAssertEqual(responder.receivedRequests, ["ping"])
-        XCTAssertFalse(FileManager.default.fileExists(atPath: openLogURL.path))
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "PONG",
+            result.diagnostics
+        )
+        XCTAssertEqual(responder.receivedRequests, ["ping"], result.diagnostics)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: openLogURL.path), result.diagnostics)
     }
 
     @Test func testCaseVariantBareRelativeDirectoryPathOpenBypassesProtectedSocket() throws {
@@ -1294,14 +1371,17 @@ import Testing
             executablePath: cliPath,
             arguments: ["Docs"],
             environment: environment,
-            currentDirectoryURL: root,
-            timeout: 5
+            currentDirectoryURL: root
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "OK")
-        XCTAssertEqual(responder.receivedRequests, [])
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK",
+            result.diagnostics
+        )
+        XCTAssertEqual(responder.receivedRequests, [], result.diagnostics)
 
         let openArguments = try readFakeOpenArguments(from: openLogURL)
         XCTAssertEqual(openArguments.last, workingDirectory.standardizedFileURL.path)
@@ -1339,13 +1419,16 @@ import Testing
             executablePath: cliPath,
             arguments: ["--socket", socketPath, "."],
             environment: environment,
-            currentDirectoryURL: workingDirectory,
-            timeout: 5
+            currentDirectoryURL: workingDirectory
         )
 
-        XCTAssertFalse(result.timedOut, result.stdout)
-        XCTAssertEqual(result.status, 0, result.stdout)
-        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "OK workspace:explicit")
+        XCTAssertFalse(result.timedOut, result.diagnostics)
+        XCTAssertEqual(result.status, 0, result.diagnostics)
+        XCTAssertEqual(
+            result.stdout.trimmingCharacters(in: .whitespacesAndNewlines),
+            "OK workspace:explicit",
+            result.diagnostics
+        )
 
         let request = try XCTUnwrap(responder.receivedRequests.first)
         let requestData = try XCTUnwrap(request.data(using: .utf8))
@@ -1384,6 +1467,25 @@ import Testing
         let directory = CmuxStateDirectory.url(homeDirectory: home)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory.appendingPathComponent("cmux.sock", isDirectory: false)
+    }
+
+    /// Points the stable last-socket-path marker inside `home` at a path of the test's own.
+    ///
+    /// `CFFIXED_USER_HOME` moves the socket directory but not socket discovery: the CLI
+    /// reads the first marker file it can open, and the second candidate is the
+    /// machine-wide `/tmp/cmux-last-socket-path`, which on a developer's machine names the
+    /// socket of the cmux they are running. Writing the per-home marker keeps the candidate
+    /// list inside the test even when the test's own default socket is missing. The path
+    /// written is deliberately one that does not exist, so it can never be connected to.
+    private func writeStableSocketMarker(home: URL) throws {
+        let directory = CmuxStateDirectory.url(homeDirectory: home)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let markerURL = directory.appendingPathComponent(
+            SocketPathMarkerFiles.stableMarkerFileName,
+            isDirectory: false
+        )
+        try "/tmp/cmux-marker-\(UUID().uuidString.prefix(8)).sock\n"
+            .write(to: markerURL, atomically: true, encoding: .utf8)
     }
 
     private func writeTheme(named name: String, background: String, to directory: URL) throws {
@@ -1475,47 +1577,22 @@ import Testing
         "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
     }
 
-    private func lstatPathExists(_ path: String) -> Bool {
-        var st = stat()
-        return lstat(path, &st) == 0
-    }
-
-    private func runShell(_ command: String, timeout: TimeInterval) -> ProcessRunResult {
+    /// Runs a shell command with its environment spelled out.
+    ///
+    /// The environment is a required parameter. A child that inherits the test host's
+    /// environment also inherits whatever `CMUX_*` variables the host was launched with,
+    /// and that is one of the ways a spawned CLI ends up talking to the cmux the
+    /// developer is actually running.
+    private func runShell(
+        _ command: String,
+        environment: [String: String],
+        timeout: TimeInterval? = nil
+    ) -> ProcessRunResult {
         let process = Process()
-        let stdoutPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", command]
-        process.standardInput = FileHandle.nullDevice
-        process.standardOutput = stdoutPipe
-
-        do {
-            try process.run()
-        } catch {
-            return ProcessRunResult(status: -1, stdout: String(describing: error), timedOut: false)
-        }
-
-        let exitSignal = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            process.waitUntilExit()
-            exitSignal.signal()
-        }
-
-        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
-        if timedOut {
-            process.terminate()
-            if exitSignal.wait(timeout: .now() + 1) == .timedOut,
-               process.isRunning {
-                kill(process.processIdentifier, SIGKILL)
-                _ = exitSignal.wait(timeout: .now() + 1)
-            }
-        }
-
-        return ProcessRunResult(
-            status: process.terminationStatus,
-            stdout: String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
-            timedOut: timedOut,
-            terminationReason: process.terminationReason
-        )
+        process.environment = environment
+        return runToCompletion(process, timeout: timeout)
     }
 
     func runProcess(
@@ -1523,23 +1600,48 @@ import Testing
         arguments: [String],
         environment: [String: String],
         currentDirectoryURL: URL? = nil,
-        timeout: TimeInterval
+        timeout: TimeInterval? = nil
     ) -> ProcessRunResult {
         let process = Process()
-        let outputPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = arguments
         process.environment = environment
         process.currentDirectoryURL = currentDirectoryURL
+        return runToCompletion(process, timeout: timeout)
+    }
+
+    /// Runs `process` to completion, capturing stdout and stderr on separate pipes.
+    ///
+    /// Both readers start before the wait. Calling `readDataToEndOfFile()` only after
+    /// `waitUntilExit()` returns deadlocks as soon as the child fills a pipe buffer, and
+    /// that deadlock is indistinguishable from a hang inside the CLI.
+    ///
+    /// - Parameter timeout: This run's deadline. A test that asserts how long the CLI
+    ///   waits passes its own; everything else takes ``CMUXCLITestHangGuard/seconds``.
+    private func runToCompletion(
+        _ process: Process,
+        timeout: TimeInterval? = nil
+    ) -> ProcessRunResult {
+        let budget = timeout ?? CMUXCLITestHangGuard.seconds
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
         process.standardInput = FileHandle.nullDevice
-        process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
 
         do {
             try process.run()
         } catch {
-            return ProcessRunResult(status: -1, stdout: String(describing: error), timedOut: false)
+            // Five sibling suites share this runner and print only `stdout` when they
+            // fail, so a launch failure has to reach stdout as well or those tests
+            // report an empty message.
+            let message = "test runner could not spawn "
+                + "\(process.executableURL?.path ?? "<none>"): \(error)"
+            return ProcessRunResult(status: -1, stdout: message, stderr: message, timedOut: false)
         }
+
+        let stdoutDrain = PipeDrain(stdoutPipe.fileHandleForReading)
+        let stderrDrain = PipeDrain(stderrPipe.fileHandleForReading)
 
         let exitSignal = DispatchSemaphore(value: 0)
         DispatchQueue.global(qos: .userInitiated).async {
@@ -1547,7 +1649,7 @@ import Testing
             exitSignal.signal()
         }
 
-        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        let timedOut = exitSignal.wait(timeout: .now() + budget) == .timedOut
         if timedOut {
             process.terminate()
             if exitSignal.wait(timeout: .now() + 1) == .timedOut,
@@ -1557,12 +1659,47 @@ import Testing
             }
         }
 
+        // The child is gone by now, so its ends of both pipes are closed and each reader
+        // sees EOF. The ceiling covers a grandchild that inherited a write end and
+        // outlived its parent: report what was read rather than block the suite on it.
+        let stdoutText = stdoutDrain.text(waitingUpTo: 5)
+        let stderrText = stderrDrain.text(waitingUpTo: 5)
+
         return ProcessRunResult(
             status: process.terminationStatus,
-            stdout: String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+            stdout: stdoutText,
+            stderr: stderrText,
             timedOut: timedOut,
             terminationReason: process.terminationReason
         )
+    }
+
+    /// Reads one pipe on a background queue so a child writing more than a pipe buffer
+    /// never blocks while the test is waiting for it to exit.
+    private final class PipeDrain: @unchecked Sendable {
+        private let lock = NSLock()
+        private var data = Data()
+        private let finished = DispatchSemaphore(value: 0)
+
+        init(_ handle: FileHandle) {
+            DispatchQueue.global(qos: .userInitiated).async { [self] in
+                store(handle.readDataToEndOfFile())
+            }
+        }
+
+        private func store(_ read: Data) {
+            lock.lock()
+            data = read
+            lock.unlock()
+            finished.signal()
+        }
+
+        func text(waitingUpTo timeout: TimeInterval) -> String {
+            _ = finished.wait(timeout: .now() + timeout)
+            lock.lock()
+            defer { lock.unlock() }
+            return String(data: data, encoding: .utf8) ?? ""
+        }
     }
 
     private func fakeOpenScript() -> String {

--- a/cmuxTests/CMUXCLISessionsListForkDiagnosticsTests.swift
+++ b/cmuxTests/CMUXCLISessionsListForkDiagnosticsTests.swift
@@ -322,12 +322,16 @@ extension CMUXCLIErrorOutputRegressionTests {
     }
 
     @Test func testSessionsListDoesNotInferPiFamilyFromBasenameWhenStructuredIdentityDisagrees() throws {
+        // The agent and the launcher have to be a matched pair: a captured launch command is
+        // only used when its launcher describes the requested agent, and an unmatched pair is
+        // dropped, which leaves the record with no fork argv at all instead of exercising the
+        // rule below. "omo" is opencode's wrapper launcher, so this record is forkable and its
+        // structured identity is opencode, while the executable basename is still "pi" — that
+        // disagreement is what must not promote the record into the pi family. Nothing stats
+        // /tmp/pi here, because the omo launcher answers fork support before the opencode
+        // executable probe.
         let session = try sessionsListDiagnosticSession(
-            // Any non-pi-family catalog agent serves here; the property under test is that a
-            // /tmp/pi basename must not promote this record into the pi family. "project-agent"
-            // is not in the catalog at all, so the CLI rejected it before emitting any JSON and
-            // this test could never have run its assertions.
-            agent: "grok",
+            agent: "opencode",
             launcher: "omo",
             executablePath: "/tmp/pi",
             arguments: ["/tmp/pi", "omo"]

--- a/cmuxTests/CMUXCLISessionsListForkDiagnosticsTests.swift
+++ b/cmuxTests/CMUXCLISessionsListForkDiagnosticsTests.swift
@@ -282,7 +282,11 @@ extension CMUXCLIErrorOutputRegressionTests {
         processEnvironment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         processEnvironment["CMUX_AGENT_HOOK_STATE_DIR"] = stateDir.path
         let result = runProcess(executablePath: cliPath, arguments: ["sessions", "list", "--agent", agent, "--session", sessionId, "--json"], environment: processEnvironment, timeout: 5)
-        #expect(result.status == 0, Comment(rawValue: result.stdout))
+        // Require rather than expect: a non-zero exit means stdout holds an error message, and
+        // letting that fall through makes every caller fail on JSON parsing instead of on the real
+        // reason. That is how an unknown-agent fixture read as a decoding problem for a week.
+        try #require(!result.timedOut, Comment(rawValue: result.stdout))
+        try #require(result.status == 0, Comment(rawValue: result.stdout))
         let outputData = try #require(result.stdout.data(using: .utf8))
         let object = try #require(JSONSerialization.jsonObject(with: outputData) as? [String: Any])
         let sessions = try #require(object["sessions"] as? [[String: Any]])
@@ -319,7 +323,11 @@ extension CMUXCLIErrorOutputRegressionTests {
 
     @Test func testSessionsListDoesNotInferPiFamilyFromBasenameWhenStructuredIdentityDisagrees() throws {
         let session = try sessionsListDiagnosticSession(
-            agent: "project-agent",
+            // Any non-pi-family catalog agent serves here; the property under test is that a
+            // /tmp/pi basename must not promote this record into the pi family. "project-agent"
+            // is not in the catalog at all, so the CLI rejected it before emitting any JSON and
+            // this test could never have run its assertions.
+            agent: "grok",
             launcher: "omo",
             executablePath: "/tmp/pi",
             arguments: ["/tmp/pi", "omo"]

--- a/cmuxTests/CMUXCLITestAssertions.swift
+++ b/cmuxTests/CMUXCLITestAssertions.swift
@@ -1,6 +1,18 @@
 import Foundation
 import Testing
 
+/// How long a spawned CLI may run before the suite calls it a hang.
+///
+/// Most of these tests check what the CLI printed and which socket it talked to, never
+/// how fast it got there, so a tight per-test budget can only invent failures on a busy
+/// machine. This budget is the default for those runs: long enough that only a stuck
+/// process reaches it, and short enough that a stuck process still fails the test
+/// instead of stalling the suite forever. A test that genuinely measures how long the
+/// CLI waits passes its own, tighter budget instead.
+enum CMUXCLITestHangGuard {
+    static let seconds: TimeInterval = 60
+}
+
 extension CMUXCLIErrorOutputRegressionTests {
     func XCTAssertFalse(
         _ expression: @autoclosure () throws -> Bool,

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -1299,21 +1299,14 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 panelChanged: false
             )
         )
-        XCTAssertFalse(
-            ContentView.commandPaletteShouldReuseForkableAgentProbeResult(
-                panelKey: panelKey,
-                supportedPanelKeys: [panelKey],
-                supportedRemoteContextsByPanelKey: [panelKey: false],
-                snapshotFingerprintsByPanelKey: [panelKey: fingerprint],
-                expectedSnapshotFingerprint: nil,
-                isRemoteTerminal: false,
-                cachedResultHadFallback: true,
-                panelChanged: false
-            )
-        )
     }
 
-    func testForkableAgentProbeResultClearBeforeProbeClearsFallbackBackedCache() {
+    // A fallback-backed cache used to be refused here outright. That is no longer this
+    // helper's job: reuse is gated on TTL freshness, and the fallback case is re-verified
+    // against SharedLiveAgentIndex at the call site. Both directions of the freshness gate
+    // are covered by commandPaletteFallbackProbeResultReusesUntilValidationTTL in
+    // WorkspaceForkConversationContextMenuTests, so there is nothing to assert twice.
+    func testForkableAgentProbeResultClearBeforeProbeClearsStaleCache() {
         let workspaceId = UUID()
         let panelId = UUID()
         let panelKey = ContentView.commandPaletteForkableAgentPanelKey(
@@ -1331,18 +1324,6 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 expectedSnapshotFingerprint: fingerprint,
                 isRemoteTerminal: false,
                 cachedResultHadFallback: false,
-                panelChanged: false
-            )
-        )
-        XCTAssertTrue(
-            ContentView.commandPaletteShouldClearForkableAgentProbeResultBeforeProbe(
-                panelKey: panelKey,
-                supportedPanelKeys: [panelKey],
-                supportedRemoteContextsByPanelKey: [panelKey: false],
-                snapshotFingerprintsByPanelKey: [panelKey: fingerprint],
-                expectedSnapshotFingerprint: fingerprint,
-                isRemoteTerminal: false,
-                cachedResultHadFallback: true,
                 panelChanged: false
             )
         )

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1966,7 +1966,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
     }
 
     @MainActor
-    func testDaemonBootstrapUploadUsesAbsoluteHomePathForScpDestination() throws {
+    func testDaemonBootstrapUploadUsesAbsoluteHomePathForRemoteDestination() throws {
         let fileManager = FileManager.default
         let directoryURL = fileManager.temporaryDirectory.appendingPathComponent(
             "cmux-remote-daemon-upload-\(UUID().uuidString)",
@@ -2000,10 +2000,11 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         // configureRemoteConnection enqueues its session transition as a main-actor Task.
         // Blocking the main actor here would stop that Task from ever being scheduled,
         // so the work being waited on could never happen. wait(for:) pumps the run loop.
-        let scpInvoked = expectation(description: "daemon upload invoked")
-        scpInvoked.assertForOverFulfill = false
+        let uploadInvoked = expectation(description: "daemon upload invoked")
+        uploadInvoked.assertForOverFulfill = false
         let lock = NSLock()
-        var scpDestination: String?
+        var uploadCommand: String?
+        var uploadDestination: String?
         let remoteProcessScript: RemoteProcessScript = { executable, arguments, _, _ in
             if executable == "/usr/bin/ssh" {
                 let command = arguments.last ?? ""
@@ -2022,14 +2023,25 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 if command.contains("mkdir -p") {
                     return (status: 0, stdout: "", stderr: "")
                 }
+                // The daemon upload streams the binary through an ssh exec channel into `cat >`
+                // rather than shelling out to scp, so the remote path this test is about arrives
+                // inside the command and the destination host is its own argument.
+                if command.contains("cat > ") {
+                    lock.lock()
+                    uploadCommand = command
+                    uploadDestination = arguments.dropLast().last
+                    lock.unlock()
+                    uploadInvoked.fulfill()
+                    return (status: 1, stdout: "", stderr: "intentional stop after upload destination capture")
+                }
                 return (status: 0, stdout: "", stderr: "")
             }
             if executable == "/usr/bin/scp" {
-                lock.lock()
-                scpDestination = arguments.last
-                lock.unlock()
-                scpInvoked.fulfill()
-                return (status: 1, stdout: "", stderr: "intentional stop after upload destination capture")
+                // Discriminating, not defensive: if the upload ever goes back to scp this test
+                // should say so rather than quietly waiting out its budget, which is exactly how
+                // it failed when the transport moved and the stub did not.
+                XCTFail("daemon upload used scp; it is expected to stream over the ssh exec channel")
+                return (status: 1, stdout: "", stderr: "unexpected scp")
             }
             XCTFail("unexpected executable \(executable)")
             return (status: 1, stdout: "", stderr: "unexpected executable")
@@ -2054,19 +2066,24 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 
         workspace.configureRemoteConnection(config, autoConnect: true)
 
-        wait(for: [scpInvoked], timeout: 2.0)
+        wait(for: [uploadInvoked], timeout: 2.0)
         lock.lock()
-        let capturedDestination = scpDestination
+        let capturedCommand = uploadCommand
+        let capturedDestination = uploadDestination
         lock.unlock()
-        let destination = try XCTUnwrap(capturedDestination)
+        // The property under test is unchanged — the daemon lands on an absolute path under the
+        // remote HOME rather than a relative one — but it now lives in the remote command instead
+        // of an scp destination, so assert it there.
+        let command = try XCTUnwrap(capturedCommand)
         XCTAssertTrue(
-            destination.hasPrefix("test@hpc.example:/home/test/.cmux/bin/cmuxd-remote/"),
-            "expected scp to target an absolute path under remote HOME, got \(destination)"
+            command.contains("/home/test/.cmux/bin/cmuxd-remote/"),
+            "expected the upload to target an absolute path under remote HOME, got \(command)"
         )
         XCTAssertTrue(
-            destination.contains("/linux-amd64/cmuxd-remote.tmp-"),
-            "expected daemon platform temp path in \(destination)"
+            command.contains("/linux-amd64/cmuxd-remote.tmp-"),
+            "expected daemon platform temp path in \(command)"
         )
+        XCTAssertEqual(try XCTUnwrap(capturedDestination), "test@hpc.example")
     }
 
     @MainActor
@@ -2090,10 +2107,12 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 
         // Expectation rather than a semaphore, for the reason above: blocking the main
         // actor would starve the session transition this test is waiting on.
-        let scpInvoked = expectation(description: "daemon upload invoked")
-        scpInvoked.assertForOverFulfill = false
+        let uploadInvoked = expectation(description: "daemon upload invoked")
+        uploadInvoked.assertForOverFulfill = false
         let lock = NSLock()
-        var scpDestination: String?
+        var uploadCommand: String?
+        var helloCountBeforeUpload = 0
+        var helloCount = 0
         let remoteProcessScript: RemoteProcessScript = { executable, arguments, _, _ in
             let executableName = URL(fileURLWithPath: executable).lastPathComponent
             if executable == "/usr/bin/ssh" {
@@ -2111,6 +2130,9 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                     )
                 }
                 if remoteDaemonServeCommand(command) {
+                    lock.lock()
+                    helloCount += 1
+                    lock.unlock()
                     return (
                         status: 0,
                         stdout: #"{"id":1,"ok":true,"result":{"name":"cmuxd-remote","version":"old","capabilities":["proxy.stream.push"]}}"# + "\n",
@@ -2120,14 +2142,23 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 if command.contains("mkdir -p") {
                     return (status: 0, stdout: "", stderr: "")
                 }
+                // The upload streams over the ssh exec channel into `cat >`, not scp. Recording how
+                // many hellos preceded it is what keeps this test about a *reinstall*: an upload
+                // before any hello would be a first install and would not exercise the
+                // missing-capability path this test is named for.
+                if command.contains("cat > ") {
+                    lock.lock()
+                    uploadCommand = command
+                    helloCountBeforeUpload = helloCount
+                    lock.unlock()
+                    uploadInvoked.fulfill()
+                    return (status: 1, stdout: "", stderr: "intentional stop after capability reinstall")
+                }
                 return (status: 0, stdout: "", stderr: "")
             }
             if executable == "/usr/bin/scp" {
-                lock.lock()
-                scpDestination = arguments.last
-                lock.unlock()
-                scpInvoked.fulfill()
-                return (status: 1, stdout: "", stderr: "intentional stop after capability reinstall")
+                XCTFail("daemon upload used scp; it is expected to stream over the ssh exec channel")
+                return (status: 1, stdout: "", stderr: "unexpected scp")
             }
             if executableName == "go" {
                 if let outputFlagIndex = arguments.firstIndex(of: "-o"),
@@ -2166,14 +2197,22 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 
         workspace.configureRemoteConnection(config, autoConnect: true)
 
-        wait(for: [scpInvoked], timeout: 2.0)
+        wait(for: [uploadInvoked], timeout: 2.0)
         lock.lock()
-        let capturedDestination = scpDestination
+        let capturedCommand = uploadCommand
+        let capturedHelloCount = helloCountBeforeUpload
         lock.unlock()
-        let destination = try XCTUnwrap(capturedDestination)
+        let command = try XCTUnwrap(capturedCommand)
         XCTAssertTrue(
-            destination.hasPrefix("test@hpc.example:/home/test/.cmux/bin/cmuxd-remote/"),
-            "expected missing pty.session to reinstall the old daemon, got \(destination)"
+            command.contains("/home/test/.cmux/bin/cmuxd-remote/"),
+            "expected missing pty.session to reinstall the old daemon, got \(command)"
+        )
+        // Without this the test would also pass on a plain first install, which is not what it is
+        // named for: the reinstall is only meaningful once a hello has reported the old capabilities.
+        XCTAssertGreaterThan(
+            capturedHelloCount,
+            0,
+            "expected the reinstall to follow a capability hello, not to be a first install"
         )
     }
 

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -115,6 +115,14 @@ private final class NativeSSHCleanupRecorder {
 }
 
 final class WorkspaceRemoteConnectionTests: XCTestCase {
+    /// A control path in the resolved form the broker will claim lifecycle ownership of:
+    /// the cmux prefix followed by 40 hex digits, which is what `ssh -G` expands `%C` into
+    /// before a configuration reaches the app. `NativeSSHControlMasterKey` refuses to own a
+    /// path still containing `%`, so a fixture carrying a raw `%C` template never gets a
+    /// lease and can never produce a cleanup request.
+    private static let resolvedControlPath =
+        "/tmp/cmux-ssh-\(getuid())-0123456789abcdef0123456789abcdef01234567"
+
     private struct ProcessRunResult {
         let status: Int32, stdout: String, stderr: String
         let timedOut: Bool
@@ -1036,7 +1044,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
     }
 
     @MainActor
-    func testForegroundSSHAuthReadyBeforeRemoteConfigureStartsDeferredConnect() {
+    func testForegroundSSHAuthReadyBeforeRemoteConfigureStartsDeferredConnect() async {
         let workspace = Workspace()
         let config = WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",
@@ -1069,12 +1077,16 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             "ControlPath=\(resolvedControlPath)"
         )
         XCTAssertEqual(workspace.remoteConnectionState, .connecting)
+        // configureRemoteConnection enqueues the session transition as a serialized main-actor
+        // Task; the controller id is assigned when that transition starts the controller, which
+        // is one hop later. Await the transition rather than reading the id straight after.
+        await workspace.remoteSessionTransitionTask?.value
         XCTAssertNotNil(workspace.activeRemoteSessionControllerID)
         workspace.disconnectRemoteConnection(clearConfiguration: true)
     }
 
     @MainActor
-    func testForegroundSSHAuthReadyReconnectsConfiguredConnectingRemoteWorkspace() {
+    func testForegroundSSHAuthReadyReconnectsConfiguredConnectingRemoteWorkspace() async {
         let workspace = Workspace()
         let config = WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",
@@ -1094,6 +1106,10 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         XCTAssertNil(workspace.activeRemoteSessionControllerID)
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-a")
         XCTAssertEqual(workspace.remoteConnectionState, .connecting)
+        // The XCTAssertNil above is the point of this test — no controller starts until
+        // authentication lands — so the wait belongs here, after the notification, not after
+        // configureRemoteConnection.
+        await workspace.remoteSessionTransitionTask?.value
         XCTAssertNotNil(workspace.activeRemoteSessionControllerID)
         workspace.disconnectRemoteConnection(clearConfiguration: true)
     }
@@ -1180,7 +1196,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
                 "StrictHostKeyChecking=accept-new",
             ],
             localProxyPort: nil,
@@ -1211,7 +1227,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 "-o", "ControlMaster=no",
                 "-p", "2222",
                 "-i", "/Users/test/.ssh/id_ed25519",
-                "-o", "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "-o", "ControlPath=\(Self.resolvedControlPath)",
                 "-o", "StrictHostKeyChecking=accept-new",
                 "-O", "exit",
                 "cmux-macmini",
@@ -1230,7 +1246,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64035,
@@ -1257,7 +1273,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 "-o", "ControlMaster=no",
                 "-p", "2222",
                 "-i", "/Users/test/.ssh/id_ed25519",
-                "-o", "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "-o", "ControlPath=\(Self.resolvedControlPath)",
                 "-O", "exit",
                 "cmux-macmini",
             ]
@@ -1275,7 +1291,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
                 "StrictHostKeyChecking=accept-new",
             ],
             localProxyPort: nil,
@@ -1327,7 +1343,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64014,
@@ -1356,7 +1372,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             [
                 "-o", "BatchMode=yes",
                 "-o", "ControlMaster=no",
-                "-o", "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "-o", "ControlPath=\(Self.resolvedControlPath)",
                 "-O", "exit",
                 "cmux-macmini",
             ]
@@ -1411,7 +1427,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
                 "StrictHostKeyChecking=accept-new",
             ],
             localProxyPort: nil,
@@ -1441,12 +1457,50 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 "-o", "ControlMaster=no",
                 "-p", "2222",
                 "-i", "/Users/test/.ssh/id_ed25519",
-                "-o", "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "-o", "ControlPath=\(Self.resolvedControlPath)",
                 "-o", "StrictHostKeyChecking=accept-new",
                 "-O", "exit",
                 "cmux-macmini",
             ]
         )
+    }
+
+    @MainActor
+    func testClosingRemoteWorkspaceWithUnresolvedControlTemplateRequestsNoCleanup() throws {
+        // The counterpart to the test above. An unresolved `%C` template is deliberately left
+        // unowned, because cmux cannot know which socket it will expand to, so closing the
+        // workspace must not try to tear a master down. Legacy unresolved masters are retired by
+        // ControlPersist instead. Without this, every cleanup fixture could quietly regress to a
+        // template and the suite would still pass, having stopped testing cleanup at all.
+        let cleanup = NativeSSHCleanupRecorder()
+        let manager = TabManager(nativeSSHConnectionBroker: cleanup.broker)
+        let remoteWorkspace = manager.addWorkspace()
+        let config = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: 2222,
+            identityFile: "/Users/test/.ssh/id_ed25519",
+            sshOptions: [
+                "ControlMaster=auto",
+                "ControlPersist=600",
+                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "StrictHostKeyChecking=accept-new",
+            ],
+            localProxyPort: nil,
+            relayPort: 64019,
+            relayID: String(repeating: "a", count: 16),
+            relayToken: String(repeating: "b", count: 64),
+            localSocketPath: "/tmp/cmux-debug-test.sock",
+            terminalStartupCommand: "ssh cmux-macmini"
+        )
+        let cleanupRequested = expectation(description: "control master cleanup requested")
+        cleanupRequested.isInverted = true
+        cleanup.onRequest = { cleanupRequested.fulfill() }
+
+        remoteWorkspace.configureRemoteConnection(config, autoConnect: false)
+        manager.closeWorkspace(remoteWorkspace)
+
+        wait(for: [cleanupRequested], timeout: 1.0)
+        XCTAssertTrue(cleanup.arguments.isEmpty, "expected no cleanup for an unresolved control template, got \(cleanup.arguments)")
     }
 
     @MainActor
@@ -1460,7 +1514,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64016,
@@ -1675,7 +1729,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64017,
@@ -1727,7 +1781,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64018,
@@ -1779,7 +1833,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64019,
@@ -1829,7 +1883,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64013,
@@ -1867,7 +1921,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             sshOptions: [
                 "ControlMaster=auto",
                 "ControlPersist=600",
-                "ControlPath=/tmp/cmux-ssh-\(getuid())-%C",
+                "ControlPath=\(Self.resolvedControlPath)",
             ],
             localProxyPort: nil,
             relayPort: 64020,
@@ -1942,7 +1996,12 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             }
         }
 
-        let scpInvoked = DispatchSemaphore(value: 0)
+        // An XCTestExpectation, not a semaphore: these tests are @MainActor, and
+        // configureRemoteConnection enqueues its session transition as a main-actor Task.
+        // Blocking the main actor here would stop that Task from ever being scheduled,
+        // so the work being waited on could never happen. wait(for:) pumps the run loop.
+        let scpInvoked = expectation(description: "daemon upload invoked")
+        scpInvoked.assertForOverFulfill = false
         let lock = NSLock()
         var scpDestination: String?
         let remoteProcessScript: RemoteProcessScript = { executable, arguments, _, _ in
@@ -1969,7 +2028,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 lock.lock()
                 scpDestination = arguments.last
                 lock.unlock()
-                scpInvoked.signal()
+                scpInvoked.fulfill()
                 return (status: 1, stdout: "", stderr: "intentional stop after upload destination capture")
             }
             XCTFail("unexpected executable \(executable)")
@@ -1995,7 +2054,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 
         workspace.configureRemoteConnection(config, autoConnect: true)
 
-        XCTAssertEqual(scpInvoked.wait(timeout: .now() + 2), .success)
+        wait(for: [scpInvoked], timeout: 2.0)
         lock.lock()
         let capturedDestination = scpDestination
         lock.unlock()
@@ -2029,7 +2088,10 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             }
         }
 
-        let scpInvoked = DispatchSemaphore(value: 0)
+        // Expectation rather than a semaphore, for the reason above: blocking the main
+        // actor would starve the session transition this test is waiting on.
+        let scpInvoked = expectation(description: "daemon upload invoked")
+        scpInvoked.assertForOverFulfill = false
         let lock = NSLock()
         var scpDestination: String?
         let remoteProcessScript: RemoteProcessScript = { executable, arguments, _, _ in
@@ -2064,7 +2126,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 lock.lock()
                 scpDestination = arguments.last
                 lock.unlock()
-                scpInvoked.signal()
+                scpInvoked.fulfill()
                 return (status: 1, stdout: "", stderr: "intentional stop after capability reinstall")
             }
             if executableName == "go" {
@@ -2104,7 +2166,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
 
         workspace.configureRemoteConnection(config, autoConnect: true)
 
-        XCTAssertEqual(scpInvoked.wait(timeout: .now() + 2), .success)
+        wait(for: [scpInvoked], timeout: 2.0)
         lock.lock()
         let capturedDestination = scpDestination
         lock.unlock()


### PR DESCRIPTION
Three unrelated red suites, one commit each. All three are test-side defects; no product code changes.

Measured on `main` at `b5fac3145f`, one suite per app host, base arm and fix arm on the same base.

| suite | before | after |
|---|---|---|
| `CommandPaletteSearchEngineTests` | 2 failures, 65 tests | **0 failures**, 65 tests |
| `WorkspaceRemoteConnectionTests` | 10 failures, **38** tests executed, 2 host restarts | **0 failures**, all **83** executed, **0** restarts |
| `CMUXCLIErrorOutputRegressionTests` | 6 failing tests | 2 failing, 47 run |

## The remote-connection suite was hiding most of itself

`testPersistentReverseRelayCancelsStaleControlMasterForwardBeforeReusingRelayPort` asserts
`operations.count >= 2` and then reads `operations[0]`. A count assertion does not stop execution, so
when it fails the next line traps: `Fatal error: Index out of range`. That takes down the shared app
host rather than failing one test, and every verdict still pending in that host is absent from the
summary instead of red. It happened twice in one run. Both sites now unwrap instead of subscripting,
which is why the executed count goes from 38 to 83 — the back half of the suite had not been running
at all.

Four `@MainActor` tests waited on a `DispatchSemaphore`. `configureRemoteConnection` enqueues its
session transition as a serialized main-actor `Task`, so blocking the main actor stopped the very work
being waited on from ever being scheduled. They now use expectations, which pump the run loop. One of
those four was not in the failing set I started from and turned out to be failing too.

Fifteen fixtures passed an unresolved `%C` control path. `NativeSSHControlMasterKey` deliberately
refuses to claim lifecycle ownership of a path it cannot resolve, so no lease was taken and cleanup
could never run — and six inverted expectations were passing vacuously as a consequence, since they
assert that cleanup does *not* happen. They now use the resolved 40-hex form `ssh -G` produces, and a
new test pins the unowned-template policy so the fixtures cannot quietly regress to a template and take
the coverage with them.

Two more read `activeRemoteSessionControllerID` immediately after `configureRemoteConnection` and now
await the transition.

## The palette assertions were asserting a gate that no longer exists

#8173 replaced the fork-probe reuse gate: `!cachedResultHadFallback` became `cachedResultIsFresh`, and
the fallback case is now re-verified against `SharedLiveAgentIndex` at the call site rather than being
refused outright. The parameter stayed in both helper signatures, so two assertions still compiled while
asserting the opposite of what the product does. `WorkspaceForkConversationContextMenuTests` asserts the
new contract in both directions, so removing them loses no coverage; I ran that suite to confirm the
change does not flip it.

Removing the now-dead `cachedResultHadFallback` parameter would have turned this into a compile error at
review time instead of two silently wrong assertions. That is worth doing and is not in this PR.

## The CLI fixture broke its own invariant

The CLI derives a theme reload target from the socket file name, collapsing runs of non-alphanumerics in
the slug to dots. #6452 gave this fixture a unique socket path with a raw `UUID` to stop two runs
colliding in `/tmp`, which put the UUID's dashes into the derived identifier as dots — so the expected
literal could no longer match and the test spent its five-second budget waiting. The `stdout` assertion
kept passing because the derived id still has the expected value as a prefix, which is why this looked
like a timeout rather than a mismatch. The unique suffix is now hex-only, and the expected identifier
stays a plain template rather than a call into the CLI's own helper, which would agree by construction.

## Two commits added since the measurements above

The remote-connection suite reached zero because two of its tests were waiting on a transport that no
longer exists. #8434 moved the daemon upload off `scp` onto the ssh exec channel, streaming the binary
into `cat >`, and did not touch these tests — whose stubs only fulfilled inside an
`executable == "/usr/bin/scp"` branch. Both now capture the upload from the ssh branch, and the scp
branch is kept as a loud failure so a transport regression cannot present as a timeout again. The
reinstall test also records how many capability hellos preceded the upload and requires at least one,
because retargeting alone would have let it pass on a plain first install.

Three CLI fixtures were also wrong. Two replied to the CLI with a bareword: `SocketClient` accepts only
`OK`, `OK …`, `PONG`, `ERROR: …` or JSON as a complete single-line reply, so a bareword sends it into
the multiline drain pass, where reconfiguring the receive timeout on an already-closed socket fails
with EINVAL and the CLI prints "Invalid argument" instead of the reply it had buffered. They were the
only two barewords in the suite. Both now also assert which responder received the request, which is
the property they exist for and cannot be made vacuous by a later change to the reply.

## What is still red, and why I am not claiming otherwise

`CMUXCLIErrorOutputRegressionTests` runs 47 tests with 2 still failing, down from 6.

`testCLIErrorPathDoesNotCrashWhenStderrIsClosed` asserts a CLI that no longer exists: since #f48922aa94
an unknown command exits 2 with a one-line message and no usage dump, and that message goes to stderr,
which the test closes. The crash it was written to catch is still real, so the fix is to keep the guard
and drop the stale expectations, which needs `terminationReason` plumbed through the runner rather than
a fixture edit.

`testSessionsListDoesNotInferPiFamilyFromBasenameWhenStructuredIdentityDisagrees` passed `agent:
"project-agent"`, which is not in the CLI's catalog, so the command errored before emitting JSON and the
test had never once run its assertions. Switching to a catalog agent got it running for the first time,
and the assertions then failed with `fork_unavailable_reason = "agent_has_no_fork_command"` — the
fixture also needs an agent that has a fork command, which the one I picked does not. Still red, now for
a reason the failure output states plainly.

Two further things this suite needs that are not fixture-sized, and are not in this PR. Its shared
runner merges stderr into the stdout pipe that around thirty tests then parse as JSON, so one stray
diagnostic line fails a content test; and it reads that pipe only after waiting, so a full buffer
presents as a timeout. Separately, `CFFIXED_USER_HOME` does not isolate socket resolution, because
`readLastSocketPath` also consults the machine-global `/tmp/cmux-last-socket-path` — measured, a CLI
spawned with a pristine temp home and a scrubbed environment still reached a live running app. Three
tests also bind `/tmp/cmux.sock`, and the responder unlinks a path before binding it.
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787469216&installation_model_id=21920&pr_number=8836&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8836&signature=33eabfa1bd8762c479c023323b3bef8d3e2e8986648b610fa8ba9ab961814d19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three red test suites and stops the remote‑connection tests from killing their host. Restores full execution of `WorkspaceRemoteConnectionTests` (38→83, 0 restarts), makes `CommandPaletteSearchEngineTests` green, and hardens CLI regression tests; no product code changes.

- **Bug Fixes**
  - Remote-connection tests: replace semaphores with expectations; await session transitions; use `XCTUnwrap` instead of indexing; switch fixtures to a resolved 40‑hex `ControlPath` and add a test asserting unowned `%C` templates request no cleanup; retarget daemon‑upload to the ssh exec channel (`cat >`), assert absolute HOME paths and destination host, fail if `scp` is used, and require a capability hello before reinstall (test renamed).
  - Command palette: remove obsolete `cachedResultHadFallback` assertions and rename the clear test to reflect stale‑cache behavior; freshness‑gate coverage lives in `WorkspaceForkConversationContextMenuTests`.
  - CLI: isolate spawns from the machine’s cmux (pin `CMUX_SOCKET_PATH` where not testing resolution, write per‑home last‑socket marker, avoid binding `/tmp/cmux.sock`); capture stderr on its own pipe with background drains and add a 60‑second hang guard; fix socket‑selection tests to use OK‑framed replies and assert which socket handled the request; sessions list diagnostics now require a completed, zero‑exit run and use catalog agent `opencode` with `omo`; the stderr‑closed guard runs under `exec`, pins `CMUX_SOCKET_PATH` and HOME, asserts exit 1, and verifies no signal; theme reload tests derive the target from a dash‑free socket suffix and scope bundle IDs (and nightly sockets) per run.

<sup>Written for commit 06cd24c4ac71b44186224284789cdb9b05771567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated CLI socket-resolution regression fixtures and expectations for stricter reply framing; added deterministic environment setup and clearer assertions about which responder handled requests.
  * Strengthened command palette search engine coverage by separating stale-cache invalidation from reuse/clearing behavior, improving forkable-agent probe scenarios.
  * Improved sessions list diagnostics tests with hard failure checks, ensuring processes don’t time out and exit with the expected status.
  * Hardened remote connection tests with deterministic SSH ControlPath lifecycle handling and more reliable async synchronization; improved PTY/relay bootstrap assertions.
  * Enhanced CLI test diagnostics (stdout/stderr capture, signal classification) and added a consistent per-process hang guard timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
