### PR TITLE
Kill corpse-redials and make Iroh client dials single-flight per peer

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
@@ -9,6 +9,16 @@ actor CmxIrohClientSessionPool {
         let deviceID: String
     }
 
+    private struct PeerKey: Hashable, Sendable {
+        let identity: CmxIrohPeerIdentity
+        let deviceID: String
+
+        init(_ key: SessionKey) {
+            identity = key.identity
+            deviceID = key.deviceID
+        }
+    }
+
     private struct PendingConnection: Sendable {
         let id: UUID
         let task: Task<CmxIrohClientSession, any Error>
@@ -39,26 +49,39 @@ actor CmxIrohClientSessionPool {
     private let contextProvider: any CmxIrohClientContextProvider
     private let protocolConfiguration: CmxIrohProtocolConfiguration
     private let diagnosticLog: DiagnosticLog?
+    private let clock: any CmxIrohRelayClock
     private var lifecycleRevision: UInt64 = 0
     private var nextDiagnosticSessionID = 0
     private var runtimeGeneration: UInt64?
     private var sessions: [SessionKey: PooledSession] = [:]
     private var sessionOrder: [SessionKey] = []
     private var connectionTasks: [SessionKey: PendingConnection] = [:]
+    private var retiredDialDrains: [PeerKey: [UUID: Task<Void, Never>]] = [:]
+    private var retiredDialWaiters: [
+        PeerKey: [UUID: CheckedContinuation<Void, Never>]
+    ] = [:]
     private var controlOwners: [SessionKey: ControlOwner] = [:]
     private var controlWaiters: [SessionKey: [ControlWaiter]] = [:]
     private var selectedPathContinuations: [UUID: AsyncStream<Void>.Continuation] = [:]
+
+    /// Upper bound on how long a new dial defers to a cancelled predecessor that
+    /// ignores cancellation. Past the bound the new dial proceeds (accepting the
+    /// old overlap behavior) so one wedged iroh dial cannot become a permanent
+    /// connect outage for that Mac.
+    static var retiredDialSettleWaitLimitSeconds: TimeInterval { 10 }
 
     init(
         supervisor: CmxIrohEndpointSupervisor,
         contextProvider: any CmxIrohClientContextProvider,
         protocolConfiguration: CmxIrohProtocolConfiguration = .cmuxMobileV1,
-        diagnosticLog: DiagnosticLog? = nil
+        diagnosticLog: DiagnosticLog? = nil,
+        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock()
     ) {
         self.supervisor = supervisor
         self.contextProvider = contextProvider
         self.protocolConfiguration = protocolConfiguration
         self.diagnosticLog = diagnosticLog
+        self.clock = clock
     }
 
     func activate(runtimeGeneration: UInt64) async {
@@ -77,75 +100,100 @@ actor CmxIrohClientSessionPool {
         preservesControlOwnerOnClosed: Bool = false
     ) async throws -> CmxIrohClientSession {
         let key = try sessionKey(for: request)
-        while let pooled = sessions[key] {
-            let isClosed = await pooled.session.isClosed()
-            guard sessions[key]?.id == pooled.id else { continue }
-            if !isClosed {
-                return pooled.session
-            }
-            await invalidateSession(
-                for: key,
-                matching: pooled.id,
-                releasesControlOwner: !preservesControlOwnerOnClosed,
-                reason: .closedSessionEvicted,
-                failure: .connectionClosed
-            )
-        }
-
-        let revision = lifecycleRevision
-        let pending: PendingConnection
-        if let existing = connectionTasks[key] {
-            pending = existing
-        } else {
-            let supervisor = supervisor
-            let contextProvider = contextProvider
-            let protocolConfiguration = protocolConfiguration
-            let task = Task {
-                let endpoint = try await supervisor.activeEndpoint()
-                let context = try await contextProvider.context(for: request)
-                let session = try CmxIrohClientSession(
-                    endpoint: endpoint,
-                    targetIdentity: key.identity,
-                    dialPlan: context.dialPlan,
-                    credential: context.credential,
-                    privateFallbackAuthorization: context.privateFallbackAuthorization,
-                    privateFallbackValidator: contextProvider,
-                    privateFallbackContextProvider: {
-                        try await contextProvider.contextWithPrivateFallback(
-                            for: request,
-                            basedOn: context
-                        )
-                    },
-                    protocolConfiguration: protocolConfiguration
-                )
-                do {
-                    try await session.connect()
-                    try Task.checkCancellation()
-                    return session
-                } catch {
-                    await session.close()
-                    throw error
+        var corpseRetriesRemaining = 1
+        redial: while true {
+            while let pooled = sessions[key] {
+                let isClosed = await pooled.session.isClosed()
+                guard sessions[key]?.id == pooled.id else { continue }
+                if !isClosed {
+                    return pooled.session
                 }
+                await invalidateSession(
+                    for: key,
+                    matching: pooled.id,
+                    releasesControlOwner: !preservesControlOwnerOnClosed,
+                    reason: .closedSessionEvicted,
+                    failure: .connectionClosed
+                )
             }
-            pending = PendingConnection(id: UUID(), task: task)
-            connectionTasks[key] = pending
-        }
 
-        do {
-            let connected = try await pending.task.value
-            guard lifecycleRevision == revision else {
-                await connected.close()
-                throw CancellationError()
+            let revision = lifecycleRevision
+            let pending: PendingConnection
+            if let existing = connectionTasks[key] {
+                pending = existing
+            } else {
+                let peer = PeerKey(key)
+                let supervisor = supervisor
+                let contextProvider = contextProvider
+                let protocolConfiguration = protocolConfiguration
+                let task = Task { [weak self] in
+                    // Serialize behind cancelled predecessor dials so a corpse
+                    // admission can never race this dial's admission host-side.
+                    await self?.waitForRetiredDials(peer: peer)
+                    try Task.checkCancellation()
+                    let endpoint = try await supervisor.activeEndpoint()
+                    let context = try await contextProvider.context(for: request)
+                    let session = try CmxIrohClientSession(
+                        endpoint: endpoint,
+                        targetIdentity: key.identity,
+                        dialPlan: context.dialPlan,
+                        credential: context.credential,
+                        privateFallbackAuthorization: context.privateFallbackAuthorization,
+                        privateFallbackValidator: contextProvider,
+                        privateFallbackContextProvider: {
+                            try await contextProvider.contextWithPrivateFallback(
+                                for: request,
+                                basedOn: context
+                            )
+                        },
+                        protocolConfiguration: protocolConfiguration
+                    )
+                    do {
+                        try await session.connect()
+                        try Task.checkCancellation()
+                        return session
+                    } catch {
+                        await session.close()
+                        throw error
+                    }
+                }
+                pending = PendingConnection(id: UUID(), task: task)
+                connectionTasks[key] = pending
             }
-            if connectionTasks[key]?.id == pending.id {
-                connectionTasks[key] = nil
+
+            let connected: CmxIrohClientSession
+            do {
+                connected = try await pending.task.value
+                guard lifecycleRevision == revision else {
+                    await connected.close()
+                    throw CancellationError()
+                }
+                if connectionTasks[key]?.id == pending.id {
+                    connectionTasks[key] = nil
+                }
+            } catch {
+                if connectionTasks[key]?.id == pending.id {
+                    connectionTasks[key] = nil
+                }
+                throw error
             }
+
             if let installed = sessions[key] {
                 if installed.session !== connected {
                     await connected.close()
                 }
-                return installed.session
+                continue redial
             }
+
+            if await connected.isClosed() {
+                await connected.close()
+                guard corpseRetriesRemaining > 0 else {
+                    throw CmxIrohClientSessionError.alreadyClosed
+                }
+                corpseRetriesRemaining -= 1
+                continue redial
+            }
+
             let sessionID = UUID()
             let diagnosticID = makeDiagnosticSessionID()
             let closureTask = Task { [weak self] in
@@ -180,11 +228,6 @@ actor CmxIrohClientSessionPool {
             )
             publishSelectedPathChange()
             return connected
-        } catch {
-            if connectionTasks[key]?.id == pending.id {
-                connectionTasks[key] = nil
-            }
-            throw error
         }
     }
 
@@ -283,9 +326,9 @@ actor CmxIrohClientSessionPool {
 
     private func invalidateAll(reason: DiagnosticSessionLifecycleKind) async {
         lifecycleRevision &+= 1
-        let tasks = connectionTasks.values.map(\.task)
-        connectionTasks.removeAll(keepingCapacity: false)
-        for task in tasks { task.cancel() }
+        for key in Array(connectionTasks.keys) {
+            retirePendingConnection(for: key)
+        }
         let closing = sessions
         let closingOwners = controlOwners
         sessions.removeAll(keepingCapacity: false)
@@ -381,8 +424,7 @@ actor CmxIrohClientSessionPool {
         if let expectedID, sessions[key]?.id != expectedID { return }
         let currentOwner = controlOwners[key]
         let owner = releasesControlOwner ? currentOwner : nil
-        connectionTasks[key]?.task.cancel()
-        connectionTasks[key] = nil
+        retirePendingConnection(for: key)
         let pooled = sessions.removeValue(forKey: key)
         sessionOrder.removeAll { $0 == key }
         pooled?.closureTask.cancel()
@@ -400,6 +442,102 @@ actor CmxIrohClientSessionPool {
             releaseControlOwner(for: key, ownerID: owner.id)
         }
         publishSelectedPathChange()
+    }
+
+    /// Cancels the pending dial for `key` and tracks it until it fully resolves.
+    /// iroh's connect does not observe Swift cancellation, so a cancelled dial can
+    /// still complete QUIC admission on the host seconds later; the host then
+    /// closes the newer live connection for the same device. Draining retired
+    /// dials before the next dial starts keeps at most one admission in flight
+    /// per peer.
+    private func retirePendingConnection(for key: SessionKey) {
+        guard let pending = connectionTasks.removeValue(forKey: key) else { return }
+        pending.task.cancel()
+        let peer = PeerKey(key)
+        let drainID = UUID()
+        retiredDialDrains[peer, default: [:]][drainID] = Task { [weak self] in
+            // The dial task closes its own session on failure or observed
+            // cancellation; a session returned here won the post-cancellation
+            // race and must be settled (closed unless it was installed).
+            let orphan = try? await pending.task.value
+            if let self {
+                await self.settleRetiredDial(
+                    peer: peer,
+                    drainID: drainID,
+                    orphan: orphan
+                )
+            } else if let orphan {
+                await orphan.close()
+            }
+        }
+    }
+
+    private func settleRetiredDial(
+        peer: PeerKey,
+        drainID: UUID,
+        orphan: CmxIrohClientSession?
+    ) async {
+        if let orphan, !sessions.values.contains(where: { $0.session === orphan }) {
+            await orphan.close()
+        }
+        retiredDialDrains[peer]?[drainID] = nil
+        if retiredDialDrains[peer]?.isEmpty == true {
+            retiredDialDrains[peer] = nil
+        }
+        guard retiredDialDrains[peer] == nil,
+              let waiters = retiredDialWaiters.removeValue(forKey: peer) else {
+            return
+        }
+        for continuation in waiters.values {
+            continuation.resume()
+        }
+    }
+
+    /// Defers a fresh dial while cancelled predecessor dials for the same peer
+    /// are still resolving. Single-shot: waits for the drains present on entry,
+    /// bounded by `retiredDialSettleWaitLimitSeconds` via the injected clock, and
+    /// returns early if the waiting dial task itself is cancelled.
+    private func waitForRetiredDials(peer: PeerKey) async {
+        guard retiredDialDrains[peer]?.isEmpty == false else { return }
+        let waiterID = UUID()
+        let clock = clock
+        let deadline = clock.now()
+            .addingTimeInterval(Self.retiredDialSettleWaitLimitSeconds)
+        // This injected-clock sleep is the bounded deadline that prevents a
+        // permanently wedged retired dial from blocking all future connections.
+        let timeout = Task { [weak self] in
+            try? await clock.sleep(until: deadline)
+            guard !Task.isCancelled else { return }
+            await self?.resumeRetiredDialWaiter(peer: peer, waiterID: waiterID)
+        }
+        defer { timeout.cancel() }
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if retiredDialDrains[peer]?.isEmpty ?? true {
+                    continuation.resume()
+                } else {
+                    retiredDialWaiters[peer, default: [:]][waiterID] = continuation
+                }
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.resumeRetiredDialWaiter(
+                    peer: peer,
+                    waiterID: waiterID
+                )
+            }
+        }
+    }
+
+    private func resumeRetiredDialWaiter(peer: PeerKey, waiterID: UUID) {
+        guard let continuation = retiredDialWaiters[peer]?
+            .removeValue(forKey: waiterID) else {
+            return
+        }
+        if retiredDialWaiters[peer]?.isEmpty == true {
+            retiredDialWaiters[peer] = nil
+        }
+        continuation.resume()
     }
 
     private func invalidateSession(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolSingleFlightTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolSingleFlightTests.swift
@@ -1,0 +1,212 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohClientSessionPoolSingleFlightTests {
+    @Test
+    func deadOnArrivalDialIsNeverInstalledOrReturnedAndRedialsFresh() async throws {
+        let fixture = try SingleFlightPoolFixture()
+        let connection1 = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        await connection1.close(errorCode: 0, reason: "pre_dead")
+        let connection2 = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [
+                .connection(connection1),
+                .connection(connection2),
+            ]
+        )
+        let pool = try await fixture.pool(endpoint: endpoint, generation: 1)
+        let transport = try CmxIrohByteTransportFactory(sessionPool: pool)
+            .makeTransport(for: fixture.request)
+
+        try await transport.connect()
+
+        #expect(await endpoint.observedDialedAddresses().count == 2)
+        #expect(await connection1.observedCloseCallCount() >= 2)
+        #expect(await connection2.observedCloseCallCount() == 0)
+        await transport.close()
+        #expect(await connection2.observedCloseCallCount() == 1)
+        await pool.deactivate()
+    }
+
+    @Test
+    func concurrentAcquirersCoalesceOntoOneInFlightDial() async throws {
+        let fixture = try SingleFlightPoolFixture()
+        let connection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        let endpoint = TestGatedDialEndpoint(localIdentity: fixture.localIdentity)
+        let pool = try await fixture.pool(endpoint: endpoint, generation: 1)
+        let tasks = (0 ..< 4).map { _ in
+            Task {
+                try await pool.session(for: fixture.request)
+            }
+        }
+
+        let reachedDial = await waitForDialCount(endpoint, atLeast: 1)
+        #expect(reachedDial)
+        for _ in 0 ..< 200 {
+            await Task.yield()
+            #expect(await endpoint.observedDialCount() == 1)
+        }
+        await endpoint.releaseNextDial(with: connection)
+
+        let first = try await tasks[0].value
+        for task in tasks.dropFirst() {
+            #expect(try await task.value === first)
+        }
+        #expect(await endpoint.observedDialCount() == 1)
+        await pool.deactivate()
+        await endpoint.close()
+    }
+
+    @Test
+    func generationBumpDrainsCancelledDialBeforeRedialing() async throws {
+        let fixture = try SingleFlightPoolFixture()
+        let connection1 = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        let connection2 = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        let endpoint = TestGatedDialEndpoint(localIdentity: fixture.localIdentity)
+        let pool = try await fixture.pool(endpoint: endpoint, generation: 1)
+        let factory = CmxIrohByteTransportFactory(sessionPool: pool)
+        let transport1 = try factory.makeTransport(for: fixture.request)
+        let connect1 = Task {
+            try await transport1.connect()
+        }
+
+        #expect(await waitForDialCount(endpoint, atLeast: 1))
+        await pool.activate(runtimeGeneration: 2)
+
+        let transport2 = try factory.makeTransport(for: fixture.request)
+        let connect2 = Task {
+            try await transport2.connect()
+        }
+        for _ in 0 ..< 200 {
+            await Task.yield()
+            #expect(await endpoint.observedDialCount() == 1)
+        }
+
+        await endpoint.releaseNextDial(with: connection1)
+        #expect(await waitForCloseCount(connection1, atLeast: 1))
+        #expect(await waitForDialCount(endpoint, atLeast: 2))
+        await endpoint.releaseNextDial(with: connection2)
+        try await connect2.value
+
+        let firstConnectSucceeded: Bool
+        do {
+            try await connect1.value
+            firstConnectSucceeded = true
+        } catch {
+            firstConnectSucceeded = false
+        }
+        #expect(!firstConnectSucceeded)
+        #expect(await connection1.observedCloseCallCount() == 1)
+        #expect(await connection2.observedCloseCallCount() == 0)
+        await transport2.close()
+        await pool.deactivate()
+        await endpoint.close()
+    }
+
+    private func waitForDialCount(
+        _ endpoint: TestGatedDialEndpoint,
+        atLeast expectedCount: Int
+    ) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if await endpoint.observedDialCount() >= expectedCount { return true }
+            await Task.yield()
+        }
+        return false
+    }
+
+    private func waitForCloseCount(
+        _ connection: TestIrohConnection,
+        atLeast expectedCount: Int
+    ) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if await connection.observedCloseCallCount() >= expectedCount {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+}
+
+private struct SingleFlightPoolFixture {
+    let localIdentity: CmxIrohPeerIdentity
+    let remoteIdentity: CmxIrohPeerIdentity
+    let request: CmxByteTransportRequest
+    let context: CmxIrohClientContext
+
+    init() throws {
+        localIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "ab", count: 32)
+        )
+        remoteIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "cd", count: 32)
+        )
+        request = CmxByteTransportRequest(
+            route: try CmxAttachRoute(
+                id: "iroh-pool-single-flight",
+                kind: .iroh,
+                endpoint: .peer(identity: remoteIdentity, pathHints: [])
+            ),
+            expectedPeerDeviceID: "123e4567-e89b-42d3-a456-426614174030",
+            authorizationMode: .transportAdmission
+        )
+        context = CmxIrohClientContext(
+            dialPlan: try testIrohDialPlan(),
+            credential: try .pairGrant("e30.e30.AA")
+        )
+    }
+
+    func pool(
+        endpoint: any CmxIrohEndpoint,
+        generation: UInt64
+    ) async throws -> CmxIrohClientSessionPool {
+        let configuration = try CmxIrohEndpointConfiguration(
+            secretKey: CmxIrohSecretKey(bytes: Data(repeating: 7, count: 32)),
+            alpns: [CmxIrohProtocolConfiguration.cmuxMobileV1.alpn],
+            managedRelayURLs: [],
+            relays: []
+        )
+        let supervisor = CmxIrohEndpointSupervisor(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            configuration: configuration
+        )
+        _ = try await supervisor.activate()
+        let pool = CmxIrohClientSessionPool(
+            supervisor: supervisor,
+            contextProvider: TestIrohClientContextProvider(context: context),
+            protocolConfiguration: .testApplicationLanes
+        )
+        await pool.activate(runtimeGeneration: generation)
+        return pool
+    }
+
+    func controlStream() -> CmxIrohBidirectionalStream {
+        let admissionCodec = CmxIrohAdmissionAckCodec()
+        return CmxIrohBidirectionalStream(
+            receiveStream: TestIrohReceiveStream(
+                buffer: admissionCodec.encode(.accepted)
+                    + admissionCodec.encodeFrame(.serverReady)
+            ),
+            sendStream: TestIrohSendStream()
+        )
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolSingleFlightTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolSingleFlightTests.swift
@@ -122,6 +122,45 @@ struct CmxIrohClientSessionPoolSingleFlightTests {
         await endpoint.close()
     }
 
+    // Commit 2: this test depends on the pool's new injected clock parameter.
+    @Test
+    func wedgedRetiredDialDoesNotBlockRedialPastTheSettleBound() async throws {
+        let fixture = try SingleFlightPoolFixture()
+        let connection2 = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        let endpoint = TestGatedDialEndpoint(localIdentity: fixture.localIdentity)
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            clock: ImmediateHostActivationClock()
+        )
+        let factory = CmxIrohByteTransportFactory(sessionPool: pool)
+        let transport1 = try factory.makeTransport(for: fixture.request)
+        let connect1 = Task {
+            try await transport1.connect()
+        }
+
+        #expect(await waitForDialCount(endpoint, atLeast: 1))
+        await pool.activate(runtimeGeneration: 2)
+
+        let transport2 = try factory.makeTransport(for: fixture.request)
+        let connect2 = Task {
+            try await transport2.connect()
+        }
+        #expect(await waitForDialCount(endpoint, atLeast: 2))
+        await endpoint.releaseNewestDial(with: connection2)
+        try await connect2.value
+
+        #expect(await connection2.observedCloseCallCount() == 0)
+        connect1.cancel()
+        await endpoint.close()
+        _ = try? await connect1.value
+        await transport2.close()
+        await pool.deactivate()
+    }
+
     private func waitForDialCount(
         _ endpoint: TestGatedDialEndpoint,
         atLeast expectedCount: Int
@@ -177,7 +216,8 @@ private struct SingleFlightPoolFixture {
 
     func pool(
         endpoint: any CmxIrohEndpoint,
-        generation: UInt64
+        generation: UInt64,
+        clock: any CmxIrohRelayClock = CmxIrohSystemRelayClock()
     ) async throws -> CmxIrohClientSessionPool {
         let configuration = try CmxIrohEndpointConfiguration(
             secretKey: CmxIrohSecretKey(bytes: Data(repeating: 7, count: 32)),
@@ -193,7 +233,8 @@ private struct SingleFlightPoolFixture {
         let pool = CmxIrohClientSessionPool(
             supervisor: supervisor,
             contextProvider: TestIrohClientContextProvider(context: context),
-            protocolConfiguration: .testApplicationLanes
+            protocolConfiguration: .testApplicationLanes,
+            clock: clock
         )
         await pool.activate(runtimeGeneration: generation)
         return pool

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestGatedDialEndpoint.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestGatedDialEndpoint.swift
@@ -1,0 +1,73 @@
+import CMUXMobileCore
+import Foundation
+@testable import CmuxIrohTransport
+
+/// Test endpoint whose parked dials deliberately ignore task cancellation.
+actor TestGatedDialEndpoint: CmxIrohEndpoint {
+    private let localIdentity: CmxIrohPeerIdentity
+    private var dialCount = 0
+    private var pendingDials: [
+        CheckedContinuation<any CmxIrohConnection, any Error>
+    ] = []
+
+    init(localIdentity: CmxIrohPeerIdentity) {
+        self.localIdentity = localIdentity
+    }
+
+    func identity() -> CmxIrohPeerIdentity {
+        localIdentity
+    }
+
+    func address() -> CmxIrohEndpointAddress {
+        CmxIrohEndpointAddress(identity: localIdentity, pathHints: [])
+    }
+
+    func connect(
+        to _: CmxIrohEndpointAddress,
+        alpn _: Data
+    ) async throws -> any CmxIrohConnection {
+        dialCount += 1
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingDials.append(continuation)
+        }
+    }
+
+    func accept() async throws -> (any CmxIrohConnection)? {
+        nil
+    }
+
+    func replaceRelays(_: [CmxIrohRelayConfiguration]) {}
+
+    func healthEvents() -> AsyncStream<CmxIrohEndpointHealthEvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func isHealthy() -> Bool { true }
+
+    func close() {
+        let pending = pendingDials
+        pendingDials.removeAll()
+        for continuation in pending {
+            continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    func releaseNextDial(with connection: any CmxIrohConnection) {
+        guard !pendingDials.isEmpty else { return }
+        pendingDials.removeFirst().resume(returning: connection)
+    }
+
+    func releaseNewestDial(with connection: any CmxIrohConnection) {
+        guard !pendingDials.isEmpty else { return }
+        pendingDials.removeLast().resume(returning: connection)
+    }
+
+    func failNextDial(_ error: TestIrohTransportError) {
+        guard !pendingDials.isEmpty else { return }
+        pendingDials.removeFirst().resume(throwing: error)
+    }
+
+    func observedDialCount() -> Int {
+        dialCount
+    }
+}


### PR DESCRIPTION
Two client-side transport fixes for the recovery churn documented in https://github.com/manaflow-ai/cmux/issues/8531. Suspension-lifecycle redesign is out of scope here and stays tracked in https://github.com/manaflow-ai/cmux/issues/8573.

**Ring evidence.** Phone rings from 2026-07-22 and 2026-07-23 (role=1, decoded from `DiagnosticEventCode`/`DiagnosticTaxonomy` vocabulary) show two patterns. First, corpse-redials: after a session dies with a terminal close, the next acquire installs a session whose QUIC connection is already dead — the 07-22 ring shows `established` followed by `remoteClosed` 166 microseconds later at 14:11:17.069, then `transportDialStarted` -> `transportDialFailed ms=0 b=18 (connectionClosed)` with the same attempt id (3/3 involuntary deaths at 14:11:17, 14:20:36, 14:54:07 redialed the corpse). Second, the wake burst: on foreground after a suspension death (07-23 ring, 16:18:28-16:18:43) the phone runs five overlapping dial attempts to one Mac; sessions 35-39 each establish and die within 1-3 s as every late admission makes the host close the previously admitted connection for that device, burning ~4 sessions in ~3 s with duplicate concurrent dials and an `rpcFailed timedOut` before stabilizing.

**Root causes (client side, `CmxIrohClientSessionPool`).** (1) `session(for:)` validated pooled sessions on entry but installed and returned a freshly dialed session without checking liveness, so a connection that lost the race with a host-side close was still installed, handed to the caller, and instantly killed. (2) Pool invalidation (`invalidateAll` on the wake-path `activate(runtimeGeneration:)` bump from `CmxIrohClientRuntime.didBecomeActive()`, and per-session invalidation) cancelled the in-flight dial task and forgot it. iroh-ffi's connect ignores Swift cancellation, so the abandoned dial kept handshaking and completed admission on the host seconds later, which killed the newer live connection and re-triggered recovery — the murder loop in the ring.

**Fix.**
- Dead-on-arrival gate: `session(for:)` never installs or returns a session whose connection already reports closed; it closes the corpse and dials fresh once (then surfaces `alreadyClosed`, which classifies as `connectionClosed`). A raced-in installed session is also re-validated instead of being returned unchecked.
- Single-flight dials per peer: cancelled pending dials are retired into a drain set keyed by (identity, deviceID) — deliberately generation-independent, because the wake path bumps `runtimeGeneration` mid-dial. A new dial task first waits for retired dials for that peer to fully resolve (their sessions are settled: closed unless installed) before dialing, so at most one admission is ever in flight per Mac and concurrent recovery triggers (control acquire, event-stream restart, lane opens, straggler RPC redials) coalesce onto the one pending dial via the existing `connectionTasks` sharing.
- The drain wait is bounded (10 s via injected `CmxIrohRelayClock`, default system clock), so one wedged iroh dial degrades to today's overlap behavior instead of becoming a permanent connect outage for that Mac. Supersede semantics are preserved: `activate`/`deactivate`/explicit invalidation still cancel the in-flight dial immediately; a newer user-initiated connect is never blocked behind recovery, it coalesces or supersedes exactly as before.

**Tests** (two-commit red/green: commit 1 adds the failing tests, commit 2 the fix):
- `deadOnArrivalDialIsNeverInstalledOrReturnedAndRedialsFresh` — a pre-dead dialed connection is never handed to the caller; the pool redials fresh (red on main: only one dial happens and the corpse is returned).
- `concurrentAcquirersCoalesceOntoOneInFlightDial` — 4 concurrent acquirers produce exactly one dial and share one session.
- `generationBumpDrainsCancelledDialBeforeRedialing` — the wake sequence (dial in flight, `activate(runtimeGeneration: 2)`, new acquire) defers the new dial until the cancelled corpse dial resolves and its connection is closed (red on main: overlapping dials).
- `wedgedRetiredDialDoesNotBlockRedialPastTheSettleBound` — a wedged corpse dial delays the next dial only up to the settle bound.

Host-side admission registry, the iroh fork, and web/ are untouched. The `transportDialStarted`/`transportDialFailed ms=0` pair that a retired RPC client emits when its lifecycle gate refuses `makeTransport` is telemetry-only (no network dial happens) and is deliberately left alone to keep this slice bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787471283&installation_model_id=21920&pr_number=8840&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8840&signature=ca57bc9dcc290dc044bc85c954a8cfe8f74d4c3027dd35f657c3f8fb5e8d3bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops corpse-redials and overlapping wake dials by hardening the Iroh client session pool. Rejects already-closed connections and runs dials single-flight per peer to prevent host-side admission churn.

- **Bug Fixes**
  - Dead-on-arrival gate: `session(for:)` now checks liveness before install/return; closes corpses, redials once, and re-validates raced-in installs.
  - Single-flight dials per peer: cancelled dials are retired and drained by (identity, deviceID) across generations; new dials wait for drains (max 10s via injected `CmxIrohRelayClock`) so only one admission is in flight; coalescing and supersede semantics preserved.
  - Invalidation (`activate/deactivate` and per-session) now retires pending dials instead of cancel-and-forget to avoid late admissions killing newer connections; added targeted tests and a non-cancellable `TestGatedDialEndpoint`.

<sup>Written for commit c0799bacae198c7ed536ca6853dc6ebdc6a17db2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling to prevent overlapping connection attempts for the same peer.
  * Automatically retries when a newly connected session is already closed or becomes invalid.
  * Ensured cancelled or invalidated connections are cleaned up before new attempts proceed.
  * Added bounded waiting so stalled connections cannot block reconnection indefinitely.

* **Tests**
  * Added coverage for concurrent connection coalescing, failed initial connections, generation changes, cleanup, and recovery from stalled attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->