### PR TITLE
Honor terminal clipboard access confirmations

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
@@ -150,8 +150,8 @@ public final class GhosttyRuntime {
             GhosttyRuntime.handleAction(app, target: target, action: action)
         }
         runtimeConfig.read_clipboard_cb = cmuxIOSRuntimeReadClipboardCallback
-        runtimeConfig.confirm_read_clipboard_cb = { _, _, _, _ in
-            // iOS embed doesn't currently support clipboard confirmation prompts.
+        runtimeConfig.confirm_read_clipboard_cb = { userdata, _, state, _ in
+            GhosttyRuntime.denyClipboardRead(userdata, state: state)
         }
         runtimeConfig.write_clipboard_cb = { userdata, location, content, len, confirm in
             GhosttyRuntime.handleWriteClipboard(
@@ -346,6 +346,7 @@ public final class GhosttyRuntime {
         len: Int,
         confirm: Bool
     ) {
+        guard !confirm else { return }
         guard let content, len > 0 else { return }
 
         for index in 0..<len {
@@ -359,6 +360,32 @@ public final class GhosttyRuntime {
                 clipboardWriter(value)
             }
             return
+        }
+    }
+
+    nonisolated private static func denyClipboardRead(
+        _ userdata: UnsafeMutableRawPointer?,
+        state: UnsafeMutableRawPointer?
+    ) {
+        let userdataBits: Int = userdata.map { Int(bitPattern: $0) } ?? 0
+        let stateBits: Int = state.map { Int(bitPattern: $0) } ?? 0
+        Task { @MainActor in
+            let userdataPointer = userdataBits == 0
+                ? nil
+                : UnsafeMutableRawPointer(bitPattern: userdataBits)
+            let statePointer = stateBits == 0
+                ? nil
+                : UnsafeMutableRawPointer(bitPattern: stateBits)
+            guard let surfaceView = surfaceView(from: userdataPointer),
+                  let surface = surfaceView.surface else { return }
+            "".withCString { pointer in
+                ghostty_surface_complete_clipboard_request(
+                    surface,
+                    pointer,
+                    statePointer,
+                    true
+                )
+            }
         }
     }
 
@@ -452,6 +479,8 @@ private extension GhosttyRuntime {
         scrollback-limit = 2000000
         font-family = Menlo
         font-size = 10
+        clipboard-read = deny
+        clipboard-write = deny
         window-padding-balance = false
         window-padding-y = 0
         cursor-style = bar

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -869,19 +869,38 @@ class GhosttyApp {
         runtimeConfig.confirm_read_clipboard_cb = { userdata, content, state, _ in
             guard let content else { return }
             guard let callbackContext = GhosttyApp.callbackContext(from: userdata),
-                  let surface = callbackContext.runtimeSurface else { return }
+                  let requestSurface = callbackContext.runtimeSurface else { return }
 
-            ghostty_surface_complete_clipboard_request(surface, content, state, true)
+            let requestedContents = String(cString: content)
+            let stateBits: Int = state.map { Int(bitPattern: $0) } ?? 0
             DispatchQueue.main.async {
-                callbackContext.terminalSurface?.noteClipboardReadCompleted()
+                TerminalClipboardRuntimeBridge.handleReadConfirmation(
+                    contents: requestedContents,
+                    window: callbackContext.surfaceView?.window,
+                    requester: TerminalClipboardAccessPrompter.shared
+                ) { contents, confirmed in
+                    guard callbackContext.runtimeSurface == requestSurface else { return }
+                    let statePointer = stateBits == 0
+                        ? nil
+                        : UnsafeMutableRawPointer(bitPattern: stateBits)
+                    contents.withCString { pointer in
+                        ghostty_surface_complete_clipboard_request(
+                            requestSurface,
+                            pointer,
+                            statePointer,
+                            confirmed
+                        )
+                    }
+                    callbackContext.terminalSurface?.noteClipboardReadCompleted()
+                }
             }
         }
-        runtimeConfig.write_clipboard_cb = { _, location, content, len, _ in
-            // Write clipboard
-            guard let content = content, len > 0 else { return }
+        runtimeConfig.write_clipboard_cb = { userdata, location, content, len, requiresConfirmation in
+            guard let content, len > 0 else { return }
             let buffer = UnsafeBufferPointer(start: content, count: Int(len))
 
             var fallback: String?
+            var preferred: String?
             for item in buffer {
                 guard let dataPtr = item.data else { continue }
                 let value = String(cString: dataPtr)
@@ -889,8 +908,8 @@ class GhosttyApp {
                 if let mimePtr = item.mime {
                     let mime = String(cString: mimePtr)
                     if mime.hasPrefix("text/plain") {
-                        GhosttyApp.terminalPasteboard.writeString(value, to: location)
-                        return
+                        preferred = value
+                        break
                     }
                 }
 
@@ -899,8 +918,17 @@ class GhosttyApp {
                 }
             }
 
-            if let fallback {
-                GhosttyApp.terminalPasteboard.writeString(fallback, to: location)
+            guard let contents = preferred ?? fallback else { return }
+            let callbackContext = GhosttyApp.callbackContext(from: userdata)
+            DispatchQueue.main.async {
+                TerminalClipboardRuntimeBridge.handleWrite(
+                    contents: contents,
+                    requiresConfirmation: requiresConfirmation,
+                    window: callbackContext?.surfaceView?.window,
+                    requester: TerminalClipboardAccessPrompter.shared
+                ) {
+                    GhosttyApp.terminalPasteboard.writeString(contents, to: location)
+                }
             }
         }
         runtimeConfig.close_surface_cb = { userdata, needsConfirmClose in

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -874,6 +874,7 @@ class GhosttyApp {
             let requestedContents = String(cString: content)
             let stateBits: Int = state.map { Int(bitPattern: $0) } ?? 0
             DispatchQueue.main.async {
+                guard callbackContext.runtimeSurface == requestSurface else { return }
                 TerminalClipboardRuntimeBridge.handleReadConfirmation(
                     contents: requestedContents,
                     window: callbackContext.surfaceView?.window,
@@ -919,14 +920,21 @@ class GhosttyApp {
             }
 
             guard let contents = preferred ?? fallback else { return }
-            let callbackContext = GhosttyApp.callbackContext(from: userdata)
+            guard requiresConfirmation else {
+                GhosttyApp.terminalPasteboard.writeString(contents, to: location)
+                return
+            }
+            guard let callbackContext = GhosttyApp.callbackContext(from: userdata),
+                  let requestSurface = callbackContext.runtimeSurface else { return }
             DispatchQueue.main.async {
+                guard callbackContext.runtimeSurface == requestSurface else { return }
                 TerminalClipboardRuntimeBridge.handleWrite(
                     contents: contents,
-                    requiresConfirmation: requiresConfirmation,
-                    window: callbackContext?.surfaceView?.window,
+                    requiresConfirmation: true,
+                    window: callbackContext.surfaceView?.window,
                     requester: TerminalClipboardAccessPrompter.shared
                 ) {
+                    guard callbackContext.runtimeSurface == requestSurface else { return }
                     GhosttyApp.terminalPasteboard.writeString(contents, to: location)
                 }
             }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -373,6 +373,10 @@ class GhosttyApp {
     /// namespace enum).
     static let terminalPasteboard = TerminalPasteboardService()
 
+    /// Serializes terminal clipboard confirmation sheets across all surfaces.
+    @MainActor
+    static let terminalClipboardAccessPrompter = TerminalClipboardAccessPrompter()
+
     /// The process-wide serialized native-surface free queue (was the
     /// `TerminalSurfaceRuntimeTeardownCoordinator.shared` actor singleton).
     static let terminalSurfaceRuntimeTeardown = TerminalSurfaceRuntimeTeardownCoordinator()
@@ -878,7 +882,7 @@ class GhosttyApp {
                 TerminalClipboardRuntimeBridge.handleReadConfirmation(
                     contents: requestedContents,
                     window: callbackContext.surfaceView?.window,
-                    requester: TerminalClipboardAccessPrompter.shared
+                    requester: GhosttyApp.terminalClipboardAccessPrompter
                 ) { contents, confirmed in
                     guard callbackContext.runtimeSurface == requestSurface else { return }
                     let statePointer = stateBits == 0
@@ -932,7 +936,7 @@ class GhosttyApp {
                     contents: contents,
                     requiresConfirmation: true,
                     window: callbackContext.surfaceView?.window,
-                    requester: TerminalClipboardAccessPrompter.shared
+                    requester: GhosttyApp.terminalClipboardAccessPrompter
                 ) {
                     guard callbackContext.runtimeSurface == requestSurface else { return }
                     GhosttyApp.terminalPasteboard.writeString(contents, to: location)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -877,7 +877,7 @@ class GhosttyApp {
 
             let requestedContents = String(cString: content)
             let stateBits: Int = state.map { Int(bitPattern: $0) } ?? 0
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 guard callbackContext.runtimeSurface == requestSurface else { return }
                 TerminalClipboardRuntimeBridge.handleReadConfirmation(
                     contents: requestedContents,
@@ -930,7 +930,7 @@ class GhosttyApp {
             }
             guard let callbackContext = GhosttyApp.callbackContext(from: userdata),
                   let requestSurface = callbackContext.runtimeSurface else { return }
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 guard callbackContext.runtimeSurface == requestSurface else { return }
                 TerminalClipboardRuntimeBridge.handleWrite(
                     contents: contents,

--- a/Sources/TerminalClipboardAccess.swift
+++ b/Sources/TerminalClipboardAccess.swift
@@ -1,0 +1,218 @@
+import AppKit
+
+enum TerminalClipboardAccessOperation: Equatable, Sendable {
+    case read
+    case write
+
+    var title: String {
+        switch self {
+        case .read:
+            return String(
+                localized: "terminal.clipboardAccess.read.title",
+                defaultValue: "Allow Clipboard Read?"
+            )
+        case .write:
+            return String(
+                localized: "terminal.clipboardAccess.write.title",
+                defaultValue: "Allow Clipboard Change?"
+            )
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .read:
+            return String(
+                localized: "terminal.clipboardAccess.read.message",
+                defaultValue: "A program in this terminal wants to read these clipboard contents."
+            )
+        case .write:
+            return String(
+                localized: "terminal.clipboardAccess.write.message",
+                defaultValue: "A program in this terminal wants to replace your clipboard with these contents."
+            )
+        }
+    }
+}
+
+@MainActor
+protocol TerminalClipboardAccessRequesting: AnyObject {
+    func requestApproval(
+        operation: TerminalClipboardAccessOperation,
+        contents: String,
+        window: NSWindow?,
+        completion: @escaping (Bool) -> Void
+    )
+}
+
+@MainActor
+enum TerminalClipboardRuntimeBridge {
+    static func handleWrite(
+        contents: String,
+        requiresConfirmation: Bool,
+        window: NSWindow?,
+        requester: any TerminalClipboardAccessRequesting,
+        write: @escaping () -> Void
+    ) {
+        guard requiresConfirmation else {
+            write()
+            return
+        }
+
+        requester.requestApproval(
+            operation: .write,
+            contents: contents,
+            window: window
+        ) { approved in
+            guard approved else { return }
+            write()
+        }
+    }
+
+    static func handleReadConfirmation(
+        contents: String,
+        window: NSWindow?,
+        requester: any TerminalClipboardAccessRequesting,
+        complete: @escaping (_ contents: String, _ confirmed: Bool) -> Void
+    ) {
+        requester.requestApproval(
+            operation: .read,
+            contents: contents,
+            window: window
+        ) { approved in
+            complete(approved ? contents : "", true)
+        }
+    }
+}
+
+enum TerminalClipboardAccessPromptText {
+    static let maximumVisibleScalarCount = 4_096
+
+    static func preview(_ contents: String) -> String {
+        var result = ""
+        result.reserveCapacity(min(contents.utf8.count, maximumVisibleScalarCount))
+
+        for (index, scalar) in contents.unicodeScalars.enumerated() {
+            guard index < maximumVisibleScalarCount else {
+                result.append("\n…")
+                break
+            }
+
+            switch scalar.value {
+            case 0x09, 0x0A:
+                result.unicodeScalars.append(scalar)
+            default:
+                switch scalar.properties.generalCategory {
+                case .control, .format, .surrogate, .privateUse, .unassigned:
+                    result.append(
+                        contentsOf: "\\u{\(String(scalar.value, radix: 16, uppercase: true))}"
+                    )
+                default:
+                    result.unicodeScalars.append(scalar)
+                }
+            }
+        }
+
+        return result
+    }
+}
+
+@MainActor
+final class TerminalClipboardAccessPrompter: TerminalClipboardAccessRequesting {
+    static let shared = TerminalClipboardAccessPrompter()
+
+    private final class PendingApproval {
+        let operation: TerminalClipboardAccessOperation
+        let contents: String
+        weak var window: NSWindow?
+        let completion: (Bool) -> Void
+
+        init(
+            operation: TerminalClipboardAccessOperation,
+            contents: String,
+            window: NSWindow,
+            completion: @escaping (Bool) -> Void
+        ) {
+            self.operation = operation
+            self.contents = contents
+            self.window = window
+            self.completion = completion
+        }
+    }
+
+    private var pendingApprovals: [PendingApproval] = []
+    private var isPresenting = false
+
+    func requestApproval(
+        operation: TerminalClipboardAccessOperation,
+        contents: String,
+        window: NSWindow?,
+        completion: @escaping (Bool) -> Void
+    ) {
+        guard let window, window.isVisible else {
+            completion(false)
+            return
+        }
+
+        pendingApprovals.append(
+            PendingApproval(
+                operation: operation,
+                contents: contents,
+                window: window,
+                completion: completion
+            )
+        )
+        presentNextIfPossible()
+    }
+
+    private func presentNextIfPossible() {
+        guard !isPresenting else { return }
+
+        while !pendingApprovals.isEmpty {
+            let approval = pendingApprovals.removeFirst()
+            guard let window = approval.window,
+                  window.isVisible,
+                  window.attachedSheet == nil else {
+                approval.completion(false)
+                continue
+            }
+
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = approval.operation.title
+            alert.addButton(
+                withTitle: String(
+                    localized: "common.cancel",
+                    defaultValue: "Cancel"
+                )
+            )
+            alert.addButton(
+                withTitle: String(
+                    localized: "common.allow",
+                    defaultValue: "Allow"
+                )
+            )
+
+            let preview = TerminalClipboardAccessPromptText.preview(approval.contents)
+            let alertContent: CmuxAlertContent
+            if preview.isEmpty {
+                alertContent = CmuxAlertContent(informativeText: approval.operation.message)
+            } else {
+                let flattenedText = "\(approval.operation.message)\n\n\(preview)"
+                alertContent = CmuxAlertContent(
+                    flattenedText: flattenedText,
+                    separatingScrollableDetails: preview
+                )
+            }
+            alertContent.apply(to: alert, presentingWindow: window)
+
+            isPresenting = true
+            alert.beginSheetModal(for: window) { [weak self] response in
+                approval.completion(response == .alertSecondButtonReturn)
+                self?.isPresenting = false
+                self?.presentNextIfPossible()
+            }
+            return
+        }
+    }
+}

--- a/Sources/TerminalClipboardAccess.swift
+++ b/Sources/TerminalClipboardAccess.swift
@@ -119,8 +119,6 @@ enum TerminalClipboardAccessPromptText {
 
 @MainActor
 final class TerminalClipboardAccessPrompter: TerminalClipboardAccessRequesting {
-    static let shared = TerminalClipboardAccessPrompter()
-
     private final class PendingApproval {
         let operation: TerminalClipboardAccessOperation
         let contents: String

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1832,6 +1832,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		8362A0010000000000000001 /* TerminalCallerTTYResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8362A0020000000000000002 /* TerminalCallerTTYResolver.swift */; };
 		8362B0010000000000000001 /* TerminalCallerTTYResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8362B0020000000000000002 /* TerminalCallerTTYResolverTests.swift */; };
 		E4D1768B7041CDE4F9A084A4 /* TerminalClearScreenKeepScrollbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */; };
+		C15200000000000000000001 /* TerminalClipboardAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000002 /* TerminalClipboardAccessTests.swift */; };
 		C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
 		D35A00000000000000000014 /* TerminalController+AgentPromptDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */; };
 		8054A0030000000000000003 /* TerminalController+BrowserAutomationRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8054A0040000000000000004 /* TerminalController+BrowserAutomationRecovery.swift */; };
@@ -4019,6 +4020,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		8362A0020000000000000002 /* TerminalCallerTTYResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCallerTTYResolver.swift; sourceTree = "<group>"; };
 		8362B0020000000000000002 /* TerminalCallerTTYResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCallerTTYResolverTests.swift; sourceTree = "<group>"; };
 		F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClearScreenKeepScrollbackTests.swift; sourceTree = "<group>"; };
+		C15200000000000000000002 /* TerminalClipboardAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClipboardAccessTests.swift; sourceTree = "<group>"; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
 		D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+AgentPromptDelivery.swift"; sourceTree = "<group>"; };
 		8054A0040000000000000004 /* TerminalController+BrowserAutomationRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+BrowserAutomationRecovery.swift"; sourceTree = "<group>"; };
@@ -6347,6 +6349,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */,
 				EC010C02 /* TerminalUploadCommandTests.swift */,
 				02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
+				C15200000000000000000002 /* TerminalClipboardAccessTests.swift */,
 				A11E5E1E0000000000000012 /* TerminalSelectionAccessibilityIngressGateTests.swift */,
 				570ED364A7E41085FB2D31FE /* MainWindowSelfSizingTests.swift */,
 				43DB195131CD53CCCCEEEB79 /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift */,
@@ -9239,6 +9242,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,
 				8362B0010000000000000001 /* TerminalCallerTTYResolverTests.swift in Sources */,
 				E4D1768B7041CDE4F9A084A4 /* TerminalClearScreenKeepScrollbackTests.swift in Sources */,
+				C15200000000000000000001 /* TerminalClipboardAccessTests.swift in Sources */,
 				8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */,
 				9C1BEA3D2E6F49709A71C020 /* TerminalControllerTerminalTextTests.swift in Sources */,
 				6190C0126190C0126190C012 /* TerminalCopyOnSelectManagedConfigLayeringTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1832,6 +1832,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		8362A0010000000000000001 /* TerminalCallerTTYResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8362A0020000000000000002 /* TerminalCallerTTYResolver.swift */; };
 		8362B0010000000000000001 /* TerminalCallerTTYResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8362B0020000000000000002 /* TerminalCallerTTYResolverTests.swift */; };
 		E4D1768B7041CDE4F9A084A4 /* TerminalClearScreenKeepScrollbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */; };
+		C15200000000000000000003 /* TerminalClipboardAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000004 /* TerminalClipboardAccess.swift */; };
 		C15200000000000000000001 /* TerminalClipboardAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15200000000000000000002 /* TerminalClipboardAccessTests.swift */; };
 		C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
 		D35A00000000000000000014 /* TerminalController+AgentPromptDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */; };
@@ -4020,6 +4021,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		8362A0020000000000000002 /* TerminalCallerTTYResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCallerTTYResolver.swift; sourceTree = "<group>"; };
 		8362B0020000000000000002 /* TerminalCallerTTYResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCallerTTYResolverTests.swift; sourceTree = "<group>"; };
 		F2B7555E04A04849992547A2 /* TerminalClearScreenKeepScrollbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClearScreenKeepScrollbackTests.swift; sourceTree = "<group>"; };
+		C15200000000000000000004 /* TerminalClipboardAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClipboardAccess.swift; sourceTree = "<group>"; };
 		C15200000000000000000002 /* TerminalClipboardAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalClipboardAccessTests.swift; sourceTree = "<group>"; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
 		D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+AgentPromptDelivery.swift"; sourceTree = "<group>"; };
@@ -5198,6 +5200,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C40410010000000000000020 /* FileExplorerDoubleClickActionSettings.swift */,
 				C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
+				C15200000000000000000004 /* TerminalClipboardAccess.swift */,
 				85510002A1B2C3D4E5F60001 /* GhosttyApp+ChildExitPolicy.swift */,
 				816400000000000000000002 /* GhosttyScrollView.swift */,
 				A11E5E1E0000000000000002 /* TerminalSelectionAccessibilityNotifier.swift */,
@@ -8293,6 +8296,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7490C00F7490C00F7490C00F /* TaskVMInfoMemoryPressureFootprintSampler.swift in Sources */,
 				8362A0030000000000000003 /* TerminalCallerTTYBinding.swift in Sources */,
 				8362A0010000000000000001 /* TerminalCallerTTYResolver.swift in Sources */,
+				C15200000000000000000003 /* TerminalClipboardAccess.swift in Sources */,
 				D35A00000000000000000014 /* TerminalController+AgentPromptDelivery.swift in Sources */,
 				8054A0030000000000000003 /* TerminalController+BrowserAutomationRecovery.swift in Sources */,
 				D35A00000000000000000011 /* TerminalController+BrowserDesignMode.swift in Sources */,

--- a/cmuxTests/TerminalClipboardAccessTests.swift
+++ b/cmuxTests/TerminalClipboardAccessTests.swift
@@ -1,0 +1,132 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+private final class TerminalClipboardApprovalRecorder: TerminalClipboardAccessRequesting {
+    struct Request {
+        let operation: TerminalClipboardAccessOperation
+        let contents: String
+        let window: NSWindow?
+    }
+
+    private(set) var requests: [Request] = []
+    private var completions: [(Bool) -> Void] = []
+
+    func requestApproval(
+        operation: TerminalClipboardAccessOperation,
+        contents: String,
+        window: NSWindow?,
+        completion: @escaping (Bool) -> Void
+    ) {
+        requests.append(Request(operation: operation, contents: contents, window: window))
+        completions.append(completion)
+    }
+
+    func resolveNext(approved: Bool) {
+        completions.removeFirst()(approved)
+    }
+}
+
+@Suite("Terminal clipboard access", .serialized)
+@MainActor
+struct TerminalClipboardAccessTests {
+    @Test
+    func writeWithoutConfirmationRemainsImmediate() {
+        let recorder = TerminalClipboardApprovalRecorder()
+        var writes: [String] = []
+
+        TerminalClipboardRuntimeBridge.handleWrite(
+            contents: "selection copy",
+            requiresConfirmation: false,
+            window: nil,
+            requester: recorder
+        ) {
+            writes.append("selection copy")
+        }
+
+        #expect(recorder.requests.isEmpty)
+        #expect(writes == ["selection copy"])
+    }
+
+    @Test
+    func writeRequiringConfirmationWaitsAndHonorsDenial() {
+        let recorder = TerminalClipboardApprovalRecorder()
+        var writes: [String] = []
+
+        TerminalClipboardRuntimeBridge.handleWrite(
+            contents: "replacement",
+            requiresConfirmation: true,
+            window: nil,
+            requester: recorder
+        ) {
+            writes.append("replacement")
+        }
+
+        #expect(recorder.requests.count == 1)
+        #expect(recorder.requests.first?.operation == .write)
+        #expect(recorder.requests.first?.contents == "replacement")
+        #expect(writes.isEmpty)
+
+        recorder.resolveNext(approved: false)
+
+        #expect(writes.isEmpty)
+    }
+
+    @Test
+    func writeRequiringConfirmationRunsAfterApproval() {
+        let recorder = TerminalClipboardApprovalRecorder()
+        var writes: [String] = []
+
+        TerminalClipboardRuntimeBridge.handleWrite(
+            contents: "replacement",
+            requiresConfirmation: true,
+            window: nil,
+            requester: recorder
+        ) {
+            writes.append("replacement")
+        }
+
+        #expect(writes.isEmpty)
+
+        recorder.resolveNext(approved: true)
+
+        #expect(writes == ["replacement"])
+    }
+
+    @Test(arguments: [
+        (approved: true, expectedContents: "clipboard value"),
+        (approved: false, expectedContents: ""),
+    ])
+    func readConfirmationCompletesOnce(
+        approved: Bool,
+        expectedContents: String
+    ) {
+        let recorder = TerminalClipboardApprovalRecorder()
+        var completions: [(contents: String, confirmed: Bool)] = []
+
+        TerminalClipboardRuntimeBridge.handleReadConfirmation(
+            contents: "clipboard value",
+            window: nil,
+            requester: recorder
+        ) { contents, confirmed in
+            completions.append((contents, confirmed))
+        }
+
+        #expect(recorder.requests.count == 1)
+        #expect(recorder.requests.first?.operation == .read)
+        #expect(recorder.requests.first?.contents == "clipboard value")
+        #expect(completions.isEmpty)
+
+        recorder.resolveNext(approved: approved)
+
+        #expect(completions.count == 1)
+        #expect(completions.first?.contents == expectedContents)
+        #expect(completions.first?.confirmed == true)
+    }
+}

--- a/cmuxTests/TerminalClipboardAccessTests.swift
+++ b/cmuxTests/TerminalClipboardAccessTests.swift
@@ -129,4 +129,46 @@ struct TerminalClipboardAccessTests {
         #expect(completions.first?.contents == expectedContents)
         #expect(completions.first?.confirmed == true)
     }
+
+    @Test
+    func promptTextEscapesControlCharacters() {
+        let contents = "\u{1B}]52;c;payload\u{7}"
+
+        #expect(
+            TerminalClipboardAccessPromptText.preview(contents)
+                == #"\u{1B}]52;c;payload\u{7}"#
+        )
+    }
+
+    @Test
+    func promptTextBoundsVisibleContents() {
+        let contents = String(
+            repeating: "a",
+            count: TerminalClipboardAccessPromptText.maximumVisibleScalarCount + 1
+        )
+
+        #expect(
+            TerminalClipboardAccessPromptText.preview(contents)
+                == String(
+                    repeating: "a",
+                    count: TerminalClipboardAccessPromptText.maximumVisibleScalarCount
+                ) + "\n…"
+        )
+    }
+
+    @Test
+    func missingWindowFailsClosed() {
+        let prompter = TerminalClipboardAccessPrompter()
+        var approved: Bool?
+
+        prompter.requestApproval(
+            operation: .read,
+            contents: "clipboard value",
+            window: nil
+        ) {
+            approved = $0
+        }
+
+        #expect(approved == false)
+    }
 }

--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -28,6 +28,35 @@ Its universal ReleaseFast GhosttyKit archive is published at
 https://github.com/manaflow-ai/ghostty/releases/tag/xcframework-c55514dd52d806e9aa661ee20381aa19c91c1c09-crashsubdir-cmux-crash-v1
 and its SHA-256 is pinned in `scripts/ghosttykit-checksums.txt`.
 
+### Terminal clipboard confirmation defaults
+
+- Pending fork PR: https://github.com/manaflow-ai/ghostty/pull/138
+- Commits:
+  - `60f35fedd` (test: require clipboard access confirmation defaults)
+  - `21f089e33` (fix: prompt for terminal clipboard writes by default)
+- Files:
+  - `include/ghostty.h`
+  - `src/Surface.zig`
+  - `src/apprt/embedded.zig`
+  - `src/config/Config.zig`
+- Summary:
+  - Terminal-driven clipboard reads and writes default to `ask`.
+  - The embedded write callback documents that `confirm = true` requires
+    explicit approval and must leave the clipboard unchanged after denial.
+  - cmux handles the read and write confirmation callbacks through one
+    serialized AppKit prompt path. The iOS embed denies terminal-driven
+    clipboard access because it does not present confirmation prompts.
+- Integration note:
+  - The cmux PR pins the pending fork commit so its builds exercise the new
+    default. Land the fork PR first, then verify the pinned commit is reachable
+    from fork `main` before merging the cmux PR.
+- Conflict notes:
+  - Preserve the `confirm` boolean across `Surface.clipboardWrite`,
+    `apprt.embedded.Surface.setClipboard`, and the C callback contract.
+  - If upstream changes clipboard defaults or confirmation ownership, retain
+    the invariant that an `ask` request cannot access the platform clipboard
+    before the embedder approves it.
+
 ### External frontend rendering and recovery
 
 - Commits:

--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -28,35 +28,6 @@ Its universal ReleaseFast GhosttyKit archive is published at
 https://github.com/manaflow-ai/ghostty/releases/tag/xcframework-c55514dd52d806e9aa661ee20381aa19c91c1c09-crashsubdir-cmux-crash-v1
 and its SHA-256 is pinned in `scripts/ghosttykit-checksums.txt`.
 
-### Terminal clipboard confirmation defaults
-
-- Pending fork PR: https://github.com/manaflow-ai/ghostty/pull/138
-- Commits:
-  - `60f35fedd` (test: require clipboard access confirmation defaults)
-  - `21f089e33` (fix: prompt for terminal clipboard writes by default)
-- Files:
-  - `include/ghostty.h`
-  - `src/Surface.zig`
-  - `src/apprt/embedded.zig`
-  - `src/config/Config.zig`
-- Summary:
-  - Terminal-driven clipboard reads and writes default to `ask`.
-  - The embedded write callback documents that `confirm = true` requires
-    explicit approval and must leave the clipboard unchanged after denial.
-  - cmux handles the read and write confirmation callbacks through one
-    serialized AppKit prompt path. The iOS embed denies terminal-driven
-    clipboard access because it does not present confirmation prompts.
-- Integration note:
-  - The cmux PR pins the pending fork commit so its builds exercise the new
-    default. Land the fork PR first, then verify the pinned commit is reachable
-    from fork `main` before merging the cmux PR.
-- Conflict notes:
-  - Preserve the `confirm` boolean across `Surface.clipboardWrite`,
-    `apprt.embedded.Surface.setClipboard`, and the C callback contract.
-  - If upstream changes clipboard defaults or confirmation ownership, retain
-    the invariant that an `ask` request cannot access the platform clipboard
-    before the embedder approves it.
-
 ### External frontend rendering and recovery
 
 - Commits:


### PR DESCRIPTION
## Summary
- honor Ghostty confirmation requests for terminal clipboard reads and writes
- serialize localized prompts and preserve immediate user-initiated copy behavior
- deny terminal clipboard protocol access in the iOS runtime, which has no confirmation UI
- keep the existing Ghostty clipboard defaults unchanged

## Testing
- added confirmation-flow regressions in the first commit
- passed 7 focused Swift tests before and after separating the Ghostty policy change
- passed tagged macOS read/write approval and denial checks
- passed isolated iOS simulator build, install, sign-in, pairing, and clipboard-preservation check
- confirmed the three local web routes return 200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts when terminal applications read from or write to the system clipboard.
  * Clipboard requests are queued to present one approval dialog at a time.
  * Prompts include localized titles, explanations, and safe previews of clipboard content.
  * Clipboard access defaults to denied unless explicitly approved.

* **Bug Fixes**
  * Prevented clipboard operations from completing before user approval.
  * Ensured denied or unavailable requests fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->