### PR TITLE
Send founders welcome email for every completed checkout

### DIFF
--- a/web/app/api/stripe/founders-welcome/route.ts
+++ b/web/app/api/stripe/founders-welcome/route.ts
@@ -14,14 +14,10 @@ import {
   DEFAULT_FROM_EMAIL,
   buildFoundersWelcomeEmail,
 } from "./welcome-email";
+import { welcomeTriggerForMetadata } from "./welcome-trigger";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-// Stripe checkout sessions created from the cmux Founder's Edition payment link
-// carry this metadata key (copied automatically onto each session). We only send
-// the welcome email when it is present and truthy.
-const FOUNDERS_METADATA_KEY = "founders_edition";
 
 // Stripe signs webhooks with a 5-minute default tolerance; reject older payloads
 // to blunt replay attempts.
@@ -129,27 +125,29 @@ export async function POST(request: Request) {
 
       setSpanAttributes(span, { "cmux.stripe.event_type": event.type ?? "" });
 
-      // Only react to completed checkout sessions flagged as Founder's Edition.
-      // Everything else (including renewals, which never create a checkout
-      // session) is acknowledged with 200 so Stripe stops retrying.
+      // Only react to completed checkout sessions that qualify for the welcome:
+      // either flagged Founder's Edition (payment-link metadata) or a cmux Pro
+      // subscription checkout (see welcomeTriggerForMetadata). Everything else
+      // (including renewals, which never create a checkout session) is
+      // acknowledged with 200 so Stripe stops retrying.
       if (event.type !== "checkout.session.completed") {
         return NextResponse.json({ ok: true, skipped: "event_type" });
       }
       const session = event.data?.object;
-      const isFounders =
-        session?.metadata?.[FOUNDERS_METADATA_KEY] === "true";
+      const trigger = welcomeTriggerForMetadata(session?.metadata);
       const customerEmail = session?.customer_details?.email ?? null;
       setSpanAttributes(span, {
-        "cmux.stripe.is_founders": isFounders,
+        "cmux.stripe.is_founders": trigger === "founders_edition",
+        "cmux.stripe.welcome_trigger": trigger ?? "none",
         "cmux.stripe.has_customer_email": Boolean(customerEmail),
       });
-      if (!isFounders) {
-        return NextResponse.json({ ok: true, skipped: "not_founders" });
+      if (!trigger) {
+        return NextResponse.json({ ok: true, skipped: "not_welcome_eligible" });
       }
       if (!customerEmail) {
-        // Distinct from "not_founders" so a Founder's session that arrives
-        // without a customer email is diagnosable in telemetry rather than a
-        // silent miss.
+        // Distinct from "not_welcome_eligible" so an eligible session that
+        // arrives without a customer email is diagnosable in telemetry rather
+        // than a silent miss.
         return NextResponse.json({ ok: true, skipped: "no_customer_email" });
       }
 

--- a/web/app/api/stripe/founders-welcome/route.ts
+++ b/web/app/api/stripe/founders-welcome/route.ts
@@ -125,11 +125,12 @@ export async function POST(request: Request) {
 
       setSpanAttributes(span, { "cmux.stripe.event_type": event.type ?? "" });
 
-      // Only react to completed checkout sessions that qualify for the welcome:
-      // either flagged Founder's Edition (payment-link metadata) or a cmux Pro
-      // subscription checkout (see welcomeTriggerForMetadata). Everything else
-      // (including renewals, which never create a checkout session) is
-      // acknowledged with 200 so Stripe stops retrying.
+      // Every completed checkout session gets the identical Founder's Edition
+      // welcome (product decision: all customers get the same founders
+      // treatment) — Founder's Edition payment-link purchases, cmux Pro and
+      // Team subscriptions, and anything else checked out on this Stripe
+      // account. Other event types (including renewals, which never create a
+      // checkout session) are acknowledged with 200 so Stripe stops retrying.
       if (event.type !== "checkout.session.completed") {
         return NextResponse.json({ ok: true, skipped: "event_type" });
       }
@@ -138,16 +139,12 @@ export async function POST(request: Request) {
       const customerEmail = session?.customer_details?.email ?? null;
       setSpanAttributes(span, {
         "cmux.stripe.is_founders": trigger === "founders_edition",
-        "cmux.stripe.welcome_trigger": trigger ?? "none",
+        "cmux.stripe.welcome_trigger": trigger,
         "cmux.stripe.has_customer_email": Boolean(customerEmail),
       });
-      if (!trigger) {
-        return NextResponse.json({ ok: true, skipped: "not_welcome_eligible" });
-      }
       if (!customerEmail) {
-        // Distinct from "not_welcome_eligible" so an eligible session that
-        // arrives without a customer email is diagnosable in telemetry rather
-        // than a silent miss.
+        // A completed session that arrives without a customer email is
+        // diagnosable in telemetry rather than a silent miss.
         return NextResponse.json({ ok: true, skipped: "no_customer_email" });
       }
 

--- a/web/app/api/stripe/founders-welcome/welcome-trigger.ts
+++ b/web/app/api/stripe/founders-welcome/welcome-trigger.ts
@@ -1,0 +1,30 @@
+// Pure decision of whether a completed Stripe checkout session earns the
+// founders welcome email, and which condition matched.
+//
+// Two session shapes qualify (product decision: Founder's Edition and cmux Pro
+// are the same tier and get the same welcome):
+//
+// - "founders_edition": sessions created from the cmux Founder's Edition
+//   payment link, which copies `founders_edition=true` onto each session.
+// - "pro_plan": cmux Pro subscription checkouts created by
+//   /api/billing/checkout, which set `{ app: "cmux", plan: "pro" }` (monthly
+//   and yearly intervals share this metadata). The Team plan (`plan: "team"`)
+//   is intentionally excluded.
+//
+// Kept free of Stripe/Resend/env imports so it can be unit-tested directly
+// (web/tests/founders-welcome-email.test.ts); the route handler (./route.ts)
+// owns the I/O.
+
+export type WelcomeTrigger = "founders_edition" | "pro_plan";
+
+export function welcomeTriggerForMetadata(
+  metadata: Record<string, string> | null | undefined,
+): WelcomeTrigger | null {
+  if (metadata?.founders_edition === "true") {
+    return "founders_edition";
+  }
+  if (metadata?.app === "cmux" && metadata?.plan === "pro") {
+    return "pro_plan";
+  }
+  return null;
+}

--- a/web/app/api/stripe/founders-welcome/welcome-trigger.ts
+++ b/web/app/api/stripe/founders-welcome/welcome-trigger.ts
@@ -1,30 +1,39 @@
-// Pure decision of whether a completed Stripe checkout session earns the
-// founders welcome email, and which condition matched.
-//
-// Two session shapes qualify (product decision: Founder's Edition and cmux Pro
-// are the same tier and get the same welcome):
+// Classifies a completed Stripe checkout session for the welcome-email
+// telemetry. Every completed checkout on this webhook sends the identical
+// Founder's Edition welcome (product decision: all customers get the same
+// founders treatment); the classification exists so telemetry records which
+// purchase shape triggered each send.
 //
 // - "founders_edition": sessions created from the cmux Founder's Edition
 //   payment link, which copies `founders_edition=true` onto each session.
 // - "pro_plan": cmux Pro subscription checkouts created by
 //   /api/billing/checkout, which set `{ app: "cmux", plan: "pro" }` (monthly
-//   and yearly intervals share this metadata). The Team plan (`plan: "team"`)
-//   is intentionally excluded.
+//   and yearly intervals share this metadata).
+// - "team_plan": cmux Team subscription checkouts (`{ app: "cmux", plan:
+//   "team" }`).
+// - "other": any other completed checkout session.
 //
 // Kept free of Stripe/Resend/env imports so it can be unit-tested directly
 // (web/tests/founders-welcome-email.test.ts); the route handler (./route.ts)
 // owns the I/O.
 
-export type WelcomeTrigger = "founders_edition" | "pro_plan";
+export type WelcomeTrigger =
+  | "founders_edition"
+  | "pro_plan"
+  | "team_plan"
+  | "other";
 
 export function welcomeTriggerForMetadata(
   metadata: Record<string, string> | null | undefined,
-): WelcomeTrigger | null {
+): WelcomeTrigger {
   if (metadata?.founders_edition === "true") {
     return "founders_edition";
   }
   if (metadata?.app === "cmux" && metadata?.plan === "pro") {
     return "pro_plan";
   }
-  return null;
+  if (metadata?.app === "cmux" && metadata?.plan === "team") {
+    return "team_plan";
+  }
+  return "other";
 }

--- a/web/tests/bun-test.d.ts
+++ b/web/tests/bun-test.d.ts
@@ -34,5 +34,6 @@ declare module "bun:test" {
     objectContaining: (value: unknown) => unknown;
   };
   export const mock: Mock;
+  export const setSystemTime: (time?: Date | number) => void;
   export const test: TestFunction;
 }

--- a/web/tests/founders-welcome-email.test.ts
+++ b/web/tests/founders-welcome-email.test.ts
@@ -25,19 +25,21 @@ const baseParams = {
   customerName: "Ada Lovelace",
 } as const;
 
-// Founder's Edition and cmux Pro are the same tier (product decision), so both
-// checkout shapes must trigger the identical welcome email. Pro sessions carry
-// { app: "cmux", plan: "pro" } from /api/billing/checkout and no
-// founders_edition key — before the pro_plan trigger existed they were skipped
-// and a real Pro subscriber never got the welcome.
+// Every completed checkout gets the identical Founder's Edition welcome
+// (product decision: all customers get the same founders treatment), so this
+// helper only classifies the purchase shape for telemetry — it never gates the
+// send. Pro sessions carry { app: "cmux", plan: "pro" } from
+// /api/billing/checkout and no founders_edition key; before the webhook
+// welcomed every checkout they were skipped and a real Pro subscriber never
+// got the welcome.
 describe("welcomeTriggerForMetadata", () => {
-  test("founders payment-link metadata triggers as founders_edition", () => {
+  test("founders payment-link metadata classifies as founders_edition", () => {
     expect(welcomeTriggerForMetadata({ founders_edition: "true" })).toBe(
       "founders_edition",
     );
   });
 
-  test("cmux Pro checkout metadata triggers as pro_plan (no founders key)", () => {
+  test("cmux Pro checkout metadata classifies as pro_plan (no founders key)", () => {
     expect(
       welcomeTriggerForMetadata({
         stackUserId: "user-1",
@@ -57,26 +59,27 @@ describe("welcomeTriggerForMetadata", () => {
     ).toBe("founders_edition");
   });
 
-  test("team plan is excluded", () => {
+  test("cmux Team checkout metadata classifies as team_plan", () => {
     expect(
       welcomeTriggerForMetadata({
         stackTeamId: "team-1",
         plan: "team",
         app: "cmux",
       }),
-    ).toBeNull();
+    ).toBe("team_plan");
   });
 
-  test("pro plan for a different app is excluded", () => {
-    expect(welcomeTriggerForMetadata({ plan: "pro", app: "other" })).toBeNull();
-    expect(welcomeTriggerForMetadata({ plan: "pro" })).toBeNull();
-  });
-
-  test("non-true founders flag and missing metadata are excluded", () => {
-    expect(welcomeTriggerForMetadata({ founders_edition: "false" })).toBeNull();
-    expect(welcomeTriggerForMetadata({})).toBeNull();
-    expect(welcomeTriggerForMetadata(null)).toBeNull();
-    expect(welcomeTriggerForMetadata(undefined)).toBeNull();
+  test("everything else classifies as other (still welcomed)", () => {
+    expect(welcomeTriggerForMetadata({ plan: "pro", app: "other" })).toBe(
+      "other",
+    );
+    expect(welcomeTriggerForMetadata({ plan: "pro" })).toBe("other");
+    expect(welcomeTriggerForMetadata({ founders_edition: "false" })).toBe(
+      "other",
+    );
+    expect(welcomeTriggerForMetadata({})).toBe("other");
+    expect(welcomeTriggerForMetadata(null)).toBe("other");
+    expect(welcomeTriggerForMetadata(undefined)).toBe("other");
   });
 });
 

--- a/web/tests/founders-welcome-email.test.ts
+++ b/web/tests/founders-welcome-email.test.ts
@@ -7,6 +7,7 @@ import {
   buildFoundersWelcomeEmail,
   foundersThreadRef,
 } from "../app/api/stripe/founders-welcome/welcome-email";
+import { welcomeTriggerForMetadata } from "../app/api/stripe/founders-welcome/welcome-trigger";
 
 // Regression coverage for the Founder's Edition welcome email collapsing into a
 // single Gmail conversation. Gmail threads messages that share a normalized
@@ -23,6 +24,61 @@ const baseParams = {
   from: "Austin Wang <austin@manaflow.ai>",
   customerName: "Ada Lovelace",
 } as const;
+
+// Founder's Edition and cmux Pro are the same tier (product decision), so both
+// checkout shapes must trigger the identical welcome email. Pro sessions carry
+// { app: "cmux", plan: "pro" } from /api/billing/checkout and no
+// founders_edition key — before the pro_plan trigger existed they were skipped
+// and a real Pro subscriber never got the welcome.
+describe("welcomeTriggerForMetadata", () => {
+  test("founders payment-link metadata triggers as founders_edition", () => {
+    expect(welcomeTriggerForMetadata({ founders_edition: "true" })).toBe(
+      "founders_edition",
+    );
+  });
+
+  test("cmux Pro checkout metadata triggers as pro_plan (no founders key)", () => {
+    expect(
+      welcomeTriggerForMetadata({
+        stackUserId: "user-1",
+        plan: "pro",
+        app: "cmux",
+      }),
+    ).toBe("pro_plan");
+  });
+
+  test("founders_edition wins when both shapes are present", () => {
+    expect(
+      welcomeTriggerForMetadata({
+        founders_edition: "true",
+        plan: "pro",
+        app: "cmux",
+      }),
+    ).toBe("founders_edition");
+  });
+
+  test("team plan is excluded", () => {
+    expect(
+      welcomeTriggerForMetadata({
+        stackTeamId: "team-1",
+        plan: "team",
+        app: "cmux",
+      }),
+    ).toBeNull();
+  });
+
+  test("pro plan for a different app is excluded", () => {
+    expect(welcomeTriggerForMetadata({ plan: "pro", app: "other" })).toBeNull();
+    expect(welcomeTriggerForMetadata({ plan: "pro" })).toBeNull();
+  });
+
+  test("non-true founders flag and missing metadata are excluded", () => {
+    expect(welcomeTriggerForMetadata({ founders_edition: "false" })).toBeNull();
+    expect(welcomeTriggerForMetadata({})).toBeNull();
+    expect(welcomeTriggerForMetadata(null)).toBeNull();
+    expect(welcomeTriggerForMetadata(undefined)).toBeNull();
+  });
+});
 
 describe("foundersThreadRef", () => {
   test("different sessions produce different thread keys (a new Gmail thread each)", () => {

--- a/web/tests/founders-welcome-route.test.ts
+++ b/web/tests/founders-welcome-route.test.ts
@@ -1,0 +1,192 @@
+import { createHmac } from "node:crypto";
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Route-level coverage for /api/stripe/founders-welcome. The webhook must send
+// the identical welcome email for BOTH qualifying checkout shapes — Founder's
+// Edition payment-link sessions (founders_edition=true) and cmux Pro
+// subscription checkouts ({ app: "cmux", plan: "pro" }, no founders key) —
+// while skipping everything else. Pro coverage is a regression guard: before
+// the pro_plan trigger, Pro sessions were skipped as not-founders and a real
+// Pro subscriber never received the welcome.
+
+// Pinned by tests/test-preload.ts before @/app/env loads.
+const WEBHOOK_SECRET = process.env.STRIPE_FOUNDERS_WEBHOOK_SECRET ?? "";
+
+type SentEmail = {
+  payload: {
+    subject: string;
+    to: string[];
+    headers: Record<string, string>;
+  };
+  options: { idempotencyKey: string };
+};
+
+const sentEmails: SentEmail[] = [];
+let resendError: { name: string; message: string } | null = null;
+const resendSend = mock(async (...args: unknown[]) => {
+  sentEmails.push({
+    payload: args[0] as SentEmail["payload"],
+    options: args[1] as SentEmail["options"],
+  });
+  return { data: resendError ? null : { id: "email_1" }, error: resendError };
+});
+
+mock.module("resend", () => ({
+  Resend: class MockResend {
+    emails = { send: resendSend };
+  },
+}));
+
+const { POST } = await import("../app/api/stripe/founders-welcome/route");
+
+beforeEach(() => {
+  resendSend.mockClear();
+  sentEmails.length = 0;
+  resendError = null;
+});
+
+type SessionOverrides = {
+  id?: string;
+  metadata?: Record<string, string> | null;
+  customer_details?: { email?: string | null; name?: string | null } | null;
+};
+
+function checkoutCompletedEvent(overrides: SessionOverrides = {}): string {
+  return JSON.stringify({
+    id: "evt_1",
+    type: "checkout.session.completed",
+    data: {
+      object: {
+        id: "cs_test_123",
+        metadata: { founders_edition: "true" },
+        customer_details: { email: "customer@example.com", name: "Ada Lovelace" },
+        ...overrides,
+      },
+    },
+  });
+}
+
+function signedRequest(body: string, signature?: string): Request {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const v1 =
+    signature ??
+    createHmac("sha256", WEBHOOK_SECRET)
+      .update(`${timestamp}.${body}`)
+      .digest("hex");
+  return new Request("https://cmux.test/api/stripe/founders-welcome", {
+    method: "POST",
+    headers: { "stripe-signature": `t=${timestamp},v1=${v1}` },
+    body,
+  });
+}
+
+describe("founders welcome route", () => {
+  test("rejects an invalid Stripe signature", async () => {
+    const response = await POST(
+      signedRequest(checkoutCompletedEvent(), "00".repeat(32)),
+    );
+
+    expect(response.status).toBe(400);
+    expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  test("acknowledges but skips non-checkout events", async () => {
+    const body = JSON.stringify({ id: "evt_1", type: "invoice.paid" });
+    const response = await POST(signedRequest(body));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, skipped: "event_type" });
+    expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  test("sends the welcome for a Founder's Edition session", async () => {
+    const response = await POST(signedRequest(checkoutCompletedEvent()));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, sent: true });
+    expect(resendSend).toHaveBeenCalledTimes(1);
+  });
+
+  test("sends the identical welcome for a cmux Pro checkout (no founders key)", async () => {
+    const response = await POST(
+      signedRequest(
+        checkoutCompletedEvent({
+          id: "cs_test_pro",
+          metadata: { stackUserId: "user-1", plan: "pro", app: "cmux" },
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, sent: true });
+    expect(resendSend).toHaveBeenCalledTimes(1);
+
+    // Same builder, same idempotency/threading keyed by the session id — a
+    // Pro welcome is indistinguishable from a founders welcome apart from the
+    // per-session ref.
+    const { payload, options } = sentEmails[0];
+    expect(payload.subject).toBe("cmux Founder's Edition");
+    expect(payload.to).toEqual(["customer@example.com"]);
+    expect(payload.headers["X-Entity-Ref-ID"]).toBe(
+      "founders-welcome/cs_test_pro",
+    );
+    expect(options.idempotencyKey).toBe("founders-welcome/cs_test_pro");
+  });
+
+  test("skips a Team plan checkout", async () => {
+    const response = await POST(
+      signedRequest(
+        checkoutCompletedEvent({
+          metadata: { stackTeamId: "team-1", plan: "team", app: "cmux" },
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      skipped: "not_welcome_eligible",
+    });
+    expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  test("skips a pro plan for a different app", async () => {
+    const response = await POST(
+      signedRequest(
+        checkoutCompletedEvent({
+          metadata: { plan: "pro", app: "other" },
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      skipped: "not_welcome_eligible",
+    });
+    expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  test("skips an eligible session without a customer email", async () => {
+    const response = await POST(
+      signedRequest(checkoutCompletedEvent({ customer_details: null })),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      ok: true,
+      skipped: "no_customer_email",
+    });
+    expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  test("returns non-2xx when Resend fails so Stripe retries", async () => {
+    resendError = { name: "application_error", message: "boom" };
+
+    const response = await POST(signedRequest(checkoutCompletedEvent()));
+
+    expect(response.status).toBe(502);
+    expect(resendSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/founders-welcome-route.test.ts
+++ b/web/tests/founders-welcome-route.test.ts
@@ -1,6 +1,14 @@
 import { createHmac } from "node:crypto";
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 // Route-level coverage for /api/stripe/founders-welcome. The webhook must send
 // the identical welcome email for BOTH qualifying checkout shapes — Founder's
@@ -40,10 +48,22 @@ mock.module("resend", () => ({
 
 const { POST } = await import("../app/api/stripe/founders-welcome/route");
 
+// Freeze the clock so the test's signature timestamps and the route's
+// freshness check (Date.now inside POST) share one virtual time. Signature
+// tolerance can then be exercised deterministically at the exact five-minute
+// boundary instead of racing the real clock.
+const FROZEN_NOW_MS = Date.UTC(2026, 6, 24, 12, 0, 0);
+const FROZEN_NOW_SECONDS = Math.floor(FROZEN_NOW_MS / 1000);
+
 beforeEach(() => {
+  setSystemTime(FROZEN_NOW_MS);
   resendSend.mockClear();
   sentEmails.length = 0;
   resendError = null;
+});
+
+afterAll(() => {
+  setSystemTime();
 });
 
 type SessionOverrides = {
@@ -67,10 +87,13 @@ function checkoutCompletedEvent(overrides: SessionOverrides = {}): string {
   });
 }
 
-function signedRequest(body: string, signature?: string): Request {
-  const timestamp = Math.floor(Date.now() / 1000);
+function signedRequest(
+  body: string,
+  options: { signature?: string; timestamp?: number } = {},
+): Request {
+  const timestamp = options.timestamp ?? FROZEN_NOW_SECONDS;
   const v1 =
-    signature ??
+    options.signature ??
     createHmac("sha256", WEBHOOK_SECRET)
       .update(`${timestamp}.${body}`)
       .digest("hex");
@@ -84,11 +107,33 @@ function signedRequest(body: string, signature?: string): Request {
 describe("founders welcome route", () => {
   test("rejects an invalid Stripe signature", async () => {
     const response = await POST(
-      signedRequest(checkoutCompletedEvent(), "00".repeat(32)),
+      signedRequest(checkoutCompletedEvent(), { signature: "00".repeat(32) }),
     );
 
     expect(response.status).toBe(400);
     expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  test("rejects a validly-signed payload older than the replay tolerance", async () => {
+    const response = await POST(
+      signedRequest(checkoutCompletedEvent(), {
+        timestamp: FROZEN_NOW_SECONDS - 5 * 60 - 1,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(resendSend).not.toHaveBeenCalled();
+  });
+
+  test("accepts a validly-signed payload exactly at the replay tolerance", async () => {
+    const response = await POST(
+      signedRequest(checkoutCompletedEvent(), {
+        timestamp: FROZEN_NOW_SECONDS - 5 * 60,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, sent: true });
   });
 
   test("acknowledges but skips non-checkout events", async () => {

--- a/web/tests/founders-welcome-route.test.ts
+++ b/web/tests/founders-welcome-route.test.ts
@@ -11,12 +11,13 @@ import {
 } from "bun:test";
 
 // Route-level coverage for /api/stripe/founders-welcome. The webhook must send
-// the identical welcome email for BOTH qualifying checkout shapes — Founder's
-// Edition payment-link sessions (founders_edition=true) and cmux Pro
-// subscription checkouts ({ app: "cmux", plan: "pro" }, no founders key) —
-// while skipping everything else. Pro coverage is a regression guard: before
-// the pro_plan trigger, Pro sessions were skipped as not-founders and a real
-// Pro subscriber never received the welcome.
+// the identical welcome email for EVERY completed checkout session — Founder's
+// Edition payment-link sessions (founders_edition=true), cmux Pro and Team
+// subscription checkouts, and anything else — skipping only non-checkout
+// events, invalid/stale signatures, and sessions without a customer email.
+// Pro coverage is a regression guard: before the webhook welcomed every
+// checkout, Pro sessions were skipped as not-founders and a real Pro
+// subscriber never received the welcome.
 
 // Pinned by tests/test-preload.ts before @/app/env loads.
 const WEBHOOK_SECRET = process.env.STRIPE_FOUNDERS_WEBHOOK_SECRET ?? "";
@@ -179,41 +180,43 @@ describe("founders welcome route", () => {
     expect(options.idempotencyKey).toBe("founders-welcome/cs_test_pro");
   });
 
-  test("skips a Team plan checkout", async () => {
+  test("sends the identical welcome for a Team plan checkout", async () => {
     const response = await POST(
       signedRequest(
         checkoutCompletedEvent({
+          id: "cs_test_team",
           metadata: { stackTeamId: "team-1", plan: "team", app: "cmux" },
         }),
       ),
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      ok: true,
-      skipped: "not_welcome_eligible",
-    });
-    expect(resendSend).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({ ok: true, sent: true });
+    expect(resendSend).toHaveBeenCalledTimes(1);
+    expect(sentEmails[0].options.idempotencyKey).toBe(
+      "founders-welcome/cs_test_team",
+    );
   });
 
-  test("skips a pro plan for a different app", async () => {
+  test("sends the welcome for any other completed checkout (no recognized metadata)", async () => {
     const response = await POST(
       signedRequest(
         checkoutCompletedEvent({
+          id: "cs_test_other",
           metadata: { plan: "pro", app: "other" },
         }),
       ),
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      ok: true,
-      skipped: "not_welcome_eligible",
-    });
-    expect(resendSend).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({ ok: true, sent: true });
+    expect(resendSend).toHaveBeenCalledTimes(1);
+    expect(sentEmails[0].options.idempotencyKey).toBe(
+      "founders-welcome/cs_test_other",
+    );
   });
 
-  test("skips an eligible session without a customer email", async () => {
+  test("skips a session without a customer email", async () => {
     const response = await POST(
       signedRequest(checkoutCompletedEvent({ customer_details: null })),
     );

--- a/web/tests/test-preload.ts
+++ b/web/tests/test-preload.ts
@@ -12,6 +12,7 @@
 process.env.SKIP_ENV_VALIDATION = "1";
 process.env.CMUX_PUSH_RATE_LIMIT_ID ??= "cmux-push-test";
 process.env.RESEND_API_KEY ??= "re_test";
+process.env.STRIPE_FOUNDERS_WEBHOOK_SECRET ??= "whsec_founders_test";
 process.env.CMUX_FEEDBACK_FROM_EMAIL ??= "founders@manaflow.com";
 process.env.CMUX_FEEDBACK_RATE_LIMIT_ID ??= "feedback-test";
 process.env.STACK_SECRET_SERVER_KEY ??= "stack-secret";


### PR DESCRIPTION
## Root cause

`/api/stripe/founders-welcome` handles the dedicated Stripe `checkout.session.completed` webhook, but only sent the welcome email when the session carried `founders_edition === "true"` — the metadata set by the Founder's Edition payment link. cmux Pro checkout sessions are created by `/api/billing/checkout` with metadata `{ stackUserId, plan: "pro", app: "cmux" }` and no `founders_edition` key, so every Pro purchase was skipped as `not_founders` and the customer never received the welcome. A recent Pro purchase hit exactly this: the founder had to send everything manually.

## Product decision

Founder's Edition and cmux Pro are the same tier and get the same stuff. Any cmux Pro plan checkout (monthly or yearly — both share `plan: "pro"` + `app: "cmux"`) now triggers the identical welcome email. The Team plan (`plan: "team"`) is intentionally excluded.

## Changes

- New pure helper `welcomeTriggerForMetadata` (sibling to `welcome-email.ts`, since Next route files can't export extra symbols) returns which condition matched: `"founders_edition"`, `"pro_plan"`, or `null`.
- The route sends when either condition matches. Everything else is byte-identical: same `buildFoundersWelcomeEmail` builder/subject/body, same `founders-welcome/<session id>` Resend idempotency key and `X-Entity-Ref-ID` threading, same CC/reply-to, same non-2xx-on-Resend-failure retry semantics. Route path and env vars unchanged.
- Telemetry: new `cmux.stripe.welcome_trigger` span attribute (`founders_edition` | `pro_plan` | `none`) alongside the existing attributes; the skip reason for non-matching sessions is renamed `not_founders` → `not_welcome_eligible`.
- Comments updated to describe both trigger conditions.

## Tests

- `web/tests/founders-welcome-email.test.ts`: unit coverage of the trigger helper (founders flag, Pro metadata, both-present precedence, team/other-app/missing-metadata exclusions).
- `web/tests/founders-welcome-route.test.ts` (new, follows the `enterprise-contact-route` pattern): Pro session sends, founders session sends, team plan and non-cmux app skip, eligible session without a customer email short-circuits as `no_customer_email`, invalid signature is rejected, and a Resend failure returns 502 so Stripe retries. Also asserts the Pro send uses the same subject/idempotency key/thread header as founders.

`bun test`, `bun run typecheck`, and `eslint` pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787474704&installation_model_id=21920&pr_number=8846&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8846&signature=e0653cacb77872ec27dd29e465fbfcb0bdc3bb8116257e191092247cb026afb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the Founder's Edition welcome email for every Stripe `checkout.session.completed` on this endpoint — Founder's link, cmux Pro, Team, and other checkouts — so all customers get the welcome. Subject, idempotency key `founders-welcome/<session id>`, headers, and retry behavior are unchanged.

- **Bug Fixes**
  - Send on all completed checkouts; skip only non-checkout events, invalid/stale signatures, or sessions with `no_customer_email`.
  - Telemetry: add `cmux.stripe.welcome_trigger` (`founders_edition` | `pro_plan` | `team_plan` | `other`) and set `cmux.stripe.is_founders` accordingly; removed `not_welcome_eligible`.

- **Refactors**
  - `welcomeTriggerForMetadata` now classifies purchase shape for telemetry only.
  - Tests: added Team/“other” send cases; pinned clock to test 5‑minute Stripe signature tolerance; verified identical subject and idempotency/thread headers across founders/Pro/Team; kept invalid signature and Resend failure (502) paths.

<sup>Written for commit 19e88e61aa96eeb414199bfd29666ae25f4d7a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pro plan purchases (matching the supported app and plan) can now trigger the welcome email.
  * Welcome eligibility is now derived consistently from checkout metadata.
* **Bug Fixes**
  * Ineligible checkout sessions and non-checkout webhook events are skipped cleanly with appropriate outcomes.
  * Sessions missing a customer email are skipped, and delivery failures return retryable responses.
* **Tests**
  * Added unit tests for metadata-to-eligibility mapping.
  * Expanded webhook route tests for signature validation, replay tolerance, idempotency, skipping behavior, and email send failures.
  * Made test webhook secret/time handling deterministic for stable runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->