### PR TITLE
cmuxTests: stop FileDropOverlayViewTests killing its test host on a missing environment object

### DIFF
--- a/cmuxTests/FileDropOverlayViewTests.swift
+++ b/cmuxTests/FileDropOverlayViewTests.swift
@@ -19,6 +19,12 @@ final class FileDropOverlayViewTests: XCTestCase {
         let root = ContentView(updateViewModel: UpdateStateModel(), windowId: windowId)
             .environmentObject(TabManager())
             .environmentObject(TerminalNotificationStore.shared)
+            // ContentView reads SidebarUnreadModel from the environment. A missing
+            // @EnvironmentObject is a SwiftUI fatalError rather than a nil, so leaving it out does
+            // not fail this test, it kills the app host and discards every verdict still pending in
+            // it. The model belongs to the notification store, so hand over that store's instance
+            // rather than a detached one.
+            .environmentObject(TerminalNotificationStore.shared.sidebarUnread)
             .environmentObject(SidebarState())
             .environmentObject(SidebarSelectionState())
             .environmentObject(FileExplorerState())

--- a/cmuxTests/FileDropOverlayViewTests.swift
+++ b/cmuxTests/FileDropOverlayViewTests.swift
@@ -1,8 +1,8 @@
 import AppKit
 import ObjectiveC.runtime
 import SwiftUI
+import Testing
 import WebKit
-import XCTest
 import CmuxUpdater
 
 #if canImport(cmux_DEV)
@@ -12,7 +12,8 @@ import CmuxUpdater
 #endif
 
 @MainActor
-final class FileDropOverlayViewTests: XCTestCase {
+@Suite(.serialized)
+struct FileDropOverlayViewTests {
     private func makeContentViewWindow(windowId: UUID = UUID()) -> NSWindow {
         _ = NSApplication.shared
 
@@ -134,7 +135,8 @@ final class FileDropOverlayViewTests: XCTestCase {
         window.contentView?.layoutSubtreeIfNeeded()
     }
 
-    func testContentViewInstallsSingleFileDropOverlayAcrossRepeatedLayouts() {
+    @Test
+    func contentViewInstallsSingleFileDropOverlayAcrossRepeatedLayouts() throws {
         let window = makeContentViewWindow()
         defer {
             NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
@@ -145,24 +147,21 @@ final class FileDropOverlayViewTests: XCTestCase {
         realizeWindowLayout(window)
         realizeWindowLayout(window)
 
-        guard let themeFrame = window.contentView?.superview else {
-            XCTFail("Expected theme frame")
-            return
-        }
+        let themeFrame = try #require(window.contentView?.superview)
 
         let overlays = fileDropOverlays(in: themeFrame)
-        XCTAssertEqual(
-            overlays.count,
-            1,
+        #expect(
+            overlays.count == 1,
             "ContentView should install exactly one FileDropOverlayView even after repeated layout passes"
         )
-        XCTAssertTrue(
+        #expect(
             (objc_getAssociatedObject(window, &fileDropOverlayKey) as? FileDropOverlayView) === overlays.first,
             "The window-associated file-drop overlay should match the single installed view"
         )
     }
 
-    func testOverlayResolvesPortalHostedBrowserWebViewForFileDrops() {
+    @Test
+    func overlayResolvesPortalHostedBrowserWebViewForFileDrops() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),
             styleMask: [.titled, .closable],
@@ -175,11 +174,8 @@ final class FileDropOverlayViewTests: XCTestCase {
         }
         realizeWindowLayout(window)
 
-        guard let contentView = window.contentView,
-              let container = contentView.superview else {
-            XCTFail("Expected content container")
-            return
-        }
+        let contentView = try #require(window.contentView)
+        let container = try #require(contentView.superview)
 
         let anchor = NSView(frame: NSRect(x: 40, y: 36, width: 220, height: 150))
         contentView.addSubview(anchor)
@@ -197,13 +193,14 @@ final class FileDropOverlayViewTests: XCTestCase {
             NSPoint(x: anchor.bounds.midX, y: anchor.bounds.midY),
             to: nil
         )
-        XCTAssertTrue(
+        #expect(
             overlay.webViewUnderPoint(point) === webView,
             "File-drop overlay should resolve portal-hosted browser panes so Finder uploads still reach WKWebView"
         )
     }
 
-    func testOverlayDelegatesBrowserFileDragLifecycleToPortalHostedWebView() {
+    @Test
+    func overlayDelegatesBrowserFileDragLifecycleToPortalHostedWebView() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),
             styleMask: [.titled, .closable],
@@ -216,11 +213,8 @@ final class FileDropOverlayViewTests: XCTestCase {
         }
         realizeWindowLayout(window)
 
-        guard let contentView = window.contentView,
-              let container = contentView.superview else {
-            XCTFail("Expected content container")
-            return
-        }
+        let contentView = try #require(window.contentView)
+        let container = try #require(contentView.superview)
 
         let anchor = NSView(frame: NSRect(x: 52, y: 44, width: 210, height: 140))
         contentView.addSubview(anchor)
@@ -236,7 +230,7 @@ final class FileDropOverlayViewTests: XCTestCase {
 
         let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.drag.\(UUID().uuidString)"))
         pasteboard.clearContents()
-        XCTAssertTrue(
+        #expect(
             pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/upload.mov") as NSURL]),
             "Expected file URL drag payload"
         )
@@ -251,19 +245,19 @@ final class FileDropOverlayViewTests: XCTestCase {
             pasteboard: pasteboard
         )
 
-        XCTAssertEqual(overlay.draggingEntered(dragInfo), .copy)
-        XCTAssertTrue(overlay.prepareForDragOperation(dragInfo))
-        XCTAssertTrue(overlay.performDragOperation(dragInfo))
+        #expect(overlay.draggingEntered(dragInfo) == .copy)
+        #expect(overlay.prepareForDragOperation(dragInfo))
+        #expect(overlay.performDragOperation(dragInfo))
         overlay.concludeDragOperation(dragInfo)
 
-        XCTAssertEqual(
-            webView.dragCalls,
-            ["entered", "prepare", "perform", "conclude"],
+        #expect(
+            webView.dragCalls == ["entered", "prepare", "perform", "conclude"],
             "Finder file drops over browser panes should still reach the portal-hosted WKWebView"
         )
     }
 
-    func testOverlayDoesNotRecordTextDragWhenWebViewRejectsDrop() {
+    @Test
+    func overlayDoesNotRecordTextDragWhenWebViewRejectsDrop() throws {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)
         defaults.set(FileDropDefaultBehavior.text.rawValue, forKey: FileDropBehaviorSettings.defaultBehaviorKey)
@@ -287,11 +281,8 @@ final class FileDropOverlayViewTests: XCTestCase {
         }
         realizeWindowLayout(window)
 
-        guard let contentView = window.contentView,
-              let container = contentView.superview else {
-            XCTFail("Expected content container")
-            return
-        }
+        let contentView = try #require(window.contentView)
+        let container = try #require(contentView.superview)
 
         let anchor = NSView(frame: NSRect(x: 52, y: 44, width: 210, height: 140))
         contentView.addSubview(anchor)
@@ -308,7 +299,7 @@ final class FileDropOverlayViewTests: XCTestCase {
 
         let pasteboard = NSPasteboard(name: NSPasteboard.Name("cmux.test.drag.\(UUID().uuidString)"))
         pasteboard.clearContents()
-        XCTAssertTrue(
+        #expect(
             pasteboard.writeObjects([URL(fileURLWithPath: "/tmp/rejected-upload.mov") as NSURL]),
             "Expected file URL drag payload"
         )
@@ -323,16 +314,15 @@ final class FileDropOverlayViewTests: XCTestCase {
             pasteboard: pasteboard
         )
 
-        XCTAssertEqual(overlay.draggingEntered(dragInfo), .copy)
-        XCTAssertTrue(overlay.prepareForDragOperation(dragInfo))
-        XCTAssertFalse(overlay.performDragOperation(dragInfo))
-        XCTAssertFalse(overlay.didPerformDragAsText)
-        XCTAssertNil(overlay.performedTextDragWebView)
+        #expect(overlay.draggingEntered(dragInfo) == .copy)
+        #expect(overlay.prepareForDragOperation(dragInfo))
+        #expect(!overlay.performDragOperation(dragInfo))
+        #expect(!overlay.didPerformDragAsText)
+        #expect(overlay.performedTextDragWebView == nil)
 
         overlay.concludeDragOperation(dragInfo)
-        XCTAssertEqual(
-            webView.dragCalls,
-            ["entered", "prepare", "perform"],
+        #expect(
+            webView.dragCalls == ["entered", "prepare", "perform"],
             "Rejected text drops should not be recorded as performed or receive a text-route conclude"
         )
     }


### PR DESCRIPTION
`FileDropOverlayViewTests` kills its own test host. Measured one suite per host on `main`: one restart, and only 3 of its tests execute before the host dies. During maintainer closeout, the touched unit suite was also migrated in place from XCTest to Swift Testing, preserving all four behaviors while serializing its shared AppKit/defaults state.

The crash is a SwiftUI `fatalError`, not a window over-release:

```
SwiftUICore/EnvironmentObject.swift:92: Fatal error: No ObservableObject of type SidebarUnreadModel
found. A View.environmentObject(_:) for SidebarUnreadModel must be present
```

`ContentView` declares `@EnvironmentObject var sidebarUnread: SidebarUnreadModel` in two places, and `makeContentViewWindow` injected six environment objects but not that one. A missing `@EnvironmentObject` is a `fatalError` rather than a nil, so this does not fail a test — it takes the shared app host down, and every verdict still pending in that host goes missing from the summary instead of turning red.

The model belongs to `TerminalNotificationStore`, which this test already injects, so it now hands over that store's instance rather than a detached one. That matches the product wiring and the sibling suite that already does it this way.

## Why this is worth its own change

I measured the seven suites that kill their host on current `main`, then re-ran them with the window-release guard from #8832 applied. Four stopped dying. This suite did not, because its cause is unrelated — which is how the environment-object `fatalError` became visible at all.

The counts from any host-killing suite are a lower bound, and for three of the seven the host died before reporting anything, so their apparent "0 failures" was the `Executed 0 tests, with 0 failures` line a crashed host appends rather than a real result.

## Scope check

Four other test files mention `ContentView`. Two never mount it into a hosting view, so the body never evaluates and the environment is never read. The other two inject no environment objects at all and are not constructing the app's `ContentView` the same way. So this is the only file with this shape, and the change is one line plus a comment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787478036&installation_model_id=21920&pr_number=8851&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8851&signature=58a8a94e7f3ec359708930a7bf5515f45ae9a7c6c90eeafd89bfce81335b376c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix test host crashes in FileDropOverlayViewTests by injecting the missing SidebarUnreadModel and migrate the suite to Swift Testing for clearer, reliable assertions. This removes the SwiftUI fatalError and lets all tests run to completion.

- **Bug Fixes**
  - Inject `.environmentObject(TerminalNotificationStore.shared.sidebarUnread)` when building `ContentView`, using the store-owned instance to match app wiring and avoid a missing `@EnvironmentObject` crash.

- **Refactors**
  - Migrated from XCTest to Swift Testing (`@Suite(.serialized)`, `@Test`, `#expect`, `#require`) with no behavior changes.

<sup>Written for commit 5ea544a2fb7a4c89c275434f7960a9196998c36a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup to provide required notification state, preventing failures caused by missing environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- Contributor verification on a combined build: `FileDropOverlayViewTests` executed 4 tests with 0 failures, `restarts=0`, and `crashlines=0`.
- The same suite on unfixed `main` restarted its host and reported only 3 tests, demonstrating the missing verdict.
- This maintainer closeout relies on PR CI per repository policy; no local `xcodebuild test` was run.

## Demo Video

- Not applicable: this is a test-fixture-only change with no production UI change.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] The focused suite was tested against fixed and unfixed behavior.
- [x] The behavior-level test fixture was updated.
- [x] Docs/changelog are not needed for this test-only fix.
- [x] Bot reviews ran against the latest commit.
- [x] All actionable code review bot comments are resolved.
- [x] There are no unresolved human review comments.