### PR TITLE
Retry cloud provider reconnects and refine shared rails

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -158,12 +158,12 @@ pub fn workspace_state_dir() -> Option<PathBuf> {
     }
     #[cfg(target_os = "linux")]
     {
-        return env_path("XDG_STATE_HOME")
-            .map(|state| state.join("cmux-tui").join("sessions"))
-            .or_else(|| {
+        env_path("XDG_STATE_HOME").map(|state| state.join("cmux-tui").join("sessions")).or_else(
+            || {
                 home_dir()
                     .map(|home| home.join(".local").join("state").join("cmux-tui").join("sessions"))
-            });
+            },
+        )
     }
     #[cfg(windows)]
     {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -15322,6 +15322,25 @@ mod tests {
     }
 
     #[test]
+    fn failed_provider_reconnect_remains_pending_for_retry() {
+        let mux = Mux::new("provider-reconnect-retry-test", SurfaceOptions::default());
+        let (mut app, events) = test_app_with_events(Session::Local(mux));
+        app.machine_ui = Some(provider_machine_ui());
+        let (controller, requests) =
+            fake_controller(FakeMachineAction::Fail("provider is still offline"));
+        install_machine_controller(&mut app, controller);
+        app.machine_ui.as_mut().unwrap().request = Some(MachineRequest::ReconnectProvider);
+
+        settle_machine_action(&mut app, &events);
+
+        assert_eq!(
+            app.machine_ui.as_ref().and_then(|ui| ui.request.as_ref()),
+            Some(&MachineRequest::ReconnectProvider)
+        );
+        assert_eq!(requests.lock().unwrap().as_slice(), &[MachineRequest::ReconnectProvider]);
+    }
+
+    #[test]
     fn rejected_provider_workspace_mirror_commit_surfaces_the_session_error() {
         let mux = Mux::new("managed-workspace-rejected-mirror-test", SurfaceOptions::default());
         let placement = mux

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -15489,6 +15489,55 @@ mod tests {
     }
 
     #[test]
+    fn stale_replacement_settlement_preserves_newer_reconnect_action() {
+        for (case, committed) in [
+            ("committed", Ok(true)),
+            ("rejected", Ok(false)),
+            ("failed", Err("stale failure".into())),
+        ] {
+            let mux = Mux::new(format!("stale-replacement-{case}"), SurfaceOptions::default());
+            let mut app = test_app(Session::Local(mux));
+            app.machine_ui = Some(provider_machine_ui());
+            app.machine_action_in_flight = true;
+            app.machine_action_request = Some(MachineRequest::ReconnectProvider);
+            app.machine_provider_reconnect_attempts = 3;
+            let retry_at = Instant::now() + Duration::from_secs(10);
+            app.machine_provider_reconnect_retry_at = Some(retry_at);
+            app.pending_machine_replacement =
+                Some(pending_machine_replacement(&app, 2, &format!("newer-replacement-{case}")));
+
+            let action = app.apply_machine_controller_completion(
+                super::MachineControllerCompletion::ReplacementSettled {
+                    action_id: 1,
+                    committed,
+                    updates: None,
+                },
+            );
+
+            assert_eq!(action, RenderAction::Draw);
+            assert_eq!(
+                app.pending_machine_replacement.as_ref().map(|pending| pending.action_id),
+                Some(2)
+            );
+            assert!(app.machine_action_in_flight);
+            assert_eq!(app.machine_action_request, Some(MachineRequest::ReconnectProvider));
+            assert_eq!(app.machine_provider_reconnect_attempts, 3);
+            assert_eq!(app.machine_provider_reconnect_retry_at, Some(retry_at));
+            assert_eq!(
+                app.status_message.as_deref(),
+                Some(
+                    format!(
+                        "{}: {}",
+                        localization::catalog().sidebar.machine_action_failed,
+                        localization::catalog().sidebar.machine_replacement_stale
+                    )
+                    .as_str()
+                )
+            );
+        }
+    }
+
+    #[test]
     fn rejected_provider_workspace_mirror_commit_surfaces_the_session_error() {
         let mux = Mux::new("managed-workspace-rejected-mirror-test", SurfaceOptions::default());
         let placement = mux
@@ -16364,6 +16413,43 @@ mod tests {
             default_colors: cmux_tui_core::DefaultColors::default(),
             generation: 2,
             pty_input: dispatcher.sender(),
+        }
+    }
+
+    fn pending_machine_replacement(
+        app: &App,
+        action_id: u64,
+        label: &str,
+    ) -> super::PendingMachineReplacement {
+        let mux = Mux::new(label, SurfaceOptions::default());
+        let dispatcher = PtyInputDispatcher::spawn(|_| {}).unwrap();
+        let generation = app.session_generation.wrapping_add(1).max(1);
+        let (session, event_worker, mux_titles, mux_recovery_generation) = prepare_ordered_session(
+            Session::Local(mux),
+            dispatcher.sender(),
+            app.app_events.clone(),
+            generation,
+        )
+        .unwrap();
+        let tree = session.tree();
+        super::PendingMachineReplacement {
+            action_id,
+            action: super::PreparedMachineAction {
+                ui: provider_machine_ui(),
+                session_mutation: None,
+                session_label: None,
+                session: super::PreparedMachineSession {
+                    session,
+                    event_worker,
+                    generation,
+                    mux_titles,
+                    mux_recovery_generation,
+                    tree,
+                    label: label.into(),
+                    session_available: true,
+                    color_error: None,
+                },
+            },
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -15432,6 +15432,55 @@ mod tests {
     }
 
     #[test]
+    fn queued_user_action_runs_before_failed_provider_reconnect_retry() {
+        let mux = Mux::new("provider-reconnect-user-action-test", SurfaceOptions::default());
+        let (mut app, events) = test_app_with_events(Session::Local(mux));
+        app.machine_ui = Some(provider_machine_ui());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        install_machine_controller(
+            &mut app,
+            Box::new(FakeMachineController {
+                actions: VecDeque::from([
+                    FakeMachineAction::Return(Box::new(MachineActionResult::ui(
+                        provider_machine_ui(),
+                    ))),
+                    FakeMachineAction::Return(Box::new(MachineActionResult::ui(
+                        provider_machine_ui(),
+                    ))),
+                ]),
+                requests: requests.clone(),
+            }),
+        );
+        let user_request = MachineRequest::SelectProviderScope("team".into());
+        app.machine_action_in_flight = true;
+        app.machine_action_request = Some(MachineRequest::ReconnectProvider);
+        app.machine_ui.as_mut().unwrap().request = Some(user_request.clone());
+
+        app.apply_machine_controller_completion(super::MachineControllerCompletion::Action {
+            result: Err("provider is still offline".into()),
+            updates: None,
+        });
+
+        assert_eq!(app.machine_ui.as_ref().and_then(|ui| ui.request.as_ref()), Some(&user_request));
+        app.machine_provider_reconnect_retry_at = Some(Instant::now() - Duration::from_millis(1));
+
+        settle_machine_action(&mut app, &events);
+        assert_eq!(requests.lock().unwrap().as_slice(), &[user_request]);
+        assert!(app.machine_provider_reconnect_retry_at.is_some());
+
+        settle_machine_action(&mut app, &events);
+        assert_eq!(
+            requests.lock().unwrap().as_slice(),
+            &[
+                MachineRequest::SelectProviderScope("team".into()),
+                MachineRequest::ReconnectProvider,
+            ]
+        );
+        assert_eq!(app.machine_provider_reconnect_attempts, 0);
+        assert!(app.machine_provider_reconnect_retry_at.is_none());
+    }
+
+    #[test]
     fn rejected_provider_workspace_mirror_commit_surfaces_the_session_error() {
         let mux = Mux::new("managed-workspace-rejected-mirror-test", SurfaceOptions::default());
         let placement = mux

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4487,6 +4487,22 @@ impl App {
                 RenderAction::None
             }
             MachineControllerCompletion::ReplacementSettled { action_id, committed, updates } => {
+                if !self
+                    .pending_machine_replacement
+                    .as_ref()
+                    .is_some_and(|pending| pending.action_id == action_id)
+                {
+                    self.status_message = Some(format!(
+                        "{}: {}",
+                        localization::catalog().sidebar.machine_action_failed,
+                        localization::catalog().sidebar.machine_replacement_stale
+                    ));
+                    return RenderAction::Draw;
+                }
+                let pending = self
+                    .pending_machine_replacement
+                    .take()
+                    .expect("matching pending replacement was checked");
                 self.machine_action_in_flight = false;
                 let reconnecting = self.take_machine_action_was_provider_reconnect();
                 let mut action = RenderAction::None;
@@ -4495,18 +4511,6 @@ impl App {
                         if reconnecting {
                             self.clear_machine_provider_reconnect();
                         }
-                        let Some(pending) = self
-                            .pending_machine_replacement
-                            .take()
-                            .filter(|pending| pending.action_id == action_id)
-                        else {
-                            self.status_message = Some(format!(
-                                "{}: {}",
-                                localization::catalog().sidebar.machine_action_failed,
-                                localization::catalog().sidebar.machine_replacement_stale
-                            ));
-                            return RenderAction::Draw;
-                        };
                         let PreparedMachineAction { ui, session_mutation, session_label, session } =
                             pending.action;
                         self.install_prepared_machine_session(session);
@@ -4520,13 +4524,13 @@ impl App {
                         }
                     }
                     Ok(false) => {
-                        self.pending_machine_replacement.take();
+                        drop(pending);
                         if reconnecting {
                             self.schedule_machine_provider_reconnect();
                         }
                     }
                     Err(error) => {
-                        self.pending_machine_replacement.take();
+                        drop(pending);
                         if reconnecting {
                             self.schedule_machine_provider_reconnect();
                         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4305,14 +4305,20 @@ impl App {
         if self.machine_action_in_flight {
             return RenderAction::None;
         }
-        if self.machine_provider_reconnect_retry_at.is_some_and(|retry_at| {
-            Instant::now() < retry_at
-                && self
+        if let Some(retry_at) = self.machine_provider_reconnect_retry_at {
+            if Instant::now() < retry_at {
+                if self
                     .machine_ui
                     .as_ref()
                     .is_some_and(|ui| matches!(ui.request, Some(MachineRequest::ReconnectProvider)))
-        }) {
-            return RenderAction::None;
+                {
+                    return RenderAction::None;
+                }
+            } else if let Some(ui) = self.machine_ui.as_mut()
+                && ui.request.is_none()
+            {
+                ui.request = Some(MachineRequest::ReconnectProvider);
+            }
         }
         let Some(request) = self.machine_ui.as_mut().and_then(|ui| ui.request.take()) else {
             return RenderAction::None;
@@ -4359,7 +4365,9 @@ impl App {
             .min(MACHINE_PROVIDER_RECONNECT_MAX_BACKOFF_EXPONENT);
         self.machine_provider_reconnect_retry_at =
             Some(Instant::now() + Duration::from_secs(1_u64 << exponent));
-        if let Some(ui) = self.machine_ui.as_mut() {
+        if let Some(ui) = self.machine_ui.as_mut()
+            && ui.request.is_none()
+        {
             ui.request = Some(MachineRequest::ReconnectProvider);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14546,7 +14546,8 @@ mod tests {
         assert_eq!(buffer[(12, 2)].symbol(), "│");
         assert_eq!(buffer[(12, 2)].style().fg, Some(app.config.theme.notification_warning));
         assert!(row_contains(buffer, 1, "•"), "tab bar should contain unread dot");
-        assert_eq!(buffer[(0, 2)].symbol(), "•", "sidebar should contain unread dot");
+        assert_eq!(buffer[(0, 2)].symbol(), "▎", "sidebar should retain the active rail");
+        assert_eq!(buffer[(1, 2)].symbol(), "•", "sidebar should contain unread dot");
 
         app.replace_tree(notify_tree(surface.id, false));
         let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
@@ -14558,7 +14559,7 @@ mod tests {
         let buffer = terminal.backend().buffer();
         assert_eq!(buffer[(12, 2)].style().fg, Some(app.config.theme.border_active));
         assert!(!row_contains(buffer, 1, "•"), "tab bar dot should clear");
-        assert_ne!(buffer[(0, 2)].symbol(), "•", "sidebar dot should clear");
+        assert_ne!(buffer[(1, 2)].symbol(), "•", "sidebar dot should clear");
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -72,6 +72,7 @@ const ROUTING_REFRESH_RETRIES: u8 = 1;
 const BACKGROUND_REFRESH_RETRIES: u8 = 6;
 const APP_EVENT_CAPACITY: usize = 4_096;
 const PTY_FAILURE_CAPACITY: usize = 512;
+const MACHINE_PROVIDER_RECONNECT_MAX_BACKOFF_EXPONENT: u8 = 5;
 
 pub enum AppEvent {
     SessionScoped {
@@ -2900,6 +2901,9 @@ pub struct App {
     app_events: SyncSender<AppEvent>,
     machine_action_worker: Option<MachineActionWorker>,
     machine_action_in_flight: bool,
+    machine_action_request: Option<MachineRequest>,
+    machine_provider_reconnect_attempts: u8,
+    machine_provider_reconnect_retry_at: Option<Instant>,
     pending_machine_replacement: Option<PendingMachineReplacement>,
     machine_update_pump: Option<MachineUpdatePump>,
     machine_update_generation: u64,
@@ -3919,6 +3923,9 @@ pub fn run_with_machine_updates(
         app_events: tx,
         machine_action_worker,
         machine_action_in_flight: false,
+        machine_action_request: None,
+        machine_provider_reconnect_attempts: 0,
+        machine_provider_reconnect_retry_at: None,
         pending_machine_replacement: None,
         machine_update_pump: None,
         machine_update_generation: 0,
@@ -4209,6 +4216,7 @@ impl App {
                     Err(_) => break,
                 }
             }
+            action = action.merge(self.process_machine_requests());
             // Always drain retained failures. PtyFailuresReady only shortens
             // the idle wait, so a failed try_send cannot create a lost wakeup.
             action = action.merge(self.apply_pty_failures());
@@ -4297,6 +4305,15 @@ impl App {
         if self.machine_action_in_flight {
             return RenderAction::None;
         }
+        if self.machine_provider_reconnect_retry_at.is_some_and(|retry_at| {
+            Instant::now() < retry_at
+                && self
+                    .machine_ui
+                    .as_ref()
+                    .is_some_and(|ui| matches!(ui.request, Some(MachineRequest::ReconnectProvider)))
+        }) {
+            return RenderAction::None;
+        }
         let Some(request) = self.machine_ui.as_mut().and_then(|ui| ui.request.take()) else {
             return RenderAction::None;
         };
@@ -4313,8 +4330,11 @@ impl App {
             generation: self.session_generation.wrapping_add(1).max(1),
             pty_input: self.pty_input.sender(),
         };
-        match worker.perform(request, preparation) {
-            Ok(()) => self.machine_action_in_flight = true,
+        match worker.perform(request.clone(), preparation) {
+            Ok(()) => {
+                self.machine_action_in_flight = true;
+                self.machine_action_request = Some(request);
+            }
             Err(MachineSubmitError::Busy(request)) => {
                 if let Some(ui) = self.machine_ui.as_mut() {
                     ui.request = Some(request);
@@ -4328,6 +4348,29 @@ impl App {
             }
         }
         RenderAction::None
+    }
+
+    fn schedule_machine_provider_reconnect(&mut self) {
+        self.machine_provider_reconnect_attempts =
+            self.machine_provider_reconnect_attempts.saturating_add(1);
+        let exponent = self
+            .machine_provider_reconnect_attempts
+            .saturating_sub(1)
+            .min(MACHINE_PROVIDER_RECONNECT_MAX_BACKOFF_EXPONENT);
+        self.machine_provider_reconnect_retry_at =
+            Some(Instant::now() + Duration::from_secs(1_u64 << exponent));
+        if let Some(ui) = self.machine_ui.as_mut() {
+            ui.request = Some(MachineRequest::ReconnectProvider);
+        }
+    }
+
+    fn clear_machine_provider_reconnect(&mut self) {
+        self.machine_provider_reconnect_attempts = 0;
+        self.machine_provider_reconnect_retry_at = None;
+    }
+
+    fn take_machine_action_was_provider_reconnect(&mut self) -> bool {
+        matches!(self.machine_action_request.take(), Some(MachineRequest::ReconnectProvider))
     }
 
     fn apply_machine_controller_completion(
@@ -4350,9 +4393,13 @@ impl App {
             }
             MachineControllerCompletion::Action { result, updates } => {
                 self.machine_action_in_flight = false;
+                let reconnecting = self.take_machine_action_was_provider_reconnect();
                 let result = match result {
                     Ok(result) => result,
                     Err(error) => {
+                        if reconnecting {
+                            self.schedule_machine_provider_reconnect();
+                        }
                         self.status_message = Some(format!(
                             "{}: {error}",
                             localization::catalog().sidebar.machine_action_failed
@@ -4360,6 +4407,9 @@ impl App {
                         return RenderAction::Draw;
                     }
                 };
+                if reconnecting {
+                    self.clear_machine_provider_reconnect();
+                }
                 let MachineActionResult {
                     ui,
                     replacement,
@@ -4397,6 +4447,9 @@ impl App {
                         let _ = worker.abort_replacement(action_id);
                     }
                     self.machine_action_in_flight = false;
+                    if self.take_machine_action_was_provider_reconnect() {
+                        self.schedule_machine_provider_reconnect();
+                    }
                     self.status_message = Some(format!(
                         "{}: {}",
                         localization::catalog().sidebar.machine_action_failed,
@@ -4413,6 +4466,9 @@ impl App {
                 {
                     self.pending_machine_replacement.take();
                     self.machine_action_in_flight = false;
+                    if self.take_machine_action_was_provider_reconnect() {
+                        self.schedule_machine_provider_reconnect();
+                    }
                     self.status_message = Some(format!(
                         "{}: {}",
                         localization::catalog().sidebar.machine_action_failed,
@@ -4424,9 +4480,13 @@ impl App {
             }
             MachineControllerCompletion::ReplacementSettled { action_id, committed, updates } => {
                 self.machine_action_in_flight = false;
+                let reconnecting = self.take_machine_action_was_provider_reconnect();
                 let mut action = RenderAction::None;
                 match committed {
                     Ok(true) => {
+                        if reconnecting {
+                            self.clear_machine_provider_reconnect();
+                        }
                         let Some(pending) = self
                             .pending_machine_replacement
                             .take()
@@ -4453,9 +4513,15 @@ impl App {
                     }
                     Ok(false) => {
                         self.pending_machine_replacement.take();
+                        if reconnecting {
+                            self.schedule_machine_provider_reconnect();
+                        }
                     }
                     Err(error) => {
                         self.pending_machine_replacement.take();
+                        if reconnecting {
+                            self.schedule_machine_provider_reconnect();
+                        }
                         self.status_message = Some(format!(
                             "{}: {error}",
                             localization::catalog().sidebar.machine_action_failed
@@ -15326,9 +15392,19 @@ mod tests {
         let mux = Mux::new("provider-reconnect-retry-test", SurfaceOptions::default());
         let (mut app, events) = test_app_with_events(Session::Local(mux));
         app.machine_ui = Some(provider_machine_ui());
-        let (controller, requests) =
-            fake_controller(FakeMachineAction::Fail("provider is still offline"));
-        install_machine_controller(&mut app, controller);
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        install_machine_controller(
+            &mut app,
+            Box::new(FakeMachineController {
+                actions: VecDeque::from([
+                    FakeMachineAction::Fail("provider is still offline"),
+                    FakeMachineAction::Return(Box::new(MachineActionResult::ui(
+                        provider_machine_ui(),
+                    ))),
+                ]),
+                requests: requests.clone(),
+            }),
+        );
         app.machine_ui.as_mut().unwrap().request = Some(MachineRequest::ReconnectProvider);
 
         settle_machine_action(&mut app, &events);
@@ -15338,6 +15414,20 @@ mod tests {
             Some(&MachineRequest::ReconnectProvider)
         );
         assert_eq!(requests.lock().unwrap().as_slice(), &[MachineRequest::ReconnectProvider]);
+        assert_eq!(app.machine_provider_reconnect_attempts, 1);
+        assert!(app.machine_provider_reconnect_retry_at.is_some());
+        assert_eq!(app.process_machine_requests(), RenderAction::None);
+        assert_eq!(requests.lock().unwrap().len(), 1);
+
+        app.machine_provider_reconnect_retry_at = Some(Instant::now() - Duration::from_millis(1));
+        settle_machine_action(&mut app, &events);
+
+        assert_eq!(
+            requests.lock().unwrap().as_slice(),
+            &[MachineRequest::ReconnectProvider, MachineRequest::ReconnectProvider]
+        );
+        assert_eq!(app.machine_provider_reconnect_attempts, 0);
+        assert!(app.machine_provider_reconnect_retry_at.is_none());
     }
 
     #[test]
@@ -16620,6 +16710,9 @@ mod tests {
             app_events: events,
             machine_action_worker: None,
             machine_action_in_flight: false,
+            machine_action_request: None,
+            machine_provider_reconnect_attempts: 0,
+            machine_provider_reconnect_retry_at: None,
             pending_machine_replacement: None,
             machine_update_pump: None,
             machine_update_generation: 0,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -15739,6 +15739,24 @@ mod tests {
     }
 
     #[test]
+    fn personal_scope_row_does_not_repeat_the_same_label() {
+        let mux = Mux::new("provider-personal-scope-style-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        let mut ui = provider_controls_ui();
+        let mut provider = ui.provider.clone().unwrap();
+        provider.selected_scope_id = "personal".into();
+        ui.set_provider_presentation(provider);
+        app.machine_ui = Some(ui);
+        app.sync_layout((100, 16));
+        let mut terminal = Terminal::new(TestBackend::new(100, 16)).unwrap();
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains(" Personal ▾"), "{text}");
+        assert!(!text.contains("personal · Personal"), "{text}");
+    }
+
+    #[test]
     fn provider_snapshot_update_invalidates_stale_menu_and_prompt() {
         let mux = Mux::new("provider-overlay-invalidation-test", SurfaceOptions::default());
         let mut app = test_app(Session::Local(mux));

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4487,10 +4487,10 @@ impl App {
                 RenderAction::None
             }
             MachineControllerCompletion::ReplacementSettled { action_id, committed, updates } => {
-                if !self
+                if self
                     .pending_machine_replacement
                     .as_ref()
-                    .is_some_and(|pending| pending.action_id == action_id)
+                    .is_none_or(|pending| pending.action_id != action_id)
                 {
                     self.status_message = Some(format!(
                         "{}: {}",

--- a/cmux-tui/crates/cmux-tui/src/ui/rail.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/rail.rs
@@ -257,6 +257,45 @@ pub fn divider(area: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn active_entry_keeps_the_shared_rail_when_it_has_a_status_indicator() {
+        let mut terminal = Terminal::new(TestBackend::new(16, 3)).unwrap();
+        let palette = RailPalette {
+            base: Style::default(),
+            dim: Style::default(),
+            active: Style::default().add_modifier(Modifier::BOLD),
+            border: Style::default(),
+            rail: Color::Cyan,
+        };
+        terminal
+            .draw(|frame| {
+                entry(
+                    frame,
+                    Rect { x: 0, y: 0, width: 16, height: 3 },
+                    0,
+                    Entry {
+                        name: "machine",
+                        subtitle: "running",
+                        highlighted: true,
+                        active: true,
+                        indicator: Some(Color::Green),
+                        dimmed: false,
+                    },
+                    palette,
+                );
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), "▎");
+        assert_eq!(buffer[(0, 1)].symbol(), "▎");
+        assert_eq!(buffer[(1, 0)].symbol(), "•");
+        assert_eq!(buffer[(3, 0)].symbol(), "m");
+        assert_eq!(buffer[(1, 1)].symbol(), "r");
+    }
 
     #[test]
     fn short_viewport_pins_footer_and_keeps_selected_action_visible() {

--- a/cmux-tui/crates/cmux-tui/src/ui/rail.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/rail.rs
@@ -183,11 +183,23 @@ pub fn entry(frame: &mut Frame, area: Rect, y: u16, entry: Entry<'_>, palette: R
             buf[(area.x, y + 1)].set_symbol("▎").set_style(rail_style);
         }
     }
-    if let Some(color) = entry.indicator {
-        buf[(area.x, y)].set_symbol("•").set_style(style.fg(color).add_modifier(Modifier::BOLD));
+    let indicator = entry.indicator.filter(|_| content_w > 3);
+    if let Some(color) = indicator {
+        buf[(area.x + 1, y)]
+            .set_symbol("•")
+            .set_style(style.fg(color).add_modifier(Modifier::BOLD));
+    }
+    let name_offset = if indicator.is_some() { 3 } else { 1 };
+    if content_w > name_offset {
+        buf.set_stringn(
+            area.x + name_offset as u16,
+            y,
+            truncate(entry.name, content_w - name_offset),
+            content_w - name_offset,
+            style,
+        );
     }
     if content_w > 1 {
-        buf.set_stringn(area.x + 1, y, truncate(entry.name, content_w - 1), content_w - 1, style);
         buf.set_stringn(
             area.x + 1,
             y + 1,

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -133,7 +133,11 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
                         ProviderScopeKind::Personal => messages.personal_scope,
                         ProviderScopeKind::Team => messages.team_scope,
                     };
-                    format!("{kind} · {} ▾", scope.name)
+                    if scope.name.trim().eq_ignore_ascii_case(kind) {
+                        format!("{} ▾", scope.name)
+                    } else {
+                        format!("{kind} · {} ▾", scope.name)
+                    }
                 })
                 .unwrap_or_else(|| format!("{} ▾", messages.scope));
             rail::button(


### PR DESCRIPTION
## Summary

- retain failed `ReconnectProvider` requests and retry them with bounded 1–32 second backoff
- let the same `npx cmux --cloud` process recover after an SSH edge restart
- keep the active rail visible beside machine/workspace status dots
- avoid duplicate personal-scope labels such as `personal · Personal`
- remove an upstream Linux-only Clippy warning that otherwise makes current `main` fail the TUI lint gate

The machine and workspace sidebars continue to use the same shared rail renderer; this only fixes reconnect liveness and the two visual collisions found while dogfooding cmux Cloud.

## Testing

- `cargo fmt --check`
- Linux arm64, Rust 1.97.1, Zig 0.15.2: 472 unit tests, 10 CLI tests, 3 terminal-host-mode tests, and 19 terminal-host-recovery tests passed
- strict `cargo clippy --locked -p cmux-tui --all-targets -- -D warnings`
- red/green behavior tests for provider reconnect, active rail/status indicator placement, and personal-scope label deduplication
- tmux dogfood with an offline local npm package: stopped the SSH edge for five seconds, observed a failed retry, restarted only the edge, and verified the same TUI PID reconnected and executed a command in the existing terminal
- tmux mouse dogfood: independently resized both native rails and selected machine/workspace rows

One pre-existing `stalled_renderer_is_disconnected_without_freezing_the_host` timing assertion is unreliable in a Docker-for-Mac arm64 container; it is untouched by this diff. The native GitHub Linux/macOS jobs remain the merge authority for that platform-sensitive test.

## Demo Video

- No uploaded video; the exact terminal flow was recorded as tmux captures and an enumerated dogfood ledger in `manaflow-ai/cmux-cloud#4`.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787478712&installation_model_id=21920&pr_number=8854&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8854&signature=865a2e5b535b9ded708d9c7f97b236190dce1a5cafafb2ea7fe5bbd682680a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded retry for provider reconnects with 1–32s exponential backoff so a single `npx cmux --cloud` session can recover after SSH edge restarts, and keeps user actions responsive during backoff. Preserves reconnect state across stale replacement settlements, refines the sidebar rail UI, and keeps a couple of lints clean.

- **New Features**
  - Retries `ReconnectProvider` with 1–32s exponential backoff, keeping the request pending and reissuing until success.
  - Preserves and prioritizes queued user actions; they run before a reconnect retry.

- **Bug Fixes**
  - Keeps reconnect backoff/state when a stale machine replacement settlement arrives.
  - Refines the sidebar rail: active rail stays visible beside status dots, unread dot shifts one column, and the “Personal” scope label is no longer duplicated.
  - Keeps the replacement‑id guard and Linux workspace state path warning‑clean.

<sup>Written for commit d512ed062cb7b5ee335a7067587db4957797e297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persisted, bounded exponential backoff for provider reconnect retries, including suppression of new actions while a reconnect retry is pending.
  * Updated reconnect handling to recover from failed reconnect triggers and clear retry state on success.
* **Bug Fixes**
  * Fixed narrow-rail entry rendering to keep the active rail glyph visible and correctly position optional indicators and entry text.
  * Prevented duplicate provider-scope label prefixes and corrected unread indicator clearing/placement.
* **Tests**
  * Added/updated tests for reconnect retry state, action ordering, stale settlement handling, and updated rail/scope label assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->