### PR TITLE
Fix the main build: four errors across three files

### DIFF
--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -278,7 +278,7 @@ extension TerminalController {
         )
         content.apply(to: alert, presentingWindow: nil)
 
-        switch alert.runModal() {
+        return switch alert.runModal() {
         case .alertFirstButtonReturn: .auto
         case .alertSecondButtonReturn: .prompt
         default: .manual

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -1,3 +1,4 @@
+import CmuxWorkspaces
 import Foundation
 
 extension DockSplitStore {

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -41,11 +41,12 @@ extension DockSplitStore {
                 )
             }
         let persistedPanelIds = Set(panelSnapshots.map(\.id))
-        let sourceWorkspaceIdsByPanelId = Dictionary(uniqueKeysWithValues: panelSnapshots.compactMap {
-            panel in
-            guard let transfer = detachedSurfaceTransfersByPanelId[panel.id] else { return nil }
-            return (panel.id, transfer.sessionRestoreWorkspaceId)
-        })
+        let sourceWorkspaceIdsByPanelId: [UUID: UUID] = Dictionary(
+            uniqueKeysWithValues: panelSnapshots.compactMap { panel -> (UUID, UUID)? in
+                guard let transfer = detachedSurfaceTransfersByPanelId[panel.id] else { return nil }
+                return (panel.id, transfer.sessionRestoreWorkspaceId)
+            }
+        )
         let layout = layoutCodec.pruned(
             rawLayout,
             keeping: persistedPanelIds
@@ -329,7 +330,7 @@ extension DockSplitStore {
         let expectedSessionId = resumeBinding?.isAgentHookBinding == true
             ? resumeBinding?.checkpointId
             : restorableAgent?.sessionId
-        let relevantObservation = observation.flatMap { entry in
+        let relevantObservation = observation.flatMap { entry -> RestorableAgentSessionIndex.Entry? in
             guard entry.snapshot.kind == expectedKind, entry.snapshot.sessionId == expectedSessionId else {
                 return nil
             }

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -214,6 +214,7 @@ struct DockWorkingDirectoryInheritanceTests {
     ) -> Workspace.DetachedSurfaceTransfer {
         Workspace.DetachedSurfaceTransfer(
             sourceWorkspaceId: sourceWorkspaceId,
+            sessionRestoreSourceWorkspaceId: nil,
             panelId: panel.id,
             panel: panel,
             title: panel.displayTitle,


### PR DESCRIPTION
Building `main` fails. Three errors, all in the two Dock session-restore files that
arrived with #8690, and the first one hides the other two:

```
Sources/DockSplitStore+RestoredAgentLifecycle.swift:13:62: error: cannot find type 'PanelShellActivityState' in scope
Sources/DockSplitStore+SessionSnapshot.swift:44:43: error: generic parameter 'Key' could not be inferred
Sources/DockSplitStore+SessionSnapshot.swift:44:43: error: generic parameter 'Value' could not be inferred
Sources/DockSplitStore+SessionSnapshot.swift:332:47: error: generic parameter 'U' could not be inferred
```

Repro on a clean checkout of `main` at 4dc00aebb8:

```
xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
  -destination 'platform=macOS' build
```

**The missing import.** `DockSplitStore+RestoredAgentLifecycle.swift` declares
`updatePanelShellActivityState(panelId:state:)`, whose `state` is a
`PanelShellActivityState`. That type is a `public enum` in the CmuxWorkspaces package, and
Swift resolves imports per file, so the app target depending on the package is not enough on
its own. Every other file under `Sources/` that names the type imports CmuxWorkspaces; this
one imports only Foundation.

**The two inference failures.** Both are the same shape: a multi-statement closure whose
bail-out is a bare `return nil`, handed to something generic. Line 44 gives it to
`Dictionary(uniqueKeysWithValues:)`, which then has to solve `Key` and `Value`; line 332 gives
it to `Optional.flatMap`, which has to solve `U`. A bare `return nil` carries no type, so the
closure's result type and the generic parameters each wait on the other. Naming the return
types breaks the cycle, using the types the surrounding code already fixes:
`SessionSplitContainerSnapshot` declares `sourceWorkspaceIdsByPanelId` as `[UUID: UUID]?`,
`sessionRestoreWorkspaceId` is a `UUID`, and `observation` is a
`RestorableAgentSessionIndex.Entry?`. Behaviour is unchanged.

**A fourth error, in a third file.** `surfacePromptForResumeApproval` builds an `NSAlert` over
several statements and ends with a bare `switch alert.runModal()` whose cases are `.auto`,
`.prompt` and `.manual`:

```
Sources/ControlSurfaceResumeTarget.swift:282:40: error: reference to member 'auto' cannot be resolved without a contextual type
Sources/ControlSurfaceResumeTarget.swift:283:41: error: reference to member 'prompt' cannot be resolved without a contextual type
Sources/ControlSurfaceResumeTarget.swift:284:19: error: reference to member 'manual' cannot be resolved without a contextual type
```

Swift gives a function body an implicit return only when the body is a single expression, so
in a multi-statement body that switch is an expression statement with nothing to type it, and
the leading-dot members have no `SurfaceResumeApprovalPolicy` to resolve against. Returning it
supplies the contextual type. Every other trailing switch of this shape under `Sources/` is the
single-expression body of a computed property or a one-statement function, which is why this is
the only one that fails.

Worth saying how this got in, because it will happen again otherwise: `ci.yml` is
`workflow_dispatch:`-only, so no pull request is ever built. The checks that appear on a PR
are reviewers, not a compile, so a commit that does not build can land looking green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined how resume approval outcomes are processed for consistency.
  * Improved robustness of workspace/session snapshot mapping and related filtering behavior.
* **Tests**
  * Updated workspace inheritance test setup to explicitly omit a restore source workspace ID where appropriate.
* **No user-visible changes**
  * These changes are intended to be behavior-preserving for end-users, with improvements focused on reliability and internal consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->