### PR TITLE
Bound mobile event emission: synchronous admission, shed-or-close, stall teardown (#8842)

### DIFF
--- a/Sources/Mobile/MobileHostConnectionEventQueue.swift
+++ b/Sources/Mobile/MobileHostConnectionEventQueue.swift
@@ -1,0 +1,332 @@
+import CMUXMobileCore
+import Foundation
+
+/// Per-topic shedding policy for server-pushed mobile events.
+///
+/// "Droppable" topics are the refresh-class streams a client can always
+/// recover without the host replaying the exact dropped payload:
+/// - `terminal.render_grid`: the producer is asked to re-emit a full frame for
+///   every surface whose queued frame was shed
+///   (``MobileTerminalRenderObserver/requestRenderGridFullResync(surfaceIDStrings:)``),
+///   and the per-connection queue refuses further deltas for that surface until
+///   the full frame arrives. The iOS client has no delta-continuity check, so a
+///   silently dropped delta would corrupt its grid invisibly; the
+///   poison-until-full rule makes a shed unobservable beyond one stale paint.
+/// - `terminal.bytes`: chunks carry a byte-offset `seq`; the client detects the
+///   gap and requests a replay on its own.
+/// - `terminal.updated` / `workspace.updated`: level-triggered pings; the newer
+///   occurrence that forced the shed supersedes the shed one.
+///
+/// Every other topic keeps the close-on-overflow contract: those payloads
+/// cannot be re-derived by the client, so tearing the connection down (the
+/// client reconnects and re-syncs from authoritative state) is the only
+/// lossless bound.
+enum MobileHostEventTopicPolicy {
+    static let renderGridTopic = "terminal.render_grid"
+
+    static func isDroppable(topic: String, coalesceKey: String?) -> Bool {
+        switch topic {
+        case renderGridTopic:
+            // A render-grid event without a surface key cannot be resynced
+            // per-surface, so it keeps the lossless close-on-overflow path.
+            return coalesceKey != nil
+        case "terminal.bytes", "terminal.updated", "workspace.updated":
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+/// Outcome of one synchronous admission attempt on a connection's event queue.
+struct MobileHostEventEnqueueResult: Sendable {
+    /// The event was appended to the bounded queue.
+    let admitted: Bool
+    /// The caller must start the (single) drain task for this connection.
+    let startDrain: Bool
+    /// A non-droppable event overflowed the bounded queue; the caller must
+    /// close the connection — the lossless-topic contract.
+    let shouldClose: Bool
+    /// Surfaces whose queued render-grid frames were shed; the caller must ask
+    /// the producer for a full-frame resync of each.
+    let renderGridResyncSurfaceIDs: Set<String>
+
+    static let rejected = MobileHostEventEnqueueResult(
+        admitted: false,
+        startDrain: false,
+        shouldClose: false,
+        renderGridResyncSurfaceIDs: []
+    )
+}
+
+/// Bounded, synchronously-admitted mailbox between the event fan-out
+/// (``MobileHostService/emitEvent(topic:payload:)``) and one connection's
+/// drain loop.
+///
+/// This is the owner boundary for issue #8842: admission runs *before* any
+/// per-connection work is scheduled, on the emitter's thread, against an
+/// explicit bound — so the memory pinned per connection is O(capacity) no
+/// matter how far emission runs ahead of a slow, paused, or half-dead
+/// subscriber. The previous path spawned one unstructured Task per connection
+/// per event, each retaining the full payload dictionary until the connection
+/// actor reached its own bounded check, which left everything upstream of the
+/// bound unbounded.
+final class MobileHostConnectionEventQueue: @unchecked Sendable {
+    struct QueuedEvent: Sendable {
+        let topic: String
+        let coalesceKey: String?
+        let frame: Data
+    }
+
+    static let defaultMaximumEventCount = 256
+    static let defaultMaximumByteCount =
+        MobileSyncFrameCodec.defaultMaximumFrameByteCount
+        + MobileSyncFrameCodec.headerByteCount
+
+    private let lock = NSLock()
+    private let maximumEventCount: Int
+    private let maximumByteCount: Int
+    private var subscribedTopics: Set<String> = []
+    private var queuedEvents: [QueuedEvent] = []
+    private var queuedByteCount = 0
+    private var drainActive = false
+    private var isClosed = false
+    /// Surfaces whose delta chain was broken by a shed frame. Only a
+    /// full-frame render-grid event readmits the surface; deltas are refused so
+    /// the client can never apply a delta whose predecessor was dropped.
+    private var poisonedRenderGridSurfaceIDs: Set<String> = []
+    /// Poisoned surfaces whose replacement full frame ALSO had to be dropped
+    /// (queue full of non-droppable events). Re-requested once the drain frees
+    /// room, so a fully stalled connection cannot spin the producer.
+    private var resyncAfterDrainSurfaceIDs: Set<String> = []
+
+    init(
+        maximumEventCount: Int = MobileHostConnectionEventQueue.defaultMaximumEventCount,
+        maximumByteCount: Int = MobileHostConnectionEventQueue.defaultMaximumByteCount
+    ) {
+        self.maximumEventCount = maximumEventCount
+        self.maximumByteCount = maximumByteCount
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return queuedEvents.count
+    }
+
+    var byteCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return queuedByteCount
+    }
+
+    /// Replaces the subscribed-topic snapshot used for synchronous admission.
+    /// The owning connection calls this on subscribe/unsubscribe/close.
+    func updateSubscribedTopics(_ topics: Set<String>) {
+        lock.lock()
+        subscribedTopics = topics
+        lock.unlock()
+    }
+
+    func isSubscribed(topic: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return subscribedTopics.contains(topic)
+    }
+
+    /// Synchronous bounded admission. Safe to call from any thread; never
+    /// blocks on the network, the connection actor, or the runtime.
+    func enqueue(
+        topic: String,
+        coalesceKey: String?,
+        isFullRenderGridFrame: Bool,
+        frame: Data
+    ) -> MobileHostEventEnqueueResult {
+        lock.lock()
+        guard !isClosed, subscribedTopics.contains(topic) else {
+            lock.unlock()
+            return .rejected
+        }
+        let isRenderGrid = topic == MobileHostEventTopicPolicy.renderGridTopic
+        if isRenderGrid,
+           let coalesceKey,
+           !isFullRenderGridFrame,
+           poisonedRenderGridSurfaceIDs.contains(coalesceKey) {
+            // The surface's delta chain is already broken; only the pending
+            // full frame may readmit it.
+            lock.unlock()
+            return .rejected
+        }
+        var resyncSurfaceIDs = Set<String>()
+        if !hasRoomLocked(for: frame) {
+            shedDroppableEventsLocked(for: frame, resyncSurfaceIDs: &resyncSurfaceIDs)
+        }
+        if isRenderGrid,
+           let coalesceKey,
+           !isFullRenderGridFrame,
+           poisonedRenderGridSurfaceIDs.contains(coalesceKey) {
+            // The shed pass just broke this surface's chain; this delta builds
+            // on the shed frames, so it must not slip into the freed room.
+            lock.unlock()
+            return MobileHostEventEnqueueResult(
+                admitted: false,
+                startDrain: false,
+                shouldClose: false,
+                renderGridResyncSurfaceIDs: resyncSurfaceIDs
+            )
+        }
+        guard hasRoomLocked(for: frame) else {
+            guard MobileHostEventTopicPolicy.isDroppable(topic: topic, coalesceKey: coalesceKey) else {
+                lock.unlock()
+                return MobileHostEventEnqueueResult(
+                    admitted: false,
+                    startDrain: false,
+                    shouldClose: true,
+                    renderGridResyncSurfaceIDs: resyncSurfaceIDs
+                )
+            }
+            if isRenderGrid, let coalesceKey {
+                if poisonedRenderGridSurfaceIDs.insert(coalesceKey).inserted {
+                    resyncSurfaceIDs.insert(coalesceKey)
+                } else if isFullRenderGridFrame {
+                    // The replacement full frame itself could not be admitted;
+                    // ask again once the drain makes room.
+                    resyncAfterDrainSurfaceIDs.insert(coalesceKey)
+                }
+            }
+            lock.unlock()
+            return MobileHostEventEnqueueResult(
+                admitted: false,
+                startDrain: false,
+                shouldClose: false,
+                renderGridResyncSurfaceIDs: resyncSurfaceIDs
+            )
+        }
+        queuedEvents.append(QueuedEvent(topic: topic, coalesceKey: coalesceKey, frame: frame))
+        queuedByteCount += frame.count
+        if isRenderGrid, isFullRenderGridFrame, let coalesceKey {
+            poisonedRenderGridSurfaceIDs.remove(coalesceKey)
+            resyncAfterDrainSurfaceIDs.remove(coalesceKey)
+        }
+        let startDrain = !drainActive
+        if startDrain {
+            drainActive = true
+        }
+        lock.unlock()
+        return MobileHostEventEnqueueResult(
+            admitted: true,
+            startDrain: startDrain,
+            shouldClose: false,
+            renderGridResyncSurfaceIDs: resyncSurfaceIDs
+        )
+    }
+
+    func dequeue() -> QueuedEvent? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !queuedEvents.isEmpty else { return nil }
+        let event = queuedEvents.removeFirst()
+        queuedByteCount -= event.frame.count
+        return event
+    }
+
+    /// Called by the drain loop after `dequeue` returned nil. Returns true when
+    /// events raced in and the loop must keep draining; otherwise the drain is
+    /// marked finished so the next enqueue can claim a fresh one.
+    func finishDrain() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if queuedEvents.isEmpty || isClosed {
+            drainActive = false
+            return false
+        }
+        return true
+    }
+
+    /// Marks the drain inactive after an abnormal exit (close, lane
+    /// negotiation, failed delivery) so a later enqueue can claim a fresh one.
+    func abandonDrain() {
+        lock.lock()
+        drainActive = false
+        lock.unlock()
+    }
+
+    /// Claims the drain when events are pending and none is running (used when
+    /// independent-lane negotiation finishes and delivery may resume).
+    func claimDrain() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isClosed, !drainActive, !queuedEvents.isEmpty else { return false }
+        drainActive = true
+        return true
+    }
+
+    /// Poisoned surfaces whose full-frame resync should be re-requested now
+    /// that the drain has made progress.
+    func takeResyncAfterDrainRequests() -> Set<String> {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !resyncAfterDrainSurfaceIDs.isEmpty else { return [] }
+        let requests = resyncAfterDrainSurfaceIDs
+        resyncAfterDrainSurfaceIDs.removeAll()
+        return requests
+    }
+
+    /// Rejects all future admissions and releases every queued payload.
+    func close() {
+        lock.lock()
+        isClosed = true
+        queuedEvents.removeAll(keepingCapacity: false)
+        queuedByteCount = 0
+        poisonedRenderGridSurfaceIDs.removeAll()
+        resyncAfterDrainSurfaceIDs.removeAll()
+        subscribedTopics.removeAll()
+        lock.unlock()
+    }
+
+    private func hasRoomLocked(for frame: Data) -> Bool {
+        queuedEvents.count < maximumEventCount
+            && queuedByteCount + frame.count <= maximumByteCount
+    }
+
+    private func shedDroppableEventsLocked(
+        for frame: Data,
+        resyncSurfaceIDs: inout Set<String>
+    ) {
+        var index = 0
+        while !hasRoomLocked(for: frame), index < queuedEvents.count {
+            let event = queuedEvents[index]
+            guard MobileHostEventTopicPolicy.isDroppable(
+                topic: event.topic,
+                coalesceKey: event.coalesceKey
+            ) else {
+                index += 1
+                continue
+            }
+            queuedEvents.remove(at: index)
+            queuedByteCount -= event.frame.count
+            if event.topic == MobileHostEventTopicPolicy.renderGridTopic,
+               let surfaceID = event.coalesceKey,
+               poisonedRenderGridSurfaceIDs.insert(surfaceID).inserted {
+                resyncSurfaceIDs.insert(surfaceID)
+            }
+        }
+        // A shed frame breaks its surface's delta chain, so every remaining
+        // queued render-grid frame for that surface — each builds on the shed
+        // one — must go with it. The pending full-frame resync re-bases the
+        // chain for the whole connection.
+        guard !resyncSurfaceIDs.isEmpty else { return }
+        var freedByteCount = 0
+        let brokenSurfaceIDs = resyncSurfaceIDs
+        queuedEvents.removeAll { event in
+            guard event.topic == MobileHostEventTopicPolicy.renderGridTopic,
+                  let surfaceID = event.coalesceKey,
+                  brokenSurfaceIDs.contains(surfaceID) else {
+                return false
+            }
+            freedByteCount += event.frame.count
+            return true
+        }
+        queuedByteCount -= freedByteCount
+    }
+}

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -2594,9 +2594,5 @@ extension MobileHostConnection {
     func debugQueuedEventCountForTesting() -> Int {
         eventQueue.count
     }
-
-    func debugQueuedEventByteCountForTesting() -> Int {
-        eventQueue.byteCount
-    }
 }
 #endif

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -405,22 +405,133 @@ final class MobileHostService {
     /// Static form for callers already on non-main queues or Sendable
     /// notification closures. This path only touches the connection registry,
     /// not actor-isolated listener state.
+    ///
+    /// The event is encoded exactly once and admitted synchronously into each
+    /// connection's bounded queue. No per-connection task or payload copy
+    /// outlives this call, so emission cost stays O(connections) and pinned
+    /// memory stays O(queue capacity) no matter how far producers run ahead of
+    /// a slow, paused, or half-dead subscriber (issue #8842).
     nonisolated static func emitEvent(topic: String, payload: [String: Any]) {
         guard MobileHostEventSubscriptionTracker.hasSubscribers(topic: topic) else {
             return
         }
+        guard let frame = encodedEventFrame(topic: topic, payload: payload) else {
+            mobileHostLog.error(
+                "mobile host dropped unencodable event topic=\(topic, privacy: .public)"
+            )
+            return
+        }
+        deliverEventFrame(
+            frame,
+            topic: topic,
+            coalesceKey: eventCoalesceKey(topic: topic, payload: payload),
+            isFullRenderGridFrame: topic == MobileHostEventTopicPolicy.renderGridTopic
+                && payload["full"] as? Bool == true
+        )
+    }
+
+    /// Render-grid fast path: the frame is already JSON-encoded, so the event
+    /// envelope is spliced around it without parsing the grid into a dictionary
+    /// and re-serializing it — this is the hottest producer in the app
+    /// (issue #8842).
+    nonisolated static func emitRenderGridEvent(
+        payloadJSON: Data,
+        surfaceID: String,
+        isFullFrame: Bool
+    ) {
+        let topic = MobileHostEventTopicPolicy.renderGridTopic
+        guard MobileHostEventSubscriptionTracker.hasSubscribers(topic: topic) else {
+            return
+        }
+        var envelope = Data(#"{"kind":"event","topic":"terminal.render_grid","payload":"#.utf8)
+        envelope.append(payloadJSON)
+        envelope.append(UInt8(ascii: "}"))
+        guard let frame = try? MobileSyncFrameCodec.encodeFrame(envelope) else {
+            mobileHostLog.error("mobile host dropped oversized render-grid event")
+            return
+        }
+        deliverEventFrame(
+            frame,
+            topic: topic,
+            coalesceKey: surfaceID,
+            isFullRenderGridFrame: isFullFrame
+        )
+    }
+
+    /// Encodes the shared event envelope once for every connection. Returns
+    /// `nil` for payloads that cannot be serialized or frames over the wire
+    /// limit; such an event is undeliverable to every connection, so the
+    /// caller drops it instead of punishing any peer.
+    nonisolated static func encodedEventFrame(
+        topic: String,
+        payload: [String: Any]
+    ) -> Data? {
+        let envelope: [String: Any] = [
+            "kind": "event",
+            "topic": topic,
+            "payload": payload,
+        ]
+        guard let encoded = try? JSONSerialization.data(withJSONObject: envelope) else {
+            return nil
+        }
+        return try? MobileSyncFrameCodec.encodeFrame(encoded)
+    }
+
+    /// The per-surface key bounded queues coalesce render-grid and byte events
+    /// on. `nil` for topics without per-surface recovery semantics.
+    nonisolated static func eventCoalesceKey(topic: String, payload: [String: Any]) -> String? {
+        switch topic {
+        case MobileHostEventTopicPolicy.renderGridTopic, "terminal.bytes":
+            return payload["surface_id"] as? String
+        default:
+            return nil
+        }
+    }
+
+    /// Fans one encoded event frame out to every registered connection through
+    /// synchronous bounded admission, then acts on the admission outcomes:
+    /// starts at most one drain per connection, closes connections whose
+    /// non-droppable events overflowed, and requests full-frame resyncs for
+    /// surfaces whose queued render-grid frames were shed.
+    nonisolated private static func deliverEventFrame(
+        _ frame: Data,
+        topic: String,
+        coalesceKey: String?,
+        isFullRenderGridFrame: Bool
+    ) {
         let connections = MobileHostConnectionRegistry.shared.snapshot()
         guard !connections.isEmpty else { return }
         #if DEBUG
         cmuxDebugLog("mobile.emit topic=\(topic) connections=\(connections.count)")
         #endif
+        var resyncSurfaceIDs = Set<String>()
         for connection in connections {
-            Task {
-                let delivered = await connection.sendEvent(topic: topic, payload: payload)
-                #if DEBUG
-                cmuxDebugLog("mobile.emit -> connection delivered=\(delivered) topic=\(topic)")
-                #endif
+            let result = connection.enqueueEventFrame(
+                frame,
+                topic: topic,
+                coalesceKey: coalesceKey,
+                isFullRenderGridFrame: isFullRenderGridFrame
+            )
+            resyncSurfaceIDs.formUnion(result.renderGridResyncSurfaceIDs)
+            if result.startDrain {
+                Task { await connection.drainQueuedEvents() }
             }
+            if result.shouldClose {
+                Task {
+                    await connection.close(
+                        reason: "event queue exceeded bounded capacity",
+                        exit: CmxIrohAdmittedConnectionExit(
+                            lifecycle: .controlWriteFailed,
+                            failure: .sendQueueOverflow
+                        )
+                    )
+                }
+            }
+        }
+        if !resyncSurfaceIDs.isEmpty {
+            MobileTerminalRenderObserver.requestRenderGridFullResync(
+                surfaceIDStrings: resyncSurfaceIDs
+            )
         }
     }
 
@@ -1666,19 +1777,15 @@ actor MobileHostConnection {
     private static let maximumReceiveBufferByteCount = MobileSyncFrameCodec.defaultMaximumFrameByteCount + MobileSyncFrameCodec.headerByteCount
     private static let defaultFirstFrameTimeoutNanoseconds: UInt64 = 15 * 1_000_000_000
     private static let defaultIdleTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000
-    private static let maximumQueuedEventCount = 256
-    private static let maximumQueuedEventByteCount =
-        MobileSyncFrameCodec.defaultMaximumFrameByteCount
-        + MobileSyncFrameCodec.headerByteCount
+    /// Bounded deadline for one control-lane event write. A peer that accepted
+    /// the connection but stopped reading (TCP zero-window, QUIC flow-control
+    /// stall) would otherwise pin the drain — and with it this connection's
+    /// queue, transport, and tasks — indefinitely (issue #8842).
+    private static let defaultEventSendStallTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000
 
     private struct EventSubscription: Sendable {
         let topics: Set<String>
         let transport: MobileHostEventTransport
-    }
-
-    private struct QueuedEvent: Sendable {
-        let topic: String
-        let frame: Data
     }
 
     private struct ResponseTask: Sendable {
@@ -1697,14 +1804,20 @@ actor MobileHostConnection {
     private let handleRequest: @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult
     private let onClose: @Sendable (UUID) async -> Void
     private let responseWorkQuota = MobileHostRPCWorkQuota()
+    /// Bounded pre-write mailbox with synchronous admission from the event
+    /// fan-out. Nonisolated so ``MobileHostService/emitEvent(topic:payload:)``
+    /// admits events without scheduling any per-event actor work.
+    nonisolated let eventQueue = MobileHostConnectionEventQueue()
+    private let eventSendStallTimeoutNanoseconds: UInt64
+    /// Invalidates the pending event-send stall deadline: bumped when a send
+    /// starts and again when it settles, so a deadline armed for send N can
+    /// never close the connection after N completed.
+    private var eventSendGeneration: UInt64 = 0
     private var receiveBuffer = Data()
     private var firstFrameTimeoutTask: Task<Void, Never>?
     private var idleTimeoutTask: Task<Void, Never>?
     private var responseTasks: [UUID: ResponseTask] = [:]
     private var receiveTask: Task<Void, Never>?
-    private var queuedEvents: [QueuedEvent] = []
-    private var queuedEventByteCount = 0
-    private var eventDrainTask: Task<Void, Never>?
     private var independentEventRevision: UInt64 = 0
     private var independentEventNegotiationInProgress = false
     private var didDecodeFirstFrame = false
@@ -1722,6 +1835,7 @@ actor MobileHostConnection {
         connection: NWConnection,
         firstFrameTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultFirstFrameTimeoutNanoseconds,
         idleTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultIdleTimeoutNanoseconds,
+        eventSendStallTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultEventSendStallTimeoutNanoseconds,
         independentEventWriter: (any MobileHostIndependentEventWriting)? = nil,
         authorizeRequest: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult?,
         onAuthorizedRequest: @escaping @Sendable (MobileHostRPCRequest) async -> Void,
@@ -1735,6 +1849,7 @@ actor MobileHostConnection {
         self.independentEventWriter = independentEventWriter
         self.firstFrameTimeoutNanoseconds = firstFrameTimeoutNanoseconds
         self.idleTimeoutNanoseconds = idleTimeoutNanoseconds
+        self.eventSendStallTimeoutNanoseconds = eventSendStallTimeoutNanoseconds
         self.authorizeRequest = authorizeRequest
         self.onAuthorizedRequest = onAuthorizedRequest
         self.handleRequest = handleRequest
@@ -1746,6 +1861,7 @@ actor MobileHostConnection {
         transport: any CmxByteTransport,
         firstFrameTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultFirstFrameTimeoutNanoseconds,
         idleTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultIdleTimeoutNanoseconds,
+        eventSendStallTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultEventSendStallTimeoutNanoseconds,
         independentEventWriter: (any MobileHostIndependentEventWriting)? = nil,
         authorizeRequest: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult?,
         onAuthorizedRequest: @escaping @Sendable (MobileHostRPCRequest) async -> Void,
@@ -1758,6 +1874,7 @@ actor MobileHostConnection {
         self.independentEventWriter = independentEventWriter
         self.firstFrameTimeoutNanoseconds = firstFrameTimeoutNanoseconds
         self.idleTimeoutNanoseconds = idleTimeoutNanoseconds
+        self.eventSendStallTimeoutNanoseconds = eventSendStallTimeoutNanoseconds
         self.authorizeRequest = authorizeRequest
         self.onAuthorizedRequest = onAuthorizedRequest
         self.handleRequest = handleRequest
@@ -1835,10 +1952,9 @@ actor MobileHostConnection {
         idleTimeoutTask = nil
         receiveTask?.cancel()
         receiveTask = nil
-        eventDrainTask?.cancel()
-        eventDrainTask = nil
-        queuedEvents.removeAll(keepingCapacity: false)
-        queuedEventByteCount = 0
+        // Rejects all future admissions and releases every queued payload; the
+        // drain loop observes the closed queue and exits on its own.
+        eventQueue.close()
         let tasks = responseTasks.values.map(\.task)
         responseTasks.removeAll()
         for task in tasks {
@@ -2156,6 +2272,7 @@ actor MobileHostConnection {
             topics: topics,
             transport: transport
         )
+        eventQueue.updateSubscribedTopics(currentSubscribedTopics())
         MobileHostEventSubscriptionTracker.replace(
             previousTopics: previousTopics,
             nextTopics: topics
@@ -2169,6 +2286,7 @@ actor MobileHostConnection {
     func unsubscribe(streamID: String) async -> Bool {
         let previousSubscription = subscriptions.removeValue(forKey: streamID)
         let removed = previousSubscription != nil
+        eventQueue.updateSubscribedTopics(currentSubscribedTopics())
         if let previousSubscription {
             MobileHostEventSubscriptionTracker.replace(
                 previousTopics: previousSubscription.topics,
@@ -2195,9 +2313,16 @@ actor MobileHostConnection {
         return false
     }
 
-    /// Enqueues a server-pushed event for this connection. One drain task owns
-    /// wire writes. The queue is bounded; overflow closes the connection so a
-    /// slow phone cannot accumulate unbounded tasks or stale terminal deltas.
+    /// The union of every stream's topics, mirrored into the event queue so
+    /// fan-out admission can check subscription without an actor hop.
+    private func currentSubscribedTopics() -> Set<String> {
+        subscriptions.values.reduce(into: Set<String>()) { $0.formUnion($1.topics) }
+    }
+
+    /// Encodes and enqueues one server-pushed event for this connection
+    /// through the same bounded synchronous admission as the fan-out path
+    /// (``MobileHostService/emitEvent(topic:payload:)``). Returns whether the
+    /// event was admitted.
     @discardableResult
     func sendEvent(topic: String, payload: [String: Any]) async -> Bool {
         guard !isClosed else {
@@ -2206,35 +2331,30 @@ actor MobileHostConnection {
             #endif
             return false
         }
-        guard isSubscribed(to: topic) else {
-            #if DEBUG
-            cmuxDebugLog("mobile.send skip: not subscribed topic=\(topic) connID=\(self.id.uuidString) subs=\(subscriptions.count)")
-            #endif
-            return false
-        }
-        let envelope: [String: Any] = [
-            "kind": "event",
-            "topic": topic,
-            "payload": payload,
-        ]
-        guard let data = try? JSONSerialization.data(withJSONObject: envelope) else { return false }
-        let frame: Data
-        do {
-            frame = try MobileSyncFrameCodec.encodeFrame(data)
-        } catch {
-            // MobileSyncFrameCodec.encodeFrame only throws frameTooLarge: a
-            // local wire-limit violation, so protocolViolation is honest here.
-            await close(
-                reason: "event frame encode failed",
-                exit: CmxIrohAdmittedConnectionExit(
-                    lifecycle: .controlWriteFailed,
-                    failure: .protocolViolation
-                )
+        guard let frame = MobileHostService.encodedEventFrame(topic: topic, payload: payload) else {
+            // An unencodable or over-limit event is undeliverable to every
+            // connection: a host-side producer fault, not this peer's.
+            mobileHostLog.error(
+                "mobile host dropped unencodable event topic=\(topic, privacy: .public)"
             )
             return false
         }
-        guard queuedEvents.count < Self.maximumQueuedEventCount,
-              frame.count <= Self.maximumQueuedEventByteCount - queuedEventByteCount else {
+        let result = eventQueue.enqueue(
+            topic: topic,
+            coalesceKey: MobileHostService.eventCoalesceKey(topic: topic, payload: payload),
+            isFullRenderGridFrame: topic == MobileHostEventTopicPolicy.renderGridTopic
+                && payload["full"] as? Bool == true,
+            frame: frame
+        )
+        if !result.renderGridResyncSurfaceIDs.isEmpty {
+            MobileTerminalRenderObserver.requestRenderGridFullResync(
+                surfaceIDStrings: result.renderGridResyncSurfaceIDs
+            )
+        }
+        if result.startDrain {
+            Task { await self.drainQueuedEvents() }
+        }
+        if result.shouldClose {
             // The bounded queue fills when the control stream stops draining
             // (e.g. the peer's network path died mid-write) while terminal
             // events keep arriving. The peer violated nothing; field host
@@ -2247,12 +2367,25 @@ actor MobileHostConnection {
                     failure: .sendQueueOverflow
                 )
             )
-            return false
         }
-        queuedEvents.append(QueuedEvent(topic: topic, frame: frame))
-        queuedEventByteCount += frame.count
-        startEventDrainIfNeeded()
-        return true
+        return result.admitted
+    }
+
+    /// Synchronous bounded admission from the fan-out path. Never blocks and
+    /// never schedules per-event work; the caller acts on the returned
+    /// outcome (drain start, overflow close, render-grid resync).
+    nonisolated func enqueueEventFrame(
+        _ frame: Data,
+        topic: String,
+        coalesceKey: String?,
+        isFullRenderGridFrame: Bool
+    ) -> MobileHostEventEnqueueResult {
+        eventQueue.enqueue(
+            topic: topic,
+            coalesceKey: coalesceKey,
+            isFullRenderGridFrame: isFullRenderGridFrame,
+            frame: frame
+        )
     }
 
     private func prepareIndependentEventWriter() async -> Bool {
@@ -2268,7 +2401,9 @@ actor MobileHostConnection {
         independentEventNegotiationInProgress = true
         defer {
             independentEventNegotiationInProgress = false
-            startEventDrainIfNeeded()
+            if eventQueue.claimDrain() {
+                Task { await self.drainQueuedEvents() }
+            }
         }
         let probePayload = Data(#"{"kind":"event_stream_probe"}"#.utf8)
         guard let probeFrame = try? MobileSyncFrameCodec.encodeFrame(probePayload) else {
@@ -2290,30 +2425,36 @@ actor MobileHostConnection {
         return false
     }
 
-    private func startEventDrainIfNeeded() {
-        guard eventDrainTask == nil,
-              !independentEventNegotiationInProgress,
-              !isClosed else { return }
-        eventDrainTask = Task { [weak self] in
-            guard let self else { return }
-            await self.drainEventQueue()
+    /// Single-writer drain loop: at most one instance runs per connection
+    /// (enforced by the queue's drain claim), pulling from the bounded queue
+    /// and writing to the negotiated lane. Exits when the queue is empty, the
+    /// connection closes, lane negotiation pauses delivery, or a delivery
+    /// fails or stalls (which closes the connection).
+    func drainQueuedEvents() async {
+        while true {
+            if isClosed || independentEventNegotiationInProgress {
+                eventQueue.abandonDrain()
+                return
+            }
+            guard let event = eventQueue.dequeue() else {
+                if eventQueue.finishDrain() { continue }
+                return
+            }
+            guard eventQueue.isSubscribed(topic: event.topic) else { continue }
+            guard await deliverQueuedEvent(event) else {
+                eventQueue.abandonDrain()
+                return
+            }
+            let resyncSurfaceIDs = eventQueue.takeResyncAfterDrainRequests()
+            if !resyncSurfaceIDs.isEmpty {
+                MobileTerminalRenderObserver.requestRenderGridFullResync(
+                    surfaceIDStrings: resyncSurfaceIDs
+                )
+            }
         }
     }
 
-    private func drainEventQueue() async {
-        defer { eventDrainTask = nil }
-        while !Task.isCancelled, !isClosed, !queuedEvents.isEmpty {
-            let event = queuedEvents.removeFirst()
-            queuedEventByteCount -= event.frame.count
-            guard isSubscribed(to: event.topic) else { continue }
-            guard await deliverQueuedEvent(event) else { return }
-        }
-        if !isClosed, !queuedEvents.isEmpty {
-            startEventDrainIfNeeded()
-        }
-    }
-
-    private func deliverQueuedEvent(_ event: QueuedEvent) async -> Bool {
+    private func deliverQueuedEvent(_ event: MobileHostConnectionEventQueue.QueuedEvent) async -> Bool {
         let prefersIndependent = subscriptions.values.contains {
             $0.transport == .irohServerEvents && $0.topics.contains(event.topic)
         }
@@ -2327,10 +2468,44 @@ actor MobileHostConnection {
                 await independentEventWriter.reset()
                 // Deliver the event that exposed the dead/backpressured lane on
                 // control immediately. Subsequent events also use control.
-                return await sendControlFrame(event.frame)
+                return await sendEventControlFrame(event.frame)
             }
         }
-        return await sendControlFrame(event.frame)
+        return await sendEventControlFrame(event.frame)
+    }
+
+    /// Writes one event frame on the control lane under the bounded stall
+    /// deadline. On a stall the connection is closed — `transport.close()`
+    /// resolves the pending write — converting a half-dead subscriber into
+    /// deterministic teardown instead of a forever-pinned drain.
+    private func sendEventControlFrame(_ frame: Data) async -> Bool {
+        guard !isClosed else { return false }
+        let timeoutNanoseconds = eventSendStallTimeoutNanoseconds
+        guard timeoutNanoseconds > 0 else {
+            return await sendControlFrame(frame)
+        }
+        eventSendGeneration &+= 1
+        let generation = eventSendGeneration
+        let deadlineTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+            guard !Task.isCancelled else { return }
+            await self?.closeIfEventSendStillInFlight(generation: generation)
+        }
+        let delivered = await sendControlFrame(frame)
+        eventSendGeneration &+= 1
+        deadlineTask.cancel()
+        return delivered && !isClosed
+    }
+
+    private func closeIfEventSendStillInFlight(generation: UInt64) async {
+        guard eventSendGeneration == generation, !isClosed else { return }
+        await close(
+            reason: "event send stalled past the bounded deadline",
+            exit: CmxIrohAdmittedConnectionExit(
+                lifecycle: .controlWriteFailed,
+                failure: .timedOut
+            )
+        )
     }
 
     private func downgradeIndependentSubscriptionsToControl() {
@@ -2417,7 +2592,11 @@ extension MobileHostConnection {
     }
 
     func debugQueuedEventCountForTesting() -> Int {
-        queuedEvents.count
+        eventQueue.count
+    }
+
+    func debugQueuedEventByteCountForTesting() -> Int {
+        eventQueue.byteCount
     }
 }
 #endif

--- a/Sources/Mobile/MobileTerminalRenderObserver.swift
+++ b/Sources/Mobile/MobileTerminalRenderObserver.swift
@@ -1,6 +1,7 @@
 import CMUXMobileCore
 import CmuxTerminal
 import Foundation
+import os
 
 /// Pushes terminal render events only while a mobile client is actively subscribed.
 /// Ghostty notification demand is tied to subscriptions so the desktop terminal
@@ -313,8 +314,12 @@ final class MobileTerminalRenderObserver {
         ) else { return }
         let frame = emission.frame
         renderGridStatesBySurfaceID[surfaceID] = emission.state
-        guard let payload = try? frame.jsonObject() else { return }
-        MobileHostService.emitEvent(topic: "terminal.render_grid", payload: payload)
+        guard let payloadJSON = try? JSONEncoder().encode(frame) else { return }
+        MobileHostService.emitRenderGridEvent(
+            payloadJSON: payloadJSON,
+            surfaceID: frame.surfaceID,
+            isFullFrame: frame.full
+        )
         #if DEBUG
         cmuxDebugLog(
             "mobile.render_grid surface=\(surfaceID.uuidString.prefix(8)) full=\(frame.full) " +
@@ -372,6 +377,48 @@ final class MobileTerminalRenderObserver {
         // Store the revision read before enumeration. If topology changed during
         // the snapshot, the next flush observes a newer value and reconciles again.
         reconciledSurfaceTopologyGeneration = generation
+    }
+
+    /// Requests that the producer re-emit a full render-grid frame for each
+    /// surface, because a connection's bounded queue had to shed one of that
+    /// surface's frames (issue #8842). A full frame re-bases every
+    /// subscriber's delta chain, so the shed frames are unobservable beyond a
+    /// briefly stale paint. Callable from any thread; hops to the main actor
+    /// are coalesced so a stalled connection cannot flood it.
+    nonisolated static func requestRenderGridFullResync(surfaceIDStrings: Set<String>) {
+        guard !surfaceIDStrings.isEmpty else { return }
+        let shouldSchedule = pendingRenderGridResyncSurfaceIDs.withLock { pending in
+            let wasEmpty = pending.isEmpty
+            pending.formUnion(surfaceIDStrings)
+            return wasEmpty
+        }
+        guard shouldSchedule else { return }
+        Task { @MainActor in
+            let drainedSurfaceIDStrings = pendingRenderGridResyncSurfaceIDs.withLock { pending in
+                let drained = pending
+                pending.removeAll()
+                return drained
+            }
+            shared.performRenderGridFullResync(surfaceIDStrings: drainedSurfaceIDStrings)
+        }
+    }
+
+    nonisolated private static let pendingRenderGridResyncSurfaceIDs =
+        OSAllocatedUnfairLock<Set<String>>(initialState: [])
+
+    private func performRenderGridFullResync(surfaceIDStrings: Set<String>) {
+        guard MobileHostService.hasEventSubscribers(topic: "terminal.render_grid") else {
+            return
+        }
+        var didInvalidate = false
+        for surfaceIDString in surfaceIDStrings {
+            guard let surfaceID = UUID(uuidString: surfaceIDString) else { continue }
+            clearRenderGridCache(surfaceID: surfaceID)
+            pendingSurfaceIDs.insert(surfaceID)
+            didInvalidate = true
+        }
+        guard didInvalidate else { return }
+        scheduleTerminalUpdateFlush()
     }
 
     private func clearRenderGridCache(surfaceID: UUID) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1095,6 +1095,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */; };
 		C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */; };
 		C1A071000000000000000002 /* MobileHostConnectionEventLaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A071000000000000000012 /* MobileHostConnectionEventLaneTests.swift */; };
+		3193896015BA410783C141A6 /* MobileHostConnectionEventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C1A79BC24A46F8AC504E77 /* MobileHostConnectionEventQueue.swift */; };
 		C1A071000000000000000003 /* MobileHostConnectionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A071000000000000000013 /* MobileHostConnectionLifecycleTests.swift */; };
 		B8B056D90000000000000001 /* MobileHostIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B056D90000000000000002 /* MobileHostIdentity.swift */; };
 		B8B056D80000000000000001 /* MobileHostIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B056D80000000000000002 /* MobileHostIdentityTests.swift */; };
@@ -3298,6 +3299,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostAuthorizationTests.swift; sourceTree = "<group>"; };
 		C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostBuildIdentity.swift; sourceTree = "<group>"; };
 		C1A071000000000000000012 /* MobileHostConnectionEventLaneTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostConnectionEventLaneTests.swift; sourceTree = "<group>"; };
+		79C1A79BC24A46F8AC504E77 /* MobileHostConnectionEventQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostConnectionEventQueue.swift; sourceTree = "<group>"; };
 		C1A071000000000000000013 /* MobileHostConnectionLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostConnectionLifecycleTests.swift; sourceTree = "<group>"; };
 		B8B056D90000000000000002 /* MobileHostIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentity.swift; sourceTree = "<group>"; };
 		B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityTests.swift; sourceTree = "<group>"; };
@@ -4666,6 +4668,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F7A110000000000000000002 /* MobileTerminalThemeInvalidationScheduler.swift */,
 				F7A110000000000000000004 /* MobileTerminalThemeEmissionDecision.swift */,
 				4F05EBBC2FE0D5CB2F662B8A /* MobileTerminalByteTee.swift */,
+				79C1A79BC24A46F8AC504E77 /* MobileHostConnectionEventQueue.swift */,
 				ACA7C4A70000000000000100 /* AgentChat */,
 			);
 			name = Mobile;
@@ -7804,6 +7807,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEA7710000000000000009 /* MobileConnectTitlebarAccessory.swift in Sources */,
 				C1A070000000000000000001 /* MobileHostAuthorizationSupport.swift in Sources */,
 				C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */,
+				3193896015BA410783C141A6 /* MobileHostConnectionEventQueue.swift in Sources */,
 				B8B056D90000000000000001 /* MobileHostIdentity.swift in Sources */,
 				A17070900000000000000002 /* MobileHostIrohApplicationLaneRouter.swift in Sources */,
 				C1A070000000000000000002 /* MobileHostIrohAuthObserver.swift in Sources */,

--- a/cmuxTests/MobileHostConnectionEventLaneTests.swift
+++ b/cmuxTests/MobileHostConnectionEventLaneTests.swift
@@ -400,9 +400,8 @@ extension MobileHostAuthorizationTests {
         }
 
         #expect(await transport.observedCloseCount() == 0)
-        #expect(await session.debugQueuedEventCountForTesting() <= 256)
-        #expect(await session.debugQueuedEventByteCountForTesting()
-            <= MobileHostConnectionEventQueue.defaultMaximumByteCount)
+        #expect(session.eventQueue.count <= 256)
+        #expect(session.eventQueue.byteCount <= MobileHostConnectionEventQueue.defaultMaximumByteCount)
         #expect(registry.count == 1)
 
         await session.close(reason: "test cleanup")

--- a/cmuxTests/MobileHostConnectionEventLaneTests.swift
+++ b/cmuxTests/MobileHostConnectionEventLaneTests.swift
@@ -285,6 +285,123 @@ extension MobileHostAuthorizationTests {
         await session.close(reason: "test complete")
     }
 
+    // MARK: - Bounded emission under a stalled subscriber (issue #8842)
+
+    /// A stalled, never-draining render-grid subscriber must not force the host
+    /// to tear the connection down when the bounded event queue fills: dropped
+    /// render-grid deltas are recoverable (the producer re-emits a full frame),
+    /// while close-on-overflow churns connection resources (sockets, lanes,
+    /// tasks) every few seconds for as long as the subscriber stays slow —
+    /// the reconnect-churn half of the issue #8842 field incident.
+    @Test func testStalledRenderGridSubscriberStaysOpenWithBoundedEventQueue() async throws {
+        let transport = StalledSendMobileHostByteTransport()
+        let session = MobileHostConnection(
+            id: UUID(),
+            transport: transport,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { _ in }
+        )
+        await session.subscribe(streamID: "events", topics: ["terminal.render_grid"])
+
+        // Sustained synthetic emission far past the bounded queue capacity
+        // while the transport never completes a single send.
+        for sequence in 0..<768 {
+            _ = await session.sendEvent(
+                topic: "terminal.render_grid",
+                payload: [
+                    "surface_id": "surface-8842",
+                    "full": false,
+                    "state_seq": sequence,
+                ]
+            )
+        }
+
+        // The connection survives the overflow (no teardown churn) and the
+        // pending event queue stays bounded no matter how far emission ran
+        // ahead of the stalled writer.
+        #expect(await transport.observedCloseCount() == 0)
+        #expect(await session.debugQueuedEventCountForTesting() <= 256)
+        #expect(await session.isSubscribed(to: "terminal.render_grid"))
+
+        await session.close(reason: "test cleanup")
+        #expect(await transport.observedCloseCount() == 1)
+    }
+
+    /// Events that cannot be re-derived by the client (state-sync deltas and
+    /// other non-refresh topics) must keep the close-on-overflow contract: the
+    /// host may never silently drop them, so a subscriber that stops draining
+    /// is torn down at the bounded capacity instead of growing without bound.
+    @Test func testStalledSubscriberOverflowOnNonRecoverableTopicClosesConnection() async throws {
+        let transport = StalledSendMobileHostByteTransport()
+        let session = MobileHostConnection(
+            id: UUID(),
+            transport: transport,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { _ in }
+        )
+        await session.subscribe(streamID: "events", topics: ["mobile.sync.delta"])
+
+        var admitted = 0
+        for sequence in 0..<300 {
+            if await session.sendEvent(
+                topic: "mobile.sync.delta",
+                payload: ["revision": sequence]
+            ) {
+                admitted += 1
+            }
+        }
+
+        #expect(await transport.observedCloseCount() == 1)
+        #expect(admitted <= 258)
+        #expect(await session.debugQueuedEventCountForTesting() == 0)
+    }
+
+    /// After close, every per-connection resource must be released: the
+    /// connection actor and its transport deallocate even when a send was
+    /// stalled mid-flight at close time, so a churned subscriber cannot strand
+    /// tasks, buffers, or transport resources on the host.
+    @Test func testCloseReleasesConnectionAndTransportResources() async throws {
+        var transport: StalledSendMobileHostByteTransport? = StalledSendMobileHostByteTransport()
+        weak var weakTransport = transport
+        var session: MobileHostConnection? = MobileHostConnection(
+            id: UUID(),
+            transport: transport!,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { _ in }
+        )
+        weak var weakSession = session
+
+        await session!.subscribe(streamID: "events", topics: ["terminal.render_grid"])
+        for sequence in 0..<8 {
+            _ = await session!.sendEvent(
+                topic: "terminal.render_grid",
+                payload: [
+                    "surface_id": "surface-8842-release",
+                    "full": false,
+                    "state_seq": sequence,
+                ]
+            )
+        }
+        await transport!.waitUntilSendStalled()
+        await session!.close(reason: "release test")
+        #expect(await session!.debugQueuedEventCountForTesting() == 0)
+
+        session = nil
+        transport = nil
+        for _ in 0..<2_000 {
+            if weakSession == nil, weakTransport == nil { break }
+            await Task.yield()
+        }
+        #expect(weakSession == nil)
+        #expect(weakTransport == nil)
+    }
+
     @Test func testIdempotentReassertionCannotReenableALaneWithAnInFlightFailure() async throws {
         let control = RecordingMobileHostByteTransport()
         let independent = TestMobileHostIndependentEventWriter(
@@ -343,4 +460,65 @@ extension MobileHostAuthorizationTests {
         await session.close(reason: "test complete")
     }
 
+}
+
+/// A byte transport whose `send` never completes on its own: it models a
+/// subscriber that stopped draining (paused phone, dead network path with the
+/// socket still open). `close()` fails every stalled send so teardown paths
+/// stay deterministic and no task is stranded across tests.
+actor StalledSendMobileHostByteTransport: CmxByteTransport {
+    private enum StalledSendError: Error {
+        case closed
+    }
+
+    private var sendWaiters: [CheckedContinuation<Void, any Error>] = []
+    private var sendStalledWaiters: [CheckedContinuation<Void, Never>] = []
+    private var closeCount = 0
+    private var isClosed = false
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? { nil }
+
+    func send(_: Data) async throws {
+        guard !isClosed else {
+            throw StalledSendError.closed
+        }
+        let stalled = sendStalledWaiters
+        sendStalledWaiters.removeAll()
+        for waiter in stalled {
+            waiter.resume()
+        }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                sendWaiters.append(continuation)
+            }
+        } onCancel: {
+            Task { await self.failStalledSends() }
+        }
+    }
+
+    func close() async {
+        closeCount += 1
+        isClosed = true
+        failStalledSends()
+    }
+
+    /// Waits until at least one send has parked on the stalled transport.
+    func waitUntilSendStalled() async {
+        if !sendWaiters.isEmpty { return }
+        await withCheckedContinuation { continuation in
+            sendStalledWaiters.append(continuation)
+        }
+    }
+
+    func observedCloseCount() -> Int { closeCount }
+
+    private func failStalledSends() {
+        let waiters = sendWaiters
+        sendWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume(throwing: StalledSendError.closed)
+        }
+    }
 }

--- a/cmuxTests/MobileHostConnectionEventLaneTests.swift
+++ b/cmuxTests/MobileHostConnectionEventLaneTests.swift
@@ -198,13 +198,17 @@ extension MobileHostAuthorizationTests {
             handleRequest: { _ in .ok([:]) },
             onClose: { _ in }
         )
+        // A non-droppable topic (state-sync deltas cannot be re-derived by the
+        // client) keeps the close-on-overflow contract; recoverable topics like
+        // terminal.render_grid are shed instead — see
+        // testStalledRenderGridSubscriberStaysOpenWithBoundedEventQueue.
         _ = await session.debugHandleSubscriptionRPCForTesting(
             MobileHostRPCRequest(
                 id: "subscribe",
                 method: "mobile.events.subscribe",
                 params: [
                     "stream_id": "events",
-                    "topics": ["terminal.updated"],
+                    "topics": ["mobile.sync.delta"],
                     "event_transport": "iroh_server_events_v1",
                 ],
                 auth: nil
@@ -213,7 +217,7 @@ extension MobileHostAuthorizationTests {
 
         #expect(
             await session.sendEvent(
-                topic: "terminal.updated",
+                topic: "mobile.sync.delta",
                 payload: ["seq": 0]
             )
         )
@@ -222,14 +226,14 @@ extension MobileHostAuthorizationTests {
         for sequence in 1...256 {
             #expect(
                 await session.sendEvent(
-                    topic: "terminal.updated",
+                    topic: "mobile.sync.delta",
                     payload: ["seq": sequence]
                 )
             )
         }
         #expect(
             !(await session.sendEvent(
-                topic: "terminal.updated",
+                topic: "mobile.sync.delta",
                 payload: ["seq": 257]
             ))
         )
@@ -358,6 +362,194 @@ extension MobileHostAuthorizationTests {
         #expect(await transport.observedCloseCount() == 1)
         #expect(admitted <= 258)
         #expect(await session.debugQueuedEventCountForTesting() == 0)
+    }
+
+    /// End-to-end fan-out proof for issue #8842: sustained emission through the
+    /// static `emitEvent` path into a registered, never-draining subscriber
+    /// keeps the pending payload count and byte budget bounded, spawns no
+    /// per-event teardown churn, and leaves the connection attached.
+    @Test func testEmitEventFanOutKeepsStalledConnectionBounded() async throws {
+        let registry = MobileHostConnectionRegistry.shared
+        for connection in registry.removeAll() {
+            await connection.close(reason: "test setup")
+        }
+        let transport = StalledSendMobileHostByteTransport()
+        let connectionID = UUID()
+        let session = MobileHostConnection(
+            id: connectionID,
+            transport: transport,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { id in
+                MobileHostConnectionRegistry.shared.remove(id: id)
+            }
+        )
+        #expect(registry.insert(session, id: connectionID, authorization: .stackBearer, limit: 10))
+        await session.subscribe(streamID: "events", topics: ["terminal.render_grid"])
+
+        for sequence in 0..<600 {
+            MobileHostService.emitEvent(
+                topic: "terminal.render_grid",
+                payload: [
+                    "surface_id": "surface-fanout-8842",
+                    "full": false,
+                    "state_seq": sequence,
+                ]
+            )
+        }
+
+        #expect(await transport.observedCloseCount() == 0)
+        #expect(await session.debugQueuedEventCountForTesting() <= 256)
+        #expect(await session.debugQueuedEventByteCountForTesting()
+            <= MobileHostConnectionEventQueue.defaultMaximumByteCount)
+        #expect(registry.count == 1)
+
+        await session.close(reason: "test cleanup")
+        for connection in registry.removeAll() {
+            await connection.close(reason: "test cleanup")
+        }
+    }
+
+    /// A subscriber whose transport accepted a frame but never completes the
+    /// write (TCP zero-window peer) is torn down by the bounded event-send
+    /// stall deadline instead of pinning the connection's queue, tasks, and
+    /// socket forever.
+    @Test func testEventSendStallDeadlineClosesStalledConnection() async throws {
+        let transport = StalledSendMobileHostByteTransport()
+        let recorder = MobileHostConnectionCloseRecorder()
+        let connectionID = UUID()
+        let session = MobileHostConnection(
+            id: connectionID,
+            transport: transport,
+            eventSendStallTimeoutNanoseconds: 5_000_000,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { id in
+                await recorder.record(id)
+            }
+        )
+        await session.subscribe(streamID: "events", topics: ["terminal.render_grid"])
+        _ = await session.sendEvent(
+            topic: "terminal.render_grid",
+            payload: ["surface_id": "surface-stall-8842", "full": true]
+        )
+        await transport.waitUntilSendStalled()
+        for _ in 0..<2_000 {
+            if !(await recorder.recordedIDs().isEmpty) { break }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        #expect(await recorder.recordedIDs() == [connectionID])
+        #expect(await transport.observedCloseCount() == 1)
+    }
+
+    // MARK: - Bounded event queue admission policy
+
+    @Test func testEventQueueShedsRenderGridDeltasAndPoisonsUntilFullFrame() {
+        let queue = MobileHostConnectionEventQueue(
+            maximumEventCount: 2,
+            maximumByteCount: 1_000_000
+        )
+        queue.updateSubscribedTopics(["terminal.render_grid"])
+        let frame = Data(repeating: 0x61, count: 16)
+        #expect(queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        #expect(queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        // Overflow sheds s1's queued deltas (the arriving delta builds on
+        // them), requests a full-frame resync, and refuses the newest delta
+        // too: the client must never see a post-gap delta.
+        let overflow = queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        )
+        #expect(!overflow.admitted)
+        #expect(!overflow.shouldClose)
+        #expect(overflow.renderGridResyncSurfaceIDs == ["s1"])
+        #expect(queue.count == 0)
+        // While poisoned, deltas stay refused even though there is room.
+        let poisonedDelta = queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        )
+        #expect(!poisonedDelta.admitted)
+        #expect(poisonedDelta.renderGridResyncSurfaceIDs.isEmpty)
+        // The full-frame resync re-bases the chain and readmits the surface.
+        #expect(queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: true, frame: frame
+        ).admitted)
+        #expect(queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        #expect(queue.count == 2)
+    }
+
+    @Test func testEventQueueOverflowOnNonDroppableTopicRequestsClose() {
+        let queue = MobileHostConnectionEventQueue(
+            maximumEventCount: 1,
+            maximumByteCount: 1_000_000
+        )
+        queue.updateSubscribedTopics(["mobile.sync.delta"])
+        let frame = Data(repeating: 0x61, count: 16)
+        #expect(queue.enqueue(
+            topic: "mobile.sync.delta", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        let overflow = queue.enqueue(
+            topic: "mobile.sync.delta", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        )
+        #expect(!overflow.admitted)
+        #expect(overflow.shouldClose)
+    }
+
+    @Test func testEventQueueEnforcesByteBudgetBySheddingOldestDroppable() {
+        let queue = MobileHostConnectionEventQueue(
+            maximumEventCount: 100,
+            maximumByteCount: 64
+        )
+        queue.updateSubscribedTopics(["terminal.bytes"])
+        let frame = Data(repeating: 0x61, count: 48)
+        #expect(queue.enqueue(
+            topic: "terminal.bytes", coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        // The second chunk cannot fit under the byte budget; the oldest chunk
+        // is shed and the client recovers via its byte-seq gap detection.
+        let second = queue.enqueue(
+            topic: "terminal.bytes", coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        )
+        #expect(second.admitted)
+        #expect(queue.count == 1)
+        #expect(queue.byteCount == 48)
+    }
+
+    @Test func testEventQueueRejectsUnsubscribedTopicsAndClosedQueues() {
+        let queue = MobileHostConnectionEventQueue()
+        queue.updateSubscribedTopics(["terminal.render_grid"])
+        let frame = Data(repeating: 0x61, count: 8)
+        #expect(!queue.enqueue(
+            topic: "terminal.updated", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        #expect(queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: true, frame: frame
+        ).admitted)
+        queue.close()
+        #expect(queue.count == 0)
+        #expect(!queue.enqueue(
+            topic: "terminal.render_grid", coalesceKey: "s1",
+            isFullRenderGridFrame: true, frame: frame
+        ).admitted)
     }
 
     /// After close, every per-connection resource must be released: the


### PR DESCRIPTION
Fixes #8842 (production app OOM'd the whole machine after ~2.3 days: 4.12 GB RSS, 3,200 fds, jetsam largestProcess, forced hard reset). Implements the backpressure design predicted necessary in #5438.

## Root cause (owner boundary)

The owner of the leaked state was the pair **`MobileHostService.emitEvent` (fan-out producer) + `MobileHostConnection` (per-connection consumer)**.

The invariant that must hold: *memory, tasks, and connection resources attributable to mobile event emission are O(bounded-queue-capacity) per connection regardless of subscriber drain behavior, and all per-connection resources are released deterministically when a subscriber stops draining.*

Why the old path failed:

1. **Unbounded pre-admission region.** `emitEvent` spawned one unstructured `Task` per registered connection per event, each retaining the full `[String: Any]` payload; each connection actor then re-serialized the same payload (JSON + frame encode) *before* reaching its bounded-queue admission check. The bound applied only to encoded frames — the region upstream of it (task allocations, retained payload graphs, actor mailboxes) grew without bound whenever consumers lagged producers. Render-grid/bytes events are continuous (every Ghostty tick × every surface; ~130 surfaces in the incident), so a slow/paused subscriber grew RSS and burned CPU indefinitely. This matches the incident's cpu_resource stacks: the heaviest Swift-Concurrency stack (`completeTaskWithClosure` machinery), `mobileRenderGridFrame`, `rowSignatures`/`renderGridEmission`/`jsonObject`/`encode(to:)`.
2. **Close-on-overflow churn.** Overflow tore the connection down even for recoverable streams, so a slow-but-alive subscriber cycled connect → fill → close → reconnect → full replay, churning NWConnection/Iroh lane resources for days (fd growth 785 → 3,200).
3. **No stall detection on the control lane.** A peer that accepted the connection but stopped reading (TCP zero-window / QUIC flow-control stall) pinned the drain — and with it the connection's queue, transport, and tasks — until the queue happened to overflow. (The Iroh independent event lane already had a 3 s send deadline; the control lane had none.)

## Fix mechanism

- **Encode once, admit synchronously** (`Sources/Mobile/MobileHostConnectionEventQueue.swift`): the event envelope is encoded a single time and admitted into each connection's lock-protected, count- and byte-bounded queue on the emitter's thread. No per-event tasks; at most one drain task per connection, claimed/abandoned through the queue so exactly one writer exists.
- **Shed instead of close for recoverable topics.** Under overflow, queued `terminal.render_grid` frames are shed per surface, and the surface is *poisoned* against further deltas until a full frame arrives — the iOS client has **no delta-continuity check** (verified against `VerifiedTerminalReplayStateMachine` and the delivery path), so a silently dropped delta would corrupt its grid invisibly. Shedding asks the producer (`MobileTerminalRenderObserver.requestRenderGridFullResync`, coalesced main-actor hop) to clear that surface's emission cache, which makes the next emission a `full=true` frame that re-bases every subscriber's chain. `terminal.bytes` (client detects byte-`seq` gaps and requests replay) and `terminal.updated`/`workspace.updated` (level-triggered pings) shed with no extra machinery. **Non-recoverable topics (e.g. `mobile.sync.delta`, `chat.message`, notifications) keep the exact close-on-overflow contract.**
- **Deterministic teardown for half-dead peers.** Control-lane event writes run under a bounded stall deadline (default 30 s, injectable for tests). On stall the connection closes; `transport.close()` resolves the pending write, releasing the drain task, queue payloads, subscription demand (which stops the producer), and the socket.
- **Render-grid CPU reduction.** The frame is JSON-encoded once and spliced into the envelope (`emitRenderGridEvent`), replacing the previous encode → parse (`jsonObject()`) → per-connection re-serialize round trip from the incident's hot stacks.

Behavior change worth noting: an *unencodable/oversized* event is now dropped host-side with an error log instead of closing the connection — such an event is undeliverable to every peer and is a host producer fault, not the phone's.

## Regression proof (two-commit red/green)

- **Commit 1 (red)**: `testStalledRenderGridSubscriberStaysOpenWithBoundedEventQueue` — a stalled, never-draining render-grid subscriber under sustained synthetic emission must keep the pending queue bounded *without* connection teardown. Fails on the old code (closes at capacity). Green guards alongside: non-recoverable topic still closes at capacity; all per-connection resources (connection actor + transport, weak-ref assertions) release after close even with a send stalled mid-flight.
- **Commit 2 (green + more)**: fan-out–level boundedness through the real static `emitEvent` path into the registry (pending count and byte budget bounded, no churn); stall-deadline teardown test with an injected 5 ms deadline; admission-policy unit tests for the queue (shed-and-poison-until-full-frame, non-droppable close, byte budget shedding, unsubscribed/closed rejection).

fd boundedness follows from the two mechanisms rather than a direct fd counter: no reconnect churn for slow subscribers (no per-cycle socket/lane allocation), and stalled connections are torn down on a bounded deadline with `transport.close()` (NWConnection cancel / Iroh lane reset) releasing the descriptor; the weak-ref release test pins the teardown path.

## Verification performed

- `xcodebuild build-for-testing` (tagged derived-data path) succeeded at both commits — commit 1 compiles (so its CI red is test failures, not build breakage) and commit 2 compiles clean.
- `scripts/check-pbxproj.sh` and `scripts/lint-pbxproj-test-wiring.sh` pass (new source file wired into the app target; tests added to already-wired files).
- Localization audit: no user-facing strings were added or changed (only `os_log` diagnostics and code comments), so no `Localizable.xcstrings` changes are required.
- Existing event-lane/lifecycle tests were re-traced against the new admission path; `testIndependentEventBackpressureClosesAtBoundedQueueCapacity` now uses a non-droppable topic (`mobile.sync.delta`) since droppable topics intentionally no longer close at capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787480076&installation_model_id=21920&pr_number=8858&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8858&signature=be8963b79e50e6e5f2a8dcd598a8d25fd949e6d036895857bc163927ddaca13f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OOM and fd churn from stalled mobile subscribers by bounding event emission per connection with synchronous admission and shed-or-close policies. Adds a stall deadline and a single-encode render-grid path to reduce CPU and ensure deterministic teardown.

- **Bug Fixes**
  - Added `MobileHostConnectionEventQueue` for synchronous, bounded admission per connection; no per-event tasks and at most one drain task.
  - On overflow, shed recoverable topics (`terminal.render_grid`, `terminal.bytes`, level pings); render-grid surfaces are poisoned until a full frame; non-recoverable topics still close on overflow.
  - Added a 30s send-stall deadline for control-lane writes to close half-dead peers and release queues, tasks, and sockets. Unencodable/oversized events are dropped with an error log.
  - Tests now read internal `eventQueue` counters directly; removed the extra ForTesting seam.

- **Performance**
  - Encode once and fan out the same frame; `emitRenderGridEvent` avoids parse/re-encode of grid payloads.
  - Keeps memory and byte usage per connection bounded and stops reconnect churn for slow subscribers.
  - Cuts CPU by removing per-event tasks and redundant serialization.

<sup>Written for commit 808d5749e8fd3b6a2076145b7c0d3ece3c14a67a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile event delivery reliability by preventing unbounded buffering during high-traffic or stalled connections.
  - Automatically drops recoverable updates when necessary while preserving critical events.
  - Added automatic render-grid recovery when updates are missed or arrive out of sequence.
  - Connections now close cleanly when critical events cannot be delivered or sending remains stalled.
- **Performance**
  - Improved event fan-out and render-grid delivery efficiency for mobile connections.
- **Tests**
  - Added coverage for backpressure, event loss recovery, stalled sends, queue limits, and connection cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->