### PR TITLE
Fix tmux pane reseed with stale scroll regions

### DIFF
--- a/Sources/RemoteTmuxControlConnection+CommandResults.swift
+++ b/Sources/RemoteTmuxControlConnection+CommandResults.swift
@@ -331,15 +331,15 @@ extension RemoteTmuxControlConnection {
             // surface REUSED across reconnect: if it was on the alt screen before and the
             // remote pane is now on primary, force it back (1049l) so the capture doesn't
             // paint onto a stale alt screen.
-            if lines.first?.trimmingCharacters(in: .whitespaces) == "1" {
-                appendPaneSeedPrefix(
-                    paneId: paneId, seedID: seedID, data: Self.altScreenEnterSequence
-                )
-            } else {
-                appendPaneSeedPrefix(
-                    paneId: paneId, seedID: seedID, data: Self.altScreenExitSequence
-                )
-            }
+            let screenSelection = lines.first?.trimmingCharacters(in: .whitespaces) == "1"
+                ? Self.altScreenEnterSequence
+                : Self.altScreenExitSequence
+            var prefix = screenSelection
+            // DECSTBM is screen-local and survives on a reused surface. Reset it on
+            // the selected screen before painting the capture so stale margins cannot
+            // scroll or clip snapshot rows. The authoritative pane state follows.
+            prefix.append(Data("\u{1b}[r".utf8))
+            appendPaneSeedPrefix(paneId: paneId, seedID: seedID, data: prefix)
         case .perWindowSize:
             // A successful per-window size push replies with an empty block;
             // the interesting outcome (%error -> capability fallback) is

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -1071,6 +1071,55 @@ import Testing
         #expect(seeds.last?.snapshot == expectedPrimary)
     }
 
+    @Test func reseedSelectsScreenAndResetsScrollRegionBeforeCapturePaint() {
+        let fixture = attachedConnection()
+        defer { fixture.close() }
+
+        var rendered: [Data] = []
+        let token = fixture.connection.addObserver(onPaneOutput: { paneID, data in
+            guard paneID == 7 else { return }
+            rendered.append(data)
+        })
+        defer { fixture.connection.removeObserver(token) }
+
+        for (iteration, alternateOn) in ["1", "0"].enumerated() {
+            fixture.connection.capturePane(paneId: 7, clearScrollback: true)
+            let capturedRow = iteration == 0 ? "ALTERNATE_RESEED" : "PRIMARY_RESEED"
+            let paneState = Self.paneStateLine(cursorX: 0, cursorY: 0)
+            var stream = Data()
+            var commandNumber = 80 + iteration * 10
+            for kind in fixture.connection.pendingCommandKindsForTesting {
+                let lines: [String]
+                switch kind {
+                case .paneAltScreen:
+                    lines = [alternateOn]
+                case .capturePane:
+                    lines = [capturedRow]
+                case .paneState:
+                    lines = [paneState]
+                default:
+                    lines = []
+                }
+                stream.append(Self.commandResultBlock(number: commandNumber, lines: lines))
+                commandNumber += 1
+            }
+            deliverRechunked(stream, to: fixture.connection)
+
+            let screenSelection = alternateOn == "1"
+                ? RemoteTmuxControlConnection.altScreenEnterSequence
+                : RemoteTmuxControlConnection.altScreenExitSequence
+            var expected = Data("\u{1b}[H\u{1b}[2J\u{1b}[3J".utf8)
+            expected.append(screenSelection)
+            expected.append(Data("\u{1b}[r\u{1b}[H\u{1b}[2J\(capturedRow)".utf8))
+            expected.append(
+                RemoteTmuxControlMessageDecoding().paneStateSeedSequence(from: paneState)
+            )
+            #expect(rendered.last == expected)
+        }
+
+        #expect(rendered.count == 2)
+    }
+
     /// A visible-screen repair after a verified pane-height grow must not turn
     /// rows already represented in primary-screen history into a second copy.
     /// This drives the real Ghostty manual-I/O parser because observer-byte

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -785,7 +785,7 @@ import Testing
         )
 
         var expected = RemoteTmuxControlConnection.altScreenExitSequence
-        expected.append(Data("\u{1b}[H\u{1b}[2Jprompt\r\n❯ hostname".utf8))
+        expected.append(Data("\u{1b}[r\u{1b}[H\u{1b}[2Jprompt\r\n❯ hostname".utf8))
         expected.append(
             RemoteTmuxControlMessageDecoding().paneStateSeedSequence(from: paneState)
         )
@@ -824,7 +824,7 @@ import Testing
         )
 
         var unfilteredSeed = RemoteTmuxControlConnection.altScreenExitSequence
-        unfilteredSeed.append(Data("\u{1b}[H\u{1b}[2Jdir git:main\r\n❯".utf8))
+        unfilteredSeed.append(Data("\u{1b}[r\u{1b}[H\u{1b}[2Jdir git:main\r\n❯".utf8))
         unfilteredSeed.append(
             RemoteTmuxControlMessageDecoding().paneStateSeedSequence(from: paneState)
         )
@@ -875,7 +875,7 @@ import Testing
         #expect(seed.catchUpOutput == [Data("after-capture".utf8)])
 
         var snapshot = RemoteTmuxControlConnection.altScreenExitSequence
-        snapshot.append(Data("\u{1b}[H\u{1b}[2Jauthoritative".utf8))
+        snapshot.append(Data("\u{1b}[r\u{1b}[H\u{1b}[2Jauthoritative".utf8))
         #expect(seed.snapshot == snapshot)
         #expect(
             seed.state
@@ -1063,11 +1063,11 @@ import Testing
         #expect(seeds.count == 2)
         #expect(seeds.allSatisfy { $0.kind == .visibleRepaint })
         var expectedAlternate = RemoteTmuxControlConnection.altScreenEnterSequence
-        expectedAlternate.append(Data("\u{1b}[H\u{1b}[2JALT_SCREEN".utf8))
+        expectedAlternate.append(Data("\u{1b}[r\u{1b}[H\u{1b}[2JALT_SCREEN".utf8))
         #expect(seeds.first?.snapshot == expectedAlternate)
 
         var expectedPrimary = RemoteTmuxControlConnection.altScreenExitSequence
-        expectedPrimary.append(Data("\u{1b}[H\u{1b}[2JPRIMARY_SCREEN".utf8))
+        expectedPrimary.append(Data("\u{1b}[r\u{1b}[H\u{1b}[2JPRIMARY_SCREEN".utf8))
         #expect(seeds.last?.snapshot == expectedPrimary)
     }
 

--- a/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
+++ b/cmuxTests/RemoteTmuxPaneSeedTransportTests.swift
@@ -1120,6 +1120,105 @@ import Testing
         #expect(rendered.count == 2)
     }
 
+    /// DECSTBM is screen-local. A reused surface can retain a different
+    /// restricted region on primary and alternate screens, so each capture
+    /// fills an eight-row viewport: without the reset, rows scroll out through
+    /// the stale region while the snapshot is painted.
+    @Test(.timeLimit(.minutes(1)))
+    func reusedSurfaceReseedResetsScreenLocalScrollRegionsBeforeCapturePaint() async throws {
+        let fixture = attachedConnection()
+        defer { fixture.close() }
+        let layout = RemoteTmuxLayoutNode(
+            width: 80, height: 8, x: 0, y: 0, content: .pane(7)
+        )
+        fixture.connection.windowsByID[1] = RemoteTmuxWindow(
+            id: 1, name: "main", width: 80, height: 8, layout: layout
+        )
+        fixture.connection.windowOrder = [1]
+        fixture.connection.recordPublishedPaneOwnership(windowId: 1, paneIds: [7])
+
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let workspace = try #require(manager.selectedWorkspace)
+        workspace.isRemoteTmuxMirror = true
+        let sessionMirror = RemoteTmuxSessionMirror(
+            host: fixture.connection.host,
+            sessionName: "work",
+            connection: fixture.connection,
+            tabManager: manager,
+            workspace: workspace
+        )
+        defer { sessionMirror.detachObserver() }
+        let panelID = try #require(sessionMirror.panelIdByPane[7])
+        let panel = try #require(workspace.panels[panelID] as? TerminalPanel)
+        let terminal = try hostedTerminal(panel.surface)
+        defer { terminal.window.orderOut(nil) }
+        await waitForLiveSurface(terminal.surface)
+        terminal.surface.setAssignedGrid(columns: 80, rows: 8)
+        await waitForAppliedTerminalGrid(terminal.surface, columns: 80, rows: 8)
+        finishPendingCommands(
+            on: fixture.connection,
+            captureRows: [],
+            paneHeight: 8,
+            startingAt: 20
+        )
+
+        // Restrict primary, then switch to and restrict alternate. The first
+        // reseed remains on alternate; the second returns to the stale primary
+        // region, exercising DECSTBM's screen-local persistence on one surface.
+        fixture.connection.routePaneOutput(
+            paneId: 7,
+            data: Data("\u{1b}[2;6r\u{1b}[?1049h\u{1b}[3;6r".utf8)
+        )
+
+        let alternateRows = (1...8).map { String(format: "ALT_REGION_ROW_%02d", $0) }
+        fixture.connection.capturePane(paneId: 7, clearScrollback: true)
+        finishPendingCommands(
+            on: fixture.connection,
+            captureRows: alternateRows,
+            paneHeight: 8,
+            startingAt: 40,
+            alternateOn: true
+        )
+        await waitForGhosttyState(terminal.surface) {
+            (try? readTerminalText(
+                terminal.surface,
+                pointTag: GHOSTTY_POINT_VIEWPORT
+            ))?.contains(alternateRows[7]) == true
+        }
+        let alternateViewport = try readTerminalText(
+            terminal.surface,
+            pointTag: GHOSTTY_POINT_VIEWPORT
+        )
+        #expect(
+            alternateViewport.contains(alternateRows.joined(separator: "\n")),
+            "alternate reseed must fill the active viewport without region scrolling"
+        )
+
+        let primaryRows = (1...8).map { String(format: "PRIMARY_REGION_ROW_%02d", $0) }
+        fixture.connection.capturePane(paneId: 7, clearScrollback: true)
+        finishPendingCommands(
+            on: fixture.connection,
+            captureRows: primaryRows,
+            paneHeight: 8,
+            startingAt: 60,
+            alternateOn: false
+        )
+        await waitForGhosttyState(terminal.surface) {
+            (try? readTerminalText(
+                terminal.surface,
+                pointTag: GHOSTTY_POINT_VIEWPORT
+            ))?.contains(primaryRows[7]) == true
+        }
+        let primaryViewport = try readTerminalText(
+            terminal.surface,
+            pointTag: GHOSTTY_POINT_VIEWPORT
+        )
+        #expect(
+            primaryViewport.contains(primaryRows.joined(separator: "\n")),
+            "primary reseed must fill the active viewport without region scrolling"
+        )
+    }
+
     /// A visible-screen repair after a verified pane-height grow must not turn
     /// rows already represented in primary-screen history into a second copy.
     /// This drives the real Ghostty manual-I/O parser because observer-byte
@@ -1477,7 +1576,8 @@ import Testing
         on connection: RemoteTmuxControlConnection,
         captureRows: [String],
         paneHeight: Int,
-        startingAt firstCommandNumber: Int
+        startingAt firstCommandNumber: Int,
+        alternateOn: Bool = false
     ) {
         var commandNumber = firstCommandNumber
         while let kind = connection.pendingCommandKindsForTesting.first {
@@ -1486,7 +1586,7 @@ import Testing
             case .paneReflow:
                 lines = ["0|zsh"]
             case .paneAltScreen:
-                lines = ["0"]
+                lines = [alternateOn ? "1" : "0"]
             case .capturePane:
                 lines = captureRows
             case .paneState:


### PR DESCRIPTION
## Summary

- reset DECSTBM on the selected primary/alternate screen before painting a remote tmux pane capture
- preserve authoritative pane-state restoration after the capture
- add regression coverage for both primary and alternate screen reseeds
- update existing exact-byte seed expectations

## Why

A reused Ghostty surface can retain a restricted scroll region from an inline TUI such as Pi. During `ssh-tmux` reconnect/reseed, cmux previously selected the screen and painted captured rows before restoring pane state. The stale region could clip, shift, or scroll those rows, leaving resumed tabs frozen or malformed until the TUI restarted.

## Verification

- test-only commit `70d525745`: focused regression fails twice because the stream is missing the 3-byte `ESC[r` sequence
- fix commit `dab7456cf`: `RemoteTmuxPaneSeedTransportTests` passes 26/26 on macOS with Xcode 26.6
- tagged Debug build: `./scripts/reload.sh --tag fix-tmux-seed-region` succeeded

The test environment used the already-built bundled Ghostty CLI helper because Zig 0.15.2 cannot link against the installed Xcode 26.6 SDK. This bypass affects only the unrelated build helper; cmux source and tests were compiled normally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787480831&installation_model_id=21920&pr_number=8862&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8862&signature=a0cc46844938e1f318e285baaacb1a6baa42647289f9862293599ec396507502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tmux pane reseed freezing or clipped output after `ssh-tmux` reconnects by resetting stale scroll regions on reused surfaces.

- **Bug Fixes**
  - Reset DECSTBM on the selected primary/alternate screen before painting the capture, then restore authoritative pane state.
  - Expanded tests to assert screen selection + `ESC[r` ordering and verify full-viewport reseeds on both screens (no region-induced scrolling); updated seed expectations to include `ESC[r`.

<sup>Written for commit 2874cee441d3d90648c3e5ebc28930ae3c677635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alternate-screen transitions by adding an explicit scroll-region reset before restoring pane content, reducing rendering inconsistencies from stale scrolling or cursor state.
* **Tests**
  * Updated remote pane seed transport assertions to include the new ANSI escape sequence for alternate-screen cutover behavior.
  * Expanded coverage to validate reseed/capture sequences across alternate vs primary states, including clear-scrollback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->