### PR TITLE
Add native edge-aware pane resize shortcuts

### DIFF
--- a/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Geometry/ExternalTreeNode+SplitGeometry.swift
+++ b/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Geometry/ExternalTreeNode+SplitGeometry.swift
@@ -81,11 +81,12 @@ extension ExternalTreeNode {
     }
 
     /// Plans a keyboard resize of the pane's controlling divider: walks the
-    /// tree for the splits enclosing `targetPaneId` (innermost first, the
-    /// legacy candidate order), picks the first split matching the resize
-    /// direction's orientation and child side, and converts `amountPixels`
-    /// into a divider delta along that split's axis, clamped to 0.1-0.9.
-    /// Returns `nil` when the pane is absent or no enclosing split matches.
+    /// tree for the splits enclosing `targetPaneId` (innermost first), prefers
+    /// the nearest split matching the requested edge, and falls back to the
+    /// nearest compatible opposite edge at an outer boundary. Converts
+    /// `amountPixels` into a divider delta along that split's axis, clamped to
+    /// 0.1-0.9. Returns `nil` when the pane is absent or no enclosing split
+    /// matches the direction's orientation.
     public func resizeDividerAdjustment(
         targetPaneId: String,
         direction: ResizeDirection,
@@ -98,16 +99,43 @@ extension ExternalTreeNode {
         let orientationMatches = candidates.filter { $0.orientation == direction.splitOrientation }
         guard !orientationMatches.isEmpty else { return nil }
 
-        guard let candidate = orientationMatches.first(where: {
+        let directCandidate = orientationMatches.first {
             $0.paneInFirstChild == direction.requiresPaneInFirstChild
-        }) else {
-            return nil
         }
+        let candidate = directCandidate ?? orientationMatches[0]
+        let sign = directCandidate == nil
+            ? -direction.dividerDeltaSign
+            : direction.dividerDeltaSign
 
         let delta = CGFloat(amountPixels) / candidate.axisPixels
-        let requested = candidate.dividerPosition + (direction.dividerDeltaSign * delta)
+        let requested = candidate.dividerPosition + (sign * delta)
         let clamped = min(max(requested, 0.1), 0.9)
-        return SplitDividerAdjustment(splitId: candidate.splitId, position: clamped)
+        let requestedShare = candidate.paneInFirstChild ? requested : 1 - requested
+        let actualShare = candidate.paneInFirstChild ? clamped : 1 - clamped
+        let initialShare = candidate.paneInFirstChild
+            ? candidate.dividerPosition
+            : 1 - candidate.dividerPosition
+        return SplitDividerAdjustment(
+            splitId: candidate.splitId,
+            position: clamped,
+            requestedFocusedBranchShare: requestedShare,
+            focusedBranchShare: actualShare,
+            initialFocusedBranchShare: initialShare,
+            focusedBranchIsFirst: candidate.paneInFirstChild
+        )
+    }
+
+    func dividerPosition(forSplitId splitId: UUID) -> CGFloat? {
+        switch self {
+        case .pane:
+            return nil
+        case .split(let split):
+            if split.id == splitId.uuidString {
+                return split.dividerPosition
+            }
+            return split.first.dividerPosition(forSplitId: splitId)
+                ?? split.second.dividerPosition(forSplitId: splitId)
+        }
     }
 
     private struct ResizeSplitCandidate {

--- a/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Geometry/SplitDividerAdjustment.swift
+++ b/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Geometry/SplitDividerAdjustment.swift
@@ -8,10 +8,41 @@ public struct SplitDividerAdjustment: Equatable, Sendable {
     public let splitId: UUID
     /// The normalized divider position to set.
     public let position: CGFloat
+    /// The unclamped share requested for the branch containing the focused pane.
+    public let requestedFocusedBranchShare: CGFloat?
+    /// The share actually assigned to the branch containing the focused pane.
+    public let focusedBranchShare: CGFloat?
+    /// The focused branch's share before this adjustment.
+    public let initialFocusedBranchShare: CGFloat?
+    /// Whether the branch containing the focused pane is the split's first child.
+    public let focusedBranchIsFirst: Bool?
 
-    /// Creates a planned divider move.
+    /// Creates a generic planned divider move with no branch-specific context.
     public init(splitId: UUID, position: CGFloat) {
+        self.init(
+            splitId: splitId,
+            position: position,
+            requestedFocusedBranchShare: nil,
+            focusedBranchShare: nil,
+            initialFocusedBranchShare: nil,
+            focusedBranchIsFirst: nil
+        )
+    }
+
+    /// Creates a branch-aware planned divider move.
+    public init(
+        splitId: UUID,
+        position: CGFloat,
+        requestedFocusedBranchShare: CGFloat?,
+        focusedBranchShare: CGFloat?,
+        initialFocusedBranchShare: CGFloat? = nil,
+        focusedBranchIsFirst: Bool? = nil
+    ) {
         self.splitId = splitId
         self.position = position
+        self.requestedFocusedBranchShare = requestedFocusedBranchShare
+        self.focusedBranchShare = focusedBranchShare
+        self.initialFocusedBranchShare = initialFocusedBranchShare
+        self.focusedBranchIsFirst = focusedBranchIsFirst
     }
 }

--- a/Packages/macOS/CmuxPanes/Sources/CmuxPanes/PaneLayoutService.swift
+++ b/Packages/macOS/CmuxPanes/Sources/CmuxPanes/PaneLayoutService.swift
@@ -43,13 +43,57 @@ public struct PaneLayoutService {
         amountPixels: UInt16,
         controller: BonsplitController
     ) -> Bool {
+        resizeSplitResult(
+            in: node,
+            targetPaneId: targetPaneId,
+            direction: direction,
+            amountPixels: amountPixels,
+            controller: controller
+        ).didApply
+    }
+
+    /// Applies a resize and reports the focused branch's resulting share.
+    public func resizeSplitResult(
+        in node: ExternalTreeNode,
+        targetPaneId: String,
+        direction: ResizeDirection,
+        amountPixels: UInt16,
+        controller: BonsplitController
+    ) -> PaneResizeResult {
         guard let adjustment = node.resizeDividerAdjustment(
             targetPaneId: targetPaneId,
             direction: direction,
             amountPixels: amountPixels
         ) else {
-            return false
+            return .noMatchingSplit
         }
-        return controller.setDividerPosition(adjustment.position, forSplit: adjustment.splitId, fromExternal: true)
+        guard let requestedShare = adjustment.requestedFocusedBranchShare,
+              let plannedShare = adjustment.focusedBranchShare,
+              let initialShare = adjustment.initialFocusedBranchShare,
+              let focusedBranchIsFirst = adjustment.focusedBranchIsFirst else {
+            return .rejected(reason: "The resize plan did not include focused-branch geometry.")
+        }
+        let tolerance: CGFloat = 0.000_1
+        guard abs(plannedShare - initialShare) > tolerance else {
+            return .rejected(reason: "The pane is already at its resize limit.")
+        }
+        guard controller.setDividerPosition(
+            adjustment.position,
+            forSplit: adjustment.splitId,
+            fromExternal: true
+        ) else {
+            return .rejected(reason: "Unable to update the matching split divider.")
+        }
+        guard let appliedPosition = controller.treeSnapshot().dividerPosition(forSplitId: adjustment.splitId) else {
+            return .rejected(reason: "The updated split divider could not be observed.")
+        }
+        let actualShare = focusedBranchIsFirst ? appliedPosition : 1 - appliedPosition
+        if abs(requestedShare - actualShare) > tolerance {
+            return .clamped(
+                requestedShare: requestedShare,
+                actualShare: actualShare
+            )
+        }
+        return .applied(actualShare: actualShare)
     }
 }

--- a/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Values/PaneResizeResult.swift
+++ b/Packages/macOS/CmuxPanes/Sources/CmuxPanes/Values/PaneResizeResult.swift
@@ -1,0 +1,24 @@
+public import CoreGraphics
+
+/// Outcome of a pane-size command shared by shortcut, palette, and automation entry points.
+public enum PaneResizeResult: Equatable, Sendable {
+    /// The requested resize was applied without reaching a layout bound.
+    case applied(actualShare: CGFloat)
+    /// The resize was applied after clamping an infeasible requested share.
+    case clamped(requestedShare: CGFloat, actualShare: CGFloat)
+    /// The focused pane has no split ancestor on the requested axis.
+    case noMatchingSplit
+    /// The selected layout is managed by a different geometry system.
+    case unsupportedLayout
+    /// The command could not be applied for the supplied reason.
+    case rejected(reason: String)
+
+    public var didApply: Bool {
+        switch self {
+        case .applied, .clamped:
+            return true
+        case .noMatchingSplit, .unsupportedLayout, .rejected:
+            return false
+        }
+    }
+}

--- a/Packages/macOS/CmuxPanes/Tests/CmuxPanesTests/SplitGeometryTests.swift
+++ b/Packages/macOS/CmuxPanes/Tests/CmuxPanesTests/SplitGeometryTests.swift
@@ -147,7 +147,67 @@ struct SplitGeometryTests {
         #expect(adjustment.map { abs($0.position - 0.4) < 0.0001 } == true)
     }
 
-    @Test func resizeRequiresMatchingChildSide() {
+    @Test func resizeFallsBackToOppositeEdgeAtOuterBoundaryInEveryDirection() {
+        let horizontalId = UUID()
+        let horizontal = split(
+            horizontalId,
+            orientation: "horizontal",
+            first: pane("left", width: 300),
+            second: pane("right", x: 300, width: 300)
+        )
+        let verticalId = UUID()
+        let vertical = split(
+            verticalId,
+            orientation: "vertical",
+            first: pane("top", width: 600, height: 300),
+            second: pane("bottom", y: 300, width: 600, height: 300)
+        )
+
+        let cases: [(ExternalTreeNode, UUID, String, ResizeDirection, CGFloat)] = [
+            (horizontal, horizontalId, "left", .left, 0.6),
+            (horizontal, horizontalId, "right", .right, 0.4),
+            (vertical, verticalId, "top", .up, 0.6),
+            (vertical, verticalId, "bottom", .down, 0.4),
+        ]
+
+        for (tree, splitId, paneId, direction, expectedPosition) in cases {
+            let adjustment = tree.resizeDividerAdjustment(
+                targetPaneId: paneId,
+                direction: direction,
+                amountPixels: 60
+            )
+            #expect(adjustment?.splitId == splitId)
+            #expect(adjustment.map { abs($0.position - expectedPosition) < 0.0001 } == true)
+        }
+    }
+
+    @Test func resizePrefersRequestedEdgeBeforeNearerOppositeEdge() {
+        let innerId = UUID()
+        let rootId = UUID()
+        let inner = split(
+            innerId,
+            orientation: "horizontal",
+            first: pane("a", width: 150),
+            second: pane("b", x: 150, width: 150)
+        )
+        let tree = split(
+            rootId,
+            orientation: "horizontal",
+            first: inner,
+            second: pane("c", x: 300, width: 300)
+        )
+
+        let adjustment = tree.resizeDividerAdjustment(
+            targetPaneId: "b",
+            direction: .right,
+            amountPixels: 60
+        )
+
+        #expect(adjustment?.splitId == rootId)
+        #expect(adjustment.map { $0.position > 0.5 } == true)
+    }
+
+    @Test func resizeRequiresMatchingOrientationAndKnownPane() {
         let splitId = UUID()
         let tree = split(
             splitId,
@@ -156,11 +216,7 @@ struct SplitGeometryTests {
             second: pane("b", x: 300, width: 300)
         )
 
-        // .right requires the target in the first child; "b" is the second.
-        #expect(tree.resizeDividerAdjustment(targetPaneId: "b", direction: .right, amountPixels: 10) == nil)
-        // Vertical resize has no vertical split to control.
         #expect(tree.resizeDividerAdjustment(targetPaneId: "b", direction: .up, amountPixels: 10) == nil)
-        // Unknown pane plans nothing.
         #expect(tree.resizeDividerAdjustment(targetPaneId: "zz", direction: .left, amountPixels: 10) == nil)
     }
 
@@ -200,6 +256,32 @@ struct SplitGeometryTests {
         // A huge downward move from 0.85 clamps to 0.9.
         let adjustment = tree.resizeDividerAdjustment(targetPaneId: "a", direction: .down, amountPixels: 400)
         #expect(adjustment?.position == 0.9)
+        #expect(adjustment?.requestedFocusedBranchShare.map { $0 > 1 } == true)
+        #expect(adjustment?.focusedBranchShare == 0.9)
+        #expect(adjustment?.initialFocusedBranchShare == 0.85)
+        #expect(adjustment?.focusedBranchIsFirst == true)
+        #expect(tree.dividerPosition(forSplitId: splitId) == 0.85)
+    }
+
+    @Test func resizePlanAtExistingLimitRecordsNoShareChange() {
+        let splitId = UUID()
+        let tree = split(
+            splitId,
+            orientation: "horizontal",
+            dividerPosition: 0.9,
+            first: pane("a", width: 540),
+            second: pane("b", x: 540, width: 60)
+        )
+
+        let adjustment = tree.resizeDividerAdjustment(
+            targetPaneId: "a",
+            direction: .right,
+            amountPixels: 20
+        )
+
+        #expect(adjustment?.initialFocusedBranchShare == 0.9)
+        #expect(adjustment?.focusedBranchShare == 0.9)
+        #expect(adjustment?.requestedFocusedBranchShare.map { $0 > 0.9 } == true)
     }
 
     // MARK: Direction values

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -92,6 +92,10 @@ extension ShortcutAction {
         case .splitDown: return ShortcutStroke(key: "d", command: true, shift: true)
         case .toggleSplitZoom: return ShortcutStroke(key: "\r", command: true, shift: true)
         case .equalizeSplits: return ShortcutStroke(key: "=", command: true, control: true)
+        case .growPaneLeft, .growPaneRight, .growPaneUp, .growPaneDown:
+            // Configurable but initially unbound to avoid conflicting with
+            // terminal bindings and pane-navigation shortcuts.
+            return nil
         case .splitBrowserRight: return ShortcutStroke(key: "d", command: true, option: true)
         case .splitBrowserDown: return ShortcutStroke(key: "d", command: true, shift: true, option: true)
         case .toggleCanvasLayout: return ShortcutStroke(key: "c", command: true, control: true)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -97,6 +97,10 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     case splitDown
     case toggleSplitZoom
     case equalizeSplits
+    case growPaneLeft
+    case growPaneRight
+    case growPaneUp
+    case growPaneDown
     case splitBrowserRight
     case splitBrowserDown
     case toggleRightSidebar = "toggleFileExplorer"
@@ -196,7 +200,9 @@ extension ShortcutAction {
              .clearScreenKeepScrollback:
             return .navigation
         case .focusLeft, .focusRight, .focusUp, .focusDown, .splitRight, .splitDown,
-             .toggleSplitZoom, .equalizeSplits, .splitBrowserRight, .splitBrowserDown,
+             .toggleSplitZoom, .equalizeSplits,
+             .growPaneLeft, .growPaneRight, .growPaneUp, .growPaneDown,
+             .splitBrowserRight, .splitBrowserDown,
              .toggleRightSidebar, .fileExplorerOpenSelection, .fileExplorerOpenSelectionFinderAlias,
              .toggleCanvasLayout, .canvasRevealFocusedPane, .canvasOverview,
              .canvasZoomIn, .canvasZoomOut, .canvasZoomReset, .canvasTidy,
@@ -404,6 +410,10 @@ extension ShortcutAction {
         case .splitDown: return "Split Down"
         case .toggleSplitZoom: return "Toggle Pane Zoom"
         case .equalizeSplits: return "Equalize Splits"
+        case .growPaneLeft: return "Grow Pane Left"
+        case .growPaneRight: return "Grow Pane Right"
+        case .growPaneUp: return "Grow Pane Up"
+        case .growPaneDown: return "Grow Pane Down"
         case .splitBrowserRight: return "Split Browser Right"
         case .splitBrowserDown: return "Split Browser Down"
         case .toggleRightSidebar: return "Toggle Right Sidebar"

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/ShortcutActionPaneResizeTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/ShortcutActionPaneResizeTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import CmuxSettings
+
+@Suite("Pane resize shortcut actions")
+struct ShortcutActionPaneResizeTests {
+    @Test(arguments: [
+        ShortcutAction.growPaneLeft,
+        ShortcutAction.growPaneRight,
+        ShortcutAction.growPaneUp,
+        ShortcutAction.growPaneDown,
+    ])
+    func directionalActionsAreVisibleButInitiallyUnbound(
+        action: ShortcutAction
+    ) {
+        #expect(action.defaultStroke == nil)
+        #expect(action.group == .panes)
+        #expect(action.displayName.hasPrefix("Grow Pane "))
+    }
+}

--- a/Sources/AppDelegate+EqualizeSplitsShortcut.swift
+++ b/Sources/AppDelegate+EqualizeSplitsShortcut.swift
@@ -1,4 +1,56 @@
+import AppKit
+import CmuxPanes
+
 extension AppDelegate {
+    private static let paneResizeStep: CGFloat = 20
+
+    func handlePaneResizeShortcut(event: NSEvent) -> Bool {
+        let routes: [(KeyboardShortcutSettings.Action, ResizeDirection, String, UInt16)] = [
+            (.growPaneLeft, .left, "←", 123),
+            (.growPaneRight, .right, "→", 124),
+            (.growPaneUp, .up, "↑", 126),
+            (.growPaneDown, .down, "↓", 125),
+        ]
+
+        guard let route = routes.first(where: { action, _, glyph, keyCode in
+            matchConfiguredDirectionalShortcut(
+                event: event,
+                action: action,
+                arrowGlyph: glyph,
+                arrowKeyCode: keyCode
+            )
+        }) else {
+            return false
+        }
+
+        performPaneResizeShortcut(direction: route.1, event: event)
+        return true
+    }
+
+    func performPaneResizeShortcut(direction: ResizeDirection, event: NSEvent) {
+        if focusedDockStoreForShortcut(preferredWindow: event.window) != nil {
+            NSSound.beep()
+#if DEBUG
+            cmuxDebugLog("shortcut.action name=growPane direction=\(direction) result=unsupportedDock")
+#endif
+            return
+        }
+
+        let manager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
+        if shouldSuppressSplitShortcutForTransientTerminalFocusState(tabManager: manager) {
+            return
+        }
+        let result = manager?.resizeSelectedPane(
+            direction: direction,
+            amountInPixels: Self.paneResizeStep
+        ) ?? .rejected(reason: "No workspace is selected.")
+
+        if !result.didApply { NSSound.beep() }
+#if DEBUG
+        cmuxDebugLog("shortcut.action name=growPane direction=\(direction) result=\(String(describing: result))")
+#endif
+    }
+
     func performEqualizeSplitsShortcut() {
         guard let tabManager, let workspace = tabManager.selectedWorkspace else {
 #if DEBUG

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13935,6 +13935,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             return true
         }
+        if handlePaneResizeShortcut(event: event) { return true }
         if matchConfiguredShortcut(event: event, action: .equalizeSplits) { performEqualizeSplitsShortcut(); return true }
         // Canvas layout actions share one executor with the palette, View
         // menu, and the canvas.* socket verbs.

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -134,6 +134,7 @@ enum KeyboardShortcutSettings {
         case splitRight
         case splitDown, toggleSplitZoom
         case equalizeSplits
+        case growPaneLeft, growPaneRight, growPaneUp, growPaneDown
         case splitBrowserRight
         case splitBrowserDown
 
@@ -269,6 +270,10 @@ enum KeyboardShortcutSettings {
             case .splitDown: return String(localized: "shortcut.splitDown.label", defaultValue: "Split Down")
             case .toggleSplitZoom: return String(localized: "shortcut.togglePaneZoom.label", defaultValue: "Toggle Pane Zoom")
             case .equalizeSplits: return String(localized: "shortcut.equalizeSplits.label", defaultValue: "Equalize Splits")
+            case .growPaneLeft: return String(localized: "shortcut.growPaneLeft.label", defaultValue: "Grow Pane Left")
+            case .growPaneRight: return String(localized: "shortcut.growPaneRight.label", defaultValue: "Grow Pane Right")
+            case .growPaneUp: return String(localized: "shortcut.growPaneUp.label", defaultValue: "Grow Pane Up")
+            case .growPaneDown: return String(localized: "shortcut.growPaneDown.label", defaultValue: "Grow Pane Down")
             case .splitBrowserRight: return String(localized: "shortcut.splitBrowserRight.label", defaultValue: "Split Browser Right")
             case .splitBrowserDown: return String(localized: "shortcut.splitBrowserDown.label", defaultValue: "Split Browser Down")
             case .toggleCanvasLayout: return String(localized: "shortcut.toggleCanvasLayout.label", defaultValue: "Toggle Canvas Layout")
@@ -454,6 +459,8 @@ enum KeyboardShortcutSettings {
             case .splitDown: return StoredShortcut(key: "d", command: true, shift: true, option: false, control: false)
             case .toggleSplitZoom: return StoredShortcut(key: "\r", command: true, shift: true, option: false, control: false)
             case .equalizeSplits: return StoredShortcut(key: "=", command: true, shift: false, option: false, control: true)
+            case .growPaneLeft, .growPaneRight, .growPaneUp, .growPaneDown:
+                return .unbound
             case .splitBrowserRight:
                 return StoredShortcut(key: "d", command: true, shift: false, option: true, control: false)
             case .splitBrowserDown:

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3904,6 +3904,36 @@ class TabManager: ObservableObject {
     }
 
     /// Resize split - not directly supported by bonsplit, but we can adjust divider positions
+    func resizeSelectedPane(
+        direction: ResizeDirection,
+        amountInPixels: CGFloat
+    ) -> PaneResizeResult {
+        guard amountInPixels.isFinite, amountInPixels > 0 else {
+            return .rejected(reason: "Resize amount must be a positive finite value.")
+        }
+        guard let workspace = selectedWorkspace else {
+            return .rejected(reason: "No workspace is selected.")
+        }
+        guard workspace.layoutMode != .canvas, !workspace.isRemoteTmuxMirror else {
+            return .unsupportedLayout
+        }
+        guard !workspace.bonsplitController.isSplitZoomed else {
+            return .rejected(reason: "Pane resizing is unavailable while a pane is zoomed.")
+        }
+        guard let panelId = workspace.focusedPanelId else {
+            return .rejected(reason: "No pane is focused.")
+        }
+
+        let roundedAmount = max(1, min(amountInPixels.rounded(), CGFloat(UInt16.max)))
+        return paneLayout.resizeSplitResult(
+            in: workspace.bonsplitController.treeSnapshot(),
+            targetPaneId: panelId.uuidString,
+            direction: direction,
+            amountPixels: UInt16(roundedAmount),
+            controller: workspace.bonsplitController
+        )
+    }
+
     func resizeSplit(tabId: UUID, surfaceId: UUID, direction: ResizeDirection, amount: UInt16) -> Bool {
         guard amount > 0,
               let tab = tabs.first(where: { $0.id == tabId }),

--- a/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateSurfaceShortcutRoutingTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Bonsplit
 import CmuxCanvasUI
 import Testing
 
@@ -32,6 +33,17 @@ private final class CanvasViewportSpy: CanvasViewportControlling {
 @MainActor
 @Suite(.serialized)
 struct AppDelegateSurfaceShortcutRoutingTests {
+    @Test func paneGrowShortcutsAreUnboundByDefault() {
+        for action in [
+            KeyboardShortcutSettings.Action.growPaneLeft,
+            .growPaneRight,
+            .growPaneUp,
+            .growPaneDown,
+        ] {
+            #expect(action.defaultShortcut == .unbound)
+        }
+    }
+
     @Test func rightSidebarModeShortcutsDoNotFallThroughWhenResponderTemporarilyClears() throws {
         try withIsolatedShortcutSettings {
             let appDelegate = try #require(AppDelegate.shared)
@@ -396,6 +408,108 @@ struct AppDelegateSurfaceShortcutRoutingTests {
             #expect(firstFrame.height == secondFrame.height)
             #expect(workspace.bonsplitController.allPaneIds.count == originalBonsplitPaneCount)
         }
+    }
+
+    @Test func configuredGrowPaneShortcutsUseOppositeEdgeAtEveryOuterBoundary() throws {
+        try assertPaneResizeShortcut(
+            action: .growPaneLeft,
+            key: "x",
+            keyCode: 123,
+            orientation: .horizontal,
+            focusSecondPane: false,
+            expectedDividerToIncrease: true
+        )
+        try assertPaneResizeShortcut(
+            action: .growPaneRight,
+            key: "→",
+            keyCode: 124,
+            orientation: .horizontal,
+            focusSecondPane: true,
+            expectedDividerToIncrease: false
+        )
+        try assertPaneResizeShortcut(
+            action: .growPaneUp,
+            key: "↑",
+            keyCode: 126,
+            orientation: .vertical,
+            focusSecondPane: false,
+            expectedDividerToIncrease: true
+        )
+        try assertPaneResizeShortcut(
+            action: .growPaneDown,
+            key: "↓",
+            keyCode: 125,
+            orientation: .vertical,
+            focusSecondPane: true,
+            expectedDividerToIncrease: false
+        )
+    }
+
+    private func assertPaneResizeShortcut(
+        action: KeyboardShortcutSettings.Action,
+        key: String,
+        keyCode: UInt16,
+        orientation: SplitOrientation,
+        focusSecondPane: Bool,
+        expectedDividerToIncrease: Bool
+    ) throws {
+        try withTemporaryShortcut(action: action) {
+            let appDelegate = try #require(AppDelegate.shared)
+            let windowId = appDelegate.createMainWindow()
+            defer { closeWindow(withId: windowId) }
+
+            let window = try #require(mainWindow(for: windowId))
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            let workspace = try #require(manager.selectedWorkspace)
+            let firstPanelId = try #require(workspace.focusedPanelId)
+            let secondPanel = try #require(workspace.newTerminalSplit(from: firstPanelId, orientation: orientation))
+            guard case .split(let originalSplit) = workspace.bonsplitController.treeSnapshot(),
+                  let splitId = UUID(uuidString: originalSplit.id) else {
+                Issue.record("Expected a split")
+                return
+            }
+            #expect(workspace.bonsplitController.setDividerPosition(0.5, forSplit: splitId))
+            let focusedPanelId = focusSecondPane ? secondPanel.id : firstPanelId
+            workspace.focusPanel(focusedPanelId)
+            window.makeKeyAndOrderFront(nil)
+
+            let event = try #require(makeKeyDownEvent(
+                key: key,
+                modifiers: [.command, .shift, .control],
+                keyCode: keyCode,
+                windowNumber: window.windowNumber
+            ))
+
+#if DEBUG
+            #expect(appDelegate.debugHandleCustomShortcut(event: event))
+#else
+            Issue.record("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+            guard case .split(let resizedSplit) = workspace.bonsplitController.treeSnapshot() else {
+                Issue.record("Expected the split to remain present")
+                return
+            }
+            if expectedDividerToIncrease {
+                #expect(resizedSplit.dividerPosition > 0.5)
+            } else {
+                #expect(resizedSplit.dividerPosition < 0.5)
+            }
+            #expect(workspace.focusedPanelId == focusedPanelId)
+        }
+    }
+
+    @Test func selectedPaneResizeRejectsCanvasAndRemoteManagedLayouts() throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+
+        workspace.setLayoutMode(.canvas)
+        #expect(manager.resizeSelectedPane(direction: .left, amountInPixels: 20) == .unsupportedLayout)
+
+        workspace.setLayoutMode(.splits)
+        workspace.isRemoteTmuxMirror = true
+        defer { workspace.isRemoteTmuxMirror = false }
+        #expect(manager.resizeSelectedPane(direction: .right, amountInPixels: 20) == .unsupportedLayout)
     }
 
     private func makeKeyDownEvent(


### PR DESCRIPTION
## Summary

- expose four configurable native actions: Grow Pane Left/Right/Up/Down
- route all four actions through one `TabManager` / `PaneLayoutService` resize path backed by Bonsplit
- prefer the nearest requested edge, then fall back to the nearest compatible opposite edge at outer boundaries
- reject Canvas, remote-tmux mirrors, zoomed panes, transient focus states, and Dock-focused routing
- return structured applied, clamped, unavailable, unsupported, and rejected outcomes
- keep the new actions unbound by default to avoid terminal/navigation conflicts
- add labels for all 19 existing locales

## Verification

- `CmuxPanes`: 31 tests passed
- `CmuxSettings`: 262 tests passed
- focused app routing test passed for all four outer-boundary directions
- focused app test passed for unbound defaults
- Swift parser validation passed for all changed Swift files
- localization JSON and 4 keys × 19 locales validated
- `git diff --check` passed
- `scripts/check-pbxproj.sh` passed
- `scripts/lint-pbxproj-test-wiring.sh` passed (577 test files)
- tagged `cmux DEV pane-resize` build succeeded and launched

## Notes

- Exact split ratios, presets, Command Palette input, CLI support, and restoration are intentionally deferred from this incremental PR.
- Local app-test/build verification on current upstream `main` required temporary compile-only workarounds for unrelated existing errors in `PanelShellActivityState`, `DockSplitStore+SessionSnapshot.swift`, `ControlSurfaceResumeTarget.swift`, and `DockWorkingDirectoryInheritanceTests.swift`. Those workarounds are not included in this branch.

Closes #8855

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787491617&installation_model_id=21920&pr_number=8865&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8865&signature=9be0c54590ee68881028836a2b9d107d1341d582640fd5092304951407e58f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native, edge-aware pane resize shortcuts (Grow Pane Left/Right/Up/Down). Resizing is unified through `Bonsplit` with clear outcomes and safe defaults.

- **New Features**
  - Four configurable actions, unbound by default to avoid conflicts, surfaced in Settings under the Panes group.
  - Single resize path via `TabManager` and `PaneLayoutService` on `Bonsplit` for all directions.
  - Edge-aware logic: prefer the requested edge; fall back to the nearest opposite edge at outer boundaries.
  - Structured results via `PaneResizeResult`: applied, clamped, noMatchingSplit, unsupportedLayout, rejected(reason).
  - Safety checks: reject Canvas layouts, remote-tmux mirrors, zoomed panes, transient focus states, and Dock-focused routing; beep on no-ops.
  - Added labels for all 19 locales; tests added in `CmuxPanes`, `CmuxSettings`, and app shortcut routing.

<sup>Written for commit 9ff84172bd6b7c7d9dd7f6a60af5b8a3ee740492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

