### PR TITLE
Fix main build: two compile errors from PR 8690

### DIFF
--- a/Sources/ControlSurfaceResumeTarget.swift
+++ b/Sources/ControlSurfaceResumeTarget.swift
@@ -278,7 +278,7 @@ extension TerminalController {
         )
         content.apply(to: alert, presentingWindow: nil)
 
-        switch alert.runModal() {
+        return switch alert.runModal() {
         case .alertFirstButtonReturn: .auto
         case .alertSecondButtonReturn: .prompt
         default: .manual

--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -1,3 +1,4 @@
+import CmuxWorkspaces
 import Foundation
 
 extension DockSplitStore {

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -42,7 +42,7 @@ extension DockSplitStore {
             }
         let persistedPanelIds = Set(panelSnapshots.map(\.id))
         let sourceWorkspaceIdsByPanelId = Dictionary(uniqueKeysWithValues: panelSnapshots.compactMap {
-            panel in
+            panel -> (UUID, UUID)? in
             guard let transfer = detachedSurfaceTransfersByPanelId[panel.id] else { return nil }
             return (panel.id, transfer.sessionRestoreWorkspaceId)
         })
@@ -329,7 +329,7 @@ extension DockSplitStore {
         let expectedSessionId = resumeBinding?.isAgentHookBinding == true
             ? resumeBinding?.checkpointId
             : restorableAgent?.sessionId
-        let relevantObservation = observation.flatMap { entry in
+        let relevantObservation = observation.flatMap { entry -> RestorableAgentSessionIndex.Entry? in
             guard entry.snapshot.kind == expectedKind, entry.snapshot.sessionId == expectedSessionId else {
                 return nil
             }


### PR DESCRIPTION
Current main fails to compile the macOS app: `Sources/DockSplitStore+RestoredAgentLifecycle.swift:13: error: cannot find type 'PanelShellActivityState' in scope` (seen on the cloud reload builder, https://github.com/manaflow-ai/cmux/actions/runs/30104418455).

`PanelShellActivityState` lives in the `CmuxWorkspaces` package, and https://github.com/manaflow-ai/cmux/pull/8690 merged this file importing only Foundation, a semantic merge miss since sibling users of the type like `Sources/Workspace+AgentLifecycle.swift` import `CmuxWorkspaces`. One-line import fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787498600&installation_model_id=21920&pr_number=8869&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8869&signature=f22cfff7c0eb7392a4de4bdb24a3db5cd563770fe8ef75134d894ee0d1152a74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS app build by importing `CmuxWorkspaces`, adding an explicit `return switch` in `surfacePromptForResumeApproval`, and annotating closure result types in `DockSplitStore+SessionSnapshot`. Resolves the missing `PanelShellActivityState` type, a trailing switch compile error, and type inference failures on Xcode 26.5.

<sup>Written for commit a75a6339abb80c1a3adba6220360fe1102b1d51c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during session restoration by ensuring required workspace functionality is available.
* **Refactor**
  * Improved resume approval logic so the selected resume policy is consistently returned from the approval prompt.
  * Tightened internal session snapshot computations with clearer, explicit return types (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->