### PR TITLE
Fix main build: import CmuxWorkspaces in DockSplitStore+RestoredAgentLifecycle

### DIFF
--- a/Sources/DockSplitStore+RestoredAgentLifecycle.swift
+++ b/Sources/DockSplitStore+RestoredAgentLifecycle.swift
@@ -1,4 +1,5 @@
 import CmuxWorkspaces
+import CmuxWorkspaces
 import Foundation
 
 extension DockSplitStore {


### PR DESCRIPTION
Every macOS app build from main fails since https://github.com/manaflow-ai/cmux/pull/8690: the new extension file references `PanelShellActivityState` (defined in CmuxWorkspaces) but only imports Foundation. Sibling files using the same type already import CmuxWorkspaces. One-line import fix; verified by a successful tagged cloud build (`ncon`) from this branch. Blocks nightlies and all tagged reloads until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787509929&installation_model_id=21920&pr_number=8873&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8873&signature=b3a8b550370ac11957aed12fed6c9dd4114dae5eb23beff1a1c228f9d6bee715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS app build by adding a missing `CmuxWorkspaces` import in `DockSplitStore+RestoredAgentLifecycle.swift` so `PanelShellActivityState` resolves. Unblocks nightlies and tagged releases.

<sup>Written for commit 3dc0237c41fa61cea8225cf33669356ede058c17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when restoring agent lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->