### PR TITLE
Add browser profile targeting to CLI pane creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -942,6 +942,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_contract_help.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_layout_focus_contract.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_operation_deadline.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_browser_profile_cli.py
           python3 tests/test_stress_cli_socket_api.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omo_openagent_plugin_migration.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_autodiscovery.py

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4648,7 +4648,7 @@ struct CMUXCLI {
             let type = optionValue(commandArgs, name: "--type")
             let direction = optionValue(commandArgs, name: "--direction") ?? "right"
             let url = optionValue(commandArgs, name: "--url")
-            let profile = optionValue(commandArgs, name: "--profile")
+            let profile = try parseBrowserProfileOption(commandArgs).selector
             let placement = optionValue(commandArgs, name: "--placement")
             let focusOpt = optionValue(commandArgs, name: "--focus")
             var params: [String: Any] = ["direction": direction]
@@ -4659,20 +4659,13 @@ struct CMUXCLI {
             if let type { params["type"] = type }
             if let url { params["url"] = url }
             if let profile {
-                let selector = profile.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !selector.isEmpty else {
-                    throw CLIError(message: String(
-                        localized: "cli.browser.profile.error.emptySelector",
-                        defaultValue: "--profile requires a non-empty profile name or UUID"
-                    ))
-                }
                 guard type?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "browser" else {
                     throw CLIError(message: String(
                         localized: "browser.profile.automation.error.profileRequiresBrowserPane",
                         defaultValue: "Browser profiles can only be used when creating a browser pane"
                     ))
                 }
-                params["profile"] = selector
+                params["profile"] = profile
             }
             if let placement { params["placement"] = placement }
             try applyFocusOption(focusOpt, defaultValue: false, to: &params)
@@ -13403,20 +13396,7 @@ struct CMUXCLI {
             let (workspaceOpt, argsAfterWorkspace) = parseOption(subArgs, name: "--workspace")
             let (windowOpt, argsAfterWindow) = parseOption(argsAfterWorkspace, name: "--window")
             let (focusOpt, argsAfterFocus) = parseOption(argsAfterWindow, name: "--focus")
-            let (profileOpt, urlArgs) = parseOption(argsAfterFocus, name: "--profile")
-            let profileSelector: String?
-            if let profileOpt {
-                let selector = profileOpt.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !selector.isEmpty else {
-                    throw CLIError(message: String(
-                        localized: "cli.browser.profile.error.emptySelector",
-                        defaultValue: "--profile requires a non-empty profile name or UUID"
-                    ))
-                }
-                profileSelector = selector
-            } else {
-                profileSelector = nil
-            }
+            let (profileSelector, urlArgs) = try parseBrowserProfileOption(argsAfterFocus)
             // Reject unrecognized flags instead of folding them into the URL, where they
             // would silently produce an unparseable URL (blank page) or a search query.
             if let strayFlag = urlArgs.first(where: { $0.hasPrefix("--") }) {
@@ -17033,6 +17013,49 @@ struct CMUXCLI {
             remaining.append(arg)
         }
         return (value, remaining)
+    }
+
+    func parseBrowserProfileOption(_ args: [String]) throws -> (selector: String?, remaining: [String]) {
+        var remaining: [String] = []
+        var selector: String?
+        var index = 0
+        var pastTerminator = false
+        while index < args.count {
+            let arg = args[index]
+            if pastTerminator || arg == "--" {
+                pastTerminator = true
+                remaining.append(arg)
+                index += 1
+                continue
+            }
+            if arg == "--profile" {
+                guard index + 1 < args.count, !args[index + 1].hasPrefix("-") else {
+                    throw CLIError(message: String(
+                        localized: "cli.browser.profile.error.emptySelector",
+                        defaultValue: "--profile requires a non-empty profile name or UUID"
+                    ))
+                }
+                selector = args[index + 1]
+                index += 2
+                continue
+            }
+            if arg.hasPrefix("--profile=") {
+                selector = String(arg.dropFirst("--profile=".count))
+                index += 1
+                continue
+            }
+            remaining.append(arg)
+            index += 1
+        }
+        guard let selector else { return (nil, remaining) }
+        let normalized = selector.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else {
+            throw CLIError(message: String(
+                localized: "cli.browser.profile.error.emptySelector",
+                defaultValue: "--profile requires a non-empty profile name or UUID"
+            ))
+        }
+        return (normalized, remaining)
     }
 
     func parseRepeatedOption(_ args: [String], name: String) -> ([String], [String]) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4666,6 +4666,12 @@ struct CMUXCLI {
                         defaultValue: "--profile requires a non-empty profile name or UUID"
                     ))
                 }
+                guard type?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "browser" else {
+                    throw CLIError(message: String(
+                        localized: "browser.profile.automation.error.profileRequiresBrowserPane",
+                        defaultValue: "Browser profiles can only be used when creating a browser pane"
+                    ))
+                }
                 params["profile"] = selector
             }
             if let placement { params["placement"] = placement }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13398,6 +13398,19 @@ struct CMUXCLI {
             let (windowOpt, argsAfterWindow) = parseOption(argsAfterWorkspace, name: "--window")
             let (focusOpt, argsAfterFocus) = parseOption(argsAfterWindow, name: "--focus")
             let (profileOpt, urlArgs) = parseOption(argsAfterFocus, name: "--profile")
+            let profileSelector: String?
+            if let profileOpt {
+                let selector = profileOpt.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !selector.isEmpty else {
+                    throw CLIError(message: String(
+                        localized: "cli.browser.profile.error.emptySelector",
+                        defaultValue: "--profile requires a non-empty profile name or UUID"
+                    ))
+                }
+                profileSelector = selector
+            } else {
+                profileSelector = nil
+            }
             // Reject unrecognized flags instead of folding them into the URL, where they
             // would silently produce an unparseable URL (blank page) or a search query.
             if let strayFlag = urlArgs.first(where: { $0.hasPrefix("--") }) {
@@ -13418,6 +13431,12 @@ struct CMUXCLI {
 
             if surfaceRaw != nil, subcommand == "open" {
                 // Treat `browser <surface> open <url>` as navigate for agent-browser ergonomics.
+                guard profileSelector == nil else {
+                    throw CLIError(message: String(
+                        localized: "cli.browser.profile.error.navigateUnsupported",
+                        defaultValue: "--profile is only supported when browser open creates a new pane; omit the surface selector"
+                    ))
+                }
                 let sid = try requireSurface()
                 guard !url.isEmpty else {
                     throw CLIError(message: "browser <surface> open requires a URL")
@@ -13434,15 +13453,8 @@ struct CMUXCLI {
             if !url.isEmpty {
                 params["url"] = url
             }
-            if let profileOpt {
-                let selector = profileOpt.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !selector.isEmpty else {
-                    throw CLIError(message: String(
-                        localized: "cli.browser.profile.error.emptySelector",
-                        defaultValue: "--profile requires a non-empty profile name or UUID"
-                    ))
-                }
-                params["profile"] = selector
+            if let profileSelector {
+                params["profile"] = profileSelector
             }
             if let sourceSurface = try normalizeSurfaceHandle(surfaceRaw, client: client) {
                 params["surface_id"] = sourceSurface

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4648,6 +4648,7 @@ struct CMUXCLI {
             let type = optionValue(commandArgs, name: "--type")
             let direction = optionValue(commandArgs, name: "--direction") ?? "right"
             let url = optionValue(commandArgs, name: "--url")
+            let profile = optionValue(commandArgs, name: "--profile")
             let placement = optionValue(commandArgs, name: "--placement")
             let focusOpt = optionValue(commandArgs, name: "--focus")
             var params: [String: Any] = ["direction": direction]
@@ -4657,6 +4658,16 @@ struct CMUXCLI {
             if let wsId { params["workspace_id"] = wsId }
             if let type { params["type"] = type }
             if let url { params["url"] = url }
+            if let profile {
+                let selector = profile.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !selector.isEmpty else {
+                    throw CLIError(message: String(
+                        localized: "cli.browser.profile.error.emptySelector",
+                        defaultValue: "--profile requires a non-empty profile name or UUID"
+                    ))
+                }
+                params["profile"] = selector
+            }
             if let placement { params["placement"] = placement }
             try applyFocusOption(focusOpt, defaultValue: false, to: &params)
             let payload = try client.sendV2(method: "pane.create", params: params)
@@ -13109,7 +13120,10 @@ struct CMUXCLI {
             }
             var markers: [String] = []
             if (profile["current"] as? Bool) == true {
-                markers.append("current")
+                markers.append(String(
+                    localized: "cli.browser.profiles.marker.lastUsed",
+                    defaultValue: "last used"
+                ))
             }
             if (profile["built_in_default"] as? Bool) == true {
                 markers.append("default")
@@ -13382,7 +13396,8 @@ struct CMUXCLI {
             // Parse routing flags before URL assembly so they never leak into the URL string.
             let (workspaceOpt, argsAfterWorkspace) = parseOption(subArgs, name: "--workspace")
             let (windowOpt, argsAfterWindow) = parseOption(argsAfterWorkspace, name: "--window")
-            let (focusOpt, urlArgs) = parseOption(argsAfterWindow, name: "--focus")
+            let (focusOpt, argsAfterFocus) = parseOption(argsAfterWindow, name: "--focus")
+            let (profileOpt, urlArgs) = parseOption(argsAfterFocus, name: "--profile")
             // Reject unrecognized flags instead of folding them into the URL, where they
             // would silently produce an unparseable URL (blank page) or a search query.
             if let strayFlag = urlArgs.first(where: { $0.hasPrefix("--") }) {
@@ -13418,6 +13433,16 @@ struct CMUXCLI {
             var params: [String: Any] = [:]
             if !url.isEmpty {
                 params["url"] = url
+            }
+            if let profileOpt {
+                let selector = profileOpt.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !selector.isEmpty else {
+                    throw CLIError(message: String(
+                        localized: "cli.browser.profile.error.emptySelector",
+                        defaultValue: "--profile requires a non-empty profile name or UUID"
+                    ))
+                }
+                params["profile"] = selector
             }
             if let sourceSurface = try normalizeSurfaceHandle(surfaceRaw, client: client) {
                 params["surface_id"] = sourceSurface
@@ -16009,6 +16034,7 @@ struct CMUXCLI {
               --workspace <id|ref|index>          Target workspace (default: $CMUX_WORKSPACE_ID)
               --window <id|ref|index>             Window context for workspace refs and indexes
               --url <url>                         URL for browser panes
+              \(String(localized: "cli.newPane.help.profileDescription", defaultValue: "--profile <name|uuid>                Browser profile name or UUID"))
               --focus <true|false>                Focus the new pane (default: false)
 
             Example:
@@ -16835,7 +16861,7 @@ struct CMUXCLI {
             `open`/`open-split`/`new`/`identify` can run without an explicit surface.
 
             Subcommands:
-              open|open-split|new [url] [--workspace <id|ref|index>] [--window <id|ref|index>] [--focus <true|false>]
+              open|open-split|new [url] [--workspace <id|ref|index>] [--window <id|ref|index>] [--focus <true|false>] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]"))
                 open/open-split/new default to $CMUX_WORKSPACE_ID when --workspace is omitted and --window is not set
                 --focus defaults to false
               disable | enable | status
@@ -35224,7 +35250,7 @@ export default CMUXSessionRestore;
           top [--all] [--workspace <id|ref|index>] [--window <id|ref|index>] [--processes] [--sort <cpu|mem|proc>] [--flat] [--format <tree|tsv>]
           memory [--all] [--workspace <id|ref|index>] [--groups <count>]
           focus-pane --pane <id|ref|index> [--workspace <id|ref|index>] [--window <id|ref|index>]
-          new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--focus <true|false>]
+          new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]")) [--focus <true|false>]
           new-surface [--type <terminal|browser|agent-session>] [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--url <url>] [--provider <codex|claude|opencode>] [--renderer <react|solid>] [--focus <true|false>]
           close-surface [--surface <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>]
           move-surface --surface <id|ref|index> [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--before <id|ref|index>] [--after <id|ref|index>] [--index <n>] [--focus <true|false>]
@@ -35299,8 +35325,8 @@ export default CMUXSessionRestore;
 
           browser [--surface <id|ref|index> | <surface>] <subcommand> ...
           browser disable | enable | status
-          browser open [url] [--focus <true|false>] (create browser split in caller's workspace; if surface supplied, behaves like navigate)
-          browser open-split [url]
+          browser open [url] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]")) [--focus <true|false>] (create browser split in caller's workspace; if surface supplied, behaves like navigate)
+          browser open-split [url] \(String(localized: "cli.browser.profile.option", defaultValue: "[--profile <name|uuid>]"))
           browser goto|navigate <url> [--snapshot-after]
           browser back|forward|reload [--snapshot-after]
           browser react-grab toggle [--surface <id>] [--return-to <terminal-surface>]

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Profiles/Repository/BrowserProfileRepository.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Profiles/Repository/BrowserProfileRepository.swift
@@ -80,6 +80,33 @@ public final class BrowserProfileRepository {
         profiles.first(where: { $0.id == id })
     }
 
+    /// Resolves a profile selector as an existing UUID or display name.
+    ///
+    /// UUID lookup takes precedence. A UUID-shaped selector whose identifier is
+    /// not present still falls back to an exact, case-insensitive display-name
+    /// match.
+    /// - Parameter rawSelector: A profile UUID or display name.
+    /// - Returns: The unique match, no match, or every ambiguous name match.
+    public func resolveProfileSelection(_ rawSelector: String) -> BrowserProfileSelectionResolution {
+        let selector = rawSelector.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let id = UUID(uuidString: selector),
+           let profile = profileDefinition(id: id) {
+            return .matched(profile)
+        }
+
+        let matches = profiles.filter {
+            $0.displayName.localizedCaseInsensitiveCompare(selector) == .orderedSame
+        }
+        switch matches.count {
+        case 0:
+            return .notFound
+        case 1:
+            return .matched(matches[0])
+        default:
+            return .ambiguous(matches)
+        }
+    }
+
     /// Display name for a profile id, falling back to the default profile name.
     /// - Parameter id: The profile id.
     /// - Returns: The profile's display name, or the default name when unknown.

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Profiles/Values/BrowserProfileSelectionResolution.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Profiles/Values/BrowserProfileSelectionResolution.swift
@@ -1,0 +1,12 @@
+/// The result of resolving a user-supplied browser profile selector.
+///
+/// Selectors first match an existing profile UUID, then fall back to an exact,
+/// case-insensitive display-name match.
+public enum BrowserProfileSelectionResolution: Equatable, Sendable {
+    /// The selector identified exactly one profile.
+    case matched(BrowserProfileDefinition)
+    /// No profile UUID or display name matched the selector.
+    case notFound
+    /// More than one profile has the requested display name.
+    case ambiguous([BrowserProfileDefinition])
+}

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Profiles/BrowserProfileRepositoryTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Profiles/BrowserProfileRepositoryTests.swift
@@ -233,6 +233,40 @@ struct BrowserProfileRepositoryTests {
         #expect(defaults.string(forKey: BrowserProfileRepository.lastUsedProfileDefaultsKey) == p.id.uuidString)
     }
 
+    @Test func profileSelectionResolvesUUIDBeforeDisplayName() {
+        let (repo, _) = makeRepository()
+        let defaultID = BrowserProfileRepository.builtInDefaultProfileID
+        let namedLikeDefaultID = repo.createProfile(named: defaultID.uuidString)!
+
+        #expect(repo.resolveProfileSelection(defaultID.uuidString) == .matched(
+            repo.profileDefinition(id: defaultID)!
+        ))
+        #expect(namedLikeDefaultID.id != defaultID)
+    }
+
+    @Test func profileSelectionFallsBackFromMissingUUIDToCaseInsensitiveDisplayName() {
+        let (repo, _) = makeRepository()
+        let missingID = UUID()
+        let namedLikeMissingID = repo.createProfile(named: missingID.uuidString)!
+        let work = repo.createProfile(named: "Work Profile")!
+
+        #expect(repo.resolveProfileSelection(missingID.uuidString.lowercased()) == .matched(namedLikeMissingID))
+        #expect(repo.resolveProfileSelection("  work profile  ") == .matched(work))
+    }
+
+    @Test func profileSelectionReportsEveryAmbiguousDisplayNameCandidate() {
+        let (repo, _) = makeRepository()
+        let first = repo.createProfile(named: "Shared")!
+        let second = repo.createProfile(named: "shared")!
+
+        #expect(repo.resolveProfileSelection("SHARED") == .ambiguous([first, second]))
+    }
+
+    @Test func profileSelectionReportsUnknownSelector() {
+        let (repo, _) = makeRepository()
+        #expect(repo.resolveProfileSelection("Missing Profile") == .notFound)
+    }
+
     @Test func effectiveLastUsedFallsBackWhenMissing() {
         let (_, defaults) = makeRepository()
         // Force lastUsed to a stale id via persistence, then reload.

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Profiles/BrowserProfileRepositoryTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/Profiles/BrowserProfileRepositoryTests.swift
@@ -259,7 +259,11 @@ struct BrowserProfileRepositoryTests {
         let first = repo.createProfile(named: "Shared")!
         let second = repo.createProfile(named: "shared")!
 
-        #expect(repo.resolveProfileSelection("SHARED") == .ambiguous([first, second]))
+        guard case .ambiguous(let candidates) = repo.resolveProfileSelection("SHARED") else {
+            Issue.record("Expected ambiguous profile selection")
+            return
+        }
+        #expect(Set(candidates.map(\.id)) == [first.id, second.id])
     }
 
     @Test func profileSelectionReportsUnknownSelector() {

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
@@ -310,6 +310,9 @@ extension ControlCommandCoordinator {
             directionRaw: string(params, "direction"),
             typeRaw: string(params, "type"),
             urlRaw: string(params, "url"),
+            profileRaw: string(params, "profile")
+                ?? string(params, "profile_id")
+                ?? string(params, "profile_name"),
             workingDirectory: optionalTrimmedRawString(params, "working_directory"),
             initialCommand: optionalTrimmedRawString(params, "initial_command"),
             tmuxStartCommand: optionalTrimmedRawString(params, "tmux_start_command"),
@@ -376,6 +379,21 @@ extension ControlCommandCoordinator {
                 "placement_strategy": .string("external_browser_disabled"),
                 "url": .string(url),
             ]))
+        case .invalidBrowserProfile(let selector, let message, let candidates):
+            var data: [String: JSONValue] = ["profile": .string(selector)]
+            if !candidates.isEmpty {
+                data["candidates"] = .array(candidates.map { candidate in
+                    .object([
+                        "id": .string(candidate.id.uuidString),
+                        "name": .string(candidate.displayName),
+                    ])
+                })
+            }
+            return .err(
+                code: "invalid_params",
+                message: message,
+                data: .object(data)
+            )
         case .workspaceNotFound:
             return .err(code: "not_found", message: "Workspace not found", data: nil)
         case .noSourceSurface:

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
@@ -317,6 +317,7 @@ extension ControlCommandCoordinator {
             hasInvalidProfileParam: profileKeys.contains {
                 hasNonNull(params, $0) && string(params, $0) == nil
             },
+            hasMultipleProfileParams: profileKeys.filter { hasNonNull(params, $0) }.count > 1,
             workingDirectory: optionalTrimmedRawString(params, "working_directory"),
             initialCommand: optionalTrimmedRawString(params, "initial_command"),
             tmuxStartCommand: optionalTrimmedRawString(params, "tmux_start_command"),

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
@@ -305,6 +305,7 @@ extension ControlCommandCoordinator {
         guard context?.controlPaneRoutingResolvesTabManager(routing: routing) ?? false else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
+        let profileKeys = ["profile", "profile_id", "profile_name"]
 
         let inputs = ControlPaneCreateInputs(
             directionRaw: string(params, "direction"),
@@ -313,6 +314,9 @@ extension ControlCommandCoordinator {
             profileRaw: string(params, "profile")
                 ?? string(params, "profile_id")
                 ?? string(params, "profile_name"),
+            hasInvalidProfileParam: profileKeys.contains {
+                hasNonNull(params, $0) && string(params, $0) == nil
+            },
             workingDirectory: optionalTrimmedRawString(params, "working_directory"),
             initialCommand: optionalTrimmedRawString(params, "initial_command"),
             tmuxStartCommand: optionalTrimmedRawString(params, "tmux_start_command"),

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneBrowserProfileCandidate.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneBrowserProfileCandidate.swift
@@ -1,0 +1,18 @@
+public import Foundation
+
+/// A browser profile candidate included in an ambiguous `pane.create` error.
+public struct ControlPaneBrowserProfileCandidate: Sendable, Equatable {
+    /// The candidate's stable profile identifier.
+    public let id: UUID
+    /// The candidate's human-readable display name.
+    public let displayName: String
+
+    /// Creates an ambiguous browser profile candidate.
+    /// - Parameters:
+    ///   - id: The candidate's stable profile identifier.
+    ///   - displayName: The candidate's human-readable display name.
+    public init(id: UUID, displayName: String) {
+        self.id = id
+        self.displayName = displayName
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateInputs.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateInputs.swift
@@ -20,6 +20,9 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
     /// The trimmed browser profile selector from `profile`, `profile_id`, or
     /// `profile_name`, if present.
     public let profileRaw: String?
+    /// Whether any non-null browser profile selector had a non-string or empty
+    /// value and must be rejected instead of treated as an omitted selector.
+    public let hasInvalidProfileParam: Bool
     /// The trimmed-non-empty `working_directory`, if any (legacy
     /// `v2OptionalTrimmedRawString`).
     public let workingDirectory: String?
@@ -54,6 +57,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
     ///   - typeRaw: The trimmed `type` string, if present.
     ///   - urlRaw: The raw `url` string, if present.
     ///   - profileRaw: The browser profile UUID or display name, if present.
+    ///   - hasInvalidProfileParam: Whether a supplied selector was malformed.
     ///   - workingDirectory: The trimmed-non-empty working directory, if any.
     ///   - initialCommand: The trimmed-non-empty initial command, if any.
     ///   - tmuxStartCommand: The trimmed-non-empty tmux start command, if any.
@@ -68,6 +72,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
         typeRaw: String?,
         urlRaw: String?,
         profileRaw: String? = nil,
+        hasInvalidProfileParam: Bool = false,
         workingDirectory: String?,
         initialCommand: String?,
         tmuxStartCommand: String?,
@@ -82,6 +87,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
         self.typeRaw = typeRaw
         self.urlRaw = urlRaw
         self.profileRaw = profileRaw
+        self.hasInvalidProfileParam = hasInvalidProfileParam
         self.workingDirectory = workingDirectory
         self.initialCommand = initialCommand
         self.tmuxStartCommand = tmuxStartCommand

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateInputs.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateInputs.swift
@@ -17,6 +17,9 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
     /// The raw `url` string, if present (legacy `v2String`), used for the URL
     /// and the browser-disabled error data.
     public let urlRaw: String?
+    /// The trimmed browser profile selector from `profile`, `profile_id`, or
+    /// `profile_name`, if present.
+    public let profileRaw: String?
     /// The trimmed-non-empty `working_directory`, if any (legacy
     /// `v2OptionalTrimmedRawString`).
     public let workingDirectory: String?
@@ -50,6 +53,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
     ///   - directionRaw: The trimmed `direction` string, if present.
     ///   - typeRaw: The trimmed `type` string, if present.
     ///   - urlRaw: The raw `url` string, if present.
+    ///   - profileRaw: The browser profile UUID or display name, if present.
     ///   - workingDirectory: The trimmed-non-empty working directory, if any.
     ///   - initialCommand: The trimmed-non-empty initial command, if any.
     ///   - tmuxStartCommand: The trimmed-non-empty tmux start command, if any.
@@ -63,6 +67,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
         directionRaw: String?,
         typeRaw: String?,
         urlRaw: String?,
+        profileRaw: String? = nil,
         workingDirectory: String?,
         initialCommand: String?,
         tmuxStartCommand: String?,
@@ -76,6 +81,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
         self.directionRaw = directionRaw
         self.typeRaw = typeRaw
         self.urlRaw = urlRaw
+        self.profileRaw = profileRaw
         self.workingDirectory = workingDirectory
         self.initialCommand = initialCommand
         self.tmuxStartCommand = tmuxStartCommand

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateInputs.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateInputs.swift
@@ -23,6 +23,9 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
     /// Whether any non-null browser profile selector had a non-string or empty
     /// value and must be rejected instead of treated as an omitted selector.
     public let hasInvalidProfileParam: Bool
+    /// Whether more than one non-null browser profile selector alias was
+    /// supplied.
+    public let hasMultipleProfileParams: Bool
     /// The trimmed-non-empty `working_directory`, if any (legacy
     /// `v2OptionalTrimmedRawString`).
     public let workingDirectory: String?
@@ -58,6 +61,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
     ///   - urlRaw: The raw `url` string, if present.
     ///   - profileRaw: The browser profile UUID or display name, if present.
     ///   - hasInvalidProfileParam: Whether a supplied selector was malformed.
+    ///   - hasMultipleProfileParams: Whether multiple selector aliases were supplied.
     ///   - workingDirectory: The trimmed-non-empty working directory, if any.
     ///   - initialCommand: The trimmed-non-empty initial command, if any.
     ///   - tmuxStartCommand: The trimmed-non-empty tmux start command, if any.
@@ -73,6 +77,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
         urlRaw: String?,
         profileRaw: String? = nil,
         hasInvalidProfileParam: Bool = false,
+        hasMultipleProfileParams: Bool = false,
         workingDirectory: String?,
         initialCommand: String?,
         tmuxStartCommand: String?,
@@ -88,6 +93,7 @@ public struct ControlPaneCreateInputs: Sendable, Equatable {
         self.urlRaw = urlRaw
         self.profileRaw = profileRaw
         self.hasInvalidProfileParam = hasInvalidProfileParam
+        self.hasMultipleProfileParams = hasMultipleProfileParams
         self.workingDirectory = workingDirectory
         self.initialCommand = initialCommand
         self.tmuxStartCommand = tmuxStartCommand

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlPaneCreateResolution.swift
@@ -52,6 +52,14 @@ public enum ControlPaneCreateResolution: Sendable, Equatable {
     /// URL opened externally (legacy `ok`, the external-open payload). Carries
     /// the resolved window (may be absent) and the opened URL string.
     case browserDisabledOpenedExternally(windowID: UUID?, url: String)
+    /// An explicit browser profile selector did not identify exactly one
+    /// profile. An empty candidate list means no profile matched; otherwise the
+    /// candidates share the requested display name.
+    case invalidBrowserProfile(
+        selector: String,
+        message: String,
+        candidates: [ControlPaneBrowserProfileCandidate]
+    )
     /// A TabManager resolved but no workspace did (legacy `not_found` /
     /// "Workspace not found", `data: nil`).
     case workspaceNotFound

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -29304,6 +29304,23 @@
         }
       }
     },
+    "browser.profile.automation.error.invalidProfileSelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser profile must be a non-empty name or UUID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイルには空でない名前または UUID を指定してください"
+          }
+        }
+      }
+    },
     "browser.profile.automation.error.missingName": {
       "extractionState": "manual",
       "localizations": {
@@ -32628,6 +32645,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "--profile には空でないプロファイル名または UUID が必要です"
+          }
+        }
+      }
+    },
+    "cli.browser.profile.error.navigateUnsupported": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "--profile is only supported when browser open creates a new pane; omit the surface selector"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "--profile は browser open が新しいペインを作成する場合にのみ使用できます。サーフェスセレクターを省略してください"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -29259,13 +29259,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Multiple cmux browser profiles match '%@'. Use the profile ID instead."
+            "value": "Multiple cmux browser profiles match '%@': %@. Use a profile UUID."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "'%@' に一致する cmux ブラウザープロファイルが複数あります。代わりにプロファイル ID を使用してください。"
+            "value": "'%@' に一致する cmux ブラウザープロファイルが複数あります: %@。プロファイル UUID を使用してください。"
           }
         }
       }
@@ -29412,13 +29412,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No cmux browser profile matches '%@'"
+            "value": "No cmux browser profile matches '%@'. Run 'cmux browser profiles' to list available profiles."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "'%@' に一致する cmux ブラウザープロファイルが見つかりません"
+            "value": "'%@' に一致する cmux ブラウザープロファイルが見つかりません。使用可能なプロファイルを表示するには 'cmux browser profiles' を実行してください。"
           }
         }
       }
@@ -32611,6 +32611,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "viewport <width> <height> | reset"
+          }
+        }
+      }
+    },
+    "cli.browser.profile.error.emptySelector": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "--profile requires a non-empty profile name or UUID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "--profile には空でないプロファイル名または UUID が必要です"
+          }
+        }
+      }
+    },
+    "cli.browser.profile.option": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[--profile <name|uuid>]"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[--profile <名前|UUID>]"
+          }
+        }
+      }
+    },
+    "cli.browser.profiles.marker.lastUsed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "last used"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回使用"
           }
         }
       }
@@ -43258,6 +43309,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "使い方: cmux mobile set-font <ポイント数> [--surface <id>] [--workspace <id>]"
+          }
+        }
+      }
+    },
+    "cli.newPane.help.profileDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "--profile <name|uuid>                Browser profile name or UUID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "--profile <名前|UUID>                 ブラウザープロファイル名または UUID"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -29270,6 +29270,23 @@
         }
       }
     },
+    "browser.profile.automation.error.browserDisabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser profiles cannot be used while the cmux browser is disabled"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux ブラウザーが無効な間はブラウザープロファイルを使用できません"
+          }
+        }
+      }
+    },
     "browser.profile.automation.error.cannotDeleteDefaultProfile": {
       "extractionState": "manual",
       "localizations": {
@@ -29355,6 +29372,23 @@
         }
       }
     },
+    "browser.profile.automation.error.multipleProfileSelectors": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Specify only one browser profile selector"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイルセレクターは 1 つだけ指定してください"
+          }
+        }
+      }
+    },
     "browser.profile.automation.error.profileClearFailed": {
       "extractionState": "manual",
       "localizations": {
@@ -29436,6 +29470,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "'%@' に一致する cmux ブラウザープロファイルが見つかりません。使用可能なプロファイルを表示するには 'cmux browser profiles' を実行してください。"
+          }
+        }
+      }
+    },
+    "browser.profile.automation.error.profileRequiresBrowserPane": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser profiles can only be used when creating a browser pane"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイルはブラウザーペインの作成時にのみ使用できます"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -29491,6 +29491,23 @@
         }
       }
     },
+    "browser.profile.automation.error.profileUnavailableInRemoteWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser profiles cannot be selected when creating a browser pane in a remote workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートワークスペースでブラウザーペインを作成する場合、ブラウザープロファイルは選択できません"
+          }
+        }
+      }
+    },
     "browser.profile.automation.error.profileRenameFailed": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate+WindowDock.swift
+++ b/Sources/AppDelegate+WindowDock.swift
@@ -205,6 +205,6 @@ extension SessionWindowSnapshot {
         tabManager.workspaces.isEmpty &&
             dock == nil &&
             !liveWorkspaces.isEmpty &&
-            liveWorkspaces.allSatisfy(\.isRemoteTmuxMirror)
+            liveWorkspaces.allSatisfy { $0.isRemoteTmuxMirror }
     }
 }

--- a/Sources/AppDelegate+WindowDock.swift
+++ b/Sources/AppDelegate+WindowDock.swift
@@ -201,6 +201,7 @@ extension AppDelegate {
 }
 
 extension SessionWindowSnapshot {
+    @MainActor
     func omitsRemoteMirrorOnlyWindow(liveWorkspaces: [Workspace]) -> Bool {
         tabManager.workspaces.isEmpty &&
             dock == nil &&

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -314,6 +314,7 @@ final class DockSplitStore: BonsplitDelegate {
         environment: [String: String] = [:],
         tmuxStartCommand: String? = nil,
         initialDividerPosition: CGFloat? = nil,
+        preferredProfileID: UUID? = nil,
         focus: Bool = true
     ) -> UUID? {
         ensureLoaded()
@@ -328,7 +329,8 @@ final class DockSplitStore: BonsplitDelegate {
                 requestedWorkingDirectory: workingDirectory,
                 sourcePanelId: source
             ),
-            tmuxStartCommand: tmuxStartCommand
+            tmuxStartCommand: tmuxStartCommand,
+            preferredProfileID: preferredProfileID
         ) else { return nil }
 
         guard let source, let sourcePaneId = paneId(forPanelId: source) else {

--- a/Sources/Panels/BrowserAutomation.swift
+++ b/Sources/Panels/BrowserAutomation.swift
@@ -70,6 +70,7 @@ enum BrowserImportAutomationError: LocalizedError, CustomStringConvertible {
 enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
     case missingName
     case missingProfile
+    case invalidProfileSelector
     case profileNotFound(String)
     case ambiguousProfile(String, [BrowserProfileDefinition])
     case profileCreationFailed(String)
@@ -90,6 +91,11 @@ enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
             return String(
                 localized: "browser.profile.automation.error.missingProfile",
                 defaultValue: "Missing browser profile"
+            )
+        case .invalidProfileSelector:
+            return String(
+                localized: "browser.profile.automation.error.invalidProfileSelector",
+                defaultValue: "Browser profile must be a non-empty name or UUID"
             )
         case .profileNotFound(let query):
             return String.localizedStringWithFormat(

--- a/Sources/Panels/BrowserAutomation.swift
+++ b/Sources/Panels/BrowserAutomation.swift
@@ -71,7 +71,7 @@ enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
     case missingName
     case missingProfile
     case profileNotFound(String)
-    case ambiguousProfile(String)
+    case ambiguousProfile(String, [BrowserProfileDefinition])
     case profileCreationFailed(String)
     case profileRenameFailed(String)
     case cannotDeleteDefaultProfile
@@ -95,17 +95,21 @@ enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
             return String.localizedStringWithFormat(
                 String(
                     localized: "browser.profile.automation.error.profileNotFound",
-                    defaultValue: "No cmux browser profile matches '%@'"
+                    defaultValue: "No cmux browser profile matches '%@'. Run 'cmux browser profiles' to list available profiles."
                 ),
                 query
             )
-        case .ambiguousProfile(let query):
+        case .ambiguousProfile(let query, let candidates):
+            let candidateList = candidates
+                .map { "\($0.displayName) (\($0.id.uuidString))" }
+                .joined(separator: ", ")
             return String.localizedStringWithFormat(
                 String(
                     localized: "browser.profile.automation.error.ambiguousProfile",
-                    defaultValue: "Multiple cmux browser profiles match '%@'. Use the profile ID instead."
+                    defaultValue: "Multiple cmux browser profiles match '%@': %@. Use a profile UUID."
                 ),
-                query
+                query,
+                candidateList
             )
         case .profileCreationFailed(let name):
             return String.localizedStringWithFormat(
@@ -329,7 +333,7 @@ enum BrowserProfileAutomation {
                 $0.displayName.localizedCaseInsensitiveCompare(normalized) == .orderedSame
         }
         if matches.count > 1 {
-            throw BrowserProfileAutomationError.ambiguousProfile(query)
+            throw BrowserProfileAutomationError.ambiguousProfile(query, matches)
         }
         return matches.first
     }

--- a/Sources/Panels/BrowserAutomation.swift
+++ b/Sources/Panels/BrowserAutomation.swift
@@ -70,7 +70,10 @@ enum BrowserImportAutomationError: LocalizedError, CustomStringConvertible {
 enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
     case missingName
     case missingProfile
+    case browserDisabled
     case invalidProfileSelector
+    case multipleProfileSelectors
+    case profileRequiresBrowserPane
     case profileNotFound(String)
     case ambiguousProfile(String, [BrowserProfileDefinition])
     case profileCreationFailed(String)
@@ -92,10 +95,25 @@ enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
                 localized: "browser.profile.automation.error.missingProfile",
                 defaultValue: "Missing browser profile"
             )
+        case .browserDisabled:
+            return String(
+                localized: "browser.profile.automation.error.browserDisabled",
+                defaultValue: "Browser profiles cannot be used while the cmux browser is disabled"
+            )
         case .invalidProfileSelector:
             return String(
                 localized: "browser.profile.automation.error.invalidProfileSelector",
                 defaultValue: "Browser profile must be a non-empty name or UUID"
+            )
+        case .multipleProfileSelectors:
+            return String(
+                localized: "browser.profile.automation.error.multipleProfileSelectors",
+                defaultValue: "Specify only one browser profile selector"
+            )
+        case .profileRequiresBrowserPane:
+            return String(
+                localized: "browser.profile.automation.error.profileRequiresBrowserPane",
+                defaultValue: "Browser profiles can only be used when creating a browser pane"
             )
         case .profileNotFound(let query):
             return String.localizedStringWithFormat(

--- a/Sources/Panels/BrowserAutomation.swift
+++ b/Sources/Panels/BrowserAutomation.swift
@@ -74,6 +74,7 @@ enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
     case invalidProfileSelector
     case multipleProfileSelectors
     case profileRequiresBrowserPane
+    case profileUnavailableInRemoteWorkspace
     case profileNotFound(String)
     case ambiguousProfile(String, [BrowserProfileDefinition])
     case profileCreationFailed(String)
@@ -114,6 +115,11 @@ enum BrowserProfileAutomationError: LocalizedError, CustomStringConvertible {
             return String(
                 localized: "browser.profile.automation.error.profileRequiresBrowserPane",
                 defaultValue: "Browser profiles can only be used when creating a browser pane"
+            )
+        case .profileUnavailableInRemoteWorkspace:
+            return String(
+                localized: "browser.profile.automation.error.profileUnavailableInRemoteWorkspace",
+                defaultValue: "Browser profiles cannot be selected when creating a browser pane in a remote workspace"
             )
         case .profileNotFound(let query):
             return String.localizedStringWithFormat(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -379,6 +379,10 @@ final class BrowserProfileStore: ObservableObject {
         repository.profileDefinition(id: id)
     }
 
+    func resolveProfileSelection(_ selector: String) -> BrowserProfileSelectionResolution {
+        repository.resolveProfileSelection(selector)
+    }
+
     func displayName(for id: UUID) -> String {
         repository.displayName(for: id)
     }

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -246,6 +246,13 @@ extension TerminalController: ControlPaneContext {
         guard let ws = resolveWorkspace(routing: routing, tabManager: tabManager) else {
             return .workspaceNotFound
         }
+        if panelType == .browser, preferredBrowserProfileID != nil, ws.isRemoteWorkspace {
+            return .invalidBrowserProfile(
+                selector: inputs.profileRaw ?? "",
+                message: BrowserProfileAutomationError.profileUnavailableInRemoteWorkspace.description,
+                candidates: []
+            )
+        }
         if panelType == .terminal {
             let remoteTarget: RemoteTmuxControlPaneLocation?
             if let requestedSurfaceID = inputs.requestedSourceSurfaceID {

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -163,12 +163,23 @@ extension TerminalController: ControlPaneContext {
         if case .dock = placement, let invalid = validateDockPaneCreateRouting(routing: routing, tabManager: tabManager, panelType: panelType) {
             return invalid
         }
-        if panelType == .browser, BrowserAvailabilitySettings.isDisabled() {
-            return browserDisabledCreateResolution(rawURL: inputs.urlRaw, url: url, tabManager: tabManager)
-        }
-
+        let hasProfileParam = inputs.profileRaw != nil
+            || inputs.hasInvalidProfileParam
+            || inputs.hasMultipleProfileParams
         let preferredBrowserProfileID: UUID?
-        if panelType == .browser, inputs.hasInvalidProfileParam {
+        if panelType != .browser, hasProfileParam {
+            return .invalidBrowserProfile(
+                selector: inputs.profileRaw ?? "",
+                message: BrowserProfileAutomationError.profileRequiresBrowserPane.description,
+                candidates: []
+            )
+        } else if inputs.hasMultipleProfileParams {
+            return .invalidBrowserProfile(
+                selector: inputs.profileRaw ?? "",
+                message: BrowserProfileAutomationError.multipleProfileSelectors.description,
+                candidates: []
+            )
+        } else if panelType == .browser, inputs.hasInvalidProfileParam {
             return .invalidBrowserProfile(
                 selector: inputs.profileRaw ?? "",
                 message: BrowserProfileAutomationError.invalidProfileSelector.description,
@@ -195,6 +206,16 @@ extension TerminalController: ControlPaneContext {
             }
         } else {
             preferredBrowserProfileID = nil
+        }
+        if panelType == .browser, BrowserAvailabilitySettings.isDisabled() {
+            if let selector = inputs.profileRaw {
+                return .invalidBrowserProfile(
+                    selector: selector,
+                    message: BrowserProfileAutomationError.browserDisabled.description,
+                    candidates: []
+                )
+            }
+            return browserDisabledCreateResolution(rawURL: inputs.urlRaw, url: url, tabManager: tabManager)
         }
 
         let orientation = direction.orientation

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -168,7 +168,13 @@ extension TerminalController: ControlPaneContext {
         }
 
         let preferredBrowserProfileID: UUID?
-        if panelType == .browser, let selector = inputs.profileRaw {
+        if panelType == .browser, inputs.hasInvalidProfileParam {
+            return .invalidBrowserProfile(
+                selector: inputs.profileRaw ?? "",
+                message: BrowserProfileAutomationError.invalidProfileSelector.description,
+                candidates: []
+            )
+        } else if panelType == .browser, let selector = inputs.profileRaw {
             switch BrowserProfileStore.shared.resolveProfileSelection(selector) {
             case .matched(let profile):
                 preferredBrowserProfileID = profile.id

--- a/Sources/TerminalController+ControlPaneContext.swift
+++ b/Sources/TerminalController+ControlPaneContext.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import CmuxBrowser
 import CmuxControlSocket
 import Foundation
 
@@ -166,6 +167,30 @@ extension TerminalController: ControlPaneContext {
             return browserDisabledCreateResolution(rawURL: inputs.urlRaw, url: url, tabManager: tabManager)
         }
 
+        let preferredBrowserProfileID: UUID?
+        if panelType == .browser, let selector = inputs.profileRaw {
+            switch BrowserProfileStore.shared.resolveProfileSelection(selector) {
+            case .matched(let profile):
+                preferredBrowserProfileID = profile.id
+            case .notFound:
+                return .invalidBrowserProfile(
+                    selector: selector,
+                    message: BrowserProfileAutomationError.profileNotFound(selector).description,
+                    candidates: []
+                )
+            case .ambiguous(let profiles):
+                return .invalidBrowserProfile(
+                    selector: selector,
+                    message: BrowserProfileAutomationError.ambiguousProfile(selector, profiles).description,
+                    candidates: profiles.map {
+                        ControlPaneBrowserProfileCandidate(id: $0.id, displayName: $0.displayName)
+                    }
+                )
+            }
+        } else {
+            preferredBrowserProfileID = nil
+        }
+
         let orientation = direction.orientation
         let insertFirst = direction.insertFirst
 
@@ -186,6 +211,7 @@ extension TerminalController: ControlPaneContext {
                 orientation: orientation,
                 insertFirst: insertFirst,
                 initialDividerPosition: initialDividerPosition.map { CGFloat($0) },
+                preferredProfileID: preferredBrowserProfileID,
                 inputs: inputs
             )
         }
@@ -260,6 +286,7 @@ extension TerminalController: ControlPaneContext {
                 orientation: orientation,
                 insertFirst: insertFirst,
                 url: url,
+                preferredProfileID: preferredBrowserProfileID,
                 focus: focus,
                 creationPolicy: .automationPreload,
                 initialDividerPosition: initialDividerPosition.map { CGFloat($0) }

--- a/Sources/TerminalController+ControlPaneDock.swift
+++ b/Sources/TerminalController+ControlPaneDock.swift
@@ -15,6 +15,7 @@ extension TerminalController {
         orientation: SplitOrientation,
         insertFirst: Bool,
         initialDividerPosition: CGFloat?,
+        preferredProfileID: UUID?,
         inputs: ControlPaneCreateInputs
     ) -> ControlPaneCreateResolution {
         if let invalid = validateDockPaneCreateRouting(routing: routing, tabManager: tabManager, panelType: panelType) {
@@ -47,6 +48,7 @@ extension TerminalController {
             environment: inputs.startupEnvironment,
             tmuxStartCommand: kind == .terminal ? inputs.tmuxStartCommand : nil,
             initialDividerPosition: initialDividerPosition,
+            preferredProfileID: preferredProfileID,
             focus: focus
         )
         guard let newPanelId else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6514,6 +6514,35 @@ class TerminalController {
             return error
         }
 
+        let preferredProfileID: UUID?
+        if let selector = v2String(params, "profile")
+            ?? v2String(params, "profile_id")
+            ?? v2String(params, "profile_name") {
+            switch BrowserProfileStore.shared.resolveProfileSelection(selector) {
+            case .matched(let profile):
+                preferredProfileID = profile.id
+            case .notFound:
+                return .err(
+                    code: "invalid_params",
+                    message: BrowserProfileAutomationError.profileNotFound(selector).description,
+                    data: ["profile": selector]
+                )
+            case .ambiguous(let profiles):
+                return .err(
+                    code: "invalid_params",
+                    message: BrowserProfileAutomationError.ambiguousProfile(selector, profiles).description,
+                    data: [
+                        "profile": selector,
+                        "candidates": profiles.map {
+                            ["id": $0.id.uuidString, "name": $0.displayName]
+                        },
+                    ]
+                )
+            }
+        } else {
+            preferredProfileID = nil
+        }
+
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create browser", data: nil)
         v2MainSync {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
@@ -6576,6 +6605,7 @@ class TerminalController {
                     url: url,
                     focus: focus,
                     selectWhenNotFocused: true,
+                    preferredProfileID: preferredProfileID,
                     creationPolicy: .automationPreload,
                     omnibarVisible: omnibarVisible,
                     transparentBackground: transparentBackground,
@@ -6588,6 +6618,7 @@ class TerminalController {
                     from: sourceSurfaceId,
                     orientation: .horizontal,
                     url: url,
+                    preferredProfileID: preferredProfileID,
                     focus: focus,
                     creationPolicy: .automationPreload,
                     omnibarVisible: omnibarVisible,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6504,17 +6504,15 @@ class TerminalController {
         }
         let respectExternalOpenRules = v2Bool(params, "respect_external_open_rules") ?? false
 
-        if BrowserAvailabilitySettings.isDisabled() {
-            if v2IsDiffViewerURL(url) {
-                return .err(code: "browser_disabled", message: "cmux browser is disabled", data: nil)
-            }
-            return v2BrowserDisabledExternalOpenResult(rawURL: urlStr, url: url, tabManager: tabManager)
-        }
-        if let error = v2RegisterDiffViewerURLIfNeeded(params: params, url: url) {
-            return error
-        }
-
         let profileKeys = ["profile", "profile_id", "profile_name"]
+        let suppliedProfileKeys = profileKeys.filter { v2HasNonNullParam(params, $0) }
+        if suppliedProfileKeys.count > 1 {
+            return .err(
+                code: "invalid_params",
+                message: BrowserProfileAutomationError.multipleProfileSelectors.description,
+                data: ["profile_parameters": suppliedProfileKeys]
+            )
+        }
         if let invalidProfileKey = profileKeys.first(where: {
             v2HasNonNullParam(params, $0) && v2String(params, $0) == nil
         }) {
@@ -6525,10 +6523,11 @@ class TerminalController {
             )
         }
 
-        let preferredProfileID: UUID?
-        if let selector = v2String(params, "profile")
+        let profileSelector = v2String(params, "profile")
             ?? v2String(params, "profile_id")
-            ?? v2String(params, "profile_name") {
+            ?? v2String(params, "profile_name")
+        let preferredProfileID: UUID?
+        if let selector = profileSelector {
             switch BrowserProfileStore.shared.resolveProfileSelection(selector) {
             case .matched(let profile):
                 preferredProfileID = profile.id
@@ -6554,6 +6553,23 @@ class TerminalController {
             preferredProfileID = nil
         }
 
+        if BrowserAvailabilitySettings.isDisabled() {
+            if let profileSelector {
+                return .err(
+                    code: "invalid_params",
+                    message: BrowserProfileAutomationError.browserDisabled.description,
+                    data: ["profile": profileSelector]
+                )
+            }
+            if v2IsDiffViewerURL(url) {
+                return .err(code: "browser_disabled", message: "cmux browser is disabled", data: nil)
+            }
+            return v2BrowserDisabledExternalOpenResult(rawURL: urlStr, url: url, tabManager: tabManager)
+        }
+        if let error = v2RegisterDiffViewerURLIfNeeded(params: params, url: url) {
+            return error
+        }
+
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create browser", data: nil)
         v2MainSync {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
@@ -6562,6 +6578,7 @@ class TerminalController {
             }
             if let url,
                respectExternalOpenRules,
+               preferredProfileID == nil,
                BrowserLinkOpenSettings.shouldOpenExternally(url) {
                 guard NSWorkspace.shared.open(url) else {
                     result = .err(

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6576,6 +6576,14 @@ class TerminalController {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
+            if let profileSelector, preferredProfileID != nil, ws.isRemoteWorkspace {
+                result = .err(
+                    code: "invalid_params",
+                    message: BrowserProfileAutomationError.profileUnavailableInRemoteWorkspace.description,
+                    data: ["profile": profileSelector]
+                )
+                return
+            }
             if let url,
                respectExternalOpenRules,
                preferredProfileID == nil,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6514,6 +6514,17 @@ class TerminalController {
             return error
         }
 
+        let profileKeys = ["profile", "profile_id", "profile_name"]
+        if let invalidProfileKey = profileKeys.first(where: {
+            v2HasNonNullParam(params, $0) && v2String(params, $0) == nil
+        }) {
+            return .err(
+                code: "invalid_params",
+                message: BrowserProfileAutomationError.invalidProfileSelector.description,
+                data: ["profile_parameter": invalidProfileKey]
+            )
+        }
+
         let preferredProfileID: UUID?
         if let selector = v2String(params, "profile")
             ?? v2String(params, "profile_id")

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B424PWRS000000000000PW01 /* BrowserPortalWebViewRenderingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424PWRS000000000000PW02 /* BrowserPortalWebViewRenderingState.swift */; };
 		B4245003000000000000PW01 /* BrowserPrewarmedWebViewPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4245004000000000000PW01 /* BrowserPrewarmedWebViewPool.swift */; };
 		B6585001B6585001B658PW01 /* BrowserPrewarmedWebViewPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6585002B6585002B658PW02 /* BrowserPrewarmedWebViewPoolTests.swift */; };
+		2720B0012720B0012720B001 /* BrowserProfileSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2720F0012720F0012720F001 /* BrowserProfileSocketTests.swift */; };
 		8478A0000000000000000002 /* BrowserRecoveryHTTPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */; };
 		7B5F1A2E9C0D4B6A8E217304 /* BrowserReliabilityRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */; };
 		BFBAC1A77CEE7A2DF91DA02C /* BrowserRemoteWorkspaceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */; };
@@ -2636,6 +2637,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B424PWRS000000000000PW02 /* BrowserPortalWebViewRenderingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPortalWebViewRenderingState.swift; sourceTree = "<group>"; };
 		B4245004000000000000PW01 /* BrowserPrewarmedWebViewPool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPrewarmedWebViewPool.swift; sourceTree = "<group>"; };
 		B6585002B6585002B658PW02 /* BrowserPrewarmedWebViewPoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPrewarmedWebViewPoolTests.swift; sourceTree = "<group>"; };
+		2720F0012720F0012720F001 /* BrowserProfileSocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserProfileSocketTests.swift; sourceTree = "<group>"; };
 		8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserRecoveryHTTPServer.swift; sourceTree = "<group>"; };
 		7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserReliabilityRegressionUITests.swift; sourceTree = "<group>"; };
 		109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserRemoteWorkspaceStatus.swift; sourceTree = "<group>"; };
@@ -6491,6 +6493,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */,
 				C46790000000000000000008 /* RosettaNativeRelaunchTests.swift */,
 				C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */,
+				2720F0012720F0012720F001 /* BrowserProfileSocketTests.swift */,
 				A6AC72080000000000000002 /* CMUXWorkspaceLoadingCLIRegressionTests.swift */,
 				C0DE31390000000000000112 /* CMUXOpenHTMLFocusTests.swift */,
 				C0DE75890000000000000004 /* DeflatedAssetTestSupport.swift */,
@@ -8912,6 +8915,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C42660050000000000000001 /* BrowserPDFPreviewActionUnitTests.swift in Sources */,
 				C0DE78950000000000000001 /* BrowserPortalFirstRevealScrollTests.swift in Sources */,
 				B6585001B6585001B658PW01 /* BrowserPrewarmedWebViewPoolTests.swift in Sources */,
+				2720B0012720B0012720B001 /* BrowserProfileSocketTests.swift in Sources */,
 				8827C0010000000000000001 /* BrowserScreenshotCropTests.swift in Sources */,
 				C2035A060000000000000001 /* BrowserSSLTrustBypassStateTests.swift in Sources */,
 				C7B800062D4202A13C962D2D /* BrowserSystemProxyMirrorTests.swift in Sources */,

--- a/cmuxTests/BrowserProfileSocketTests.swift
+++ b/cmuxTests/BrowserProfileSocketTests.swift
@@ -123,6 +123,36 @@ struct BrowserProfileSocketTests {
         #expect((unknownError["message"] as? String)?.contains(unknownSelector) == true)
         #expect((unknownError["data"] as? [String: Any])?["profile"] as? String == unknownSelector)
 
+        let malformedOpenResponse = try call(
+            method: "browser.open_split",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "profile": "   ",
+            ]
+        )
+        let malformedOpenError = try errorPayload(malformedOpenResponse)
+        #expect(malformedOpenError["code"] as? String == "invalid_params")
+        #expect((malformedOpenError["message"] as? String)?.contains("non-empty") == true)
+        #expect(
+            (malformedOpenError["data"] as? [String: Any])?["profile_parameter"] as? String
+                == "profile"
+        )
+
+        let malformedPaneResponse = try call(
+            method: "pane.create",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "direction": "right",
+                "type": "browser",
+                "profile_name": 123,
+            ]
+        )
+        let malformedPaneError = try errorPayload(malformedPaneResponse)
+        #expect(malformedPaneError["code"] as? String == "invalid_params")
+        #expect((malformedPaneError["message"] as? String)?.contains("non-empty") == true)
+
         let ambiguousResponse = try call(
             method: "pane.create",
             params: [

--- a/cmuxTests/BrowserProfileSocketTests.swift
+++ b/cmuxTests/BrowserProfileSocketTests.swift
@@ -14,15 +14,7 @@ struct BrowserProfileSocketTests {
         let wasBrowserDisabled = BrowserAvailabilitySettings.isDisabled(defaults: defaults)
         let store = BrowserProfileStore.shared
         let previousLastUsedProfileID = store.effectiveLastUsedProfileID
-        let suffix = UUID().uuidString
-        let target = try #require(store.createProfile(named: "Issue 2720 Target \(suffix)"))
-        let fallback = try #require(store.createProfile(named: "Issue 2720 Fallback \(suffix)"))
-        let ambiguousName = "Issue 2720 Shared \(suffix)"
-        let ambiguousFirst = try #require(store.createProfile(named: ambiguousName))
-        let ambiguousSecond = try #require(store.createProfile(named: ambiguousName.lowercased()))
-        let createdProfileIDs = [target.id, fallback.id, ambiguousFirst.id, ambiguousSecond.id]
-
-        BrowserAvailabilitySettings.setDisabled(false, defaults: defaults)
+        var createdProfileIDs: [UUID] = []
         defer {
             TerminalController.shared.setActiveTabManager(nil)
             for profileID in createdProfileIDs {
@@ -32,6 +24,18 @@ struct BrowserProfileSocketTests {
             BrowserAvailabilitySettings.setDisabled(wasBrowserDisabled, defaults: defaults)
         }
 
+        let suffix = UUID().uuidString
+        let target = try #require(store.createProfile(named: "Issue 2720 Target \(suffix)"))
+        createdProfileIDs.append(target.id)
+        let fallback = try #require(store.createProfile(named: "Issue 2720 Fallback \(suffix)"))
+        createdProfileIDs.append(fallback.id)
+        let ambiguousName = "Issue 2720 Shared \(suffix)"
+        let ambiguousFirst = try #require(store.createProfile(named: ambiguousName))
+        createdProfileIDs.append(ambiguousFirst.id)
+        let ambiguousSecond = try #require(store.createProfile(named: ambiguousName.lowercased()))
+        createdProfileIDs.append(ambiguousSecond.id)
+
+        BrowserAvailabilitySettings.setDisabled(false, defaults: defaults)
         store.noteUsed(fallback.id)
         let openManager = TabManager()
         defer { openManager.tabs.forEach { $0.teardownAllPanels() } }

--- a/cmuxTests/BrowserProfileSocketTests.swift
+++ b/cmuxTests/BrowserProfileSocketTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import CmuxCore
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)

--- a/cmuxTests/BrowserProfileSocketTests.swift
+++ b/cmuxTests/BrowserProfileSocketTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct BrowserProfileSocketTests {
+    @Test func browserCreationCommandsHonorExplicitProfilesAndRejectInvalidSelectors() throws {
+        let defaults = UserDefaults.standard
+        let wasBrowserDisabled = BrowserAvailabilitySettings.isDisabled(defaults: defaults)
+        let store = BrowserProfileStore.shared
+        let previousLastUsedProfileID = store.effectiveLastUsedProfileID
+        let suffix = UUID().uuidString
+        let target = try #require(store.createProfile(named: "Issue 2720 Target \(suffix)"))
+        let fallback = try #require(store.createProfile(named: "Issue 2720 Fallback \(suffix)"))
+        let ambiguousName = "Issue 2720 Shared \(suffix)"
+        let ambiguousFirst = try #require(store.createProfile(named: ambiguousName))
+        let ambiguousSecond = try #require(store.createProfile(named: ambiguousName.lowercased()))
+        let createdProfileIDs = [target.id, fallback.id, ambiguousFirst.id, ambiguousSecond.id]
+
+        BrowserAvailabilitySettings.setDisabled(false, defaults: defaults)
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            for profileID in createdProfileIDs {
+                _ = store.deleteProfile(id: profileID)
+            }
+            store.noteUsed(previousLastUsedProfileID)
+            BrowserAvailabilitySettings.setDisabled(wasBrowserDisabled, defaults: defaults)
+        }
+
+        store.noteUsed(fallback.id)
+        let openManager = TabManager()
+        defer { openManager.tabs.forEach { $0.teardownAllPanels() } }
+        let openWorkspace = try #require(openManager.selectedWorkspace)
+        let openSourceID = try #require(openWorkspace.focusedPanelId)
+        TerminalController.shared.setActiveTabManager(openManager)
+
+        let openResponse = try call(
+            method: "browser.open_split",
+            params: [
+                "workspace_id": openWorkspace.id.uuidString,
+                "surface_id": openSourceID.uuidString,
+                "url": "about:blank",
+                "profile": target.displayName.lowercased(),
+                "focus": false,
+            ]
+        )
+        let openResult = try successfulResult(openResponse)
+        let openedSurfaceID = try #require(
+            (openResult["surface_id"] as? String).flatMap(UUID.init(uuidString:))
+        )
+        let openedPanel = try #require(openWorkspace.panels[openedSurfaceID] as? BrowserPanel)
+        #expect(openedPanel.profileID == target.id)
+
+        store.noteUsed(fallback.id)
+        let paneManager = TabManager()
+        defer { paneManager.tabs.forEach { $0.teardownAllPanels() } }
+        let paneWorkspace = try #require(paneManager.selectedWorkspace)
+        let paneSourceID = try #require(paneWorkspace.focusedPanelId)
+        TerminalController.shared.setActiveTabManager(paneManager)
+
+        let paneResponse = try call(
+            method: "pane.create",
+            params: [
+                "workspace_id": paneWorkspace.id.uuidString,
+                "surface_id": paneSourceID.uuidString,
+                "direction": "right",
+                "type": "browser",
+                "url": "about:blank",
+                "profile": target.id.uuidString,
+                "focus": false,
+            ]
+        )
+        let paneResult = try successfulResult(paneResponse)
+        let paneSurfaceID = try #require(
+            (paneResult["surface_id"] as? String).flatMap(UUID.init(uuidString:))
+        )
+        let panePanel = try #require(paneWorkspace.panels[paneSurfaceID] as? BrowserPanel)
+        #expect(panePanel.profileID == target.id)
+
+        store.noteUsed(fallback.id)
+        let fallbackManager = TabManager()
+        defer { fallbackManager.tabs.forEach { $0.teardownAllPanels() } }
+        let fallbackWorkspace = try #require(fallbackManager.selectedWorkspace)
+        let fallbackSourceID = try #require(fallbackWorkspace.focusedPanelId)
+        TerminalController.shared.setActiveTabManager(fallbackManager)
+
+        let fallbackResponse = try call(
+            method: "browser.open_split",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "url": "about:blank",
+                "focus": false,
+            ]
+        )
+        let fallbackResult = try successfulResult(fallbackResponse)
+        let fallbackSurfaceID = try #require(
+            (fallbackResult["surface_id"] as? String).flatMap(UUID.init(uuidString:))
+        )
+        let fallbackPanel = try #require(fallbackWorkspace.panels[fallbackSurfaceID] as? BrowserPanel)
+        #expect(fallbackPanel.profileID == fallback.id)
+
+        let unknownSelector = "Issue 2720 Missing \(suffix)"
+        let unknownResponse = try call(
+            method: "browser.open_split",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "profile": unknownSelector,
+            ]
+        )
+        let unknownError = try errorPayload(unknownResponse)
+        #expect(unknownError["code"] as? String == "invalid_params")
+        #expect((unknownError["message"] as? String)?.contains(unknownSelector) == true)
+        #expect((unknownError["data"] as? [String: Any])?["profile"] as? String == unknownSelector)
+
+        let ambiguousResponse = try call(
+            method: "pane.create",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "direction": "right",
+                "type": "browser",
+                "profile": ambiguousName.uppercased(),
+            ]
+        )
+        let ambiguousError = try errorPayload(ambiguousResponse)
+        let ambiguousMessage = try #require(ambiguousError["message"] as? String)
+        let ambiguousCandidates = try #require(
+            (ambiguousError["data"] as? [String: Any])?["candidates"] as? [[String: Any]]
+        )
+        #expect(ambiguousError["code"] as? String == "invalid_params")
+        #expect(ambiguousMessage.contains(ambiguousFirst.id.uuidString))
+        #expect(ambiguousMessage.contains(ambiguousSecond.id.uuidString))
+        #expect(Set(ambiguousCandidates.compactMap { $0["id"] as? String }) == [
+            ambiguousFirst.id.uuidString,
+            ambiguousSecond.id.uuidString,
+        ])
+    }
+
+    private func call(method: String, params: [String: Any]) throws -> [String: Any] {
+        let request: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": UUID().uuidString,
+            "method": method,
+            "params": params,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: request)
+        let line = try #require(String(data: data, encoding: .utf8))
+        let response = TerminalController.shared.handleSocketLine(line)
+        return try #require(
+            JSONSerialization.jsonObject(with: Data(response.utf8)) as? [String: Any]
+        )
+    }
+
+    private func successfulResult(_ response: [String: Any]) throws -> [String: Any] {
+        #expect(response["ok"] as? Bool == true)
+        return try #require(response["result"] as? [String: Any])
+    }
+
+    private func errorPayload(_ response: [String: Any]) throws -> [String: Any] {
+        #expect(response["ok"] as? Bool == false)
+        return try #require(response["error"] as? [String: Any])
+    }
+}

--- a/cmuxTests/BrowserProfileSocketTests.swift
+++ b/cmuxTests/BrowserProfileSocketTests.swift
@@ -123,6 +123,60 @@ struct BrowserProfileSocketTests {
         #expect((unknownError["message"] as? String)?.contains(unknownSelector) == true)
         #expect((unknownError["data"] as? [String: Any])?["profile"] as? String == unknownSelector)
 
+        BrowserAvailabilitySettings.setDisabled(true, defaults: defaults)
+        let disabledOpenResponse = try call(
+            method: "browser.open_split",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "profile": unknownSelector,
+            ]
+        )
+        let disabledOpenError = try errorPayload(disabledOpenResponse)
+        #expect(disabledOpenError["code"] as? String == "invalid_params")
+        #expect((disabledOpenError["message"] as? String)?.contains(unknownSelector) == true)
+
+        let disabledPaneResponse = try call(
+            method: "pane.create",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "direction": "right",
+                "type": "browser",
+                "profile": unknownSelector,
+            ]
+        )
+        let disabledPaneError = try errorPayload(disabledPaneResponse)
+        #expect(disabledPaneError["code"] as? String == "invalid_params")
+        #expect((disabledPaneError["message"] as? String)?.contains(unknownSelector) == true)
+
+        let disabledSelectedOpenResponse = try call(
+            method: "browser.open_split",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "profile": target.id.uuidString,
+            ]
+        )
+        let disabledSelectedOpenError = try errorPayload(disabledSelectedOpenResponse)
+        #expect(disabledSelectedOpenError["code"] as? String == "invalid_params")
+        #expect((disabledSelectedOpenError["message"] as? String)?.contains("disabled") == true)
+
+        let disabledSelectedPaneResponse = try call(
+            method: "pane.create",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "direction": "right",
+                "type": "browser",
+                "profile": target.id.uuidString,
+            ]
+        )
+        let disabledSelectedPaneError = try errorPayload(disabledSelectedPaneResponse)
+        #expect(disabledSelectedPaneError["code"] as? String == "invalid_params")
+        #expect((disabledSelectedPaneError["message"] as? String)?.contains("disabled") == true)
+        BrowserAvailabilitySettings.setDisabled(false, defaults: defaults)
+
         let malformedOpenResponse = try call(
             method: "browser.open_split",
             params: [
@@ -152,6 +206,48 @@ struct BrowserProfileSocketTests {
         let malformedPaneError = try errorPayload(malformedPaneResponse)
         #expect(malformedPaneError["code"] as? String == "invalid_params")
         #expect((malformedPaneError["message"] as? String)?.contains("non-empty") == true)
+
+        let multipleOpenResponse = try call(
+            method: "browser.open_split",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "profile": target.displayName,
+                "profile_id": fallback.id.uuidString,
+            ]
+        )
+        let multipleOpenError = try errorPayload(multipleOpenResponse)
+        #expect(multipleOpenError["code"] as? String == "invalid_params")
+        #expect((multipleOpenError["message"] as? String)?.contains("only one") == true)
+
+        let multiplePaneResponse = try call(
+            method: "pane.create",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "direction": "right",
+                "type": "browser",
+                "profile": target.displayName,
+                "profile_name": fallback.displayName,
+            ]
+        )
+        let multiplePaneError = try errorPayload(multiplePaneResponse)
+        #expect(multiplePaneError["code"] as? String == "invalid_params")
+        #expect((multiplePaneError["message"] as? String)?.contains("only one") == true)
+
+        let terminalProfileResponse = try call(
+            method: "pane.create",
+            params: [
+                "workspace_id": fallbackWorkspace.id.uuidString,
+                "surface_id": fallbackSourceID.uuidString,
+                "direction": "right",
+                "type": "terminal",
+                "profile": target.displayName,
+            ]
+        )
+        let terminalProfileError = try errorPayload(terminalProfileResponse)
+        #expect(terminalProfileError["code"] as? String == "invalid_params")
+        #expect((terminalProfileError["message"] as? String)?.contains("browser pane") == true)
 
         let ambiguousResponse = try call(
             method: "pane.create",

--- a/cmuxTests/BrowserProfileSocketTests.swift
+++ b/cmuxTests/BrowserProfileSocketTests.swift
@@ -273,6 +273,55 @@ struct BrowserProfileSocketTests {
         ])
     }
 
+    @Test func explicitProfilesAreRejectedForRemoteWorkspaceCreation() throws {
+        let defaults = UserDefaults.standard
+        let wasBrowserDisabled = BrowserAvailabilitySettings.isDisabled(defaults: defaults)
+        let manager = TabManager()
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            manager.tabs.forEach { $0.teardownAllPanels() }
+            BrowserAvailabilitySettings.setDisabled(wasBrowserDisabled, defaults: defaults)
+        }
+
+        BrowserAvailabilitySettings.setDisabled(false, defaults: defaults)
+        let workspace = try #require(manager.selectedWorkspace)
+        workspace.configureRemoteConnection(
+            WorkspaceRemoteConfiguration(
+                destination: "example.com",
+                port: nil,
+                identityFile: nil,
+                sshOptions: [],
+                localProxyPort: nil,
+                relayPort: nil,
+                relayID: nil,
+                relayToken: nil,
+                localSocketPath: nil,
+                terminalStartupCommand: nil
+            ),
+            autoConnect: false
+        )
+        let sourceID = try #require(workspace.focusedPanelId)
+        let profileID = BrowserProfileStore.shared.builtInDefaultProfileID.uuidString
+        TerminalController.shared.setActiveTabManager(manager)
+
+        for method in ["browser.open_split", "pane.create"] {
+            var params: [String: Any] = [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": sourceID.uuidString,
+                "profile": profileID,
+                "focus": false,
+            ]
+            if method == "pane.create" {
+                params["direction"] = "right"
+                params["type"] = "browser"
+            }
+
+            let error = try errorPayload(try call(method: method, params: params))
+            #expect(error["code"] as? String == "invalid_params")
+            #expect((error["message"] as? String)?.contains("remote workspace") == true)
+        }
+    }
+
     private func call(method: String, params: [String: Any]) throws -> [String: Any] {
         let request: [String: Any] = [
             "jsonrpc": "2.0",

--- a/tests/test_browser_profile_cli.py
+++ b/tests/test_browser_profile_cli.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Browser creation CLI commands forward profile selectors to the socket API."""
+
+from __future__ import annotations
+
+import json
+import os
+import socketserver
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+PROFILE_ID = "11111111-1111-4111-8111-111111111111"
+
+
+class FakeCmuxState:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def handle(self, method: str, params: dict[str, object]) -> dict[str, object]:
+        self.calls.append((method, params))
+        if method == "browser.open_split":
+            return {
+                "surface_id": "22222222-2222-4222-8222-222222222222",
+                "surface_ref": "surface:2",
+                "pane_id": "33333333-3333-4333-8333-333333333333",
+                "pane_ref": "pane:2",
+                "created_split": True,
+            }
+        if method == "pane.create":
+            return {
+                "surface_id": "22222222-2222-4222-8222-222222222222",
+                "surface_ref": "surface:2",
+                "pane_id": "33333333-3333-4333-8333-333333333333",
+                "pane_ref": "pane:2",
+            }
+        if method == "browser.profiles.list":
+            return {
+                "current_profile_id": PROFILE_ID,
+                "profiles": [
+                    {
+                        "id": PROFILE_ID,
+                        "name": "Work Profile",
+                        "slug": "work-profile",
+                        "built_in_default": False,
+                        "current": True,
+                    }
+                ],
+            }
+        raise RuntimeError(f"unexpected method: {method}")
+
+
+class FakeCmuxHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        while line := self.rfile.readline():
+            request = json.loads(line.decode("utf-8"))
+            try:
+                result = self.server.state.handle(  # type: ignore[attr-defined]
+                    request["method"],
+                    request.get("params", {}),
+                )
+                response = {"ok": True, "result": result, "id": request.get("id")}
+            except Exception as exc:  # noqa: BLE001
+                response = {
+                    "ok": False,
+                    "error": {"code": "fake_error", "message": str(exc)},
+                    "id": request.get("id"),
+                }
+            self.wfile.write((json.dumps(response) + "\n").encode("utf-8"))
+            self.wfile.flush()
+
+
+class ThreadedUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    daemon_threads = True
+    state: FakeCmuxState
+
+
+def run_cli(cli: str, socket_path: str, arguments: list[str]) -> str:
+    environment = dict(os.environ)
+    for key in ["CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_TAB_ID"]:
+        environment.pop(key, None)
+    result = subprocess.run(
+        [cli, "--socket", socket_path, *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+        timeout=5,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"CLI failed ({' '.join(arguments)}): {result.stdout}\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+def assert_last_call(
+    state: FakeCmuxState,
+    expected_method: str,
+    expected_profile: str | None,
+) -> None:
+    method, params = state.calls[-1]
+    if method != expected_method:
+        raise AssertionError(f"expected {expected_method}, got {method}")
+    if params.get("profile") != expected_profile:
+        raise AssertionError(
+            f"{expected_method} expected profile={expected_profile!r}, got {params!r}"
+        )
+
+
+def main() -> int:
+    cli = resolve_cmux_cli()
+    with tempfile.TemporaryDirectory(prefix="cmux-browser-profile-") as temporary:
+        socket_path = str(Path(temporary) / "cmux.sock")
+        state = FakeCmuxState()
+        server = ThreadedUnixServer(socket_path, FakeCmuxHandler)
+        server.state = state
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            run_cli(
+                cli,
+                socket_path,
+                ["browser", "open", "https://example.com", "--profile", "Work Profile"],
+            )
+            assert_last_call(state, "browser.open_split", "Work Profile")
+
+            run_cli(
+                cli,
+                socket_path,
+                ["browser", "open-split", "https://example.com", "--profile", PROFILE_ID],
+            )
+            assert_last_call(state, "browser.open_split", PROFILE_ID)
+
+            run_cli(
+                cli,
+                socket_path,
+                [
+                    "new-pane",
+                    "--type",
+                    "browser",
+                    "--url",
+                    "https://example.com",
+                    "--profile",
+                    "Work Profile",
+                ],
+            )
+            assert_last_call(state, "pane.create", "Work Profile")
+
+            run_cli(cli, socket_path, ["browser", "open", "https://example.com"])
+            assert_last_call(state, "browser.open_split", None)
+
+            profiles = run_cli(cli, socket_path, ["browser", "profiles"])
+            if "Work Profile" not in profiles or PROFILE_ID not in profiles:
+                raise AssertionError(f"profile list omitted name or UUID: {profiles!r}")
+            if "last used" not in profiles:
+                raise AssertionError(f"profile list did not mark last-used profile: {profiles!r}")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+    print("PASS: browser profile CLI plumbing")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_browser_profile_cli.py
+++ b/tests/test_browser_profile_cli.py
@@ -177,6 +177,16 @@ def main() -> int:
             )
             assert_last_call(state, "pane.create", "Work Profile")
 
+            calls_before_terminal_profile = len(state.calls)
+            assert_cli_fails(
+                cli,
+                socket_path,
+                ["new-pane", "--profile", "Work Profile"],
+                "Browser profiles can only be used when creating a browser pane",
+            )
+            if len(state.calls) != calls_before_terminal_profile:
+                raise AssertionError("new-pane sent a browser profile for a terminal pane")
+
             run_cli(cli, socket_path, ["browser", "open", "https://example.com"])
             assert_last_call(state, "browser.open_split", None)
 

--- a/tests/test_browser_profile_cli.py
+++ b/tests/test_browser_profile_cli.py
@@ -98,6 +98,32 @@ def run_cli(cli: str, socket_path: str, arguments: list[str]) -> str:
     return result.stdout.strip()
 
 
+def assert_cli_fails(
+    cli: str,
+    socket_path: str,
+    arguments: list[str],
+    expected_message: str,
+) -> None:
+    environment = dict(os.environ)
+    for key in ["CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_TAB_ID"]:
+        environment.pop(key, None)
+    result = subprocess.run(
+        [cli, "--socket", socket_path, *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+        timeout=5,
+    )
+    if result.returncode == 0:
+        raise AssertionError(f"CLI unexpectedly succeeded ({' '.join(arguments)})")
+    output = f"{result.stdout}\n{result.stderr}"
+    if expected_message not in output:
+        raise AssertionError(
+            f"expected failure containing {expected_message!r}, got {output!r}"
+        )
+
+
 def assert_last_call(
     state: FakeCmuxState,
     expected_method: str,
@@ -153,6 +179,23 @@ def main() -> int:
 
             run_cli(cli, socket_path, ["browser", "open", "https://example.com"])
             assert_last_call(state, "browser.open_split", None)
+
+            calls_before_rejected_open = len(state.calls)
+            assert_cli_fails(
+                cli,
+                socket_path,
+                [
+                    "browser",
+                    "surface:1",
+                    "open",
+                    "https://example.com",
+                    "--profile",
+                    "Work Profile",
+                ],
+                "--profile is only supported when browser open creates a new pane",
+            )
+            if len(state.calls) != calls_before_rejected_open:
+                raise AssertionError("surface-qualified browser open sent an ignored profile")
 
             profiles = run_cli(cli, socket_path, ["browser", "profiles"])
             if "Work Profile" not in profiles or PROFILE_ID not in profiles:

--- a/tests/test_browser_profile_cli.py
+++ b/tests/test_browser_profile_cli.py
@@ -187,6 +187,16 @@ def main() -> int:
             if len(state.calls) != calls_before_terminal_profile:
                 raise AssertionError("new-pane sent a browser profile for a terminal pane")
 
+            calls_before_missing_profile = len(state.calls)
+            assert_cli_fails(
+                cli,
+                socket_path,
+                ["new-pane", "--type", "browser", "--profile"],
+                "--profile requires a non-empty profile name or UUID",
+            )
+            if len(state.calls) != calls_before_missing_profile:
+                raise AssertionError("new-pane sent a profile request without a selector")
+
             run_cli(cli, socket_path, ["browser", "open", "https://example.com"])
             assert_last_call(state, "browser.open_split", None)
 


### PR DESCRIPTION
Closes #2720

Issue: https://github.com/manaflow-ai/cmux/issues/2720

## Summary

- Resolve explicit browser profile selectors in the `CmuxBrowser` domain, preferring an existing UUID before exact case-insensitive display-name matching.
- Thread the validated profile UUID through `browser.open_split` and `pane.create`, including Dock pane creation, while leaving an omitted selector as `nil` so the existing source/workspace/last-used fallback chain is unchanged.
- Return structured `invalid_params` errors for unknown and ambiguous selectors; ambiguous errors include every candidate display name and UUID.
- Add `--profile <name-or-uuid>` plumbing and help for `browser open`, `browser open-split`, and `new-pane --type browser`.
- Reuse the existing `browser profiles` socket API in the CLI and label its effective current profile as `last used`.
- Localize all new and changed terminal-facing text in English and Japanese.

## Acceptance criteria

- [x] `cmux browser open <url> --profile <name-or-uuid>` forwards and applies the selected profile.
- [x] `cmux browser open-split <url> --profile <name-or-uuid>` forwards and applies the selected profile.
- [x] `cmux new-pane --type browser --url <url> --profile <name-or-uuid>` forwards and applies the selected profile.
- [x] `cmux browser profiles` lists profile display names and UUIDs and marks the last-used profile.
- [x] UUID selection takes precedence, then falls back to case-insensitive display-name matching.
- [x] Unknown selectors return a clear error instead of falling back.
- [x] Ambiguous display names return a clear error listing candidate names and UUIDs.
- [x] Omitting `--profile` preserves the existing profile fallback behavior.

## Verification

- `swift test --package-path Packages/macOS/CmuxBrowser --filter BrowserProfileRepositoryTests` (22 tests passed under native arm64)
- `swift test --package-path Packages/macOS/CmuxControlSocket` (278 tests passed under native arm64)
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/lint-feature-flags.py`
- Parsed `Resources/Localizable.xcstrings` with duplicate-key detection and verified English/Japanese coverage for every changed key.
- App builds and Xcode tests were intentionally not run locally per task constraints; the PR's app/socket behavior tests run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--profile <name|uuid>` support for browser pane creation, browser open/split flows, and split/tab creation with a resolved “preferred profile” carried through.
* **Bug Fixes**
  * Improved profile selector handling: trims input, resolves UUIDs first, then case-insensitive display names; ambiguity and not-found now return clearer `invalid_params` responses (including candidate details when applicable).
  * Updated “last used” marker text/label and refined localized CLI help/error messaging.
* **Tests**
  * Added unit/integration coverage for selector resolution behavior and CLI socket plumbing; registered new Swift tests and extended CI regression runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->