### PR TITLE
Allow dev.cmux.app.demo as a production APNs topic

### DIFF
--- a/web/services/apns/routePolicy.ts
+++ b/web/services/apns/routePolicy.ts
@@ -73,6 +73,7 @@ const PROD_BUNDLE_IDS = new Set([
   "com.cmuxterm.app",
   "dev.cmux.app.beta",
   "dev.cmux.app.internal",
+  "dev.cmux.app.demo",
 ]);
 
 function stringValue(value: unknown): string {

--- a/web/tests/apns.test.ts
+++ b/web/tests/apns.test.ts
@@ -201,6 +201,16 @@ describe("apns route policy", () => {
     });
   });
 
+  test("allows the demo TestFlight bundle id as a production APNs topic", () => {
+    // The manual demo lane variant ships dev.cmux.app.demo
+    // (.github/workflows/ios-testflight.yml, variant=demo); TestFlight uses the
+    // production APNs environment, same as the internal lane above.
+    expect(normalizeApnsBundle("dev.cmux.app.demo")).toEqual({
+      bundleId: "dev.cmux.app.demo",
+      environment: "production",
+    });
+  });
+
   test("bounds and trims push payloads before sending to APNs", () => {
     const parsed = parsePushPayload({
       title: " agent ",


### PR DESCRIPTION
The new manual demo TestFlight lane (variant=demo in ios-testflight.yml, companion PR from feat-demo-tf-lane) ships dev.cmux.app.demo. Without this allowlist entry every cmux DEMO phone fails device-token registration with invalid_bundle_id and pushes never arrive, the same failure mode the internal lane hit before dev.cmux.app.internal was added (see web/tests/apns.test.ts). Adds the bundle id to PROD_BUNDLE_IDS plus a matching test; bun test tests/apns.test.ts passes 30/30 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787514973&installation_model_id=21920&pr_number=8875&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8875&signature=c6dedd5c338ee8391d53329be02c0bc98ecd83e00603ee25bac774e9f44b1738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `dev.cmux.app.demo` as a production APNs topic so demo TestFlight builds can register device tokens and receive pushes. Fixes invalid_bundle_id errors on DEMO devices.

- **Bug Fixes**
  - Added `dev.cmux.app.demo` to `PROD_BUNDLE_IDS` and covered with a test.

<sup>Written for commit 7da9b51bde9d0ff454557654a95abdbf1ed018ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APNs handling for an additional production app bundle, ensuring notifications are routed with the correct production environment.

* **Tests**
  * Added coverage to verify correct handling of the newly supported production bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->