### PR TITLE
Hide one computer row without hiding sibling build instances

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
@@ -279,10 +279,10 @@ extension MobileShellComposite {
         let remainingPhysicalIDs = Set(pairedMacsForIdentityMatching
             .filter { !targetPairingIDs.contains($0.id) }
             .map(\.macDeviceID))
+        // Workspace state is keyed by PHYSICAL device id, so it is shared by
+        // every app instance of a Mac. Prune it only when no visible sibling
+        // instance remains; a per-instance hide leaves the sibling's state.
         let fullyHiddenPhysicalIDs = targetPhysicalIDs.subtracting(remainingPhysicalIDs)
-        for pairingID in targetPairingIDs.subtracting(targetPhysicalIDs) {
-            pruneWorkspaceStateForHiddenMac(pairingID)
-        }
         for id in fullyHiddenPhysicalIDs {
             if let subscription = secondaryMacSubscriptions[id] {
                 subscription.cancel()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+HiddenMacs.swift
@@ -162,11 +162,19 @@ extension MobileShellComposite {
         await loadRegistryDevices()
     }
 
-    /// Hides the logical computer represented by a visible stored Mac id.
+    /// Hides the legacy untagged computer represented by a visible stored Mac id.
+    ///
+    /// Tagged row actions must use
+    /// ``hideStoredPairedMacEntries(representativeID:aliasIDs:)`` so a physical
+    /// Mac's sibling app instances remain visible.
     public func hideMac(macDeviceID: String) async {
-        guard let scope = await currentScopeSnapshot() else { return }
-        let macDeviceIDs = Array(Set(pairedMacAliasIDs(for: macDeviceID))).sorted()
-        await hideStoredMacDeviceIDs(macDeviceIDs, scope: scope)
+        await hideStoredPairedMacEntries(
+            representativeID: MobilePairedMac.pairingID(
+                macDeviceID: macDeviceID,
+                instanceTag: nil
+            ),
+            aliasIDs: pairedMacAliasIDs(for: macDeviceID)
+        )
     }
 
     /// Hides one exact tagged app instance without hiding sibling instances.
@@ -179,10 +187,48 @@ extension MobileShellComposite {
         await hideStoredPairedMacs(targets, scope: scope)
     }
 
+    /// Hides the stored pairing entries represented by one visible computer row.
+    ///
+    /// Raw device IDs in `aliasIDs` inherit the representative's instance tag
+    /// before matching, while already-composite pairing IDs retain their embedded
+    /// tag. Targets are then selected by exact ``MobilePairedMac/id`` equality.
+    /// - Parameters:
+    ///   - representativeID: The visible row's composite pairing ID.
+    ///   - aliasIDs: Stored IDs coalesced into that row. An empty array falls
+    ///     back to `representativeID`.
+    public func hideStoredPairedMacEntries(
+        representativeID: String,
+        aliasIDs: [String]
+    ) async {
+        guard !representativeID.isEmpty,
+              let scope = await currentScopeSnapshot() else { return }
+        let representative = MobilePairedMac.pairingIdentity(from: representativeID)
+        let targetPairingIDs: Set<String> = Set(
+            ([representativeID] + aliasIDs).compactMap { storedID in
+                guard !storedID.isEmpty else { return nil }
+                let identity = MobilePairedMac.pairingIdentity(from: storedID)
+                return MobilePairedMac.pairingID(
+                    macDeviceID: identity.macDeviceID,
+                    instanceTag: identity.instanceTag ?? representative.instanceTag
+                )
+            }
+        )
+        let targets = pairedMacsForIdentityMatching.filter {
+            targetPairingIDs.contains($0.id)
+        }
+        guard !targets.isEmpty else { return }
+        await hideStoredPairedMacs(targets, scope: scope)
+    }
+
     /// Hides exactly one stored paired-Mac row.
     public func hideStoredMac(macDeviceID: String) async {
-        guard let scope = await currentScopeSnapshot() else { return }
-        await hideStoredMacDeviceIDs([macDeviceID], scope: scope)
+        await hideStoredPairedMacEntries(
+            representativeID: MobilePairedMac.pairingID(
+                macDeviceID: macDeviceID,
+                instanceTag: nil
+            ),
+            aliasIDs: [macDeviceID]
+        )
     }
 
     /// Hides exactly one tagged stored pairing.
@@ -192,34 +238,6 @@ extension MobileShellComposite {
             $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
         }
         guard !targets.isEmpty else { return }
-        await hideStoredPairedMacs(targets, scope: scope)
-    }
-
-    func hideStoredMacDeviceIDs(
-        _ macDeviceIDs: [String],
-        scope: MobileShellScopeSnapshot
-    ) async {
-        guard !macDeviceIDs.isEmpty else { return }
-        let targetIDSet = Set(macDeviceIDs)
-        var targets = pairedMacsForIdentityMatching.filter {
-            targetIDSet.contains($0.macDeviceID)
-        }
-        let foundPhysicalIDs = Set(targets.map(\.macDeviceID))
-        for id in targetIDSet.subtracting(foundPhysicalIDs) {
-            let identity = MobilePairedMac.pairingIdentity(from: id)
-            let now = Date()
-            targets.append(MobilePairedMac(
-                macDeviceID: identity.macDeviceID,
-                displayName: nil,
-                routes: [],
-                createdAt: now,
-                lastSeenAt: now,
-                isActive: false,
-                stackUserID: scope.userID,
-                teamID: scope.teamID,
-                instanceTag: identity.instanceTag
-            ))
-        }
         await hideStoredPairedMacs(targets, scope: scope)
     }
 
@@ -246,8 +264,14 @@ extension MobileShellComposite {
         }
 
         invalidateStoredMacReconnectAttempt()
+        let foregroundPairingID = foregroundMacDeviceID.map {
+            MobilePairedMac.pairingID(
+                macDeviceID: $0,
+                instanceTag: connectedMacInstanceTag
+            )
+        }
         let isActiveMac = targets.contains(where: \.isActive)
-            || foregroundMacDeviceID.map(targetPhysicalIDs.contains) == true
+            || foregroundPairingID.map(targetPairingIDs.contains) == true
         if isActiveMac {
             disconnectLiveConnection(preservingOtherMacWorkspaceState: true)
         }
@@ -256,6 +280,9 @@ extension MobileShellComposite {
             .filter { !targetPairingIDs.contains($0.id) }
             .map(\.macDeviceID))
         let fullyHiddenPhysicalIDs = targetPhysicalIDs.subtracting(remainingPhysicalIDs)
+        for pairingID in targetPairingIDs.subtracting(targetPhysicalIDs) {
+            pruneWorkspaceStateForHiddenMac(pairingID)
+        }
         for id in fullyHiddenPhysicalIDs {
             if let subscription = secondaryMacSubscriptions[id] {
                 subscription.cancel()
@@ -270,16 +297,16 @@ extension MobileShellComposite {
         clearSavedMacHintWhenNoStoredMacsRemainIfNeeded()
     }
 
-    /// Removes every workspace snapshot owned by a hidden stored Mac.
-    func pruneWorkspaceStateForHiddenMac(_ macDeviceID: String) {
-        guard !macDeviceID.isEmpty else { return }
-        if foregroundMacDeviceID == macDeviceID {
+    /// Removes every workspace snapshot owned by a hidden stored Mac identity.
+    func pruneWorkspaceStateForHiddenMac(_ storedMacID: String) {
+        guard !storedMacID.isEmpty else { return }
+        if foregroundMacDeviceID == storedMacID {
             foregroundMacDeviceID = nil
         }
         let pruned = workspacesByMac.reduce(into: [String: MacWorkspaceState]()) { result, entry in
             let (key, state) = entry
-            guard key != macDeviceID, state.macDeviceID != macDeviceID else { return }
-            let filteredWorkspaces = state.workspaces.filter { $0.macDeviceID != macDeviceID }
+            guard key != storedMacID, state.macDeviceID != storedMacID else { return }
+            let filteredWorkspaces = state.workspaces.filter { $0.macDeviceID != storedMacID }
             var filteredState = state
             filteredState.workspaces = filteredWorkspaces
             result[key] = filteredState

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3385,6 +3385,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Backs the "Rescan QR" action.
     public func disconnectAndHideActiveMac() {
         let staleMacID = connectedMacDeviceID ?? activeTicket?.macDeviceID
+        let staleMacInstanceTag = connectedMacInstanceTag
+        let staleRepresentativeID = staleMacID.map {
+            MobilePairedMac.pairingID(
+                macDeviceID: $0,
+                instanceTag: staleMacInstanceTag
+            )
+        }
+        let staleAliasIDs = staleMacID.map {
+            pairedMacAliasIDs(for: $0, instanceTag: staleMacInstanceTag)
+        } ?? []
         disconnectLiveConnection()
         // Bump the reconnect generation so an in-flight reconnect cannot reclaim
         // the foreground while the retained pairing is being hidden. Preserve the
@@ -3392,13 +3402,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         storedMacReconnectGeneration &+= 1
         isReconnectingStoredMac = false
         didFinishStoredMacReconnectAttempt = false
-        if let macID = staleMacID {
+        if let representativeID = staleRepresentativeID {
             hasKnownPairedMac = true
             // The shell action is synchronous for its UI caller; the device-local
             // marker and list pruning continue on the main actor without deleting
             // the retained paired-Mac row.
             Task {
-                await self.hideMac(macDeviceID: macID)
+                await self.hideStoredPairedMacEntries(
+                    representativeID: representativeID,
+                    aliasIDs: staleAliasIDs
+                )
             }
         }
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
@@ -279,6 +279,151 @@ import Testing
         #expect(restored.customIcon == "laptopcomputer")
     }
 
+    @Test(arguments: ["stable", "nightly"])
+    func hidingTaggedRowLeavesSiblingInstanceVisible(hiddenTag: String) async throws {
+        let siblingTag = hiddenTag == "stable" ? "nightly" : "stable"
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "shared-mac",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        port: 50922,
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: true,
+                        instanceTag: "stable"
+                    ),
+                    try Self.pairedMac(
+                        id: "shared-mac",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        port: 50923,
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false,
+                        instanceTag: "nightly"
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            connectionState: .connected,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" },
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+        await store.loadPairedMacs()
+        let representative = try #require(
+            store.displayPairedMacs.first { $0.instanceTag == hiddenTag }
+        )
+
+        await store.hideStoredPairedMacEntries(
+            representativeID: representative.id,
+            aliasIDs: store.pairedMacAliasIDs(
+                for: representative.macDeviceID,
+                instanceTag: representative.instanceTag
+            )
+        )
+
+        #expect(store.pairedMacs.map(\.instanceTag) == [siblingTag])
+        #expect(store.displayPairedMacs.map(\.instanceTag) == [siblingTag])
+        #expect(store.hiddenComputers.map(\.instanceTag) == [hiddenTag])
+        #expect(
+            store.connectionState
+                == (hiddenTag == "stable" ? .disconnected : .connected)
+        )
+    }
+
+    @Test func hidingActiveTaggedRowPrunesOnlyItsPairingWorkspaceState() async throws {
+        let stableID = MobilePairedMac.pairingID(
+            macDeviceID: "shared-mac",
+            instanceTag: "stable"
+        )
+        let nightlyID = MobilePairedMac.pairingID(
+            macDeviceID: "shared-mac",
+            instanceTag: "nightly"
+        )
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "shared-mac",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        port: 50922,
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: true,
+                        instanceTag: "stable"
+                    ),
+                    try Self.pairedMac(
+                        id: "shared-mac",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        port: 50923,
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false,
+                        instanceTag: "nightly"
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            connectionState: .connected,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" },
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+        await store.loadPairedMacs()
+        store.setWorkspaceStatesForTesting([
+            stableID: MacWorkspaceState(
+                macDeviceID: stableID,
+                workspaces: [
+                    MobileWorkspacePreview(
+                        id: "stable-workspace",
+                        macDeviceID: stableID,
+                        name: "Stable",
+                        terminals: []
+                    ),
+                ],
+                status: .connected
+            ),
+            nightlyID: MacWorkspaceState(
+                macDeviceID: nightlyID,
+                workspaces: [
+                    MobileWorkspacePreview(
+                        id: "nightly-workspace",
+                        macDeviceID: nightlyID,
+                        name: "Nightly",
+                        terminals: []
+                    ),
+                ],
+                status: .connected
+            ),
+        ], foregroundMacDeviceID: "shared-mac")
+        let stable = try #require(
+            store.displayPairedMacs.first { $0.instanceTag == "stable" }
+        )
+
+        await store.hideStoredPairedMacEntries(
+            representativeID: stable.id,
+            aliasIDs: store.pairedMacAliasIDs(
+                for: stable.macDeviceID,
+                instanceTag: stable.instanceTag
+            )
+        )
+
+        #expect(store.connectionState == .disconnected)
+        #expect(store.foregroundMacDeviceIDForTesting() == nil)
+        #expect(store.displayPairedMacs.map(\.instanceTag) == ["nightly"])
+        #expect(store.workspaces.map(\.rpcWorkspaceID.rawValue) == ["nightly-workspace"])
+    }
+
     @Test func hideKeepsSQLiteRowAndCreatesNoPendingDeleteOrTombstone() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositeHideMacTests.swift
@@ -337,15 +337,7 @@ import Testing
         )
     }
 
-    @Test func hidingActiveTaggedRowPrunesOnlyItsPairingWorkspaceState() async throws {
-        let stableID = MobilePairedMac.pairingID(
-            macDeviceID: "shared-mac",
-            instanceTag: "stable"
-        )
-        let nightlyID = MobilePairedMac.pairingID(
-            macDeviceID: "shared-mac",
-            instanceTag: "nightly"
-        )
+    @Test func hidingTaggedRowKeepsSharedWorkspaceStateUntilLastInstanceHides() async throws {
         let pairedStore = DelayedTeamPairedMacStore(
             recordsByTeam: [
                 "team-a": [
@@ -380,26 +372,16 @@ import Testing
             hiddenMacStore: InMemoryPairedMacHiddenStore()
         )
         await store.loadPairedMacs()
+        // Production keys workspace state by PHYSICAL device id, shared by
+        // every app instance of the Mac.
         store.setWorkspaceStatesForTesting([
-            stableID: MacWorkspaceState(
-                macDeviceID: stableID,
+            "shared-mac": MacWorkspaceState(
+                macDeviceID: "shared-mac",
                 workspaces: [
                     MobileWorkspacePreview(
-                        id: "stable-workspace",
-                        macDeviceID: stableID,
-                        name: "Stable",
-                        terminals: []
-                    ),
-                ],
-                status: .connected
-            ),
-            nightlyID: MacWorkspaceState(
-                macDeviceID: nightlyID,
-                workspaces: [
-                    MobileWorkspacePreview(
-                        id: "nightly-workspace",
-                        macDeviceID: nightlyID,
-                        name: "Nightly",
+                        id: "shared-workspace",
+                        macDeviceID: "shared-mac",
+                        name: "Shared",
                         terminals: []
                     ),
                 ],
@@ -418,10 +400,27 @@ import Testing
             )
         )
 
+        // A visible sibling instance remains, so the shared physical
+        // workspace state must survive the per-instance hide.
         #expect(store.connectionState == .disconnected)
-        #expect(store.foregroundMacDeviceIDForTesting() == nil)
         #expect(store.displayPairedMacs.map(\.instanceTag) == ["nightly"])
-        #expect(store.workspaces.map(\.rpcWorkspaceID.rawValue) == ["nightly-workspace"])
+        #expect(store.workspaces.map(\.rpcWorkspaceID.rawValue) == ["shared-workspace"])
+
+        let nightly = try #require(
+            store.displayPairedMacs.first { $0.instanceTag == "nightly" }
+        )
+        await store.hideStoredPairedMacEntries(
+            representativeID: nightly.id,
+            aliasIDs: store.pairedMacAliasIDs(
+                for: nightly.macDeviceID,
+                instanceTag: nightly.instanceTag
+            )
+        )
+
+        // No instance remains visible: the physical state is pruned.
+        #expect(store.displayPairedMacs.isEmpty)
+        #expect(store.workspaces.isEmpty)
+        #expect(store.foregroundMacDeviceIDForTesting() == nil)
     }
 
     @Test func hideKeepsSQLiteRowAndCreatesNoPendingDeleteOrTombstone() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairedMacCoalescingTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairedMacCoalescingTests.swift
@@ -101,7 +101,14 @@ import Testing
         #expect(customizedDuplicateRows.first { $0.macDeviceID == "mac-old" }?.customName == "Old custom")
         #expect(customizedDuplicateRows.first { $0.macDeviceID == "mac-fresh" }?.customName == "Desk setup")
 
-        await store.hideMac(macDeviceID: "mac-fresh")
+        let representative = try #require(store.displayPairedMacs.first)
+        await store.hideStoredPairedMacEntries(
+            representativeID: representative.id,
+            aliasIDs: store.pairedMacAliasIDs(
+                for: representative.macDeviceID,
+                instanceTag: representative.instanceTag
+            )
+        )
 
         #expect(store.pairedMacs.map(\.macDeviceID) == ["mac-other"])
         #expect(store.displayPairedMacs.map(\.macDeviceID) == ["mac-other"])

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -158,7 +158,10 @@ struct DeviceTreeView: View {
 
     private func hideComputer(_ computer: MacComputerSnapshot) {
         Task {
-            await store.hideMac(macDeviceID: computer.deviceId)
+            await store.hideStoredPairedMacEntries(
+                representativeID: computer.id,
+                aliasIDs: computer.aliasIDs
+            )
             await reload()
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -288,7 +288,10 @@ struct DisconnectedWorkspaceShellView: View {
 
     private func hideComputer(_ computer: MacComputerSnapshot) {
         Task {
-            await store?.hideMac(macDeviceID: computer.deviceId)
+            await store?.hideStoredPairedMacEntries(
+                representativeID: computer.id,
+                aliasIDs: computer.aliasIDs
+            )
         }
     }
     #else

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -26,7 +26,10 @@ extension MacComputerSnapshot {
         let connectionStatuses = store.macConnectionStatuses
         var snapshots = store.displayPairedMacs.map { mac in
             let presenceInstanceTag = instanceTag ?? mac.instanceTag
-            let aliases = store.pairedMacAliasIDs(for: mac.macDeviceID)
+            let aliases = store.pairedMacAliasIDs(
+                for: mac.macDeviceID,
+                instanceTag: mac.instanceTag
+            )
             let summary = store.presenceSummary(
                 for: mac.macDeviceID,
                 instanceTag: presenceInstanceTag


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/8760: row-swipe hide expanded through the bare physical device id, so hiding a Mac's Stable row also hid its Nightly row. Row hides now target the row's alias group via hideStoredPairedMacEntries (exact pairing-id matching, raw aliases inherit the row's tag, physical-wide expansion deleted). Alias duplicates still hide together; detail view and host picker unchanged. 36 tests in 3 suites pass incl. new sibling-survival and alias-duplicate coverage. Full mechanism in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787515556&installation_model_id=21920&pr_number=8877&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8877&signature=bc04c33f381e457a2aedd6f8b207acf46971494c51f9ad4cd1b3723e12b2ce65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Hide action so it only hides the selected computer row (specific build instance) without hiding its sibling instances. Workspace state is shared per physical device and is only pruned when the last sibling instance is hidden.

- **Bug Fixes**
  - Added hideStoredPairedMacEntries: raw alias IDs inherit the row’s tag; targets match by exact pairing ID; removed physical-wide expansion.
  - Updated UI and shell calls to pass representativeID and aliasIDs; detail view and host picker behavior unchanged.
  - Scoped active-connection handling and foreground selection to the hidden pairing; sibling instance stays visible.
  - Clarified workspace semantics: keep shared physical state while any sibling remains; prune only after the last instance hides. Added tests for sibling survival and shared-workspace behavior.

<sup>Written for commit 32b6d9159c34008069c1782cdf4801503ac15398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hiding of stored Macs to operate on composite pairing identities, ensuring correct behavior when multiple instances share the same device.
  * Disconnect-and-hide now targets the retained paired entry using representative/alias pairing IDs, improving active/foreground handling.
  * Updated computer dismissal flows to hide the correct stored paired entries (including iOS disconnect/reconnect UI).
* **Tests**
  * Added async test coverage for instance-tag-specific hiding, connection state transitions, foreground selection, and workspace pruning/sibling visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->