### PR TITLE
Adopt the fork's cancellable ConnectAttempt for Iroh client dials

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
@@ -64,10 +64,8 @@ actor CmxIrohClientSessionPool {
     private var controlWaiters: [SessionKey: [ControlWaiter]] = [:]
     private var selectedPathContinuations: [UUID: AsyncStream<Void>.Continuation] = [:]
 
-    /// Upper bound on how long a new dial defers to a cancelled predecessor that
-    /// ignores cancellation. Past the bound the new dial proceeds (accepting the
-    /// old overlap behavior) so one wedged iroh dial cannot become a permanent
-    /// connect outage for that Mac.
+    /// Never-hit safety bound for a dial that ignores cancellation, retained so
+    /// one wedged dial can never become a permanent connect outage.
     static var retiredDialSettleWaitLimitSeconds: TimeInterval { 10 }
 
     init(
@@ -445,11 +443,11 @@ actor CmxIrohClientSessionPool {
     }
 
     /// Cancels the pending dial for `key` and tracks it until it fully resolves.
-    /// iroh's connect does not observe Swift cancellation, so a cancelled dial can
-    /// still complete QUIC admission on the host seconds later; the host then
-    /// closes the newer live connection for the same device. Draining retired
-    /// dials before the next dial starts keeps at most one admission in flight
-    /// per peer.
+    /// `pending.task.cancel()` crosses the FFI boundary because
+    /// ``CmxIrohLibEndpoint`` dials through a `ConnectAttempt` whose `cancel()`
+    /// runs on task cancellation, so retired dials settle in milliseconds. The
+    /// drain set still serializes endpoint implementations that ignore
+    /// cancellation and keeps at most one admission in flight per peer.
     private func retirePendingConnection(for key: SessionKey) {
         guard let pending = connectionTasks.removeValue(forKey: key) else { return }
         pending.task.cancel()

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohDiagnosticFailure.swift
@@ -17,6 +17,11 @@ extension IrohError: @retroactive DiagnosticFailureProviding {
     private static func diagnosticFailureKind(
         message: String
     ) -> DiagnosticFailureKind {
+        // iroh-ffi's ConnectAttempt fails a cancelled dial with this fixed marker
+        // (CONNECT_CANCELLED_MESSAGE, iroh-ffi src/endpoint.rs, v1.0.2-cmux.4).
+        if message.contains("outgoing connection cancelled") {
+            return .cancelled
+        }
         if message.contains("ConnectionLost(TimedOut)") {
             return .transportIdleTimedOut
         }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLibEndpoint.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohLibEndpoint.swift
@@ -112,7 +112,18 @@ actor CmxIrohLibEndpoint: CmxIrohEndpoint {
         for endpointAddress in try endpointAddresses(address) {
             do {
                 try Task.checkCancellation()
-                let connection = try await driver.connect(addr: endpointAddress, alpn: alpn)
+                // Dial through the fork's cancellable ConnectAttempt so Swift task
+                // cancellation crosses the FFI boundary: onCancel fires the attempt's
+                // CancellationToken and the Rust side fails the dial immediately.
+                // Cancel racing completion is benign: the fork's select! is biased
+                // toward cancellation, and a completed-but-cancelled connection is
+                // dropped (dropping the last handle closes it).
+                let attempt = try driver.beginConnect(addr: endpointAddress, alpn: alpn)
+                let connection = try await withTaskCancellationHandler(operation: {
+                    try await attempt.connect()
+                }, onCancel: {
+                    attempt.cancel()
+                })
                 let wrapped = try CmxIrohLibConnection(driver: connection)
                 guard await wrapped.remoteIdentity() == address.identity else {
                     await wrapped.close(errorCode: 1, reason: "identity_mismatch")

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolCancellationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolCancellationTests.swift
@@ -1,0 +1,175 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohClientSessionPoolCancellationTests {
+    @Test
+    func retiredDialSettlesViaCancellationNotTheDeadManBound() async throws {
+        let fixture = try CancellationPoolFixture()
+        let connection2 = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        let endpoint = TestCancellableDialEndpoint(
+            localIdentity: fixture.localIdentity
+        )
+        let pool = try await fixture.pool(endpoint: endpoint, generation: 1)
+        let factory = CmxIrohByteTransportFactory(sessionPool: pool)
+        let transport1 = try factory.makeTransport(for: fixture.request)
+        let connect1 = Task {
+            try await transport1.connect()
+        }
+
+        #expect(await waitForDialCount(endpoint, atLeast: 1))
+        await pool.activate(runtimeGeneration: 2)
+
+        let transport2 = try factory.makeTransport(for: fixture.request)
+        let connect2 = Task {
+            try await transport2.connect()
+        }
+        #expect(await waitForDialCount(endpoint, atLeast: 2))
+        await endpoint.releaseNextDial(with: connection2)
+        try await connect2.value
+
+        let connect1Result = await connect1.result
+        if case .success = connect1Result {
+            Issue.record("The retired dial unexpectedly succeeded")
+        }
+        #expect(await endpoint.observedDeliveredConnectionCount() == 1)
+        #expect(await connection2.observedCloseCallCount() == 0)
+
+        await transport2.close()
+        await pool.deactivate()
+        await endpoint.close()
+    }
+
+    @Test
+    func cancelledDialBurstYieldsExactlyOneEstablishedSession() async throws {
+        let fixture = try CancellationPoolFixture()
+        let goodConnection = TestIrohConnection(
+            remoteIdentity: fixture.remoteIdentity,
+            bidirectionalStreams: [fixture.controlStream()]
+        )
+        let endpoint = TestCancellableDialEndpoint(
+            localIdentity: fixture.localIdentity
+        )
+        let pool = try await fixture.pool(endpoint: endpoint, generation: 1)
+        let factory = CmxIrohByteTransportFactory(sessionPool: pool)
+        var cancelledConnects: [Task<Void, any Error>] = []
+
+        for index in 1 ... 3 {
+            let transport = try factory.makeTransport(for: fixture.request)
+            let connect = Task {
+                try await transport.connect()
+            }
+            cancelledConnects.append(connect)
+            #expect(await waitForDialCount(endpoint, atLeast: index))
+            await pool.activate(runtimeGeneration: UInt64(index) + 1)
+        }
+
+        let finalTransport = try factory.makeTransport(for: fixture.request)
+        let finalConnect = Task {
+            try await finalTransport.connect()
+        }
+        #expect(await waitForDialCount(endpoint, atLeast: 4))
+        await endpoint.releaseNextDial(with: goodConnection)
+        try await finalConnect.value
+
+        for connect in cancelledConnects {
+            if case .success = await connect.result {
+                Issue.record("A retired burst dial unexpectedly succeeded")
+            }
+        }
+        #expect(await endpoint.observedDialCount() == 4)
+        #expect(await endpoint.observedDeliveredConnectionCount() == 1)
+        #expect(await goodConnection.observedCloseCallCount() == 0)
+
+        _ = try await pool.session(for: fixture.request)
+        #expect(await endpoint.observedDialCount() == 4)
+
+        await finalTransport.close()
+        await pool.deactivate()
+        await endpoint.close()
+    }
+
+    /// Bounded 1ms-sleep poll: unlike a yield loop, real suspension guarantees
+    /// the dial task gets scheduled even when parallel suites saturate the
+    /// cooperative pool, while still failing cleanly if the dial never starts.
+    private func waitForDialCount(
+        _ endpoint: TestCancellableDialEndpoint,
+        atLeast expectedCount: Int
+    ) async -> Bool {
+        for _ in 0 ..< 2_000 {
+            if await endpoint.observedDialCount() >= expectedCount { return true }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return false
+    }
+}
+
+private struct CancellationPoolFixture {
+    let localIdentity: CmxIrohPeerIdentity
+    let remoteIdentity: CmxIrohPeerIdentity
+    let request: CmxByteTransportRequest
+    let context: CmxIrohClientContext
+
+    init() throws {
+        localIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "ab", count: 32)
+        )
+        remoteIdentity = try CmxIrohPeerIdentity(
+            endpointID: String(repeating: "cd", count: 32)
+        )
+        request = CmxByteTransportRequest(
+            route: try CmxAttachRoute(
+                id: "iroh-pool-cancellation",
+                kind: .iroh,
+                endpoint: .peer(identity: remoteIdentity, pathHints: [])
+            ),
+            expectedPeerDeviceID: "123e4567-e89b-42d3-a456-426614174030",
+            authorizationMode: .transportAdmission
+        )
+        context = CmxIrohClientContext(
+            dialPlan: try testIrohDialPlan(),
+            credential: try .pairGrant("e30.e30.AA")
+        )
+    }
+
+    func pool(
+        endpoint: any CmxIrohEndpoint,
+        generation: UInt64
+    ) async throws -> CmxIrohClientSessionPool {
+        let configuration = try CmxIrohEndpointConfiguration(
+            secretKey: CmxIrohSecretKey(bytes: Data(repeating: 7, count: 32)),
+            alpns: [CmxIrohProtocolConfiguration.cmuxMobileV1.alpn],
+            managedRelayURLs: [],
+            relays: []
+        )
+        let supervisor = CmxIrohEndpointSupervisor(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            configuration: configuration
+        )
+        _ = try await supervisor.activate()
+        let pool = CmxIrohClientSessionPool(
+            supervisor: supervisor,
+            contextProvider: TestIrohClientContextProvider(context: context),
+            protocolConfiguration: .testApplicationLanes,
+            clock: ParkingRelayClock()
+        )
+        await pool.activate(runtimeGeneration: generation)
+        return pool
+    }
+
+    func controlStream() -> CmxIrohBidirectionalStream {
+        let admissionCodec = CmxIrohAdmissionAckCodec()
+        return CmxIrohBidirectionalStream(
+            receiveStream: TestIrohReceiveStream(
+                buffer: admissionCodec.encode(.accepted)
+                    + admissionCodec.encodeFrame(.serverReady)
+            ),
+            sendStream: TestIrohSendStream()
+        )
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohDiagnosticFailureTests.swift
@@ -51,6 +51,7 @@ import Testing
             DiagnosticFailureKind.connectionClosed
         ),
         ("ConnectionLost(LocallyClosed)", DiagnosticFailureKind.cancelled),
+        ("outgoing connection cancelled", DiagnosticFailureKind.cancelled),
         (
             "No addressing information available\nCaused by:\n    All address lookup services failed or produced no results",
             DiagnosticFailureKind.dnsFailed

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohLibEndpointCancellationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohLibEndpointCancellationTests.swift
@@ -1,0 +1,227 @@
+import CMUXMobileCore
+import Foundation
+import IrohLib
+import Testing
+@testable import CmuxIrohTransport
+
+@Suite
+struct CmxIrohLibEndpointCancellationTests {
+    @Test
+    func taskCancellationCancelsTheInFlightAttempt() async throws {
+        let attempt = ParkedConnectAttempt()
+        let fixture = try LibEndpointCancellationFixture(attempt: attempt)
+        let dial = Task {
+            try await fixture.endpoint.connect(
+                to: fixture.address,
+                alpn: fixture.alpn
+            )
+        }
+
+        #expect(await attempt.waitUntilParked())
+        dial.cancel()
+
+        let result = await dial.result
+        if case let .failure(error) = result {
+            #expect(error is CancellationError)
+        } else {
+            Issue.record("The cancelled dial unexpectedly succeeded")
+        }
+        #expect(attempt.observedCancelCallCount() >= 1)
+    }
+
+    @Test
+    func cancelledAttemptMarkerClassifiesToCancelledWithoutTaskCancellation() async throws {
+        let fixture = try LibEndpointCancellationFixture(
+            attempt: ImmediateCancelledConnectAttempt()
+        )
+
+        do {
+            _ = try await fixture.endpoint.connect(
+                to: fixture.address,
+                alpn: fixture.alpn
+            )
+            Issue.record("The cancelled attempt unexpectedly succeeded")
+        } catch {
+            #expect(DiagnosticFailureKind.classify(error) == .cancelled)
+        }
+    }
+}
+
+private struct LibEndpointCancellationFixture {
+    let endpoint: CmxIrohLibEndpoint
+    let address: CmxIrohEndpointAddress
+    let alpn: Data
+
+    init(attempt: ConnectAttempt) throws {
+        let localIdentity = try CmxIrohLibIdentity.peerIdentity(
+            SecretKey.generate().public()
+        )
+        let remoteIdentity = try CmxIrohLibIdentity.peerIdentity(
+            SecretKey.generate().public()
+        )
+        let configuration = try CmxIrohEndpointConfiguration(
+            secretKey: CmxIrohSecretKey(bytes: Data(repeating: 7, count: 32)),
+            alpns: [CmxIrohProtocolConfiguration.cmuxMobileV1.alpn],
+            managedRelayURLs: [],
+            relays: []
+        )
+        endpoint = CmxIrohLibEndpoint(
+            driver: AttemptOnlyEndpoint(attempt: attempt),
+            identity: localIdentity,
+            configuration: configuration
+        )
+        address = CmxIrohEndpointAddress(
+            identity: remoteIdentity,
+            pathHints: []
+        )
+        alpn = CmxIrohProtocolConfiguration.cmuxMobileV1.alpn
+    }
+}
+
+// UniFFI requires unchecked sendability; the test message is immutable.
+private final class TestIrohError: IrohError, @unchecked Sendable {
+    private let testMessage: String
+
+    required init(unsafeFromHandle handle: UInt64) {
+        testMessage = ""
+        super.init(unsafeFromHandle: handle)
+    }
+
+    init(message: String) {
+        testMessage = message
+        super.init(noHandle: NoHandle())
+    }
+
+    override func message() -> String {
+        testMessage
+    }
+}
+
+// UniFFI invokes these synchronous overrides from arbitrary executors; `lock`
+// serializes the one parked continuation with cancellation and observations.
+private final class ParkedConnectAttempt: ConnectAttempt, @unchecked Sendable {
+    private let lock = NSLock()
+    private var parkedContinuation: CheckedContinuation<Connection, any Error>?
+    private var parked = false
+    private var cancelCallCount = 0
+    private var cancelled = false
+
+    required init(unsafeFromHandle handle: UInt64) {
+        super.init(unsafeFromHandle: handle)
+    }
+
+    init() {
+        super.init(noHandle: NoHandle())
+    }
+
+    override func cancel() {
+        let continuation = lock.withLock {
+            cancelCallCount += 1
+            cancelled = true
+            defer { parkedContinuation = nil }
+            return parkedContinuation
+        }
+        continuation?.resume(
+            throwing: TestIrohError(
+                message: "outgoing connection cancelled"
+            )
+        )
+    }
+
+    override func connect() async throws -> Connection {
+        try await withCheckedThrowingContinuation { continuation in
+            let shouldCancel = lock.withLock {
+                guard !cancelled else { return true }
+                parked = true
+                parkedContinuation = continuation
+                return false
+            }
+            if shouldCancel {
+                continuation.resume(
+                    throwing: TestIrohError(
+                        message: "outgoing connection cancelled"
+                    )
+                )
+            }
+        }
+    }
+
+    /// Bounded 1ms-sleep poll: unlike a yield loop, real suspension guarantees
+    /// the dial task gets scheduled even when parallel suites saturate the
+    /// cooperative pool, while still failing cleanly if the dial never parks.
+    func waitUntilParked() async -> Bool {
+        for _ in 0 ..< 2_000 {
+            if lock.withLock({ parked }) { return true }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return false
+    }
+
+    func observedCancelCallCount() -> Int {
+        lock.withLock { cancelCallCount }
+    }
+}
+
+// UniFFI requires unchecked sendability; `lock` protects the cancel counter.
+private final class ImmediateCancelledConnectAttempt:
+    ConnectAttempt,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var cancelCallCount = 0
+
+    required init(unsafeFromHandle handle: UInt64) {
+        super.init(unsafeFromHandle: handle)
+    }
+
+    init() {
+        super.init(noHandle: NoHandle())
+    }
+
+    override func cancel() {
+        lock.withLock {
+            cancelCallCount += 1
+        }
+    }
+
+    override func connect() async throws -> Connection {
+        throw TestIrohError(
+            message: "outgoing connection cancelled"
+        )
+    }
+}
+
+// UniFFI requires unchecked sendability; the fake endpoint stores one immutable
+// attempt and performs no other mutable work.
+private final class AttemptOnlyEndpoint: Endpoint, @unchecked Sendable {
+    private let testAttempt: ConnectAttempt?
+
+    required init(unsafeFromHandle handle: UInt64) {
+        testAttempt = nil
+        super.init(unsafeFromHandle: handle)
+    }
+
+    init(attempt: ConnectAttempt) {
+        testAttempt = attempt
+        super.init(noHandle: NoHandle())
+    }
+
+    override func beginConnect(
+        addr _: EndpointAddr,
+        alpn _: Data
+    ) throws -> ConnectAttempt {
+        guard let testAttempt else {
+            throw TestIrohError(message: "missing test attempt")
+        }
+        return testAttempt
+    }
+
+    override func connect(
+        addr _: EndpointAddr,
+        alpn _: Data
+    ) async throws -> Connection {
+        throw TestIrohError(
+            message: "plain Endpoint.connect must not be used; dial must go through beginConnect"
+        )
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/ParkingRelayClock.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/ParkingRelayClock.swift
@@ -1,0 +1,10 @@
+import Foundation
+@testable import CmuxIrohTransport
+
+/// A retry clock whose sleep parks (cancellation-aware) for an hour, so the
+/// retired-dial dead-man bound can never fire inside a test. Any progress a
+/// test observes therefore proves dials settled via cancellation, not the bound.
+struct ParkingRelayClock: CmxIrohRelayClock {
+    func now() -> Date { Date(timeIntervalSince1970: 1_800_000_000) }
+    func sleep(until _: Date) async throws { try await Task.sleep(for: .seconds(3_600)) }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestCancellableDialEndpoint.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestCancellableDialEndpoint.swift
@@ -1,0 +1,93 @@
+import CMUXMobileCore
+import Foundation
+@testable import CmuxIrohTransport
+
+/// Test endpoint whose parked dials settle immediately when their task is cancelled.
+actor TestCancellableDialEndpoint: CmxIrohEndpoint {
+    private let localIdentity: CmxIrohPeerIdentity
+    private var dialCount = 0
+    private var deliveredConnectionCount = 0
+    private var pendingDialOrder: [UUID] = []
+    private var pendingDials: [
+        UUID: CheckedContinuation<any CmxIrohConnection, any Error>
+    ] = [:]
+
+    init(localIdentity: CmxIrohPeerIdentity) {
+        self.localIdentity = localIdentity
+    }
+
+    func identity() -> CmxIrohPeerIdentity {
+        localIdentity
+    }
+
+    func address() -> CmxIrohEndpointAddress {
+        CmxIrohEndpointAddress(identity: localIdentity, pathHints: [])
+    }
+
+    func connect(
+        to _: CmxIrohEndpointAddress,
+        alpn _: Data
+    ) async throws -> any CmxIrohConnection {
+        dialCount += 1
+        let dialID = UUID()
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                pendingDialOrder.append(dialID)
+                pendingDials[dialID] = continuation
+            }
+        }, onCancel: {
+            Task { await self.cancelDial(dialID) }
+        })
+    }
+
+    func accept() async throws -> (any CmxIrohConnection)? {
+        nil
+    }
+
+    func replaceRelays(_: [CmxIrohRelayConfiguration]) {}
+
+    func healthEvents() -> AsyncStream<CmxIrohEndpointHealthEvent> {
+        AsyncStream { $0.finish() }
+    }
+
+    func isHealthy() -> Bool { true }
+
+    func close() {
+        let pending = Array(pendingDials.values)
+        pendingDials.removeAll()
+        pendingDialOrder.removeAll()
+        for continuation in pending {
+            continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    func releaseNextDial(with connection: any CmxIrohConnection) {
+        guard !pendingDialOrder.isEmpty else { return }
+        let dialID = pendingDialOrder.removeFirst()
+        guard let continuation = pendingDials.removeValue(forKey: dialID) else {
+            return
+        }
+        deliveredConnectionCount += 1
+        continuation.resume(returning: connection)
+    }
+
+    func observedDialCount() -> Int {
+        dialCount
+    }
+
+    func observedDeliveredConnectionCount() -> Int {
+        deliveredConnectionCount
+    }
+
+    private func cancelDial(_ dialID: UUID) {
+        guard let continuation = pendingDials.removeValue(forKey: dialID) else {
+            return
+        }
+        pendingDialOrder.removeAll { $0 == dialID }
+        continuation.resume(throwing: CancellationError())
+    }
+}


### PR DESCRIPTION
Slice A1 of the cancellable-dials design (cmuxterm-hq `out/iroh-fork-program/DESIGN-A-cancellable-dials.md`, approved 2026-07-24). Follow-up to the wake-hardening drain set in https://github.com/manaflow-ai/cmux/pull/8840.

`CmxIrohLibEndpoint` now dials through the pinned iroh-ffi v1.0.2-cmux.4 `Endpoint.beginConnect(addr:alpn:)` and awaits `ConnectAttempt.connect()` inside `withTaskCancellationHandler`, with `onCancel` running the attempt's synchronous idempotent `cancel()`. Swift task cancellation crosses the FFI boundary at cmux's own seam: the fork's biased `select!` fails a cancelled dial immediately, and a cancel racing completion drops the completed connection, so the app-level admission handshake can never run for a cancelled attempt (no ghost admissions, no supersede-kills). The pool's retire path (`pending.task.cancel()` from PR 8840) therefore settles retired dials in milliseconds; the drain set and its 10s dead-man bound are kept exactly as-is and become a never-hit safety net. `IrohError` classification gains the fork's fixed cancelled marker (`outgoing connection cancelled`, `CONNECT_CANCELLED_MESSAGE` in iroh-ffi `src/endpoint.rs`) so a cancelled dial that surfaces the raw error classifies `.cancelled` instead of `.unknown`.

Two-commit red/green: the first commit's tests fail on `main` (the marker classified `.unknown`; the dial did not go through a cancellable attempt seam), the second commit turns them green.

Tests: `swift test --package-path Packages/Shared/CmuxIrohTransport` 473/473 green (3 consecutive full runs; new suites stress-run 20x isolated), `swift test --package-path Packages/Shared/CMUXMobileCore` 292/292 green. New coverage: task cancellation invokes `ConnectAttempt.cancel()` across the seam and surfaces `CancellationError`; the cancelled marker classifies `.cancelled` with and without Swift task cancellation; a retired dial settles via cancellation while a parking clock proves the 10s dead-man never fires; a burst of cancelled dials plus one live dial yields exactly one delivered connection with zero closes against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787516533&installation_model_id=21920&pr_number=8878&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8878&signature=d04126fe9b5c01bb51c96cb5aba736a10b8ea9e02cd56f60216c796a063667bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Iroh client dials cancellable so cancelling the Swift task aborts the in‑flight FFI attempt and prevents ghost admissions. Cancelled dials now classify as `.cancelled`, and retired dials settle in milliseconds; the 10s dead‑man remains a safety net.

- **Bug Fixes**
  - Dial via `Endpoint.beginConnect` + `ConnectAttempt.connect()` wrapped in `withTaskCancellationHandler`; `onCancel` calls `attempt.cancel()`.
  - Pool retire uses `pending.task.cancel()` to settle quickly; prevents cancelled/overlapping dials from reaching admission; dead‑man bound unchanged.
  - Map `IrohError` message "outgoing connection cancelled" to `.cancelled`.

- **Dependencies**
  - Uses forked `iroh-ffi` `v1.0.2-cmux.4` with cancellable `ConnectAttempt`.

<sup>Written for commit 6f0f9e5eb87a80cbc03b6f7c5bfdbbb1eeffcc96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Connection attempts now stop promptly when cancelled.
  - Cancelled connection attempts are consistently reported as cancelled diagnostics.
  - Retired connection attempts settle through cancellation instead of waiting for timeout safeguards.

- **Tests**
  - Added coverage for endpoint and session-pool cancellation scenarios.
  - Added deterministic test support for validating cancellation behavior and successful session recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->