### PR TITLE
fix: do not persist or restore host-local TTY names in session snapshots

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1679,6 +1679,8 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var notifications: [SessionNotificationSnapshot]? = nil
     var gitBranch: SessionGitBranchSnapshot?
     var listeningPorts: [Int]
+    /// Retained only for identity-bound persistent remote PTYs. Host-local TTY
+    /// names are runtime allocations and must never cross a cmux relaunch.
     var ttyName: String?
     var terminal: SessionTerminalPanelSnapshot?
     var browser: SessionBrowserPanelSnapshot?

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -433,7 +433,11 @@ extension Workspace {
         } else {
             listeningPorts = (surfaceListeningPorts[panelId] ?? []).sorted()
         }
-        let ttyName = surfaceTTYNames[panelId]
+        let persistentRemotePTYSessionID = remotePTYSessionIDForSnapshot(panelId: panelId)
+        let persistsRemoteTTYIdentity =
+            persistentRemotePTYSessionID != nil &&
+            !isDefaultFreestyleSSHDRemoteWorkspace
+        let ttyName = persistsRemoteTTYIdentity ? surfaceTTYNames[panelId] : nil
         let terminalSnapshot: SessionTerminalPanelSnapshot?
         let browserSnapshot: SessionBrowserPanelSnapshot?
         let markdownSnapshot: SessionMarkdownPanelSnapshot?
@@ -546,7 +550,7 @@ extension Workspace {
                 resumeBinding: resumeBinding,
                 textBoxDraft: terminalPanel.sessionTextBoxDraftSnapshot(),
                 isRemoteTerminal: activeRemoteTerminalSurfaceIds.contains(panelId),
-                remotePTYSessionID: remotePTYSessionIDForSnapshot(panelId: panelId),
+                remotePTYSessionID: persistentRemotePTYSessionID,
                 wasAgentRunning: agentWasRunning
             )
             browserSnapshot = nil
@@ -1653,7 +1657,11 @@ extension Workspace {
                 restoredResumeSessionWorkingDirectoriesByPanelId.removeValue(forKey: terminalPanel.id)
             }
             terminalPanel.restoreSessionTextBoxDraft(snapshot.terminal?.textBoxDraft)
-            applySessionPanelMetadata(snapshot, toPanelId: terminalPanel.id)
+            applySessionPanelMetadata(
+                snapshot,
+                toPanelId: terminalPanel.id,
+                restoredPersistentRemotePTYSessionID: restoredRemotePTYSessionID
+            )
             return terminalPanel.id
         case .browser:
             guard let browserPanel = newBrowserSurface(
@@ -1738,7 +1746,11 @@ extension Workspace {
         }
     }
 
-    func applySessionPanelMetadata(_ snapshot: SessionPanelSnapshot, toPanelId panelId: UUID) {
+    func applySessionPanelMetadata(
+        _ snapshot: SessionPanelSnapshot,
+        toPanelId panelId: UUID,
+        restoredPersistentRemotePTYSessionID: String? = nil
+    ) {
         adoptPersistedStableSurfaceId(from: snapshot, panelId: panelId)
 
         if let title = snapshot.title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
@@ -1802,12 +1814,15 @@ extension Workspace {
 
         surfaceListeningPorts[panelId] = Array(Set(snapshot.listeningPorts)).sorted()
 
-        if let ttyName = snapshot.ttyName?.trimmingCharacters(in: .whitespacesAndNewlines), !ttyName.isEmpty {
+        // A persistent remote PTY has a durable session identity and remains
+        // alive across cmux restarts. Local PTY names are ephemeral OS
+        // allocations, so legacy local snapshot values are deliberately ignored.
+        if normalizedRemotePTYSessionID(restoredPersistentRemotePTYSessionID) != nil,
+           let ttyName = snapshot.ttyName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !ttyName.isEmpty {
             surfaceTTYNames[panelId] = ttyName
-        } else {
-            surfaceTTYNames.removeValue(forKey: panelId)
+            syncRemotePortScanTTYs()
         }
-        syncRemotePortScanTTYs()
 
         if let browserSnapshot = snapshot.browser,
            let browserPanel = browserPanel(for: panelId) {

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -670,3 +670,261 @@ import Testing
         return directory.appendingPathComponent(executableName, isDirectory: false).path
     }
 }
+
+@Suite("Session persistence TTY metadata", .serialized)
+struct SessionPersistenceTTYMetadataTests {
+    @MainActor
+    @Test("local TTY names are neither persisted nor restored")
+    func localTTYNamesAreNeitherPersistedNorRestored() throws {
+        let source = Workspace()
+        let firstSourcePanelId = try #require(source.focusedPanelId)
+        let secondSourcePanel = try #require(
+            source.newTerminalSplit(from: firstSourcePanelId, orientation: .horizontal, focus: true)
+        )
+        let sourcePanelIds = [firstSourcePanelId, secondSourcePanel.id]
+        for panelId in sourcePanelIds {
+            source.surfaceTTYNames[panelId] = "ttys025"
+        }
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        let encodedSnapshot = try JSONEncoder().encode(snapshot)
+        var legacyObject = try #require(
+            JSONSerialization.jsonObject(with: encodedSnapshot) as? [String: Any]
+        )
+        var panels = try #require(legacyObject["panels"] as? [[String: Any]])
+        #expect(panels.count == 2)
+        #expect(panels.allSatisfy { $0["ttyName"] == nil })
+
+        // Simulate the installed schema, in which two restored surfaces can
+        // carry the same stale local PTY allocation.
+        for index in panels.indices {
+            panels[index]["ttyName"] = "ttys025"
+        }
+        legacyObject["panels"] = panels
+        let legacyData = try JSONSerialization.data(withJSONObject: legacyObject)
+        let legacySnapshot = try JSONDecoder().decode(SessionWorkspaceSnapshot.self, from: legacyData)
+
+        let restored = Workspace()
+        let restoredPanelIds = restored.restoreSessionSnapshot(legacySnapshot)
+        let firstRestoredPanelId = try #require(restoredPanelIds[firstSourcePanelId])
+        let secondRestoredPanelId = try #require(restoredPanelIds[secondSourcePanel.id])
+        #expect(restored.surfaceTTYNames[firstRestoredPanelId] == nil)
+        #expect(restored.surfaceTTYNames[secondRestoredPanelId] == nil)
+        #expect(restored.surfaceTTYDevices[firstRestoredPanelId] == nil)
+        #expect(restored.surfaceTTYDevices[secondRestoredPanelId] == nil)
+
+        // A subsequent live runtime report still establishes exactly one
+        // current owner and refreshes the device-id index used for live lookup.
+        restored.surfaceTTYNames[firstRestoredPanelId] = "/dev/null"
+        #expect(restored.surfaceTTYNames[firstRestoredPanelId] == "/dev/null")
+        #expect(restored.surfaceTTYNames[secondRestoredPanelId] == nil)
+        #expect(restored.surfaceTTYDevices[firstRestoredPanelId] != nil)
+        #expect(restored.surfaceTTYDevices[secondRestoredPanelId] == nil)
+    }
+
+    @MainActor
+    @Test("legacy remote TTY metadata without a reattach identity is ignored")
+    func legacyRemoteTTYWithoutReattachIdentityIsIgnored() throws {
+        let source = Workspace()
+        source.configureRemoteConnection(
+            WorkspaceRemoteConfiguration(
+                destination: "dev@example.com",
+                port: 2222,
+                identityFile: nil,
+                sshOptions: [],
+                localProxyPort: nil,
+                relayPort: 64009,
+                relayID: "relay-session-tty-legacy-test",
+                relayToken: String(repeating: "b", count: 64),
+                localSocketPath: "/tmp/cmux-session-tty-legacy-test.sock",
+                terminalStartupCommand: SSHPTYAttachStartupCommandBuilder.command(),
+                preserveAfterTerminalExit: true,
+                persistentDaemonSlot: "session-tty-legacy-test"
+            ),
+            autoConnect: false
+        )
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.surfaceTTYNames[sourcePanelId] = "pts/legacy-stale"
+
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == sourcePanelId })
+        let originalSessionID = try #require(snapshot.panels[panelIndex].terminal?.remotePTYSessionID)
+        #expect(snapshot.panels[panelIndex].ttyName == "pts/legacy-stale")
+
+        // Simulate a legacy remote snapshot that carries a TTY allocation but
+        // no durable identity that cmux can prove it is reattaching.
+        var terminalSnapshot = try #require(snapshot.panels[panelIndex].terminal)
+        terminalSnapshot.isRemoteTerminal = nil
+        terminalSnapshot.remotePTYSessionID = nil
+        snapshot.panels[panelIndex].terminal = terminalSnapshot
+
+        let reservedSocketPath = Self.reserveRemoteRestoreSocket()
+        defer { Self.cleanupRemoteRestoreSocket(reservedSocketPath) }
+
+        let restored = Workspace()
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+
+        // The fresh remote surface receives a new runtime identity, but that
+        // post-spawn identity must not authorize the legacy TTY value.
+        let freshSessionID = try #require(restored.remotePTYSessionIDsByPanelId[restoredPanelId])
+        #expect(freshSessionID != originalSessionID)
+        #expect(restored.surfaceTTYNames[restoredPanelId] == nil)
+    }
+
+    @MainActor
+    @Test("non-persistent remote TTY names are neither persisted nor restored")
+    func nonPersistentRemoteTTYNamesAreNeitherPersistedNorRestored() throws {
+        let source = Workspace()
+        source.configureRemoteConnection(
+            WorkspaceRemoteConfiguration(
+                destination: "dev@example.com",
+                port: 2222,
+                identityFile: nil,
+                sshOptions: [],
+                localProxyPort: nil,
+                relayPort: nil,
+                relayID: nil,
+                relayToken: nil,
+                localSocketPath: nil,
+                terminalStartupCommand: "ssh -p 2222 dev@example.com",
+                preserveAfterTerminalExit: false
+            ),
+            autoConnect: false
+        )
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.surfaceTTYNames[sourcePanelId] = "pts/ephemeral"
+
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == sourcePanelId })
+        #expect(snapshot.panels[panelIndex].ttyName == nil)
+        #expect(snapshot.panels[panelIndex].terminal?.remotePTYSessionID == nil)
+
+        // Existing releases may have persisted a remote shell's host-local PTY
+        // even though there is no durable session to reattach after relaunch.
+        snapshot.panels[panelIndex].ttyName = "pts/legacy-ephemeral"
+
+        let restored = Workspace()
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+        #expect(restored.remoteConfiguration?.preserveAfterTerminalExit == false)
+        #expect(restored.remotePTYSessionIDsByPanelId[restoredPanelId] == nil)
+        #expect(restored.surfaceTTYNames[restoredPanelId] == nil)
+        #expect(restored.surfaceTTYDevices[restoredPanelId] == nil)
+    }
+
+    @MainActor
+    @Test("managed Cloud VM TTY names are neither persisted nor restored")
+    func managedCloudVMTTYNamesAreNeitherPersistedNorRestored() throws {
+        let source = Workspace()
+        source.configureRemoteConnection(
+            WorkspaceRemoteConfiguration(
+                transport: .websocket,
+                destination: "cloud-vm",
+                port: nil,
+                identityFile: nil,
+                sshOptions: [],
+                localProxyPort: nil,
+                relayPort: nil,
+                relayID: nil,
+                relayToken: nil,
+                localSocketPath: "/tmp/cmux-cloud-tty-test.sock",
+                managedCloudVMID: "vm-tty-test",
+                terminalStartupCommand: "stale websocket connect command",
+                preserveAfterTerminalExit: true,
+                persistentDaemonSlot: "cmux-default-freestyle-sshd-v1",
+                skipDaemonBootstrap: true
+            ),
+            autoConnect: false
+        )
+        #expect(source.isDefaultFreestyleSSHDRemoteWorkspace)
+        let sourcePanelId = try #require(source.focusedPanelId)
+        source.surfaceTTYNames[sourcePanelId] = "ttys025"
+
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        let panelIndex = try #require(snapshot.panels.firstIndex { $0.id == sourcePanelId })
+        #expect(snapshot.panels[panelIndex].ttyName == nil)
+
+        // Existing releases may already have serialized this host-local value.
+        snapshot.panels[panelIndex].ttyName = "ttys025"
+
+        let restored = Workspace()
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+        #expect(restored.isDefaultFreestyleSSHDRemoteWorkspace)
+        #expect(restored.remotePTYSessionIDsByPanelId[restoredPanelId] != nil)
+        #expect(restored.surfaceTTYNames[restoredPanelId] == nil)
+    }
+
+    @MainActor
+    @Test("persistent remote TTY names retain their per-surface identity")
+    func persistentRemoteTTYNamesRetainTheirPerSurfaceIdentity() throws {
+        let source = Workspace()
+        source.configureRemoteConnection(
+            WorkspaceRemoteConfiguration(
+                destination: "dev@example.com",
+                port: 2222,
+                identityFile: nil,
+                sshOptions: [],
+                localProxyPort: nil,
+                relayPort: 64008,
+                relayID: "relay-session-tty-test",
+                relayToken: String(repeating: "a", count: 64),
+                localSocketPath: "/tmp/cmux-session-tty-test.sock",
+                terminalStartupCommand: SSHPTYAttachStartupCommandBuilder.command(),
+                preserveAfterTerminalExit: true,
+                persistentDaemonSlot: "session-tty-test"
+            ),
+            autoConnect: false
+        )
+        let firstSourcePanelId = try #require(source.focusedPanelId)
+        let secondSourcePanel = try #require(
+            source.newTerminalSplit(from: firstSourcePanelId, orientation: .horizontal, focus: true)
+        )
+        let expectedTTYByPanelId = [
+            firstSourcePanelId: "pts/10",
+            secondSourcePanel.id: "pts/11",
+        ]
+        for (panelId, ttyName) in expectedTTYByPanelId {
+            source.surfaceTTYNames[panelId] = ttyName
+        }
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        for (panelId, expectedTTY) in expectedTTYByPanelId {
+            let panelSnapshot = try #require(snapshot.panels.first { $0.id == panelId })
+            #expect(panelSnapshot.ttyName == expectedTTY)
+            #expect(panelSnapshot.terminal?.remotePTYSessionID != nil)
+        }
+
+        let reservedSocketPath = Self.reserveRemoteRestoreSocket()
+        defer { Self.cleanupRemoteRestoreSocket(reservedSocketPath) }
+
+        let restored = Workspace()
+        let restoredPanelIds = restored.restoreSessionSnapshot(snapshot)
+        #expect(restored.remoteConfiguration?.preserveAfterTerminalExit == true)
+        #expect(restored.remoteConfiguration?.localSocketPath == reservedSocketPath)
+        #expect(restored.remoteConfiguration?.persistentDaemonSlot == "session-tty-test")
+        for (sourcePanelId, expectedTTY) in expectedTTYByPanelId {
+            let restoredPanelId = try #require(restoredPanelIds[sourcePanelId])
+            let expectedSessionID = try #require(
+                snapshot.panels.first { $0.id == sourcePanelId }?.terminal?.remotePTYSessionID
+            )
+            #expect(restored.remotePTYSessionIDsByPanelId[restoredPanelId] == expectedSessionID)
+            #expect(restored.surfaceTTYNames[restoredPanelId] == expectedTTY)
+        }
+    }
+
+    @MainActor
+    private static func reserveRemoteRestoreSocket() -> String {
+        TerminalController.shared.stop()
+        let requestedPath = "/tmp/cmux-tty-restore-\(UUID().uuidString).sock"
+        return TerminalController.shared.reserveStartupSocketPath(requestedPath)
+    }
+
+    @MainActor
+    private static func cleanupRemoteRestoreSocket(_ path: String) {
+        TerminalController.shared.stop()
+        try? FileManager.default.removeItem(atPath: path)
+        try? FileManager.default.removeItem(atPath: path + ".lock")
+    }
+}


### PR DESCRIPTION
## Summary

- What changed? Session persistence no longer writes or restores **host-local** TTY names.
  `SessionPanelSnapshot.ttyName` is persisted only when the panel has a durable remote PTY
  session id, and `applySessionPanelMetadata` restores `surfaceTTYNames` only for those
  normalized remote PTY sessions. Host-local names are left for the live shell integration
  (`surface.report_tty`) to re-report.
- Why? macOS recycles PTY device names across app relaunches. A restored surface that carries
  its old host-local `ttyName` (while its process is gone) can alias the same tty as a live
  surface that legitimately received the recycled name. `system.tree` then reports two surfaces
  claiming one tty, which breaks external consumers that use the tty as a physical-identity key
  (observed live with a wake-supervision tool: a dead restored surface and a live surface both
  claimed `ttys002`, wedging fail-closed automation until the stale claim was manually cleared).
  Remote PTY identities are stable across relaunches, so they remain persisted.

## Testing

- Two-commit structure per the regression-test policy: commit 1 adds
  `SessionPersistenceResumeBindingTests` covering the unsafe restoration (red), commit 2 lands
  the fix (green).
- Verified the new suite passes locally on the branch base where the cmuxTests target compiles.
  Note for maintainers: on current `main`, the cmuxTests target does not compile with a stock
  Xcode toolchain here — `@_implementationOnly import XCTest` in
  `cmuxTests/KimiResumeReviewRegressionTests.swift:3` cascades type-inference errors into
  unrelated test files (e.g. `SidebarWorkspaceRowRetirementTests.swift:12`). Happy to file
  separately if useful; relying on CI for the full-suite run of this PR.
- Manually verified the defect class on the installed app: a dead surface retains its stale tty
  claim in `cmux rpc system.tree` after relaunch; with this change, host-local tty names are no
  longer persisted/restored, so restored surfaces come back without a stale claim.

## Demo Video

- N/A (no UI change; behavior is observable via `cmux rpc system.tree` before/after relaunch).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787520861&installation_model_id=21920&pr_number=8882&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8882&signature=386886fe5149791914503c9ef3dd0adf12d7bd92090fd57b0d54059d223f3dbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop persisting and restoring host-local TTY names in session snapshots to avoid stale or conflicting TTY claims after relaunch. `ttyName` is now persisted only for panels with a durable remote PTY session.

- **Bug Fixes**
  - Persist `SessionPanelSnapshot.ttyName` only when a normalized remote PTY session exists and the workspace is not the default freestyle SSHD.
  - On restore, apply `ttyName` only if reattaching to a persistent remote PTY; ignore legacy local/ephemeral values.
  - Added `SessionPersistenceTTYMetadataTests` to cover local TTYs, legacy remote without identity, non-persistent remote, managed Cloud VM, and persistent remote cases.

<sup>Written for commit 19016e96de245433c0e3143e68cff4a1b542e41f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration to prevent stale or invalid local TTY names from being reused after relaunch.
  * Preserved TTY identity only for eligible persistent remote terminal sessions.
  * Added safeguards for legacy and non-persistent remote session metadata.
* **Tests**
  * Added coverage for local, legacy remote, managed cloud, non-persistent, and persistent remote TTY restoration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->