### PR TITLE
Preserve restored agent resume bindings

### DIFF
--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -133,10 +133,13 @@ extension DockSplitStore {
             terminalSnapshot.resumeBinding,
             restorableAgent: restorableAgent
         )
-        let agentWasRunning = terminalSnapshot.wasAgentRunning ?? true
-        let shouldAutoResumeAgent = AgentSessionAutoResumeSettings.isEnabled(
-            defaults: agentSessionAutoResumeDefaults
-        ) && agentWasRunning
+        let shouldAutoResumeAgent = Workspace.shouldAutoResumeRestoredAgent(
+            autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(
+                defaults: agentSessionAutoResumeDefaults
+            ),
+            wasAgentRunning: terminalSnapshot.wasAgentRunning,
+            resumeBinding: resumeBinding
+        )
         let resumeBindingForStartup = hibernation != nil ||
             (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true)
             ? nil

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -133,9 +133,13 @@ extension DockSplitStore {
                 : nil
             let resumeStartupInput = policy.surfaceResumeStartupInput(
                 resumeBinding,
-                autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(
-                    defaults: agentSessionAutoResumeDefaults
-                ) && (agentWasRunning ?? true),
+                autoResumeAgentSessions: Workspace.shouldAutoResumeRestoredAgent(
+                    autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(
+                        defaults: agentSessionAutoResumeDefaults
+                    ),
+                    wasAgentRunning: agentWasRunning,
+                    resumeBinding: resumeBinding
+                ),
                 promptForApproval: false,
                 approvalStoreURL: SurfaceResumeApprovalStore.defaultURL()
             )

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -351,6 +351,19 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         autoResume == true
     }
 
+    var hasAutoRestorableAgentCheckpointIdentity: Bool {
+        guard isAgentHookBinding,
+              allowsAutomaticResume,
+              let checkpointId = checkpointId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !checkpointId.isEmpty,
+              let kind = kind?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !kind.isEmpty,
+              RestorableAgentKind(rawValue: kind) != nil else {
+            return false
+        }
+        return true
+    }
+
     func shouldYieldToDetectedSurfaceResumeBinding(_ detectedBinding: SurfaceResumeBindingSnapshot) -> Bool {
         detectedBinding.isProcessDetected && (isProcessDetected || isAgentHookBinding)
     }

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -95,9 +95,6 @@ extension Workspace {
              (.promptIdle, .some(.observedAgentCommandRunning)):
             restoredAgentResumeStatesByPanelId.removeValue(forKey: panelId)
             restoredResumeSessionWorkingDirectoriesByPanelId.removeValue(forKey: panelId)
-            if surfaceResumeBindingsByPanelId[panelId]?.isAgentHookBinding == true {
-                surfaceResumeBindingsByPanelId.removeValue(forKey: panelId)
-            }
         default:
             break
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -497,7 +497,13 @@ extension Workspace {
             }()
             let resumeStartupInput = sessionRestorePolicy.surfaceResumeStartupInput(
                 resumeBinding,
-                autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(defaults: agentSessionAutoResumeDefaults) && (agentWasRunning ?? true),
+                autoResumeAgentSessions: Self.shouldAutoResumeRestoredAgent(
+                    autoResumeAgentSessions: AgentSessionAutoResumeSettings.isEnabled(
+                        defaults: agentSessionAutoResumeDefaults
+                    ),
+                    wasAgentRunning: agentWasRunning,
+                    resumeBinding: resumeBinding
+                ),
                 promptForApproval: false,
                 approvalStoreURL: SurfaceResumeApprovalStore.defaultURL()
             )
@@ -977,6 +983,18 @@ extension Workspace {
         return restorableAgent
     }
 
+    nonisolated static func shouldAutoResumeRestoredAgent(
+        autoResumeAgentSessions: Bool,
+        wasAgentRunning: Bool?,
+        resumeBinding: SurfaceResumeBindingSnapshot?
+    ) -> Bool {
+        guard autoResumeAgentSessions else { return false }
+        if wasAgentRunning ?? true {
+            return true
+        }
+        return resumeBinding?.hasAutoRestorableAgentCheckpointIdentity == true
+    }
+
     nonisolated private static func normalizedResumeBindingValue(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
@@ -1247,10 +1265,6 @@ extension Workspace {
             )
             let restoredHibernation = restorableAgent != nil ? snapshot.terminal?.hibernation : nil
             let autoResumeAgentSessions = AgentSessionAutoResumeSettings.isEnabled(defaults: agentSessionAutoResumeDefaults)
-            // Only auto-resume if the agent was actively running when the snapshot was saved.
-            // wasAgentRunning == nil means a legacy snapshot; treat as true for backwards compatibility.
-            let agentWasRunningAtQuit = snapshot.terminal?.wasAgentRunning ?? true
-            let shouldAutoResumeAgent = autoResumeAgentSessions && agentWasRunningAtQuit
             let remoteStartupCommand = remoteTerminalStartupCommand()
             let restoresRemoteWorkspaceTerminalSnapshot =
                 remoteStartupCommand != nil &&
@@ -1284,6 +1298,11 @@ extension Workspace {
             let resumeBinding = Self.resumeBindingForSessionRestore(
                 locatedResumeBinding,
                 restorableAgent: restorableAgent
+            )
+            let shouldAutoResumeAgent = Self.shouldAutoResumeRestoredAgent(
+                autoResumeAgentSessions: autoResumeAgentSessions,
+                wasAgentRunning: snapshot.terminal?.wasAgentRunning,
+                resumeBinding: resumeBinding
             )
             let resumeBindingForStartup =
                 restoredHibernation != nil ||

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -345,7 +345,7 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
     }
 
     @MainActor
-    func testAgentHookBindingExitedBeforeSnapshotDoesNotAutoResumeEvenWhenTrusted() throws {
+    func testTrustedAgentHookBindingAutoResumesEvenWhenSnapshotRecordedExitedAgent() throws {
         try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
             let defaults = UserDefaults.standard
             defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
@@ -386,14 +386,70 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
 
             XCTAssertFalse(input.hasInitialInput)
             XCTAssertEqual(input.byteCount, 0)
-            XCTAssertNil(restoredPanel.surface.debugInitialCommand())
+            try assertAgentAutoResumeUsesStartupCommand(
+                restoredPanel,
+                scriptContains: ["codex resume codex-exited-binding-session"]
+            )
             XCTAssertEqual(
-                restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.agent?.sessionId,
-                "codex-exited-binding-session"
+                restored.restoredAgentResumeStatesByPanelId[restoredPanelId],
+                .autoResumeCommandRunning
             )
             XCTAssertEqual(
                 restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.resumeBinding?.source,
                 "agent-hook"
+            )
+        }
+    }
+
+    @MainActor
+    func testTrustedAgentHookBindingAutoResumesWhenSnapshotRunningStateIsUnknown() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) // autoResumeAgentSessions = true (default)
+
+            let source = Workspace()
+            let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+            let sourceIndex = try makeRestorableAgentIndex(
+                workspaceId: source.id,
+                panelId: sourcePanelId,
+                sessionId: "6c88315a-888e-438a-821e-5a9ff58a23e6"
+            )
+            let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+                SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
+                    name: "Claude",
+                    kind: "claude",
+                    command: "claude --resume 6c88315a-888e-438a-821e-5a9ff58a23e6",
+                    cwd: "/tmp/repo",
+                    checkpointId: "6c88315a-888e-438a-821e-5a9ff58a23e6",
+                    source: "agent-hook",
+                    autoResume: true,
+                    updatedAt: 1_777_777_777
+                ),
+            ])
+            source.updatePanelShellActivityState(panelId: sourcePanelId, state: .unknown)
+            let snapshot = source.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: sourceIndex,
+                surfaceResumeBindingIndex: bindingIndex
+            )
+
+            XCTAssertNil(snapshot.panels.first?.terminal?.wasAgentRunning)
+
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+            let input = restoredPanel.surface.debugInitialInputMetadata()
+
+            XCTAssertFalse(input.hasInitialInput)
+            XCTAssertEqual(input.byteCount, 0)
+            try assertAgentAutoResumeUsesStartupCommand(
+                restoredPanel,
+                scriptContains: ["claude --resume 6c88315a-888e-438a-821e-5a9ff58a23e6"]
+            )
+            XCTAssertEqual(
+                restored.restoredAgentResumeStatesByPanelId[restoredPanelId],
+                .autoResumeCommandRunning
             )
         }
     }

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -357,23 +357,21 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 panelId: sourcePanelId,
                 sessionId: "codex-exited-binding-session"
             )
-            let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
-                SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
-                    name: "Codex",
-                    kind: "codex",
-                    command: "codex resume codex-exited-binding-session",
-                    cwd: "/tmp/repo",
-                    checkpointId: "codex-exited-binding-session",
-                    source: "agent-hook",
-                    autoResume: true,
-                    updatedAt: 1_777_777_777
-                ),
-            ])
+            let binding = SurfaceResumeBindingSnapshot(
+                name: "Codex",
+                kind: "codex",
+                command: "codex resume codex-exited-binding-session",
+                cwd: "/tmp/repo",
+                checkpointId: "codex-exited-binding-session",
+                source: "agent-hook",
+                autoResume: true,
+                updatedAt: 1_777_777_777
+            )
+            XCTAssertTrue(source.setSurfaceResumeBinding(binding, panelId: sourcePanelId))
             source.updatePanelShellActivityState(panelId: sourcePanelId, state: .promptIdle)
             let snapshot = source.sessionSnapshot(
                 includeScrollback: false,
-                restorableAgentIndex: sourceIndex,
-                surfaceResumeBindingIndex: bindingIndex
+                restorableAgentIndex: sourceIndex
             )
 
             XCTAssertEqual(snapshot.panels.first?.terminal?.wasAgentRunning, false)
@@ -414,23 +412,21 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 panelId: sourcePanelId,
                 sessionId: "6c88315a-888e-438a-821e-5a9ff58a23e6"
             )
-            let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
-                SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: sourcePanelId): SurfaceResumeBindingSnapshot(
-                    name: "Claude",
-                    kind: "claude",
-                    command: "claude --resume 6c88315a-888e-438a-821e-5a9ff58a23e6",
-                    cwd: "/tmp/repo",
-                    checkpointId: "6c88315a-888e-438a-821e-5a9ff58a23e6",
-                    source: "agent-hook",
-                    autoResume: true,
-                    updatedAt: 1_777_777_777
-                ),
-            ])
+            let binding = SurfaceResumeBindingSnapshot(
+                name: "Claude",
+                kind: "claude",
+                command: "claude --resume 6c88315a-888e-438a-821e-5a9ff58a23e6",
+                cwd: "/tmp/repo",
+                checkpointId: "6c88315a-888e-438a-821e-5a9ff58a23e6",
+                source: "agent-hook",
+                autoResume: true,
+                updatedAt: 1_777_777_777
+            )
+            XCTAssertTrue(source.setSurfaceResumeBinding(binding, panelId: sourcePanelId))
             source.updatePanelShellActivityState(panelId: sourcePanelId, state: .unknown)
             let snapshot = source.sessionSnapshot(
                 includeScrollback: false,
-                restorableAgentIndex: sourceIndex,
-                surfaceResumeBindingIndex: bindingIndex
+                restorableAgentIndex: sourceIndex
             )
 
             XCTAssertNil(snapshot.panels.first?.terminal?.wasAgentRunning)

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -375,6 +375,16 @@ struct AgentSessionAutoResumeSwiftTests {
             restored.updatePanelShellActivityState(panelId: restoredPanelId, state: .promptIdle)
             try #require(restored.restoredAgentResumeStatesByPanelId[restoredPanelId] == nil)
             #expect(restored.restoredResumeSessionWorkingDirectoriesByPanelId[restoredPanelId] == nil)
+            #expect(
+                restored.sessionSnapshot(includeScrollback: false)
+                    .panels.first?.terminal?.resumeBinding?.source == "agent-hook"
+            )
+            let prunedSnapshot = restored.sessionSnapshot(
+                includeScrollback: false,
+                restorableAgentIndex: .empty,
+                surfaceResumeBindingIndex: .empty
+            )
+            #expect(prunedSnapshot.panels.first?.terminal?.resumeBinding == nil)
             #expect(restored.sessionSnapshot(includeScrollback: false).panels.first?.terminal?.resumeBinding == nil)
             restored.updatePanelDirectory(panelId: restoredPanelId, directory: repairedDir)
 

--- a/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
+++ b/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
@@ -79,4 +79,74 @@ struct WorkspaceIsStaleAgentHookBindingTests {
         #expect(snapshot.panels.first?.terminal?.resumeBinding == nil)
         #expect(workspace.surfaceResumeBinding(panelId: panelId) == nil)
     }
+
+    @Test
+    func localAgentHookBindingLivenessRequiresSameSurfaceAndCheckpoint() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = Self.agentHookBinding(autoResume: true)
+
+        let matchingIndex = try Self.indexWithDetectedSession(
+            workspaceId: workspace.id,
+            panelId: panelId,
+            sessionId: "session-1"
+        )
+        #expect(workspace.isStaleAgentHookBinding(
+            binding,
+            panelId: panelId,
+            restorableAgentIndex: matchingIndex
+        ) == false)
+
+        let neighborIndex = try Self.indexWithDetectedSession(
+            workspaceId: workspace.id,
+            panelId: UUID(),
+            sessionId: "session-1"
+        )
+        #expect(workspace.isStaleAgentHookBinding(
+            binding,
+            panelId: panelId,
+            restorableAgentIndex: neighborIndex
+        ) == true)
+
+        let mismatchedCheckpointIndex = try Self.indexWithDetectedSession(
+            workspaceId: workspace.id,
+            panelId: panelId,
+            sessionId: "session-2"
+        )
+        #expect(workspace.isStaleAgentHookBinding(
+            binding,
+            panelId: panelId,
+            restorableAgentIndex: mismatchedCheckpointIndex
+        ) == true)
+    }
+
+    private static func indexWithDetectedSession(
+        workspaceId: UUID,
+        panelId: UUID,
+        sessionId: String
+    ) throws -> RestorableAgentSessionIndex {
+        let fileManager = FileManager.default
+        let home = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-agent-hook-liveness-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: home) }
+
+        return RestorableAgentSessionIndex.load(
+            homeDirectory: home.path,
+            fileManager: fileManager,
+            registry: CmuxVaultAgentRegistry(registrations: []),
+            detectedSnapshots: [
+                RestorableAgentSessionIndex.PanelKey(workspaceId: workspaceId, panelId: panelId): (
+                    snapshot: SessionRestorableAgentSnapshot(kind: .claude, sessionId: sessionId),
+                    updatedAt: 1_777_777_777,
+                    processIDs: [424_242],
+                    agentProcessIDs: [424_242],
+                    sessionIDSource: .explicit
+                ),
+            ],
+            processArgumentsProvider: { _ in nil },
+            processIdentityProvider: { _ in nil }
+        )
+    }
 }

--- a/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
+++ b/cmuxTests/WorkspaceIsStaleAgentHookBindingTests.swift
@@ -17,12 +17,15 @@ import Testing
 @Suite
 struct WorkspaceIsStaleAgentHookBindingTests {
     private static func agentHookBinding(
-        launchFlavor: SurfaceResumeLaunchFlavor
+        launchFlavor: SurfaceResumeLaunchFlavor = .local,
+        autoResume: Bool? = nil
     ) -> SurfaceResumeBindingSnapshot {
         SurfaceResumeBindingSnapshot(
             command: "claude --resume session-1",
+            kind: "claude",
             checkpointId: "session-1",
             source: "agent-hook",
+            autoResume: autoResume,
             launchFlavor: launchFlavor
         )
     }
@@ -51,5 +54,29 @@ struct WorkspaceIsStaleAgentHookBindingTests {
         // NOT be reported as stale (that would delete a still-live remote
         // binding on the next reconciliation).
         #expect(workspace.isStaleAgentHookBinding(binding, panelId: panelId) == false)
+    }
+
+    @Test
+    func bindingOnlyPromptIdleKeepsDurableAgentHookBindingUntilLivenessScanPrunes() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let panelId = try #require(workspace.focusedPanelId)
+        let binding = Self.agentHookBinding(autoResume: true)
+        #expect(workspace.setSurfaceResumeBinding(binding, panelId: panelId))
+        workspace.restoredAgentResumeStatesByPanelId[panelId] = .observedAgentCommandRunning
+
+        workspace.updateBindingOnlyRestoredAgentResumeState(panelId: panelId, shellState: .promptIdle)
+
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panelId] == nil)
+        #expect(workspace.surfaceResumeBinding(panelId: panelId)?.checkpointId == "session-1")
+
+        let snapshot = workspace.sessionSnapshot(
+            includeScrollback: false,
+            restorableAgentIndex: .empty,
+            surfaceResumeBindingIndex: .empty
+        )
+
+        #expect(snapshot.panels.first?.terminal?.resumeBinding == nil)
+        #expect(workspace.surfaceResumeBinding(panelId: panelId) == nil)
     }
 }


### PR DESCRIPTION
## Summary
- preserve binding-only `agent-hook` resume bindings when prompt-idle reconciliation clears transient restored-agent state
- keep stale/completed pruning in scan-backed persistence reconciliation
- add regression coverage for prompt-idle preservation followed by liveness-scan pruning

## Verification
- `./scripts/lint-pbxproj-test-wiring.sh`
- `xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath ~/Library/Developer/Xcode/DerivedData/cmux-rsbind -only-testing:cmuxTests/WorkspaceIsStaleAgentHookBindingTests` blocked before executing tests by unrelated sidebar test compile errors already present in the test target: `SidebarWorkspaceRowRetirementTests.swift`, `SidebarWorkspaceRowSuspensionTests.swift`, `SidebarWorkspaceTableSuspensionTests.swift`. Result bundle: `~/Library/Developer/Xcode/DerivedData/cmux-rsbind/Logs/Test/Test-cmux-unit-2026.07.24_14-52-15--0700.xcresult`
- `./scripts/reload-cloud.sh --tag rsbind` succeeded, run https://github.com/manaflow-ai/cmux/actions/runs/30130017800
- tagged socket dogfood: launched `cmux DEV rsbind.app`, verified `identify` targeted `/tmp/cmux-debug-rsbind.sock`, set `surface.resume.set` via raw RPC with `source=agent-hook` and `auto_resume=true`, confirmed immediate binding, then confirmed fake checkpoint with no matching live process was pruned after the liveness scan

## Notes
No user-facing strings changed; localization audit: source/test-only behavior change, no UI strings, menus, settings, docs, or command help modified.

Autoreview was not invoked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787523586&installation_model_id=21920&pr_number=8885&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8885&signature=ca5a0fbabaa334883f3271bf311bc2dd554410a254506bdf14c9d1fa2f1d9392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve binding-only `agent-hook` resume bindings after prompt-idle so auto-resume survives restore, and allow trusted hook checkpoints to auto-resume even if the snapshot marked the agent as exited or unknown; stale bindings are still pruned by liveness. Adds regression coverage.

- **Bug Fixes**
  - Stop clearing `agent-hook` resume bindings when a restored panel enters prompt-idle.
  - Auto-resume trusted `agent-hook` checkpoints (valid kind + checkpoint with `autoResume=true`) even when `wasAgentRunning` is false or unknown.
  - Keep liveness pruning for bindings with no matching live process on the same panel/checkpoint.

<sup>Written for commit 737e2f2a4c4e9ed6533b88956dbd16ca04c32083. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved durable agent-hook surface resume bindings when a restored agent transitions to prompt-idle.
  * Adjusted restored-agent auto-resume eligibility to use computed resume binding identity rather than legacy defaults.
  * Improved session snapshot/restore pruning to reflect the latest binding and resume decisions.

* **Tests**
  * Added regression coverage for prompt-idle durable bindings and liveness cleanup.
  * Updated auto-resume tests for agent-hook bindings when the recorded agent running state is exited or unknown.
  * Enhanced snapshot assertions for startup scripts and restored resume state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->