### PR TITLE
Fix TestFlight demo variant CI guard

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -498,7 +498,10 @@ jobs:
         env:
           BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number || github.event.inputs.build_number || 'unknown' }}
           INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
-          UPLOAD_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+          UPLOAD_BUNDLE_ID: ${{ github.event.inputs.marketing_version_override != '' && 'dev.cmux.app.beta' || github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+          UPLOAD_DISPLAY_NAME: ${{ github.event.inputs.marketing_version_override != '' && 'cmux BETA' || github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
+          UPLOAD_AUDIENCE: ${{ github.event.inputs.marketing_version_override != '' && 'external TestFlight testers' || 'internal TestFlight group' }}
+          UPLOAD_REVIEW_NOTE: ${{ github.event.inputs.marketing_version_override != '' && 'Beta App Review may be required' || 'no beta review needed' }}
         run: |
           {
             echo "### iOS TestFlight upload"
@@ -511,7 +514,7 @@ jobs:
               echo "- marketing version: checked-in beta marketing version"
             fi
             echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
-            echo "- audience: internal TestFlight group (${IOS_BETA_DISPLAY_NAME}) on the ${UPLOAD_BUNDLE_ID} app; no beta review needed"
+            echo "- audience: ${UPLOAD_AUDIENCE} (${UPLOAD_DISPLAY_NAME}) on the ${UPLOAD_BUNDLE_ID} app; ${UPLOAD_REVIEW_NOTE}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Persist uploaded build metadata

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -238,7 +238,7 @@ jobs:
       ASC_API_KEY_P8_BASE64: ${{ secrets.ASC_API_KEY_P8_BASE64 }}
       CMUX_TESTFLIGHT_EXTERNAL_GROUP_ID: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_ID }}
       CMUX_TESTFLIGHT_EXTERNAL_GROUP_NAME: ${{ vars.IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME }}
-      CMUX_TESTFLIGHT_ASSIGN_EXTERNAL_GROUP: "0"
+      CMUX_TESTFLIGHT_ASSIGN_EXTERNAL_GROUP: ${{ github.event.inputs.marketing_version_override != '' && '1' || '0' }}
       # Internal builds use separate bundle ID and display name (set here so
       # provisioning profile step can use it). The manual demo variant ships the
       # same main head as a separate app so demos are isolated from the internal
@@ -553,7 +553,7 @@ jobs:
   assign-internal-group:
     name: Assign build to internal TestFlight group
     needs: [decide, upload]
-    if: github.ref == 'refs/heads/main' && needs.upload.result == 'success'
+    if: github.ref == 'refs/heads/main' && needs.upload.result == 'success' && github.event.inputs.marketing_version_override == ''
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 40
     env:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -506,7 +506,7 @@ jobs:
           {
             echo "### iOS TestFlight upload"
             echo
-            echo "- lane: \`beta\` (bundle id \`${UPLOAD_BUNDLE_ID}\`, internal TestFlight)"
+            echo "- lane: \`beta\` (bundle id \`${UPLOAD_BUNDLE_ID}\`, ${UPLOAD_AUDIENCE})"
             echo "- signing: manual (CI-imported iOS distribution cert + beta profile)"
             if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
               echo "- marketing version override: \`${INPUT_MARKETING_VERSION_OVERRIDE}\`"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -243,8 +243,8 @@ jobs:
       # provisioning profile step can use it). The manual demo variant ships the
       # same main head as a separate app so demos are isolated from the internal
       # firehose (and its per-app upload limit).
-      IOS_BETA_BUNDLE_ID: ${{ github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
-      IOS_BETA_DISPLAY_NAME: ${{ github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
+      IOS_BETA_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+      IOS_BETA_DISPLAY_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -401,7 +401,7 @@ jobs:
           echo "Installed $PROFILE_TYPE provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
 
       - name: Use DEMO-badged app icon
-        if: github.event.inputs.variant == 'demo'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo'
         run: |
           set -euo pipefail
           # Swap the AppIcon PNGs in the CI checkout instead of overriding
@@ -439,10 +439,10 @@ jobs:
           INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
           # Display name for automatic internal builds (auto-synced to internal group).
           # The demo variant ships as "cmux DEMO" / dev.cmux.app.demo instead.
-          IOS_BETA_DISPLAY_NAME: ${{ github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
+          IOS_BETA_DISPLAY_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
           # Internal builds use separate bundle ID (dev.cmux.app.internal) so internal
           # and external can coexist on same device.
-          IOS_BETA_BUNDLE_ID: ${{ github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+          IOS_BETA_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
           INPUT_VARIANT: ${{ github.event.inputs.variant }}
         run: |
           set -euo pipefail
@@ -498,7 +498,7 @@ jobs:
         env:
           BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number || github.event.inputs.build_number || 'unknown' }}
           INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
-          UPLOAD_BUNDLE_ID: ${{ github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+          UPLOAD_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
         run: |
           {
             echo "### iOS TestFlight upload"
@@ -564,8 +564,8 @@ jobs:
       # repo variables were wired in.
       # The demo variant assigns to the "cmux DEMO" internal group on the
       # dev.cmux.app.demo app record instead.
-      CMUX_TESTFLIGHT_INTERNAL_GROUP_ID: ${{ github.event.inputs.variant == 'demo' && 'dd5c5cde-05a6-44e5-bd71-c2ec08a3ebfe' || vars.IOS_TESTFLIGHT_INTERNAL_GROUP_ID }}
-      ASSIGN_BUNDLE_ID: ${{ github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+      CMUX_TESTFLIGHT_INTERNAL_GROUP_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dd5c5cde-05a6-44e5-bd71-c2ec08a3ebfe' || vars.IOS_TESTFLIGHT_INTERNAL_GROUP_ID }}
+      ASSIGN_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
       BUILD_NUMBER: ${{ needs.upload.outputs.final_build_number }}
     steps:
       - name: Checkout

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -511,7 +511,7 @@ jobs:
               echo "- marketing version: checked-in beta marketing version"
             fi
             echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
-            echo "- audience: internal TestFlight group (cmux INTERNAL) on the dev.cmux.app.internal app; no beta review needed"
+            echo "- audience: internal TestFlight group (${IOS_BETA_DISPLAY_NAME}) on the ${UPLOAD_BUNDLE_ID} app; no beta review needed"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Persist uploaded build metadata

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -155,6 +155,12 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
     assert upload.count(f"IOS_BETA_DISPLAY_NAME: {display_name_choice}") == 2
     assert f"UPLOAD_BUNDLE_ID: {bundle_choice}" in upload
     assert f"if: {DEMO_VARIANT_GUARD}" in upload
+    assert (
+        'echo "- audience: internal TestFlight group '
+        '(${IOS_BETA_DISPLAY_NAME}) on the ${UPLOAD_BUNDLE_ID} app; '
+        'no beta review needed"'
+        in upload
+    )
     assert f"ASSIGN_BUNDLE_ID: {bundle_choice}" in assignment
     assert f"CMUX_TESTFLIGHT_INTERNAL_GROUP_ID: {group_choice}" in assignment
 

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -198,6 +198,11 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
     )
     assert f"if: {DEMO_VARIANT_GUARD}" in upload
     assert (
+        'echo "- lane: \\`beta\\` '
+        '(bundle id \\`${UPLOAD_BUNDLE_ID}\\`, ${UPLOAD_AUDIENCE})"'
+        in upload
+    )
+    assert (
         'echo "- audience: ${UPLOAD_AUDIENCE} (${UPLOAD_DISPLAY_NAME}) '
         'on the ${UPLOAD_BUNDLE_ID} app; ${UPLOAD_REVIEW_NOTE}"'
         in upload

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -172,6 +172,11 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
     assert upload.count(f"IOS_BETA_BUNDLE_ID: {bundle_choice}") == 2
     assert upload.count(f"IOS_BETA_DISPLAY_NAME: {display_name_choice}") == 2
     assert (
+        "CMUX_TESTFLIGHT_ASSIGN_EXTERNAL_GROUP: "
+        f'{override_choice("1", "0")}'
+        in upload
+    )
+    assert (
         "UPLOAD_BUNDLE_ID: "
         f"{summary_choice('dev.cmux.app.beta', 'dev.cmux.app.demo', 'dev.cmux.app.internal')}"
         in upload
@@ -199,6 +204,13 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
     )
     assert f"ASSIGN_BUNDLE_ID: {bundle_choice}" in assignment
     assert f"CMUX_TESTFLIGHT_INTERNAL_GROUP_ID: {group_choice}" in assignment
+    assert assignment.count("needs: [decide, upload]") == 1
+    assert (
+        "if: github.ref == 'refs/heads/main' "
+        "&& needs.upload.result == 'success' "
+        "&& github.event.inputs.marketing_version_override == ''"
+        in assignment
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -19,6 +19,14 @@ IOS_PATHS = (
     "scripts/validate-xcframework-archive.py",
     ".github/workflows/ios-testflight.yml",
 )
+DEMO_VARIANT_GUARD = (
+    "github.event_name == 'workflow_dispatch' "
+    "&& github.event.inputs.variant == 'demo'"
+)
+
+
+def variant_choice(demo: str, internal: str) -> str:
+    return f"${{{{ {DEMO_VARIANT_GUARD} && '{demo}' || '{internal}' }}}}"
 
 
 def workflow_text() -> str:
@@ -131,10 +139,24 @@ def test_main_push_runs_are_preserved_and_uploaded_in_order() -> None:
 
 def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
     text = workflow_text()
+    upload = mapping_block(text, "upload", indent=2)
+    assignment = mapping_block(text, "assign-internal-group", indent=2)
 
-    assert "IOS_BETA_BUNDLE_ID: dev.cmux.app.internal" in text
-    assert "IOS_BETA_DISPLAY_NAME: cmux INTERNAL" in text
-    assert "--bundle-id dev.cmux.app.internal" in text
+    bundle_choice = variant_choice("dev.cmux.app.demo", "dev.cmux.app.internal")
+    display_name_choice = variant_choice("cmux DEMO", "cmux INTERNAL")
+    group_choice = (
+        "${{ "
+        f"{DEMO_VARIANT_GUARD} "
+        "&& 'dd5c5cde-05a6-44e5-bd71-c2ec08a3ebfe' "
+        "|| vars.IOS_TESTFLIGHT_INTERNAL_GROUP_ID }}"
+    )
+
+    assert upload.count(f"IOS_BETA_BUNDLE_ID: {bundle_choice}") == 2
+    assert upload.count(f"IOS_BETA_DISPLAY_NAME: {display_name_choice}") == 2
+    assert f"UPLOAD_BUNDLE_ID: {bundle_choice}" in upload
+    assert f"if: {DEMO_VARIANT_GUARD}" in upload
+    assert f"ASSIGN_BUNDLE_ID: {bundle_choice}" in assignment
+    assert f"CMUX_TESTFLIGHT_INTERNAL_GROUP_ID: {group_choice}" in assignment
 
 
 if __name__ == "__main__":

--- a/tests/test_ios_testflight_main_push_filter.py
+++ b/tests/test_ios_testflight_main_push_filter.py
@@ -23,10 +23,28 @@ DEMO_VARIANT_GUARD = (
     "github.event_name == 'workflow_dispatch' "
     "&& github.event.inputs.variant == 'demo'"
 )
+MARKETING_OVERRIDE_GUARD = "github.event.inputs.marketing_version_override != ''"
 
 
 def variant_choice(demo: str, internal: str) -> str:
     return f"${{{{ {DEMO_VARIANT_GUARD} && '{demo}' || '{internal}' }}}}"
+
+
+def summary_choice(external: str, demo: str, internal: str) -> str:
+    return (
+        "${{ "
+        f"{MARKETING_OVERRIDE_GUARD} && '{external}' "
+        f"|| {DEMO_VARIANT_GUARD} && '{demo}' "
+        f"|| '{internal}' }}"
+    )
+
+
+def override_choice(external: str, normal: str) -> str:
+    return (
+        "${{ "
+        f"{MARKETING_OVERRIDE_GUARD} && '{external}' "
+        f"|| '{normal}' }}"
+    )
 
 
 def workflow_text() -> str:
@@ -153,12 +171,30 @@ def test_automatic_lane_stays_on_cmux_internal_identity() -> None:
 
     assert upload.count(f"IOS_BETA_BUNDLE_ID: {bundle_choice}") == 2
     assert upload.count(f"IOS_BETA_DISPLAY_NAME: {display_name_choice}") == 2
-    assert f"UPLOAD_BUNDLE_ID: {bundle_choice}" in upload
+    assert (
+        "UPLOAD_BUNDLE_ID: "
+        f"{summary_choice('dev.cmux.app.beta', 'dev.cmux.app.demo', 'dev.cmux.app.internal')}"
+        in upload
+    )
+    assert (
+        "UPLOAD_DISPLAY_NAME: "
+        f"{summary_choice('cmux BETA', 'cmux DEMO', 'cmux INTERNAL')}"
+        in upload
+    )
+    assert (
+        "UPLOAD_AUDIENCE: "
+        f"{override_choice('external TestFlight testers', 'internal TestFlight group')}"
+        in upload
+    )
+    assert (
+        "UPLOAD_REVIEW_NOTE: "
+        f"{override_choice('Beta App Review may be required', 'no beta review needed')}"
+        in upload
+    )
     assert f"if: {DEMO_VARIANT_GUARD}" in upload
     assert (
-        'echo "- audience: internal TestFlight group '
-        '(${IOS_BETA_DISPLAY_NAME}) on the ${UPLOAD_BUNDLE_ID} app; '
-        'no beta review needed"'
+        'echo "- audience: ${UPLOAD_AUDIENCE} (${UPLOAD_DISPLAY_NAME}) '
+        'on the ${UPLOAD_BUNDLE_ID} app; ${UPLOAD_REVIEW_NOTE}"'
         in upload
     )
     assert f"ASSIGN_BUNDLE_ID: {bundle_choice}" in assignment


### PR DESCRIPTION
The demo variant changed TestFlight identities to GitHub expressions, but the required workflow guard still required the old literal values. This broke every merge gate on current main.

The workflow now explicitly permits the demo identity only for manual `workflow_dispatch` runs. Push runs resolve to the internal identity. The regression test verifies both upload and assignment jobs use the same event-gated identity choices.

Red/green proof:
- `49eb683b54`: updated contract fails against the current workflow.
- `294bcb5d6d`: event-gated workflow passes.

Verification:
- `python3 tests/test_ios_testflight_main_push_filter.py`
- `actionlint .github/workflows/ios-testflight.yml`
- `python3 tests/test_ios_testflight_external_distribution.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787525667&installation_model_id=21920&pr_number=8887&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8887&signature=eea7962878bb84f75d6841cb3d8ff194ccd5ca8c9daba4f21a490af55acf1021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TestFlight guard so the demo variant only runs on manual triggers; push runs always use the internal identity. Assignment now routes by lane (internal vs external override), and the step summary reports the chosen variant, audience, and review note.

- **Bug Fixes**
  - Gate IOS_BETA_BUNDLE_ID, IOS_BETA_DISPLAY_NAME, ASSIGN_BUNDLE_ID, CMUX_TESTFLIGHT_INTERNAL_GROUP_ID, and the DEMO icon step on workflow_dispatch + variant == 'demo'; default to internal otherwise.
  - Route assignment by lane: when marketing_version_override is set, assign to the external group during upload and skip the internal assignment job; otherwise run the internal assignment only on main after a successful upload.
  - Report the chosen variant, display name, audience, and review note in the step summary via UPLOAD_BUNDLE_ID, UPLOAD_DISPLAY_NAME, UPLOAD_AUDIENCE, and UPLOAD_REVIEW_NOTE.
  - Extend tests to cover demo gating, summary identity (including audience/review note), and assignment routing for demo, internal, and external override paths.

<sup>Written for commit 4c092f577bcf0769d9ed9731bac5a8771bd4f3fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened iOS TestFlight “demo” behavior so demo bundle/display, icon swapping, audience/review-note, and internal group assignment apply only to manual demo variant runs (not push-triggered).
  * Updated upload metadata resolution to respect marketing version overrides and format the audience line with the display name.
  * Further limited internal group assignment to main push runs with a successful upload when marketing version override is empty.
* **Tests**
  * Improved workflow YAML assertions by deriving expected guarded values and validating extracted `upload` and `assign-internal-group` blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->