### PR TITLE
Fix iOS build: form owned-userdata release callback from a closure literal

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3481,8 +3481,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
         }
         surfaceConfig.io_write_userdata = bridgePointer
+        // A C function pointer can only be formed from a global func or a
+        // capture-free closure literal, not a static method reference.
         guard let createdSurface = ghostty_surface_new_with_owned_userdata(
-            app, &surfaceConfig, GhosttySurfaceBridge.releaseRetainedOpaque
+            app, &surfaceConfig, { userdata in
+                GhosttySurfaceBridge.releaseRetainedOpaque(userdata)
+            }
         ) else {
             retainedBridge.release()
             return nil


### PR DESCRIPTION
Main's iOS build is red since f41507ece2 (an untested "cmux reload-cloud"-authored commit): it passes the static method GhosttySurfaceBridge.releaseRetainedOpaque directly as a C function pointer to ghostty_surface_new_with_owned_userdata, which Swift only permits for global funcs or capture-free closure literals. Every CmuxMobileTerminal compile fails, which killed internal TestFlight run 30139324698 (and blocks all iOS uploads). This wraps the callback in a capture-free closure literal forwarding to the same method; no behavior change. Verified against the language rule and gated on a local GhosttyKit rebuild before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787537385&installation_model_id=21920&pr_number=8897&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8897&signature=0f1f2751e3ffcc234e21ceb11340f9756e796a3e77cb31eb300c18a73b841a5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS build by forming the owned-userdata release callback as a capture‑free closure literal when calling `ghostty_surface_new_with_owned_userdata` instead of passing the static method reference. This follows Swift’s C function pointer rules and restores `CmuxMobileTerminal` iOS builds and TestFlight uploads with no behavior change.

<sup>Written for commit a47e2fc010e588318d11d3fd6592bbb74eb79706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved surface cleanup callback handling to ensure resources are released reliably when a terminal surface is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->