### PR TITLE
Fix current Swift warning regressions

### DIFF
--- a/Sources/AppDelegate+WindowDock.swift
+++ b/Sources/AppDelegate+WindowDock.swift
@@ -201,6 +201,7 @@ extension AppDelegate {
 }
 
 extension SessionWindowSnapshot {
+    @MainActor
     func omitsRemoteMirrorOnlyWindow(liveWorkspaces: [Workspace]) -> Bool {
         tabManager.workspaces.isEmpty &&
             dock == nil &&

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -813,11 +813,11 @@ struct ContentView: View {
     init(
         updateViewModel: UpdateStateModel,
         windowId: UUID,
-        featureFlags: CmuxFeatureFlags = .shared
+        featureFlags: CmuxFeatureFlags? = nil
     ) {
         self.updateViewModel = updateViewModel
         self.windowId = windowId
-        self.featureFlags = featureFlags
+        self.featureFlags = featureFlags ?? .shared
     }
 
     @EnvironmentObject var tabManager: TabManager

--- a/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarGroupHeaderRowView.swift
@@ -123,7 +123,7 @@ final class SidebarGroupHeaderTableCellView: NSTableCellView {
         contextMenuDidOpen: @escaping () -> Void,
         contextMenuDidClose: @escaping () -> Void
     ) {
-        let requiresFullApply = actions == nil
+        let requiresFullApply = self.actions == nil
         let previous = self.model
         self.actions = actions
         self.contextMenuDidOpen = contextMenuDidOpen


### PR DESCRIPTION
Current `main` fails the speculative merge gate because three newly introduced warnings exceed the checked Swift warning budget.

This isolates the remote-mirror snapshot helper to `MainActor`, resolves the feature-flag singleton inside `ContentView.init`, and restores the group-header reuse check to inspect stored presentation state. The existing suspension regression test covers the sidebar behavior.

Verified by tagged cloud build `swbud` on macOS 26. The build log contains none of the three failing warning signatures. No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787537412&installation_model_id=21920&pr_number=8898&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8898&signature=5993ca8b7a57ec89c0d3d2d31d420623fa0161df5b90a1b77df40d3e468f22f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores main to within the Swift warning budget by fixing three new warnings. No functional or UI changes.

- **Bug Fixes**
  - Annotated `SessionWindowSnapshot.omitsRemoteMirrorOnlyWindow` with `@MainActor` to silence cross-actor access warnings.
  - Updated `ContentView` init to accept `CmuxFeatureFlags?` and default to `.shared` inside, removing the static default-arg warning.
  - In `SidebarGroupHeaderTableCellView`, compute `requiresFullApply` from `self.actions` so reuse checks inspect stored presentation state.

<sup>Written for commit 8ad567fa96a965b4920973677dfc1f126468321e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar group header updates so available actions and layouts refresh correctly when first displayed.
  - Improved window handling for remote mirror-only sessions to ensure they are filtered consistently.
- **Refactor**
  - Improved feature configuration initialization for more reliable app startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->