### PR TITLE
Fix iOS terminal dock keyboard pinning (bars jump to mid-screen)

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -641,6 +641,9 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // height flows separately through `sizeThatFits`. Clear background so the
             // terminal/glass shows through.
             controller.view.backgroundColor = .clear
+            // Keyboard geometry is owned explicitly by the surface's frame math;
+            // opting out here prevents the hosted field from avoiding it a second time.
+            controller.safeAreaRegions = .container
             return controller
         }
 
@@ -677,7 +680,16 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             let width = max(1, surfaceView.bounds.width)
             let target = CGSize(width: width, height: .greatestFiniteMagnitude)
             let fitting = controller.sizeThatFits(in: target)
-            surfaceView.setComposerBandHeight(fitting.height, animated: animated)
+            let clampedHeight = min(
+                fitting.height,
+                floor(surfaceView.bounds.height * 0.45)
+            )
+            if clampedHeight < fitting.height {
+                MobileDebugLog.anchormux(
+                    "composer.bandHeightClamped measured=\(fitting.height) clamped=\(clampedHeight)"
+                )
+            }
+            surfaceView.setComposerBandHeight(clampedHeight, animated: animated)
         }
 
         /// Re-measure the open composer after a non-text layout change (rotation /

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -425,8 +425,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     var lastRenderLayoutViewportHeight: CGFloat?
     var lastRenderHasSourceLayoutViewport = false
     private var viewportCoordinator = TerminalViewportCoordinator()
+    private let keyboardTransitionPlanner = TerminalDockKeyboardTransitionPlanner()
     private var keyboardHeightAnimation: TerminalKeyboardHeightAnimation?
     private var keyboardHeightAnimationID = 0
+    private var lastKeyboardTransitionDuration: TimeInterval = 0.25
 
     #if DEBUG
     struct DebugGeometrySnapshot {
@@ -774,10 +776,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private var keyboardVisible = false
     /// Height the persistent bottom toolbar reserves in the terminal grid. The
     /// toolbar is docked above the keyboard (when up) or the home indicator
-    /// (when down) via `keyboardLayoutGuide`, so the grid must shrink by this
-    /// much to keep the bottom TUI rows visible above it. 0 until the toolbar is
-    /// installed (`installPersistentToolbar`), so the home-indicator reservation
-    /// still lands even if the toolbar UI is absent.
+    /// (when down) through the surface's frame-positioned dock math, so the grid
+    /// must shrink by this much to keep the bottom TUI rows visible above it. 0
+    /// until the toolbar is installed (`installPersistentToolbar`), so the
+    /// home-indicator reservation still lands even if the toolbar UI is absent.
     private var reservedToolbarHeight: CGFloat = 0
     /// Height of the docked accessory bar reserved in the grid geometry so the
     /// bottom TUI rows stay visible above it. Locked to the bar's actual button-row
@@ -845,9 +847,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     @objc private func handleKeyboardWillChangeFrame(_ notification: Notification) {
         guard let transition = MobileKeyboardTransition(notification: notification) else { return }
-        let overlap = transition.overlap(in: self)
+        let targetOverlap = transition.overlap(in: self)
         let willBeVisible = transition.isVisible(in: self)
-        guard abs(overlap - keyboardHeight) > 0.5 || willBeVisible != keyboardVisible else { return }
         let wasVisible = keyboardVisible
         #if DEBUG
         // The composer-up/keyboard-down desync can be reached WITHOUT the dismiss
@@ -881,28 +882,72 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // reclaims the keyboard's space (minus the now-reserved safe area + toolbar +
         // composer band).
         updateDockedToolbarVisibility()
-        startKeyboardHeightAnimation(to: overlap, transition: transition)
+        let visibleOccupancy = currentVisibleDockOccupancy()
+        let targetOccupancy = TerminalLetterboxGeometry.keyboardOccupancy(
+            keyboardHeight: targetOverlap,
+            bottomSafeAreaInset: safeAreaInsetsBottom
+        )
+        let activeAnimation = keyboardHeightAnimation
+        if transition.duration > 0 {
+            lastKeyboardTransitionDuration = transition.duration
+        }
+        let plan = keyboardTransitionPlanner.plan(for: TerminalDockKeyboardTransitionInput(
+            targetOverlap: targetOverlap,
+            notificationDuration: transition.duration,
+            visibleOccupancy: visibleOccupancy,
+            targetOccupancy: targetOccupancy,
+            isAnimating: activeAnimation != nil,
+            activeTargetOverlap: activeAnimation?.targetOverlap ?? 0,
+            lastTransitionDuration: lastKeyboardTransitionDuration
+        ))
+        switch plan {
+        case .ignore:
+            return
+        case .apply:
+            applyKeyboardTransitionImmediately(to: targetOverlap)
+        case let .animate(duration):
+            startKeyboardHeightAnimation(
+                to: targetOverlap,
+                visibleOccupancy: visibleOccupancy,
+                transition: transition,
+                duration: duration
+            )
+        }
     }
 
     private func startKeyboardHeightAnimation(
         to targetHeight: CGFloat,
-        transition: MobileKeyboardTransition
+        visibleOccupancy: CGFloat,
+        transition: MobileKeyboardTransition,
+        duration: TimeInterval
     ) {
-        stopKeyboardHeightAnimation()
         let clampedTarget = max(0, targetHeight)
-        guard transition.duration > 0, abs(clampedTarget - keyboardHeight) > 0.5 else {
-            applyKeyboardHeight(clampedTarget)
-            if clampedTarget == 0 {
-                scheduleKeyboardHideHeightResync()
-            }
+        let pinnedOverlap = keyboardTransitionPlanner.pinnedOverlap(
+            forVisibleOccupancy: visibleOccupancy,
+            bottomSafeAreaInset: safeAreaInsetsBottom
+        )
+        pinKeyboardDock(toOverlap: pinnedOverlap)
+        guard duration > 0,
+              abs(
+                TerminalLetterboxGeometry.keyboardOccupancy(
+                    keyboardHeight: clampedTarget,
+                    bottomSafeAreaInset: safeAreaInsetsBottom
+                ) - visibleOccupancy
+              ) > 0.5 else {
+            applyKeyboardTransitionImmediately(to: clampedTarget)
             return
         }
 
         keyboardHeightAnimationID &+= 1
         let animationID = keyboardHeightAnimationID
-        keyboardHeightAnimation = TerminalKeyboardHeightAnimation(id: animationID)
+        keyboardHeightAnimation = TerminalKeyboardHeightAnimation(
+            id: animationID,
+            targetOverlap: clampedTarget,
+            animationOptions: transition.animationOptions,
+            endTimestamp: CACurrentMediaTime() + duration
+        )
         startDisplayLink()
-        transition.animate {
+        transition.animate(durationOverride: duration) {
             self.applyKeyboardHeight(clampedTarget)
             self.layoutIfNeeded()
         } completion: { _ in
@@ -918,10 +963,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     private func finishKeyboardHeightAnimation(targetHeight: CGFloat) {
         stopKeyboardHeightAnimation()
-        applyKeyboardHeight(targetHeight)
-        if targetHeight == 0 {
-            scheduleKeyboardHideHeightResync()
-        }
+        settleKeyboardHeight(targetHeight)
     }
 
     private func advanceKeyboardHeightAnimation() {
@@ -933,28 +975,66 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     private func applyKeyboardHeight(_ height: CGFloat) {
         let clamped = max(0, height)
         if abs(keyboardHeight - clamped) > 0.25 {
-            keyboardHeight = clamped
             setNeedsGeometrySync()
         }
+        keyboardHeight = clamped
         layoutBottomDock()
         layoutRenderedTerminalForCurrentViewport()
         layoutZoomOverlay()
     }
 
-    /// Force a follow-up geometry sync shortly after the keyboard-hide layout
-    /// pass, so the terminal reliably returns to full height even if the first
-    /// sync read a stale safe-area inset or its display-link frame was dropped.
-    ///
-    /// Runs on the main queue (one runloop later, after UIKit has applied the
-    /// keyboard-hide layout) and only while the keyboard is still down and the
-    /// view is on a window, so a fast hide/show flicker does not re-shrink the
-    /// grid. `setNeedsGeometrySync` itself applies directly when the display link
-    /// is stopped, so this guarantees an APPLIED sync, not just a queued one.
-    private func scheduleKeyboardHideHeightResync() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self, self.window != nil, self.keyboardHeight == 0 else { return }
-            self.setNeedsGeometrySync()
+    private func applyKeyboardTransitionImmediately(to targetHeight: CGFloat) {
+        pinKeyboardDock(toOverlap: targetHeight)
+        settleKeyboardHeight(targetHeight)
+    }
+
+    private func pinKeyboardDock(toOverlap overlap: CGFloat) {
+        stopKeyboardHeightAnimation()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        UIView.performWithoutAnimation {
+            applyKeyboardHeight(overlap)
+            layoutIfNeeded()
+            removeDockAnimations()
         }
+        CATransaction.commit()
+    }
+
+    private func settleKeyboardHeight(_ targetHeight: CGFloat) {
+        keyboardHeight = max(0, targetHeight)
+        layoutBottomDock()
+        layoutRenderedTerminalForCurrentViewport()
+        layoutZoomOverlay()
+        setNeedsGeometrySync()
+    }
+
+    private func removeDockAnimations() {
+        composerContainer.layer.removeAllAnimations()
+        dockedToolbar?.layer.removeAllAnimations()
+    }
+
+    private func currentVisibleDockOccupancy() -> CGFloat {
+        let presentationFrame: CGRect?
+        if !composerContainer.isHidden, composerBandHeight > 0.5 {
+            presentationFrame = presentationFrameInOwnViewCoordinates(for: composerContainer)
+        } else if let dockedToolbar {
+            presentationFrame = presentationFrameInOwnViewCoordinates(for: dockedToolbar)
+        } else {
+            presentationFrame = nil
+        }
+        if let presentationFrame {
+            return min(max(0, bounds.maxY - presentationFrame.maxY), max(0, bounds.height))
+        }
+        return TerminalLetterboxGeometry.keyboardOccupancy(
+            keyboardHeight: keyboardHeight,
+            bottomSafeAreaInset: safeAreaInsetsBottom
+        )
+    }
+
+    private func presentationFrameInOwnViewCoordinates(for targetView: UIView) -> CGRect? {
+        guard let sourceLayer = targetView.layer.presentation() else { return nil }
+        let targetLayer = layer.presentation() ?? layer
+        return sourceLayer.convert(targetView.bounds, to: targetLayer)
     }
 
     #if DEBUG
@@ -1476,13 +1556,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             self.layoutIfNeeded()
         }
         if animated {
-            UIView.animate(
-                withDuration: Self.composerReflowDuration,
-                delay: 0,
-                options: [.curveEaseInOut, .beginFromCurrentState],
-                animations: apply,
-                completion: { _ in completion?() }
-            )
+            animateDockReflow(animations: apply, completion: completion)
         } else {
             apply()
             completion?()
@@ -1490,10 +1564,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         setNeedsGeometrySync()
     }
 
-    /// Duration (seconds) of the composer band grow/shrink reflow. Matches the system
-    /// keyboard's default animation duration so a field-grow reads as one smooth
-    /// motion with the dock; keyboard show/hide reflow samples the notification's
-    /// own curve/duration through ``startKeyboardHeightAnimation(to:transition:)``.
+    /// Duration (seconds) used for dock reflows when no keyboard transition is active.
     private static let composerReflowDuration: TimeInterval = 0.25
 
     /// Position the composer band and docked toolbar from one viewport snapshot.
@@ -1507,27 +1578,122 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         layoutArtifactChip(using: snapshot)
     }
 
-    /// Animate the whole bottom dock (composer band + toolbar) to its current target
-    /// frames over the given duration/curve. Used by the HIDE/show and composer close
-    /// paths (item 3), which have no keyboard notification and so default to the system
-    /// keyboard duration + easeInOut so the motion still reads as one smooth coordinated
-    /// reflow. Real keyboard changes use the per-frame keyboard height owner, so the
-    /// exact UIKit keyboard transaction drives the dock.
-    private func animateBottomDock(
-        duration: TimeInterval = 0.25,
-        curveOption: UIView.AnimationOptions = .curveEaseInOut
-    ) {
+    /// Animate the whole bottom dock to its current target frames.
+    private func animateBottomDock() {
         let snapshot = viewportSnapshot()
         let frames = (composer: snapshot.composerFrame, toolbar: snapshot.toolbarFrame)
-        UIView.animate(
-            withDuration: duration,
-            delay: 0,
-            options: [curveOption, .beginFromCurrentState]
-        ) { [weak self] in
+        animateDockReflow { [weak self] in
             self?.composerContainer.frame = frames.composer
             self?.dockedToolbar?.frame = frames.toolbar
             self?.layoutArtifactChip(using: snapshot)
         }
+    }
+
+    /// Reflow dock chrome on the keyboard's active clock, or the default dock clock.
+    private func animateDockReflow(
+        animations: @escaping () -> Void,
+        completion: (() -> Void)? = nil
+    ) {
+        if let keyboardHeightAnimation {
+            let duration = max(
+                0,
+                keyboardHeightAnimation.endTimestamp - CACurrentMediaTime()
+            )
+            keyboardHeightAnimationID &+= 1
+            let animationID = keyboardHeightAnimationID
+            self.keyboardHeightAnimation = TerminalKeyboardHeightAnimation(
+                id: animationID,
+                targetOverlap: keyboardHeightAnimation.targetOverlap,
+                animationOptions: keyboardHeightAnimation.animationOptions,
+                endTimestamp: keyboardHeightAnimation.endTimestamp
+            )
+            UIView.animate(
+                withDuration: duration,
+                delay: 0,
+                options: keyboardHeightAnimation.animationOptions.union([
+                    .beginFromCurrentState,
+                    .allowUserInteraction,
+                ]),
+                animations: animations
+            ) { _ in
+                if self.keyboardHeightAnimationID == animationID {
+                    self.finishKeyboardHeightAnimation(
+                        targetHeight: keyboardHeightAnimation.targetOverlap
+                    )
+                }
+                completion?()
+            }
+            return
+        }
+        UIView.animate(
+            withDuration: Self.composerReflowDuration,
+            delay: 0,
+            options: [.curveEaseInOut, .beginFromCurrentState],
+            animations: animations,
+            completion: { _ in completion?() }
+        )
+    }
+
+    private func retargetActiveKeyboardDockIfNeeded(
+        using targetSnapshot: TerminalViewportSnapshot
+    ) -> Bool {
+        guard let activeAnimation = keyboardHeightAnimation,
+              dockTargetFramesDiffer(from: targetSnapshot) else {
+            return false
+        }
+        let visibleOccupancy = currentVisibleDockOccupancy()
+        let remainingDuration = max(
+            1.0 / 60.0,
+            activeAnimation.endTimestamp - CACurrentMediaTime()
+        )
+        let pinnedOverlap = keyboardTransitionPlanner.pinnedOverlap(
+            forVisibleOccupancy: visibleOccupancy,
+            bottomSafeAreaInset: safeAreaInsetsBottom
+        )
+        pinKeyboardDock(toOverlap: pinnedOverlap)
+
+        keyboardHeightAnimationID &+= 1
+        let animationID = keyboardHeightAnimationID
+        keyboardHeightAnimation = TerminalKeyboardHeightAnimation(
+            id: animationID,
+            targetOverlap: activeAnimation.targetOverlap,
+            animationOptions: activeAnimation.animationOptions,
+            endTimestamp: CACurrentMediaTime() + remainingDuration
+        )
+        startDisplayLink()
+        UIView.animate(
+            withDuration: remainingDuration,
+            delay: 0,
+            options: activeAnimation.animationOptions.union([
+                .beginFromCurrentState,
+                .allowUserInteraction,
+            ])
+        ) {
+            self.applyKeyboardHeight(activeAnimation.targetOverlap)
+            self.layoutIfNeeded()
+        } completion: { _ in
+            guard self.keyboardHeightAnimationID == animationID else { return }
+            self.finishKeyboardHeightAnimation(targetHeight: activeAnimation.targetOverlap)
+        }
+        return true
+    }
+
+    private func dockTargetFramesDiffer(from snapshot: TerminalViewportSnapshot) -> Bool {
+        if frame(composerContainer.frame, differsFrom: snapshot.composerFrame) {
+            return true
+        }
+        if let toolbarFrame = dockedToolbar?.frame,
+           frame(toolbarFrame, differsFrom: snapshot.toolbarFrame) {
+            return true
+        }
+        return false
+    }
+
+    private func frame(_ lhs: CGRect, differsFrom rhs: CGRect) -> Bool {
+        abs(lhs.minX - rhs.minX) > 0.5
+            || abs(lhs.minY - rhs.minY) > 0.5
+            || abs(lhs.width - rhs.width) > 0.5
+            || abs(lhs.height - rhs.height) > 0.5
     }
 
     private var pinchAccumulatedScale: CGFloat = 1.0
@@ -1883,7 +2049,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public override func layoutSubviews() {
         super.layoutSubviews()
         let snapshot = viewportSnapshot()
-        layoutRenderedTerminalForCurrentViewport(using: snapshot)
+        let retargetedKeyboardDock = retargetActiveKeyboardDockIfNeeded(using: snapshot)
+        if !retargetedKeyboardDock {
+            layoutRenderedTerminalForCurrentViewport(using: snapshot)
+        }
         layoutScrollMechanicsView()
         #if DEBUG
         debugAccessibilityProxy.frame = bounds
@@ -1894,7 +2063,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         #endif
         inputProxy.frame = CGRect(x: 0, y: 0, width: bounds.width, height: 1)
         inputProxy.updateAccessoryLayoutInsets()
-        layoutBottomDock(using: snapshot)
+        if !retargetedKeyboardDock {
+            layoutBottomDock(using: snapshot)
+        }
         layoutZoomOverlay()
         MobileDebugLog.anchormux("surface.layout bounds=\(Int(bounds.width))x\(Int(bounds.height)) window=\(window != nil)")
         setNeedsGeometrySync()
@@ -1912,8 +2083,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     public override func safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
         let snapshot = viewportSnapshot()
-        layoutRenderedTerminalForCurrentViewport(using: snapshot)
-        layoutBottomDock(using: snapshot)
+        if !retargetActiveKeyboardDockIfNeeded(using: snapshot) {
+            layoutRenderedTerminalForCurrentViewport(using: snapshot)
+            layoutBottomDock(using: snapshot)
+        }
         setNeedsGeometrySync()
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalKeyboardHeightAnimation.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalKeyboardHeightAnimation.swift
@@ -1,3 +1,10 @@
+#if canImport(UIKit)
+import UIKit
+
 struct TerminalKeyboardHeightAnimation {
     let id: Int
+    let targetOverlap: CGFloat
+    let animationOptions: UIView.AnimationOptions
+    let endTimestamp: CFTimeInterval
 }
+#endif

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalDockKeyboardTransitionInput.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalDockKeyboardTransitionInput.swift
@@ -1,0 +1,54 @@
+public import CoreGraphics
+public import Foundation
+
+/// Describes the current and requested geometry for one terminal-dock keyboard transition.
+public struct TerminalDockKeyboardTransitionInput: Sendable {
+    /// The keyboard overlap requested by the current UIKit notification.
+    public var targetOverlap: CGFloat
+
+    /// The real duration supplied by UIKit, or zero when UIKit omitted one.
+    public var notificationDuration: TimeInterval
+
+    /// The dock's current on-screen bottom occupancy, measured from presentation geometry.
+    public var visibleOccupancy: CGFloat
+
+    /// The dock's requested bottom occupancy after applying the notification target.
+    public var targetOccupancy: CGFloat
+
+    /// Whether a terminal-dock keyboard animation is currently active.
+    public var isAnimating: Bool
+
+    /// The overlap targeted by the active animation when ``isAnimating`` is true.
+    public var activeTargetOverlap: CGFloat
+
+    /// The most recent nonzero UIKit keyboard-transition duration.
+    public var lastTransitionDuration: TimeInterval
+
+    /// Creates a keyboard-transition planning input.
+    ///
+    /// - Parameters:
+    ///   - targetOverlap: The keyboard overlap requested by the current notification.
+    ///   - notificationDuration: The real UIKit duration, or zero when omitted.
+    ///   - visibleOccupancy: The dock's presentation-derived bottom occupancy.
+    ///   - targetOccupancy: The requested bottom occupancy at the notification target.
+    ///   - isAnimating: Whether a terminal-dock keyboard animation is active.
+    ///   - activeTargetOverlap: The overlap targeted by the active animation.
+    ///   - lastTransitionDuration: The most recent nonzero UIKit duration.
+    public init(
+        targetOverlap: CGFloat,
+        notificationDuration: TimeInterval,
+        visibleOccupancy: CGFloat,
+        targetOccupancy: CGFloat,
+        isAnimating: Bool,
+        activeTargetOverlap: CGFloat,
+        lastTransitionDuration: TimeInterval
+    ) {
+        self.targetOverlap = targetOverlap
+        self.notificationDuration = notificationDuration
+        self.visibleOccupancy = visibleOccupancy
+        self.targetOccupancy = targetOccupancy
+        self.isAnimating = isAnimating
+        self.activeTargetOverlap = activeTargetOverlap
+        self.lastTransitionDuration = lastTransitionDuration
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalDockKeyboardTransitionPlan.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalDockKeyboardTransitionPlan.swift
@@ -1,0 +1,15 @@
+public import Foundation
+
+/// The geometry action the terminal dock should take for a keyboard notification.
+public enum TerminalDockKeyboardTransitionPlan: Equatable, Sendable {
+    /// Preserve the current settled or in-flight geometry.
+    case ignore
+
+    /// Pin the dock directly to the requested target without animation.
+    case apply
+
+    /// Animate the dock to the requested target using the supplied duration.
+    ///
+    /// - Parameter duration: The effective transition duration in seconds.
+    case animate(duration: TimeInterval)
+}

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalDockKeyboardTransitionPlanner.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalDockKeyboardTransitionPlanner.swift
@@ -1,0 +1,78 @@
+public import CoreGraphics
+import Foundation
+
+/// Produces deterministic terminal-dock actions from keyboard transition geometry.
+public struct TerminalDockKeyboardTransitionPlanner: Sendable {
+    /// Creates a stateless terminal-dock keyboard transition planner.
+    public init() {}
+
+    /// Selects how the dock should respond to a keyboard transition notification.
+    ///
+    /// A real UIKit duration is preserved. When UIKit supplies zero during an
+    /// interrupted animation, the planner scales the last real duration by the
+    /// remaining occupancy distance, matching the hardened agent-chat behavior.
+    ///
+    /// - Parameter input: Current presentation geometry and notification target data.
+    /// - Returns: The geometry action for the terminal dock.
+    public func plan(
+        for input: TerminalDockKeyboardTransitionInput
+    ) -> TerminalDockKeyboardTransitionPlan {
+        let remainingDistance = abs(input.targetOccupancy - input.visibleOccupancy)
+        if remainingDistance <= 0.5, !input.isAnimating {
+            return .ignore
+        }
+        if input.isAnimating,
+           abs(input.targetOverlap - input.activeTargetOverlap) <= 0.5 {
+            return .ignore
+        }
+        guard remainingDistance > 0.5 else {
+            return .apply
+        }
+        if input.notificationDuration > 0 {
+            return .animate(duration: input.notificationDuration)
+        }
+
+        let effectiveDuration: TimeInterval
+        if input.isAnimating {
+            let referenceDistance = max(
+                input.activeTargetOverlap,
+                input.targetOverlap,
+                input.visibleOccupancy,
+                input.targetOccupancy
+            )
+            if referenceDistance > 0.5 {
+                let remainingFraction = min(max(remainingDistance / referenceDistance, 0.15), 1)
+                effectiveDuration = max(
+                    1.0 / 60.0,
+                    input.lastTransitionDuration * TimeInterval(remainingFraction)
+                )
+            } else {
+                effectiveDuration = 0
+            }
+        } else {
+            effectiveDuration = input.lastTransitionDuration
+        }
+
+        guard effectiveDuration > 0 else {
+            return .apply
+        }
+        return .animate(duration: effectiveDuration)
+    }
+
+    /// Converts visible bottom occupancy back to the overlap model used by the surface.
+    ///
+    /// ``TerminalLetterboxGeometry/keyboardOccupancy(keyboardHeight:bottomSafeAreaInset:)``
+    /// uses the safe area whenever overlap is zero, so occupancy at or immediately
+    /// above that boundary is represented by zero rather than a small overlap.
+    ///
+    /// - Parameters:
+    ///   - visibleOccupancy: Presentation-derived bottom occupancy in points.
+    ///   - bottomSafeAreaInset: The resolved bottom safe-area inset in points.
+    /// - Returns: The overlap value that best reproduces the visible occupancy.
+    public func pinnedOverlap(
+        forVisibleOccupancy visibleOccupancy: CGFloat,
+        bottomSafeAreaInset: CGFloat
+    ) -> CGFloat {
+        visibleOccupancy > bottomSafeAreaInset + 0.5 ? visibleOccupancy : 0
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalDockKeyboardTransitionPlannerTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalDockKeyboardTransitionPlannerTests.swift
@@ -1,0 +1,123 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import CmuxMobileTerminalKit
+
+@Suite("Terminal dock keyboard transition planning")
+struct TerminalDockKeyboardTransitionPlannerTests {
+    private let planner = TerminalDockKeyboardTransitionPlanner()
+
+    @Test("settled dock ignores a notification for its visible occupancy")
+    func settledDockIgnoresMatchingTarget() {
+        let plan = planner.plan(for: input(
+            targetOverlap: 336,
+            visibleOccupancy: 336,
+            targetOccupancy: 336
+        ))
+
+        #expect(plan == .ignore)
+    }
+
+    @Test("mid-flight notification for the same destination is ignored")
+    func midFlightSameDestinationIsIgnored() {
+        let plan = planner.plan(for: input(
+            targetOverlap: 336,
+            visibleOccupancy: 180,
+            targetOccupancy: 336,
+            isAnimating: true,
+            activeTargetOverlap: 336
+        ))
+
+        #expect(plan == .ignore)
+    }
+
+    @Test("mid-flight fresh destination animates from a stale visible position")
+    func midFlightDifferentDestinationAnimates() {
+        let plan = planner.plan(for: input(
+            targetOverlap: 0,
+            notificationDuration: 0.3,
+            visibleOccupancy: 220,
+            targetOccupancy: 34,
+            isAnimating: true,
+            activeTargetOverlap: 336
+        ))
+
+        #expect(plan == .animate(duration: 0.3))
+    }
+
+    @Test("zero-duration interruption synthesizes a remaining-fraction duration")
+    func zeroDurationSynthesizesDuration() {
+        let plan = planner.plan(for: input(
+            targetOverlap: 0,
+            notificationDuration: 0,
+            visibleOccupancy: 220,
+            targetOccupancy: 34,
+            isAnimating: true,
+            activeTargetOverlap: 336,
+            lastTransitionDuration: 0.25
+        ))
+        guard case let .animate(duration) = plan else {
+            Issue.record("Expected a synthesized animation")
+            return
+        }
+
+        #expect(abs(duration - (0.25 * 186.0 / 336.0)) < 0.000_001)
+    }
+
+    @Test("tiny remaining distance applies directly when an old animation is active")
+    func tinyDistanceAppliesDirectly() {
+        let plan = planner.plan(for: input(
+            targetOverlap: 200,
+            visibleOccupancy: 199.75,
+            targetOccupancy: 200,
+            isAnimating: true,
+            activeTargetOverlap: 336
+        ))
+
+        #expect(plan == .apply)
+    }
+
+    @Test("visible occupancy converts around the safe-area boundary")
+    func pinnedOverlapConversions() {
+        #expect(planner.pinnedOverlap(
+            forVisibleOccupancy: 34,
+            bottomSafeAreaInset: 34
+        ) == 0)
+        #expect(planner.pinnedOverlap(
+            forVisibleOccupancy: 34.5,
+            bottomSafeAreaInset: 34
+        ) == 0)
+        #expect(planner.pinnedOverlap(
+            forVisibleOccupancy: 34.51,
+            bottomSafeAreaInset: 34
+        ) == 34.51)
+        #expect(planner.pinnedOverlap(
+            forVisibleOccupancy: 0,
+            bottomSafeAreaInset: 0
+        ) == 0)
+        #expect(planner.pinnedOverlap(
+            forVisibleOccupancy: 0.51,
+            bottomSafeAreaInset: 0
+        ) == 0.51)
+    }
+
+    private func input(
+        targetOverlap: CGFloat,
+        notificationDuration: TimeInterval = 0.25,
+        visibleOccupancy: CGFloat,
+        targetOccupancy: CGFloat,
+        isAnimating: Bool = false,
+        activeTargetOverlap: CGFloat = 0,
+        lastTransitionDuration: TimeInterval = 0.25
+    ) -> TerminalDockKeyboardTransitionInput {
+        TerminalDockKeyboardTransitionInput(
+            targetOverlap: targetOverlap,
+            notificationDuration: notificationDuration,
+            visibleOccupancy: visibleOccupancy,
+            targetOccupancy: targetOccupancy,
+            isAnimating: isAnimating,
+            activeTargetOverlap: activeTargetOverlap,
+            lastTransitionDuration: lastTransitionDuration
+        )
+    }
+}


### PR DESCRIPTION
On iPhone, opening the software keyboard in a terminal workspace launched the shortcut toolbar and the Message composer to the middle of the screen (roughly an extra keyboard height above their correct spot, with the two bars visibly separating mid-flight), then they settled back down about a third of a second after the keyboard finished. Sometimes they never settled and stayed stranded mid-screen.

Four stacked causes, all in the terminal dock path:

1. The composer's `UIHostingController` was the only hosting controller in the app without `safeAreaRegions = .container`, so SwiftUI keyboard avoidance ran inside the band and `sizeThatFits` measurements taken while the keyboard rose came back inflated by the keyboard overlap. That inflated height became `composerBandHeight`, and the toolbar rides the band's top edge, so both bars jumped a keyboard height too high. A later clean re-measure settled them; when none arrived they stayed stuck.
2. `handleKeyboardWillChangeFrame` guarded on the cached animation target instead of the on-screen position, so repeat notifications during an interrupted transition were swallowed and the dock stayed parked wherever it was.
3. Three animation clocks (keyboard curve, hardcoded 0.25s ease-in-out band reflow, hardcoded 0.25s `animateBottomDock`) ran additively on the same layers.
4. `layoutSubviews` and `safeAreaInsetsDidChange` snapped dock frames outside any animation mid-flight.

Fix, modeled on the already-hardened agent-chat keyboard controller: a pure `TerminalDockKeyboardTransitionPlanner` (in CmuxMobileTerminalKit, unit-tested) decides ignore/apply/animate per notification by comparing the presentation-layer visible position against the target; the surface pins the model to the visible position and removes stale dock animations before starting each transition; every non-keyboard dock reflow joins the active keyboard animation's curve and remaining duration through one `animateDockReflow` helper; mid-flight bounds or safe-area changes re-pin and animate the remainder instead of snapping; the composer host opts out of SwiftUI keyboard avoidance and clamps measured band heights to 45% of the surface as a backstop; the async `scheduleKeyboardHideHeightResync` band-aid is replaced by a deterministic completion settle.

Verification: 106 CmuxMobileTerminalKit tests pass including 6 new planner cases covering the stuck-bar re-drive, synthesized durations for zero-duration notifications, and safe-area boundary pinning. iOS simulator build and device build compile and run; keyboard-up layout verified on the simulator with the bars flush against the keyboard top. A two-commit red/green split was not practical because the buggy logic lived in unhosted UIKit paths; the planner tests lock the new behavior instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787538262&installation_model_id=21920&pr_number=8899&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8899&signature=d23aaf64b597f6413e5be039028f5431d5592fd160c96f3ed4c72e60d46e1c82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS terminal dock keyboard pinning so the toolbar and composer stay flush to the keyboard and no longer jump or get stranded mid-screen. The dock now follows keyboard transitions reliably, even during interruptions and safe-area changes.

- **Bug Fixes**
  - Opt out of SwiftUI keyboard avoidance in the composer host (`safeAreaRegions = .container`).
  - Clamp composer band height to 45% of the surface to avoid inflated measurements during keyboard rise.
  - Use a new `TerminalDockKeyboardTransitionPlanner` to decide ignore/apply/animate from presentation-layer geometry.
  - Pin the dock to the visible position and remove stale animations before each transition; route all reflows through one `animateDockReflow` on the active keyboard curve.
  - Handle zero-duration and interrupted notifications by synthesizing durations; re-pin and continue mid-flight on bounds/safe-area changes instead of snapping.
  - Replace the async keyboard-hide resync with a deterministic completion settle.

- **Refactors**
  - Added `TerminalDockKeyboardTransitionInput`, `TerminalDockKeyboardTransitionPlan`, and `TerminalDockKeyboardTransitionPlanner` in `CmuxMobileTerminalKit`, with unit tests for stuck-bar re-drive, zero-duration synthesis, and safe-area boundary pinning.
  - Extended `TerminalKeyboardHeightAnimation` to track target overlap, animation options, and end timestamp for shared dock timing.

<sup>Written for commit 1906f7c276d56ef12c80fd8c9388e64b08d5fdf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard transitions to reduce jumps, flicker, and unnecessary layout changes.
  - Kept the terminal dock correctly positioned while the keyboard appears, disappears, or changes size.
  - Improved handling of interrupted keyboard animations and varying transition durations.
  - Prevented the composer from occupying more than 45% of the available terminal surface.
  - Improved safe-area and keyboard geometry handling for the composer field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->