### PR TITLE
iOS: scope device-keyed Mac state to the exact pairing

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacUpdateHintDismissalStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacUpdateHintDismissalStore.swift
@@ -15,30 +15,35 @@ public struct MobileMacUpdateHintDismissalStore {
         self.defaults = defaults
     }
 
-    /// Returns whether a Mac dismissed the exact capability-gap signature.
+    /// Returns whether a Mac pairing dismissed the exact capability-gap signature.
     ///
     /// - Parameters:
     ///   - macDeviceID: The stable identifier of the connected Mac.
+    ///   - instanceTag: The connected app instance, or `nil` for a legacy
+    ///     untagged pairing. Sibling builds of one Mac dismiss independently.
     ///   - signature: The current hint's dismissal signature.
     /// - Returns: `true` only when the stored signature exactly matches `signature`.
-    public func isDismissed(macDeviceID: String, signature: String) -> Bool {
-        defaults.string(forKey: Self.key(for: macDeviceID)) == signature
+    public func isDismissed(macDeviceID: String, instanceTag: String?, signature: String) -> Bool {
+        defaults.string(forKey: Self.key(for: macDeviceID, instanceTag: instanceTag)) == signature
     }
 
-    /// Persists dismissal of an exact capability gap for one Mac.
+    /// Persists dismissal of an exact capability gap for one Mac pairing.
     ///
     /// - Parameters:
     ///   - macDeviceID: The stable identifier of the connected Mac.
+    ///   - instanceTag: The connected app instance, or `nil` for a legacy
+    ///     untagged pairing.
     ///   - signature: The current hint's dismissal signature.
-    public func dismiss(macDeviceID: String, signature: String) {
-        defaults.set(signature, forKey: Self.key(for: macDeviceID))
+    public func dismiss(macDeviceID: String, instanceTag: String?, signature: String) {
+        defaults.set(signature, forKey: Self.key(for: macDeviceID, instanceTag: instanceTag))
     }
 
-    /// Builds the persistence key for a Mac device identifier.
-    ///
-    /// - Parameter macDeviceID: The stable identifier of the connected Mac.
-    /// - Returns: The defaults key scoped to that Mac.
-    private static func key(for macDeviceID: String) -> String {
-        keyPrefix + macDeviceID
+    /// Builds the persistence key for one Mac pairing. Tagged pairings get a
+    /// per-build key; untagged pairings keep the legacy device-level key.
+    private static func key(for macDeviceID: String, instanceTag: String?) -> String {
+        guard let instanceTag, !instanceTag.isEmpty else {
+            return keyPrefix + macDeviceID
+        }
+        return keyPrefix + macDeviceID + "\u{1F}" + instanceTag
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+MacUpdateHint.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+MacUpdateHint.swift
@@ -9,6 +9,9 @@ internal import CmuxMobileRPC
 /// `macUpdateHint` itself).
 final class MacUpdateHintSessionState {
     var macDeviceID: String?
+    /// The connected app instance the visible hint belongs to; sibling builds
+    /// of one Mac dismiss their hints independently.
+    var instanceTag: String?
     var shownSignatures: Set<String> = []
     /// The persisted dismissal store, carried here so both the lookup and the
     /// dismissal path share one instance and tests/previews can swap in a
@@ -59,8 +62,10 @@ extension MobileShellComposite {
             return
         }
 
+        let instanceTag = activeMacInstanceTag
         guard !macUpdateHintSessionState.dismissalStore.isDismissed(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             signature: hint.dismissalSignature
         ) else {
             clearMacUpdateHint()
@@ -69,12 +74,15 @@ extension MobileShellComposite {
 
         macUpdateHint = hint
         macUpdateHintSessionState.macDeviceID = macDeviceID
+        macUpdateHintSessionState.instanceTag = instanceTag
         // Keyed per Mac so two hosts sharing one gap signature each emit an
         // event, while reconnects to the same host stay deduplicated. Named
         // "eligible" deliberately: this fires when the model computes a
         // visible hint, not when the toolbar indicator actually renders
         // (chrome, navigation state, or backgrounding can defer that).
-        guard macUpdateHintSessionState.shownSignatures.insert("\(macDeviceID)|\(hint.dismissalSignature)").inserted else { return }
+        guard macUpdateHintSessionState.shownSignatures.insert(
+            "\(macDeviceID)|\(instanceTag ?? "")|\(hint.dismissalSignature)"
+        ).inserted else { return }
         analytics.capture("ios_mac_update_hint_eligible", analyticsProperties(for: hint))
     }
 
@@ -95,6 +103,7 @@ extension MobileShellComposite {
         guard let hint = macUpdateHint, let macDeviceID = macUpdateHintSessionState.macDeviceID else { return }
         macUpdateHintSessionState.dismissalStore.dismiss(
             macDeviceID: macDeviceID,
+            instanceTag: macUpdateHintSessionState.instanceTag,
             signature: hint.dismissalSignature
         )
         clearMacUpdateHint()
@@ -105,6 +114,7 @@ extension MobileShellComposite {
     func clearMacUpdateHint() {
         macUpdateHint = nil
         macUpdateHintSessionState.macDeviceID = nil
+        macUpdateHintSessionState.instanceTag = nil
     }
 
     private func analyticsProperties(for hint: MobileMacUpdateHint) -> [String: AnalyticsValue] {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacAliases.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacAliases.swift
@@ -88,13 +88,30 @@ extension MobileShellComposite {
     }
 
     /// User customization for every stored id represented by visible paired-Mac rows.
+    ///
+    /// Workspaces carry no instance tag, so when sibling builds of one Mac are
+    /// both customized the active pairing's customization represents the
+    /// device; without that preference the result depended on iteration order.
     func pairedMacCustomizationsByAliasID() -> [String: MobilePairedMac] {
-        displayPairedMacs.reduce(into: [String: MobilePairedMac]()) { result, mac in
-            guard mac.customColor != nil || mac.customIcon != nil else { return }
-            for aliasID in pairedMacAliasIDs(for: mac.macDeviceID, instanceTag: mac.instanceTag) {
+        Self.customizationsByAliasID(for: displayPairedMacs) { mac in
+            pairedMacAliasIDs(for: mac.macDeviceID, instanceTag: mac.instanceTag)
+        }
+    }
+
+    /// Deterministic alias→customization resolution: the active pairing first,
+    /// then remaining display order, first write wins per alias id.
+    static func customizationsByAliasID(
+        for macs: [MobilePairedMac],
+        aliasesFor: (MobilePairedMac) -> [String]
+    ) -> [String: MobilePairedMac] {
+        let preferredMacs = macs.filter(\.isActive) + macs.filter { !$0.isActive }
+        var result: [String: MobilePairedMac] = [:]
+        for mac in preferredMacs where mac.customColor != nil || mac.customIcon != nil {
+            for aliasID in aliasesFor(mac) where result[aliasID] == nil {
                 result[aliasID] = mac
             }
         }
+        return result
     }
 
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairingConnectionStatus.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairingConnectionStatus.swift
@@ -1,0 +1,26 @@
+public import CmuxMobileShellModel
+
+extension MobileShellComposite {
+    /// Refines a device-keyed connection status to one exact pairing row.
+    ///
+    /// `macConnectionStatuses` is keyed by physical device id, but "Connected"
+    /// is true of exactly one app instance at a time. A `.connected` device
+    /// status therefore only applies to the row whose instance tag matches the
+    /// connected pairing; the sibling build's row must not inherit it. Legacy
+    /// rows without a tag keep the device-level status unchanged.
+    public static func exactPairingConnectionStatus(
+        deviceStatus: MobileMacConnectionStatus?,
+        connectedMacDeviceID: String?,
+        connectedMacInstanceTag: String?,
+        rowMacDeviceID: String,
+        rowInstanceTag: String?
+    ) -> MobileMacConnectionStatus? {
+        guard deviceStatus == .connected,
+              connectedMacDeviceID == rowMacDeviceID,
+              let rowInstanceTag,
+              connectedMacInstanceTag != rowInstanceTag else {
+            return deviceStatus
+        }
+        return nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacUpdateHintDismissalStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacUpdateHintDismissalStoreTests.swift
@@ -20,19 +20,40 @@ final class MobileMacUpdateHintDismissalStoreTests {
 
     @Test
     func dismissingSignaturePersistsExactMatch() {
-        store.dismiss(macDeviceID: "mac-a", signature: "cap.a>=2.0")
-        #expect(store.isDismissed(macDeviceID: "mac-a", signature: "cap.a>=2.0"))
+        store.dismiss(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0")
+        #expect(store.isDismissed(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0"))
     }
 
     @Test
     func differentSignatureRearmsHint() {
-        store.dismiss(macDeviceID: "mac-a", signature: "cap.a>=2.0")
-        #expect(!store.isDismissed(macDeviceID: "mac-a", signature: "cap.a,cap.b>=3.0"))
+        store.dismiss(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0")
+        #expect(!store.isDismissed(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a,cap.b>=3.0"))
     }
 
     @Test
     func dismissalIsScopedToMac() {
-        store.dismiss(macDeviceID: "mac-a", signature: "cap.a>=2.0")
-        #expect(!store.isDismissed(macDeviceID: "mac-b", signature: "cap.a>=2.0"))
+        store.dismiss(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0")
+        #expect(!store.isDismissed(macDeviceID: "mac-b", instanceTag: nil, signature: "cap.a>=2.0"))
+    }
+
+    @Test
+    func dismissalIsScopedToPairingNotDevice() {
+        store.dismiss(macDeviceID: "mac-a", instanceTag: "nightly", signature: "cap.a>=2.0")
+        #expect(store.isDismissed(macDeviceID: "mac-a", instanceTag: "nightly", signature: "cap.a>=2.0"))
+        #expect(!store.isDismissed(macDeviceID: "mac-a", instanceTag: "stable", signature: "cap.a>=2.0"))
+        #expect(!store.isDismissed(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0"))
+    }
+
+    @Test
+    func legacyUntaggedDismissalDoesNotSuppressTaggedPairings() {
+        store.dismiss(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0")
+        #expect(store.isDismissed(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0"))
+        #expect(!store.isDismissed(macDeviceID: "mac-a", instanceTag: "nightly", signature: "cap.a>=2.0"))
+    }
+
+    @Test
+    func emptyInstanceTagUsesLegacyDeviceKey() {
+        store.dismiss(macDeviceID: "mac-a", instanceTag: "", signature: "cap.a>=2.0")
+        #expect(store.isDismissed(macDeviceID: "mac-a", instanceTag: nil, signature: "cap.a>=2.0"))
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairingScopeTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairingScopeTests.swift
@@ -1,0 +1,84 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Sibling app builds (Nightly + Stable) share one `macDeviceID`. State that is
+/// keyed by device id must resolve deterministically to the pairing the phone
+/// actually targets instead of whichever sibling happens to iterate last.
+@MainActor
+@Suite struct MobileShellCompositePairingScopeTests {
+    @Test func activePairingCustomizationWinsForSharedDeviceAlias() async throws {
+        let pairedStore = DelayedTeamPairedMacStore(
+            recordsByTeam: [
+                "team-a": [
+                    try Self.pairedMac(
+                        id: "mac-a",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 20),
+                        isActive: true,
+                        customColor: "red",
+                        instanceTag: "nightly"
+                    ),
+                    try Self.pairedMac(
+                        id: "mac-a",
+                        displayName: "Desk Mac",
+                        host: "100.82.214.112",
+                        lastSeenAt: Date(timeIntervalSince1970: 10),
+                        isActive: false,
+                        customColor: "blue",
+                        instanceTag: "stable"
+                    ),
+                ],
+            ],
+            blockedTeams: []
+        )
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" },
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+        await store.loadPairedMacs()
+        #expect(store.displayPairedMacs.count == 2)
+
+        let customizations = store.pairedMacCustomizationsByAliasID()
+
+        // The active pairing represents the device wherever state has no
+        // per-build dimension; the sibling must not overwrite it.
+        #expect(customizations["mac-a"]?.customColor == "red")
+        #expect(customizations["mac-a"]?.instanceTag == "nightly")
+    }
+
+    private static func pairedMac(
+        id: String,
+        displayName: String,
+        host: String,
+        port: Int = 50922,
+        lastSeenAt: Date,
+        isActive: Bool,
+        customColor: String? = nil,
+        instanceTag: String? = nil
+    ) throws -> MobilePairedMac {
+        MobilePairedMac(
+            macDeviceID: id,
+            displayName: displayName,
+            routes: [try CmxAttachRoute(
+                id: "manual",
+                kind: .tailscale,
+                endpoint: .hostPort(host: host, port: port)
+            )],
+            createdAt: Date(timeIntervalSince1970: 1),
+            lastSeenAt: lastSeenAt,
+            isActive: isActive,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            customColor: customColor,
+            instanceTag: instanceTag
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairingScopeTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellCompositePairingScopeTests.swift
@@ -54,6 +54,36 @@ import Testing
         #expect(customizations["mac-a"]?.instanceTag == "nightly")
     }
 
+    @Test func exactPairingConnectionStatusOnlyMatchesConnectedPairing() {
+        typealias Status = MobileMacConnectionStatus
+        func refine(_ deviceStatus: Status?, connectedTag: String?, rowTag: String?) -> Status? {
+            MobileShellComposite.exactPairingConnectionStatus(
+                deviceStatus: deviceStatus,
+                connectedMacDeviceID: "mac-a",
+                connectedMacInstanceTag: connectedTag,
+                rowMacDeviceID: "mac-a",
+                rowInstanceTag: rowTag
+            )
+        }
+
+        #expect(refine(.connected, connectedTag: "stable", rowTag: "stable") == .connected)
+        #expect(refine(.connected, connectedTag: "stable", rowTag: "nightly") == nil)
+        #expect(refine(.connected, connectedTag: nil, rowTag: "nightly") == nil)
+        // Legacy untagged rows keep the device-level status.
+        #expect(refine(.connected, connectedTag: "stable", rowTag: nil) == .connected)
+        // Non-connected statuses pass through untouched for every row.
+        #expect(refine(.reconnecting, connectedTag: "stable", rowTag: "nightly") == .reconnecting)
+        #expect(refine(nil, connectedTag: "stable", rowTag: "nightly") == nil)
+        // A different device is unaffected by this device's connection.
+        #expect(MobileShellComposite.exactPairingConnectionStatus(
+            deviceStatus: .connected,
+            connectedMacDeviceID: "mac-b",
+            connectedMacInstanceTag: "stable",
+            rowMacDeviceID: "mac-a",
+            rowInstanceTag: "nightly"
+        ) == .connected)
+    }
+
     private static func pairedMac(
         id: String,
         displayName: String,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -317,13 +317,18 @@ struct DisconnectedWorkspaceShellView: View {
                 VStack(spacing: 8) {
                     ForEach(savedMacs) { mac in
                         Button {
-                            Task { await store.switchToMac(macDeviceID: mac.macDeviceID) }
+                            Task {
+                                await store.switchToMac(
+                                    macDeviceID: mac.macDeviceID,
+                                    instanceTag: mac.instanceTag
+                                )
+                            }
                         } label: {
                             Label(mac.displayName ?? mac.macDeviceID, systemImage: "desktopcomputer")
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
                         .buttonStyle(.bordered)
-                        .accessibilityIdentifier("MobileDisconnectedSavedMac-\(mac.macDeviceID)")
+                        .accessibilityIdentifier("MobileDisconnectedSavedMac-\(mac.id)")
                     }
                 }
                 .frame(maxWidth: 320)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -49,7 +49,13 @@ struct MacComputerDetailView: View {
         }
     }
     private var connectionStatus: MobileMacConnectionStatus? {
-        store.macConnectionStatuses[macDeviceID]
+        MobileShellComposite.exactPairingConnectionStatus(
+            deviceStatus: store.macConnectionStatuses[macDeviceID],
+            connectedMacDeviceID: store.connectedMacDeviceID,
+            connectedMacInstanceTag: store.connectedMacInstanceTag,
+            rowMacDeviceID: macDeviceID,
+            rowInstanceTag: instanceTag
+        )
     }
     private var presence: PresenceMap.DeviceSummary? {
         store.presenceSummary(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -150,7 +150,7 @@ struct MacComputerRow: View {
                 .font(.caption2)
                 .foregroundStyle(dotColor)
                 .accessibilityLabel(primaryStatusPhrase)
-                .accessibilityIdentifier("MobileComputerStatus-\(computer.deviceId)-\(statusIdentifierSuffix)")
+                .accessibilityIdentifier("MobileComputerStatus-\(computer.id)-\(statusIdentifierSuffix)")
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -36,13 +36,13 @@ extension MacComputerSnapshot {
             )
             let presence: DeviceTreePresence? = summary
                 .map { $0.online ? .online : .offline(lastSeenAt: $0.lastSeenAt) }
-            let connectionStatus = connectionStatuses[mac.macDeviceID]
-            let exactConnectionStatus = connectionStatus == .connected
-                && store.connectedMacDeviceID == mac.macDeviceID
-                && mac.instanceTag != nil
-                && store.connectedMacInstanceTag != mac.instanceTag
-                ? nil
-                : connectionStatus
+            let exactConnectionStatus = MobileShellComposite.exactPairingConnectionStatus(
+                deviceStatus: connectionStatuses[mac.macDeviceID],
+                connectedMacDeviceID: store.connectedMacDeviceID,
+                connectedMacInstanceTag: store.connectedMacInstanceTag,
+                rowMacDeviceID: mac.macDeviceID,
+                rowInstanceTag: mac.instanceTag
+            )
             return MacComputerSnapshot(
                 deviceId: mac.macDeviceID,
                 instanceTag: mac.instanceTag,


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/8816 and https://github.com/manaflow-ai/cmux/pull/8877 from a pairing-scope audit. Sibling builds of one Mac (Nightly + Stable) share a `macDeviceID`, and four spots still resolved per-device state in ways users can see.

The computer detail page read the device-keyed connection status raw, so with the phone connected to Stable, the Nightly sibling's detail page showed "Connected" in green while the Computers list correctly showed it grey. The refinement the list already applied now lives in one shared helper, `MobileShellComposite.exactPairingConnectionStatus`, used by both the list snapshot store and the detail view; legacy untagged rows keep the device-level status.

Workspace avatar customization (`pairedMacCustomizationsByAliasID`) let whichever sibling iterated last stamp its color/icon on the device's workspaces. It now resolves deterministically: the active pairing first, then display order, first write wins. The first commit adds this as a failing regression test; the second turns it green.

Mac-update-hint dismissals were keyed by device, so dismissing a hint on one build suppressed an identical-signature hint on the sibling. Keys now include the instance tag for tagged pairings (untagged pairings keep the legacy key). A hint dismissed before this change may reappear once and needs one re-dismiss.

Also: sibling rows' status dots get unique accessibility identifiers (keyed by pairing id, previously identical for both builds), and the macOS-fallback saved-Mac reconnect buttons now pass the instance tag they already had instead of routing to an arbitrary sibling.

Tests: 23 green across `MobileShellCompositePairingScopeTests` (new), `MobileMacUpdateHintDismissalStoreTests` (extended, existing call sites updated to the tagged API), and `MobileMacUpdateHintTests`, all host-runnable in CmuxMobileShell which `test-ios.yml` gates. No user-facing strings changed, so no localization entries were needed.

Known remaining device-scoped behavior, intentionally out of scope: workspaces carry no instance tag, so workspace counts and lists stay per physical device until the Mac reports per-build attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787540567&installation_model_id=21920&pr_number=8901&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8901&signature=6fc2d049dc2cc87d40cd90862b13f387928d728e76f9c67cf3217ff1fd404994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes device-keyed Mac state to the exact pairing so sibling builds (e.g., Stable/Nightly) don’t leak status, customizations, or hint dismissals. Fixes the false “Connected” state in the computer detail view and aligns UI actions/ids with pairing scope.

- **Bug Fixes**
  - Added `MobileShellComposite.exactPairingConnectionStatus` and used it in the Computers list and detail view so only the connected pairing shows “Connected” (legacy untagged rows keep device-level status).
  - Made workspace avatar customization deterministic: active pairing first, then display order, first write wins.
  - Scoped Mac update-hint dismissals per pairing by including the instance tag; untagged pairings keep the legacy device key. A previously dismissed hint may reappear once.
  - Gave sibling rows unique status-dot accessibility identifiers (keyed by pairing id), and saved-Mac reconnect buttons now pass the instance tag.

<sup>Written for commit 8ae29d96749b0d2b3a595ee12f59cfd184899202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for multiple app instances connected to the same Mac.
  - Mac update reminders can now be dismissed independently for each app instance.
  - Connection indicators now accurately reflect the selected Mac pairing and app instance.
  - Reconnecting from the disconnected view preserves the selected app instance.

- **Bug Fixes**
  - Mac customizations for shared device aliases now resolve consistently, prioritizing active pairings.
  - Improved handling of legacy and untagged pairings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->