### PR TITLE
iOS: make the files chip count exactly match the gallery rows

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
@@ -37,6 +37,7 @@ public struct ChatArtifactGalleryBuilder: Sendable {
         }
         let ordering = ChatArtifactGalleryOrdering()
         let stableItems = orderedItems ?? ordering.sorted(items)
+        let eligibility = ChatArtifactGalleryRowEligibility()
         let normalizedQuery = query?.trimmingCharacters(in: .whitespacesAndNewlines)
         let isSearch = normalizedQuery?.isEmpty == false
         let createdCandidates: [ChatArtifactIndexedReference]
@@ -47,9 +48,13 @@ public struct ChatArtifactGalleryBuilder: Sendable {
             attachedCandidates = []
             referencedCandidates = ordering.matching(stableItems, query: normalizedQuery)
         } else {
-            createdCandidates = stableItems.filter { $0.provenance == .created }
-            attachedCandidates = stableItems.filter { $0.provenance == .attached }
-            referencedCandidates = stableItems.filter { $0.provenance == .referenced }
+            let candidates = eligibility.defaultCandidates(
+                items,
+                orderedItems: stableItems
+            )
+            createdCandidates = candidates.created
+            attachedCandidates = candidates.attached
+            referencedCandidates = candidates.referenced
         }
         let count = max(1, pageSize)
         let starts = pageStarts(
@@ -91,11 +96,23 @@ public struct ChatArtifactGalleryBuilder: Sendable {
 
         return ChatArtifactGalleryPage(
             sessionID: sessionID,
-            created: isSearch ? [] : statItems(pageCreated, includeDirectories: includeDirectories),
+            created: isSearch ? [] : eligibility.rows(
+                pageCreated,
+                includeDirectories: includeDirectories,
+                includeMissing: true
+            ),
             createdTotal: createdCandidates.count,
-            attached: isSearch ? [] : statItems(pageAttached, includeDirectories: includeDirectories),
+            attached: isSearch ? [] : eligibility.rows(
+                pageAttached,
+                includeDirectories: includeDirectories,
+                includeMissing: true
+            ),
             attachedTotal: attachedCandidates.count,
-            referenced: statItems(pageReferenced, includeDirectories: includeDirectories),
+            referenced: eligibility.rows(
+                pageReferenced,
+                includeDirectories: includeDirectories,
+                includeMissing: true
+            ),
             referencedTotal: referencedCandidates.count,
             nextCursor: nextCursor,
             generation: generation
@@ -123,57 +140,4 @@ public struct ChatArtifactGalleryBuilder: Sendable {
         return (created.count, attached.count, referenced.count - remaining.count)
     }
 
-    /// Counts immediate children for a gallery directory row without sorting
-    /// or per-entry metadata, stopping at the shared listing limit so the cost
-    /// never scales past the cap for large folders.
-    private func directoryChildCount(path: String) -> (count: Int, isCapped: Bool)? {
-        guard let enumerator = FileManager.default.enumerator(
-            at: URL(fileURLWithPath: path, isDirectory: true),
-            includingPropertiesForKeys: [],
-            options: [.skipsSubdirectoryDescendants]
-        ) else {
-            return nil
-        }
-        var count = 0
-        while enumerator.nextObject() != nil {
-            count += 1
-            if count > ArtifactByteReader.maximumDirectoryEntryCount {
-                return (count: ArtifactByteReader.maximumDirectoryEntryCount, isCapped: true)
-            }
-        }
-        return (count: count, isCapped: false)
-    }
-
-    private func statItems(
-        _ references: [ChatArtifactIndexedReference],
-        includeDirectories: Bool
-    ) -> [ChatArtifactGalleryItem] {
-        let reader = ArtifactByteReader()
-        return references.compactMap { reference in
-            do {
-                let stat = try reader.stat(path: reference.path)
-                guard includeDirectories || !stat.isDirectory else { return nil }
-                let children = stat.isDirectory ? directoryChildCount(path: reference.path) : nil
-                return ChatArtifactGalleryItem(
-                    path: reference.path,
-                    kind: stat.kind,
-                    displayName: URL(fileURLWithPath: reference.path).lastPathComponent,
-                    size: stat.size,
-                    modifiedAt: stat.modifiedAt,
-                    exists: stat.exists,
-                    childCount: children?.count,
-                    childCountIsCapped: children?.isCapped ?? false,
-                    provenance: reference.provenance
-                )
-            } catch {
-                return ChatArtifactGalleryItem(
-                    path: reference.path,
-                    kind: reader.kind(path: reference.path, isDirectory: false),
-                    displayName: URL(fileURLWithPath: reference.path).lastPathComponent,
-                    exists: false,
-                    provenance: reference.provenance
-                )
-            }
-        }
-    }
 }

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowCountCache.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowCountCache.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Caches authoritative gallery row counts for a short filesystem freshness window.
+public actor ChatArtifactGalleryRowCountCache {
+    private struct Key: Hashable {
+        let sessionID: String
+        let generation: String
+        let includeDirectories: Bool
+        let includeMissing: Bool
+    }
+
+    private struct Entry {
+        let total: Int
+        let storedAt: Date
+    }
+
+    private let maximumAge: TimeInterval
+    private var entries: [Key: Entry] = [:]
+
+    /// Creates a gallery row count cache.
+    ///
+    /// - Parameter maximumAge: Maximum age of a cached stat-derived count.
+    public init(maximumAge: TimeInterval = 2) {
+        self.maximumAge = max(0, maximumAge)
+    }
+
+    /// Returns a fresh cached total for an exact snapshot and filter key.
+    ///
+    /// - Parameters:
+    ///   - sessionID: Stable identity of the transcript session.
+    ///   - generation: Transcript snapshot generation.
+    ///   - includeDirectories: Whether the cached count includes directories.
+    ///   - includeMissing: Whether the cached count includes missing references.
+    ///   - now: Time used to enforce the cache's maximum age.
+    /// - Returns: The cached total, or `nil` when absent or stale.
+    public func total(
+        sessionID: String,
+        generation: String,
+        includeDirectories: Bool,
+        includeMissing: Bool,
+        now: Date
+    ) -> Int? {
+        removeExpiredEntries(now: now)
+        return entries[Key(
+            sessionID: sessionID,
+            generation: generation,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        )]?.total
+    }
+
+    /// Stores a stat-derived total for an exact snapshot and filter key.
+    ///
+    /// A new generation or filter combination for the same session replaces
+    /// that session's older count so the cache remains tiny.
+    ///
+    /// - Parameters:
+    ///   - total: Authoritative gallery row total.
+    ///   - sessionID: Stable identity of the transcript session.
+    ///   - generation: Transcript snapshot generation.
+    ///   - includeDirectories: Whether the count includes directories.
+    ///   - includeMissing: Whether the count includes missing references.
+    ///   - now: Time at which the count was computed.
+    public func store(
+        _ total: Int,
+        sessionID: String,
+        generation: String,
+        includeDirectories: Bool,
+        includeMissing: Bool,
+        now: Date
+    ) {
+        removeExpiredEntries(now: now)
+        entries = entries.filter { $0.key.sessionID != sessionID }
+        entries[Key(
+            sessionID: sessionID,
+            generation: generation,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        )] = Entry(total: total, storedAt: now)
+    }
+
+    private func removeExpiredEntries(now: Date) {
+        entries = entries.filter {
+            now.timeIntervalSince($0.value.storedAt) <= maximumAge
+        }
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowCountCache.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowCountCache.swift
@@ -16,12 +16,57 @@ public actor ChatArtifactGalleryRowCountCache {
 
     private let maximumAge: TimeInterval
     private var entries: [Key: Entry] = [:]
+    private var inFlightComputations: [Key: Task<Int, Never>] = [:]
 
     /// Creates a gallery row count cache.
     ///
     /// - Parameter maximumAge: Maximum age of a cached stat-derived count.
     public init(maximumAge: TimeInterval = 2) {
         self.maximumAge = max(0, maximumAge)
+    }
+
+    /// Returns the cached total, computing it at most once under concurrent
+    /// misses: callers that land on the same (session, generation, filters)
+    /// key await one shared sweep instead of issuing overlapping ones.
+    public func total(
+        sessionID: String,
+        generation: String,
+        includeDirectories: Bool,
+        includeMissing: Bool,
+        now: Date,
+        compute: @escaping @Sendable () -> Int
+    ) async -> Int {
+        if let cached = total(
+            sessionID: sessionID,
+            generation: generation,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing,
+            now: now
+        ) {
+            return cached
+        }
+        let key = Key(
+            sessionID: sessionID,
+            generation: generation,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        )
+        if let inFlight = inFlightComputations[key] {
+            return await inFlight.value
+        }
+        let task = Task<Int, Never>(priority: .utility) { compute() }
+        inFlightComputations[key] = task
+        let computed = await task.value
+        inFlightComputations[key] = nil
+        store(
+            computed,
+            sessionID: sessionID,
+            generation: generation,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing,
+            now: Date()
+        )
+        return computed
     }
 
     /// Returns a fresh cached total for an exact snapshot and filter key.

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
@@ -37,26 +37,38 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
     ///   - includeDirectories: Whether directories are eligible gallery rows.
     ///   - includeMissing: Whether references that fail stat remain as missing rows.
     /// - Returns: The number of rows the default gallery view renders.
+    /// Counting is stat-only: it shares `isEligible` with row building but
+    /// never constructs `ChatArtifactGalleryItem`s and never enumerates
+    /// directory children, so a count over a large session costs one stat per
+    /// reference. Ordering and provenance grouping cannot change a total, so
+    /// `orderedItems` is accepted for call-site symmetry but not required.
     public func defaultRowCount(
         _ items: [ChatArtifactIndexedReference],
         orderedItems: [ChatArtifactIndexedReference]? = nil,
         includeDirectories: Bool,
         includeMissing: Bool
     ) -> Int {
-        let candidates = defaultCandidates(items, orderedItems: orderedItems)
-        return rows(
-            candidates.created,
-            includeDirectories: includeDirectories,
-            includeMissing: includeMissing
-        ).count + rows(
-            candidates.attached,
-            includeDirectories: includeDirectories,
-            includeMissing: includeMissing
-        ).count + rows(
-            candidates.referenced,
-            includeDirectories: includeDirectories,
-            includeMissing: includeMissing
-        ).count
+        (orderedItems ?? items).count { reference in
+            isEligible(
+                reference,
+                includeDirectories: includeDirectories,
+                includeMissing: includeMissing
+            )
+        }
+    }
+
+    /// The single row-inclusion rule shared by page rows and count-only scans.
+    public func isEligible(
+        _ reference: ChatArtifactIndexedReference,
+        includeDirectories: Bool,
+        includeMissing: Bool
+    ) -> Bool {
+        do {
+            let stat = try ArtifactByteReader().stat(path: reference.path)
+            return includeDirectories || !stat.isDirectory
+        } catch {
+            return includeMissing
+        }
     }
 
     func defaultCandidates(
@@ -80,10 +92,17 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
         includeDirectories: Bool,
         includeMissing: Bool
     ) -> ChatArtifactGalleryItem? {
+        // Inclusion is decided by the shared predicate so page rows and
+        // count-only scans cannot drift. Rows are page-bounded, so the second
+        // stat during item construction below is trivial.
+        guard isEligible(
+            reference,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        ) else { return nil }
         let reader = ArtifactByteReader()
         do {
             let stat = try reader.stat(path: reference.path)
-            guard includeDirectories || !stat.isDirectory else { return nil }
             let children = stat.isDirectory ? directoryChildCount(path: reference.path) : nil
             return ChatArtifactGalleryItem(
                 path: reference.path,
@@ -97,7 +116,6 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
                 provenance: reference.provenance
             )
         } catch {
-            guard includeMissing else { return nil }
             return ChatArtifactGalleryItem(
                 path: reference.path,
                 kind: reader.kind(path: reference.path, isDirectory: false),

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
@@ -37,11 +37,12 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
     ///   - includeDirectories: Whether directories are eligible gallery rows.
     ///   - includeMissing: Whether references that fail stat remain as missing rows.
     /// - Returns: The number of rows the default gallery view renders.
-    /// Counting is stat-only: it shares `isEligible` with row building but
-    /// never constructs `ChatArtifactGalleryItem`s and never enumerates
-    /// directory children, so a count over a large session costs one stat per
-    /// reference. Ordering and provenance grouping cannot change a total, so
-    /// `orderedItems` is accepted for call-site symmetry but not required.
+    /// Counting is existence-only: one `fileExists` syscall per reference,
+    /// no `ChatArtifactGalleryItem` construction, no directory child
+    /// enumeration, and no `ArtifactByteReader.stat` (which can read file
+    /// bytes to classify extension-less files). Ordering and provenance
+    /// grouping cannot change a total, so `orderedItems` is accepted for
+    /// call-site symmetry but not required.
     public func defaultRowCount(
         _ items: [ChatArtifactIndexedReference],
         orderedItems: [ChatArtifactIndexedReference]? = nil,
@@ -57,18 +58,37 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
         }
     }
 
-    /// The single row-inclusion rule shared by page rows and count-only scans.
+    /// Cheap eligibility for count-only scans: same rule as page rows, fed
+    /// from a single existence syscall.
     public func isEligible(
         _ reference: ChatArtifactIndexedReference,
         includeDirectories: Bool,
         includeMissing: Bool
     ) -> Bool {
-        do {
-            let stat = try ArtifactByteReader().stat(path: reference.path)
-            return includeDirectories || !stat.isDirectory
-        } catch {
-            return includeMissing
-        }
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(
+            atPath: reference.path,
+            isDirectory: &isDirectory
+        )
+        return Self.isRowIncluded(
+            exists: exists,
+            isDirectory: isDirectory.boolValue,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        )
+    }
+
+    /// The single row-inclusion rule shared by page rows and count-only
+    /// scans. Both feed it their own filesystem observation; the decision
+    /// logic itself cannot drift.
+    static func isRowIncluded(
+        exists: Bool,
+        isDirectory: Bool,
+        includeDirectories: Bool,
+        includeMissing: Bool
+    ) -> Bool {
+        guard exists else { return includeMissing }
+        return includeDirectories || !isDirectory
     }
 
     func defaultCandidates(
@@ -92,17 +112,19 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
         includeDirectories: Bool,
         includeMissing: Bool
     ) -> ChatArtifactGalleryItem? {
-        // Inclusion is decided by the shared predicate so page rows and
-        // count-only scans cannot drift. Rows are page-bounded, so the second
-        // stat during item construction below is trivial.
-        guard isEligible(
-            reference,
-            includeDirectories: includeDirectories,
-            includeMissing: includeMissing
-        ) else { return nil }
+        // One stat outcome drives BOTH the inclusion decision and the row
+        // payload, so what renders cannot diverge from the shared rule and
+        // there is no second stat (and no window for the file to change
+        // between decision and construction).
         let reader = ArtifactByteReader()
         do {
             let stat = try reader.stat(path: reference.path)
+            guard Self.isRowIncluded(
+                exists: stat.exists,
+                isDirectory: stat.isDirectory,
+                includeDirectories: includeDirectories,
+                includeMissing: includeMissing
+            ) else { return nil }
             let children = stat.isDirectory ? directoryChildCount(path: reference.path) : nil
             return ChatArtifactGalleryItem(
                 path: reference.path,
@@ -116,6 +138,12 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
                 provenance: reference.provenance
             )
         } catch {
+            guard Self.isRowIncluded(
+                exists: false,
+                isDirectory: false,
+                includeDirectories: includeDirectories,
+                includeMissing: includeMissing
+            ) else { return nil }
             return ChatArtifactGalleryItem(
                 path: reference.path,
                 kind: reader.kind(path: reference.path, isDirectory: false),

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
@@ -59,23 +59,31 @@ public struct ChatArtifactGalleryRowEligibility: Sendable {
     }
 
     /// Cheap eligibility for count-only scans: same rule as page rows, fed
-    /// from a single existence syscall.
+    /// from one attributes read. `attributesOfItem` observes a symlink itself
+    /// (matching `ArtifactByteReader.stat`), where `fileExists` would traverse
+    /// it and disagree with the gallery about dangling links.
     public func isEligible(
         _ reference: ChatArtifactIndexedReference,
         includeDirectories: Bool,
         includeMissing: Bool
     ) -> Bool {
-        var isDirectory: ObjCBool = false
-        let exists = FileManager.default.fileExists(
-            atPath: reference.path,
-            isDirectory: &isDirectory
-        )
-        return Self.isRowIncluded(
-            exists: exists,
-            isDirectory: isDirectory.boolValue,
-            includeDirectories: includeDirectories,
-            includeMissing: includeMissing
-        )
+        do {
+            let attributes = try FileManager.default.attributesOfItem(atPath: reference.path)
+            let isDirectory = (attributes[.type] as? FileAttributeType) == .typeDirectory
+            return Self.isRowIncluded(
+                exists: true,
+                isDirectory: isDirectory,
+                includeDirectories: includeDirectories,
+                includeMissing: includeMissing
+            )
+        } catch {
+            return Self.isRowIncluded(
+                exists: false,
+                isDirectory: false,
+                includeDirectories: includeDirectories,
+                includeMissing: includeMissing
+            )
+        }
     }
 
     /// The single row-inclusion rule shared by page rows and count-only

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryRowEligibility.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Applies the filesystem eligibility rules shared by gallery pages and row counts.
+public struct ChatArtifactGalleryRowEligibility: Sendable {
+    /// Creates a gallery row eligibility evaluator.
+    public init() {}
+
+    /// Builds the eligible gallery rows for transcript references.
+    ///
+    /// A failed stat becomes a missing row only when `includeMissing` is true.
+    /// Directory rows are omitted unless `includeDirectories` is true.
+    ///
+    /// - Parameters:
+    ///   - references: Transcript references to stat and project into rows.
+    ///   - includeDirectories: Whether directories are eligible gallery rows.
+    ///   - includeMissing: Whether references that fail stat remain as missing rows.
+    /// - Returns: Gallery rows that satisfy both eligibility flags.
+    public func rows(
+        _ references: [ChatArtifactIndexedReference],
+        includeDirectories: Bool,
+        includeMissing: Bool
+    ) -> [ChatArtifactGalleryItem] {
+        references.compactMap {
+            row(
+                for: $0,
+                includeDirectories: includeDirectories,
+                includeMissing: includeMissing
+            )
+        }
+    }
+
+    /// Counts the rows in the gallery's default unfiltered, recent session view.
+    ///
+    /// - Parameters:
+    ///   - items: De-duplicated transcript references from one index snapshot.
+    ///   - orderedItems: Optional generation-cached ordering of `items`.
+    ///   - includeDirectories: Whether directories are eligible gallery rows.
+    ///   - includeMissing: Whether references that fail stat remain as missing rows.
+    /// - Returns: The number of rows the default gallery view renders.
+    public func defaultRowCount(
+        _ items: [ChatArtifactIndexedReference],
+        orderedItems: [ChatArtifactIndexedReference]? = nil,
+        includeDirectories: Bool,
+        includeMissing: Bool
+    ) -> Int {
+        let candidates = defaultCandidates(items, orderedItems: orderedItems)
+        return rows(
+            candidates.created,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        ).count + rows(
+            candidates.attached,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        ).count + rows(
+            candidates.referenced,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing
+        ).count
+    }
+
+    func defaultCandidates(
+        _ items: [ChatArtifactIndexedReference],
+        orderedItems: [ChatArtifactIndexedReference]? = nil
+    ) -> (
+        created: [ChatArtifactIndexedReference],
+        attached: [ChatArtifactIndexedReference],
+        referenced: [ChatArtifactIndexedReference]
+    ) {
+        let stableItems = orderedItems ?? ChatArtifactGalleryOrdering().sorted(items)
+        return (
+            created: stableItems.filter { $0.provenance == .created },
+            attached: stableItems.filter { $0.provenance == .attached },
+            referenced: stableItems.filter { $0.provenance == .referenced }
+        )
+    }
+
+    private func row(
+        for reference: ChatArtifactIndexedReference,
+        includeDirectories: Bool,
+        includeMissing: Bool
+    ) -> ChatArtifactGalleryItem? {
+        let reader = ArtifactByteReader()
+        do {
+            let stat = try reader.stat(path: reference.path)
+            guard includeDirectories || !stat.isDirectory else { return nil }
+            let children = stat.isDirectory ? directoryChildCount(path: reference.path) : nil
+            return ChatArtifactGalleryItem(
+                path: reference.path,
+                kind: stat.kind,
+                displayName: URL(fileURLWithPath: reference.path).lastPathComponent,
+                size: stat.size,
+                modifiedAt: stat.modifiedAt,
+                exists: stat.exists,
+                childCount: children?.count,
+                childCountIsCapped: children?.isCapped ?? false,
+                provenance: reference.provenance
+            )
+        } catch {
+            guard includeMissing else { return nil }
+            return ChatArtifactGalleryItem(
+                path: reference.path,
+                kind: reader.kind(path: reference.path, isDirectory: false),
+                displayName: URL(fileURLWithPath: reference.path).lastPathComponent,
+                exists: false,
+                provenance: reference.provenance
+            )
+        }
+    }
+
+    /// Counts immediate children for a gallery directory row without sorting
+    /// or per-entry metadata, stopping at the shared listing limit so the cost
+    /// never scales past the cap for large folders.
+    private func directoryChildCount(path: String) -> (count: Int, isCapped: Bool)? {
+        guard let enumerator = FileManager.default.enumerator(
+            at: URL(fileURLWithPath: path, isDirectory: true),
+            includingPropertiesForKeys: [],
+            options: [.skipsSubdirectoryDescendants]
+        ) else {
+            return nil
+        }
+        var count = 0
+        while enumerator.nextObject() != nil {
+            count += 1
+            if count > ArtifactByteReader.maximumDirectoryEntryCount {
+                return (count: ArtifactByteReader.maximumDirectoryEntryCount, isCapped: true)
+            }
+        }
+        return (count: count, isCapped: false)
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactScanResponse.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactScanResponse.swift
@@ -78,20 +78,25 @@ public struct TerminalArtifactScanResponse: Sendable, Equatable, Codable {
     public let sessionID: String?
     /// Complete Session-tab artifact count, present for supported count-only scans.
     public let sessionArtifactTotal: Int?
+    /// Rows rendered by the files sheet's default landing view, when supported.
+    public let galleryRowTotal: Int?
 
     /// Creates a scan response.
     /// - Parameters:
     ///   - artifacts: Capped terminal artifacts sorted by detection order.
     ///   - sessionID: Agent session bound to the terminal, when available.
     ///   - sessionArtifactTotal: Complete Session-tab count for a count-only scan.
+    ///   - galleryRowTotal: Rows in the files sheet's default landing view.
     public init(
         artifacts: [TerminalArtifactReference],
         sessionID: String? = nil,
-        sessionArtifactTotal: Int? = nil
+        sessionArtifactTotal: Int? = nil,
+        galleryRowTotal: Int? = nil
     ) {
         self.artifacts = artifacts
         self.sessionID = sessionID
         self.sessionArtifactTotal = sessionArtifactTotal
+        self.galleryRowTotal = galleryRowTotal
     }
 
     /// Creates the lightweight response for a session-scoped count scan.
@@ -103,15 +108,18 @@ public struct TerminalArtifactScanResponse: Sendable, Equatable, Codable {
     /// - Parameters:
     ///   - sessionID: Agent session bound to the terminal.
     ///   - sessionArtifacts: Transcript-index snapshot used by the gallery.
+    ///   - galleryRowTotal: Stat-filtered rows in the gallery's default view.
     /// - Returns: A count-only terminal scan response.
     public static func sessionCount(
         sessionID: String,
-        sessionArtifacts: [ChatArtifactIndexedReference]
+        sessionArtifacts: [ChatArtifactIndexedReference],
+        galleryRowTotal: Int?
     ) -> TerminalArtifactScanResponse {
         TerminalArtifactScanResponse(
             artifacts: [],
             sessionID: sessionID,
-            sessionArtifactTotal: ChatArtifactGalleryOrdering().sessionTotal(sessionArtifacts)
+            sessionArtifactTotal: ChatArtifactGalleryOrdering().sessionTotal(sessionArtifacts),
+            galleryRowTotal: galleryRowTotal
         )
     }
 
@@ -119,6 +127,7 @@ public struct TerminalArtifactScanResponse: Sendable, Equatable, Codable {
         case artifacts
         case sessionID = "session_id"
         case sessionArtifactTotal = "session_artifact_total"
+        case galleryRowTotal = "gallery_row_total"
     }
 
     public init(from decoder: any Decoder) throws {
@@ -126,5 +135,6 @@ public struct TerminalArtifactScanResponse: Sendable, Equatable, Codable {
         artifacts = (try? container.decode([TerminalArtifactReference].self, forKey: .artifacts)) ?? []
         sessionID = try? container.decode(String.self, forKey: .sessionID)
         sessionArtifactTotal = try? container.decode(Int.self, forKey: .sessionArtifactTotal)
+        galleryRowTotal = try? container.decode(Int.self, forKey: .galleryRowTotal)
     }
 }

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
@@ -353,11 +353,19 @@ struct ChatArtifactGalleryTests {
         #expect(FileManager.default.createFile(atPath: attached.path, contents: Data()))
         defer { try? FileManager.default.removeItem(at: root) }
 
+        let danglingLink = root.appendingPathComponent("dangling-link")
+        try FileManager.default.createSymbolicLink(
+            at: danglingLink,
+            withDestinationURL: root.appendingPathComponent("no-such-target")
+        )
         let snapshot = [
-            ChatArtifactIndexedReference(path: created.path, provenance: .created, lastReferencedSeq: 4),
-            ChatArtifactIndexedReference(path: attached.path, provenance: .attached, lastReferencedSeq: 3),
-            ChatArtifactIndexedReference(path: directory.path, provenance: .referenced, lastReferencedSeq: 2),
-            ChatArtifactIndexedReference(path: missing.path, provenance: .referenced, lastReferencedSeq: 1),
+            ChatArtifactIndexedReference(path: created.path, provenance: .created, lastReferencedSeq: 5),
+            ChatArtifactIndexedReference(path: attached.path, provenance: .attached, lastReferencedSeq: 4),
+            ChatArtifactIndexedReference(path: directory.path, provenance: .referenced, lastReferencedSeq: 3),
+            ChatArtifactIndexedReference(path: missing.path, provenance: .referenced, lastReferencedSeq: 2),
+            // A dangling symlink: attributesOfItem observes the link itself,
+            // so count and rows must both treat it as an existing entry.
+            ChatArtifactIndexedReference(path: danglingLink.path, provenance: .referenced, lastReferencedSeq: 1),
         ]
         let builder = ChatArtifactGalleryBuilder()
         let eligibility = ChatArtifactGalleryRowEligibility()

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
@@ -295,12 +295,100 @@ struct ChatArtifactGalleryTests {
 
         let response = TerminalArtifactScanResponse.sessionCount(
             sessionID: "session-1",
-            sessionArtifacts: records
+            sessionArtifacts: records,
+            galleryRowTotal: 2
         )
 
         #expect(response.artifacts.isEmpty)
         #expect(response.sessionID == "session-1")
         #expect(response.sessionArtifactTotal == 3)
+        #expect(response.galleryRowTotal == 2)
+    }
+
+    @Test("row eligibility applies missing-file and directory flags")
+    func rowEligibilityFlags() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-gallery-eligibility-\(UUID().uuidString)", isDirectory: true)
+        let directory = root.appendingPathComponent("folder", isDirectory: true)
+        let file = root.appendingPathComponent("report.txt")
+        let missing = root.appendingPathComponent("missing.txt")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        #expect(FileManager.default.createFile(atPath: file.path, contents: Data("ok".utf8)))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let references = [
+            ChatArtifactIndexedReference(path: file.path, provenance: .created, lastReferencedSeq: 3),
+            ChatArtifactIndexedReference(path: directory.path, provenance: .attached, lastReferencedSeq: 2),
+            ChatArtifactIndexedReference(path: missing.path, provenance: .referenced, lastReferencedSeq: 1),
+        ]
+        let eligibility = ChatArtifactGalleryRowEligibility()
+
+        #expect(eligibility.rows(
+            references,
+            includeDirectories: false,
+            includeMissing: false
+        ).map(\.path) == [file.path])
+        #expect(eligibility.rows(
+            references,
+            includeDirectories: false,
+            includeMissing: true
+        ).map(\.path) == [file.path, missing.path])
+        #expect(eligibility.rows(
+            references,
+            includeDirectories: true,
+            includeMissing: false
+        ).map(\.path) == [file.path, directory.path])
+    }
+
+    @Test("default gallery pages and authoritative row count share eligibility")
+    func defaultGalleryPagesMatchAuthoritativeCount() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-gallery-count-\(UUID().uuidString)", isDirectory: true)
+        let directory = root.appendingPathComponent("folder", isDirectory: true)
+        let created = root.appendingPathComponent("created.txt")
+        let attached = root.appendingPathComponent("attached.png")
+        let missing = root.appendingPathComponent("missing.md")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        #expect(FileManager.default.createFile(atPath: created.path, contents: Data()))
+        #expect(FileManager.default.createFile(atPath: attached.path, contents: Data()))
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let snapshot = [
+            ChatArtifactIndexedReference(path: created.path, provenance: .created, lastReferencedSeq: 4),
+            ChatArtifactIndexedReference(path: attached.path, provenance: .attached, lastReferencedSeq: 3),
+            ChatArtifactIndexedReference(path: directory.path, provenance: .referenced, lastReferencedSeq: 2),
+            ChatArtifactIndexedReference(path: missing.path, provenance: .referenced, lastReferencedSeq: 1),
+        ]
+        let builder = ChatArtifactGalleryBuilder()
+        let eligibility = ChatArtifactGalleryRowEligibility()
+
+        for includeDirectories in [false, true] {
+            for includeMissing in [false, true] {
+                var cursor: ChatArtifactGalleryCursor?
+                var renderedRowCount = 0
+                repeat {
+                    let page = builder.page(
+                        sessionID: "session",
+                        items: snapshot,
+                        generation: "generation",
+                        cursor: cursor,
+                        pageSize: 2,
+                        query: nil,
+                        includeDirectories: includeDirectories
+                    )
+                    renderedRowCount += (page.created + page.attached + page.referenced)
+                        .filter { includeMissing || $0.exists }
+                        .count
+                    cursor = page.nextCursor.flatMap(ChatArtifactGalleryCursor.init(token:))
+                } while cursor != nil
+
+                #expect(renderedRowCount == eligibility.defaultRowCount(
+                    snapshot,
+                    includeDirectories: includeDirectories,
+                    includeMissing: includeMissing
+                ))
+            }
+        }
     }
 
     @Test("written paths outrank attachments and references while last seq advances")

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalWireCodableTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalWireCodableTests.swift
@@ -91,15 +91,20 @@ struct TerminalWireCodableTests {
     @Test("Terminal artifact scan metadata round-trips with unix modified time")
     func terminalArtifactScanMetadataRoundTrip() throws {
         let modifiedAt = Date(timeIntervalSince1970: 1_649_116_800.25)
-        let response = TerminalArtifactScanResponse(artifacts: [
-            TerminalArtifactReference(
-                path: "/tmp/report.txt",
-                kind: .text,
-                displayName: "report.txt",
-                size: 3_072,
-                modifiedAt: modifiedAt
-            ),
-        ], sessionID: "session-1", sessionArtifactTotal: 12)
+        let response = TerminalArtifactScanResponse(
+            artifacts: [
+                TerminalArtifactReference(
+                    path: "/tmp/report.txt",
+                    kind: .text,
+                    displayName: "report.txt",
+                    size: 3_072,
+                    modifiedAt: modifiedAt
+                ),
+            ],
+            sessionID: "session-1",
+            sessionArtifactTotal: 12,
+            galleryRowTotal: 7
+        )
         let coding = ChatWireCoding()
         let data = try coding.encode(response)
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -110,6 +115,7 @@ struct TerminalWireCodableTests {
         #expect((artifact["modified_at"] as? NSNumber)?.doubleValue == modifiedAt.timeIntervalSince1970)
         #expect(object["session_id"] as? String == "session-1")
         #expect(object["session_artifact_total"] as? Int == 12)
+        #expect(object["gallery_row_total"] as? Int == 7)
         #expect(try coding.decode(TerminalArtifactScanResponse.self, from: data) == response)
     }
 
@@ -130,12 +136,14 @@ struct TerminalWireCodableTests {
         let legacy = Data(#"{"artifacts":[],"session_id":"session-1"}"#.utf8)
         let legacyResponse = try ChatWireCoding().decode(TerminalArtifactScanResponse.self, from: legacy)
         #expect(legacyResponse.sessionArtifactTotal == nil)
+        #expect(legacyResponse.galleryRowTotal == nil)
 
         let newer = Data(
-            #"{"artifacts":[],"session_id":"session-1","session_artifact_total":9,"future_field":true}"#.utf8
+            #"{"artifacts":[],"session_id":"session-1","session_artifact_total":9,"gallery_row_total":6,"future_field":true}"#.utf8
         )
         let newerResponse = try ChatWireCoding().decode(TerminalArtifactScanResponse.self, from: newer)
         #expect(newerResponse.sessionArtifactTotal == 9)
+        #expect(newerResponse.galleryRowTotal == 6)
     }
 
     @Test("terminal directory listing round-trips cap metadata and decodes legacy payloads")

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource+TerminalArtifacts.swift
@@ -13,16 +13,19 @@ extension MobileChatEventSource {
     ///     keeps the existing visible-screen-plus-scrollback behavior.
     ///   - countOnly: Whether to skip terminal items and return only the bound
     ///     session's complete gallery count when supported.
+    ///   - includeMissing: Whether missing Session rows count toward the result.
     /// - Returns: Capped file references detected by the Mac.
     public func terminalArtifactScan(
         workspaceID: String,
         surfaceID: String,
         visibleOnly: Bool = false,
-        countOnly: Bool = false
+        countOnly: Bool = false,
+        includeMissing: Bool = true
     ) async throws -> TerminalArtifactScanResponse {
         var params: [String: Any] = [
             "workspace_id": workspaceID,
             "surface_id": surfaceID,
+            "include_missing": includeMissing,
         ]
         if visibleOnly {
             params["visible_only"] = true

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -13,6 +13,7 @@ extension GhosttySurfaceRepresentable.Coordinator {
         func updateArtifactCountMode(
             artifactFilesEnabled: Bool,
             terminalFilesChipEnabled: Bool,
+            showMissingFiles: Bool,
             sessionArtifactCountEnabled: Bool
         ) -> Bool {
             let artifactChipGate = TerminalArtifactChipFeatureGate(
@@ -21,9 +22,11 @@ extension GhosttySurfaceRepresentable.Coordinator {
             )
             let changed = self.artifactFilesEnabled != artifactFilesEnabled
                 || self.artifactChipGate != artifactChipGate
+                || self.showMissingFiles != showMissingFiles
                 || self.sessionArtifactCountEnabled != sessionArtifactCountEnabled
             self.artifactFilesEnabled = artifactFilesEnabled
             self.artifactChipGate = artifactChipGate
+            self.showMissingFiles = showMissingFiles
             self.sessionArtifactCountEnabled = sessionArtifactCountEnabled
             guard changed else { return false }
 
@@ -93,29 +96,32 @@ extension GhosttySurfaceRepresentable.Coordinator {
             let workspaceID = workspaceID
             let surfaceID = surfaceID
             let artifactChipGate = artifactChipGate
+            let showMissingFiles = showMissingFiles
             artifactCountTaskRequest = request
             artifactCountTask = Task { @MainActor [weak self, weak surfaceView] in
-                let scan: (sessionTotal: Int?, sessionID: String?)?
+                let response: TerminalArtifactScanResponse?
                 do {
-                    scan = try await artifactChipGate.performScan { [weak self] in
+                    response = try await artifactChipGate.performScan { [weak self] in
                         guard let source = self?.store?.makeChatEventSource() else { return nil }
-                        let response = try await source.terminalArtifactScan(
+                        return try await source.terminalArtifactScan(
                             workspaceID: workspaceID,
                             surfaceID: surfaceID,
-                            countOnly: true
+                            visibleOnly: true,
+                            countOnly: true,
+                            includeMissing: showMissingFiles
                         )
-                        return (response.sessionArtifactTotal, response.sessionID)
                     }
                 } catch {
-                    scan = nil
+                    response = nil
                 }
 
                 guard let self, let surfaceView else { return }
                 let completion = self.artifactCountState.complete(
                     request,
-                    sessionTotal: scan?.sessionTotal,
-                    sessionID: scan?.sessionID,
-                    scanSucceeded: scan != nil,
+                    galleryRowTotal: response?.galleryRowTotal,
+                    sessionTotal: response?.sessionArtifactTotal,
+                    sessionID: response?.sessionID,
+                    scanSucceeded: response != nil,
                     currentSurfaceGeneration: surfaceView.visibleArtifactCountGeneration,
                     freshestLocalCount: self.freshestLocalArtifactCount
                 )

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -37,6 +37,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     var artifactFilesEnabled: Bool = false
     var terminalFolderTapEnabled: Bool = true
     var terminalFilesChipEnabled: Bool = false
+    var showMissingFiles: Bool = false
     var sessionArtifactCountEnabled: Bool = false
     var visibleArtifactCount: Int = 0
     var onArtifactFilesRequested: @MainActor (_ anchor: UnitPoint) -> Void = { _ in }
@@ -52,6 +53,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             artifactFilesEnabled: artifactFilesEnabled,
             terminalFolderTapEnabled: terminalFolderTapEnabled,
             terminalFilesChipEnabled: terminalFilesChipEnabled,
+            showMissingFiles: showMissingFiles,
             sessionArtifactCountEnabled: sessionArtifactCountEnabled,
             visibleArtifactCount: visibleArtifactCount,
             onArtifactFilesRequested: onArtifactFilesRequested,
@@ -133,6 +135,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         let artifactCountModeChanged = context.coordinator.updateArtifactCountMode(
             artifactFilesEnabled: artifactFilesEnabled,
             terminalFilesChipEnabled: terminalFilesChipEnabled,
+            showMissingFiles: showMissingFiles,
             sessionArtifactCountEnabled: sessionArtifactCountEnabled
         )
         surfaceView.artifactFilesEnabled = artifactFilesEnabled
@@ -171,6 +174,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         var artifactFilesEnabled: Bool
         var terminalFolderTapEnabled: Bool
         var artifactChipGate: TerminalArtifactChipFeatureGate
+        var showMissingFiles: Bool
         var sessionArtifactCountEnabled: Bool
         var visibleArtifactCount: Int
         var onArtifactFilesRequested: @MainActor (_ anchor: UnitPoint) -> Void
@@ -227,6 +231,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             artifactFilesEnabled: Bool,
             terminalFolderTapEnabled: Bool,
             terminalFilesChipEnabled: Bool,
+            showMissingFiles: Bool = false,
             sessionArtifactCountEnabled: Bool,
             visibleArtifactCount: Int,
             onArtifactFilesRequested: @escaping @MainActor (_ anchor: UnitPoint) -> Void,
@@ -244,6 +249,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 artifactsAvailable: artifactFilesEnabled,
                 preferenceEnabled: terminalFilesChipEnabled
             )
+            self.showMissingFiles = showMissingFiles
             self.sessionArtifactCountEnabled = sessionArtifactCountEnabled
             self.visibleArtifactCount = visibleArtifactCount
             self.artifactCountNeedsRefresh = artifactChipGate.isEnabled

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -56,15 +56,16 @@ struct TerminalArtifactChipCountState: Sendable {
     private var inFlight: Request?
     private var trailing: Pending?
     private var consecutiveRearmCount = 0
-    /// Last successful session total, held across transient scan failures so
+    /// Last successful gallery total (or positive legacy session total), held
+    /// across transient scan failures so
     /// the chip does not regress to the viewport-only count (which oscillates
     /// while output streams) whenever one RPC drops.
-    private var lastSessionTotal: Int?
+    private var lastAuthoritativeTotal: Int?
     /// Session the held total belongs to. A terminal can bind a new agent
     /// session without remounting the coordinator, and its first count-only
     /// responses can carry the new session's ID with no total yet — the held
     /// total from the previous session must be invalidated then, not shown.
-    private var lastSessionTotalSessionID: String?
+    private var lastAuthoritativeSessionID: String?
 
     static let maxConsecutiveRearms = 3
 
@@ -73,8 +74,8 @@ struct TerminalArtifactChipCountState: Sendable {
         inFlight = nil
         trailing = nil
         consecutiveRearmCount = 0
-        lastSessionTotal = nil
-        lastSessionTotalSessionID = nil
+        lastAuthoritativeTotal = nil
+        lastAuthoritativeSessionID = nil
     }
 
     mutating func trigger(
@@ -101,17 +102,18 @@ struct TerminalArtifactChipCountState: Sendable {
     }
 
     /// The count the chip should show for a fresh local scan: the last known
-    /// session total wins while the session has artifacts, the viewport-only
-    /// count otherwise.
+    /// authoritative total wins when one exists, the viewport-only count
+    /// otherwise.
     private func displayCount(forLocalCount localCount: Int) -> Int {
-        if let lastSessionTotal, lastSessionTotal > 0 {
-            return lastSessionTotal
+        if let lastAuthoritativeTotal {
+            return lastAuthoritativeTotal
         }
         return localCount
     }
 
     mutating func complete(
         _ request: Request,
+        galleryRowTotal: Int? = nil,
         sessionTotal: Int?,
         sessionID: String? = nil,
         scanSucceeded: Bool = true,
@@ -123,20 +125,21 @@ struct TerminalArtifactChipCountState: Sendable {
             return .stale
         }
         inFlight = nil
-        if let sessionID, sessionID != lastSessionTotalSessionID {
+        if let sessionID, sessionID != lastAuthoritativeSessionID {
             // Session identity is generation-independent: any response naming
             // a different session proves the binding changed, even when its
             // count is stale for the current viewport (during streaming most
             // responses are). Invalidate the old session's total here; totals
             // themselves are cached only from accepted responses below.
-            lastSessionTotal = nil
-            lastSessionTotalSessionID = sessionID
-        } else if scanSucceeded, sessionID == nil, lastSessionTotalSessionID != nil {
+            lastAuthoritativeTotal = nil
+            lastAuthoritativeSessionID = sessionID
+        } else if scanSucceeded, sessionID == nil, lastAuthoritativeSessionID != nil {
             // A SUCCESSFUL response with no session means the binding is gone
             // (e.g. the session moved to another surface) — unlike a transport
             // failure, which proves nothing and holds. Clear the stale total.
-            lastSessionTotal = nil
-            lastSessionTotalSessionID = nil
+            lastAuthoritativeTotal = nil
+            lastAuthoritativeSessionID = nil
+        }
         }
 
         let outcome: CompletionOutcome
@@ -145,9 +148,14 @@ struct TerminalArtifactChipCountState: Sendable {
             // response's total may be stale for the superseded surface state
             // and must not seed provisional reports. The re-armed request
             // re-fetches under the current generation.
-            if let sessionTotal {
-                lastSessionTotal = sessionTotal
-                lastSessionTotalSessionID = sessionID ?? lastSessionTotalSessionID
+            if let galleryRowTotal {
+                lastAuthoritativeTotal = galleryRowTotal
+                lastAuthoritativeSessionID = sessionID ?? lastAuthoritativeSessionID
+            } else if let sessionTotal {
+                // Preserve the old-Mac behavior exactly: positive Session
+                // totals win, while zero falls back to the local viewport count.
+                lastAuthoritativeTotal = sessionTotal > 0 ? sessionTotal : nil
+                lastAuthoritativeSessionID = sessionID ?? lastAuthoritativeSessionID
             }
             outcome = .reported(Report(
                 count: displayCount(forLocalCount: request.localCount),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -140,7 +140,6 @@ struct TerminalArtifactChipCountState: Sendable {
             lastAuthoritativeTotal = nil
             lastAuthoritativeSessionID = nil
         }
-        }
 
         let outcome: CompletionOutcome
         if request.surfaceGeneration == currentSurfaceGeneration {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -156,6 +156,13 @@ struct TerminalArtifactChipCountState: Sendable {
                 // totals win, while zero falls back to the local viewport count.
                 lastAuthoritativeTotal = sessionTotal > 0 ? sessionTotal : nil
                 lastAuthoritativeSessionID = sessionID ?? lastAuthoritativeSessionID
+            } else if lastAuthoritativeTotal == 0, request.localCount > 0 {
+                // The scan FAILED while fresh local evidence says files are on
+                // screen. A held zero must not keep the chip unmounted until
+                // the transport recovers; drop it so the local count shows
+                // (and stays shown across subsequent failed scans) until a
+                // successful scan re-establishes the authoritative total.
+                lastAuthoritativeTotal = nil
             }
             outcome = .reported(Report(
                 count: displayCount(forLocalCount: request.localCount),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
@@ -31,6 +31,7 @@ extension WorkspaceDetailView {
         artifactFilesEnabled: store.supportsTerminalArtifacts,
         terminalFolderTapEnabled: terminalFolderTapEnabled,
         terminalFilesChipEnabled: terminalFilesChipEnabled,
+        showMissingFiles: showMissingFiles,
         sessionArtifactCountEnabled: store.supportsChatArtifactGallery,
         visibleArtifactCount: visibleArtifactCount,
         onArtifactFilesRequested: { anchor in

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -93,6 +93,9 @@ struct WorkspaceDetailView: View {
     var terminalFilesChipEnabled: Bool {
         displaySettings.terminalFilesChipEnabled
     }
+    var showMissingFiles: Bool {
+        displaySettings.showMissingFiles
+    }
     var terminalFolderTapEnabled: Bool {
         displaySettings.terminalFolderTapEnabled
     }

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -148,6 +148,51 @@ struct TerminalArtifactChipCountStateTests {
         #expect(upgraded == .init(count: 12, surfaceGeneration: 5))
     }
 
+    @Test("a failed scan with fresh local evidence drops a held authoritative zero")
+    func failedScanDropsHeldZero() throws {
+        var state = TerminalArtifactChipCountState()
+        let empty = try request(from: state.trigger(
+            localCount: 0,
+            surfaceGeneration: 5,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            empty,
+            galleryRowTotal: 0,
+            sessionTotal: 0,
+            currentSurfaceGeneration: 5,
+            freshestLocalCount: 0
+        ).outcome == .reported(.init(count: 0, surfaceGeneration: 5)))
+
+        // Files appear on screen, but the refresh scan fails: the held zero
+        // must yield to the local evidence instead of hiding the chip until
+        // the transport recovers.
+        let failed = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 5,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            failed,
+            galleryRowTotal: nil,
+            sessionTotal: nil,
+            currentSurfaceGeneration: 5,
+            freshestLocalCount: 3
+        ).outcome == .reported(.init(count: 3, surfaceGeneration: 5)))
+
+        // The dropped zero stays dropped: later provisional reports show the
+        // local count while the transport is down.
+        guard case .reportAndRequest(let provisional, _) = state.trigger(
+            localCount: 3,
+            surfaceGeneration: 5,
+            supportsSessionCount: true
+        ) else {
+            Issue.record("Expected a provisional report plus a session request")
+            throw UnexpectedAction()
+        }
+        #expect(provisional == .init(count: 3, surfaceGeneration: 5))
+    }
+
     @Test("reset forgets the remembered session total")
     func resetForgetsSessionTotal() throws {
         var state = TerminalArtifactChipCountState()

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -51,10 +51,13 @@ struct TerminalArtifactChipCountStateTests {
         #expect(state.complete(
             first,
             sessionTotal: 12,
+            sessionID: "session-a",
             currentSurfaceGeneration: 7,
             freshestLocalCount: 3
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
 
+        // Production-shaped failure: the scan explicitly did NOT succeed, so
+        // neither the no-session clearing branch nor the success path runs.
         let second = try request(from: state.trigger(
             localCount: 1,
             surfaceGeneration: 7,
@@ -63,9 +66,45 @@ struct TerminalArtifactChipCountStateTests {
         #expect(state.complete(
             second,
             sessionTotal: nil,
+            sessionID: nil,
+            scanSucceeded: false,
             currentSurfaceGeneration: 7,
             freshestLocalCount: 1
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+    }
+
+    @Test("a successful response with no session clears the held total")
+    func successfulNoSessionResponseClearsHeldTotal() throws {
+        var state = TerminalArtifactChipCountState()
+        let first = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            first,
+            sessionTotal: 12,
+            sessionID: "session-a",
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 3
+        ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+
+        // The session moved off this surface: the scan SUCCEEDS but resolves
+        // no session. Unlike a transport failure, this proves the binding is
+        // gone, so the held 12 must yield to the local count.
+        let second = try request(from: state.trigger(
+            localCount: 2,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+        #expect(state.complete(
+            second,
+            sessionTotal: nil,
+            sessionID: nil,
+            scanSucceeded: true,
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 2
+        ).outcome == .reported(.init(count: 2, surfaceGeneration: 7)))
     }
 
     @Test("gallery row total is authoritative over the legacy session total")

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -96,12 +96,15 @@ struct TerminalArtifactChipCountStateTests {
         ))
         #expect(state.complete(
             first,
-            galleryRowTotal: 0,
+            galleryRowTotal: 5,
             sessionTotal: 12,
             currentSurfaceGeneration: 7,
             freshestLocalCount: 3
-        ).outcome == .reported(.init(count: 0, surfaceGeneration: 7)))
+        ).outcome == .reported(.init(count: 5, surfaceGeneration: 7)))
 
+        // A positive gallery total holds across a failed refresh; a held
+        // ZERO yielding to local evidence is covered by
+        // failedScanDropsHeldZero.
         let second = try request(from: state.trigger(
             localCount: 9,
             surfaceGeneration: 8,
@@ -113,7 +116,7 @@ struct TerminalArtifactChipCountStateTests {
             sessionTotal: nil,
             currentSurfaceGeneration: 8,
             freshestLocalCount: 9
-        ).outcome == .reported(.init(count: 0, surfaceGeneration: 8)))
+        ).outcome == .reported(.init(count: 5, surfaceGeneration: 8)))
     }
 
     @Test("session-count triggers report the local count immediately and refine async")

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -51,13 +51,10 @@ struct TerminalArtifactChipCountStateTests {
         #expect(state.complete(
             first,
             sessionTotal: 12,
-            sessionID: "session-a",
             currentSurfaceGeneration: 7,
             freshestLocalCount: 3
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
 
-        // Production-shaped failure: the scan explicitly did NOT succeed, so
-        // neither the no-session clearing branch nor the success path runs.
         let second = try request(from: state.trigger(
             localCount: 1,
             surfaceGeneration: 7,
@@ -66,15 +63,31 @@ struct TerminalArtifactChipCountStateTests {
         #expect(state.complete(
             second,
             sessionTotal: nil,
-            sessionID: nil,
-            scanSucceeded: false,
             currentSurfaceGeneration: 7,
             freshestLocalCount: 1
         ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
     }
 
-    @Test("a successful response with no session clears the held total")
-    func successfulNoSessionResponseClearsHeldTotal() throws {
+    @Test("gallery row total is authoritative over the legacy session total")
+    func galleryRowTotalWins() throws {
+        var state = TerminalArtifactChipCountState()
+        let request = try request(from: state.trigger(
+            localCount: 3,
+            surfaceGeneration: 7,
+            supportsSessionCount: true
+        ))
+
+        #expect(state.complete(
+            request,
+            galleryRowTotal: 5,
+            sessionTotal: 12,
+            currentSurfaceGeneration: 7,
+            freshestLocalCount: 3
+        ).outcome == .reported(.init(count: 5, surfaceGeneration: 7)))
+    }
+
+    @Test("failed scans hold the last authoritative gallery row total")
+    func failedScanHoldsLastGalleryRowTotal() throws {
         var state = TerminalArtifactChipCountState()
         let first = try request(from: state.trigger(
             localCount: 3,
@@ -83,28 +96,24 @@ struct TerminalArtifactChipCountStateTests {
         ))
         #expect(state.complete(
             first,
+            galleryRowTotal: 0,
             sessionTotal: 12,
-            sessionID: "session-a",
             currentSurfaceGeneration: 7,
             freshestLocalCount: 3
-        ).outcome == .reported(.init(count: 12, surfaceGeneration: 7)))
+        ).outcome == .reported(.init(count: 0, surfaceGeneration: 7)))
 
-        // The session moved off this surface: the scan SUCCEEDS but resolves
-        // no session. Unlike a transport failure, this proves the binding is
-        // gone, so the held 12 must yield to the local count.
         let second = try request(from: state.trigger(
-            localCount: 2,
-            surfaceGeneration: 7,
+            localCount: 9,
+            surfaceGeneration: 8,
             supportsSessionCount: true
         ))
         #expect(state.complete(
             second,
+            galleryRowTotal: nil,
             sessionTotal: nil,
-            sessionID: nil,
-            scanSucceeded: true,
-            currentSurfaceGeneration: 7,
-            freshestLocalCount: 2
-        ).outcome == .reported(.init(count: 2, surfaceGeneration: 7)))
+            currentSurfaceGeneration: 8,
+            freshestLocalCount: 9
+        ).outcome == .reported(.init(count: 0, surfaceGeneration: 8)))
     }
 
     @Test("session-count triggers report the local count immediately and refine async")
@@ -166,6 +175,35 @@ struct TerminalArtifactChipCountStateTests {
             currentSurfaceGeneration: 8,
             freshestLocalCount: 2
         ).outcome == .reported(.init(count: 2, surfaceGeneration: 8)))
+    }
+
+    @Test("reset for a show-missing mode change forgets the authoritative total")
+    func showMissingModeResetForgetsAuthoritativeTotal() throws {
+        var state = TerminalArtifactChipCountState()
+        let seeded = try request(from: state.trigger(
+            localCount: 1,
+            surfaceGeneration: 10,
+            supportsSessionCount: true
+        ))
+        _ = state.complete(
+            seeded,
+            galleryRowTotal: 8,
+            sessionTotal: 12,
+            currentSurfaceGeneration: 10,
+            freshestLocalCount: 1
+        )
+
+        state.reset()
+
+        guard case .reportAndRequest(let provisional, _) = state.trigger(
+            localCount: 2,
+            surfaceGeneration: 11,
+            supportsSessionCount: true
+        ) else {
+            Issue.record("Expected reset state to use the local fallback")
+            throw UnexpectedAction()
+        }
+        #expect(provisional == .init(count: 2, surfaceGeneration: 11))
     }
 
     @Test("responses from an old state or surface generation are dropped")

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -5,6 +5,7 @@ import Foundation
 private enum TerminalControllerChatArtifactIndexProvider {
     static let shared = AgentChatArtifactIndex()
     static let ordering = ChatArtifactGalleryOrderingCache()
+    static let rowCounts = ChatArtifactGalleryRowCountCache(maximumAge: 2)
 }
 
 extension TerminalController {
@@ -84,6 +85,47 @@ extension TerminalController {
             workingDirectory: record.workingDirectory
         )
         return (record.sessionID, snapshot)
+    }
+
+    /// Returns the stat-filtered count for the gallery's default landing view.
+    func mobileChatArtifactGalleryRowTotal(
+        sessionID: String,
+        generation: String,
+        artifacts: [ChatArtifactIndexedReference],
+        includeDirectories: Bool,
+        includeMissing: Bool
+    ) async -> Int {
+        if let cached = await TerminalControllerChatArtifactIndexProvider.rowCounts.total(
+            sessionID: sessionID,
+            generation: generation,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing,
+            now: Date()
+        ) {
+            return cached
+        }
+        let orderedItems = await TerminalControllerChatArtifactIndexProvider.ordering.ordered(
+            artifacts,
+            indexID: sessionID,
+            generation: generation
+        )
+        let total = await Task.detached(priority: .utility) {
+            ChatArtifactGalleryRowEligibility().defaultRowCount(
+                artifacts,
+                orderedItems: orderedItems,
+                includeDirectories: includeDirectories,
+                includeMissing: includeMissing
+            )
+        }.value
+        await TerminalControllerChatArtifactIndexProvider.rowCounts.store(
+            total,
+            sessionID: sessionID,
+            generation: generation,
+            includeDirectories: includeDirectories,
+            includeMissing: includeMissing,
+            now: Date()
+        )
+        return total
     }
 
     func v2MobileChatArtifactStat(params: [String: Any]) async -> V2CallResult {

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -104,15 +104,11 @@ extension TerminalController {
         ) {
             return cached
         }
-        let orderedItems = await TerminalControllerChatArtifactIndexProvider.ordering.ordered(
-            artifacts,
-            indexID: sessionID,
-            generation: generation
-        )
+        // Counting is order-independent, so skip the ordering cache entirely;
+        // the count is a stat-only sweep over the raw snapshot.
         let total = await Task.detached(priority: .utility) {
             ChatArtifactGalleryRowEligibility().defaultRowCount(
                 artifacts,
-                orderedItems: orderedItems,
                 includeDirectories: includeDirectories,
                 includeMissing: includeMissing
             )

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -95,33 +95,23 @@ extension TerminalController {
         includeDirectories: Bool,
         includeMissing: Bool
     ) async -> Int {
-        if let cached = await TerminalControllerChatArtifactIndexProvider.rowCounts.total(
+        // Counting is order-independent, so the ordering cache is skipped;
+        // the sweep is existence-only over the raw snapshot, runs off the
+        // caller inside the cache actor, and concurrent misses on the same
+        // (session, generation, filters) key share one computation.
+        await TerminalControllerChatArtifactIndexProvider.rowCounts.total(
             sessionID: sessionID,
             generation: generation,
             includeDirectories: includeDirectories,
             includeMissing: includeMissing,
             now: Date()
         ) {
-            return cached
-        }
-        // Counting is order-independent, so skip the ordering cache entirely;
-        // the count is a stat-only sweep over the raw snapshot.
-        let total = await Task.detached(priority: .utility) {
             ChatArtifactGalleryRowEligibility().defaultRowCount(
                 artifacts,
                 includeDirectories: includeDirectories,
                 includeMissing: includeMissing
             )
-        }.value
-        await TerminalControllerChatArtifactIndexProvider.rowCounts.store(
-            total,
-            sessionID: sessionID,
-            generation: generation,
-            includeDirectories: includeDirectories,
-            includeMissing: includeMissing,
-            now: Date()
-        )
-        return total
+        }
     }
 
     func v2MobileChatArtifactStat(params: [String: Any]) async -> V2CallResult {

--- a/Sources/TerminalController+MobileTerminalArtifacts.swift
+++ b/Sources/TerminalController+MobileTerminalArtifacts.swift
@@ -53,11 +53,16 @@ extension TerminalController {
         let includeDirectories = v2Bool(params, "include_directories") ?? false
         let includeMissing = v2Bool(params, "include_missing") ?? true
         let requestsGalleryRowTotal = params.keys.contains("include_missing")
+        // Count-only refreshes recur on every settled output change, so they
+        // must not capture terminal text up front: `readTerminalTextForSnapshot`
+        // takes the Ghostty surface lock inside `v2MainSync`, and a session
+        // workspace never uses the text for a count. Only the no-session
+        // fallback re-resolves with viewport text below.
         let resolution = await mobileTerminalArtifactContext(
             params: params,
             requiresPath: false,
             includeScrollback: !visibleOnly,
-            includeTerminalText: !countOnly || visibleOnly
+            includeTerminalText: !countOnly
         )
         guard case .success(let context) = resolution else {
             return resolution.failureResult
@@ -69,8 +74,17 @@ extension TerminalController {
                         TerminalArtifactScanResponse(artifacts: [])
                     )
                 }
+                let textResolution = await mobileTerminalArtifactContext(
+                    params: params,
+                    requiresPath: false,
+                    includeScrollback: false,
+                    includeTerminalText: true
+                )
+                guard case .success(let textContext) = textResolution else {
+                    return textResolution.failureResult
+                }
                 let scanned = await Task.detached(priority: .utility) {
-                    context.scan(includeDirectories: includeDirectories)
+                    textContext.scan(includeDirectories: includeDirectories)
                 }.value
                 return TerminalArtifactWire.result(
                     TerminalArtifactScanResponse(

--- a/Sources/TerminalController+MobileTerminalArtifacts.swift
+++ b/Sources/TerminalController+MobileTerminalArtifacts.swift
@@ -51,19 +51,32 @@ extension TerminalController {
         let visibleOnly = v2Bool(params, "visible_only") ?? false
         let countOnly = v2Bool(params, "count_only") ?? false
         let includeDirectories = v2Bool(params, "include_directories") ?? false
+        let includeMissing = v2Bool(params, "include_missing") ?? true
+        let requestsGalleryRowTotal = params.keys.contains("include_missing")
         let resolution = await mobileTerminalArtifactContext(
             params: params,
             requiresPath: false,
             includeScrollback: !visibleOnly,
-            includeTerminalText: !countOnly
+            includeTerminalText: !countOnly || visibleOnly
         )
         guard case .success(let context) = resolution else {
             return resolution.failureResult
         }
         if countOnly {
             guard let sessionID = context.sessionID else {
+                guard visibleOnly, requestsGalleryRowTotal else {
+                    return TerminalArtifactWire.result(
+                        TerminalArtifactScanResponse(artifacts: [])
+                    )
+                }
+                let scanned = await Task.detached(priority: .utility) {
+                    context.scan(includeDirectories: includeDirectories)
+                }.value
                 return TerminalArtifactWire.result(
-                    TerminalArtifactScanResponse(artifacts: [])
+                    TerminalArtifactScanResponse(
+                        artifacts: [],
+                        galleryRowTotal: scanned.artifacts.count
+                    )
                 )
             }
             do {
@@ -72,9 +85,22 @@ extension TerminalController {
                         TerminalArtifactScanResponse(artifacts: [], sessionID: sessionID)
                     )
                 }
+                let galleryRowTotal: Int?
+                if requestsGalleryRowTotal {
+                    galleryRowTotal = await mobileChatArtifactGalleryRowTotal(
+                        sessionID: indexedSession.sessionID,
+                        generation: indexedSession.snapshot.generation,
+                        artifacts: indexedSession.snapshot.artifacts,
+                        includeDirectories: includeDirectories,
+                        includeMissing: includeMissing
+                    )
+                } else {
+                    galleryRowTotal = nil
+                }
                 let response = TerminalArtifactScanResponse.sessionCount(
                     sessionID: indexedSession.sessionID,
-                    sessionArtifacts: indexedSession.snapshot.artifacts
+                    sessionArtifacts: indexedSession.snapshot.artifacts,
+                    galleryRowTotal: galleryRowTotal
                 )
                 return TerminalArtifactWire.result(response)
             } catch {


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/8822. The chip's number now equals the row count of the files sheet's default landing view, computed on the Mac from the same code path that builds the sheet's rows.

Previously the chip total was the raw session index size — it counted deleted files and directories the sheet may drop — and the no-session fallback was a phone-side viewport token count the Mac never saw, so the number changed while scrolling and never matched the sheet.

Mechanism:
- New shared `ChatArtifactGalleryRowEligibility` (CmuxAgentChat) owns stat + directory-capability + missing-file row rules; `ChatArtifactGalleryBuilder` now builds pages through it, and the new authoritative count uses `defaultRowCount` over the same snapshot — the two cannot drift. An invariant test pages a fabricated snapshot exhaustively (missing files, directories, all provenances, both flags) and asserts rendered rows == count.
- Count-only scans (`mobile.terminal.artifact.scan`) gain `include_missing` and return `galleryRowTotal`: the session-gallery row count (2s generation-keyed cache, statted off-main) or, with no session, the row count of the same visible-only scan the In View tab renders. Requests without the new param get byte-identical legacy behavior; old Macs return nil and the phone falls back to the previous semantics.
- iOS sends its Show Missing Files setting with each count, prefers `galleryRowTotal`, holds it across failed scans (from the base PR), and resets the count state when the setting changes.

Live-verified on a sim paired to a tagged Mac: an agent session referencing 3 files shows "3 files", the count holds while 90 lines of pathless output flood the viewport (old behavior: drops to 0), and survives a Mac app restart via the durable transcript index. Gates: CmuxAgentChat swift test (358 tests), CmuxMobileShellUI iOS-sim build-tests, macOS app build. Red/green commit structure (invariant test first).

No user-facing strings changed (localization audit: none needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787541204&installation_model_id=21920&pr_number=8902&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8902&signature=55129b853d682e0734c9151cd3da49e9029c05aa3a2a9a54d0a465b061b1a5e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the iOS files chip show the exact number of rows the gallery renders. Counting is stat-only, uses the same rule as page rendering, and handles symlinks correctly, so the number is stable and accurate.

- **New Features**
  - Shared eligibility now powers both gallery pages and counts; the builder uses it to avoid drift and TOCTOU.
  - Counts are existence-only via one attributesOfItem per reference; dangling symlinks count as existing.
  - Added a 2s `ChatArtifactGalleryRowCountCache` that coalesces concurrent sweeps by session, generation, and filters.
  - Terminal scan accepts `include_missing` and returns `gallery_row_total`; session count-only scans skip terminal text, and only the no-session visible-only fallback re-resolves with viewport text.
  - iOS sends `showMissingFiles`, passes it as `include_missing`, prefers `galleryRowTotal` over the legacy total, holds the last successful total, and resets when the setting changes.

- **Bug Fixes**
  - Chip count no longer flickers or drops to 0 while output streams; it matches the files sheet default view and respects directory/missing-file settings.
  - A held authoritative zero now yields to fresh local evidence on a failed refresh; local count shows until a later successful scan.
  - Counts now match rendered rows for symlinks.

<sup>Written for commit e62e83db3ec563ddab9ceca6d605a03705374c1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gallery counts now accurately reflect displayed files, directories, and optionally missing entries.
  * Added support for showing missing files in artifact galleries.
  * Artifact count indicators retain authoritative gallery totals across refreshes and failures.
  * Scan responses now include gallery row totals for improved count display.

* **Bug Fixes**
  * Improved consistency between paginated gallery results and displayed artifact counts.
  * Added caching to keep gallery count updates responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->