### PR TITLE
iOS: stop terminal zoom + push-up during keyboard transitions

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -291,7 +291,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                         surfaceView.retryViewportReport()
                         return
                     }
-                    surfaceView.markViewportReportConfirmed()
+                    surfaceView.markViewportReportConfirmed(reportID: report.id)
                     if let renderEpoch = effectiveGrid.renderEpoch,
                        let renderRevisionFloor = effectiveGrid.renderRevisionFloor {
                         self.verifiedReplayState.acknowledgeViewport(

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
@@ -232,6 +232,7 @@ extension GhosttySurfaceView {
         lastRenderLayoutViewportHeight = nil
         lastRenderHasSourceLayoutViewport = false
         lastAppliedContentScale = 0
+        resetLastAppliedContainerSize()
 
         surfaceGeneration &+= 1
         outputQueueGeneration &+= 1

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+ViewportCapacityFit.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+ViewportCapacityFit.swift
@@ -27,19 +27,26 @@ extension GhosttySurfaceView {
 
     /// The viewport report for the current geometry: base-font row and column
     /// capacity (see `TerminalRowCapacityFit`).
+    ///
+    /// `measuredFontSize` is the font the surface was rendering at when the
+    /// cell size was measured (captured with the geometry pass), NOT the
+    /// current `liveFontSize`: a zoom applied between the measurement and
+    /// this call would otherwise break the base-font normalization by the
+    /// zoom ratio and report a grid several times too small or too large.
     func capacityReportGrid(
         for natural: TerminalGridSize,
         containerPixelWidth: CGFloat,
         containerPixelHeight: CGFloat,
         cellPixelWidth: CGFloat,
-        cellPixelHeight: CGFloat
+        cellPixelHeight: CGFloat,
+        measuredFontSize: Float32
     ) -> TerminalGridSize {
         guard let fit = TerminalRowCapacityFit(
             containerPixelHeight: containerPixelHeight,
             cellPixelHeight: cellPixelHeight,
             containerPixelWidth: containerPixelWidth,
             cellPixelWidth: cellPixelWidth,
-            liveFontSize: liveFontSize
+            liveFontSize: measuredFontSize
         ), let rows = fit.capacityRows(atBaseFontSize: userBaseFontSize),
               let columns = fit.capacityColumns(atBaseFontSize: userBaseFontSize) else { return natural }
         return TerminalGridSize(
@@ -53,12 +60,16 @@ extension GhosttySurfaceView {
     /// Re-derive the rendered font from the effective grid. The supplied width
     /// is the same stable width used for the column report, so a transient
     /// overlay sample cannot make a valid full-width grant look oversized.
+    ///
+    /// `measuredFontSize` pairs with the supplied cell size (measured in the
+    /// same geometry pass); see `capacityReportGrid`.
     func autoFitFontToEffectiveRows(
         renderedRows: Int,
         containerPixelWidth: CGFloat,
         containerPixelHeight: CGFloat,
         cellPixelWidth: CGFloat,
-        cellPixelHeight: CGFloat
+        cellPixelHeight: CGFloat,
+        measuredFontSize: Float32
     ) {
         guard pendingFontSize == nil else { return }
         guard let eff = effectiveGrid else {
@@ -73,7 +84,7 @@ extension GhosttySurfaceView {
             cellPixelHeight: cellPixelHeight,
             containerPixelWidth: containerPixelWidth,
             cellPixelWidth: cellPixelWidth,
-            liveFontSize: liveFontSize
+            liveFontSize: measuredFontSize
         ), let baseRows = fit.capacityRows(atBaseFontSize: userBaseFontSize),
               let baseColumns = fit.capacityColumns(atBaseFontSize: userBaseFontSize) else { return }
         if eff.cols >= baseColumns && eff.rows >= baseRows {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -432,6 +432,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     var lastRenderRect: CGRect = .zero
     var lastRenderLayoutViewportHeight: CGFloat?
     var lastRenderHasSourceLayoutViewport = false
+    /// The container size last actually applied to libghostty via
+    /// `set_size`. Used to detect an unsettled SHRINK (keyboard rising) so
+    /// the local resize can be deferred until the grid negotiation settles
+    /// (see `syncSurfaceGeometry`); `.zero` until the first applied pass.
+    private var lastAppliedContainerSize: CGSize = .zero
+
+    /// Render-pipeline reset seam: the recreated surface has no applied
+    /// container size yet, so a shrink right after a reset must not defer.
+    func resetLastAppliedContainerSize() {
+        lastAppliedContainerSize = .zero
+    }
     private var viewportCoordinator = TerminalViewportCoordinator()
     private let keyboardTransitionPlanner = TerminalDockKeyboardTransitionPlanner()
     private var keyboardHeightAnimation: TerminalKeyboardHeightAnimation?
@@ -3329,6 +3340,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         /// times too small (or too large) and the daemon grants a bogus
         /// shared PTY size (the keyboard-transition font-oscillation bug).
         let measuredFontSize: Float32
+        /// False when this pass deferred the `set_size` (unsettled shrink):
+        /// the measured natural grid and render size still describe the
+        /// PREVIOUS layout, so the render's source-layout bookkeeping must
+        /// not be re-stamped with the new layout height (the stale-live
+        /// clamp would otherwise snap the old render to the target viewport
+        /// instead of letting it ride the keyboard).
+        let appliedResize: Bool
     }
 
     private func syncSurfaceGeometryAndWait(shouldReassertNaturalSize: Bool = true) async -> Bool {
@@ -3402,12 +3420,38 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let pushContentScale = abs(lastAppliedContentScale - scale) > 0.001
         if pushContentScale { lastAppliedContentScale = scale }
         let generation = surfaceGeneration
+        // While the grid negotiation is unsettled and the container SHRANK
+        // (keyboard rising), do NOT resize the local surface yet. An eager
+        // local shrink keeps the bottom of the SCREEN — trailing blank rows
+        // included — so the visible content collapses to the tail of the old
+        // screen jumped to the top ("all rows momentarily pushed up") until
+        // the remote reflow lands one round-trip later. Deferring the resize
+        // keeps the old render, which the bottom-pinned render rect slides
+        // up with the keyboard (prompt stays glued to the keyboard top), and
+        // the settle pass applies ONE resize whose result matches the
+        // remote's reflowed content. Width changes (rotation, split) and
+        // growth keep the immediate resize; the capacity report below is
+        // pure container/cell math, so the negotiation still starts now.
+        let deferShrinkResize = snapshot.viewportNegotiationUnsettled
+            && lastAppliedContainerSize.height > 0
+            && abs(containerW - lastAppliedContainerSize.width) < 0.5
+            && containerH < lastAppliedContainerSize.height - 0.5
+        if !deferShrinkResize {
+            lastAppliedContainerSize = container
+        } else {
+            MobileDebugLog.anchormux(
+                "geom.deferShrink container=\(Int(containerW))x\(Int(containerH)) "
+                + "applied=\(Int(lastAppliedContainerSize.width))x\(Int(lastAppliedContainerSize.height))"
+            )
+        }
 
         outputQueue.async { [weak self] in
             if pushContentScale {
                 ghostty_surface_set_content_scale(surface, scale, scale)
             }
-            ghostty_surface_set_size(surface, containerPxW, containerPxH)
+            if !deferShrinkResize {
+                ghostty_surface_set_size(surface, containerPxW, containerPxH)
+            }
             let measured = ghostty_surface_size(surface)
 
             var cell = CGSize.zero
@@ -3419,7 +3463,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             }
 
             var pinnedSize: CGSize?
-            if let eff, eff.cols > 0, eff.rows > 0, cell.width > 0, cell.height > 0 {
+            // A deferred shrink leaves the surface at its previous size, so
+            // the letterbox fit (which resizes the surface) is skipped too;
+            // the settle pass re-derives the pin against the applied size.
+            if let eff, !deferShrinkResize, eff.cols > 0, eff.rows > 0, cell.width > 0, cell.height > 0 {
                 let fillsNaturalGrid = eff.cols >= Int(measured.columns) && eff.rows >= Int(measured.rows)
                 let withinOneCell = (Int(measured.columns) - eff.cols) <= 1 && (Int(measured.rows) - eff.rows) <= 1
                 let exactGridFitsInsideNatural = eff.cols <= Int(measured.columns)
@@ -3451,7 +3498,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 naturalSize: natural,
                 sourceLayoutViewportHeight: snapshot.layoutViewportRect.height,
                 pinnedSize: pinnedSize,
-                measuredFontSize: measuredFontSize
+                measuredFontSize: measuredFontSize,
+                appliedResize: !deferShrinkResize
             )
             Task { @MainActor in
                 guard let self else {
@@ -3504,8 +3552,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             ?? CGRect(origin: .zero, size: naturalRenderSize)
         let snapshot = viewportSnapshot()
         layoutBottomDock(using: snapshot)
-        lastRenderLayoutViewportHeight = result.sourceLayoutViewportHeight
-        lastRenderHasSourceLayoutViewport = true
+        if result.appliedResize {
+            lastRenderLayoutViewportHeight = result.sourceLayoutViewportHeight
+            lastRenderHasSourceLayoutViewport = true
+        }
         let renderRect = snapshot.renderRect(
             forRenderSize: measuredRenderRect.size,
             clampsStaleLiveViewport: shouldClampStaleLiveViewport(using: snapshot)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -396,6 +396,14 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// the natural grid would be unchanged afterwards, nothing would ever
     /// re-report, and the letterbox gap above the terminal would be permanent.
     private var viewportReportID: UInt64 = 0
+    /// True from the moment a natural-grid report is handed to the delegate
+    /// until the daemon's round-trip resolves for the NEWEST report (echo
+    /// confirmed, or the bounded retries are exhausted). While set, the
+    /// stretch-to-fill auto-fit is deferred: `effectiveGrid` is about to be
+    /// superseded by the grant answering this report, and fitting the
+    /// rendered font against the outgoing value produces a transient zoom
+    /// that reverts one round-trip later.
+    private var awaitingViewportEcho = false
     /// Frames of "no zoom in progress" required before the natural grid is
     /// reported to the Mac. Active zoom is already gated separately
     /// (`zoomSettleFrames != nil` holds the report during a pinch), so this is
@@ -1160,7 +1168,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             chromeHidden: chromeHidden,
             chromeVisible: dockedToolbarShouldBeVisible && dockedToolbar?.isHidden == false,
             toolbarFrame: dockedToolbar?.frame,
-            toolbarPresentationFrame: dockedToolbar?.layer.presentation()?.frame
+            toolbarPresentationFrame: dockedToolbar?.layer.presentation()?.frame,
+            viewportNegotiationUnsettled: keyboardHeightAnimation != nil
+                || pendingViewportReport != nil
+                || awaitingViewportEcho
         ))
     }
 
@@ -2890,6 +2901,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                     pendingViewportReport = nil
                     viewportReportSettleFrames = 0
                     viewportReportID &+= 1
+                    awaitingViewportEcho = true
                     MobileDebugLog.anchormux("zoom.report grid=\(pending.columns)x\(pending.rows) id=\(viewportReportID)")
                     delegate?.ghosttySurfaceView(self, didResize: pending, reportID: viewportReportID)
                 }
@@ -3135,7 +3147,17 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// confirmed `applyViewSize` resets the counter. No-op once the cap is hit.
     public func retryViewportReport() {
         guard viewportReportRetries < Self.maxViewportReportRetries,
-              let pending = lastReportedSize, pending.columns > 0, pending.rows > 0 else { return }
+              let pending = lastReportedSize, pending.columns > 0, pending.rows > 0 else {
+            // Round-trip permanently failed (or nothing to retry): release
+            // the deferred auto-fit so the rendered font converges on the
+            // best-known (stale) grant instead of staying parked until some
+            // future confirmation that may never come.
+            if awaitingViewportEcho {
+                awaitingViewportEcho = false
+                setNeedsGeometrySync(reassertNaturalSize: false)
+            }
+            return
+        }
         viewportReportRetries += 1
         MobileDebugLog.anchormux(
             "zoom.viewport.retry \(viewportReportRetries)/\(Self.maxViewportReportRetries) "
@@ -3186,6 +3208,24 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     public func markViewportReportConfirmed() {
         viewportReportRetries = 0
+    }
+
+    /// Mark the round-trip for `reportID` as resolved. Only the NEWEST
+    /// report's confirmation releases the deferred stretch-to-fill auto-fit:
+    /// an out-of-order reply for an older report means the grant answering
+    /// the current capacity is still in flight.
+    public func markViewportReportConfirmed(reportID: UInt64) {
+        viewportReportRetries = 0
+        guard reportID == viewportReportID else { return }
+        if awaitingViewportEcho {
+            awaitingViewportEcho = false
+            // Run the auto-fit that was deferred while the round-trip was in
+            // flight. `applyViewSize` schedules a sync only when the echoed
+            // grid CHANGED, so an unchanged echo needs this explicit resync
+            // for the fit (and it re-reports nothing: reassert is false and
+            // the natural grid is unchanged).
+            setNeedsGeometrySync(reassertNaturalSize: false)
+        }
     }
 
     private func applyViewSize(cols: Int, rows: Int, confirmedViewportEcho: Bool) {
@@ -3280,6 +3320,15 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         /// Pinned render size in points when letterboxed to an effective
         /// grid; nil means fill the container.
         let pinnedSize: CGSize?
+        /// The font size the surface was rendering at when `cellPixelSize`
+        /// was measured. Capacity reports and the stretch-to-fill auto-fit
+        /// must normalize with THIS font, not the main-actor `liveFontSize`
+        /// read at apply time: a zoom queued between the measurement and the
+        /// apply makes the pair incoherent and the base-font normalization
+        /// off by the zoom ratio — the phone then reports a grid several
+        /// times too small (or too large) and the daemon grants a bogus
+        /// shared PTY size (the keyboard-transition font-oscillation bug).
+        let measuredFontSize: Float32
     }
 
     private func syncSurfaceGeometryAndWait(shouldReassertNaturalSize: Bool = true) async -> Bool {
@@ -3315,6 +3364,12 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // The main thread only applies the UIKit result. This is the single
         // off-main surface owner: main never calls a blocking libghostty API.
         let scale = preferredScreenScale
+        // The font the surface will measure with. Font pushes and geometry
+        // passes share the serial `outputQueue`, and `liveFontSize` is
+        // written on the main thread at the moment the font push is
+        // enqueued, so capturing it here (at this pass's enqueue) pairs it
+        // with exactly the cell size this pass measures.
+        let measuredFontSize = liveFontSize
         // Reserve, from the bottom up, the keyboard/safe-area inset (keyboard
         // height when up, else the bottom safe area so the always-visible toolbar
         // clears the home indicator), the open composer band, and the persistent
@@ -3395,7 +3450,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
                 cellPixelSize: cell,
                 naturalSize: natural,
                 sourceLayoutViewportHeight: snapshot.layoutViewportRect.height,
-                pinnedSize: pinnedSize
+                pinnedSize: pinnedSize,
+                measuredFontSize: measuredFontSize
             )
             Task { @MainActor in
                 guard let self else {
@@ -3495,19 +3551,47 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             containerPixelWidth: reportContainerWidth * scale,
             containerPixelHeight: containerH * scale,
             cellPixelWidth: result.cellPixelSize.width,
-            cellPixelHeight: result.cellPixelSize.height
+            cellPixelHeight: result.cellPixelSize.height,
+            measuredFontSize: result.measuredFontSize
         )
         // Stretch-to-fill: keep the RENDERED font tracking only real row
         // constraints. When the daemon grants the base-font natural grid back,
         // decay to the user's base font so the full-width grid can render
         // without horizontal overflow.
-        autoFitFontToEffectiveRows(
-            renderedRows: naturalSize.rows,
-            containerPixelWidth: reportContainerWidth * scale,
-            containerPixelHeight: containerH * scale,
-            cellPixelWidth: result.cellPixelSize.width,
-            cellPixelHeight: result.cellPixelSize.height
-        )
+        //
+        // Re-fit ONLY when the negotiation is settled: this pass's capacity
+        // matches the last report the daemon actually saw, no report is
+        // debouncing or awaiting its echo, and no keyboard transition is in
+        // flight. During a keyboard show/hide the container changes
+        // immediately while `effectiveGrid` is still the PREVIOUS grant (the
+        // phone itself caused the mismatch, and the corrected grant is one
+        // round-trip away) — fitting against that stale grant stretched the
+        // font toward filling the new container and then snapped back when
+        // the echo landed: the "text zooms in when the keyboard closes" bug.
+        // The settle paths (keyboard animation completion, report echo) each
+        // schedule another geometry sync, so exactly one fit runs on the
+        // settled grant.
+        if keyboardHeightAnimation == nil,
+           pendingViewportReport == nil,
+           !awaitingViewportEcho,
+           reportGrid == lastReportedSize {
+            autoFitFontToEffectiveRows(
+                renderedRows: naturalSize.rows,
+                containerPixelWidth: reportContainerWidth * scale,
+                containerPixelHeight: containerH * scale,
+                cellPixelWidth: result.cellPixelSize.width,
+                cellPixelHeight: result.cellPixelSize.height,
+                measuredFontSize: result.measuredFontSize
+            )
+        } else {
+            MobileDebugLog.anchormux(
+                "zoom.autofit.deferred kbAnim=\(keyboardHeightAnimation != nil ? 1 : 0) "
+                + "pendingReport=\(pendingViewportReport != nil ? 1 : 0) "
+                + "awaitingEcho=\(awaitingViewportEcho ? 1 : 0) "
+                + "reportGrid=\(reportGrid.columns)x\(reportGrid.rows) "
+                + "lastReported=\(lastReportedSize.map { "\($0.columns)x\($0.rows)" } ?? "nil")"
+            )
+        }
         let effectiveMatchesNatural = effectiveGrid.map { grid in
             grid.cols == naturalSize.columns && grid.rows == naturalSize.rows
         } ?? true

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportCoordinator.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportCoordinator.swift
@@ -71,7 +71,8 @@ struct TerminalViewportCoordinator {
                 y: 0,
                 width: bounds.width,
                 height: liveViewportHeight
-            )
+            ),
+            viewportNegotiationUnsettled: inputs.viewportNegotiationUnsettled
         )
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportInputs.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportInputs.swift
@@ -12,6 +12,12 @@ struct TerminalViewportInputs {
     let chromeVisible: Bool
     let toolbarFrame: CGRect?
     let toolbarPresentationFrame: CGRect?
+    /// True while the shared-grid negotiation is unsettled: a keyboard
+    /// transition is in flight, a capacity report is debouncing, or the
+    /// newest report's echo has not confirmed. The render pin treats the
+    /// current effective grid as provisional then (see
+    /// `TerminalLetterboxGeometry.renderPinnedBottomEdge`).
+    let viewportNegotiationUnsettled: Bool
 }
 #endif
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportSnapshot.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportSnapshot.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import CmuxMobileTerminalKit
 import CoreGraphics
 
 struct TerminalViewportSnapshot {
@@ -9,6 +10,8 @@ struct TerminalViewportSnapshot {
     let toolbarFrame: CGRect
     let layoutViewportRect: CGRect
     let liveViewportRect: CGRect
+    /// See `TerminalViewportInputs.viewportNegotiationUnsettled`.
+    let viewportNegotiationUnsettled: Bool
 
     func renderViewportRect(forRenderSize renderSize: CGSize, clampsStaleLiveViewport: Bool) -> CGRect {
         let targetHeight = layoutViewportRect.height
@@ -27,9 +30,22 @@ struct TerminalViewportSnapshot {
             forRenderSize: renderSize,
             clampsStaleLiveViewport: clampsStaleLiveViewport
         )
+        // Bottom-pin against the live viewport, but never clip content that
+        // will be visible at settle: while the viewport grows (keyboard
+        // dismissal) a target-sized render keeps its top row in place and the
+        // keyboard reveals the lower rows, instead of the top rows being
+        // pushed off screen and sliding back (see
+        // `TerminalLetterboxGeometry.renderPinnedBottomEdge`).
+        let bottomEdge = TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: viewport.maxY,
+            targetViewportMaxY: layoutViewportRect.maxY,
+            viewportMinY: viewport.minY,
+            renderHeight: renderSize.height,
+            holdsProvisionalPin: viewportNegotiationUnsettled
+        )
         return CGRect(
             x: viewport.minX,
-            y: viewport.maxY - renderSize.height,
+            y: bottomEdge - renderSize.height,
             width: renderSize.width,
             height: renderSize.height
         )

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -211,6 +211,61 @@ public struct TerminalLetterboxGeometry {
         )
     }
 
+    /// The bottom edge (max Y) the render rect should pin to inside the
+    /// viewport, given the LIVE viewport bottom (the toolbar's presentation
+    /// position mid keyboard animation) and the TARGET layout viewport bottom
+    /// (where the animation will settle).
+    ///
+    /// The render is bottom-pinned to the live viewport so a letterboxed box
+    /// and the prompt line ride the keyboard edge. But during a keyboard
+    /// DISMISSAL the surface is already sized for the (taller) target
+    /// viewport while the live viewport is still keyboard-small; pinning the
+    /// tall render to the small live bottom shoves the top rows off screen by
+    /// `renderHeight - liveHeight` and they slide back down as the keyboard
+    /// leaves (the "content pushed up, then settles" glitch). Content that is
+    /// visible at settle must never be clipped mid-flight, so the bottom edge
+    /// is allowed to extend past the live viewport (under the keyboard) up to
+    /// the point where the render's top reaches the viewport top — but never
+    /// past the target bottom, so a small letterboxed box still rides the
+    /// live edge instead of jumping behind the keyboard.
+    ///
+    /// - `renderHeight <= live`: pins to the live bottom (unchanged).
+    /// - `renderHeight > live` during growth: pins to
+    ///   `min(target, viewportMinY + renderHeight)` — the top stays put and
+    ///   lower rows are revealed as the keyboard departs.
+    /// - Steady state (`live == target`): identical to the legacy behavior.
+    ///
+    /// `holdsProvisionalPin` marks a render whose size still reflects an
+    /// UNSETTLED grid negotiation (keyboard transition in flight, or the
+    /// capacity report's round-trip has not confirmed). While the viewport
+    /// grows under a provisional pin, the render holds its top edge instead
+    /// of riding the live bottom: the granted grid is one round-trip from
+    /// being superseded, and riding the departing keyboard slid the squeezed
+    /// content to the bottom only for the fresh grant to snap it back to the
+    /// top (the "content bounces down then up on keyboard close" glitch).
+    /// A settled letterboxed box (a genuinely smaller device pins the shared
+    /// grid) keeps the legacy ride so it stays glued to the dock.
+    ///
+    /// - Parameters:
+    ///   - liveViewportMaxY: The live viewport bottom edge in points.
+    ///   - targetViewportMaxY: The target (layout) viewport bottom edge.
+    ///   - viewportMinY: The viewport top edge in points.
+    ///   - renderHeight: The render rect height in points.
+    ///   - holdsProvisionalPin: True while the grid negotiation is unsettled.
+    /// - Returns: The bottom edge to pin the render rect to.
+    public static func renderPinnedBottomEdge(
+        liveViewportMaxY: CGFloat,
+        targetViewportMaxY: CGFloat,
+        viewportMinY: CGFloat,
+        renderHeight: CGFloat,
+        holdsProvisionalPin: Bool = false
+    ) -> CGFloat {
+        if holdsProvisionalPin, liveViewportMaxY < targetViewportMaxY {
+            return min(targetViewportMaxY, viewportMinY + renderHeight)
+        }
+        return max(liveViewportMaxY, min(targetViewportMaxY, viewportMinY + renderHeight))
+    }
+
     /// The cell size in device pixels derived from a measured surface size.
     ///
     /// Returns `.zero` when any measured dimension is non-positive, matching the

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -289,4 +289,108 @@ struct TerminalLetterboxGeometryTests {
         )
         #expect(clamped == CGSize(width: 402, height: 700))
     }
+
+    @Test("render pin: steady state matches the legacy live-bottom pin")
+    func renderPinSteadyState() {
+        // live == target (no transition). A render shorter than the viewport
+        // bottom-pins to the live edge (letterboxed box rides above the
+        // toolbar), exactly like the legacy `maxY - height` math.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 700, targetViewportMaxY: 700,
+            viewportMinY: 0, renderHeight: 400
+        ) == 700)
+        // A render taller than the viewport still pins to the live bottom
+        // (the prompt row must stay visible; the top overflow is clipped).
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 700, targetViewportMaxY: 700,
+            viewportMinY: 0, renderHeight: 900
+        ) == 700)
+    }
+
+    @Test("render pin: keyboard rise keeps the legacy ride-the-keyboard slide")
+    func renderPinKeyboardRise() {
+        // Shrinking viewport (keyboard rising): live > target. The old
+        // full-height render keeps sliding with the live edge so the prompt
+        // rides the keyboard top; no behavior change.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 600, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714
+        ) == 600)
+        // The target-sized render (after the resize) also rides the live edge.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 600, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 403
+        ) == 600)
+    }
+
+    @Test("render pin: keyboard dismissal never clips settled-visible content")
+    func renderPinKeyboardDismissal() {
+        // Growing viewport (keyboard dismissing): live < target. The surface
+        // is already target-sized (766). The legacy live pin gave
+        // 403 - 766 = -363 (top rows shoved off screen, sliding back as the
+        // keyboard left). The pin must hold the render's top at the viewport
+        // top instead: bottom edge = min(target, renderHeight).
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 403, targetViewportMaxY: 766,
+            viewportMinY: 0, renderHeight: 766
+        ) == 766)
+        // Mid-animation the live edge catches up; the pin stays at the
+        // target so the content does not move.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 600, targetViewportMaxY: 766,
+            viewportMinY: 0, renderHeight: 766
+        ) == 766)
+        // A settled small letterboxed box still rides the live edge during
+        // the dismissal (it stays glued to the dock).
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 403, targetViewportMaxY: 766,
+            viewportMinY: 0, renderHeight: 400
+        ) == 403)
+        // A mid-height render pins to its own height until the live edge
+        // passes it, then rides — continuous at the crossover.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 403, targetViewportMaxY: 766,
+            viewportMinY: 0, renderHeight: 500
+        ) == 500)
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 500, targetViewportMaxY: 766,
+            viewportMinY: 0, renderHeight: 500
+        ) == 500)
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 620, targetViewportMaxY: 766,
+            viewportMinY: 0, renderHeight: 500
+        ) == 620)
+    }
+
+    @Test("render pin: provisional pin holds the top while the viewport grows")
+    func renderPinProvisionalGrowth() {
+        // Keyboard dismissal with the grid negotiation still unsettled: the
+        // squeezed keyboard-up render (397pt) must NOT ride the departing
+        // keyboard down (it snaps back to the top one round-trip later when
+        // the fresh grant unpins it). It holds its top edge instead.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 403, targetViewportMaxY: 714,
+            viewportMinY: 0, renderHeight: 397, holdsProvisionalPin: true
+        ) == 397)
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 650, targetViewportMaxY: 714,
+            viewportMinY: 0, renderHeight: 397, holdsProvisionalPin: true
+        ) == 397)
+        // A target-sized render under a provisional pin also stays put.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 403, targetViewportMaxY: 714,
+            viewportMinY: 0, renderHeight: 714, holdsProvisionalPin: true
+        ) == 714)
+        // Shrinking (keyboard rise) keeps the live ride even while
+        // provisional — the keyboard pushes the content up naturally.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 600, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714, holdsProvisionalPin: true
+        ) == 600)
+        // Steady (live == target) is unaffected by the provisional flag.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 714, targetViewportMaxY: 714,
+            viewportMinY: 0, renderHeight: 397, holdsProvisionalPin: true
+        ) == 714)
+    }
 }


### PR DESCRIPTION
Dogfood feedback on the kbpin build (https://github.com/manaflow-ai/cmux/pull/8899, since merged): the terminal font visibly zoomed when the software keyboard closed and snapped back a moment later, and rows were pushed off the top of the screen mid-transition before sliding back down. Field recording analysis plus a simulator repro against a live Mac narrowed it to three defects in the shared-grid negotiation around a keyboard container change.

1. **Stale-grant font stretch.** The stretch-to-fill auto-fit ran on the geometry pass right after the keyboard target changed, while `effectiveGrid` still held the previous grant (`zoom.autofit eff=72x34 baseGrid=72x65 font 10.0->18.98` captured live at dismissal start). It stretched the rendered font toward filling the new container with the stale row count and decayed one RPC round-trip later — the "text zooms in when the keyboard closes" glitch. The fit now waits for a settled negotiation (no keyboard animation in flight, no debouncing report, newest report echo confirmed, pass capacity equal to the last reported grid); the settle paths (animation completion, echo confirmation, retry exhaustion) each schedule one final sync so exactly one fit runs on the settled grant.

2. **Live-viewport bottom-pin overshoot.** The render rect bottom-pinned to the live viewport unconditionally. During a dismissal the surface is already sized for the taller target viewport, so the pin pushed the top rows off screen by `renderHeight - liveHeight` (`renderRect=440x766@-344` in the captured log) and they slid back down as the keyboard left. `TerminalLetterboxGeometry.renderPinnedBottomEdge` now caps the clip at the settled amount, and a provisionally pinned render (negotiation unsettled) holds its top edge instead of riding the departing keyboard down and snapping back up when the fresh grant unpins it. Settled letterbox boxes and the keyboard-rise path keep the legacy live-edge ride.

3. **Incoherent cell/font pairs in capacity reports.** Reports normalized the measured cell size with `liveFontSize` read at apply time; a font change queued between the measurement and the apply skews the base-font normalization by the zoom ratio and under-reports the grid several-fold (the ~10-row grants visible in the field recording, which seed the oscillation). The geometry pass now captures the font it measured with, and the report/fit use that paired value.

Verification: `CmuxMobileTerminalKit` host tests green (110 tests, includes new `renderPinnedBottomEdge` cases); simulator E2E dance (keyboard raise + dismiss over a live attach) recorded and frame-analyzed on this branch — text top position and row pitch constant through both transitions; debug log shows `zoom.autofit.deferred` during transitions, `renderRect=440x397@0` held through the dismissal, then the echoed grant growing the render in place with zero motion. A host-runnable behavior test for defects 1/3 is not practical (they live in the iOS-only `CmuxMobileTerminal` target, which does not resolve on macOS hosts); the Kit pin math is unit-tested and the rest is covered by the recorded E2E evidence.

No user-facing strings changed (debug log lines only), so no localization updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787552228&installation_model_id=21920&pr_number=8907&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8907&signature=b94b30ff0e0734fc9b366af55b88826aba2fad43b6e157b145b07bb797092cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS keyboard transition glitches: stops the terminal font from zooming on keyboard close and prevents rows from being pushed off-screen during show/hide. Grid negotiation, render pinning, and local resizing now stay stable throughout keyboard animations.

- **Bug Fixes**
  - Deferred stretch-to-fill until the negotiation settles; added `awaitingViewportEcho`, `markViewportReportConfirmed(reportID:)`, and a final geometry sync on settle/timeout.
  - Stopped content push-up: on dismissal, capped the live-bottom pin with `TerminalLetterboxGeometry.renderPinnedBottomEdge(..., holdsProvisionalPin:)`; on keyboard rise, deferred local shrink resize (skip `set_size` and letterbox fit), kept the old render, avoided re-stamping source-layout height, and applied one resize on settle. Tracked the last applied container size and reset it on pipeline recreation; width changes and growth still resize immediately. Added unit tests in `CmuxMobileTerminalKit`.
  - Paired capacity reports with the measured font. Captured `measuredFontSize` in the geometry pass and used it in `capacityReportGrid` and `autoFitFontToEffectiveRows` to prevent bogus small-grid grants.

<sup>Written for commit 66e897c13522815cdb49cd27d502a6101879778d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal layout stability during keyboard transitions and viewport resizing.
  * Prevented temporary rendering jumps while viewport updates are still being confirmed.
  * Confirm viewport reports with the correct identifier to avoid stale confirmation.
  * Ensured font fitting uses the measured font size from the geometry pass.
  * Refined pinned-edge rendering during unsettled viewport negotiation and improved recovery when retries can’t complete.
* **Tests**
  * Added coverage for pinned-edge behavior in steady state, keyboard appearance, dismissal, and transitional growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->