### PR TITLE
docs(skills): fix new-split example to pass a surface ref

### DIFF
--- a/skills/cmux/SKILL.md
+++ b/skills/cmux/SKILL.md
@@ -28,7 +28,7 @@ cmux list-pane-surfaces --pane pane:1
 
 # create/focus/move
 cmux new-workspace
-cmux new-split right --panel pane:1
+cmux new-split right --surface surface:1
 cmux move-surface --surface surface:7 --pane pane:2 --focus true
 cmux split-off --surface surface:7 right
 cmux reorder-surface --surface surface:7 --before surface:3

--- a/skills/cmux/references/panes-surfaces.md
+++ b/skills/cmux/references/panes-surfaces.md
@@ -12,7 +12,7 @@ cmux list-pane-surfaces --pane pane:1
 ## Create Splits/Surfaces
 
 ```bash
-cmux new-split right --panel pane:1
+cmux new-split right --surface surface:1
 cmux new-surface --type terminal --pane pane:1
 cmux new-surface --type browser --pane pane:1 --url https://example.com
 ```


### PR DESCRIPTION
## Summary

The cmux skill docs (`skills/cmux/SKILL.md` and `skills/cmux/references/panes-surfaces.md`) show:

```bash
cmux new-split right --panel pane:1
```

but `--panel` is an alias for `--surface` and the value is resolved as a **surface** handle, so following the documented example fails:

```
$ cmux new-split right --panel pane:6
Error: not_found: Surface not found
```

## Details

- `cmux new-split --help` documents `--panel <id|ref>` as "Alias for --surface".
- In `CLI/cmux.swift`, `new-split` computes `surfaceRaw = sfArg ?? panelArg ?? $CMUX_SURFACE_ID` and passes it to `normalizeSurfaceHandle`, so a `pane:N` ref can never resolve.
- Passing a surface ref works as expected: `cmux new-split right --panel surface:13` → `OK surface:14 workspace:4`.

This PR updates both examples to use a surface ref with the primary `--surface` flag. These are the only two occurrences of `--panel pane:` in the repo.

An agent following the skill verbatim hits this error on its first split attempt, so the docs fix should save some confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787552921&installation_model_id=21920&pr_number=8908&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8908&signature=fa121b7e3d38aa2e8daa85c7df01500fabd98954132ae91a64e35897d60c12f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `cmux new-split` docs by passing a surface ref instead of a pane ref. Replaces `--panel pane:1` with `--surface surface:1` in SKILL.md and panes-surfaces.md so the example runs without “Surface not found”.

<sup>Written for commit fe638857cabd55a9523cab7d1719b848759765f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated split-creation examples to use surface-based targeting.
  * Aligned command examples across the cmux guides for a more consistent workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->