### PR TITLE
Fix verified replay crash on iOS surface queue

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplaySubmission.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplaySubmission.swift
@@ -62,29 +62,17 @@ extension GhosttySurfaceView {
         submission: VerifiedReplayRenderSubmission,
         generation: UInt64
     ) {
-        guard let read else {
-            outputQueue.async {
-                ghostty_surface_render_now_with_token(submission.surface, submission.token)
-            }
-            return
-        }
-        outputQueue.async { [weak self] in
-            let observed = verifiedReplayExportThenSubmit(
-                export: { exportVerifiedReplayGridSynchronously(read) },
-                submit: {
-                    ghostty_surface_render_now_with_token(
-                        submission.surface,
-                        submission.token
-                    )
-                }
+        enqueueVerifiedReplaySubmissionOnSurfaceQueue(
+            outputQueue: outputQueue,
+            read: read,
+            submission: submission,
+            generation: generation
+        ) { [weak self] observed, submission, generation in
+            self?.acceptVerifiedReplayObservedFrame(
+                observed,
+                submission: submission,
+                generation: generation
             )
-            Task { @MainActor [weak self] in
-                self?.acceptVerifiedReplayObservedFrame(
-                    observed,
-                    submission: submission,
-                    generation: generation
-                )
-            }
         }
     }
 
@@ -100,6 +88,39 @@ extension GhosttySurfaceView {
         pendingVerifiedReplayPresentation = nil
         pending.continuation.resume(returning: result)
         return true
+    }
+}
+
+private nonisolated func enqueueVerifiedReplaySubmissionOnSurfaceQueue(
+    outputQueue: GhosttySurfaceWorkQueue,
+    read: VerifiedReplaySurfaceRead?,
+    submission: VerifiedReplayRenderSubmission,
+    generation: UInt64,
+    acceptObservedFrame: @escaping @MainActor @Sendable (
+        MobileTerminalRenderGridFrame?,
+        VerifiedReplayRenderSubmission,
+        UInt64
+    ) -> Void
+) {
+    guard let read else {
+        outputQueue.async {
+            ghostty_surface_render_now_with_token(submission.surface, submission.token)
+        }
+        return
+    }
+    outputQueue.async {
+        let observed = verifiedReplayExportThenSubmit(
+            export: { exportVerifiedReplayGridSynchronously(read) },
+            submit: {
+                ghostty_surface_render_now_with_token(
+                    submission.surface,
+                    submission.token
+                )
+            }
+        )
+        Task { @MainActor in
+            acceptObservedFrame(observed, submission, generation)
+        }
     }
 }
 
@@ -186,7 +207,7 @@ extension MobileTerminalRenderGridFrame {
     }
 }
 
-private func exportVerifiedReplayGridSynchronously(
+private nonisolated func exportVerifiedReplayGridSynchronously(
     _ read: VerifiedReplaySurfaceRead
 ) -> MobileTerminalRenderGridFrame? {
     let exported = read.surfaceID.withCString { pointer in

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayFrameCapture.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayFrameCapture.swift
@@ -216,7 +216,7 @@ func verifiedReplayPresentationGeometry(
 /// Keeps authoritative grid export and its tokened Metal submission adjacent
 /// inside one serial surface-queue closure. Publishing the exported frame to
 /// MainActor happens only after this synchronous operation returns.
-func verifiedReplayExportThenSubmit<Frame>(
+nonisolated func verifiedReplayExportThenSubmit<Frame>(
     export: () -> Frame?,
     submit: () -> Void
 ) -> Frame? {

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplaySubmissionTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplaySubmissionTests.swift
@@ -1,4 +1,5 @@
 #if canImport(UIKit)
+import Foundation
 import Testing
 @testable import CmuxMobileTerminal
 
@@ -19,5 +20,30 @@ func verifiedReplayExportAndTokenSubmissionStayAdjacent() {
 
     #expect(exported == 42)
     #expect(events == ["export", "submit", "publish"])
+}
+
+@Test("grid export and token submission can run on the surface work queue")
+func verifiedReplayExportAndTokenSubmissionRunOffMainThread() async {
+    let result = await withCheckedContinuation { continuation in
+        DispatchQueue(label: "dev.cmux.tests.verified-replay.surface").async {
+            var events: [String] = []
+            let ranOnMainThread = Thread.isMainThread
+            let exported = verifiedReplayExportThenSubmit(
+                export: {
+                    events.append("export")
+                    return 42
+                },
+                submit: {
+                    events.append("submit")
+                }
+            )
+            events.append("publish")
+            continuation.resume(returning: (exported, events, ranOnMainThread))
+        }
+    }
+
+    #expect(result.0 == 42)
+    #expect(result.1 == ["export", "submit", "publish"])
+    #expect(!result.2)
 }
 #endif


### PR DESCRIPTION
Crash:
- ASC TestFlight crash submission `AGJW8L5KYKWqxwPIsgzTRTU` for `dev.cmux.app.demo` was created on 2026-07-25 at 08:40:56Z with comment `Crash when opejing oaggy scroll ws`.
- The submission is attached to build `20260725040209`, ASC build id `2dc7c258-19fa-4bc1-a0ac-e640b404a716`, GitHub Actions run `30143235527`, SHA `4d7144e2b7224519e2cf79728d881cd41d7b5ef5`.
- ASC currently shows no crash submissions for the initially suspected build `20260724204644`.
- Exception: `EXC_BREAKPOINT (SIGTRAP)`, termination `SIGNAL 5 Trace/BPT trap`, triggered by thread 7.
- Thread 7 traps in `_swift_task_checkIsolatedSwift` through `dispatch_assert_queue` while running a dispatch work item. Thread 0 is committing the Ghostty renderer IOSurface through QuartzCore.

Root cause:
- Verified replay queued a synchronous grid export and tokened render submission from a MainActor method directly into `GhosttySurfaceWorkQueue`.
- The background queue path invoked helpers that were not explicit nonisolated boundaries, so Swift runtime executor checking could treat the work as actor-isolated and trap when the surface queue ran it.

Fix:
- Move verified replay queue work into a private `nonisolated` scheduler helper.
- Publish the exported frame back through an explicit `@MainActor @Sendable` callback.
- Mark the synchronous export helper and export-then-submit helper as `nonisolated` because they are pure queue-local work.
- Add a focused test that exercises export-then-submit from a serial background queue.

Verification:
- `asc testflight crashes list/view/log` pulled the TestFlight submission and raw crash log.
- `asc testflight feedback list --include-screenshots` found no screenshot feedback.
- `asc builds dsyms --build-id 2dc7c258-19fa-4bc1-a0ac-e640b404a716` reported no dSYMs available; a best-effort beta archive symbol rebuild waited 20 minutes and timed out with no cloud slot.
- `./scripts/reload-cloud.sh --tag ioscr` passed, GitHub Actions run `30152046102`, installed `cmux DEV ioscr.app`.
- `./scripts/ensure-ghosttykit.sh` linked the cached `GhosttyKit.xcframework` for local iOS package resolution.
- `swift test --package-path Packages/iOS/CmuxMobileTerminal --filter VerifiedReplaySubmission` could not run locally because this iOS-only package is seen by SwiftPM as macOS 10.13 while its local dependencies require macOS 14.0.
- `CMUX_PORT=4258 CMUX_PORT_RANGE=1 CMUX_PORT_END=4258 bun dev` is running in visible helper terminal `surface:166` after filtering empty optional relay env vars from the local secret file. Warmed `/`, `/handler/sign-in`, and `/handler/after-sign-in` with final 200 responses.
- `CMUX_PORT=4258 CMUX_PORT_RANGE=1 CMUX_PORT_END=4258 ./ios/scripts/reload.sh --tag ioscr --simulator cmux-ioscr-021054` passed and launched `dev.cmux.ios.ioscr` on simulator UDID `979BA8C6-58D1-4838-8022-C56C0A11DD00`.
- Best-effort physical iPhone reload with `./ios/scripts/reload-cloud.sh --tag ioscr --device-id 4A52829D-6427-599F-A166-4058881D2DF4` exhausted the 20-minute cloud wait, then the local fallback reported Aziz unavailable: `boot=unknown, tunnel=unavailable`.

Do not merge until iOS dogfood approval.
