### PR TITLE
cmuxTests: model shipped behavior in two input/transport fixtures

### DIFF
--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1496,8 +1496,11 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
             backing: .buffered,
             defer: false
         )
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
         defer {
-            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
             window.orderOut(nil)
         }
 
@@ -1520,12 +1523,6 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
         // synthetic ESC as insertText("\u{1B}"); the lone control byte fills the key
         // accumulator and the textForKeyEvent tilde fallback under test never runs.
         // Route around AppKit interpretation the way the focus-reassertion suite does.
-        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
-        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
-        defer {
-            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
-            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
-        }
         GhosttyNSView.debugTextInputEventHandler = { _, _ in true }
 
         var pressText: String?

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1516,6 +1516,18 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
         hostedView.setActive(true)
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
+        // In a host without an active input context, interpretKeyEvents consumes the
+        // synthetic ESC as insertText("\u{1B}"); the lone control byte fills the key
+        // accumulator and the textForKeyEvent tilde fallback under test never runs.
+        // Route around AppKit interpretation the way the focus-reassertion suite does.
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        defer {
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+        }
+        GhosttyNSView.debugTextInputEventHandler = { _, _ in true }
+
         var pressText: String?
         var pressUnshiftedCodepoint: UInt32?
         GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in

--- a/cmuxTests/CLIRemoteShellStartupPerformanceTests.swift
+++ b/cmuxTests/CLIRemoteShellStartupPerformanceTests.swift
@@ -248,7 +248,9 @@ struct CLIRemoteShellStartupPerformanceTests {
           shift
         done
         [ -n "$remote_command" ] && exec /bin/sh -c "$remote_command"
-        case "$last" in /bin/sh\\ -c*) exec /bin/sh -c "$last" ;; esac
+        # The staged installer arrives either as the legacy literal /bin/sh -c form or
+        # per-word quoted ('/bin/sh' '-c' ...); a real remote login shell parses both.
+        case "$last" in /bin/sh\\ -c*|"'/bin/sh' '-c' "*) exec /bin/sh -c "$last" ;; esac
         exit 0
         """
     }


### PR DESCRIPTION
Two suites in the cmux-unit problem set fail on fixture assumptions the product outgrew, not on the behavior they test. Both fail identically on plain main and on main plus every open fix branch, each suite run alone.

**CLIRemoteShellStartupPerformanceTests.generatedSSHStartupDoesNotBlockOnRelayRPCWarmup** looked like the remote shell blocking on relay RPC warmup. It is not: the warmup is backgrounded and detached in the generated startup command, and executing the real generated command under instrumented fakes shows the shell starting while the warmup gate is still closed. The test fails one step earlier. Its fake ssh recognizes a positional remote command only when it is spelled literally `/bin/sh -c ...`; since 98a701ffd9 the staged installer arrives per-word quoted (`'/bin/sh' '-c' '...'`), which a real remote login shell parses fine but the fake's prefix match does not. The fake install hop exited without staging the bootstrap script, the main hop failed to find it, and the shell marker never appeared. The fake now accepts both spellings, and the outer wrapper's exit code masking (which made the run still report success) is unchanged, so the test again measures what its name says.

**GhosttyBackquoteRegressionTests.testShiftBackquoteEscFallbackSendsLiteralTilde** asserts the shifted-backquote ESC fallback forwards a literal tilde. The product path is intact; the failure came from the host environment. Without an active input context, `interpretKeyEvents` consumes the synthetic ESC as `insertText("\u{1B}")`, the lone control byte lands in the key accumulator, and the `textForKeyEvent` fallback under test never runs — the observer saw the keycode-50 press with nil text, which is how the assertion failed while the codepoint assertion beside it passed. The test now stubs `debugTextInputEventHandler` exactly like GhosttyPhysicalInputFocusReassertionTests already does, and restores the key-event observer it previously leaked.

Verified on this branch, each suite alone with a fresh test build: both suites pass (1 test each, the CLI one in 2.2 seconds against its mock socket server).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787563900&installation_model_id=21920&pr_number=8911&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8911&signature=bfda611f94cb3ce54680fdb51712d0377d5fec9a90bd529ca721ed61a6f73b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix two test fixtures to match shipped behavior, resolving false failures in remote shell startup and the backquote ESC fallback. Improves reliability of both suites without changing product code or behavior.

- Bug Fixes
  - CLIRemoteShellStartupPerformanceTests: Fake ssh now accepts both literal "/bin/sh -c" and per-word quoted "'/bin/sh' '-c' ..." forms; exit-code masking unchanged.
  - GhosttyBackquoteRegressionTests: Stubbed `debugTextInputEventHandler` to bypass AppKit consuming the synthetic ESC so the tilde fallback runs; teardown now restores both `debugTextInputEventHandler` and the key-event observer to their previous values.

<sup>Written for commit 552790d8a4a8ea2c19c9d61b901f81a790a62963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for keyboard input fallback behavior, ensuring correct literal tilde entry when synthetic Escape keypresses are involved.
  * Expanded remote shell startup testing to recognize additional command-quoting formats, improving validation of consistent installer launch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->