### PR TITLE
Mermaid diagrams no longer double-scale under viewer zoom on newer WebKit

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1183,6 +1183,12 @@ html { scroll-behavior: smooth; }
 
   var mermaidInitialized = false;
   var cmuxMarkdownZoom = 1;
+  // Whether this engine's pageZoom scales the whole CSS viewport (newer WebKit,
+  // where fixed-px SVG bounds already track the prose) or only text metrics
+  // (older WebKit, where Mermaid SVGs need manual compensation). Unknown until
+  // the first zoom change supplies a viewport-width edge to measure.
+  var cmuxEngineScalesSVG = null;
+  var cmuxViewportProbeWidth = window.innerWidth;
   var mermaidResizeObserver = null;
   var mermaidObservedWidth = 0;
 
@@ -1274,16 +1280,17 @@ html { scroll-behavior: smooth; }
     return { width: width, height: height };
   }
 
-  function mermaidCurrentBaseSize(svg, natural) {
+  function mermaidCurrentBaseSize(svg, natural, containerScale) {
     var container = svg.closest ? svg.closest('.cmux-mermaid') : svg.parentElement;
     var rect = container && container.getBoundingClientRect ? container.getBoundingClientRect() : null;
     var containerWidth = rect ? rect.width : NaN;
     if (!Number.isFinite(containerWidth) || containerWidth <= 0) {
       containerWidth = container ? container.clientWidth : NaN;
     }
+    var scale = Number.isFinite(containerScale) && containerScale > 0 ? containerScale : 1;
     var width = natural.width;
     if (Number.isFinite(containerWidth) && containerWidth > 0) {
-      width = Math.min(containerWidth, natural.width);
+      width = Math.min(containerWidth * scale, natural.width);
     }
     return { width: width, height: width * (natural.height / natural.width) };
   }
@@ -1323,10 +1330,24 @@ html { scroll-behavior: smooth; }
       svg.setAttribute('data-cmux-mermaid-zoom', '1');
       return;
     }
-    var base = mermaidCurrentBaseSize(svg, natural);
-    // WKWebView pageZoom scales markdown text metrics here, but Mermaid SVG bounds stay fixed.
-    var width = Math.max(1, base.width * cmuxMarkdownZoom);
-    var height = Math.max(1, base.height * cmuxMarkdownZoom);
+    var width;
+    var height;
+    if (cmuxEngineScalesSVG === true) {
+      // This engine's pageZoom scales the whole viewport: the container's CSS
+      // width is already divided by the zoom, and the engine multiplies any
+      // CSS size we set. Pin the zoom-1 fitted size (letting a wide diagram
+      // overflow and scroll at its enlarged size) and let the engine scale it;
+      // multiplying here as well renders the diagram zoom-squared.
+      var pinned = mermaidCurrentBaseSize(svg, natural, cmuxMarkdownZoom);
+      width = Math.max(1, pinned.width);
+      height = Math.max(1, pinned.height);
+    } else {
+      // Older WKWebView pageZoom scales markdown text metrics but leaves fixed
+      // px SVG bounds alone, so the shell must size the diagram up itself.
+      var base = mermaidCurrentBaseSize(svg, natural, 1);
+      width = Math.max(1, base.width * cmuxMarkdownZoom);
+      height = Math.max(1, base.height * cmuxMarkdownZoom);
+    }
     svg.style.maxWidth = '';
     svg.setAttribute('data-cmux-mermaid-scaled', '1');
     svg.style.width = width + 'px';
@@ -1342,7 +1363,23 @@ html { scroll-behavior: smooth; }
   }
 
   window.__cmuxSetMarkdownZoom = function(zoom) {
+    var previousZoom = cmuxMarkdownZoom;
+    var previousWidth = cmuxViewportProbeWidth;
     cmuxMarkdownZoom = normalizedMarkdownZoom(zoom);
+    // The native side sets pageZoom immediately before this call, so the
+    // viewport-width edge across a zoom change tells the engine generations
+    // apart: the width shrinks by the zoom factor when the engine scales the
+    // whole viewport, and stays put when it only scales text metrics.
+    if (previousWidth > 0 && Math.abs(cmuxMarkdownZoom - previousZoom) > 0.0001) {
+      var expectedIfEngineScales = previousWidth * previousZoom / cmuxMarkdownZoom;
+      var tolerance = Math.max(2, expectedIfEngineScales * 0.02);
+      if (Math.abs(window.innerWidth - expectedIfEngineScales) <= tolerance) {
+        cmuxEngineScalesSVG = true;
+      } else if (Math.abs(window.innerWidth - previousWidth) <= tolerance) {
+        cmuxEngineScalesSVG = false;
+      }
+    }
+    cmuxViewportProbeWidth = window.innerWidth;
     mermaidObservedWidth = mermaidContentWidth(null);
     applyMermaidZoom(contentEl);
   };

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1186,9 +1186,8 @@ html { scroll-behavior: smooth; }
   // Whether this engine's pageZoom scales the whole CSS viewport (newer WebKit,
   // where fixed-px SVG bounds already track the prose) or only text metrics
   // (older WebKit, where Mermaid SVGs need manual compensation). Unknown until
-  // the first zoom change supplies a viewport-width edge to measure.
+  // the first non-default zoom supplies both host and CSS viewport widths.
   var cmuxEngineScalesSVG = null;
-  var cmuxViewportProbeWidth = window.innerWidth;
   var mermaidResizeObserver = null;
   var mermaidObservedWidth = 0;
 
@@ -1362,24 +1361,34 @@ html { scroll-behavior: smooth; }
     Array.prototype.forEach.call(scope.querySelectorAll('.cmux-mermaid svg'), applyMermaidZoomToSVG);
   }
 
-  window.__cmuxSetMarkdownZoom = function(zoom) {
-    var previousZoom = cmuxMarkdownZoom;
-    var previousWidth = cmuxViewportProbeWidth;
-    cmuxMarkdownZoom = normalizedMarkdownZoom(zoom);
-    // The native side sets pageZoom immediately before this call, so the
-    // viewport-width edge across a zoom change tells the engine generations
-    // apart: the width shrinks by the zoom factor when the engine scales the
-    // whole viewport, and stays put when it only scales text metrics.
-    if (previousWidth > 0 && Math.abs(cmuxMarkdownZoom - previousZoom) > 0.0001) {
-      var expectedIfEngineScales = previousWidth * previousZoom / cmuxMarkdownZoom;
-      var tolerance = Math.max(2, expectedIfEngineScales * 0.02);
-      if (Math.abs(window.innerWidth - expectedIfEngineScales) <= tolerance) {
-        cmuxEngineScalesSVG = true;
-      } else if (Math.abs(window.innerWidth - previousWidth) <= tolerance) {
-        cmuxEngineScalesSVG = false;
-      }
+  function detectPageZoomViewportScaling(zoom, hostViewportWidth) {
+    var hostWidth = Number(hostViewportWidth);
+    var cssWidth = window.innerWidth;
+    if (
+      !Number.isFinite(hostWidth) ||
+      hostWidth <= 0 ||
+      !Number.isFinite(cssWidth) ||
+      cssWidth <= 0 ||
+      Math.abs(zoom - 1) <= 0.0001
+    ) {
+      return null;
     }
-    cmuxViewportProbeWidth = window.innerWidth;
+    var expectedViewportWidth = hostWidth / zoom;
+    var viewportDistance = Math.abs(cssWidth - expectedViewportWidth);
+    var legacyDistance = Math.abs(cssWidth - hostWidth);
+    var tolerance = Math.max(2, Math.max(hostWidth, expectedViewportWidth) * 0.02);
+    if (Math.min(viewportDistance, legacyDistance) > tolerance) { return null; }
+    return viewportDistance < legacyDistance;
+  }
+
+  window.__cmuxSetMarkdownZoom = function(zoom, hostViewportWidth) {
+    cmuxMarkdownZoom = normalizedMarkdownZoom(zoom);
+    // Native supplies the current WKWebView width after setting pageZoom. A
+    // single contemporaneous sample distinguishes the engine generations:
+    // newer WebKit reports hostWidth / zoom, while older WebKit reports the
+    // unscaled hostWidth. No resize-sensitive historical baseline is needed.
+    var detectedScaling = detectPageZoomViewportScaling(cmuxMarkdownZoom, hostViewportWidth);
+    if (detectedScaling !== null) { cmuxEngineScalesSVG = detectedScaling; }
     mermaidObservedWidth = mermaidContentWidth(null);
     applyMermaidZoom(contentEl);
   };

--- a/Sources/Panels/MarkdownFontSizeSettings.swift
+++ b/Sources/Panels/MarkdownFontSizeSettings.swift
@@ -6,10 +6,10 @@ import Foundation
 /// The value is the `.markdown-body` font size in points. The web shell renders
 /// the body at `baseRenderPointSize` px intrinsically, so the panel applies
 /// `pointSize / baseRenderPointSize` as the WKWebView `pageZoom` to scale the
-/// rendered document the way browser zoom does. Mermaid SVGs also receive this
-/// factor in the shell because Mermaid emits inline max-width values that
-/// WebKit text zoom does not resize. Keep `baseRenderPointSize` in sync with
-/// the `.markdown-body { font-size: ... }` rule in `Resources/markdown-viewer/shell.html`.
+/// rendered document the way browser zoom does. The shell adapts Mermaid SVG
+/// sizing to the runtime WebKit viewport-scaling behavior. Keep
+/// `baseRenderPointSize` in sync with the `.markdown-body { font-size: ... }`
+/// rule in `Resources/markdown-viewer/shell.html`.
 enum MarkdownFontSizeSettings {
     /// UserDefaults / cmux.json key (`markdown.fontSize`).
     static let key = "markdown.fontSize"

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -206,7 +206,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
             let zoom = MarkdownFontSizeSettings.pageZoom(forPointSize: lastFontSize)
             let shouldSyncShell = forceShellSync || abs(webView.pageZoom - zoom) > 0.0001
             if abs(webView.pageZoom - zoom) > 0.0001 { webView.pageZoom = zoom }
-            if shouldSyncShell { webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom && window.__cmuxSetMarkdownZoom(\(Double(zoom)));", completionHandler: nil) }
+            if shouldSyncShell { webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom && window.__cmuxSetMarkdownZoom(\(Double(zoom)), \(Double(webView.bounds.width)));", completionHandler: nil) }
         }
 
         /// Records the desired body prose font and applies it as an inline

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -61,7 +61,13 @@ final class MarkdownMermaidZoomTests {
         let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
         let zoomedWidth = try #require(zoomed["width"])
         let zoomedProseHeight = try #require(zoomed["proseHeight"])
-        #expect(zoomedWidth > baselineWidth * 1.8)
+        // Rendered growth is CSS width times the viewport shrink factor: newer
+        // WebKit scales the whole viewport under pageZoom (CSS rects stay put,
+        // innerWidth shrinks by the zoom), older WebKit leaves innerWidth alone
+        // and the shell inflates the CSS rect instead. The product of the two
+        // is the on-screen size either way.
+        let zoomedDeviceScale = try #require(baseline["innerWidth"]) / #require(zoomed["innerWidth"])
+        #expect(zoomedWidth * zoomedDeviceScale > baselineWidth * 1.8)
         #expect(abs((zoomedWidth / baselineWidth) - (zoomedProseHeight / baselineProseHeight)) <= 0.25)
         let exported = try await exportedMermaidSnapshot(in: webView)
         #expect((exported["width"] ?? "missing") == "")
@@ -88,7 +94,8 @@ final class MarkdownMermaidZoomTests {
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let fittedZoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
         let fittedZoomedWidth = try #require(fittedZoomed["width"])
-        #expect(fittedZoomedWidth > fittedWidth * 1.8)
+        let fittedDeviceScale = try #require(fitted["innerWidth"]) / #require(fittedZoomed["innerWidth"])
+        #expect(fittedZoomedWidth * fittedDeviceScale > fittedWidth * 1.8)
         #expect((try #require(fittedZoomed["leftOffset"])) >= -1)
 
         let widerFrame = NSRect(x: 0, y: 0, width: 960, height: 480)
@@ -148,6 +155,7 @@ final class MarkdownMermaidZoomTests {
                 containerWidth: containerRect ? (containerRect.width || 0) : 0,
                 leftOffset: containerRect ? ((rect.left || 0) - (containerRect.left || 0)) : 0,
                 proseHeight: proseRect ? (proseRect.height || 0) : 0,
+                innerWidth: window.innerWidth || 0,
                 zoom: Number.isFinite(zoom) ? zoom : 1
               };
             })();

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -57,6 +57,16 @@ final class MarkdownMermaidZoomTests {
         #expect(abs((baseline["zoom"] ?? -1) - 1) <= 0.001)
         #expect(abs(baselineWidth - 240) <= 2)
 
+        // Resize before the first classifying zoom transition. The shell's
+        // viewport sample must describe this new size, not its load-time frame.
+        let resizedFrame = NSRect(x: 0, y: 0, width: 900, height: 480)
+        window.setFrame(resizedFrame, display: true)
+        webView.frame = resizedFrame
+        let resizedBaseline = try await waitForMermaidSnapshot(
+            in: webView,
+            minimumInnerWidth: try #require(baseline["innerWidth"]) * 1.15
+        )
+
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
         let zoomedWidth = try #require(zoomed["width"])
@@ -66,7 +76,7 @@ final class MarkdownMermaidZoomTests {
         // innerWidth shrinks by the zoom), older WebKit leaves innerWidth alone
         // and the shell inflates the CSS rect instead. The product of the two
         // is the on-screen size either way.
-        let zoomedDeviceScale = try #require(baseline["innerWidth"]) / #require(zoomed["innerWidth"])
+        let zoomedDeviceScale = try #require(resizedBaseline["innerWidth"]) / #require(zoomed["innerWidth"])
         #expect(zoomedWidth * zoomedDeviceScale > baselineWidth * 1.8)
         #expect(abs((zoomedWidth / baselineWidth) - (zoomedProseHeight / baselineProseHeight)) <= 0.25)
         let exported = try await exportedMermaidSnapshot(in: webView)
@@ -98,7 +108,7 @@ final class MarkdownMermaidZoomTests {
         #expect(fittedZoomedWidth * fittedDeviceScale > fittedWidth * 1.8)
         #expect((try #require(fittedZoomed["leftOffset"])) >= -1)
 
-        let widerFrame = NSRect(x: 0, y: 0, width: 960, height: 480)
+        let widerFrame = NSRect(x: 0, y: 0, width: 1_200, height: 480)
         window.setFrame(widerFrame, display: true)
         webView.frame = widerFrame
         _ = try await webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom(2);")
@@ -120,7 +130,8 @@ final class MarkdownMermaidZoomTests {
     private func waitForMermaidSnapshot(
         in webView: WKWebView,
         expectedZoom: Double? = nil,
-        minimumWidth: Double? = nil
+        minimumWidth: Double? = nil,
+        minimumInnerWidth: Double? = nil
     ) async throws -> [String: Double] {
         let deadline = Date().addingTimeInterval(10)
         var lastSnapshot: [String: Double]?
@@ -129,7 +140,8 @@ final class MarkdownMermaidZoomTests {
                 lastSnapshot = snapshot
                 let zoomMatches = expectedZoom.map { abs((snapshot["zoom"] ?? -1) - $0) <= 0.001 } ?? true
                 let widthMatches = minimumWidth.map { (snapshot["width"] ?? 0) >= $0 } ?? ((snapshot["width"] ?? 0) > 0)
-                if zoomMatches && widthMatches {
+                let innerWidthMatches = minimumInnerWidth.map { (snapshot["innerWidth"] ?? 0) >= $0 } ?? true
+                if zoomMatches && widthMatches && innerWidthMatches {
                     return snapshot
                 }
             }

--- a/cmuxTests/MarkdownMermaidZoomTests.swift
+++ b/cmuxTests/MarkdownMermaidZoomTests.swift
@@ -54,6 +54,7 @@ final class MarkdownMermaidZoomTests {
         let baseline = try await waitForMermaidSnapshot(in: webView)
         let baselineWidth = try #require(baseline["width"])
         let baselineProseHeight = try #require(baseline["proseHeight"])
+        let baselineInnerWidth = try positiveInnerWidth(in: baseline)
         #expect(abs((baseline["zoom"] ?? -1) - 1) <= 0.001)
         #expect(abs(baselineWidth - 240) <= 2)
 
@@ -64,8 +65,9 @@ final class MarkdownMermaidZoomTests {
         webView.frame = resizedFrame
         let resizedBaseline = try await waitForMermaidSnapshot(
             in: webView,
-            minimumInnerWidth: try #require(baseline["innerWidth"]) * 1.15
+            minimumInnerWidth: baselineInnerWidth * 1.15
         )
+        let resizedInnerWidth = try positiveInnerWidth(in: resizedBaseline)
 
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let zoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
@@ -76,7 +78,7 @@ final class MarkdownMermaidZoomTests {
         // innerWidth shrinks by the zoom), older WebKit leaves innerWidth alone
         // and the shell inflates the CSS rect instead. The product of the two
         // is the on-screen size either way.
-        let zoomedDeviceScale = try #require(resizedBaseline["innerWidth"]) / #require(zoomed["innerWidth"])
+        let zoomedDeviceScale = resizedInnerWidth / (try positiveInnerWidth(in: zoomed))
         #expect(zoomedWidth * zoomedDeviceScale > baselineWidth * 1.8)
         #expect(abs((zoomedWidth / baselineWidth) - (zoomedProseHeight / baselineProseHeight)) <= 0.25)
         let exported = try await exportedMermaidSnapshot(in: webView)
@@ -104,14 +106,15 @@ final class MarkdownMermaidZoomTests {
         coordinator.setFontSize(MarkdownFontSizeSettings.defaultPointSize * 2)
         let fittedZoomed = try await waitForMermaidSnapshot(in: webView, expectedZoom: 2)
         let fittedZoomedWidth = try #require(fittedZoomed["width"])
-        let fittedDeviceScale = try #require(fitted["innerWidth"]) / #require(fittedZoomed["innerWidth"])
+        let fittedDeviceScale = try positiveInnerWidth(in: fitted) / positiveInnerWidth(in: fittedZoomed)
         #expect(fittedZoomedWidth * fittedDeviceScale > fittedWidth * 1.8)
         #expect((try #require(fittedZoomed["leftOffset"])) >= -1)
 
         let widerFrame = NSRect(x: 0, y: 0, width: 1_200, height: 480)
         window.setFrame(widerFrame, display: true)
         webView.frame = widerFrame
-        _ = try await webView.evaluateJavaScript("window.__cmuxSetMarkdownZoom(2);")
+        _ = try await webView.evaluateJavaScript(
+            "window.__cmuxSetMarkdownZoom(2, \(Double(webView.bounds.width)));")
         let widened = try await waitForMermaidSnapshot(
             in: webView,
             expectedZoom: 2,
@@ -127,6 +130,12 @@ final class MarkdownMermaidZoomTests {
         _ = try await webView.evaluateJavaScript("window.__cmuxRenderMarkdown(\(literal)[0]);")
     }
 
+    private func positiveInnerWidth(in snapshot: [String: Double]) throws -> Double {
+        let innerWidth = try #require(snapshot["innerWidth"])
+        try #require(innerWidth > 0)
+        return innerWidth
+    }
+
     private func waitForMermaidSnapshot(
         in webView: WKWebView,
         expectedZoom: Double? = nil,
@@ -140,7 +149,8 @@ final class MarkdownMermaidZoomTests {
                 lastSnapshot = snapshot
                 let zoomMatches = expectedZoom.map { abs((snapshot["zoom"] ?? -1) - $0) <= 0.001 } ?? true
                 let widthMatches = minimumWidth.map { (snapshot["width"] ?? 0) >= $0 } ?? ((snapshot["width"] ?? 0) > 0)
-                let innerWidthMatches = minimumInnerWidth.map { (snapshot["innerWidth"] ?? 0) >= $0 } ?? true
+                let innerWidth = snapshot["innerWidth"] ?? 0
+                let innerWidthMatches = innerWidth > 0 && (minimumInnerWidth.map { innerWidth >= $0 } ?? true)
                 if zoomMatches && widthMatches && innerWidthMatches {
                     return snapshot
                 }


### PR DESCRIPTION
Zoom the markdown viewer with a Mermaid diagram on screen and the diagram grows twice as fast as the text: at 2x zoom it paints at 4x and clips at the container. Repro: open any markdown file with a mermaid block, press the font-size-up shortcut twice, and compare the diagram to the prose around it.

33e5380de8 added the compensation for a real WebKit limitation at the time: `pageZoom` scaled markdown text metrics but left fixed-px SVG bounds alone, so the shell sized diagrams up by the zoom itself. Newer WebKit scales the whole CSS viewport under `pageZoom` — the SVG already tracks the prose — so the manual sizing multiplies a second time. A standalone WKWebView probe with the shell's exact markup shows both behaviors: without the compensation the SVG renders at exactly the zoom factor on the current engine, with it the SVG renders at zoom squared.

The shell now tells the engines apart at runtime instead of assuming either: the native side sets `pageZoom` immediately before syncing the shell, so the viewport-width edge across a zoom change identifies the engine (the width shrinks by the zoom factor when the engine scales the viewport, and stays put when it only scales text). On viewport-scaling engines the shell pins the diagram at its zoom-1 fitted size and lets the engine multiply — pinning rather than restoring intrinsic sizing keeps the wide-diagram contract, where a zoomed diagram overflows and scrolls at its enlarged size instead of re-fitting to the shrunken viewport. On older engines the June behavior is unchanged.

The zoom test measured raw CSS client rects, which only grow under the old engine's model — on the new engine neither prose nor diagram grows in CSS px, since the engine scales at paint time. It now multiplies CSS width by the viewport shrink factor, which equals the on-screen size under either engine, and the diagram-tracks-prose ratio assertion is untouched.

Verified: `MarkdownMermaidZoomTests` alone against a fresh test build on the current engine, red on main (2 issues) to green with this change. The old-engine branch is byte-for-byte the June sizing and cannot be exercised on this machine's WebKit; the probe above is its evidence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787566499&installation_model_id=21920&pr_number=8914&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8914&signature=266671ecf485ba9f3dfc7a828214d3ef8e60026e33be4380ddd61f69f51fc130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Mermaid diagrams doubling in size when the markdown viewer is zoomed on newer WebKit. The shell now classifies `pageZoom` behavior from the current viewport and sizes SVGs so diagrams track the text without clipping, even after resizes.

- **Bug Fixes**
  - Classify viewport-scaling engines by sampling the WKWebView width and `window.innerWidth` right after setting `pageZoom`; no historical baseline; robust after resizes.
  - On viewport‑scaling engines, pin the zoom‑1 fitted size and let the engine scale; preserves overflow/scroll for wide diagrams.
  - Update `MarkdownMermaidZoomTests` to compute on-screen growth as CSS width × viewport shrink factor and to cover zoom after a viewport resize.

<sup>Written for commit 7f8c2ce5d69b962ef83443e9ddf7d47a60825aa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mermaid diagram zoom handling in the Markdown viewer by correctly detecting how zoom is applied in the WebKit/WebView environment.
  * Avoided double-scaling so diagrams render at consistent sizes when page zoom changes.
  * Refined zoomed diagram sizing and fitting for more stable visual results.

* **Tests**
  * Updated Mermaid zoom snapshot testing to use viewport/device-scale-adjusted checks and stricter baseline collection criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->