### PR TITLE
Expose terminal process liveness in control topology

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+System.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+System.swift
@@ -325,6 +325,7 @@ extension ControlCommandCoordinator {
             "pane_ref": refs.paneRef,
             "index_in_pane": node.indexInPane.map { JSONValue.int(Int64($0)) } ?? .null,
             "tty": orNull(node.tty),
+            "process_alive": node.processAlive.map(JSONValue.bool) ?? .null,
         ]
         item["url"] = node.isBrowser ? .string(node.url ?? "") : .null
         if let dockScope = node.dockScopeRawValue {

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+System.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+System.swift
@@ -324,7 +324,7 @@ extension ControlCommandCoordinator {
             "pane_id": orNull(node.paneID?.uuidString),
             "pane_ref": refs.paneRef,
             "index_in_pane": node.indexInPane.map { JSONValue.int(Int64($0)) } ?? .null,
-            "tty": orNull(node.tty),
+            "tty": orNull(node.reportedTTY),
             "process_alive": node.processAlive.map(JSONValue.bool) ?? .null,
         ]
         item["url"] = node.isBrowser ? .string(node.url ?? "") : .null

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreeSurfaceNode.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreeSurfaceNode.swift
@@ -30,6 +30,9 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
     public let indexInPane: Int?
     /// The terminal's tty name, if known.
     public let tty: String?
+    /// Whether the locally spawned terminal process is alive. `nil` means the
+    /// process state is unavailable or does not apply to this surface.
+    public let processAlive: Bool?
     /// Whether this is a browser surface (drives the `url` emission: browsers
     /// emit a string — empty when no URL — and non-browsers emit JSON `null`).
     public let isBrowser: Bool
@@ -52,6 +55,8 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
     ///   - paneID: The enclosing pane's identifier, if resolved.
     ///   - indexInPane: The tab index within the pane, if resolved.
     ///   - tty: The terminal's tty name, if known.
+    ///   - processAlive: Whether the locally spawned terminal process is alive.
+    ///     `nil` means the process state is unavailable or does not apply.
     ///   - isBrowser: Whether this is a browser surface.
     ///   - url: For browsers, the current URL string.
     ///   - dockScopeRawValue: The Dock scope for a Dock-hosted surface.
@@ -66,6 +71,7 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
         paneID: UUID?,
         indexInPane: Int?,
         tty: String?,
+        processAlive: Bool? = nil,
         isBrowser: Bool,
         url: String?,
         dockScopeRawValue: String? = nil
@@ -79,7 +85,8 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
         self.selectedInPane = selectedInPane
         self.paneID = paneID
         self.indexInPane = indexInPane
-        self.tty = tty
+        self.tty = processAlive == false ? nil : tty
+        self.processAlive = processAlive
         self.isBrowser = isBrowser
         self.url = url
         self.dockScopeRawValue = dockScopeRawValue

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreeSurfaceNode.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSystemTreeSurfaceNode.swift
@@ -30,6 +30,11 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
     public let indexInPane: Int?
     /// The terminal's tty name, if known.
     public let tty: String?
+    /// The tty value emitted on the wire. Exited local processes keep their raw
+    /// topology tty for in-process consumers but suppress it in snapshots.
+    public var reportedTTY: String? {
+        processAlive == false ? nil : tty
+    }
     /// Whether the locally spawned terminal process is alive. `nil` means the
     /// process state is unavailable or does not apply to this surface.
     public let processAlive: Bool?
@@ -85,7 +90,7 @@ public struct ControlSystemTreeSurfaceNode: Sendable, Equatable {
         self.selectedInPane = selectedInPane
         self.paneID = paneID
         self.indexInPane = indexInPane
-        self.tty = processAlive == false ? nil : tty
+        self.tty = tty
         self.processAlive = processAlive
         self.isBrowser = isBrowser
         self.url = url

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSystemTreeProcessAliveTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSystemTreeProcessAliveTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+@MainActor
+private final class ProcessAliveSystemContext: ControlCommandContext {
+    var resolution = ControlSystemTreeResolution(
+        windowFound: true,
+        workspaceFound: true,
+        windows: []
+    )
+
+    func controlSystemTreeWindows(
+        requestedWindowID: UUID?,
+        includeAllWindows: Bool,
+        focusedWindowID: UUID?,
+        workspaceFilter: UUID?
+    ) -> ControlSystemTreeResolution {
+        resolution
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator system.tree process liveness")
+struct ControlCommandCoordinatorSystemTreeProcessAliveTests {
+    @Test func serializesFalseTrueAndUnknownWhileSuppressingOnlyExitedTTY() {
+        let windowID = UUID()
+        let workspaceID = UUID()
+        let paneID = UUID()
+        let falseID = UUID()
+        let trueID = UUID()
+        let unknownID = UUID()
+        let surfaces = [
+            surface(id: falseID, index: 0, tty: "ttys001", processAlive: false),
+            surface(id: trueID, index: 1, tty: "ttys002", processAlive: true),
+            surface(id: unknownID, index: 2, tty: "ttys003", processAlive: nil),
+        ]
+        let context = ProcessAliveSystemContext()
+        context.resolution = ControlSystemTreeResolution(
+            windowFound: true,
+            workspaceFound: true,
+            windows: [
+                ControlSystemTreeWindowNode(
+                    summary: ControlWindowSummary(
+                        windowID: windowID,
+                        isKeyWindow: true,
+                        isVisible: true,
+                        workspaceCount: 1,
+                        selectedWorkspaceID: workspaceID
+                    ),
+                    index: 0,
+                    workspaces: [
+                        ControlSystemTreeWorkspaceNode(
+                            workspaceID: workspaceID,
+                            index: 0,
+                            title: "Workspace",
+                            description: nil,
+                            isSelected: true,
+                            isPinned: false,
+                            panes: [
+                                ControlSystemTreePaneNode(
+                                    paneID: paneID,
+                                    index: 0,
+                                    isFocused: true,
+                                    surfaceIDs: [falseID, trueID, unknownID],
+                                    selectedSurfaceID: trueID,
+                                    surfaces: surfaces
+                                ),
+                            ]
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        let result = ControlCommandCoordinator(context: context).handle(
+            ControlRequest(id: .int(1), method: "system.tree", params: [:])
+        )
+        guard case .ok(.object(let root))? = result,
+              case .array(let windows)? = root["windows"],
+              case .object(let window) = windows.first,
+              case .array(let workspaces)? = window["workspaces"],
+              case .object(let workspace) = workspaces.first,
+              case .array(let panes)? = workspace["panes"],
+              case .object(let pane) = panes.first,
+              case .array(let payloads)? = pane["surfaces"] else {
+            Issue.record("Expected a system.tree surface payload")
+            return
+        }
+
+        #expect(payloads.count == 3)
+        #expect(field("process_alive", in: payloads[0]) == .bool(false))
+        #expect(field("tty", in: payloads[0]) == .null)
+        #expect(field("process_alive", in: payloads[1]) == .bool(true))
+        #expect(field("tty", in: payloads[1]) == .string("ttys002"))
+        #expect(field("process_alive", in: payloads[2]) == .null)
+        #expect(field("tty", in: payloads[2]) == .string("ttys003"))
+    }
+
+    private func surface(
+        id: UUID,
+        index: Int,
+        tty: String,
+        processAlive: Bool?
+    ) -> ControlSystemTreeSurfaceNode {
+        ControlSystemTreeSurfaceNode(
+            surfaceID: id,
+            index: index,
+            typeRawValue: "terminal",
+            title: "Terminal",
+            isFocused: index == 1,
+            isSelected: index == 1,
+            selectedInPane: index == 1,
+            paneID: nil,
+            indexInPane: index,
+            tty: tty,
+            processAlive: processAlive,
+            isBrowser: false,
+            url: nil
+        )
+    }
+
+    private func field(_ key: String, in payload: JSONValue) -> JSONValue? {
+        guard case .object(let object) = payload else { return nil }
+        return object[key]
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSystemTreeProcessAliveTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSystemTreeProcessAliveTests.swift
@@ -89,6 +89,8 @@ struct ControlCommandCoordinatorSystemTreeProcessAliveTests {
         }
 
         #expect(payloads.count == 3)
+        #expect(surfaces[0].tty == "ttys001")
+        #expect(surfaces[0].reportedTTY == nil)
         #expect(field("process_alive", in: payloads[0]) == .bool(false))
         #expect(field("tty", in: payloads[0]) == .null)
         #expect(field("process_alive", in: payloads[1]) == .bool(true))

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ProcessLiveness.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ProcessLiveness.swift
@@ -8,7 +8,7 @@ public extension TerminalSurface {
     @MainActor
     func processAlive() -> Bool? {
         guard !manualIO,
-              let liveSurface = liveSurfaceForGhosttyAccess(reason: "processAlive") else {
+              let liveSurface = validatedRuntimeSurfaceForObservation() else {
             return nil
         }
         return !ghostty_surface_process_exited(liveSurface)

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ProcessLiveness.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ProcessLiveness.swift
@@ -1,0 +1,16 @@
+public import GhosttyKit
+
+public extension TerminalSurface {
+    /// Reports whether this surface's locally spawned process is alive.
+    ///
+    /// Returns `nil` for manual-I/O surfaces and whenever no validated live
+    /// Ghostty runtime surface is available.
+    @MainActor
+    func processAlive() -> Bool? {
+        guard !manualIO,
+              let liveSurface = liveSurfaceForGhosttyAccess(reason: "processAlive") else {
+            return nil
+        }
+        return !ghostty_surface_process_exited(liveSurface)
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -126,10 +126,9 @@ extension TerminalSurface {
     /// down a stale wrapper instead of returning a dangling pointer.
     @MainActor
     public func liveSurfaceForGhosttyAccess(reason: String) -> ghostty_surface_t? {
-        guard hasLiveSurface, let surface else { return nil }
-        let registeredOwnerId = registry.runtimeSurfaceOwnerId(surface)
-        guard registeredOwnerId == id,
-              GhosttySurfaceRuntimeProbe.surfacePointerAppearsLive(surface) else {
+        guard let validation = runtimeSurfaceValidationSnapshot() else { return nil }
+        guard validation.isValid else {
+            let surface = validation.surface
             let callbackContext = surfaceCallbackContext
             surfaceCallbackContext = nil
             let teeLease = mobileByteTeeLease
@@ -141,7 +140,9 @@ extension TerminalSurface {
             recordTeardownRequest(reason: reason)
             markPortalLifecycleClosed(reason: reason)
 #if DEBUG
-            let registeredOwnerToken = registeredOwnerId.map { String($0.uuidString.prefix(5)) } ?? "nil"
+            let registeredOwnerToken = validation.registeredOwnerId.map {
+                String($0.uuidString.prefix(5))
+            } ?? "nil"
             logDebugEvent(
                 "surface.lifecycle.stale surface=\(id.uuidString.prefix(5)) " +
                 "workspace=\(tabId.uuidString.prefix(5)) reason=\(reason) " +
@@ -152,7 +153,34 @@ extension TerminalSurface {
             teeLease?.release()
             return nil
         }
-        return surface
+        return validation.surface
+    }
+
+    /// Returns a validated runtime pointer for read-only observation without
+    /// changing surface lifecycle state when validation fails.
+    @MainActor
+    func validatedRuntimeSurfaceForObservation() -> ghostty_surface_t? {
+        guard let validation = runtimeSurfaceValidationSnapshot(),
+              validation.isValid else {
+            return nil
+        }
+        return validation.surface
+    }
+
+    @MainActor
+    private func runtimeSurfaceValidationSnapshot() -> (
+        surface: ghostty_surface_t,
+        registeredOwnerId: UUID?,
+        isValid: Bool
+    )? {
+        guard hasLiveSurface, let surface else { return nil }
+        let registeredOwnerId = registry.runtimeSurfaceOwnerId(surface)
+        return (
+            surface: surface,
+            registeredOwnerId: registeredOwnerId,
+            isValid: registeredOwnerId == id &&
+                GhosttySurfaceRuntimeProbe.surfacePointerAppearsLive(surface)
+        )
     }
 
     func recordTeardownRequest(reason: String) {

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceProcessLivenessTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceProcessLivenessTests.swift
@@ -4,17 +4,17 @@ import GhosttyKit
 import Testing
 @testable import CmuxTerminal
 
-@_silgen_name("cmux_test_ghostty_runtime_stubs_reset")
-private func resetGhosttyRuntimeStubs()
+@_silgen_name("cmux_test_ghostty_runtime_stubs_reset_process_exited")
+private func resetGhosttyProcessExitedStub()
 
 @_silgen_name("cmux_test_ghostty_runtime_stubs_set_process_exited")
-private func setGhosttyProcessExited(_ processExited: Bool)
+private func setGhosttyProcessExited(_ surface: UnsafeMutableRawPointer, _ processExited: Bool)
 
 @MainActor
 @Suite(.serialized)
 struct TerminalSurfaceProcessLivenessTests {
     @Test func reportsOnlyValidatedLocalRuntimeState() {
-        resetGhosttyRuntimeStubs()
+        resetGhosttyProcessExitedStub()
         let registry = TerminalSurfaceRegistry()
         let coldSurface = makeSurface(registry: registry)
         let manualSurface = makeSurface(registry: registry, manualIO: true)
@@ -28,17 +28,34 @@ struct TerminalSurfaceProcessLivenessTests {
         liveSurface.installRuntimeSurfaceForTesting(runtimeSurface)
         defer {
             runtimeSurface.deallocate()
-            resetGhosttyRuntimeStubs()
+            resetGhosttyProcessExitedStub()
         }
 
-        setGhosttyProcessExited(false)
+        setGhosttyProcessExited(runtimeSurface, false)
         #expect(liveSurface.processAlive() == true)
 
-        setGhosttyProcessExited(true)
+        setGhosttyProcessExited(runtimeSurface, true)
         #expect(liveSurface.processAlive() == false)
 
         liveSurface.releaseSurfaceForTesting()
         #expect(liveSurface.processAlive() == nil)
+    }
+
+    @Test func observationDoesNotTearDownAnOwnershipMismatch() {
+        let registry = TerminalSurfaceRegistry()
+        let observedSurface = makeSurface(registry: registry)
+        let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        let otherOwner = UUID()
+        registry.registerRuntimeSurface(runtimeSurface, ownerId: otherOwner)
+        observedSurface.installRuntimeSurfaceForTesting(runtimeSurface)
+        defer {
+            observedSurface.releaseSurfaceForTesting()
+            registry.unregisterRuntimeSurface(runtimeSurface, ownerId: otherOwner)
+            runtimeSurface.deallocate()
+        }
+
+        #expect(observedSurface.processAlive() == nil)
+        #expect(observedSurface.runtimeSurfacePointer == runtimeSurface)
     }
 
     private func makeSurface(

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceProcessLivenessTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceProcessLivenessTests.swift
@@ -1,0 +1,84 @@
+import AppKit
+import CmuxTerminalCore
+import GhosttyKit
+import Testing
+@testable import CmuxTerminal
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_reset")
+private func resetGhosttyRuntimeStubs()
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_set_process_exited")
+private func setGhosttyProcessExited(_ processExited: Bool)
+
+@MainActor
+@Suite(.serialized)
+struct TerminalSurfaceProcessLivenessTests {
+    @Test func reportsOnlyValidatedLocalRuntimeState() {
+        resetGhosttyRuntimeStubs()
+        let registry = TerminalSurfaceRegistry()
+        let coldSurface = makeSurface(registry: registry)
+        let manualSurface = makeSurface(registry: registry, manualIO: true)
+
+        #expect(coldSurface.processAlive() == nil)
+        #expect(manualSurface.processAlive() == nil)
+
+        let liveSurface = makeSurface(registry: registry)
+        let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        registry.registerRuntimeSurface(runtimeSurface, ownerId: liveSurface.id)
+        liveSurface.installRuntimeSurfaceForTesting(runtimeSurface)
+        defer {
+            runtimeSurface.deallocate()
+            resetGhosttyRuntimeStubs()
+        }
+
+        setGhosttyProcessExited(false)
+        #expect(liveSurface.processAlive() == true)
+
+        setGhosttyProcessExited(true)
+        #expect(liveSurface.processAlive() == false)
+
+        liveSurface.releaseSurfaceForTesting()
+        #expect(liveSurface.processAlive() == nil)
+    }
+
+    private func makeSurface(
+        registry: TerminalSurfaceRegistry,
+        manualIO: Bool = false
+    ) -> TerminalSurface {
+        let nativeView = FakeTerminalSurfaceNativeView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
+        )
+        let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
+        return TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            manualIO: manualIO,
+            dependencies: TerminalSurfaceRuntimeDependencies(
+                registry: registry,
+                engine: FakeTerminalEngine(),
+                viewProvider: FakeTerminalSurfaceViewProvider(
+                    surfaceView: nativeView,
+                    paneHost: paneHost
+                ),
+                spawnPolicy: FakeSpawnPolicyProvider(),
+                byteTee: FakeTerminalByteTee(),
+                rendererRealization: FakeRendererRealizationScheduler(),
+                hibernationRecorder: FakeHibernationRecorder(),
+                runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
+                restoreSpawnScheduler: TerminalSurfaceRestoreSpawnScheduler(interSpawnDelay: .zero),
+                runtimeFilesystem: TerminalSurfaceRuntimeFilesystem(
+                    claudeCommandShimTemporaryDirectory: URL(
+                        fileURLWithPath: "/tmp/cmux-terminal-tests",
+                        isDirectory: true
+                    ),
+                    installClaudeCommandShim: { _, _, _ in nil },
+                    isExecutableFile: { _ in false }
+                ),
+                sessionPortBase: 40_000,
+                sessionPortRangeSize: 100,
+                scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"
+            )
+        )
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -16,6 +16,7 @@ typedef struct {
 } GhosttyRuntimeTestConfig;
 
 static bool cmux_test_needs_confirm_quit = false;
+static bool cmux_test_process_exited = false;
 static uint64_t cmux_test_foreground_pid = 0;
 static const char* cmux_test_tty_name = NULL;
 static void* cmux_test_renderer_realized_target = NULL;
@@ -27,6 +28,7 @@ static bool cmux_test_renderer_release_was_occluded = false;
 
 void cmux_test_ghostty_runtime_stubs_reset(void) {
     cmux_test_needs_confirm_quit = false;
+    cmux_test_process_exited = false;
     cmux_test_foreground_pid = 0;
     cmux_test_tty_name = NULL;
 }
@@ -51,6 +53,10 @@ void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_
     cmux_test_needs_confirm_quit = needs_confirm;
     cmux_test_foreground_pid = foreground_pid;
     cmux_test_tty_name = tty_name;
+}
+
+void cmux_test_ghostty_runtime_stubs_set_process_exited(bool process_exited) {
+    cmux_test_process_exited = process_exited;
 }
 
 uint32_t cmux_test_ghostty_renderer_realized_call_count(void) {
@@ -157,7 +163,7 @@ bool ghostty_surface_needs_confirm_quit(void *surface) {
 void ghostty_surface_new(void) {}
 bool ghostty_surface_process_exited(void *surface) {
     (void)surface;
-    return false;
+    return cmux_test_process_exited;
 }
 void ghostty_surface_process_output(void) {}
 void ghostty_surface_quicklook_font(void) {}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -17,6 +17,7 @@ typedef struct {
 
 static bool cmux_test_needs_confirm_quit = false;
 static bool cmux_test_process_exited = false;
+static void* cmux_test_process_exited_target = NULL;
 static uint64_t cmux_test_foreground_pid = 0;
 static const char* cmux_test_tty_name = NULL;
 static void* cmux_test_renderer_realized_target = NULL;
@@ -28,9 +29,13 @@ static bool cmux_test_renderer_release_was_occluded = false;
 
 void cmux_test_ghostty_runtime_stubs_reset(void) {
     cmux_test_needs_confirm_quit = false;
-    cmux_test_process_exited = false;
     cmux_test_foreground_pid = 0;
     cmux_test_tty_name = NULL;
+}
+
+void cmux_test_ghostty_runtime_stubs_reset_process_exited(void) {
+    cmux_test_process_exited = false;
+    cmux_test_process_exited_target = NULL;
 }
 
 void cmux_test_ghostty_renderer_realized_begin(void* surface) {
@@ -55,7 +60,8 @@ void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_
     cmux_test_tty_name = tty_name;
 }
 
-void cmux_test_ghostty_runtime_stubs_set_process_exited(bool process_exited) {
+void cmux_test_ghostty_runtime_stubs_set_process_exited(void* surface, bool process_exited) {
+    cmux_test_process_exited_target = surface;
     cmux_test_process_exited = process_exited;
 }
 
@@ -162,8 +168,7 @@ bool ghostty_surface_needs_confirm_quit(void *surface) {
 }
 void ghostty_surface_new(void) {}
 bool ghostty_surface_process_exited(void *surface) {
-    (void)surface;
-    return cmux_test_process_exited;
+    return surface == cmux_test_process_exited_target && cmux_test_process_exited;
 }
 void ghostty_surface_process_output(void) {}
 void ghostty_surface_quicklook_font(void) {}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -177,6 +177,24 @@ void ghostty_surface_read_text(void) {}
 void ghostty_surface_refresh(void) {}
 void ghostty_surface_render_grid_json(void) {}
 void ghostty_surface_render_grid_json_with_theme(void) {}
+ghostty_string_s ghostty_surface_render_grid_json_v2(
+    void *surface,
+    const char *surface_id,
+    uintptr_t surface_id_len,
+    uint64_t state_seq,
+    uintptr_t scrollback_lines,
+    bool include_theme,
+    bool screen_anchor
+) {
+    (void)surface;
+    (void)surface_id;
+    (void)surface_id_len;
+    (void)state_seq;
+    (void)scrollback_lines;
+    (void)include_theme;
+    (void)screen_anchor;
+    return (ghostty_string_s){0};
+}
 void ghostty_surface_set_content_scale(void) {}
 void ghostty_surface_set_display_id(void) {}
 void ghostty_surface_set_focus(void) {}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -66,8 +66,9 @@ void ghostty_surface_text_input(void);
 ghostty_string_s ghostty_surface_tty_name(void *surface);
 
 void cmux_test_ghostty_runtime_stubs_reset(void);
+void cmux_test_ghostty_runtime_stubs_reset_process_exited(void);
 void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name);
-void cmux_test_ghostty_runtime_stubs_set_process_exited(bool process_exited);
+void cmux_test_ghostty_runtime_stubs_set_process_exited(void* surface, bool process_exited);
 void cmux_test_ghostty_renderer_realized_begin(void *surface);
 void cmux_test_ghostty_renderer_realized_reset(void);
 uint32_t cmux_test_ghostty_renderer_realized_call_count(void);

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -67,6 +67,7 @@ ghostty_string_s ghostty_surface_tty_name(void *surface);
 
 void cmux_test_ghostty_runtime_stubs_reset(void);
 void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name);
+void cmux_test_ghostty_runtime_stubs_set_process_exited(bool process_exited);
 void cmux_test_ghostty_renderer_realized_begin(void *surface);
 void cmux_test_ghostty_renderer_realized_reset(void);
 uint32_t cmux_test_ghostty_renderer_realized_call_count(void);

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -54,6 +54,14 @@ void ghostty_surface_read_text(void);
 void ghostty_surface_refresh(void);
 void ghostty_surface_render_grid_json(void);
 void ghostty_surface_render_grid_json_with_theme(void);
+ghostty_string_s ghostty_surface_render_grid_json_v2(
+    void *surface,
+    const char *surface_id,
+    uintptr_t surface_id_len,
+    uint64_t state_seq,
+    uintptr_t scrollback_lines,
+    bool include_theme,
+    bool screen_anchor);
 void ghostty_surface_set_content_scale(void);
 void ghostty_surface_set_display_id(void);
 void ghostty_surface_set_focus(void);

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -135,7 +135,9 @@ extension TerminalController: ControlSystemContext {
                 dockStores.lazy.compactMap { $0.panels[surface.surfaceID] }.first
             let browserPanel = panel as? BrowserPanel
             let processAlive: Bool?
-            if workspace.isRemoteTerminalSurfaceOrDisconnectPlaceholder(surface.surfaceID) {
+            if workspace.isRemoteTerminalSurfaceOrDisconnectPlaceholder(surface.surfaceID) ||
+                workspace.pendingRemoteTerminalChildExitSurfaceIds.contains(surface.surfaceID) ||
+                workspace.endedPersistentRemotePTYAttachSurfaceIds.contains(surface.surfaceID) {
                 processAlive = nil
             } else if let terminalPanel = panel as? TerminalPanel {
 #if DEBUG

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -2,6 +2,7 @@ import AppKit
 import Bonsplit
 import CmuxControlSocket
 import CmuxFeedback
+import CmuxTerminal
 import Foundation
 
 /// The system-domain witnesses: the byte-faithful bodies of the former
@@ -133,6 +134,12 @@ extension TerminalController: ControlSystemContext {
             let panel = workspace.controlSurfaceTarget(for: surface.surfaceID)?.panel ??
                 dockStores.lazy.compactMap { $0.panels[surface.surfaceID] }.first
             let browserPanel = panel as? BrowserPanel
+            let processAlive: Bool?
+            if workspace.isRemoteTerminalSurface(surface.surfaceID) {
+                processAlive = nil
+            } else {
+                processAlive = (panel as? TerminalPanel)?.surface.processAlive()
+            }
             let node = ControlSystemTreeSurfaceNode(
                 surfaceID: surface.surfaceID,
                 index: surfaceIndex,
@@ -144,6 +151,7 @@ extension TerminalController: ControlSystemContext {
                 paneID: surface.paneID,
                 indexInPane: surface.indexInPane,
                 tty: workspace.surfaceTTYNames[surface.surfaceID],
+                processAlive: processAlive,
                 isBrowser: browserPanel != nil,
                 url: browserPanel?.currentURL?.absoluteString,
                 dockScopeRawValue: surface.dockScopeRawValue

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -135,10 +135,17 @@ extension TerminalController: ControlSystemContext {
                 dockStores.lazy.compactMap { $0.panels[surface.surfaceID] }.first
             let browserPanel = panel as? BrowserPanel
             let processAlive: Bool?
-            if workspace.isRemoteTerminalSurface(surface.surfaceID) {
+            if workspace.isRemoteTerminalSurfaceOrDisconnectPlaceholder(surface.surfaceID) {
                 processAlive = nil
+            } else if let terminalPanel = panel as? TerminalPanel {
+#if DEBUG
+                processAlive = workspace.controlProcessAliveOverridesForTesting[surface.surfaceID] ??
+                    terminalPanel.surface.processAlive()
+#else
+                processAlive = terminalPanel.surface.processAlive()
+#endif
             } else {
-                processAlive = (panel as? TerminalPanel)?.surface.processAlive()
+                processAlive = nil
             }
             let node = ControlSystemTreeSurfaceNode(
                 surfaceID: surface.surfaceID,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3099,6 +3099,7 @@ class TerminalController {
             "pane_ref": v2Ref(kind: .pane, uuid: surface.paneID),
             "index_in_pane": v2OrNull(surface.indexInPane),
             "tty": v2OrNull(surface.tty),
+            "process_alive": v2OrNull(surface.processAlive),
             "webviews": []
         ]
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3098,7 +3098,7 @@ class TerminalController {
             "pane_id": v2OrNull(surface.paneID?.uuidString),
             "pane_ref": v2Ref(kind: .pane, uuid: surface.paneID),
             "index_in_pane": v2OrNull(surface.indexInPane),
-            "tty": v2OrNull(surface.tty),
+            "tty": v2OrNull(surface.reportedTTY),
             "process_alive": v2OrNull(surface.processAlive),
             "webviews": []
         ]

--- a/Sources/Workspace+RemoteSessionLifecycle.swift
+++ b/Sources/Workspace+RemoteSessionLifecycle.swift
@@ -179,7 +179,7 @@ extension Workspace {
     @discardableResult
     func reconnectCloudTerminalSurface(surfaceId: UUID) -> Bool {
         guard isManagedCloudVMWorkspace,
-              isRemoteTerminalSurface(surfaceId) || remoteDisconnectPlaceholderPanelIds.contains(surfaceId) else {
+              isRemoteTerminalSurfaceOrDisconnectPlaceholder(surfaceId) else {
             return false
         }
         return reconnectRemoteConnection(surfaceId: surfaceId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2417,6 +2417,9 @@ final class Workspace: Identifiable, ObservableObject {
     /// the package process-runner seam (replaces the legacy process-wide
     /// `WorkspaceRemoteSessionController.runProcessOverrideForTesting` static).
     var remoteSessionProcessRunnerOverrideForTesting: (any RemoteSessionProcessRunning)?
+    /// Workspace-scoped process-state overrides for control-plane projection
+    /// tests. Unknown IDs continue through the real TerminalSurface probe.
+    var controlProcessAliveOverridesForTesting: [UUID: Bool] = [:]
 #endif
     /// The shell-activity classification per panel id; stored in the
     /// surface-registry sub-model.
@@ -5150,6 +5153,12 @@ final class Workspace: Identifiable, ObservableObject {
     @MainActor
     func isRemoteTerminalSurface(_ panelId: UUID) -> Bool {
         activeRemoteTerminalSurfaceIds.contains(panelId)
+    }
+
+    @MainActor
+    func isRemoteTerminalSurfaceOrDisconnectPlaceholder(_ panelId: UUID) -> Bool {
+        isRemoteTerminalSurface(panelId) ||
+            remoteDisconnectPlaceholderPanelIds.contains(panelId)
     }
 
     @MainActor

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -33,19 +33,37 @@ struct RemoteTmuxMirrorTopTopologyTests {
             orientation: .vertical,
             focus: false
         ))
+        let pendingRemoteChildExitPanel = try #require(workspace.newTerminalSplit(
+            from: remotePlaceholderPanel.id,
+            orientation: .horizontal,
+            focus: false
+        ))
+        let endedPersistentRemotePTYPanel = try #require(workspace.newTerminalSplit(
+            from: pendingRemoteChildExitPanel.id,
+            orientation: .vertical,
+            focus: false
+        ))
 
         workspace.surfaceTTYNames[aliveID] = "/dev/ttys901"
         workspace.surfaceTTYNames[exitedPanel.id] = "/dev/ttys902"
         workspace.surfaceTTYNames[remotePlaceholderPanel.id] = "/dev/ttys903"
+        workspace.surfaceTTYNames[pendingRemoteChildExitPanel.id] = "/dev/ttys904"
+        workspace.surfaceTTYNames[endedPersistentRemotePTYPanel.id] = "/dev/ttys905"
         workspace.controlProcessAliveOverridesForTesting = [
             aliveID: true,
             exitedPanel.id: false,
             remotePlaceholderPanel.id: true,
+            pendingRemoteChildExitPanel.id: false,
+            endedPersistentRemotePTYPanel.id: false,
         ]
         workspace.remoteDisconnectPlaceholderPanelIds.insert(remotePlaceholderPanel.id)
+        workspace.pendingRemoteTerminalChildExitSurfaceIds.insert(pendingRemoteChildExitPanel.id)
+        workspace.endedPersistentRemotePTYAttachSurfaceIds.insert(endedPersistentRemotePTYPanel.id)
         defer {
             workspace.controlProcessAliveOverridesForTesting = [:]
             workspace.remoteDisconnectPlaceholderPanelIds.remove(remotePlaceholderPanel.id)
+            workspace.pendingRemoteTerminalChildExitSurfaceIds.remove(pendingRemoteChildExitPanel.id)
+            workspace.endedPersistentRemotePTYAttachSurfaceIds.remove(endedPersistentRemotePTYPanel.id)
             let identifier = "cmux.main.\(windowID.uuidString)"
             if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
                 window.performClose(nil)
@@ -66,6 +84,8 @@ struct RemoteTmuxMirrorTopTopologyTests {
         #expect(rawByID[exitedPanel.id]?.processAlive == false)
         #expect(rawByID[exitedPanel.id]?.tty == "/dev/ttys902")
         #expect(rawByID[remotePlaceholderPanel.id]?.processAlive == nil)
+        #expect(rawByID[pendingRemoteChildExitPanel.id]?.processAlive == nil)
+        #expect(rawByID[endedPersistentRemotePTYPanel.id]?.processAlive == nil)
 
         let treeResult = try #require(ControlCommandCoordinator(context: TerminalController.shared).handle(
             ControlRequest(
@@ -84,6 +104,10 @@ struct RemoteTmuxMirrorTopTopologyTests {
         #expect(treeByID[exitedPanel.id]?["tty"] == .null)
         #expect(treeByID[remotePlaceholderPanel.id]?["process_alive"] == .null)
         #expect(treeByID[remotePlaceholderPanel.id]?["tty"] == .string("/dev/ttys903"))
+        #expect(treeByID[pendingRemoteChildExitPanel.id]?["process_alive"] == .null)
+        #expect(treeByID[pendingRemoteChildExitPanel.id]?["tty"] == .string("/dev/ttys904"))
+        #expect(treeByID[endedPersistentRemotePTYPanel.id]?["process_alive"] == .null)
+        #expect(treeByID[endedPersistentRemotePTYPanel.id]?["tty"] == .string("/dev/ttys905"))
 
         let top = try await TerminalController.shared.taskManagerTopPayload(includeProcesses: false)
         let topByID = try topSurfaceRows(top, windowID: windowID, workspaceID: workspace.id)
@@ -93,6 +117,10 @@ struct RemoteTmuxMirrorTopTopologyTests {
         #expect(topByID[exitedPanel.id]?["tty"] is NSNull)
         #expect(topByID[remotePlaceholderPanel.id]?["process_alive"] is NSNull)
         #expect(topByID[remotePlaceholderPanel.id]?["tty"] as? String == "/dev/ttys903")
+        #expect(topByID[pendingRemoteChildExitPanel.id]?["process_alive"] is NSNull)
+        #expect(topByID[pendingRemoteChildExitPanel.id]?["tty"] as? String == "/dev/ttys904")
+        #expect(topByID[endedPersistentRemotePTYPanel.id]?["process_alive"] is NSNull)
+        #expect(topByID[endedPersistentRemotePTYPanel.id]?["tty"] as? String == "/dev/ttys905")
     }
 
     /// Regression for #7910: process enrichment must not mint a second view of

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -87,11 +87,20 @@ struct RemoteTmuxMirrorTopTopologyTests {
 
             for (surfaceIndex, surface) in surfaces.enumerated() {
                 let surfaceID = surfaceIDs[surfaceIndex]
+                let expectedSurface = try #require(expectedPane.surfaces.first {
+                    $0.surfaceID == surfaceID
+                })
                 let surfaceRef = try #require(surface["ref"] as? String)
                 #expect(TerminalController.shared.v2ResolveHandleRef(surfaceRef) == surfaceID)
 
                 let paneRef = try #require(surface["pane_ref"] as? String)
                 #expect(TerminalController.shared.v2ResolveHandleRef(paneRef) == paneID)
+
+                if let expectedProcessAlive = expectedSurface.processAlive {
+                    #expect(surface["process_alive"] as? Bool == expectedProcessAlive)
+                } else {
+                    #expect(surface["process_alive"] is NSNull)
+                }
             }
         }
     }

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import CmuxControlSocket
 import Foundation
 import Testing
 
@@ -10,6 +12,89 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct RemoteTmuxMirrorTopTopologyTests {
+    /// End-to-end regression for the control-plane liveness contract. The same
+    /// live workspace must project independent true/false/null states through
+    /// both the socket `system.tree` result and the Task Manager `system.top`
+    /// payload, while preserving raw tty metadata inside the topology model.
+    @Test func processLivenessFlowsThroughTreeAndTop() async throws {
+        let app = try #require(AppDelegate.shared)
+        let windowID = app.createMainWindow()
+        let manager = try #require(app.tabManagerFor(windowId: windowID))
+        let workspace = try #require(manager.selectedWorkspace)
+        let aliveID = try #require(workspace.focusedPanelId)
+        _ = try #require(workspace.panels[aliveID] as? TerminalPanel)
+        let exitedPanel = try #require(workspace.newTerminalSplit(
+            from: aliveID,
+            orientation: .horizontal,
+            focus: false
+        ))
+        let remotePlaceholderPanel = try #require(workspace.newTerminalSplit(
+            from: exitedPanel.id,
+            orientation: .vertical,
+            focus: false
+        ))
+
+        workspace.surfaceTTYNames[aliveID] = "/dev/ttys901"
+        workspace.surfaceTTYNames[exitedPanel.id] = "/dev/ttys902"
+        workspace.surfaceTTYNames[remotePlaceholderPanel.id] = "/dev/ttys903"
+        workspace.controlProcessAliveOverridesForTesting = [
+            aliveID: true,
+            exitedPanel.id: false,
+            remotePlaceholderPanel.id: true,
+        ]
+        workspace.remoteDisconnectPlaceholderPanelIds.insert(remotePlaceholderPanel.id)
+        defer {
+            workspace.controlProcessAliveOverridesForTesting = [:]
+            workspace.remoteDisconnectPlaceholderPanelIds.remove(remotePlaceholderPanel.id)
+            let identifier = "cmux.main.\(windowID.uuidString)"
+            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
+                window.performClose(nil)
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            }
+        }
+
+        let rawTree = TerminalController.shared.controlSystemTreeWindows(
+            requestedWindowID: windowID,
+            includeAllWindows: false,
+            focusedWindowID: nil,
+            workspaceFilter: workspace.id
+        )
+        let rawSurfaces = try #require(rawTree.windows.first?.workspaces.first)
+            .panes.flatMap(\.surfaces)
+        let rawByID = Dictionary(uniqueKeysWithValues: rawSurfaces.map { ($0.surfaceID, $0) })
+        #expect(rawByID[aliveID]?.processAlive == true)
+        #expect(rawByID[exitedPanel.id]?.processAlive == false)
+        #expect(rawByID[exitedPanel.id]?.tty == "/dev/ttys902")
+        #expect(rawByID[remotePlaceholderPanel.id]?.processAlive == nil)
+
+        let treeResult = try #require(ControlCommandCoordinator(context: TerminalController.shared).handle(
+            ControlRequest(
+                id: .int(1),
+                method: "system.tree",
+                params: [
+                    "window_id": .string(windowID.uuidString),
+                    "workspace_id": .string(workspace.id.uuidString),
+                ]
+            )
+        ))
+        let treeByID = try socketTreeSurfaceRows(treeResult)
+        #expect(treeByID[aliveID]?["process_alive"] == .bool(true))
+        #expect(treeByID[aliveID]?["tty"] == .string("/dev/ttys901"))
+        #expect(treeByID[exitedPanel.id]?["process_alive"] == .bool(false))
+        #expect(treeByID[exitedPanel.id]?["tty"] == .null)
+        #expect(treeByID[remotePlaceholderPanel.id]?["process_alive"] == .null)
+        #expect(treeByID[remotePlaceholderPanel.id]?["tty"] == .string("/dev/ttys903"))
+
+        let top = try await TerminalController.shared.taskManagerTopPayload(includeProcesses: false)
+        let topByID = try topSurfaceRows(top, windowID: windowID, workspaceID: workspace.id)
+        #expect(topByID[aliveID]?["process_alive"] as? Bool == true)
+        #expect(topByID[aliveID]?["tty"] as? String == "/dev/ttys901")
+        #expect(topByID[exitedPanel.id]?["process_alive"] as? Bool == false)
+        #expect(topByID[exitedPanel.id]?["tty"] is NSNull)
+        #expect(topByID[remotePlaceholderPanel.id]?["process_alive"] is NSNull)
+        #expect(topByID[remotePlaceholderPanel.id]?["tty"] as? String == "/dev/ttys903")
+    }
+
     /// Regression for #7910: process enrichment must not mint a second view of
     /// mirror topology. `system.top` and `system.tree` must expose the same
     /// actionable pane and surface identities.
@@ -160,5 +245,64 @@ struct RemoteTmuxMirrorTopTopologyTests {
         harness.workspace.focusPanel(panel.id)
         #expect(harness.workspace.focusedPanelId == panel.id)
         #expect(harness.connection.pendingCommandKindsForTesting.count == baselinePendingCount)
+    }
+
+    private func socketTreeSurfaceRows(
+        _ result: ControlCallResult
+    ) throws -> [UUID: [String: JSONValue]] {
+        guard case .ok(.object(let root)) = result,
+              case .array(let windows)? = root["windows"] else {
+            Issue.record("Expected a successful system.tree payload")
+            return [:]
+        }
+        let surfaces = windows.flatMap { window -> [JSONValue] in
+            guard case .object(let fields) = window,
+                  case .array(let workspaces)? = fields["workspaces"] else {
+                return []
+            }
+            return workspaces.flatMap { workspace -> [JSONValue] in
+                guard case .object(let workspaceFields) = workspace,
+                      case .array(let panes)? = workspaceFields["panes"] else {
+                    return []
+                }
+                return panes.flatMap { pane -> [JSONValue] in
+                    guard case .object(let paneFields) = pane,
+                          case .array(let paneSurfaces)? = paneFields["surfaces"] else {
+                        return []
+                    }
+                    return paneSurfaces
+                }
+            }
+        }
+        return Dictionary(uniqueKeysWithValues: surfaces.compactMap { surface in
+            guard case .object(let fields) = surface,
+                  case .string(let rawID)? = fields["id"],
+                  let id = UUID(uuidString: rawID) else {
+                return nil
+            }
+            return (id, fields)
+        })
+    }
+
+    private func topSurfaceRows(
+        _ payload: [String: Any],
+        windowID: UUID,
+        workspaceID: UUID
+    ) throws -> [UUID: [String: Any]] {
+        let windows = try #require(payload["windows"] as? [[String: Any]])
+        let window = try #require(windows.first { $0["id"] as? String == windowID.uuidString })
+        let workspaces = try #require(window["workspaces"] as? [[String: Any]])
+        let workspace = try #require(workspaces.first {
+            $0["id"] as? String == workspaceID.uuidString
+        })
+        let panes = try #require(workspace["panes"] as? [[String: Any]])
+        let surfaces = panes.flatMap { $0["surfaces"] as? [[String: Any]] ?? [] }
+        return Dictionary(uniqueKeysWithValues: surfaces.compactMap { surface in
+            guard let rawID = surface["id"] as? String,
+                  let id = UUID(uuidString: rawID) else {
+                return nil
+            }
+            return (id, surface)
+        })
     }
 }

--- a/cmuxTests/SidebarHiddenPresentationTests.swift
+++ b/cmuxTests/SidebarHiddenPresentationTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxSettings
 import CmuxUpdater
 import QuartzCore
 import SwiftUI

--- a/cmuxTests/SidebarWorkspaceRowRetirementTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowRetirementTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxSettings
 import CmuxWorkspaces
 import Testing
 @testable import cmux_DEV

--- a/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
@@ -1,7 +1,6 @@
 import AppKit
 import CmuxSettings
 import CmuxSidebar
-import CmuxSettings
 import CmuxWorkspaces
 import Testing
 @testable import cmux_DEV

--- a/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CmuxSettings
 import CmuxSidebar
+import CmuxSettings
 import CmuxWorkspaces
 import Testing
 @testable import cmux_DEV


### PR DESCRIPTION
## What changed

- project local terminal process liveness into `system.tree` and `system.top`
- preserve an explicit unknown state when liveness cannot be established
- suppress stale TTY metadata only after the local process is proven exited
- cover local, remote tmux, suspended, retired, and hidden-sidebar topology paths

## Why

Restored or detached terminal surfaces could retain a TTY while their local process had already exited. Consumers had no authoritative liveness signal and could mistake stale topology for a runnable terminal.

## Impact

Control-socket clients can use `process_alive` to distinguish live, exited, and unknown terminals without inferring from TTY presence. Existing remote-session behavior remains unchanged.

## Validation

- `swift test --filter ControlCommandCoordinatorSystemTreeProcessAliveTests`
- `swift test --filter TerminalSurfaceProcessLivenessTests`
- `xcodebuild ... test -only-testing:cmuxTests/RemoteTmuxMirrorTopTopologyTests/processLivenessFlowsThroughTreeAndTop`
- `xcodebuild ... test -only-testing:cmuxTests/RemoteTmuxMirrorTopTopologyTests/topUsesTreeTopologyForMirrorWorkspaces`
- `xcodebuild ... -scheme cmux-unit ... build`
- `./scripts/lint-pbxproj-test-wiring.sh`
- tagged Debug build and live `system.tree` / `system.top` probe
- focused liveness tests repeated ten times before the upstream rebase
- `git diff --check`
- gitleaks scan of `origin/main..HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787585671&installation_model_id=21920&pr_number=8916&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8916&signature=3d2b5013f650645c5b7598082eb0bdb62a6ef43f5c82523e4de99d8504c3e313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose terminal process liveness in control topology so clients can see if a terminal is running, exited, or unknown without guessing from TTY. Adds a `process_alive` field and hides stale `tty` only after the local process is confirmed exited; remote lifecycle behavior is preserved.

- **New Features**
  - `system.tree` and Task Manager `system.top` now include `process_alive` (true/false/null) for local terminal surfaces.
  - `tty` is omitted on the wire only when `process_alive` is false; the in-memory topology keeps the raw TTY.
  - Liveness is sourced from `CmuxTerminal` (Ghostty runtime) and reported only for local terminals; remote/tmux placeholders, pending child-exit, and ended PTY-attach paths emit `null`.

- **Bug Fixes**
  - Prevents stale TTYs from making exited terminals appear runnable by providing an explicit `process_alive` signal.
  - Read-only liveness checks no longer tear down runtime surfaces on ownership mismatches.
  - Preserves remote lifecycle liveness state during disconnect placeholders, pending child exit, and ended attach; we no longer misreport these as alive or dead.

<sup>Written for commit f2ff1725d0913d3cf3a6f71a55d60f4a48a444b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

