### PR TITLE
Focused-read indicator survives surface-scoped mark-read again

### DIFF
--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1529,8 +1529,13 @@ final class TerminalNotificationStore: ObservableObject {
         if !idsToClear.isEmpty {
             notifications = updated
         }
-        clearFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
         if surfaceId == nil {
+            // Whole-tab mark-read dismisses every indicator kind, matching
+            // markRead(forTabId:). A surface-scoped mark-read must not clear the
+            // focused-read indicator: it marks notifications that were already
+            // read while the surface was focused, so it outlives mark-read and
+            // only an explicit clearFocusedReadIndicator dismisses it.
+            clearFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
             clearWorkspacePanelUnread(forTabId: tabId)
             setPanelDerivedWorkspaceUnread(false, forTabId: tabId)
             setWorkspaceRestoredUnread(false, forTabId: tabId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -4338,6 +4338,11 @@ final class Workspace: Identifiable, ObservableObject {
         guard panels[panelId] != nil else { return }
         let notificationStore = AppDelegate.shared?.notificationStore
         notificationStore?.markRead(forTabId: id, surfaceId: panelId)
+        // An explicit user mark-read dismisses the focused-read indicator too.
+        // The store's markRead deliberately does not: that indicator marks
+        // notifications already read while the surface was focused, and only a
+        // user dismissal like this one (or the workspace-level paths) ends it.
+        notificationStore?.clearFocusedReadIndicator(forTabId: id, surfaceId: panelId)
         _ = clearManualUnreadState(panelId: panelId)
         let restoredIndicator = restoredUnreadPanelIndicators[panelId]
         let didClearRestored = clearRestoredUnreadIndicatorState(panelId: panelId)


### PR DESCRIPTION
A notification that arrives on the focused surface is marked read immediately and leaves the subtle focused-read indicator, so the user still notices something happened. Since May 26 that indicator has been vanishing on any surface-scoped mark-read, and `FocusedNotificationIndicatorTests` — which has pinned "the indicator survives mark-read until explicitly cleared" since March — has been red on main behind dispatch-only CI ever since.

The culprit is bisected to a verified edge, all arms on one machine with identical isolation: green at `26cf12eaa2^`, red at `26cf12eaa2` with the same assertion that fails on today's main (also measured green at `6b0b97e200` and its parent, red at `d64f6056a1^`). That commit, "Flash manual unread workspace jumps", added an unconditional `clearFocusedReadIndicator` to both `markRead` overloads. Its own PR body scopes it to the jump flash and even notes other notification suites failing "outside this shortcut regression" — the mark-read clearing was beyond its mission and no test pinned it.

One newer test does depend on the clearing, and it names the real contract: `testToggleFocusedNotificationUnreadClearsFocusedReadIndicatorWhenPanelIsFocused` expects the unread **toggle** — an explicit user dismissal — to clear the indicator. Running this branch's first draft against plain main flagged exactly that one test, so the fix keeps both contracts at their proper layers:

- `TerminalNotificationStore.markRead(forTabId:surfaceId:)` no longer clears the focused-read indicator for a surface-scoped mark-read. Whole-tab mark-read (`surfaceId == nil`) still dismisses every indicator kind, matching `markRead(forTabId:)`.
- `Workspace.markPanelRead` — the shared path behind every explicit "mark this panel read" entrypoint, including the toggle — now clears the indicator itself, with a comment stating the ownership split.

Verified per suite against fresh test builds: `FocusedNotificationIndicatorTests` red on main to 2/2 green here. Neighbor suites `WorkspaceManualUnreadTests` (including the toggle test), `NotificationDockBadgeTests`, and `TerminalNotificationClearAllTests` have failure sets name-for-name identical to plain main in the same environment — their remaining failures are pre-existing, with fixes open separately (#8798, #8909).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787605052&installation_model_id=21920&pr_number=8927&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8927&signature=890fe842960e13f82be9751ed8715a0621e1dcc4073de33b0b1c2538402bb810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where the focused-read indicator disappeared after a surface-scoped mark-read. The indicator now persists until explicitly cleared; whole-tab mark-read still clears all indicators, and user-initiated panel mark-read clears it.

- **Bug Fixes**
  - Stop clearing the focused-read indicator in `TerminalNotificationStore.markRead(forTabId:surfaceId:)` when `surfaceId` is set.
  - Clear the indicator in `Workspace.markPanelRead` so explicit panel mark-read (including the toggle) dismisses it.

<sup>Written for commit 38d44e5f1213b415ea19a8363567d42635901feb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed read-status indicators so marking an individual panel as read also clears its focused-read indicator.
  - Preserved focused-read indicators when marking only a specific surface as read, while continuing to clear them when marking an entire tab as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->