### PR TITLE
iOS: scroll-reveal the terminal files chip

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1488,6 +1488,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     private var artifactChipShouldBeVisible: Bool {
         artifactChipHost.isRequestedVisible
+            && artifactChipScrollRevealed
             && dockedToolbarShouldBeVisible
             && dockedToolbar?.isHidden == false
             && !zoomOverlayShown
@@ -1498,6 +1499,63 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             shouldShow: artifactChipShouldBeVisible,
             animated: animated
         )
+    }
+
+    /// The chip is scroll-revealed: hidden at rest, shown while the user
+    /// scrolls, and faded out after a short linger once scrolling settles —
+    /// scrollbar-style, so it never sits over terminal content the user is
+    /// reading. Mount state (whether there are files to show) is orthogonal
+    /// and owned by the host content above.
+    private var artifactChipScrollRevealed = false
+    private var artifactChipRevealHideTask: Task<Void, Never>?
+    /// Injected so the linger is testable and cancellable
+    /// (`DispatchQueue.asyncAfter` is banned for intentional delays).
+    var artifactChipRevealClock: any Clock<Duration> = ContinuousClock()
+    /// How long the chip stays after the last scroll movement. Long enough to
+    /// move a thumb from mid-screen to the chip and tap it.
+    static let artifactChipRevealLinger: Duration = .seconds(2.2)
+
+    /// Reveals the chip for scroll activity and re-arms the idle linger.
+    ///
+    /// - Parameter armLinger: Pass `false` while a drag is beginning; the
+    ///   linger is then armed by the drag-end/deceleration-end callbacks (or
+    ///   by movement deltas), so a held-still finger keeps the chip up.
+    private func noteArtifactChipScrollActivity(armLinger: Bool = true) {
+        artifactChipRevealHideTask?.cancel()
+        artifactChipRevealHideTask = nil
+        if !artifactChipScrollRevealed {
+            artifactChipScrollRevealed = true
+            updateArtifactChipVisibility(animated: true)
+        }
+        guard armLinger else { return }
+        armArtifactChipRevealLinger()
+    }
+
+    private func armArtifactChipRevealLinger() {
+        artifactChipRevealHideTask?.cancel()
+        artifactChipRevealHideTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await self.artifactChipRevealClock.sleep(
+                for: Self.artifactChipRevealLinger,
+                tolerance: nil
+            )
+            guard !Task.isCancelled else { return }
+            self.artifactChipRevealHideTask = nil
+            // A finger resting on the screen mid-drag produces no deltas;
+            // keep the chip up until the touch actually ends.
+            if self.scrollMechanicsView.isTracking {
+                self.armArtifactChipRevealLinger()
+                return
+            }
+            self.artifactChipScrollRevealed = false
+            self.updateArtifactChipVisibility(animated: true)
+        }
+    }
+
+    private func resetArtifactChipReveal() {
+        artifactChipRevealHideTask?.cancel()
+        artifactChipRevealHideTask = nil
+        artifactChipScrollRevealed = false
     }
 
     /// Mount (or unmount, with `nil`) the host-built compose field into the surface's
@@ -1733,6 +1791,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // deceleration, and momentum. The Mac still owns terminal semantics:
         // normal-screen scrollback and alt-screen mouse-wheel delivery.
         guard deltaY != 0 else { return }
+        // Every real scroll movement (tracking and momentum) keeps the
+        // scroll-revealed chip up and pushes its idle linger out.
+        noteArtifactChipScrollActivity()
         let cellHeightPt = cellPixelSize.height / max(preferredScreenScale, 1)
         let divisor = cellHeightPt > 1 ? Double(cellHeightPt) * 3 : 42
         pendingScrollLines += -Double(deltaY) / divisor
@@ -2476,6 +2537,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         lastReportedVisibleArtifactCount = 0
         delegate?.ghosttySurfaceViewDidResetArtifactCount(self)
         artifactChipHost.setContent(nil)
+        resetArtifactChipReveal()
         updateArtifactChipVisibility(animated: false)
         completePendingSurfaceOperations(returning: false)
         cancelRenderPipelineRecoveryResumeTimer()
@@ -3929,6 +3991,26 @@ extension GhosttySurfaceView: UIScrollViewDelegate {
             : fallbackPoint
         enqueueScrollMechanicsDelta(deltaY, touchPoint: touchPoint)
         recenterScrollMechanicsViewIfNeeded()
+    }
+
+    public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        guard scrollView === scrollMechanicsView else { return }
+        // Reveal on touch-down and hold the chip (no linger) while the finger
+        // is down; the end/deceleration callbacks arm the fade-out.
+        noteArtifactChipScrollActivity(armLinger: false)
+    }
+
+    public func scrollViewDidEndDragging(
+        _ scrollView: UIScrollView,
+        willDecelerate decelerate: Bool
+    ) {
+        guard scrollView === scrollMechanicsView, !decelerate else { return }
+        armArtifactChipRevealLinger()
+    }
+
+    public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        guard scrollView === scrollMechanicsView else { return }
+        armArtifactChipRevealLinger()
     }
 }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -2565,6 +2565,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Stops user-visible and accessibility output from a surface SwiftUI has removed.
     public func prepareForDismantle() {
         isDismantled = true
+        // Block-based observers stay registered (and their closures retained
+        // by NotificationCenter) until explicitly removed; dropping the token
+        // array alone would leak a registration per surface remount.
+        for token in artifactChipAccessibilityObserverTokens {
+            NotificationCenter.default.removeObserver(token)
+        }
+        artifactChipAccessibilityObserverTokens.removeAll()
         prepareForReuseAfterDetach()
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1480,6 +1480,34 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     private func installArtifactChipContainer() {
         artifactChipHost.install(in: self, zPosition: Self.artifactChipZPosition)
+        installArtifactChipAccessibilityObservers()
+    }
+
+    /// The scroll-reveal gate is bypassed while VoiceOver or Switch Control
+    /// runs; without observing their status changes, enabling one over an
+    /// idle terminal would leave the only Files control hidden until some
+    /// unrelated visibility update. Registered once with the chip container;
+    /// block observers are removed automatically when the tokens deallocate
+    /// with the view.
+    private var artifactChipAccessibilityObserverTokens: [NSObjectProtocol] = []
+
+    private func installArtifactChipAccessibilityObservers() {
+        guard artifactChipAccessibilityObserverTokens.isEmpty else { return }
+        let names: [Notification.Name] = [
+            UIAccessibility.voiceOverStatusDidChangeNotification,
+            UIAccessibility.switchControlStatusDidChangeNotification,
+        ]
+        artifactChipAccessibilityObserverTokens = names.map { name in
+            NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.updateArtifactChipVisibility(animated: true)
+                }
+            }
+        }
     }
 
     private func layoutArtifactChip(using snapshot: TerminalViewportSnapshot) {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1488,7 +1488,13 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
 
     private var artifactChipShouldBeVisible: Bool {
         artifactChipHost.isRequestedVisible
-            && artifactChipScrollRevealed
+            // Assistive technologies cannot reasonably perform a scroll to
+            // reveal the only Files control, and the host hides its
+            // accessibility descendants while invisible — so the transient
+            // reveal is bypassed whenever VoiceOver or Switch Control runs.
+            && (artifactChipScrollRevealed
+                || UIAccessibility.isVoiceOverRunning
+                || UIAccessibility.isSwitchControlRunning)
             && dockedToolbarShouldBeVisible
             && dockedToolbar?.isHidden == false
             && !zoomOverlayShown
@@ -1522,8 +1528,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// programmatic offset changes (recentering, scroll-to-bottom) from
     /// revealing a chip nobody is interacting with.
     private func noteArtifactChipScrollActivity() {
-        guard artifactChipHost.isRequestedVisible,
-              scrollMechanicsView.isTracking
+        // Deliberately NOT gated on mounted chip content: the scroll that
+        // brings the first file into view finishes before the settled scan
+        // mounts the chip, and the recorded reveal is what lets that mount
+        // become visible without a second scroll.
+        guard scrollMechanicsView.isTracking
                 || scrollMechanicsView.isDragging
                 || scrollMechanicsView.isDecelerating,
               !artifactChipScrollRevealed else { return }
@@ -4002,10 +4011,10 @@ extension GhosttySurfaceView: UIScrollViewDelegate {
     }
 
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        guard scrollView === scrollMechanicsView,
-              artifactChipHost.isRequestedVisible else { return }
+        guard scrollView === scrollMechanicsView else { return }
         // Reveal on touch-down and hold the chip (no linger) while the finger
-        // is down; the end/deceleration callbacks arm the fade-out.
+        // is down; the end/deceleration callbacks arm the fade-out. Recorded
+        // even before any chip content mounts (see noteArtifactChipScrollActivity).
         revealArtifactChipForScroll()
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1515,20 +1515,28 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// move a thumb from mid-screen to the chip and tap it.
     static let artifactChipRevealLinger: Duration = .seconds(2.2)
 
-    /// Reveals the chip for scroll activity and re-arms the idle linger.
-    ///
-    /// - Parameter armLinger: Pass `false` while a drag is beginning; the
-    ///   linger is then armed by the drag-end/deceleration-end callbacks (or
-    ///   by movement deltas), so a held-still finger keeps the chip up.
-    private func noteArtifactChipScrollActivity(armLinger: Bool = true) {
+    /// Reveals the chip for a movement delta. Runs on every scroll frame, so
+    /// it must do no task management: past the cheap guards it is a single
+    /// bool flip per gesture. The fade-out linger is armed only by the
+    /// drag-end/deceleration-end callbacks, and the user-driven guard keeps
+    /// programmatic offset changes (recentering, scroll-to-bottom) from
+    /// revealing a chip nobody is interacting with.
+    private func noteArtifactChipScrollActivity() {
+        guard artifactChipHost.isRequestedVisible,
+              scrollMechanicsView.isTracking
+                || scrollMechanicsView.isDragging
+                || scrollMechanicsView.isDecelerating,
+              !artifactChipScrollRevealed else { return }
+        revealArtifactChipForScroll()
+    }
+
+    private func revealArtifactChipForScroll() {
         artifactChipRevealHideTask?.cancel()
         artifactChipRevealHideTask = nil
         if !artifactChipScrollRevealed {
             artifactChipScrollRevealed = true
             updateArtifactChipVisibility(animated: true)
         }
-        guard armLinger else { return }
-        armArtifactChipRevealLinger()
     }
 
     private func armArtifactChipRevealLinger() {
@@ -1791,8 +1799,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // deceleration, and momentum. The Mac still owns terminal semantics:
         // normal-screen scrollback and alt-screen mouse-wheel delivery.
         guard deltaY != 0 else { return }
-        // Every real scroll movement (tracking and momentum) keeps the
-        // scroll-revealed chip up and pushes its idle linger out.
+        // User-driven movement reveals the chip; this is guard-only work per
+        // frame (the linger is armed by the gesture-end callbacks).
         noteArtifactChipScrollActivity()
         let cellHeightPt = cellPixelSize.height / max(preferredScreenScale, 1)
         let divisor = cellHeightPt > 1 ? Double(cellHeightPt) * 3 : 42
@@ -3994,22 +4002,25 @@ extension GhosttySurfaceView: UIScrollViewDelegate {
     }
 
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        guard scrollView === scrollMechanicsView else { return }
+        guard scrollView === scrollMechanicsView,
+              artifactChipHost.isRequestedVisible else { return }
         // Reveal on touch-down and hold the chip (no linger) while the finger
         // is down; the end/deceleration callbacks arm the fade-out.
-        noteArtifactChipScrollActivity(armLinger: false)
+        revealArtifactChipForScroll()
     }
 
     public func scrollViewDidEndDragging(
         _ scrollView: UIScrollView,
         willDecelerate decelerate: Bool
     ) {
-        guard scrollView === scrollMechanicsView, !decelerate else { return }
+        guard scrollView === scrollMechanicsView, !decelerate,
+              artifactChipScrollRevealed else { return }
         armArtifactChipRevealLinger()
     }
 
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        guard scrollView === scrollMechanicsView else { return }
+        guard scrollView === scrollMechanicsView,
+              artifactChipScrollRevealed else { return }
         armArtifactChipRevealLinger()
     }
 }


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/8902 (which stacks on https://github.com/manaflow-ai/cmux/pull/8822). Requested UX: the chip should appear only while scrolling, toast-like, instead of sitting permanently over terminal content.

The chip is now hidden at rest and scroll-revealed: touch-down on the terminal's scroll surface shows it and holds it while the finger is down, every movement delta (tracking and momentum) pushes the idle linger out, and 2.2s after scrolling settles it fades away. Mount state (whether there are files to show) is unchanged — the reveal is a new visibility gate in `GhosttySurfaceView` alongside the existing toolbar and zoom-HUD gates, wired to the scroll-mechanics UIScrollView (`enqueueScrollMechanicsDelta` for movement, `willBeginDragging`/`didEndDragging`/`didEndDecelerating` for touch lifecycle). The linger runs in a cancellable Task on an injectable Clock (no `asyncAfter`); a finger resting mid-drag produces no deltas, so the hide deadline re-arms while the scroll view is still tracking. Detach/dismantle reset the reveal.

Verification: CmuxMobileTerminal compiles for the iOS sim triple; count/mount behavior covered by the base PRs' tests (this diff does not touch counting). Live scroll-feel verified on-device during dogfood — the sim rig could not synthesize trustworthy scroll gestures this round (window off-Space; posted taps not activating controls), so the reveal timing was validated on the physical iPhone build instead.

No user-facing strings changed (localization audit: none needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787606187&installation_model_id=21920&pr_number=8928&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8928&signature=cda4dd416e146276c49739614a90aa44bbe5e2050d77d88b5d9154e7ed2c536b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
iOS: scroll-reveal the terminal Files chip — hidden at rest, shown on touch-down and while dragging/decelerating, then fades 2.2s after scrolling settles. Accessibility is preserved with a VoiceOver/Switch Control bypass, live status observers, and teardown that unregisters them.

- **New Features**
  - Added a scroll-reveal gate in `GhosttySurfaceView`; programmatic offsets won’t reveal it, reveal is independent of mount (first-scroll mounts stay visible), and detach/dismantle reset it.
  - Integrated with `UIScrollView` (drag begin/end, deceleration) and `enqueueScrollMechanicsDelta`; per-frame deltas are guard-only, the fade arms once, the linger runs in a cancellable Task on an injectable `Clock`, and re-arms while tracking if a finger rests.

- **Bug Fixes**
  - Re-run chip visibility when VoiceOver/Switch Control status changes so the Files control isn’t stuck hidden or visible for assistive users.
  - Unregister VoiceOver/Switch Control observers in `prepareForDismantle` to prevent leaks across surface remounts.

<sup>Written for commit d252edc295d91240ffc82ccb8c96f0366b158ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved visibility and interaction of the bottom artifact/files chip when VoiceOver or Switch Control is enabled.
  * Added accessibility lifecycle handling to ensure reliable behavior during screen reuse.

* **User Experience**
  * The artifact/files chip now appears more predictably while scrolling and remains visible briefly after scrolling ends.
  * Scrolling interactions now provide smoother reveal and dismissal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->