### PR TITLE
Recover the Mac iroh host runtime from terminal failure without relaunch

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeFailedRestartTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeFailedRestartTests.swift
@@ -1,0 +1,90 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+
+@testable import CmuxIrohTransport
+
+extension CmxIrohHostRuntimeTests {
+    /// Pins the contract the macOS failure-recovery reconcile depends on:
+    /// a non-transient broker rejection during a registration refresh fails
+    /// closed (endpoint torn down, deactivation notified, terminal `.failed`
+    /// phase), and a later `start()` on the same runtime succeeds once the
+    /// broker accepts registration again. If `.failed` ever stops allowing
+    /// `start()`, the app-layer recovery silently degrades back to the
+    /// restart-only wedge.
+    @Test("non-transient refresh rejection fails closed, then start() recovers")
+    func nonTransientRefreshRejectionFailsClosedThenRestarts() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now, publicHintLifetime: 60 * 60)
+        let firstEndpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let restartEndpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            subsequentRegistrationErrors: [
+                .rejected(
+                    statusCode: 409,
+                    code: "binding_replacement_requires_revocation"
+                ),
+            ]
+        )
+        let clock = HostRegistrationRenewalClock(now: now)
+        let deactivations = CmxIrohTestCounter()
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [firstEndpoint, restartEndpoint]
+            ),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            now: { clock.now() },
+            registrationClock: clock,
+            handleTransport: { session, _ in await session.close() },
+            handleDeactivation: { _ in
+                await deactivations.increment()
+            }
+        )
+
+        try await runtime.start()
+        #expect(await runtime.snapshot().state == .active)
+
+        await clock.waitUntilSleeping()
+        let renewalDeadline = try #require(clock.observedSleepDeadlines().first)
+        clock.advance(to: renewalDeadline)
+        await broker.waitForRegistrationCount(2)
+        try await waitForLifecyclePhase(.failed, runtime: runtime)
+
+        #expect(await runtime.snapshot().state == .failed)
+        #expect(await deactivations.value() == 1)
+        #expect(await firstEndpoint.observedCloseCallCount() == 1)
+
+        try await runtime.start()
+
+        #expect(await broker.observedRegistrationCount() == 3)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
+    private func waitForLifecyclePhase(
+        _ phase: CmxIrohHostRuntime.LifecyclePhase,
+        runtime: CmxIrohHostRuntime
+    ) async throws {
+        for _ in 0 ..< 20_000 {
+            if await runtime.lifecyclePhase == phase { return }
+            await Task.yield()
+        }
+        Issue.record("runtime never reached \(String(describing: phase))")
+    }
+}
+
+private actor CmxIrohTestCounter {
+    private var count = 0
+
+    func increment() {
+        count += 1
+    }
+
+    func value() -> Int {
+        count
+    }
+}

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -331,7 +331,7 @@ extension MobileHostIrohRuntime {
                     }
                 )
             },
-            handleDeactivation: { _ in
+            handleDeactivation: { [weak self] _ in
                 await lanPublisher.stop()
                 await MainActor.run {
                     // The runtime owns the local Mac binding, while admitted
@@ -341,6 +341,7 @@ extension MobileHostIrohRuntime {
                     MobileHostService.shared.closeAllIrohConnections()
                     MobileHostService.shared.updateIrohBinding(nil)
                 }
+                await self?.noteActiveRuntimeDeactivated(revision: revision)
             },
             handleRelayCredential: { [weak self] response, binding in
                 guard await self?.allowsPersistence(

--- a/Sources/Mobile/MobileHostIrohRuntime+Lifecycle.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Lifecycle.swift
@@ -258,18 +258,121 @@ extension MobileHostIrohRuntime {
         // transitions. The in-flight activation already observes endpoint
         // changes and replays one pending registration refresh after startup.
         guard transitionTask == nil else { return }
-        if runtime != nil {
-            let revision = lifecycleRevision
-            Task { @MainActor [weak self] in
-                guard let self,
-                      self.desiredActive,
-                      self.runtime != nil,
-                      revision == self.lifecycleRevision else { return }
-                await self.synchronizeLANPublicationWithSettings()
-            }
+        guard let activeRuntime = runtime else {
+            scheduleReconcile(eraseAccountState: false)
             return
         }
-        scheduleReconcile(eraseAccountState: false)
+        let revision = lifecycleRevision
+        Task { @MainActor [weak self] in
+            guard let self,
+                  self.desiredActive,
+                  self.runtime === activeRuntime,
+                  revision == self.lifecycleRevision else { return }
+            if await activeRuntime.snapshot().state == .failed {
+                guard self.desiredActive,
+                      !self.signOutIntentActive,
+                      self.runtime === activeRuntime,
+                      revision == self.lifecycleRevision else { return }
+                // A fresh external signal rebuilds a failed runtime now and
+                // restarts the recovery backoff ladder.
+                self.cancelFailureRecovery(resetBackoff: true)
+                self.scheduleReconcile(
+                    eraseAccountState: false,
+                    restartActiveRuntime: true
+                )
+                return
+            }
+            guard self.runtime === activeRuntime,
+                  revision == self.lifecycleRevision else { return }
+            await self.synchronizeLANPublicationWithSettings()
+        }
+    }
+
+    /// Arms one pending rebuild after bounded exponential backoff.
+    ///
+    /// `CmxIrohHostRuntime` fails closed on a non-transient broker rejection
+    /// (for example 401/403/409): it tears the endpoint down into a terminal
+    /// `.failed` phase so a rejected binding can never keep accepting
+    /// connections. Recovery is owned here instead: every failure arms one
+    /// rebuild through the shared `reconcile` path, and any external wake
+    /// signal (`retryIfNeeded`, sign-in, settings) re-evaluates immediately,
+    /// so a rejected registration recovers without an app relaunch.
+    /// Idempotent while an attempt is pending, so overlapping failure signals
+    /// (an activation throw plus the runtime's deactivation callback) cannot
+    /// double-schedule.
+    func scheduleFailureRecovery() {
+        guard failureRecoveryTask == nil,
+              desiredActive,
+              !signOutIntentActive,
+              observedAccountID != nil else { return }
+        let delay = failureRecoverySchedule.delay(
+            failureCount: failureRecoveryFailureCount,
+            retryAfterSeconds: nil,
+            jitterUnitInterval: Double.random(in: 0 ... 1)
+        )
+        failureRecoveryFailureCount = min(failureRecoveryFailureCount + 1, 20)
+        let clock = failureRecoveryClock
+        let deadline = clock.now().addingTimeInterval(delay)
+        mobileHostIrohLog.error(
+            "Iroh host runtime failed; rebuild attempt \(self.failureRecoveryFailureCount) in \(Int(delay))s"
+        )
+        failureRecoveryTask = Task { @MainActor [weak self] in
+            do {
+                try await clock.sleep(until: deadline)
+            } catch {
+                return
+            }
+            guard let self, !Task.isCancelled else { return }
+            self.failureRecoveryTask = nil
+            await self.recoverFailedRuntimeIfNeeded()
+        }
+    }
+
+    /// Rebuilds the host runtime when it is absent or terminally failed.
+    /// Level-triggered: the action is re-derived from current state, so a
+    /// stale wake-up is a no-op rather than a disruption.
+    func recoverFailedRuntimeIfNeeded() async {
+        guard desiredActive,
+              !signOutIntentActive,
+              observedAccountID != nil,
+              transitionTask == nil else { return }
+        guard let activeRuntime = runtime else {
+            scheduleReconcile(eraseAccountState: false)
+            return
+        }
+        let state = await activeRuntime.snapshot().state
+        guard state == .failed,
+              runtime === activeRuntime,
+              transitionTask == nil,
+              desiredActive,
+              !signOutIntentActive else { return }
+        scheduleReconcile(eraseAccountState: false, restartActiveRuntime: true)
+    }
+
+    /// Invoked from the active runtime's deactivation handler. Deliberate
+    /// stops (reconcile, settings restart, sign-out) bump `lifecycleRevision`
+    /// before stopping, so a matching revision means the runtime tore itself
+    /// down after a registration-refresh failure. Failed cold starts throw
+    /// before `runtime` is assigned; `reconcile`'s failure path owns
+    /// scheduling for those.
+    func noteActiveRuntimeDeactivated(revision: UInt64) async {
+        guard revision == lifecycleRevision,
+              desiredActive,
+              !signOutIntentActive,
+              let activeRuntime = runtime else { return }
+        let state = await activeRuntime.snapshot().state
+        guard state == .failed,
+              revision == lifecycleRevision,
+              runtime === activeRuntime else { return }
+        scheduleFailureRecovery()
+    }
+
+    func cancelFailureRecovery(resetBackoff: Bool) {
+        failureRecoveryTask?.cancel()
+        failureRecoveryTask = nil
+        if resetBackoff {
+            failureRecoveryFailureCount = 0
+        }
     }
 
     /// Applies the legacy-listener setting only to account-private Bonjour

--- a/Sources/Mobile/MobileHostIrohRuntime.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime.swift
@@ -117,6 +117,10 @@ final class MobileHostIrohRuntime {
     var signOutPreparationRevision: UInt64 = 0
     var lifecycleRevision: UInt64 = 0
     var nextDiagnosticSessionID = 0
+    var failureRecoveryTask: Task<Void, Never>?
+    var failureRecoveryFailureCount = 0
+    let failureRecoveryClock: any CmxIrohRelayClock = CmxIrohSystemRelayClock()
+    let failureRecoverySchedule = CmxIrohRetrySchedule()
 
     private init() {
         let installState = CmxIrohUserDefaultsInstallStateStore()
@@ -244,6 +248,10 @@ final class MobileHostIrohRuntime {
         restartActiveRuntime: Bool,
         revision: UInt64
     ) async {
+        // Each transition re-derives failure recovery from its own outcome:
+        // success resets the backoff ladder, failure re-arms it, and a
+        // deactivating transition ends the need for it.
+        cancelFailureRecovery(resetBackoff: false)
         if eraseAccountState {
             await quarantineForSignOut()
         } else if restartActiveRuntime
@@ -279,6 +287,7 @@ final class MobileHostIrohRuntime {
         ))
         do {
             try await activate(accountID: targetAccountID, revision: revision)
+            failureRecoveryFailureCount = 0
         } catch is CancellationError {
             return
         } catch {
@@ -290,6 +299,7 @@ final class MobileHostIrohRuntime {
             mobileHostIrohLog.error(
                 "Iroh host activation failed: \(String(describing: error), privacy: .private)"
             )
+            scheduleFailureRecovery()
         }
     }
 


### PR DESCRIPTION
## Problem

`CmxIrohHostRuntime` fails closed on any non-transient trust-broker rejection (401/403/404/409, malformed responses): it tears the endpoint down into a terminal `.failed` lifecycle phase. That posture is correct, but recovery was owned by nobody. `MobileHostIrohRuntime.retryIfNeeded()` returned early whenever it still held a runtime reference (only re-syncing LAN publication), and a failed cold-start activation had no retry timer at all. Result: one rejected registration left the Mac unregistered until sign-out/sign-in, a Settings-triggered iroh restart, or an app relaunch. This is the client half of the App Store review incident, where a stale binding produced a 409 and the review Mac sat unreachable for 17 hours.

https://github.com/manaflow-ai/cmux/pull/8883 and https://github.com/manaflow-ai/cmux/pull/8888 remove the main 409 *trigger* (binding slot re-key). This PR removes the *wedge class* itself, for every non-transient rejection, including future ones.

## Mechanism

Recovery is owned by the macOS composition root and is level-triggered through the existing `reconcile` path (no new mutation path):

- Every failed activation (`reconcile` catch) and every runtime self-teardown into `.failed` (observed via the existing `handleDeactivation` callback, filtered by lifecycle revision so deliberate stops are ignored) arms one pending rebuild with bounded exponential backoff: 30s doubling to a 1h cap, jittered, using the same `CmxIrohRetrySchedule` and injected-clock idiom as the runtime's internal retries.
- `retryIfNeeded()` now checks the held runtime's snapshot: a `.failed` runtime is rebuilt immediately on any external wake signal (network path change via `MobileHostService`, app-level retry), resetting the backoff ladder.
- Each `reconcile` cancels the pending attempt on entry and re-derives recovery from its own outcome: success resets the ladder, failure re-arms it, sign-out/deactivation ends it. At most one attempt is ever pending, and stale wake-ups are no-ops.

Principled or hacky: principled. The inner runtime's fail-closed teardown is untouched (a rejected binding never keeps accepting connections), `.failed` was already designed restartable (`LifecyclePhase.allowsStart`), and the rebuild goes through the same reconcile path used by launch, sign-in, and Settings. Residual risk: a persistently rejecting broker now sees one registration attempt per backoff interval (capped at hourly) instead of silence; the challenge/register round trip is cheap and rate-limit floors (`Retry-After`) are honored by the schedule.

## Tests

`CmxIrohHostRuntimeFailedRestartTests` pins the package contract the watchdog depends on: a 409-rejected registration refresh fails closed (endpoint closed once, deactivation notified once, snapshot/phase `.failed`) and the same runtime accepts `start()` again once the broker allows registration, ending active. If `.failed` ever stops allowing `start()`, this fails instead of silently reverting to the relaunch-only wedge.

Two-commit red/green does not apply: the wedge lives in app-target singleton wiring (`MobileHostIrohRuntime` + `MobileHostService` + auth) with no practical automated harness, so the package test guards the enabling semantics and the app wiring is covered by build plus the dogfood path below. All 36 `CmxIrohHostRuntime*` package tests pass. No user-facing strings were added (log lines only), so no localization changes are needed.

## Verification

- `swift test --filter CmxIrohHostRuntime` in `Packages/Shared/CmuxIrohTransport`: 36/36 pass.
- Tagged fleet build `irecov` from this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787607419&installation_model_id=21920&pr_number=8930&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8930&signature=b0dce0faf924fd79a84797b11bc465b35f6c248b09015b0fa0548d000354e804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically recover the Mac iroh host runtime after terminal failures so a non-transient broker rejection no longer leaves the host unregistered until relaunch. Recovery is level-triggered via the existing reconcile path with bounded backoff.

- **Bug Fixes**
  - Recovery is owned in the macOS composition root; rebuilds trigger on failed activation or `.failed` deactivation.
  - Uses exponential backoff (30s → 1h cap) with jitter via `CmxIrohRetrySchedule`; only one attempt pending.
  - `retryIfNeeded()` immediately rebuilds a `.failed` runtime on external wake signals and resets backoff; each `reconcile` cancels pending recovery and re-derives from outcome.
  - `handleDeactivation` now arms recovery (filtered by `lifecycleRevision`); added `CmxIrohHostRuntimeFailedRestartTests` to verify 409 rejection fails closed and later `start()` succeeds.

<sup>Written for commit cb412f4312782ac3e340ddb3f410fbd458746119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when host runtime activation or broker registration fails.
  * Failed runtimes now retry automatically with controlled backoff and jitter.
  * Prevented duplicate recovery attempts and preserved active account state during restarts.
  * Successful reactivation now clears prior failure history.

* **Tests**
  * Added coverage verifying failed runtimes can be restarted and return to an active state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->