### PR TITLE
Make terminal dock duration test deterministic

### DIFF
--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalDockKeyboardTransitionPlannerTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalDockKeyboardTransitionPlannerTests.swift
@@ -47,21 +47,25 @@ struct TerminalDockKeyboardTransitionPlannerTests {
 
     @Test("zero-duration interruption synthesizes a remaining-fraction duration")
     func zeroDurationSynthesizesDuration() {
+        let visibleOccupancy: CGFloat = 220
+        let targetOccupancy: CGFloat = 34
+        let activeTargetOverlap: CGFloat = 336
+        let lastTransitionDuration: TimeInterval = 0.25
+        let remainingFraction =
+            abs(targetOccupancy - visibleOccupancy) / activeTargetOverlap
+        let expectedDuration =
+            lastTransitionDuration * TimeInterval(remainingFraction)
         let plan = planner.plan(for: input(
             targetOverlap: 0,
             notificationDuration: 0,
-            visibleOccupancy: 220,
-            targetOccupancy: 34,
+            visibleOccupancy: visibleOccupancy,
+            targetOccupancy: targetOccupancy,
             isAnimating: true,
-            activeTargetOverlap: 336,
-            lastTransitionDuration: 0.25
+            activeTargetOverlap: activeTargetOverlap,
+            lastTransitionDuration: lastTransitionDuration
         ))
-        guard case let .animate(duration) = plan else {
-            Issue.record("Expected a synthesized animation")
-            return
-        }
 
-        #expect(abs(duration - (0.25 * 186.0 / 336.0)) < 0.000_001)
+        #expect(plan == .animate(duration: expectedDuration))
     }
 
     @Test("tiny remaining distance applies directly when an old animation is active")


### PR DESCRIPTION
## Summary
- compare the synthesized animation plan against its deterministic expected value
- remove the one-sided duration tolerance flagged by the determinism gate

## Testing
- `swift test --filter TerminalDockKeyboardTransitionPlannerTests`
- `python3 scripts/check-test-determinism.py --strict`
- `bash tests/test_ci_self_hosted_guard.sh`

## Context
- Repairs the current-main failure from https://github.com/manaflow-ai/cmux/actions/runs/30180434670/job/89735937514

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787616570&installation_model_id=21920&pr_number=8940&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8940&signature=6f462b3a0c3af23765f1858b007da078fc5810981e5d67aab157a45f95949029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the terminal dock duration test deterministic by computing the expected duration from inputs and asserting the plan equals an exact animate duration, instead of using a tolerance. Fixes the determinism gate failure on main and stabilizes CI.

<sup>Written for commit 9bb1151f3c0e4b09c766ce57ab120103b03df96f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated animation transition tests to calculate expected durations from input values.
  * Strengthened assertions for synthesized zero-duration transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->