### PR TITLE
Fix current Swift warning regressions

### DIFF
--- a/Sources/ClosedWorkspaceHistory.swift
+++ b/Sources/ClosedWorkspaceHistory.swift
@@ -26,11 +26,12 @@ extension AppDelegate {
     /// Restores the newest restorable workspace record without consuming tab or window history.
     @discardableResult
     func reopenMostRecentlyClosedWorkspace(
-        from historyStore: ClosedItemHistoryStore = .shared,
+        from historyStore: ClosedItemHistoryStore? = nil,
         preferredTabManager: TabManager? = nil,
         shouldActivate: Bool = true
     ) -> Bool {
-        historyStore.restoreMostRecentlyClosedWorkspace { workspaceEntry in
+        let historyStore = historyStore ?? .shared
+        return historyStore.restoreMostRecentlyClosedWorkspace { workspaceEntry in
             let manager =
                 preferredTabManager
                 ?? workspaceEntry.windowId.flatMap { self.tabManagerFor(windowId: $0) }
@@ -60,9 +61,10 @@ extension TabManager {
     /// Reopens the newest closed workspace additively in this manager.
     @discardableResult
     func reopenMostRecentlyClosedWorkspace(
-        from historyStore: ClosedItemHistoryStore = .shared
+        from historyStore: ClosedItemHistoryStore? = nil
     ) -> Bool {
-        historyStore.restoreMostRecentlyClosedWorkspace { workspaceEntry in
+        let historyStore = historyStore ?? .shared
+        return historyStore.restoreMostRecentlyClosedWorkspace { workspaceEntry in
             restoreClosedWorkspace(workspaceEntry)
         }
     }

--- a/Sources/Mobile/MobileTerminalRenderGridAnchorRegistry.swift
+++ b/Sources/Mobile/MobileTerminalRenderGridAnchorRegistry.swift
@@ -27,7 +27,7 @@ final class MobileTerminalRenderGridAnchorRegistry: Sendable {
     }
 
     func remove(connectionID: UUID) {
-        anchorsByConnectionID.withLock { $0.removeValue(forKey: connectionID) }
+        _ = anchorsByConnectionID.withLock { $0.removeValue(forKey: connectionID) }
     }
 
     /// The anchor this connection negotiated; `.viewport` when it never

--- a/Sources/NotificationFeedHistoryStore.swift
+++ b/Sources/NotificationFeedHistoryStore.swift
@@ -242,12 +242,12 @@ final class NotificationFeedHistoryStore {
         guard persistenceTask == nil else { return }
         persistenceTask = Task { [weak self, persistence] in
             while !Task.isCancelled {
-                guard let snapshot = await self?.consumePendingPersistenceSnapshot() else {
+                guard let snapshot = self?.consumePendingPersistenceSnapshot() else {
                     break
                 }
                 await persistence.persist(snapshot)
             }
-            await self?.finishPersistenceTask()
+            self?.finishPersistenceTask()
         }
     }
 

--- a/Sources/TerminalController+MobileNotificationSync.swift
+++ b/Sources/TerminalController+MobileNotificationSync.swift
@@ -5,7 +5,7 @@ import Foundation
 /// `notification.dismiss` and `notification.reconcile` RPC handlers dispatched
 /// from `mobileHostHandleRPC(_:)`.
 extension TerminalController {
-    private static let mobileNotificationFeedResponseByteLimit =
+    private nonisolated static let mobileNotificationFeedResponseByteLimit =
         MobileSyncFrameCodec.defaultMaximumFrameByteCount - (64 * 1024)
     private static let mobileNotificationFeedTitleByteLimit = 512
     private static let mobileNotificationFeedSubtitleByteLimit = 512


### PR DESCRIPTION
## Summary
- Resolve the workspace history singleton inside main-actor methods instead of a nonisolated default argument.
- Explicitly discard the render-grid registry removal result.
- Remove redundant actor-local awaits from notification persistence.
- Mark the immutable mobile feed frame limit nonisolated for detached encoding.

## Validation
- Tagged macOS 26 build `wfix2`: https://github.com/manaflow-ai/cmux/actions/runs/30182008958
- The successful build log contains none of the four repaired warning signatures.
- `WorkspaceRecoveryTests` and `NotificationFeedHistoryTests` compiled through the app target with an isolated cache; execution was blocked before test launch because the GUI builder could not see Zig 0.15.2.
- Exact integration review and speculative merge CI will validate the combined current-main candidate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787620661&installation_model_id=21920&pr_number=8944&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8944&signature=3799a0db9e2753295aafa40e9caec7141081a1a4464ea9bdeccf9a758b9475d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix recent Swift warnings by tightening actor isolation and discarding unused results. Cleans up concurrency warnings and keeps the build warning-free.

- **Bug Fixes**
  - Resolve the workspace history singleton inside main-actor reopen methods; accept an optional store and default to `.shared` internally.
  - Explicitly discard the return value when removing anchors in `MobileTerminalRenderGridAnchorRegistry`.
  - Drop unnecessary awaits in `NotificationFeedHistoryStore`’s persistence loop and finish call.
  - Mark `mobileNotificationFeedResponseByteLimit` as `nonisolated` static for detached encoding.

<sup>Written for commit 7e092af21a628ac7d7e54b8a5b599281cddb8b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reopening of recently closed workspaces, including support for explicitly selecting a history store.
  * Improved notification history persistence task handling for more reliable saves.
  * Preserved mobile notification synchronization behavior while improving concurrency handling.

* **Refactor**
  * Clarified internal handling of mobile terminal connection cleanup and shared notification limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->