### PR TITLE
Fix Ghostty render-grid package-test stub link

### DIFF
--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -165,6 +165,7 @@ void ghostty_surface_read_screen_tail_vt(void) {}
 void ghostty_surface_read_text(void) {}
 void ghostty_surface_refresh(void) {}
 void ghostty_surface_render_grid_json(void) {}
+void ghostty_surface_render_grid_json_v2(void) {}
 void ghostty_surface_render_grid_json_with_theme(void) {}
 void ghostty_surface_set_content_scale(void) {}
 void ghostty_surface_set_display_id(void) {}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -53,6 +53,7 @@ void ghostty_surface_read_screen_tail_vt(void);
 void ghostty_surface_read_text(void);
 void ghostty_surface_refresh(void);
 void ghostty_surface_render_grid_json(void);
+void ghostty_surface_render_grid_json_v2(void);
 void ghostty_surface_render_grid_json_with_theme(void);
 void ghostty_surface_set_content_scale(void);
 void ghostty_surface_set_display_id(void);


### PR DESCRIPTION
## Summary
- declare the `ghostty_surface_render_grid_json_v2` package-test stub
- define the no-op symbol beside the existing render-grid stubs

## Why
The exact integration gate failed while linking `CmuxTerminalPackageTests` because production code now references the v2 symbol but the package-test stub library omitted it.

Failed gate: https://github.com/manaflow-ai/cmux/actions/runs/30182921241/job/89742735278

## Verification
- `git diff --check`
- `GHOSTTY_SHA=f11159ff48e6e47bd1879655fef8b7157a963855 ./scripts/download-prebuilt-ghosttykit.sh`
- `swift test --package-path Packages/macOS/CmuxTerminal` built, linked, and passed all 118 tests in 19 suites; SwiftPM then emitted the workflow-tolerated unexpected-binary-name diagnostic

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787622721&installation_model_id=21920&pr_number=8945&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8945&signature=7c552add6313e12fe39086cd874b43cc1e6e9d2443dad5c82dab2a90aa62f890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `ghostty_surface_render_grid_json_v2` no-op stub to `GhosttyRuntimeTestStubs` so `CmuxTerminal` tests link when production code references the v2 symbol. Fixes linker failures in `CmuxTerminalPackageTests` without changing runtime behavior.

<sup>Written for commit f97af18fa7a2d2a5ac06401f061b0b7d25c6557d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage support for an additional Ghostty rendering entry point in macOS test environments.
  * Existing test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->