### PR TITLE
Stabilize concurrent Bun runner assertions

### DIFF
--- a/web/tests/web-test-runner-isolation.test.ts
+++ b/web/tests/web-test-runner-isolation.test.ts
@@ -49,7 +49,7 @@ test("shared web test runner isolates module mocks across files", () => {
   expect(result.output).toContain("0 fail");
 });
 
-test("shared web test runner preserves sorted recursive discovery", () => {
+test("shared web test runner preserves recursive discovery", () => {
   const fixtureRoot = createRunnerFixture();
   try {
     mkdirSync(join(fixtureRoot, ".hidden"));
@@ -98,7 +98,7 @@ test("shared web test runner preserves sorted recursive discovery", () => {
       "tests/nested/gamma_test.tsx:",
       "tests/nested/omega.spec.mjs:",
     ];
-    expectHeadingsInOrder(result.output, expectedHeadings);
+    expectHeadings(result.output, expectedHeadings);
     expect(result.output).not.toContain("ignored.test.ts:");
 
     const optionedResult = runChild(
@@ -111,7 +111,7 @@ test("shared web test runner preserves sorted recursive discovery", () => {
         `option-only web test run lost discovery:\n${optionedResult.output}`,
       );
     }
-    expectHeadingsInOrder(optionedResult.output, expectedHeadings);
+    expectHeadings(optionedResult.output, expectedHeadings);
     expect(optionedResult.output).not.toContain("ignored.test.ts:");
 
     const scopedResult = runChild(
@@ -142,7 +142,7 @@ test("shared web test runner preserves sorted recursive discovery", () => {
         `default Bun test root was not preserved:\n${rootedResult.output}`,
       );
     }
-    expectHeadingsInOrder(rootedResult.output, [
+    expectHeadings(rootedResult.output, [
       "tests/beta.test.ts:",
       "tests/nested/gamma_test.tsx:",
       "tests/nested/omega.spec.mjs:",
@@ -164,7 +164,7 @@ test("shared web test runner preserves sorted recursive discovery", () => {
         `alternate Bun test root was not preserved:\n${configuredResult.output}`,
       );
     }
-    expectHeadingsInOrder(configuredResult.output, [
+    expectHeadings(configuredResult.output, [
       "tests/beta.test.ts:",
       "tests/nested/gamma_test.tsx:",
       "tests/nested/omega.spec.mjs:",
@@ -240,11 +240,11 @@ function runChild(
   return { status: result.status, output };
 }
 
-function expectHeadingsInOrder(output: string, headings: string[]): void {
-  let previousIndex = -1;
+function expectHeadings(output: string, headings: string[]): void {
+  // Bun can execute files concurrently and report their headings in completion
+  // order. The shell guard asserts the runner passes files to Bun in sorted
+  // order; this integration test asserts every discovered file actually runs.
   for (const heading of headings) {
-    const index = output.indexOf(heading);
-    expect(index).toBeGreaterThan(previousIndex);
-    previousIndex = index;
+    expect(output).toContain(heading);
   }
 }


### PR DESCRIPTION
## Summary
- stop treating Bun heading emission order as test invocation order
- keep exact sorted argv coverage in the shell guard
- retain integration coverage for every recursively discovered test file

## Testing
- `bash tests/test_ci_self_hosted_guard.sh`
- `cd web && bun test tests/web-test-runner-isolation.test.ts`
- `cd web && bun run typecheck`

Repairs the Linux failure in [PR 8941 gate run](https://github.com/manaflow-ai/cmux/actions/runs/30184270195/job/89746070163). The runner sorts argv before invoking Bun; Bun may report concurrently executed files in completion order.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787624402&installation_model_id=21920&pr_number=8947&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8947&signature=6e7190996b42efa1841aa25566f10663fcee0f502e1808fcbdcd489c129bda57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the web test runner by allowing Bun’s concurrent execution and removing order-dependent assertions that caused Linux flakes. The shell guard still verifies sorted argv; integration tests now only assert that all discovered files ran.

- **Bug Fixes**
  - Replaced order-based heading checks with presence checks in web/tests/web-test-runner-isolation.test.ts (`expectHeadingsInOrder` → `expectHeadings`); renamed test to “preserves recursive discovery”.
  - Kept exact sorted argv coverage in the CI shell guard to prevent regressions while Bun may report headings in completion order.

<sup>Written for commit f151bd30d5dc4633643c88d221f442a26cea0fa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

