### PR TITLE
Fix integration review follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -905,17 +905,6 @@ EOF
     exit 1
   fi
 
-  if ! awk '
-    /^  web-typecheck:/ { in_job=1; next }
-    in_job && /^  [[:alnum:]_-]+:/ { in_job=0 }
-    in_job && /bun-version:[[:space:]]*"1[.]3[.]14"/ { saw_pin=1 }
-    END { exit !saw_pin }
-  ' "$CI_FILE"; then
-    echo "FAIL: web-typecheck must pin the minimum mock-isolated Bun version"
-    rm -rf "$fixture_dir"
-    exit 1
-  fi
-
   if ! PATH="$fixture_dir/bin:/usr/bin:/bin" \
     CMUX_WEB_TEST_RUNNER_ARGS_LOG="$args_log" \
     /bin/bash "$fixture_runner" \

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -896,6 +896,15 @@ EOF
     exit 1
   fi
 
+  if PATH="$fixture_dir/bin:/usr/bin:/bin" \
+    CMUX_WEB_TEST_RUNNER_ARGS_LOG="$args_log" \
+    CMUX_WEB_TEST_RUNNER_BUN_VERSION="1.3.13" \
+    /bin/bash "$fixture_runner" >/dev/null 2>&1; then
+    echo "FAIL: shared web test runner must enforce the patch-level Bun isolation boundary"
+    rm -rf "$fixture_dir"
+    exit 1
+  fi
+
   if ! awk '
     /^  web-typecheck:/ { in_job=1; next }
     in_job && /^  [[:alnum:]_-]+:/ { in_job=0 }

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -863,6 +863,10 @@ check_web_test_runner_behavior() {
   cat > "$fixture_dir/bin/bun" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf '%s\n' "${CMUX_WEB_TEST_RUNNER_BUN_VERSION:-1.3.14}"
+  exit 0
+fi
 printf '%s\n' "$@" > "$CMUX_WEB_TEST_RUNNER_ARGS_LOG"
 EOF
   chmod +x "$fixture_dir/bin/bun"
@@ -879,6 +883,26 @@ EOF
   if [[ "$(cat "$args_log")" != "$expected_args" ]]; then
     echo "FAIL: shared web test runner must sort recursive Bun test patterns and exclude hidden dependencies"
     cat "$args_log"
+    rm -rf "$fixture_dir"
+    exit 1
+  fi
+
+  if PATH="$fixture_dir/bin:/usr/bin:/bin" \
+    CMUX_WEB_TEST_RUNNER_ARGS_LOG="$args_log" \
+    CMUX_WEB_TEST_RUNNER_BUN_VERSION="1.2.14" \
+    /bin/bash "$fixture_runner" >/dev/null 2>&1; then
+    echo "FAIL: shared web test runner must reject Bun versions with process-global mock leakage"
+    rm -rf "$fixture_dir"
+    exit 1
+  fi
+
+  if ! awk '
+    /^  web-typecheck:/ { in_job=1; next }
+    in_job && /^  [[:alnum:]_-]+:/ { in_job=0 }
+    in_job && /bun-version:[[:space:]]*"1[.]3[.]14"/ { saw_pin=1 }
+    END { exit !saw_pin }
+  ' "$CI_FILE"; then
+    echo "FAIL: web-typecheck must pin the minimum mock-isolated Bun version"
     rm -rf "$fixture_dir"
     exit 1
   fi

--- a/web/scripts/run-tests.sh
+++ b/web/scripts/run-tests.sh
@@ -4,6 +4,34 @@ set -euo pipefail
 WEB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$WEB_ROOT"
 
+MINIMUM_BUN_VERSION="1.3.14"
+
+bun_version_is_supported() {
+  awk -v actual="$1" -v required="$2" '
+    BEGIN {
+      split(actual, actual_parts, ".")
+      split(required, required_parts, ".")
+      for (part_index = 1; part_index <= 3; part_index++) {
+        actual_part = actual_parts[part_index] + 0
+        required_part = required_parts[part_index] + 0
+        if (actual_part > required_part) {
+          exit 0
+        }
+        if (actual_part < required_part) {
+          exit 1
+        }
+      }
+      exit 0
+    }
+  '
+}
+
+bun_version="$(bun --version)"
+if ! bun_version_is_supported "$bun_version" "$MINIMUM_BUN_VERSION"; then
+  echo "Web tests require Bun $MINIMUM_BUN_VERSION or newer; found $bun_version" >&2
+  exit 1
+fi
+
 arguments_require_bun_discovery() {
   local expects_value=0
   local positional_only=0


### PR DESCRIPTION
Repairs the exact-head Bun review finding on https://github.com/manaflow-ai/cmux/pull/8941.

- Rejects Bun versions before 1.3.14, where `--isolate` still leaks process-global mocks.
- Pins the web required check to Bun 1.3.14.

The first commit is test-only and fails on the parent head. The second commit makes it pass.

Validation:
- `bash tests/test_ci_self_hosted_guard.sh`
- Bun 1.2.14 runner rejection
- Bun 1.3.14 web suite: 890 pass, 122 skip, 0 fail
- `bun run typecheck`