### PR TITLE
Make cmux TUI packages portable across Linux distributions

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -370,13 +370,19 @@ jobs:
           if-no-files-found: error
 
   verify-linux-packages:
-    name: verify Linux package entrypoints
+    name: verify Linux package entrypoints (${{ matrix.architecture }})
     needs: package
     if: ${{ inputs.package_npm || inputs.package_pypi }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - x64
+          - arm64
     env:
       PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
     steps:
@@ -392,6 +398,12 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
+
+      - name: Set up ARM64 emulation
+        if: matrix.architecture == 'arm64'
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
 
       - name: Download npm package archive
         if: inputs.package_npm
@@ -427,4 +439,6 @@ jobs:
           if [[ "$PACKAGE_PYPI" == "true" ]]; then
             args+=(--pypi-wheels dist/pypi-wheels)
           fi
-          python3 cmux-tui/dist/scripts/test_linux_packages.py "${args[@]}"
+          python3 cmux-tui/dist/scripts/test_linux_packages.py \
+            --architecture "${{ matrix.architecture }}" \
+            "${args[@]}"

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -343,3 +343,52 @@ jobs:
           name: pypi-wheels
           path: dist/pypi-wheels/*.whl
           if-no-files-found: error
+
+  verify-linux-packages:
+    name: verify Linux package entrypoints
+    needs: package
+    if: ${{ inputs.package_npm && inputs.package_pypi }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
+    steps:
+      - name: Checkout caller ref
+        if: inputs.checkout_ref == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.checkout_ref != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Download npm package archive
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: npm-packages
+          path: dist
+
+      - name: Restore npm package directories
+        run: |
+          python3 cmux-tui/dist/scripts/package_npm_artifact.py extract \
+            --archive dist/npm-packages.tar.gz \
+            --out dist
+
+      - name: Download PyPI wheels
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: pypi-wheels
+          path: dist/pypi-wheels
+
+      - name: Test Linux distributions
+        run: |
+          python3 cmux-tui/dist/scripts/test_linux_packages.py \
+            --npm-packages dist/npm-packages \
+            --pypi-wheels dist/pypi-wheels \
+            --version "$PYPI_VERSION"

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -372,7 +372,7 @@ jobs:
   verify-linux-packages:
     name: verify Linux package entrypoints
     needs: package
-    if: ${{ inputs.package_npm && inputs.package_pypi }}
+    if: ${{ inputs.package_npm || inputs.package_pypi }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -394,26 +394,37 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Download npm package archive
+        if: inputs.package_npm
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: npm-packages
           path: dist
 
       - name: Restore npm package directories
+        if: inputs.package_npm
         run: |
           python3 cmux-tui/dist/scripts/package_npm_artifact.py extract \
             --archive dist/npm-packages.tar.gz \
             --out dist
 
       - name: Download PyPI wheels
+        if: inputs.package_pypi
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: pypi-wheels
           path: dist/pypi-wheels
 
       - name: Test Linux distributions
+        env:
+          PACKAGE_NPM: ${{ inputs.package_npm }}
+          PACKAGE_PYPI: ${{ inputs.package_pypi }}
         run: |
-          python3 cmux-tui/dist/scripts/test_linux_packages.py \
-            --npm-packages dist/npm-packages \
-            --pypi-wheels dist/pypi-wheels \
-            --version "$PYPI_VERSION"
+          set -euo pipefail
+          args=(--version "$PYPI_VERSION")
+          if [[ "$PACKAGE_NPM" == "true" ]]; then
+            args+=(--npm-packages dist/npm-packages)
+          fi
+          if [[ "$PACKAGE_PYPI" == "true" ]]; then
+            args+=(--pypi-wheels dist/pypi-wheels)
+          fi
+          python3 cmux-tui/dist/scripts/test_linux_packages.py "${args[@]}"

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -35,6 +35,9 @@ on:
 
 permissions: {}
 
+env:
+  RUST_TOOLCHAIN: "1.95.0"
+
 jobs:
   build:
     name: build ${{ matrix.target }}
@@ -50,18 +53,22 @@ jobs:
             runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
             cross: false
             ext: ""
+            compatibility_target: ""
           - target: x86_64-apple-darwin
             runner: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
             cross: true
             ext: ""
-          - target: x86_64-unknown-linux-gnu
-            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-            cross: false
-            ext: ""
-          - target: aarch64-unknown-linux-gnu
+            compatibility_target: ""
+          - target: x86_64-unknown-linux-musl
             runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
             cross: true
             ext: ""
+            compatibility_target: x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
+            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+            cross: true
+            ext: ""
+            compatibility_target: aarch64-unknown-linux-gnu
     steps:
       - name: Checkout caller ref
         if: inputs.checkout_ref == ''
@@ -89,6 +96,13 @@ jobs:
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
         with:
           version: 0.15.2
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustc --version
 
       - name: Install Rust target
         shell: bash
@@ -129,14 +143,18 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          cp "cmux-tui/target/${{ matrix.target }}/release/cmux-tui${{ matrix.ext }}" "dist/cmux-tui-${{ matrix.target }}${{ matrix.ext }}"
+          binary="dist/cmux-tui-${{ matrix.target }}${{ matrix.ext }}"
+          cp "cmux-tui/target/${{ matrix.target }}/release/cmux-tui${{ matrix.ext }}" "$binary"
+          if [[ -n "${{ matrix.compatibility_target }}" ]]; then
+            cp "$binary" "dist/cmux-tui-${{ matrix.compatibility_target }}${{ matrix.ext }}"
+          fi
           ls -la dist
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cmux-tui-${{ matrix.target }}
-          path: dist/cmux-tui-${{ matrix.target }}${{ matrix.ext }}
+          path: dist/cmux-tui-*${{ matrix.ext }}
           if-no-files-found: error
 
   build-windows:
@@ -168,6 +186,13 @@ jobs:
         uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
         with:
           version: 0.15.2
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustc --version
 
       - name: Install Rust target
         shell: bash
@@ -243,13 +268,13 @@ jobs:
       - name: Download linux x64 binary
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: cmux-tui-x86_64-unknown-linux-gnu
+          name: cmux-tui-x86_64-unknown-linux-musl
           path: dist/binaries
 
       - name: Download linux arm64 binary
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: cmux-tui-aarch64-unknown-linux-gnu
+          name: cmux-tui-aarch64-unknown-linux-musl
           path: dist/binaries
 
       - name: Build npm package directories
@@ -302,9 +327,9 @@ jobs:
               if not binary.stat().st_mode & stat.S_IXUSR:
                   raise SystemExit(f"{binary} is not executable")
           PY
-          chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-gnu
-          dist/binaries/cmux-tui-x86_64-unknown-linux-gnu --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-gnu --help >/tmp/cmux-tui-version.txt 2>&1
+          chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
+          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
+            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
 
       - name: Archive npm package directories with executable modes
         if: inputs.package_npm
@@ -320,9 +345,9 @@ jobs:
           for wheel in dist/pypi-wheels/*.whl; do
             python3 -m zipfile -l "$wheel" >"/tmp/$(basename "$wheel").list"
           done
-          chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-gnu
-          dist/binaries/cmux-tui-x86_64-unknown-linux-gnu --version >/tmp/cmux-tui-version.txt 2>&1 || \
-            dist/binaries/cmux-tui-x86_64-unknown-linux-gnu --help >/tmp/cmux-tui-version.txt 2>&1
+          chmod +x dist/binaries/cmux-tui-x86_64-unknown-linux-musl
+          dist/binaries/cmux-tui-x86_64-unknown-linux-musl --version >/tmp/cmux-tui-version.txt 2>&1 || \
+            dist/binaries/cmux-tui-x86_64-unknown-linux-musl --help >/tmp/cmux-tui-version.txt 2>&1
           python3 -m venv /tmp/cmux-tui-wheel-smoke
           /tmp/cmux-tui-wheel-smoke/bin/python -m pip install --no-index --find-links dist/pypi-wheels cmux=="$PYPI_VERSION"
           /tmp/cmux-tui-wheel-smoke/bin/cmux --help >/tmp/cmux-help.txt

--- a/cmux-tui/crates/ghostty-vt-sys/build.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build.rs
@@ -128,6 +128,8 @@ fn zig_target_for_rust_target(target: &str) -> Option<&'static str> {
         "aarch64-apple-darwin" => Some("aarch64-macos"),
         "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
         "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
+        "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
+        "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
         _ => None,
     }
 }

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -94,12 +94,10 @@ Use `.github/workflows/cmux-tui-release-cut.yml` from `main`.
 - The tag is pushed with the default `GITHUB_TOKEN`, and GitHub suppresses
   workflow triggers for token-created events, so the release-cut workflow then
   explicitly dispatches `cmux-tui-release.yml` (build + package) and
-  `tui-publish-pypi.yml` (PyPI wheels) against the new tag. A manual
-  `git push origin cmux-tui-vX.Y.Z` from a developer machine still fires both
-  tag triggers directly.
-- npm remains dispatch-gated. After the tag cut, manually dispatch
-  `tui-publish-npm.yml` with the same `X.Y.Z` version and
-  `confirm_tui_cmux=true`.
+  both registry publishers against the new tag. The npm dispatch sets
+  `confirm_tui_cmux=true`. A manual `git push origin cmux-tui-vX.Y.Z` from a
+  developer machine still fires the build and PyPI tag triggers directly, but
+  npm remains manual-dispatch only.
 
 ## Publishing
 
@@ -107,6 +105,10 @@ PyPI publishing can run from `cmux-tui-vX.Y.Z` tags or manual dispatch.
 
 npm publishing is manual dispatch only and requires `confirm_tui_cmux=true`.
 The platform packages are published first, then the `cmux` launcher.
+
+Each publisher runs its generated Linux entrypoint packages across the
+supported glibc and musl distribution matrix before its publish job starts.
+A compatibility regression therefore blocks writes to that registry.
 
 The npm launcher publish deliberately does not pass `--tag`: when the TUI
 version is greater than `0.8.3`, this coordinated release takes over the npm

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -21,6 +21,10 @@ scripts receive `--version`, so cutting a stable TUI release is just creating a
 - npm `cmux-tui-linux-arm64`: Linux arm64 binary package.
 - PyPI `cmux`: platform wheels for `uvx cmux` / `pipx run cmux`.
 
+Linux packages contain static musl binaries that run on both glibc and musl
+distributions. PyPI publishes each Linux binary under matching manylinux and
+musllinux wheel tags so installers on both runtime families can resolve it.
+
 ## One-time registry setup
 
 Add npm Trusted Publishers for all five npm package names:

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -107,8 +107,9 @@ npm publishing is manual dispatch only and requires `confirm_tui_cmux=true`.
 The platform packages are published first, then the `cmux` launcher.
 
 Each publisher runs its generated Linux entrypoint packages across the
-supported glibc and musl distribution matrix before its publish job starts.
-A compatibility regression therefore blocks writes to that registry.
+supported glibc and musl distribution matrix on x86_64 and ARM64 before its
+publish job starts. A compatibility regression therefore blocks writes to that
+registry.
 
 The npm launcher publish deliberately does not pass `--tag`: when the TUI
 version is greater than `0.8.3`, this coordinated release takes over the npm

--- a/cmux-tui/dist/scripts/package_npm.py
+++ b/cmux-tui/dist/scripts/package_npm.py
@@ -25,13 +25,13 @@ TARGETS = [
         "cpu": "x64",
     },
     {
-        "rust_target": "x86_64-unknown-linux-gnu",
+        "rust_target": "x86_64-unknown-linux-musl",
         "package": "cmux-tui-linux-x64",
         "os": "linux",
         "cpu": "x64",
     },
     {
-        "rust_target": "aarch64-unknown-linux-gnu",
+        "rust_target": "aarch64-unknown-linux-musl",
         "package": "cmux-tui-linux-arm64",
         "os": "linux",
         "cpu": "arm64",

--- a/cmux-tui/dist/scripts/package_pypi.py
+++ b/cmux-tui/dist/scripts/package_pypi.py
@@ -24,14 +24,26 @@ ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
 @dataclass(frozen=True)
 class Target:
     rust_target: str
-    platform_tag: str
+    platform_tags: tuple[str, ...]
 
 
 TARGETS = [
-    Target("aarch64-apple-darwin", "macosx_11_0_arm64"),
-    Target("x86_64-apple-darwin", "macosx_10_12_x86_64"),
-    Target("x86_64-unknown-linux-gnu", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
-    Target("aarch64-unknown-linux-gnu", "manylinux_2_17_aarch64.manylinux2014_aarch64"),
+    Target("aarch64-apple-darwin", ("macosx_11_0_arm64",)),
+    Target("x86_64-apple-darwin", ("macosx_10_12_x86_64",)),
+    Target(
+        "x86_64-unknown-linux-musl",
+        (
+            "manylinux_2_17_x86_64.manylinux2014_x86_64",
+            "musllinux_1_2_x86_64",
+        ),
+    ),
+    Target(
+        "aarch64-unknown-linux-musl",
+        (
+            "manylinux_2_17_aarch64.manylinux2014_aarch64",
+            "musllinux_1_2_aarch64",
+        ),
+    ),
 ]
 
 
@@ -173,15 +185,17 @@ def main() -> None:
         binary_path = binaries_dir / f"cmux-tui-{target.rust_target}"
         if not binary_path.is_file():
             raise SystemExit(f"missing binary: {binary_path}")
-        wheel_name = f"{DIST_NAME}-{args.version}-py3-none-{target.platform_tag}.whl"
-        wheel_path = out_dir / wheel_name
-        if wheel_path.exists():
-            wheel_path.unlink()
-        write_wheel(
-            wheel_path,
-            wheel_bytes(args.version, target.platform_tag, binary_path.read_bytes()),
-            args.version,
-        )
+        binary = binary_path.read_bytes()
+        for platform_tag in target.platform_tags:
+            wheel_name = f"{DIST_NAME}-{args.version}-py3-none-{platform_tag}.whl"
+            wheel_path = out_dir / wheel_name
+            if wheel_path.exists():
+                wheel_path.unlink()
+            write_wheel(
+                wheel_path,
+                wheel_bytes(args.version, platform_tag, binary),
+                args.version,
+            )
 
 
 if __name__ == "__main__":

--- a/cmux-tui/dist/scripts/test_linux_packages.py
+++ b/cmux-tui/dist/scripts/test_linux_packages.py
@@ -28,6 +28,11 @@ BINARY_IMAGES = (
     ("alpine-3.22", "alpine:3.22"),
 )
 
+ARCHITECTURES = {
+    "x64": ("linux/amd64", "cmux-tui-linux-x64"),
+    "arm64": ("linux/arm64", "cmux-tui-linux-arm64"),
+}
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -36,6 +41,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--npm-packages", type=pathlib.Path)
     parser.add_argument("--pypi-wheels", type=pathlib.Path)
     parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--architecture",
+        choices=ARCHITECTURES,
+        default="x64",
+        help="Linux package architecture to exercise (default: x64).",
+    )
     args = parser.parse_args()
     if args.npm_packages is None and args.pypi_wheels is None:
         parser.error("at least one of --npm-packages or --pypi-wheels is required")
@@ -50,6 +61,7 @@ def run(label: str, command: list[str]) -> None:
 def container_command(
     image: str,
     *,
+    platform: str,
     mounts: tuple[tuple[pathlib.Path, str], ...],
     script: str,
     entrypoint: str | None = None,
@@ -59,7 +71,7 @@ def container_command(
         "run",
         "--rm",
         "--platform",
-        "linux/amd64",
+        platform,
         "--network",
         "none",
     ]
@@ -110,10 +122,10 @@ server_pid=""
 """
 
 
-def test_npm(packages: pathlib.Path) -> None:
+def test_npm(packages: pathlib.Path, platform: str, package_name: str) -> None:
     launcher = packages / "cmux"
-    platform = packages / "cmux-tui-linux-x64"
-    for path in (launcher, platform):
+    platform_package = packages / package_name
+    for path in (launcher, platform_package):
         if not path.is_dir():
             raise SystemExit(f"missing npm package directory: {path}")
 
@@ -122,7 +134,7 @@ def test_npm(packages: pathlib.Path) -> None:
         node_modules = root / "node_modules"
         node_modules.mkdir()
         shutil.copytree(launcher, node_modules / launcher.name)
-        shutil.copytree(platform, node_modules / platform.name)
+        shutil.copytree(platform_package, node_modules / platform_package.name)
         bin_dir = node_modules / ".bin"
         bin_dir.mkdir()
         (bin_dir / "cmux").symlink_to("../cmux/bin/cmux.js")
@@ -132,13 +144,14 @@ def test_npm(packages: pathlib.Path) -> None:
                 f"npx on {distro}",
                 container_command(
                     image,
+                    platform=platform,
                     mounts=((root, "/test"),),
                     script=script,
                 ),
             )
 
 
-def test_uvx(wheels: pathlib.Path, version: str) -> None:
+def test_uvx(wheels: pathlib.Path, version: str, platform: str) -> None:
     if not any(wheels.glob("*.whl")):
         raise SystemExit(f"missing PyPI wheels: {wheels}")
     command = f"uvx --offline --find-links /wheels 'cmux=={version}'"
@@ -148,6 +161,7 @@ def test_uvx(wheels: pathlib.Path, version: str) -> None:
             f"uvx on {distro}",
             container_command(
                 image,
+                platform=platform,
                 entrypoint="",
                 mounts=((wheels, "/wheels"),),
                 script=script,
@@ -155,8 +169,10 @@ def test_uvx(wheels: pathlib.Path, version: str) -> None:
         )
 
 
-def test_native_binary(packages: pathlib.Path) -> None:
-    binary = packages / "cmux-tui-linux-x64" / "bin" / "cmux-tui"
+def test_native_binary(
+    packages: pathlib.Path, platform: str, package_name: str
+) -> None:
+    binary = packages / package_name / "bin" / "cmux-tui"
     if not binary.is_file():
         raise SystemExit(f"missing Linux binary: {binary}")
     for distro, image in BINARY_IMAGES:
@@ -164,6 +180,7 @@ def test_native_binary(packages: pathlib.Path) -> None:
             f"native binary on {distro}",
             container_command(
                 image,
+                platform=platform,
                 mounts=((binary, "/cmux-tui"),),
                 script="/cmux-tui --version",
             ),
@@ -174,12 +191,13 @@ def main() -> None:
     args = parse_args()
     if shutil.which("docker") is None:
         raise SystemExit("docker is required")
+    platform, package_name = ARCHITECTURES[args.architecture]
     if args.npm_packages is not None:
         npm_packages = args.npm_packages.resolve()
-        test_npm(npm_packages)
-        test_native_binary(npm_packages)
+        test_npm(npm_packages, platform, package_name)
+        test_native_binary(npm_packages, platform, package_name)
     if args.pypi_wheels is not None:
-        test_uvx(args.pypi_wheels.resolve(), args.version)
+        test_uvx(args.pypi_wheels.resolve(), args.version, platform)
 
 
 if __name__ == "__main__":

--- a/cmux-tui/dist/scripts/test_linux_packages.py
+++ b/cmux-tui/dist/scripts/test_linux_packages.py
@@ -33,10 +33,13 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Exercise generated npm and PyPI cmux packages in Linux containers."
     )
-    parser.add_argument("--npm-packages", required=True, type=pathlib.Path)
-    parser.add_argument("--pypi-wheels", required=True, type=pathlib.Path)
+    parser.add_argument("--npm-packages", type=pathlib.Path)
+    parser.add_argument("--pypi-wheels", type=pathlib.Path)
     parser.add_argument("--version", required=True)
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.npm_packages is None and args.pypi_wheels is None:
+        parser.error("at least one of --npm-packages or --pypi-wheels is required")
+    return args
 
 
 def run(label: str, command: list[str]) -> None:
@@ -171,9 +174,12 @@ def main() -> None:
     args = parse_args()
     if shutil.which("docker") is None:
         raise SystemExit("docker is required")
-    test_npm(args.npm_packages.resolve())
-    test_uvx(args.pypi_wheels.resolve(), args.version)
-    test_native_binary(args.npm_packages.resolve())
+    if args.npm_packages is not None:
+        npm_packages = args.npm_packages.resolve()
+        test_npm(npm_packages)
+        test_native_binary(npm_packages)
+    if args.pypi_wheels is not None:
+        test_uvx(args.pypi_wheels.resolve(), args.version)
 
 
 if __name__ == "__main__":

--- a/cmux-tui/dist/scripts/test_linux_packages.py
+++ b/cmux-tui/dist/scripts/test_linux_packages.py
@@ -93,7 +93,7 @@ while [ ! -S "$socket" ]; do
     exit 1
   fi
   attempt=$((attempt + 1))
-  if [ "$attempt" -ge 100 ]; then
+  if [ "$attempt" -ge 600 ]; then
     cat /tmp/cmux-server.log >&2
     echo "timed out waiting for $socket" >&2
     exit 1

--- a/cmux-tui/dist/scripts/test_linux_packages.py
+++ b/cmux-tui/dist/scripts/test_linux_packages.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Run packaged cmux TUI entrypoints across Linux runtime families."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import shutil
+import subprocess
+import tempfile
+
+
+NPM_IMAGES = (
+    ("debian-12", "node:22-bookworm-slim"),
+    ("debian-11", "node:22-bullseye-slim"),
+    ("alpine", "node:22-alpine"),
+)
+
+UVX_IMAGES = (
+    ("debian-12", "ghcr.io/astral-sh/uv:python3.12-bookworm-slim"),
+    ("alpine", "ghcr.io/astral-sh/uv:python3.12-alpine"),
+)
+
+BINARY_IMAGES = (
+    ("ubuntu-20.04", "ubuntu:20.04"),
+    ("rocky-linux-9", "rockylinux:9"),
+    ("fedora-42", "fedora:42"),
+    ("alpine-3.22", "alpine:3.22"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Exercise generated npm and PyPI cmux packages in Linux containers."
+    )
+    parser.add_argument("--npm-packages", required=True, type=pathlib.Path)
+    parser.add_argument("--pypi-wheels", required=True, type=pathlib.Path)
+    parser.add_argument("--version", required=True)
+    return parser.parse_args()
+
+
+def run(label: str, command: list[str]) -> None:
+    print(f"\n=== {label} ===", flush=True)
+    subprocess.run(command, check=True)
+
+
+def container_command(
+    image: str,
+    *,
+    mounts: tuple[tuple[pathlib.Path, str], ...],
+    script: str,
+    entrypoint: str | None = None,
+) -> list[str]:
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "--platform",
+        "linux/amd64",
+        "--network",
+        "none",
+    ]
+    if entrypoint is not None:
+        command.extend(("--entrypoint", entrypoint))
+    for source, destination in mounts:
+        command.extend(("--volume", f"{source.resolve()}:{destination}:ro"))
+    command.extend((image, "sh", "-c", script))
+    return command
+
+
+def launcher_smoke(command: str) -> str:
+    return f"""
+set -eu
+export HOME=/tmp/cmux-home
+mkdir -p "$HOME"
+socket="/tmp/cmux-package-smoke-$$.sock"
+server_pid=""
+cleanup() {{
+  if [ -n "$server_pid" ]; then
+    kill -TERM "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -f "$socket"
+}}
+trap cleanup EXIT HUP INT TERM
+{command} --version
+{command} --headless --socket "$socket" >/tmp/cmux-server.log 2>&1 &
+server_pid=$!
+attempt=0
+while [ ! -S "$socket" ]; do
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    cat /tmp/cmux-server.log >&2
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 100 ]; then
+    cat /tmp/cmux-server.log >&2
+    echo "timed out waiting for $socket" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+{command} --socket "$socket" ping
+kill -TERM "$server_pid"
+wait "$server_pid" || true
+server_pid=""
+"""
+
+
+def test_npm(packages: pathlib.Path) -> None:
+    launcher = packages / "cmux"
+    platform = packages / "cmux-tui-linux-x64"
+    for path in (launcher, platform):
+        if not path.is_dir():
+            raise SystemExit(f"missing npm package directory: {path}")
+
+    with tempfile.TemporaryDirectory(prefix="cmux-npm-smoke-") as temp:
+        root = pathlib.Path(temp)
+        node_modules = root / "node_modules"
+        node_modules.mkdir()
+        shutil.copytree(launcher, node_modules / launcher.name)
+        shutil.copytree(platform, node_modules / platform.name)
+        bin_dir = node_modules / ".bin"
+        bin_dir.mkdir()
+        (bin_dir / "cmux").symlink_to("../cmux/bin/cmux.js")
+        script = "cd /test\n" + launcher_smoke("npx --offline --no-install cmux")
+        for distro, image in NPM_IMAGES:
+            run(
+                f"npx on {distro}",
+                container_command(
+                    image,
+                    mounts=((root, "/test"),),
+                    script=script,
+                ),
+            )
+
+
+def test_uvx(wheels: pathlib.Path, version: str) -> None:
+    if not any(wheels.glob("*.whl")):
+        raise SystemExit(f"missing PyPI wheels: {wheels}")
+    command = f"uvx --offline --find-links /wheels 'cmux=={version}'"
+    script = "export UV_CACHE_DIR=/tmp/uv-cache\n" + launcher_smoke(command)
+    for distro, image in UVX_IMAGES:
+        run(
+            f"uvx on {distro}",
+            container_command(
+                image,
+                entrypoint="",
+                mounts=((wheels, "/wheels"),),
+                script=script,
+            ),
+        )
+
+
+def test_native_binary(packages: pathlib.Path) -> None:
+    binary = packages / "cmux-tui-linux-x64" / "bin" / "cmux-tui"
+    if not binary.is_file():
+        raise SystemExit(f"missing Linux binary: {binary}")
+    for distro, image in BINARY_IMAGES:
+        run(
+            f"native binary on {distro}",
+            container_command(
+                image,
+                mounts=((binary, "/cmux-tui"),),
+                script="/cmux-tui --version",
+            ),
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    if shutil.which("docker") is None:
+        raise SystemExit("docker is required")
+    test_npm(args.npm_packages.resolve())
+    test_uvx(args.pypi_wheels.resolve(), args.version)
+    test_native_binary(args.npm_packages.resolve())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- build statically linked musl binaries for Linux x86_64 and ARM64 while retaining GNU-named raw artifact aliases
- keep the existing npm platform package names and publish each Python binary with both manylinux and musllinux wheel tags
- gate every npm and PyPI publish on generated-package tests across x86_64 and ARM64 Linux distributions

## Testing

- exact-head GitHub package workflow: https://github.com/manaflow-ai/cmux/actions/runs/30202488646
- generated `npx cmux` and `uvx cmux` packages on Debian 12, Debian 11, Ubuntu 20.04, Rocky Linux 9, Fedora 42, and Alpine 3.22
- x86_64 and ARM64 headless startup plus socket ping
- `actionlint .github/workflows/cmux-tui-build-package.yml`
- `cargo +1.95.0 fmt --manifest-path cmux-tui/Cargo.toml --all -- --check`
- Python package-script compilation checks
