### PR TITLE
feat(usage): multi-provider usage HUD in sidebar footer

### DIFF
--- a/Packages/macOS/CmuxUsage/Package.swift
+++ b/Packages/macOS/CmuxUsage/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CmuxUsage",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxUsage",
+            targets: ["CmuxUsage"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxUsage",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxUsageTests",
+            dependencies: ["CmuxUsage"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ClaudeUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ClaudeUsageAdapter.swift
@@ -1,0 +1,105 @@
+public import Foundation
+
+/// Claude usage adapter.
+///
+/// Claude Code authenticates via the long-lived, non-rotating `CLAUDE_CODE_OAUTH_TOKEN`
+/// (a `claude setup-token`), which is `user:inference`-scoped. The dedicated
+/// `/api/oauth/usage` endpoint requires `user:profile` (403 for this token), but the
+/// rolling-window utilization rides on the **`anthropic-ratelimit-unified-*` response
+/// headers of a real `/v1/messages` call** — which only needs `user:inference`. So this
+/// adapter makes one minimal (`max_tokens: 1`) inference call and reads the headers,
+/// discarding the body. Cost is ~1 token per call → the host polls on demand and caches.
+public struct ClaudeUsageAdapter: ProviderUsageAdapter {
+    public let provider: UsageProvider = .claude
+
+    /// Reads the OAuth token from the environment (read-only; never logged/persisted).
+    private let tokenProvider: @Sendable () -> String?
+    private let session: URLSession
+    private let now: @Sendable () -> Date
+
+    public init(
+        tokenProvider: @escaping @Sendable () -> String? = {
+            ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"]
+        },
+        session: URLSession = .shared,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.tokenProvider = tokenProvider
+        self.session = session
+        self.now = now
+    }
+
+    public func fetchUsage() async throws -> UsageSnapshot {
+        guard let token = tokenProvider(), !token.isEmpty else {
+            throw UsageAdapterError.signedOut
+        }
+
+        var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 1,
+            "messages": [["role": "user", "content": "hi"]],
+        ])
+
+        let response: URLResponse
+        do {
+            (_, response) = try await session.data(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw UsageAdapterError.malformedResponse
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw UsageAdapterError.malformedResponse
+        }
+        switch http.statusCode {
+        case 200..<300: break
+        case 401, 403: throw UsageAdapterError.signedOut
+        case 429: throw UsageAdapterError.rateLimited
+        default: throw UsageAdapterError.httpStatus(http.statusCode)
+        }
+        return try Self.parseUsage(headers: Self.normalizedHeaders(http), now: now())
+    }
+
+    // MARK: - Pure parsing (no I/O — unit-testable against captured headers)
+
+    static func parseUsage(headers: [String: String], now: Date) throws -> UsageSnapshot {
+        func number(_ key: String) -> Double? { headers[key].flatMap(Double.init) }
+
+        var windows: [UsageWindow] = []
+        // 5-hour window (18000s) and 7-day window (604800s), utilization in 0…1.
+        let specs: [(prefix: String, seconds: Int)] = [
+            ("anthropic-ratelimit-unified-5h", 18000),
+            ("anthropic-ratelimit-unified-7d", 604800),
+        ]
+        for spec in specs {
+            guard let util = number("\(spec.prefix)-utilization") else { continue }
+            let reset = number("\(spec.prefix)-reset").map { Date(timeIntervalSince1970: $0) }
+            windows.append(
+                UsageWindow(kind: .rolling(seconds: spec.seconds), usedPercent: util * 100, resetAt: reset)
+            )
+        }
+        guard !windows.isEmpty else { throw UsageAdapterError.malformedResponse }
+
+        let accountId = headers["anthropic-organization-id"] ?? "default"
+        return UsageSnapshot(
+            account: ProviderAccount(provider: .claude, accountId: accountId),
+            windows: windows,
+            freshness: .live(now),
+            fetchedAt: now
+        )
+    }
+
+    static func normalizedHeaders(_ http: HTTPURLResponse) -> [String: String] {
+        var out: [String: String] = [:]
+        for (key, value) in http.allHeaderFields {
+            if let k = key as? String, let v = value as? String { out[k.lowercased()] = v }
+        }
+        return out
+    }
+}

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ClaudeUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ClaudeUsageAdapter.swift
@@ -12,21 +12,88 @@ public import Foundation
 public struct ClaudeUsageAdapter: ProviderUsageAdapter {
     public let provider: UsageProvider = .claude
 
-    /// Reads the OAuth token from the environment (read-only; never logged/persisted).
+    /// Resolves the OAuth token (read-only; never logged/persisted). Prefers the
+    /// environment, then on-disk credential files — see ``resolveToken(environment:homeDirectory:readFile:)``.
     private let tokenProvider: @Sendable () -> String?
     private let session: URLSession
     private let now: @Sendable () -> Date
 
     public init(
-        tokenProvider: @escaping @Sendable () -> String? = {
-            ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"]
-        },
+        tokenProvider: @escaping @Sendable () -> String? = { ClaudeUsageAdapter.resolveToken() },
         session: URLSession = .shared,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.tokenProvider = tokenProvider
         self.session = session
         self.now = now
+    }
+
+    // MARK: - Token resolution (read-only, fail-closed)
+
+    static let maxCredentialFileBytes = 1_000_000
+
+    /// Resolve the Claude OAuth token, preferring `CLAUDE_CODE_OAUTH_TOKEN` in the
+    /// environment and falling back to on-disk credential files. cmux launched from
+    /// Finder/Dock/login does **not** inherit the shell environment, so the file fallback
+    /// is what makes usage resolve in normal use. All file access is read-only, size-capped
+    /// (``maxCredentialFileBytes``), and fails closed — any missing/oversized/malformed
+    /// input yields `nil` (file contents are treated as hostile input, never trusted).
+    public static func resolveToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        readFile: @Sendable (URL) -> Data? = { try? Data(contentsOf: $0) }
+    ) -> String? {
+        if let token = environment["CLAUDE_CODE_OAUTH_TOKEN"], !token.isEmpty {
+            return token
+        }
+        // 1. Standard Claude Code OAuth store: { "claudeAiOauth": { "accessToken": "…" } }.
+        if let token = tokenFromCredentialsJSON(
+            readFile(homeDirectory.appendingPathComponent(".claude/.credentials.json"))
+        ) {
+            return token
+        }
+        // 2. Shell env-file convention: a line `export CLAUDE_CODE_OAUTH_TOKEN=<value>`.
+        if let token = tokenFromEnvFile(
+            readFile(homeDirectory.appendingPathComponent(".claude/.env"))
+        ) {
+            return token
+        }
+        return nil
+    }
+
+    /// Parse the OAuth access token out of a Claude Code `.credentials.json`. Strict Codable,
+    /// size-capped, returns `nil` on any drift.
+    static func tokenFromCredentialsJSON(_ data: Data?) -> String? {
+        guard let data, data.count <= maxCredentialFileBytes else { return nil }
+        struct Creds: Decodable {
+            struct OAuth: Decodable { let accessToken: String? }
+            let claudeAiOauth: OAuth?
+        }
+        guard let creds = try? JSONDecoder().decode(Creds.self, from: data),
+              let token = creds.claudeAiOauth?.accessToken, !token.isEmpty else {
+            return nil
+        }
+        return token
+    }
+
+    /// Parse `CLAUDE_CODE_OAUTH_TOKEN` out of a shell env file (`export KEY=value` or
+    /// `KEY=value`, optional surrounding quotes). Size-capped, returns `nil` if absent/empty.
+    static func tokenFromEnvFile(_ data: Data?) -> String? {
+        guard let data, data.count <= maxCredentialFileBytes,
+              let text = String(data: data, encoding: .utf8) else { return nil }
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            var line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("export ") { line.removeFirst("export ".count) }
+            guard line.hasPrefix("CLAUDE_CODE_OAUTH_TOKEN=") else { continue }
+            var value = String(line.dropFirst("CLAUDE_CODE_OAUTH_TOKEN=".count))
+            if let quote = value.first, quote == "\"" || quote == "'",
+               value.count >= 2, value.last == quote {
+                value = String(value.dropFirst().dropLast())
+            }
+            value = value.trimmingCharacters(in: .whitespaces)
+            if !value.isEmpty { return value }
+        }
+        return nil
     }
 
     public func fetchUsage() async throws -> UsageSnapshot {

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ClaudeUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ClaudeUsageAdapter.swift
@@ -89,6 +89,11 @@ public struct ClaudeUsageAdapter: ProviderUsageAdapter {
             if let quote = value.first, quote == "\"" || quote == "'",
                value.count >= 2, value.last == quote {
                 value = String(value.dropFirst().dropLast())
+            } else if let hashRange = value.range(of: " #") {
+                // Strip an unquoted trailing shell comment (` # …`), which is not part of
+                // the value — otherwise the comment rides into the Bearer header. Only a
+                // space-hash starts a comment; a bare '#' inside the token is preserved.
+                value = String(value[..<hashRange.lowerBound])
             }
             value = value.trimmingCharacters(in: .whitespaces)
             if !value.isEmpty { return value }

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/CodexUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/CodexUsageAdapter.swift
@@ -125,6 +125,14 @@ public struct CodexUsageAdapter: ProviderUsageAdapter {
             windows.append(UsageWindow(kind: .credits, creditsRemaining: balance))
         }
 
+        // Degrade a response that carried no usage structure at all rather than
+        // reporting it as `.live` with an empty gauge (matches Claude/Grok fail-closed
+        // on empty). A recognized-but-window-less response (e.g. an unlimited plan) is
+        // still a valid live state, so only truly structureless payloads are rejected.
+        if windows.isEmpty, wire.rate_limit == nil, wire.credits == nil {
+            throw UsageAdapterError.malformedResponse
+        }
+
         let account = ProviderAccount(
             provider: .codex,
             accountId: wire.account_id ?? fallbackAccountId
@@ -154,7 +162,7 @@ public struct CodexUsageAdapter: ProviderUsageAdapter {
     }
 
     static func readAuth(fromFileAt url: URL) throws -> CodexAuth {
-        guard let data = try? Data(contentsOf: url) else {
+        guard let data = readCappedCredentialData(at: url) else {
             throw UsageAdapterError.notInstalled
         }
         guard let file = try? JSONDecoder().decode(AuthFile.self, from: data),

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/CodexUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/CodexUsageAdapter.swift
@@ -1,0 +1,167 @@
+public import Foundation
+
+/// Codex / ChatGPT usage adapter.
+///
+/// Data path (proven 2026-07-23): `GET https://chatgpt.com/backend-api/codex/usage`
+/// with `Authorization: Bearer <access_token>` and `chatgpt-account-id: <account_id>`,
+/// both read read-only from `~/.codex/auth.json`. The endpoint anti-abuse-throttles
+/// repeated hits (observed 403), so the host fetches on demand and caches — this
+/// adapter performs exactly one request per call.
+public struct CodexUsageAdapter: ProviderUsageAdapter {
+    public let provider: UsageProvider = .codex
+
+    private let authFileURL: URL
+    private let session: URLSession
+    private let now: @Sendable () -> Date
+
+    public init(
+        authFileURL: URL? = nil,
+        session: URLSession = .shared,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.authFileURL = authFileURL
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".codex/auth.json")
+        self.session = session
+        self.now = now
+    }
+
+    public func fetchUsage() async throws -> UsageSnapshot {
+        let auth = try Self.readAuth(fromFileAt: authFileURL)
+
+        var request = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/codex/usage")!)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(auth.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue(auth.accountId, forHTTPHeaderField: "chatgpt-account-id")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw UsageAdapterError.malformedResponse
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw UsageAdapterError.malformedResponse
+        }
+        switch http.statusCode {
+        case 200..<300:
+            break
+        case 401:
+            throw UsageAdapterError.signedOut
+        case 403, 429:
+            throw UsageAdapterError.rateLimited
+        default:
+            throw UsageAdapterError.httpStatus(http.statusCode)
+        }
+        guard data.count <= UsageHTTP.maxResponseBytes else {
+            throw UsageAdapterError.malformedResponse
+        }
+
+        return try Self.parseUsage(data, fallbackAccountId: auth.accountId, now: now())
+    }
+
+    // MARK: - Pure parsing (no I/O — unit-testable against the real wire schema)
+
+    /// Wire schema for the Codex usage endpoint. Only the fields the HUD needs are
+    /// modeled; unknown fields are ignored, missing fields decode to `nil`, and a
+    /// shape that doesn't decode throws `malformedResponse` (fail-closed).
+    private struct Wire: Decodable {
+        struct Window: Decodable {
+            let used_percent: Double?
+            let limit_window_seconds: Int?
+            let reset_after_seconds: Int?
+            let reset_at: Double?
+        }
+        struct RateLimit: Decodable {
+            let primary_window: Window?
+            let secondary_window: Window?
+        }
+        struct Credits: Decodable {
+            let has_credits: Bool?
+            let unlimited: Bool?
+            let balance: Double?
+        }
+        let account_id: String?
+        let plan_type: String?
+        let rate_limit: RateLimit?
+        let credits: Credits?
+    }
+
+    static func parseUsage(
+        _ data: Data,
+        fallbackAccountId: String,
+        now: Date
+    ) throws -> UsageSnapshot {
+        let wire: Wire
+        do {
+            wire = try JSONDecoder().decode(Wire.self, from: data)
+        } catch {
+            throw UsageAdapterError.malformedResponse
+        }
+
+        var windows: [UsageWindow] = []
+        for window in [wire.rate_limit?.primary_window, wire.rate_limit?.secondary_window] {
+            guard let window else { continue }
+            // A window is only meaningful if it carries a length.
+            guard let seconds = window.limit_window_seconds else { continue }
+            let resetAt: Date? = window.reset_at.map { Date(timeIntervalSince1970: $0) }
+                ?? window.reset_after_seconds.map { now.addingTimeInterval(TimeInterval($0)) }
+            windows.append(
+                UsageWindow(
+                    kind: .rolling(seconds: seconds),
+                    usedPercent: window.used_percent,
+                    resetAt: resetAt
+                )
+            )
+        }
+
+        if let credits = wire.credits, credits.has_credits == true, credits.unlimited != true,
+           let balance = credits.balance {
+            windows.append(UsageWindow(kind: .credits, creditsRemaining: balance))
+        }
+
+        let account = ProviderAccount(
+            provider: .codex,
+            accountId: wire.account_id ?? fallbackAccountId
+        )
+        return UsageSnapshot(
+            account: account,
+            planLabel: wire.plan_type,
+            windows: windows,
+            freshness: .live(now),
+            fetchedAt: now
+        )
+    }
+
+    // MARK: - Read-only credential access (never written, never logged)
+
+    struct CodexAuth: Sendable {
+        let accessToken: String
+        let accountId: String
+    }
+
+    private struct AuthFile: Decodable {
+        struct Tokens: Decodable {
+            let access_token: String?
+            let account_id: String?
+        }
+        let tokens: Tokens?
+    }
+
+    static func readAuth(fromFileAt url: URL) throws -> CodexAuth {
+        guard let data = try? Data(contentsOf: url) else {
+            throw UsageAdapterError.notInstalled
+        }
+        guard let file = try? JSONDecoder().decode(AuthFile.self, from: data),
+              let token = file.tokens?.access_token, !token.isEmpty,
+              let accountId = file.tokens?.account_id, !accountId.isEmpty else {
+            throw UsageAdapterError.signedOut
+        }
+        return CodexAuth(accessToken: token, accountId: accountId)
+    }
+}

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/GrokUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/GrokUsageAdapter.swift
@@ -1,0 +1,119 @@
+public import Foundation
+
+/// Grok usage adapter.
+///
+/// Grok's proxy has no dedicated usage endpoint, but — like Claude — a real inference
+/// call returns quota in `x-ratelimit-*` response headers (remaining/limit tokens and
+/// requests; no reset epoch). The proxy gates inference on an `x-grok-client-version`
+/// header (426 without it). The bearer key is read read-only from `~/.grok/auth.json`.
+/// One minimal call per fetch; the host polls on demand and caches.
+public struct GrokUsageAdapter: ProviderUsageAdapter {
+    public let provider: UsageProvider = .grok
+
+    private let authFileURL: URL
+    private let clientVersion: String
+    private let session: URLSession
+    private let now: @Sendable () -> Date
+
+    public init(
+        authFileURL: URL? = nil,
+        clientVersion: String = "0.2.22",
+        session: URLSession = .shared,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.authFileURL = authFileURL
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".grok/auth.json")
+        self.clientVersion = clientVersion
+        self.session = session
+        self.now = now
+    }
+
+    public func fetchUsage() async throws -> UsageSnapshot {
+        let auth = try Self.readAuth(fromFileAt: authFileURL)
+
+        var request = URLRequest(url: URL(string: "https://cli-chat-proxy.grok.com/v1/responses")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(auth.key)", forHTTPHeaderField: "Authorization")
+        request.setValue(clientVersion, forHTTPHeaderField: "x-grok-client-version")
+        request.setValue("grok-cli", forHTTPHeaderField: "x-grok-client-identifier")
+        if let userId = auth.userId { request.setValue(userId, forHTTPHeaderField: "x-grok-user-id") }
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "model": "grok-4.5",
+            "input": "hi",
+            "max_output_tokens": 1,
+        ])
+
+        let response: URLResponse
+        do {
+            (_, response) = try await session.data(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw UsageAdapterError.malformedResponse
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw UsageAdapterError.malformedResponse
+        }
+        switch http.statusCode {
+        case 200..<300: break
+        case 401, 403: throw UsageAdapterError.signedOut
+        case 429: throw UsageAdapterError.rateLimited
+        default: throw UsageAdapterError.httpStatus(http.statusCode)
+        }
+        return try Self.parseUsage(headers: ClaudeUsageAdapter.normalizedHeaders(http), now: now())
+    }
+
+    // MARK: - Pure parsing (no I/O — unit-testable against captured headers)
+
+    static func parseUsage(headers: [String: String], now: Date) throws -> UsageSnapshot {
+        func number(_ key: String) -> Double? { headers[key].flatMap(Double.init) }
+
+        var windows: [UsageWindow] = []
+        let specs: [(unit: String, remaining: String, limit: String)] = [
+            ("tokens", "x-ratelimit-remaining-tokens", "x-ratelimit-limit-tokens"),
+            ("requests", "x-ratelimit-remaining-requests", "x-ratelimit-limit-requests"),
+        ]
+        for spec in specs {
+            guard let remaining = number(spec.remaining),
+                  let limit = number(spec.limit), limit > 0 else { continue }
+            let used = max(0, min(100, (1 - remaining / limit) * 100))
+            windows.append(
+                UsageWindow(kind: .quota(unit: spec.unit), usedPercent: used, remaining: remaining, limit: limit)
+            )
+        }
+        guard !windows.isEmpty else { throw UsageAdapterError.malformedResponse }
+
+        return UsageSnapshot(
+            account: ProviderAccount(provider: .grok, accountId: "default"),
+            windows: windows,
+            freshness: .live(now),
+            fetchedAt: now
+        )
+    }
+
+    // MARK: - Read-only credential access
+
+    struct GrokAuth: Sendable {
+        let key: String
+        let userId: String?
+    }
+
+    static func readAuth(fromFileAt url: URL) throws -> GrokAuth {
+        guard let data = try? Data(contentsOf: url) else {
+            throw UsageAdapterError.notInstalled
+        }
+        // auth.json is keyed by "<issuer>::<id>" → object with .key / .user_id.
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw UsageAdapterError.signedOut
+        }
+        for value in root.values {
+            if let entry = value as? [String: Any],
+               let key = entry["key"] as? String, !key.isEmpty {
+                return GrokAuth(key: key, userId: entry["user_id"] as? String)
+            }
+        }
+        throw UsageAdapterError.signedOut
+    }
+}

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/GrokUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/GrokUsageAdapter.swift
@@ -100,18 +100,25 @@ public struct GrokUsageAdapter: ProviderUsageAdapter {
         let userId: String?
     }
 
+    /// auth.json is keyed by "<issuer>::<id>" → object carrying `.key` / `.user_id`.
+    /// Strict `Decodable` shape (fail-closed on drift), size-capped, and — when more than
+    /// one issuer entry is present — deterministic: entries are selected in sorted-key
+    /// order so the chosen account never depends on dictionary iteration order.
+    private struct AuthEntry: Decodable {
+        let key: String?
+        let user_id: String?
+    }
+
     static func readAuth(fromFileAt url: URL) throws -> GrokAuth {
-        guard let data = try? Data(contentsOf: url) else {
+        guard let data = readCappedCredentialData(at: url) else {
             throw UsageAdapterError.notInstalled
         }
-        // auth.json is keyed by "<issuer>::<id>" → object with .key / .user_id.
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        guard let root = try? JSONDecoder().decode([String: AuthEntry].self, from: data) else {
             throw UsageAdapterError.signedOut
         }
-        for value in root.values {
-            if let entry = value as? [String: Any],
-               let key = entry["key"] as? String, !key.isEmpty {
-                return GrokAuth(key: key, userId: entry["user_id"] as? String)
+        for issuerKey in root.keys.sorted() {
+            if let entry = root[issuerKey], let key = entry.key, !key.isEmpty {
+                return GrokAuth(key: key, userId: entry.user_id)
             }
         }
         throw UsageAdapterError.signedOut

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ProviderUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ProviderUsageAdapter.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Fetches a usage snapshot for one provider account.
+///
+/// Adapters are `Sendable` and hold no mutable state; the freshness/rotation
+/// invariant is a package-wide contract: an adapter **never writes or refreshes a
+/// credential**. It reads whatever the provider CLI last persisted (read-only) and
+/// calls the provider's own usage endpoint, or shells out to a CLI usage command.
+public protocol ProviderUsageAdapter: Sendable {
+    var provider: UsageProvider { get }
+    func fetchUsage() async throws -> UsageSnapshot
+}
+
+/// Shared HTTP ceiling so a hostile/oversized response can't exhaust memory
+/// (Temper F-T3: all network bodies are untrusted input).
+enum UsageHTTP {
+    /// Reject any usage response larger than this before decoding.
+    static let maxResponseBytes = 256 * 1024
+}

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ProviderUsageAdapter.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/ProviderUsageAdapter.swift
@@ -16,4 +16,16 @@ public protocol ProviderUsageAdapter: Sendable {
 enum UsageHTTP {
     /// Reject any usage response larger than this before decoding.
     static let maxResponseBytes = 256 * 1024
+    /// Reject any credential file larger than this before parsing (all auth files are
+    /// untrusted input; the same fail-closed ceiling applies on every adapter, not just
+    /// Claude — a corrupt/oversized `auth.json` must not force an unbounded allocation).
+    static let maxCredentialFileBytes = 1024 * 1024
+}
+
+/// Read a credential file read-only with a size ceiling, failing closed (`nil`) on a
+/// missing or oversized file. Shared so every adapter's auth path caps identically.
+func readCappedCredentialData(at url: URL) -> Data? {
+    guard let data = try? Data(contentsOf: url),
+          data.count <= UsageHTTP.maxCredentialFileBytes else { return nil }
+    return data
 }

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageFetcher.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageFetcher.swift
@@ -1,0 +1,78 @@
+public import Foundation
+
+/// Maps a provider to its default-configured adapter. Providers without a usable
+/// usage surface (Gemini's unlimited tier, Kimi pending) return `nil` for now.
+public enum UsageProviderRegistry {
+    public static func adapter(for provider: UsageProvider) -> (any ProviderUsageAdapter)? {
+        switch provider {
+        case .codex: return CodexUsageAdapter()
+        case .claude: return ClaudeUsageAdapter()
+        case .grok: return GrokUsageAdapter()
+        case .gemini, .kimi: return nil
+        }
+    }
+
+    /// Providers that currently expose a usable live gauge.
+    public static let gaugeable: [UsageProvider] = [.claude, .codex, .grok]
+}
+
+/// Orchestrates one on-demand fetch per provider, mapping adapter errors to a
+/// `UsageSnapshot` with the appropriate `UsageFreshness` (never throws to the UI).
+public struct UsageFetcher: Sendable {
+    private let adapterFor: @Sendable (UsageProvider) -> (any ProviderUsageAdapter)?
+    private let now: @Sendable () -> Date
+
+    public init(
+        adapterFor: @escaping @Sendable (UsageProvider) -> (any ProviderUsageAdapter)? = {
+            UsageProviderRegistry.adapter(for: $0)
+        },
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.adapterFor = adapterFor
+        self.now = now
+    }
+
+    /// Fetch one provider. Returns a snapshot whose `freshness` encodes success or the
+    /// failure reason; `lastKnown` (if any) is preserved on a soft failure.
+    public func fetch(_ provider: UsageProvider, lastKnown: UsageSnapshot? = nil) async -> UsageSnapshot {
+        guard let adapter = adapterFor(provider) else {
+            return unsupported(provider)
+        }
+        do {
+            return try await adapter.fetchUsage()
+        } catch let error as UsageAdapterError {
+            return degraded(provider, error: error, lastKnown: lastKnown)
+        } catch is CancellationError {
+            return lastKnown ?? unsupported(provider)
+        } catch {
+            return degraded(provider, error: .malformedResponse, lastKnown: lastKnown)
+        }
+    }
+
+    private func degraded(_ provider: UsageProvider, error: UsageAdapterError, lastKnown: UsageSnapshot?) -> UsageSnapshot {
+        let freshness: UsageFreshness
+        switch error {
+        case .signedOut: freshness = .signedOut
+        case .notInstalled: freshness = .notInstalled
+        case .unsupported: freshness = .unsupported
+        case .rateLimited: freshness = .rateLimited(until: now().addingTimeInterval(30 * 60))
+        case .httpStatus, .malformedResponse: freshness = .stale(since: lastKnown?.fetchedAt)
+        }
+        return UsageSnapshot(
+            account: lastKnown?.account ?? ProviderAccount(provider: provider, accountId: "default"),
+            planLabel: lastKnown?.planLabel,
+            windows: lastKnown?.windows ?? [],
+            freshness: freshness,
+            fetchedAt: now()
+        )
+    }
+
+    private func unsupported(_ provider: UsageProvider) -> UsageSnapshot {
+        UsageSnapshot(
+            account: ProviderAccount(provider: provider, accountId: "default"),
+            windows: [],
+            freshness: .unsupported,
+            fetchedAt: now()
+        )
+    }
+}

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageModels.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageModels.swift
@@ -1,0 +1,126 @@
+public import Foundation
+
+/// The AI providers whose usage the HUD can surface. Raw values match
+/// `RestorableAgentKind.rawValue` in the host app so a live agent surface can be
+/// mapped to a provider without a translation table.
+public enum UsageProvider: String, Sendable, CaseIterable, Hashable {
+    case claude
+    case codex
+    case grok
+    case kimi
+    case gemini
+
+    /// Human-facing name; localized by the host app at the view layer.
+    public var displayName: String {
+        switch self {
+        case .claude: return "Claude"
+        case .codex: return "Codex"
+        case .grok: return "Grok"
+        case .kimi: return "Kimi"
+        case .gemini: return "Gemini"
+        }
+    }
+}
+
+/// One rolling quota window (or a credit balance) reported by a provider.
+public struct UsageWindow: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        /// A rolling window of `seconds` length (e.g. 18000 = 5h, 604800 = 7d).
+        case rolling(seconds: Int)
+        /// A monetary/credit balance rather than a time window.
+        case credits
+    }
+
+    public var kind: Kind
+    /// 0…100, `nil` when the provider only exposes a credit balance.
+    public var usedPercent: Double?
+    /// Absolute instant this window resets, if the provider reports one.
+    public var resetAt: Date?
+    /// Remaining credits for `.credits` windows, if reported.
+    public var creditsRemaining: Double?
+
+    public init(
+        kind: Kind,
+        usedPercent: Double? = nil,
+        resetAt: Date? = nil,
+        creditsRemaining: Double? = nil
+    ) {
+        self.kind = kind
+        self.usedPercent = usedPercent
+        self.resetAt = resetAt
+        self.creditsRemaining = creditsRemaining
+    }
+}
+
+/// Identity of a single provider account (a provider may in principle have more
+/// than one). `id` is stable across fetches so the HUD can key snapshots by it.
+public struct ProviderAccount: Sendable, Equatable, Hashable {
+    public var provider: UsageProvider
+    /// Provider-scoped account identifier (never a token or secret).
+    public var accountId: String
+    /// Optional label the provider surfaces (email, plan owner, …). Non-secret.
+    public var displayLabel: String?
+
+    public init(provider: UsageProvider, accountId: String, displayLabel: String? = nil) {
+        self.provider = provider
+        self.accountId = accountId
+        self.displayLabel = displayLabel
+    }
+}
+
+/// How trustworthy/current a snapshot is. Drives the HUD's per-row badge.
+public enum UsageFreshness: Sendable, Equatable {
+    /// Fetched successfully at the given instant.
+    case live(Date)
+    /// Showing a prior value; the current token is expired and its CLI is idle.
+    case stale(since: Date?)
+    /// The provider is installed but not signed in (no usable credential).
+    case signedOut
+    /// The provider CLI isn't installed on this machine.
+    case notInstalled
+    /// The provider exposes no usage/limits surface cmux can read.
+    case unsupported
+    /// The provider is rate-limiting; do not poll again before `until`.
+    case rateLimited(until: Date)
+}
+
+/// Immutable, `Sendable` snapshot of one account's usage. The HUD only ever holds
+/// value copies of these — never a reference to a mutable store below a list boundary.
+public struct UsageSnapshot: Sendable, Equatable {
+    public var account: ProviderAccount
+    /// Provider plan label (e.g. "plus", "max"), if reported. Non-secret.
+    public var planLabel: String?
+    public var windows: [UsageWindow]
+    public var freshness: UsageFreshness
+    public var fetchedAt: Date
+
+    public init(
+        account: ProviderAccount,
+        planLabel: String? = nil,
+        windows: [UsageWindow],
+        freshness: UsageFreshness,
+        fetchedAt: Date
+    ) {
+        self.account = account
+        self.planLabel = planLabel
+        self.windows = windows
+        self.freshness = freshness
+        self.fetchedAt = fetchedAt
+    }
+}
+
+/// Errors an adapter can raise. Kept coarse; callers map to `UsageFreshness`.
+public enum UsageAdapterError: Error, Sendable, Equatable {
+    /// No usable credential found (file/keychain absent or token unreadable).
+    case signedOut
+    /// The provider isn't installed on this machine.
+    case notInstalled
+    /// HTTP call failed with a status code.
+    case httpStatus(Int)
+    /// The provider is rate-limiting (HTTP 429/403 on a usage endpoint).
+    case rateLimited
+    /// Response body did not match the expected schema (hostile-input guard).
+    case malformedResponse
+    /// This provider has no readable usage surface.
+    case unsupported
+}

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageModels.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageModels.swift
@@ -26,29 +26,41 @@ public enum UsageProvider: String, Sendable, CaseIterable, Hashable {
 public struct UsageWindow: Sendable, Equatable {
     public enum Kind: Sendable, Equatable {
         /// A rolling window of `seconds` length (e.g. 18000 = 5h, 604800 = 7d).
+        /// Used by Codex (`limit_window_seconds`) and Claude (`5h`/`7d`).
         case rolling(seconds: Int)
-        /// A monetary/credit balance rather than a time window.
+        /// A monetary/credit balance rather than a time window (Codex credits).
         case credits
+        /// A remaining/limit quota with no time window or reset (Grok tokens/requests).
+        /// `unit` is a display hint like "tokens" or "requests".
+        case quota(unit: String)
     }
 
     public var kind: Kind
-    /// 0…100, `nil` when the provider only exposes a credit balance.
+    /// 0…100, `nil` when the provider only exposes a raw balance.
     public var usedPercent: Double?
     /// Absolute instant this window resets, if the provider reports one.
     public var resetAt: Date?
     /// Remaining credits for `.credits` windows, if reported.
     public var creditsRemaining: Double?
+    /// Remaining count for `.quota` windows (e.g. tokens/requests left).
+    public var remaining: Double?
+    /// Total limit for `.quota` windows.
+    public var limit: Double?
 
     public init(
         kind: Kind,
         usedPercent: Double? = nil,
         resetAt: Date? = nil,
-        creditsRemaining: Double? = nil
+        creditsRemaining: Double? = nil,
+        remaining: Double? = nil,
+        limit: Double? = nil
     ) {
         self.kind = kind
         self.usedPercent = usedPercent
         self.resetAt = resetAt
         self.creditsRemaining = creditsRemaining
+        self.remaining = remaining
+        self.limit = limit
     }
 }
 

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageStore.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageStore.swift
@@ -34,15 +34,30 @@ public final class UsageStore: ObservableObject {
     /// than throwing.
     public func refresh(_ provider: UsageProvider, force: Bool = false) async {
         guard !inFlight.contains(provider) else { return }
-        if !force, let last = lastAttemptAt[provider],
-           now().timeIntervalSince(last) < minInterval {
-            return
+        if !force {
+            if let last = lastAttemptAt[provider], now().timeIntervalSince(last) < minInterval {
+                return
+            }
+            // Honor a provider's rate-limit backoff. `.rateLimited(until:)` is a real
+            // fence, not a decorative label: re-poking a throttled endpoint before `until`
+            // is itself the abuse the provider is guarding against (the check is the poke).
+            if case .rateLimited(let until)? = snapshots[provider]?.freshness, now() < until {
+                return
+            }
         }
         inFlight.insert(provider)
         lastAttemptAt[provider] = now()
         defer { inFlight.remove(provider) }
 
         let snapshot = await fetcher.fetch(provider, lastKnown: snapshots[provider])
+        // A cancelled fetch (view disappeared / sidebar rebuilt) is silence, not a
+        // provider state. Do not stamp `.unsupported`/last-known over the cache, and
+        // clear the attempt marker so the next appearance can retry immediately instead
+        // of being blocked by `minInterval` for a fetch that never actually happened.
+        if Task.isCancelled {
+            lastAttemptAt[provider] = nil
+            return
+        }
         snapshots[provider] = snapshot
     }
 

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageStore.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageStore.swift
@@ -1,0 +1,58 @@
+public import Foundation
+public import Combine
+
+/// On-demand usage cache the HUD observes. **No background timer** (Temper F-T4): callers
+/// trigger `refresh` on explicit user action (panel open, active-provider change, tap).
+/// Each provider is fetched at most once per `minInterval` and never concurrently.
+@MainActor
+public final class UsageStore: ObservableObject {
+    /// Latest snapshot per provider. UI reads value copies only.
+    @Published public private(set) var snapshots: [UsageProvider: UsageSnapshot] = [:]
+
+    private let fetcher: UsageFetcher
+    private let minInterval: TimeInterval
+    private let now: @Sendable () -> Date
+    private var inFlight: Set<UsageProvider> = []
+    private var lastAttemptAt: [UsageProvider: Date] = [:]
+
+    public init(
+        fetcher: UsageFetcher = UsageFetcher(),
+        minInterval: TimeInterval = 30,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.fetcher = fetcher
+        self.minInterval = minInterval
+        self.now = now
+    }
+
+    public func snapshot(for provider: UsageProvider) -> UsageSnapshot? {
+        snapshots[provider]
+    }
+
+    /// Refresh one provider on demand. Skips if a fetch is in flight or the last attempt
+    /// was within `minInterval` (unless `force`). Failures degrade the snapshot rather
+    /// than throwing.
+    public func refresh(_ provider: UsageProvider, force: Bool = false) async {
+        guard !inFlight.contains(provider) else { return }
+        if !force, let last = lastAttemptAt[provider],
+           now().timeIntervalSince(last) < minInterval {
+            return
+        }
+        inFlight.insert(provider)
+        lastAttemptAt[provider] = now()
+        defer { inFlight.remove(provider) }
+
+        let snapshot = await fetcher.fetch(provider, lastKnown: snapshots[provider])
+        snapshots[provider] = snapshot
+    }
+
+    /// Refresh several providers (e.g. when the panel opens). Each `refresh` awaits its
+    /// network fetch, so the MainActor is free between suspensions and the fetches overlap.
+    public func refresh(_ providers: [UsageProvider], force: Bool = false) async {
+        await withTaskGroup(of: Void.self) { group in
+            for provider in providers {
+                group.addTask { await self.refresh(provider, force: force) }
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageViews.swift
+++ b/Packages/macOS/CmuxUsage/Sources/CmuxUsage/UsageViews.swift
@@ -1,0 +1,194 @@
+public import SwiftUI
+
+/// Immutable display model for the footer tile. The app builds this from a
+/// `UsageSnapshot` (resolving the active provider) and passes localized strings in —
+/// the view holds no store reference (snapshot-boundary safe).
+public struct UsageTileModel: Equatable, Sendable {
+    public enum State: Sendable, Equatable { case ok, degraded, unavailable }
+
+    public var providerName: String
+    public var iconAssetName: String?
+    /// Primary window utilization 0…100, or nil when there's no gauge (credits/quota-only/unlimited).
+    public var usedPercent: Double?
+    /// Compact trailing text, already localized (e.g. "3h", "59%", "Unlimited").
+    public var detail: String
+    public var state: State
+
+    public init(providerName: String, iconAssetName: String?, usedPercent: Double?, detail: String, state: State) {
+        self.providerName = providerName
+        self.iconAssetName = iconAssetName
+        self.usedPercent = usedPercent
+        self.detail = detail
+        self.state = state
+    }
+}
+
+/// A compact footer chip: optional provider icon + a thin utilization ring + detail text.
+public struct UsageFooterTile: View {
+    private let model: UsageTileModel
+    private let onTap: () -> Void
+    @State private var isHovered = false
+
+    public init(model: UsageTileModel, onTap: @escaping () -> Void) {
+        self.model = model
+        self.onTap = onTap
+    }
+
+    public var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 4) {
+                if let usedPercent = model.usedPercent {
+                    UsageRing(percent: usedPercent)
+                        .frame(width: 12, height: 12)
+                }
+                Text(model.detail)
+                    .font(.system(size: 11, weight: .medium))
+                    .monospacedDigit()
+                    .foregroundStyle(model.state == .unavailable
+                        ? Color(nsColor: .tertiaryLabelColor)
+                        : Color(nsColor: .secondaryLabelColor))
+            }
+            .padding(.horizontal, 6)
+            .frame(height: 22)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.primary.opacity(isHovered ? 0.08 : 0))
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.15)) { isHovered = hovering }
+        }
+        .accessibilityLabel("\(model.providerName): \(model.detail)")
+    }
+}
+
+/// A thin circular utilization gauge (no house style existed to conflict with).
+public struct UsageRing: View {
+    private let percent: Double
+    public init(percent: Double) { self.percent = percent }
+
+    private var fraction: Double { max(0, min(1, percent / 100)) }
+    private var tint: Color {
+        switch fraction {
+        case ..<0.75: return .green
+        case ..<0.9: return .orange
+        default: return .red
+        }
+    }
+
+    public var body: some View {
+        ZStack {
+            Circle().stroke(Color.primary.opacity(0.15), lineWidth: 2)
+            Circle()
+                .trim(from: 0, to: fraction)
+                .stroke(tint, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+    }
+}
+
+/// One row in the multi-account panel: a provider account and its windows.
+public struct UsageAccountRowModel: Identifiable, Equatable, Sendable {
+    public struct Bar: Equatable, Sendable {
+        public var label: String        // localized, e.g. "5h" / "Weekly" / "Tokens"
+        public var usedPercent: Double?
+        public var detail: String       // localized, e.g. "resets in 3h" / "53M left"
+        public init(label: String, usedPercent: Double?, detail: String) {
+            self.label = label; self.usedPercent = usedPercent; self.detail = detail
+        }
+    }
+    public var id: String
+    public var providerName: String
+    public var iconAssetName: String?
+    public var statusLabel: String      // localized freshness/plan, e.g. "Max · live" / "Unlimited"
+    public var bars: [Bar]
+    public init(id: String, providerName: String, iconAssetName: String?, statusLabel: String, bars: [Bar]) {
+        self.id = id; self.providerName = providerName; self.iconAssetName = iconAssetName
+        self.statusLabel = statusLabel; self.bars = bars
+    }
+}
+
+/// Multi-account usage panel (popover body). Pure value-driven; no store reference.
+public struct UsageLimitsPanel: View {
+    private let title: String
+    private let rows: [UsageAccountRowModel]
+    private let emptyMessage: String
+
+    public init(title: String, rows: [UsageAccountRowModel], emptyMessage: String) {
+        self.title = title
+        self.rows = rows
+        self.emptyMessage = emptyMessage
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title).font(.system(size: 12, weight: .semibold))
+            if rows.isEmpty {
+                Text(emptyMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            } else {
+                ForEach(rows) { row in
+                    UsageAccountRow(row: row)
+                }
+            }
+        }
+        .padding(12)
+        .frame(minWidth: 260)
+    }
+}
+
+private struct UsageAccountRow: View {
+    let row: UsageAccountRowModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(row.providerName).font(.system(size: 12, weight: .medium))
+                Spacer(minLength: 8)
+                Text(row.statusLabel)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+            }
+            ForEach(Array(row.bars.enumerated()), id: \.offset) { _, bar in
+                HStack(spacing: 6) {
+                    Text(bar.label).font(.system(size: 10)).frame(width: 52, alignment: .leading)
+                    UsageBar(percent: bar.usedPercent)
+                    Text(bar.detail)
+                        .font(.system(size: 10)).monospacedDigit()
+                        .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                        .frame(width: 76, alignment: .trailing)
+                }
+            }
+        }
+    }
+}
+
+/// A thin horizontal utilization bar; renders a neutral track when percent is nil.
+public struct UsageBar: View {
+    private let percent: Double?
+    public init(percent: Double?) { self.percent = percent }
+
+    private var fraction: Double { max(0, min(1, (percent ?? 0) / 100)) }
+    private var tint: Color {
+        switch fraction {
+        case ..<0.75: return .green
+        case ..<0.9: return .orange
+        default: return .red
+        }
+    }
+
+    public var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.primary.opacity(0.12))
+                if percent != nil {
+                    Capsule().fill(tint).frame(width: geo.size.width * fraction)
+                }
+            }
+        }
+        .frame(height: 5)
+    }
+}

--- a/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/CodexUsageAdapterTests.swift
+++ b/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/CodexUsageAdapterTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import CmuxUsage
+
+struct CodexUsageAdapterTests {
+    /// The real wire shape observed from `backend-api/codex/usage` (ids redacted).
+    private static let realResponse = """
+    {
+      "user_id": "user-REDACTED",
+      "account_id": "user-REDACTED",
+      "email": "redacted@example.com",
+      "plan_type": "plus",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": 1,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 509867,
+          "reset_at": 1785278338
+        },
+        "secondary_window": null
+      },
+      "code_review_rate_limit": null,
+      "additional_rate_limits": null,
+      "credits": {
+        "has_credits": true,
+        "unlimited": false,
+        "overage_limit_reached": false,
+        "balance": 12.5
+      }
+    }
+    """.data(using: .utf8)!
+
+    @Test func parsesPrimaryWindowAndCredits() throws {
+        let now = Date(timeIntervalSince1970: 1_784_768_471)
+        let snapshot = try CodexUsageAdapter.parseUsage(
+            Self.realResponse, fallbackAccountId: "fallback", now: now
+        )
+
+        #expect(snapshot.planLabel == "plus")
+        #expect(snapshot.account.provider == .codex)
+
+        // Weekly rolling window at 1% used, resetting at the reported epoch.
+        let rolling = snapshot.windows.first { window in
+            if case .rolling(let seconds) = window.kind { return seconds == 604800 }
+            return false
+        }
+        #expect(rolling != nil)
+        #expect(rolling?.usedPercent == 1)
+        #expect(rolling?.resetAt == Date(timeIntervalSince1970: 1_785_278_338))
+
+        // Credit balance surfaced as its own window.
+        let credits = snapshot.windows.first { $0.kind == .credits }
+        #expect(credits?.creditsRemaining == 12.5)
+
+        if case .live(let at) = snapshot.freshness {
+            #expect(at == now)
+        } else {
+            Issue.record("expected .live freshness")
+        }
+    }
+
+    @Test func fallsBackToResetAfterSecondsWhenNoAbsoluteReset() throws {
+        let now = Date(timeIntervalSince1970: 1000)
+        let data = """
+        {"rate_limit":{"primary_window":{"used_percent":40,"limit_window_seconds":18000,"reset_after_seconds":600}}}
+        """.data(using: .utf8)!
+        let snapshot = try CodexUsageAdapter.parseUsage(data, fallbackAccountId: "acct", now: now)
+        let window = try #require(snapshot.windows.first)
+        #expect(window.usedPercent == 40)
+        // 1000 + 600s = 1600
+        #expect(window.resetAt == Date(timeIntervalSince1970: 1600))
+        #expect(snapshot.account.accountId == "acct")
+    }
+
+    @Test func failsClosedOnMalformedJSON() {
+        let garbage = "not json at all <html>".data(using: .utf8)!
+        #expect(throws: UsageAdapterError.malformedResponse) {
+            _ = try CodexUsageAdapter.parseUsage(garbage, fallbackAccountId: "x", now: Date())
+        }
+    }
+
+    @Test func ignoresUnlimitedCredits() throws {
+        let data = """
+        {"plan_type":"pro","credits":{"has_credits":true,"unlimited":true,"balance":0}}
+        """.data(using: .utf8)!
+        let snapshot = try CodexUsageAdapter.parseUsage(data, fallbackAccountId: "x", now: Date())
+        #expect(snapshot.windows.allSatisfy { $0.kind != .credits })
+    }
+
+    @Test func readAuthReadsTokenAndAccount() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-usage-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("auth.json")
+        try """
+        {"auth_mode":"chatgpt","tokens":{"access_token":"tok-abc","account_id":"acct-123"}}
+        """.data(using: .utf8)!.write(to: file)
+
+        let auth = try CodexUsageAdapter.readAuth(fromFileAt: file)
+        #expect(auth.accessToken == "tok-abc")
+        #expect(auth.accountId == "acct-123")
+    }
+
+    @Test func readAuthThrowsSignedOutWhenTokenMissing() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-usage-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("auth.json")
+        try #"{"auth_mode":"chatgpt","tokens":{}}"#.data(using: .utf8)!.write(to: file)
+
+        #expect(throws: UsageAdapterError.signedOut) {
+            _ = try CodexUsageAdapter.readAuth(fromFileAt: file)
+        }
+    }
+
+    @Test func readAuthThrowsNotInstalledWhenFileAbsent() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-usage-absent-\(UUID().uuidString).json")
+        #expect(throws: UsageAdapterError.notInstalled) {
+            _ = try CodexUsageAdapter.readAuth(fromFileAt: missing)
+        }
+    }
+}

--- a/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/CodexUsageAdapterTests.swift
+++ b/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/CodexUsageAdapterTests.swift
@@ -124,4 +124,13 @@ struct CodexUsageAdapterTests {
             _ = try CodexUsageAdapter.readAuth(fromFileAt: missing)
         }
     }
+
+    @Test func parseUsageDegradesWhenNoUsageStructure() {
+        // Valid JSON but no rate_limit and no credits → not a live gauge; must degrade
+        // (fail-closed) rather than masquerade as `.live` with an empty window set.
+        let data = Data(#"{"account_id":"a","plan_type":"plus"}"#.utf8)
+        #expect(throws: UsageAdapterError.malformedResponse) {
+            _ = try CodexUsageAdapter.parseUsage(data, fallbackAccountId: "a", now: Date())
+        }
+    }
 }

--- a/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/HeaderAdapterTests.swift
+++ b/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/HeaderAdapterTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import CmuxUsage
+
+private func approx(_ a: Double?, _ b: Double, tol: Double = 1e-6) -> Bool {
+    guard let a else { return false }
+    return abs(a - b) < tol
+}
+
+struct ClaudeUsageAdapterTests {
+    /// Real `anthropic-ratelimit-unified-*` headers captured from a live /v1/messages call.
+    private static let headers: [String: String] = [
+        "anthropic-ratelimit-unified-status": "allowed",
+        "anthropic-ratelimit-unified-5h-status": "allowed",
+        "anthropic-ratelimit-unified-5h-reset": "1784947200",
+        "anthropic-ratelimit-unified-5h-utilization": "0.07",
+        "anthropic-ratelimit-unified-7d-status": "allowed",
+        "anthropic-ratelimit-unified-7d-reset": "1785200400",
+        "anthropic-ratelimit-unified-7d-utilization": "0.59",
+        "anthropic-organization-id": "org-abc",
+    ]
+
+    @Test func parsesFiveHourAndWeeklyWindows() throws {
+        let now = Date(timeIntervalSince1970: 1_784_940_000)
+        let snap = try ClaudeUsageAdapter.parseUsage(headers: Self.headers, now: now)
+        #expect(snap.account.provider == .claude)
+        #expect(snap.account.accountId == "org-abc")
+        #expect(snap.windows.count == 2)
+
+        let fiveHour = try #require(snap.windows.first { $0.kind == .rolling(seconds: 18000) })
+        #expect(approx(fiveHour.usedPercent, 7.0))
+        #expect(fiveHour.resetAt == Date(timeIntervalSince1970: 1_784_947_200))
+
+        let weekly = try #require(snap.windows.first { $0.kind == .rolling(seconds: 604800) })
+        #expect(approx(weekly.usedPercent, 59.0))
+        #expect(weekly.resetAt == Date(timeIntervalSince1970: 1_785_200_400))
+    }
+
+    @Test func failsClosedWhenNoUnifiedHeaders() {
+        #expect(throws: UsageAdapterError.malformedResponse) {
+            _ = try ClaudeUsageAdapter.parseUsage(headers: ["content-type": "application/json"], now: Date())
+        }
+    }
+
+    @Test func defaultsAccountWhenOrgHeaderAbsent() throws {
+        var h = Self.headers
+        h["anthropic-organization-id"] = nil
+        let snap = try ClaudeUsageAdapter.parseUsage(headers: h, now: Date())
+        #expect(snap.account.accountId == "default")
+    }
+}
+
+struct GrokUsageAdapterTests {
+    /// Real `x-ratelimit-*` headers captured from a live /v1/responses call.
+    private static func headers(remainingTokens: String, limitTokens: String) -> [String: String] {
+        [
+            "x-ratelimit-limit-tokens": limitTokens,
+            "x-ratelimit-remaining-tokens": remainingTokens,
+            "x-ratelimit-limit-requests": "8300",
+            "x-ratelimit-remaining-requests": "8300",
+        ]
+    }
+
+    @Test func parsesTokenAndRequestQuotasFull() throws {
+        let now = Date(timeIntervalSince1970: 1000)
+        let snap = try GrokUsageAdapter.parseUsage(
+            headers: Self.headers(remainingTokens: "53000000", limitTokens: "53000000"), now: now
+        )
+        #expect(snap.account.provider == .grok)
+        #expect(snap.windows.count == 2)
+
+        let tokens = try #require(snap.windows.first { $0.kind == .quota(unit: "tokens") })
+        #expect(approx(tokens.usedPercent, 0.0))
+        #expect(tokens.remaining == 53_000_000)
+        #expect(tokens.limit == 53_000_000)
+
+        let requests = try #require(snap.windows.first { $0.kind == .quota(unit: "requests") })
+        #expect(approx(requests.usedPercent, 0.0))
+    }
+
+    @Test func computesUsedPercentFromRemaining() throws {
+        let snap = try GrokUsageAdapter.parseUsage(
+            headers: Self.headers(remainingTokens: "26500000", limitTokens: "53000000"), now: Date()
+        )
+        let tokens = try #require(snap.windows.first { $0.kind == .quota(unit: "tokens") })
+        #expect(approx(tokens.usedPercent, 50.0))
+    }
+
+    @Test func failsClosedWhenNoRateLimitHeaders() {
+        #expect(throws: UsageAdapterError.malformedResponse) {
+            _ = try GrokUsageAdapter.parseUsage(headers: ["date": "now"], now: Date())
+        }
+    }
+
+    @Test func readAuthExtractsKeyFromIssuerKeyedEntry() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-grok-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("auth.json")
+        try """
+        {"https://auth.x.ai::abc":{"key":"grok-key-xyz","user_id":"u-123","auth_mode":"session"}}
+        """.data(using: .utf8)!.write(to: file)
+
+        let auth = try GrokUsageAdapter.readAuth(fromFileAt: file)
+        #expect(auth.key == "grok-key-xyz")
+        #expect(auth.userId == "u-123")
+    }
+}

--- a/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/HeaderAdapterTests.swift
+++ b/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/HeaderAdapterTests.swift
@@ -48,6 +48,81 @@ struct ClaudeUsageAdapterTests {
         let snap = try ClaudeUsageAdapter.parseUsage(headers: h, now: Date())
         #expect(snap.account.accountId == "default")
     }
+
+    // MARK: Token resolution (synthetic fixtures only — never a real token)
+
+    private static let fakeToken = "sk-ant-oat-FAKE000TESTONLY"
+
+    @Test func envFileParsesExportedToken() {
+        let data = Data("export CLAUDE_CODE_OAUTH_TOKEN=\(Self.fakeToken)\n".utf8)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(data) == Self.fakeToken)
+    }
+
+    @Test func envFileParsesBareAndQuotedAmongOtherLines() {
+        let bare = Data("FOO=1\nCLAUDE_CODE_OAUTH_TOKEN=\(Self.fakeToken)\nBAR=2\n".utf8)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(bare) == Self.fakeToken)
+        let quoted = Data("export CLAUDE_CODE_OAUTH_TOKEN=\"\(Self.fakeToken)\"\n".utf8)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(quoted) == Self.fakeToken)
+    }
+
+    @Test func envFileFailsClosedOnAbsentOrEmpty() {
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(nil) == nil)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(Data("OTHER=x\n".utf8)) == nil)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(Data("export CLAUDE_CODE_OAUTH_TOKEN=\n".utf8)) == nil)
+        // Oversized input is rejected (size cap).
+        let big = Data(("export CLAUDE_CODE_OAUTH_TOKEN=" + String(repeating: "a", count: ClaudeUsageAdapter.maxCredentialFileBytes + 1)).utf8)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(big) == nil)
+    }
+
+    @Test func credentialsJSONParsesAccessToken() {
+        let data = Data("{\"claudeAiOauth\":{\"accessToken\":\"\(Self.fakeToken)\"}}".utf8)
+        #expect(ClaudeUsageAdapter.tokenFromCredentialsJSON(data) == Self.fakeToken)
+    }
+
+    @Test func credentialsJSONFailsClosedOnDrift() {
+        #expect(ClaudeUsageAdapter.tokenFromCredentialsJSON(nil) == nil)
+        #expect(ClaudeUsageAdapter.tokenFromCredentialsJSON(Data("not json".utf8)) == nil)
+        #expect(ClaudeUsageAdapter.tokenFromCredentialsJSON(Data("{\"claudeAiOauth\":{}}".utf8)) == nil)
+        #expect(ClaudeUsageAdapter.tokenFromCredentialsJSON(Data("{\"claudeAiOauth\":{\"accessToken\":\"\"}}".utf8)) == nil)
+    }
+
+    @Test func resolveTokenPrefersEnvironmentThenFiles() {
+        let home = URL(fileURLWithPath: "/fake/home")
+        // Environment wins outright.
+        let fromEnv = ClaudeUsageAdapter.resolveToken(
+            environment: ["CLAUDE_CODE_OAUTH_TOKEN": Self.fakeToken],
+            homeDirectory: home,
+            readFile: { _ in Data("export CLAUDE_CODE_OAUTH_TOKEN=other".utf8) }
+        )
+        #expect(fromEnv == Self.fakeToken)
+
+        // No env → credentials.json used before .env.
+        let fromCreds = ClaudeUsageAdapter.resolveToken(
+            environment: [:],
+            homeDirectory: home,
+            readFile: { url in
+                url.lastPathComponent == ".credentials.json"
+                    ? Data("{\"claudeAiOauth\":{\"accessToken\":\"\(Self.fakeToken)\"}}".utf8)
+                    : Data("export CLAUDE_CODE_OAUTH_TOKEN=envfile".utf8)
+            }
+        )
+        #expect(fromCreds == Self.fakeToken)
+
+        // No env, no creds file → .env fallback.
+        let fromEnvFile = ClaudeUsageAdapter.resolveToken(
+            environment: [:],
+            homeDirectory: home,
+            readFile: { url in
+                url.lastPathComponent == ".env"
+                    ? Data("export CLAUDE_CODE_OAUTH_TOKEN=\(Self.fakeToken)".utf8)
+                    : nil
+            }
+        )
+        #expect(fromEnvFile == Self.fakeToken)
+
+        // Nothing anywhere → nil.
+        #expect(ClaudeUsageAdapter.resolveToken(environment: [:], homeDirectory: home, readFile: { _ in nil }) == nil)
+    }
 }
 
 struct GrokUsageAdapterTests {

--- a/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/HeaderAdapterTests.swift
+++ b/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/HeaderAdapterTests.swift
@@ -65,6 +65,15 @@ struct ClaudeUsageAdapterTests {
         #expect(ClaudeUsageAdapter.tokenFromEnvFile(quoted) == Self.fakeToken)
     }
 
+    @Test func envFileStripsTrailingCommentButKeepsBareHash() {
+        // ` # …` is a shell comment, not part of the value.
+        let commented = Data("export CLAUDE_CODE_OAUTH_TOKEN=\(Self.fakeToken) # my token\n".utf8)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(commented) == Self.fakeToken)
+        // A bare '#' with no preceding space is part of the value (shell semantics).
+        let hashy = Data("CLAUDE_CODE_OAUTH_TOKEN=abc#def\n".utf8)
+        #expect(ClaudeUsageAdapter.tokenFromEnvFile(hashy) == "abc#def")
+    }
+
     @Test func envFileFailsClosedOnAbsentOrEmpty() {
         #expect(ClaudeUsageAdapter.tokenFromEnvFile(nil) == nil)
         #expect(ClaudeUsageAdapter.tokenFromEnvFile(Data("OTHER=x\n".utf8)) == nil)
@@ -180,5 +189,20 @@ struct GrokUsageAdapterTests {
         let auth = try GrokUsageAdapter.readAuth(fromFileAt: file)
         #expect(auth.key == "grok-key-xyz")
         #expect(auth.userId == "u-123")
+    }
+
+    @Test func readAuthPicksDeterministicallyAcrossMultipleEntries() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-grok-multi-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("auth.json")
+        // Two issuer entries — selection must be sorted-key deterministic, never
+        // dictionary-iteration order ("aaa::1" < "zzz::2").
+        try #"{"zzz::2":{"key":"key-Z","user_id":"z"},"aaa::1":{"key":"key-A","user_id":"a"}}"#
+            .data(using: .utf8)!.write(to: file)
+        let auth = try GrokUsageAdapter.readAuth(fromFileAt: file)
+        #expect(auth.key == "key-A")
+        #expect(auth.userId == "a")
     }
 }

--- a/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/UsageStoreTests.swift
+++ b/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/UsageStoreTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import CmuxUsage
+
+private actor CallCounter {
+    private(set) var count = 0
+    func bump() { count += 1 }
+}
+
+private struct FakeAdapter: ProviderUsageAdapter {
+    let provider: UsageProvider
+    let counter: CallCounter
+    let result: Result<UsageSnapshot, UsageAdapterError>
+
+    func fetchUsage() async throws -> UsageSnapshot {
+        await counter.bump()
+        switch result {
+        case .success(let snapshot): return snapshot
+        case .failure(let error): throw error
+        }
+    }
+}
+
+private func sampleSnapshot(_ provider: UsageProvider) -> UsageSnapshot {
+    UsageSnapshot(
+        account: ProviderAccount(provider: provider, accountId: "acct"),
+        windows: [UsageWindow(kind: .rolling(seconds: 18000), usedPercent: 42)],
+        freshness: .live(Date(timeIntervalSince1970: 0)),
+        fetchedAt: Date(timeIntervalSince1970: 0)
+    )
+}
+
+struct UsageFetcherTests {
+    @Test func mapsSuccessThrough() async {
+        let counter = CallCounter()
+        let fetcher = UsageFetcher(adapterFor: { p in
+            FakeAdapter(provider: p, counter: counter, result: .success(sampleSnapshot(p)))
+        })
+        let snap = await fetcher.fetch(.codex)
+        #expect(snap.windows.first?.usedPercent == 42)
+        if case .live = snap.freshness {} else { Issue.record("expected live") }
+    }
+
+    @Test func mapsSignedOutError() async {
+        let counter = CallCounter()
+        let fetcher = UsageFetcher(adapterFor: { p in
+            FakeAdapter(provider: p, counter: counter, result: .failure(.signedOut))
+        })
+        let snap = await fetcher.fetch(.claude)
+        #expect(snap.freshness == .signedOut)
+    }
+
+    @Test func mapsRateLimitedWithUntil() async {
+        let now = Date(timeIntervalSince1970: 1000)
+        let counter = CallCounter()
+        let fetcher = UsageFetcher(
+            adapterFor: { p in FakeAdapter(provider: p, counter: counter, result: .failure(.rateLimited)) },
+            now: { now }
+        )
+        let snap = await fetcher.fetch(.grok)
+        #expect(snap.freshness == .rateLimited(until: now.addingTimeInterval(1800)))
+    }
+
+    @Test func unsupportedProviderReturnsUnsupported() async {
+        let snap = await UsageFetcher().fetch(.gemini)   // no adapter registered
+        #expect(snap.freshness == .unsupported)
+    }
+
+    @Test func softFailurePreservesLastKnownWindows() async {
+        let counter = CallCounter()
+        let fetcher = UsageFetcher(adapterFor: { p in
+            FakeAdapter(provider: p, counter: counter, result: .failure(.malformedResponse))
+        })
+        let previous = sampleSnapshot(.codex)
+        let snap = await fetcher.fetch(.codex, lastKnown: previous)
+        #expect(snap.windows.first?.usedPercent == 42)   // preserved
+        if case .stale = snap.freshness {} else { Issue.record("expected stale") }
+    }
+}
+
+@MainActor
+struct UsageStoreTests {
+    @Test func cachesWithinMinInterval() async {
+        let now = Date(timeIntervalSince1970: 5000)
+        let counter = CallCounter()
+        let fetcher = UsageFetcher(
+            adapterFor: { p in FakeAdapter(provider: p, counter: counter, result: .success(sampleSnapshot(p))) },
+            now: { now }
+        )
+        let store = UsageStore(fetcher: fetcher, minInterval: 30, now: { now })
+
+        await store.refresh(.codex)
+        await store.refresh(.codex)   // within interval → skipped
+        #expect(await counter.count == 1)
+        #expect(store.snapshot(for: .codex)?.windows.first?.usedPercent == 42)
+
+        await store.refresh(.codex, force: true)   // force bypasses interval
+        #expect(await counter.count == 2)
+    }
+}

--- a/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/UsageStoreTests.swift
+++ b/Packages/macOS/CmuxUsage/Tests/CmuxUsageTests/UsageStoreTests.swift
@@ -97,4 +97,49 @@ struct UsageStoreTests {
         await store.refresh(.codex, force: true)   // force bypasses interval
         #expect(await counter.count == 2)
     }
+
+    @Test func honorsRateLimitedUntilBeyondMinInterval() async {
+        let now = Date(timeIntervalSince1970: 5000)
+        let counter = CallCounter()
+        // Adapter throws rateLimited → fetcher maps to .rateLimited(until: now + 1800s).
+        let fetcher = UsageFetcher(
+            adapterFor: { p in FakeAdapter(provider: p, counter: counter, result: .failure(.rateLimited)) },
+            now: { now }
+        )
+        // minInterval 0 so the ONLY thing that can block the 2nd refresh is the
+        // rateLimited(until:) fence — proving the store honors it, not just minInterval.
+        let store = UsageStore(fetcher: fetcher, minInterval: 0, now: { now })
+
+        await store.refresh(.codex)
+        #expect(await counter.count == 1)
+        if case .rateLimited = store.snapshot(for: .codex)?.freshness {} else {
+            Issue.record("expected rateLimited snapshot")
+        }
+        await store.refresh(.codex)   // blocked by `until`, not re-poked
+        #expect(await counter.count == 1)
+        await store.refresh(.codex, force: true)   // force still overrides
+        #expect(await counter.count == 2)
+    }
+
+    @Test func cancelledFetchDoesNotPolluteSnapshotOrBlockRetry() async {
+        let now = Date(timeIntervalSince1970: 5000)
+        let counter = CallCounter()
+        let fetcher = UsageFetcher(
+            adapterFor: { p in FakeAdapter(provider: p, counter: counter, result: .success(sampleSnapshot(p))) },
+            now: { now }
+        )
+        // Large minInterval: if a cancelled attempt wrongly counted, the retry below
+        // would be blocked and the snapshot would stay nil / stale.
+        let store = UsageStore(fetcher: fetcher, minInterval: 9999, now: { now })
+
+        let task = Task { await store.refresh(.codex) }
+        task.cancel()   // flag set before the MainActor task body can run
+        await task.value
+
+        // Cancelled fetch must not have written a snapshot…
+        #expect(store.snapshot(for: .codex) == nil)
+        // …and must not have consumed the min-interval budget: a real refresh succeeds.
+        await store.refresh(.codex)
+        #expect(store.snapshot(for: .codex)?.windows.first?.usedPercent == 42)
+    }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -256463,6 +256463,244 @@
           }
         }
       }
+    },
+    "usage.panel.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage limits"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用状況の上限"
+          }
+        }
+      }
+    },
+    "usage.panel.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No usage data available yet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まだ使用状況データがありません。"
+          }
+        }
+      }
+    },
+    "usage.tile.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用状況"
+          }
+        }
+      }
+    },
+    "usage.window.credits": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Credits"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クレジット"
+          }
+        }
+      }
+    },
+    "usage.window.5h": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5h"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5時間"
+          }
+        }
+      }
+    },
+    "usage.window.weekly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekly"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "週間"
+          }
+        }
+      }
+    },
+    "usage.detail.remaining": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残り%@"
+          }
+        }
+      }
+    },
+    "usage.detail.resetsIn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "resets in %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@後にリセット"
+          }
+        }
+      }
+    },
+    "usage.state.live": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "live"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブ"
+          }
+        }
+      }
+    },
+    "usage.state.stale": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "stale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古い"
+          }
+        }
+      }
+    },
+    "usage.state.signedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "signed out"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインアウト"
+          }
+        }
+      }
+    },
+    "usage.state.notInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "not installed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未インストール"
+          }
+        }
+      }
+    },
+    "usage.state.unsupported": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no limits"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "制限なし"
+          }
+        }
+      }
+    },
+    "usage.state.rateLimited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "rate limited"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レート制限中"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14485,6 +14485,7 @@ struct SidebarFooterButtons: View {
     var body: some View {
         HStack(spacing: 4) {
             SidebarHelpMenuButton(onSendFeedback: onSendFeedback)
+            UsageFooterHost()
             SidebarProBadge()
             // The puzzle button opens the extensions browser; it only shows
             // while the experimental Extensions feature is enabled.

--- a/Sources/UsageFooterHost.swift
+++ b/Sources/UsageFooterHost.swift
@@ -1,0 +1,267 @@
+import CmuxAppKitSupportUI
+import CmuxUsage
+import SwiftUI
+
+/// Sidebar-footer entry point for the multi-provider usage HUD.
+///
+/// Owns the on-demand `UsageStore` (safe here: the footer is a direct child of the
+/// sidebar `HStack`, **not** a row below a `LazyVStack`/`List` boundary, so holding an
+/// `ObservableObject` does not violate cmux's snapshot-boundary law). The active provider
+/// is resolved off the body path (in `.task` and on tap) and cached in `@State`, so the
+/// footer adds no new `TabManager` observation and does no work in `body` on the
+/// typing-latency-sensitive path.
+///
+/// Fetching is user-driven only (appear + tap), matching the store's no-background-timer
+/// contract. Provider usage rides undocumented response headers for Claude/Grok — an
+/// unversioned side channel — so every failure degrades to a label, never a crash.
+struct UsageFooterHost: View {
+    @StateObject private var store = UsageStore()
+    @State private var isPanelPresented = false
+    /// Provider backing the focused agent surface, resolved off the body path (in `.task`
+    /// and on tap) — never during `body`, since resolving it calls into
+    /// `SharedLiveAgentIndex` which schedules refresh work, and this footer sits on a
+    /// typing-latency-sensitive path where body must stay side-effect free.
+    @State private var activeProvider: UsageProvider?
+
+    var body: some View {
+        let snapshot = activeProvider.flatMap { store.snapshot(for: $0) }
+        let tile = UsageDisplay.tileModel(provider: activeProvider, snapshot: snapshot)
+
+        UsageFooterTile(model: tile) {
+            let resolved = Self.resolveActiveProvider()
+            activeProvider = resolved
+            isPanelPresented.toggle()
+            Task { await store.refresh(UsageProviderRegistry.gaugeable) }
+        }
+        .background(ArrowlessPopoverAnchor(
+            isPresented: $isPanelPresented,
+            preferredEdge: .maxY,
+            detachedGap: 4
+        ) {
+            UsageLimitsPanel(
+                title: String(localized: "usage.panel.title", defaultValue: "Usage limits"),
+                rows: UsageDisplay.accountRows(from: store.snapshots),
+                emptyMessage: String(localized: "usage.panel.empty", defaultValue: "No usage data available yet.")
+            )
+        })
+        .task {
+            // Resolve + refresh the active provider on appear (off the body path). The panel
+            // refreshes the rest on open. The tile reflects focus as of appear/tap, not live
+            // focus churn — the multi-provider panel is the exhaustive surface.
+            let resolved = Self.resolveActiveProvider()
+            activeProvider = resolved
+            if let resolved { await store.refresh(resolved) }
+        }
+        .accessibilityIdentifier("SidebarUsageFooterTile")
+    }
+
+    /// Resolve the provider backing the currently focused agent surface, if any.
+    /// Calls into `SharedLiveAgentIndex` (which may schedule refresh work), so it is only
+    /// ever invoked from action/task closures, never from `body`.
+    @MainActor
+    static func resolveActiveProvider() -> UsageProvider? {
+        guard
+            let workspace = AppDelegate.shared?.tabManager?.selectedWorkspace,
+            let panelId = workspace.focusedPanelId,
+            let kind = SharedLiveAgentIndex.shared.snapshot(workspaceId: workspace.id, panelId: panelId)?.kind
+        else { return nil }
+        return UsageDisplay.provider(for: kind)
+    }
+}
+
+/// Pure mapping from `UsageSnapshot` domain values to the value-driven view models.
+/// All strings localized here; the `CmuxUsage` package holds no localization.
+enum UsageDisplay {
+    /// Map a live-agent kind to a usage provider (nil for kinds with no usage surface).
+    static func provider(for kind: RestorableAgentKind) -> UsageProvider? {
+        switch kind {
+        case .claude: return .claude
+        case .codex: return .codex
+        case .grok: return .grok
+        case .kimi: return .kimi
+        case .gemini: return .gemini
+        default: return nil
+        }
+    }
+
+    // MARK: Footer tile
+
+    static func tileModel(provider: UsageProvider?, snapshot: UsageSnapshot?) -> UsageTileModel {
+        guard let provider else {
+            // No agent focused (or an agent with no usage surface): neutral resting chip.
+            return UsageTileModel(
+                providerName: String(localized: "usage.tile.none", defaultValue: "Usage"),
+                iconAssetName: nil,
+                usedPercent: nil,
+                detail: "—",
+                state: .unavailable
+            )
+        }
+        let name = provider.displayName
+        guard let snapshot else {
+            // Linked but not yet fetched.
+            return UsageTileModel(providerName: name, iconAssetName: nil, usedPercent: nil,
+                                  detail: "…", state: .degraded)
+        }
+
+        switch snapshot.freshness {
+        case .live, .stale:
+            let window = primaryWindow(snapshot.windows)
+            let pct = window?.usedPercent
+            let detail = pct.map { "\(Int($0.rounded()))%" }
+                ?? stateLabel(for: snapshot.freshness)
+            let state: UsageTileModel.State = (snapshot.freshness.isLive ? .ok : .degraded)
+            return UsageTileModel(providerName: name, iconAssetName: nil, usedPercent: pct,
+                                  detail: detail, state: state)
+        case .rateLimited:
+            return UsageTileModel(providerName: name, iconAssetName: nil, usedPercent: nil,
+                                  detail: stateLabel(for: snapshot.freshness), state: .degraded)
+        case .signedOut, .notInstalled, .unsupported:
+            return UsageTileModel(providerName: name, iconAssetName: nil, usedPercent: nil,
+                                  detail: stateLabel(for: snapshot.freshness), state: .unavailable)
+        }
+    }
+
+    // MARK: Multi-account panel
+
+    static func accountRows(from snapshots: [UsageProvider: UsageSnapshot]) -> [UsageAccountRowModel] {
+        // Stable ordering matches the gaugeable list so the panel doesn't reshuffle.
+        UsageProviderRegistry.gaugeable.compactMap { provider in
+            guard let snapshot = snapshots[provider] else { return nil }
+            return UsageAccountRowModel(
+                id: provider.rawValue,
+                providerName: provider.displayName,
+                iconAssetName: nil,
+                statusLabel: statusLabel(for: snapshot),
+                bars: snapshot.windows.map(bar(for:))
+            )
+        }
+    }
+
+    private static func bar(for window: UsageWindow) -> UsageAccountRowModel.Bar {
+        UsageAccountRowModel.Bar(
+            label: windowLabel(window),
+            usedPercent: window.usedPercent,
+            detail: windowDetail(window)
+        )
+    }
+
+    // MARK: Labels
+
+    private static func primaryWindow(_ windows: [UsageWindow]) -> UsageWindow? {
+        // Prefer the shortest rolling window with a percentage (the one nearest a limit).
+        windows
+            .filter { $0.usedPercent != nil }
+            .min { lhs, rhs in rollingSeconds(lhs) < rollingSeconds(rhs) }
+    }
+
+    private static func rollingSeconds(_ window: UsageWindow) -> Int {
+        if case .rolling(let seconds) = window.kind { return seconds }
+        return .max // non-rolling windows sort last
+    }
+
+    private static func windowLabel(_ window: UsageWindow) -> String {
+        switch window.kind {
+        case .rolling(let seconds):
+            return durationLabel(seconds: seconds)
+        case .credits:
+            return String(localized: "usage.window.credits", defaultValue: "Credits")
+        case .quota(let unit):
+            return unit
+        }
+    }
+
+    /// Compact rolling-window label. Uses fixed 5h/Weekly for the two common windows,
+    /// otherwise an abbreviated duration (localized by Foundation).
+    private static func durationLabel(seconds: Int) -> String {
+        switch seconds {
+        case 18000: return String(localized: "usage.window.5h", defaultValue: "5h")
+        case 604800: return String(localized: "usage.window.weekly", defaultValue: "Weekly")
+        default:
+            let fmt = DateComponentsFormatter()
+            fmt.allowedUnits = [.day, .hour, .minute]
+            fmt.unitsStyle = .abbreviated
+            fmt.maximumUnitCount = 1
+            return fmt.string(from: TimeInterval(seconds)) ?? "\(seconds)s"
+        }
+    }
+
+    private static func windowDetail(_ window: UsageWindow) -> String {
+        switch window.kind {
+        case .rolling:
+            if let resetAt = window.resetAt {
+                return resetDetail(resetAt)
+            }
+            if let pct = window.usedPercent {
+                return "\(Int(pct.rounded()))%"
+            }
+            return ""
+        case .credits:
+            if let remaining = window.creditsRemaining {
+                return compactNumber(remaining)
+            }
+            return ""
+        case .quota:
+            if let remaining = window.remaining {
+                return String(
+                    localized: "usage.detail.remaining",
+                    defaultValue: "\(compactNumber(remaining)) left"
+                )
+            }
+            return ""
+        }
+    }
+
+    private static func resetDetail(_ resetAt: Date) -> String {
+        let seconds = max(0, resetAt.timeIntervalSinceNow)
+        let fmt = DateComponentsFormatter()
+        fmt.allowedUnits = [.day, .hour, .minute]
+        fmt.unitsStyle = .abbreviated
+        fmt.maximumUnitCount = 1
+        let duration = fmt.string(from: seconds) ?? ""
+        return String(localized: "usage.detail.resetsIn", defaultValue: "resets in \(duration)")
+    }
+
+    private static func statusLabel(for snapshot: UsageSnapshot) -> String {
+        let base = stateLabel(for: snapshot.freshness)
+        if let plan = snapshot.planLabel, !plan.isEmpty {
+            return "\(plan) · \(base)"
+        }
+        return base
+    }
+
+    private static func stateLabel(for freshness: UsageFreshness) -> String {
+        switch freshness {
+        case .live: return String(localized: "usage.state.live", defaultValue: "live")
+        case .stale: return String(localized: "usage.state.stale", defaultValue: "stale")
+        case .signedOut: return String(localized: "usage.state.signedOut", defaultValue: "signed out")
+        case .notInstalled: return String(localized: "usage.state.notInstalled", defaultValue: "not installed")
+        case .unsupported: return String(localized: "usage.state.unsupported", defaultValue: "no limits")
+        case .rateLimited: return String(localized: "usage.state.rateLimited", defaultValue: "rate limited")
+        }
+    }
+
+    /// Human-compact number (e.g. 1.5M, 53K). Non-localized digits by design.
+    private static func compactNumber(_ value: Double) -> String {
+        let fmt = NumberFormatter()
+        fmt.numberStyle = .decimal
+        switch abs(value) {
+        case 1_000_000...:
+            fmt.maximumFractionDigits = 1
+            return (fmt.string(from: NSNumber(value: value / 1_000_000)) ?? "\(value)") + "M"
+        case 1_000...:
+            fmt.maximumFractionDigits = 0
+            return (fmt.string(from: NSNumber(value: value / 1_000)) ?? "\(value)") + "K"
+        default:
+            fmt.maximumFractionDigits = 0
+            return fmt.string(from: NSNumber(value: value)) ?? "\(value)"
+        }
+    }
+}
+
+private extension UsageFreshness {
+    var isLive: Bool {
+        if case .live = self { return true }
+        return false
+    }
+}

--- a/Sources/UsageFooterHost.swift
+++ b/Sources/UsageFooterHost.swift
@@ -203,9 +203,12 @@ enum UsageDisplay {
             return ""
         case .quota:
             if let remaining = window.remaining {
+                // String(format:) with a localized format string — NOT an interpolated
+                // `defaultValue`, which does not reliably bind its argument to the
+                // catalog value looked up by key (would render a literal "%@" in ja).
                 return String(
-                    localized: "usage.detail.remaining",
-                    defaultValue: "\(compactNumber(remaining)) left"
+                    format: String(localized: "usage.detail.remaining", defaultValue: "%@ left"),
+                    compactNumber(remaining)
                 )
             }
             return ""
@@ -219,7 +222,10 @@ enum UsageDisplay {
         fmt.unitsStyle = .abbreviated
         fmt.maximumUnitCount = 1
         let duration = fmt.string(from: seconds) ?? ""
-        return String(localized: "usage.detail.resetsIn", defaultValue: "resets in \(duration)")
+        return String(
+            format: String(localized: "usage.detail.resetsIn", defaultValue: "resets in %@"),
+            duration
+        )
     }
 
     private static func statusLabel(for snapshot: UsageSnapshot) -> String {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */; };
 		CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0200000000CDFEED02 /* CmuxUpdater */; };
 		CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */ = {isa = PBXBuildFile; productRef = CDFEED0500000000CDFEED05 /* CmuxUpdaterUI */; };
+		C05A6E0000000000000000C3 /* CmuxUsage in Frameworks */ = {isa = PBXBuildFile; productRef = C05A6E0000000000000000C2 /* CmuxUsage */; };
 		D7C0DE00000000000000A101 /* CmuxWebView+ContextMenuLinkCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C0DE00000000000000A102 /* CmuxWebView+ContextMenuLinkCapture.swift */; };
 		D7AB00000000000000000009 /* CmuxWebView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000A /* CmuxWebView+MoveTabToNewWorkspace.swift */; };
 		C6255D010000000000000001 /* CmuxWebView+ScriptedDownloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6255D010000000000000002 /* CmuxWebView+ScriptedDownloads.swift */; };
@@ -2135,6 +2136,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
 		A5001208 /* UpdateTitlebarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001218 /* UpdateTitlebarAccessory.swift */; };
 		C2035A070000000000000001 /* URLRequest+BrowserFailedNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A070000000000000002 /* URLRequest+BrowserFailedNavigation.swift */; };
+		C05A6E0000000000000000D5 /* UsageFooterHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05A6E0000000000000000D6 /* UsageFooterHost.swift */; };
 		F76550040000000000000001 /* VaultAgentProcessScanner+CodexSessionCwd.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550040000000000000002 /* VaultAgentProcessScanner+CodexSessionCwd.swift */; };
 		F76550010000000000000001 /* VaultAgentProcessScanner+ForkMarkers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */; };
 		F0F0CF0C0000000000000001 /* VaultAgentProcessScanner+ForkParentFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */; };
@@ -4421,6 +4423,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
 		A5001218 /* UpdateTitlebarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateTitlebarAccessory.swift; sourceTree = "<group>"; };
 		C2035A070000000000000002 /* URLRequest+BrowserFailedNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/URLRequest+BrowserFailedNavigation.swift"; sourceTree = "<group>"; };
+		C05A6E0000000000000000D6 /* UsageFooterHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageFooterHost.swift; sourceTree = "<group>"; };
 		F76550040000000000000002 /* VaultAgentProcessScanner+CodexSessionCwd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+CodexSessionCwd.swift"; sourceTree = "<group>"; };
 		F76550010000000000000002 /* VaultAgentProcessScanner+ForkMarkers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkMarkers.swift"; sourceTree = "<group>"; };
 		F0F0CF0C0000000000000002 /* VaultAgentProcessScanner+ForkParentFallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VaultAgentProcessScanner+ForkParentFallback.swift"; sourceTree = "<group>"; };
@@ -4645,6 +4648,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CFF12E0000000000000000A3 /* CmuxTestSupport in Frameworks */,
 				CDFEED0300000000CDFEED03 /* CmuxUpdater in Frameworks */,
 				CDFEED0600000000CDFEED06 /* CmuxUpdaterUI in Frameworks */,
+				C05A6E0000000000000000C3 /* CmuxUsage in Frameworks */,
 				5E55200000000000000000B3 /* CmuxWindowing in Frameworks */,
 				E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */,
 				A5001006 /* GhosttyKit.xcframework in Frameworks */,
@@ -5453,6 +5457,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C75100030000000000000002 /* TerminalSelectionTranslationAnchorView.swift */,
 				C75100020000000000000002 /* TerminalSelectionTranslation.swift */,
 				C13519000000000000000006 /* RestorableAgentTypes.swift */,
+				C05A6E0000000000000000D6 /* UsageFooterHost.swift */,
 				0A1107110000000000000011 /* AgentNotificationDelivery.swift */,
 				0A1107110000000000000013 /* AgentRelaunchCommandBuilder.swift */,
 				0A1107110000000000000015 /* AgentRestoreMode.swift */,
@@ -7300,6 +7305,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CD0CFE5400000000CD0CFE54 /* XCLocalSwiftPackageReference "CmuxSettingsUI" */,
 				CDFEED0100000000CDFEED01 /* XCLocalSwiftPackageReference "CmuxUpdater" */,
 				CDFEED0400000000CDFEED04 /* XCLocalSwiftPackageReference "CmuxUpdaterUI" */,
+				C05A6E0000000000000000C1 /* XCLocalSwiftPackageReference "CmuxUsage" */,
 				CF00F00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxFoundation" */,
 				CC0DE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxCore" */,
 				CC0DE10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxRemoteDaemon" */,
@@ -8842,6 +8848,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A500120D /* UpdateLogStore.swift in Sources */,
 				A5001208 /* UpdateTitlebarAccessory.swift in Sources */,
 				C2035A070000000000000001 /* URLRequest+BrowserFailedNavigation.swift in Sources */,
+				C05A6E0000000000000000D5 /* UsageFooterHost.swift in Sources */,
 				F76550040000000000000001 /* VaultAgentProcessScanner+CodexSessionCwd.swift in Sources */,
 				F76550010000000000000001 /* VaultAgentProcessScanner+ForkMarkers.swift in Sources */,
 				F0F0CF0C0000000000000001 /* VaultAgentProcessScanner+ForkParentFallback.swift in Sources */,
@@ -10306,6 +10313,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CmuxUpdaterUI;
 		};
+		C05A6E0000000000000000C1 /* XCLocalSwiftPackageReference "CmuxUsage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/macOS/CmuxUsage;
+		};
 		CC0DE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxCore" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CmuxCore;
@@ -10557,6 +10568,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCSwiftPackageProductDependency;
 			package = CDFEED0400000000CDFEED04 /* XCLocalSwiftPackageReference "CmuxUpdaterUI" */;
 			productName = CmuxUpdaterUI;
+		};
+		C05A6E0000000000000000C2 /* CmuxUsage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C05A6E0000000000000000C1 /* XCLocalSwiftPackageReference "CmuxUsage" */;
+			productName = CmuxUsage;
 		};
 		CC0DE00000000000000000A2 /* CmuxCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -202,6 +202,9 @@
          location = "group:CmuxUpdaterUI">
       </FileRef>
       <FileRef
+         location = "group:CmuxUsage">
+      </FileRef>
+      <FileRef
          location = "group:CmuxWindowing">
       </FileRef>
       <FileRef

--- a/docs/crucible/usage-hud/CRUCIBLE.md
+++ b/docs/crucible/usage-hud/CRUCIBLE.md
@@ -1,0 +1,34 @@
+# CRUCIBLE — Multi-provider AI-usage HUD
+
+**Candidate:** A usage HUD in the cmux sidebar footer (next to the `?` help button) showing
+tokens-left / % used / time-to-reset per AI provider account, across rolling 5h + weekly windows,
+with a "multi-account usage limits" panel behind a footer menu item. Providers: Claude, Codex,
+Grok, Kimi, Gemini.
+
+**Tracked as:** task #1 · Consent gate crossed (Nick: "full").
+
+## Why this glows AND what it changes
+- **It changes what Nick can see.** Right now, "how much have I got left, when does it reset?"
+  is invisible until an agent hits a wall mid-task. cmux is the one surface that runs *all five*
+  agents side by side, so it is uniquely positioned to be the single pane of glass for usage —
+  no other tool sees the whole fleet.
+- **The hard part is already built.** cmux already maps window → agent → transcript
+  (`RestorableAgentKind`, per-surface env injection, hook records). Usage tracking is 100%
+  greenfield, but it hangs off machinery that already exists.
+- **The spine is proven.** Codex returns a real `{used_percent, reset_at, credits}` object today.
+  This is not a "wouldn't it be cool" — one provider is already live end-to-end.
+
+## The spark
+If piggyback-freshness holds (cmux reads the token each CLI *already refreshes to disk*, never
+refreshing anything itself), the whole feature is **read-only observation of state that already
+exists** — no OAuth reimplementation, no footgun, no new attack surface. The HUD becomes a
+window onto files and endpoints that are already there.
+
+## The falsifier (what would prove this is slag)
+**If the CLIs refresh their tokens in memory only and do NOT persist the fresh token to a
+readable location, piggyback-freshness is impossible** — cmux would see a permanently-stale
+token, every poll 401s, and the only path left is cmux refreshing tokens itself, which
+re-introduces the rotation footgun that logs the user out of their own CLI. That single fact
+(does each CLI persist refreshed tokens?) decides whether this is a clean read-only feature or a
+credential-management minefield. It is verified per-provider in build step 1, and it gates
+everything after it.

--- a/docs/crucible/usage-hud/DESIGN.md
+++ b/docs/crucible/usage-hud/DESIGN.md
@@ -1,0 +1,258 @@
+# DESIGN — Multi-provider AI-usage HUD
+
+## Problem
+cmux runs up to five different agent CLIs side by side, but a user cannot see how much of each
+provider's rolling quota they have left or when it resets until an agent hits a wall mid-task.
+Provide an in-app HUD: a compact footer readout for the active provider + a multi-account panel
+across all providers, showing % used / tokens or credits left / time-to-reset for each account's
+rolling windows.
+
+## DECISION (2026-07-25, Nick)
+Step-1 census found **no CLI exposes a non-interactive usage command** (RESEARCH §4b), so the
+CLI-first core is unavailable. Nick chose **"hardened direct-API, all 5"**: the read-only-credential
++ direct-API path is now the PRIMARY line for every provider, carrying the full Temper hardening
+(F-T2/3/4) on the main path. `ProviderCredentialReader` is therefore a CORE component, not a
+last-resort. Invariant unchanged: cmux never refreshes/writes a token. The second cross-family strike
+(pre-merge gate) matters MORE under this decision because the credential surface is now core.
+
+## Core principle (superseded by DECISION above for path selection; hardening still applies)
+**cmux never handles credentials and never runs a background poll. It asks each CLI to report its
+own usage, on demand.** The primary and default-only path is to invoke each provider CLI's
+**non-interactive usage subcommand** (e.g. `codex usage --json`) when the user opens the panel or
+switches the active provider. The CLI owns its entire auth lifecycle — it refreshes its own token,
+attributes the call to itself, and cmux never reads, holds, or writes a token.
+
+Precise invariant (Temper F-T1 fixed the sloppy version): **cmux itself never performs a token
+refresh and never writes a token.** A CLI that cmux *invokes* may refresh its OWN token as a side
+effect of doing its job — that is the tool managing its own credential, not cmux touching auth.
+The forbidden thing is cmux running an OAuth `refresh_token` grant or writing an auth file; spawning
+`codex usage` is not that.
+
+**The credential-reading + direct-API path is demoted to a default-OFF, hardened last resort**
+(Temper F-T2/F-T5), used only for a provider that has *no* machine-readable usage command AND a
+documented usage endpoint AND an honest (non-impersonating) client identity. It is opt-in per
+provider, never default.
+
+Consequence, stated honestly: usage is shown **on demand**, not live-ticking; between fetches the
+tile shows last-known + age. A provider whose CLI can't report non-interactively (would prompt
+login) shows `resume <agent> to refresh`, never triggers an interactive prompt.
+
+## Architecture
+
+New macOS-only package **`Packages/macOS/CmuxUsage`** (these CLIs don't run on iOS).
+
+```
+CmuxUsage
+├─ Model/
+│   ├─ UsageSnapshot.swift      // immutable value type (Sendable)
+│   ├─ UsageWindow.swift        // .rolling(seconds), usedPercent, resetAt, limit?
+│   ├─ ProviderAccount.swift    // provider + accountId + displayName + freshness
+│   └─ UsageFreshness.swift     // .live(Date) | .stale(lastKnown?) | .signedOut | .unsupported | .rateLimited(until:)
+├─ Auth/
+│   └─ ProviderCredentialReader.swift   // READ-ONLY: parse auth files / keychain; compute token exp; never writes
+├─ Adapters/
+│   ├─ ProviderUsageAdapter.swift       // protocol: fetch(account) async throws -> UsageSnapshot
+│   │                                   // TWO MODES (Fold F5): .cliSubcommand (preferred) | .directAPI (fallback)
+│   ├─ CodexUsageAdapter.swift          // PROVEN
+│   ├─ ClaudeUsageAdapter.swift
+│   ├─ GeminiUsageAdapter.swift
+│   ├─ KimiUsageAdapter.swift
+│   └─ GrokUsageAdapter.swift
+└─ UsageIndex.swift             // @MainActor singleton poller (DispatchSourceTimer), publishes snapshots
+```
+
+### Data shapes
+```swift
+struct UsageWindow: Sendable, Equatable {
+    enum Kind: Sendable { case rolling(seconds: Int); case credits }   // 18000=5h, 604800=7d
+    var kind: Kind
+    var usedPercent: Double?      // 0…100, nil if provider only gives credits
+    var resetAt: Date?
+    var creditsRemaining: Double? // for the credits kind
+}
+struct UsageSnapshot: Sendable, Equatable {
+    var account: ProviderAccount
+    var planLabel: String?        // "plus", "max", …
+    var windows: [UsageWindow]
+    var freshness: UsageFreshness
+    var fetchedAt: Date
+}
+```
+
+### UsageIndex (on-demand fetcher — REVISED after Temper, no background poll)
+- `@MainActor final class UsageIndex` with `static let shared`, modeled on `SharedLiveAgentIndex`.
+- Holds `private(set) var snapshots: [AccountKey: UsageSnapshot]` where `AccountKey = provider+accountId`.
+- Publishes an **immutable dictionary snapshot**; UI reads value copies only.
+- **No background timer by default.** Fetch is triggered by explicit user action: panel open, or the
+  active provider changing. Result is cached with `fetchedAt`; the tile shows last-known + age. A
+  manual tap re-fetches. Per-provider floor (e.g. one fetch / 30s) to avoid hammering; backoff +
+  `.rateLimited(until:)` on any 429/403. This eliminates the anti-abuse surface the poller created.
+
+### Credential reader (LAST-RESORT ONLY — built only if step 1 requires it; READ-ONLY, security-critical)
+- Parses `~/.codex/auth.json`, `~/.gemini/oauth_creds.json`, `~/.kimi/credentials/kimi-code.json`,
+  `~/.grok/auth.json`; reads Keychain `"Claude Code-credentials"` via Security framework.
+- Decodes the JWT `exp` (or file `expires_at`) to compute freshness **without a network call**.
+- **Invariants:** opens files O_RDONLY; never writes; never logs a token; tokens live only in
+  memory for the duration of a request; not included in any debug dump or crash report.
+
+## UI
+
+### Footer tile (`UsageFooterTile`)
+- Inserted in `SidebarFooterButtons` HStack (`ContentView.swift:14295`), after the `?` button.
+- Shows the **active surface's** provider: a compact pill, e.g. a small ring at `usedPercent` +
+  `"3h12m"` to reset. `.signedOut`/`.unsupported` → tile hidden for that provider.
+- **Snapshot-boundary compliance:** the footer HStack is a fixed row, not inside a
+  `LazyVStack`/`List`, so observing a small store here is allowed — BUT to stay off the typing
+  hot path, the tile receives a **precomputed immutable `UsageTileModel` value** (not the store),
+  recomputed only when the active provider's snapshot changes (Equatable-gated), never in `body`.
+  Zero allocations/formatting on the render path; strings formatted on snapshot change.
+- Tap → opens the multi-account panel via `ArrowlessPopoverAnchor` (same mechanism as the help button).
+
+### Multi-account panel (`UsageLimitsPanel`)
+- Reached two ways (shared action path — cmux-shared-behavior law): (1) tapping the footer tile,
+  (2) a new "Usage limits" item in the existing help/footer menu (`SidebarHelpMenuButton` popover).
+- One row per provider account: provider icon + displayName + plan label + a bar per window
+  (5h / weekly) with % + reset countdown + credits line where present. Freshness badge per row
+  (`live` / `stale` / `signed out` / `rate-limited` / `not supported`).
+- If a list/scroll is used, rows get immutable value snapshots + closure bundles only
+  (`IndexSectionActions` pattern) — no store reference below the boundary.
+
+## Build order (REVISED after Temper — CLI-capability first, credentials last)
+
+1. **CLI usage-command census (R6 — the new gate, no credential code).** For each of the five CLIs,
+   determine empirically whether it exposes a **non-interactive, machine-readable usage command**
+   that runs without prompting and reports quota (probe `codex usage --json`, `grok`/`kimi`/`gemini`
+   equivalents, `claude` usage surface). Output a capability table: provider → {cli-usage-command |
+   none}. **This gates the architecture per provider**: has-command → CLI-first path (no tokens);
+   none → candidate for the default-off direct-API last resort (or `.unsupported`).
+2. **CodexUsageAdapter via its resolved path + on-demand fetcher.** Wire the fetcher (on-demand, no
+   background poll), cache with age, hostile-input parsing (strict schema, fail-closed). Note: the
+   cmux CLI-shim scrubs env — resolve the real CLI binary path, don't rely on a shimmed `PATH`.
+3. **Footer tile for the active provider** (Codex first) + localization (en + ja). Tile shows
+   last-known + age; tap refreshes.
+4. **Multi-account panel** (Codex only initially) + the help-menu item + shortcut policy wiring.
+   Panel-open triggers an on-demand refresh.
+5. **Remaining providers, one PR each, per-provider flagged, CLI-path preferred:** Claude → Gemini →
+   Kimi → Grok. A provider with no CLI usage command and no honest direct endpoint ends
+   `.unsupported` — an honest outcome, not a failure.
+6. **Credential-reading direct-API last resort (build ONLY if step 1 leaves a wanted provider with
+   no CLI command).** Default-off, per-provider consent, hardened per the blast-radius section. If
+   step 1 shows every wanted provider has a CLI command, `ProviderCredentialReader` is **never built**.
+7. **(Optional) per-window tokens-USED column** from transcripts, reusing the existing
+   window→transcript mapping.
+
+## Blast radius & consent spine (REVISED after Temper — cage before monster)
+- **Hostile input, not "no attack surface" (F-T3).** Auth JSON, keychain blobs, CLI stdout, and
+  usage API response bodies are ALL untrusted input parsed inside a process. Treat every one as
+  hostile: strict Codable schemas, bounded sizes, fail-closed on any drift, no code path driven by
+  payload shape. The earlier "no external-input attack surface" claim was wrong and is retracted.
+- **Credential residency is the worst-case blast radius (F-T2).** A process holding several CLIs'
+  OAuth tokens is a single point of multi-account takeover (RCE / plugin surface / crash dump).
+  Mitigation, in priority order: (1) **CLI-first path holds NO tokens at all** — this is why it's
+  the core; (2) the last-resort direct-API path, where used, minimizes residency (one provider at a
+  time, dropped immediately after the request), is per-provider consented, and is **excluded from
+  the extensions/debug/crash-dump surface** entirely.
+- **Anti-abuse: no background poll, no UA spoofing (F-T4).** Fetch only on explicit user action
+  (panel open / active-provider switch), via the CLI-attributed path. Never forge a CLI's
+  User-Agent — that's client impersonation/evasion, not mitigation. The direct-API last resort uses
+  an honest cmux identity and is default-off with the rate-limit risk documented.
+- **Feature-flagged** globally + per provider; CLI-path providers can default-on (no token, no
+  poll); direct-API providers default-OFF.
+- **cmux never runs a token refresh and never writes an auth file/keychain item** — enforced by
+  there being no such code path; a CLI cmux spawns managing its own token is out of scope of this
+  invariant (F-T1).
+
+## Claims to falsify (hand these to Temper)
+- **C1 (load-bearing):** Each CLI persists its refreshed token to a cmux-readable location, so
+  read-only piggyback sees fresh tokens. *If false for a provider → that provider is stale-only or
+  unsupported.* (Codex ✓; others unverified — gated by build step 1.)
+- **C2:** Grok/Kimi/Gemini expose a usable limits endpoint. *If false → `.unsupported`, HUD shrinks
+  to the providers that do (Codex + Claude at minimum).*
+- **C3:** A ≥60s sparse poll avoids anti-abuse across all providers. *If false → longer intervals or
+  event-driven-only refresh.*
+- **C4:** The footer HStack is safe to host a live-updating tile without touching typing latency.
+  *If false → move the tile or make it fully static + tap-to-refresh.*
+- **C5:** "One account per provider" is an acceptable v1 for a feature explicitly sold as
+  "multi-account." *If false → must discover multiple profiles per CLI in v1 (R5).*
+- **C6:** Reading the Claude keychain item from the cmux app process actually succeeds (keychain
+  ACLs may scope the item to the Claude Code binary only). *If false → Claude becomes stale-only or
+  needs a different source.*
+
+## Rejected alternatives
+- **Trawl transcripts for everything.** Rejected: transcripts have tokens *used*, never *limits/left*.
+- **cmux refreshes tokens itself.** Rejected: rotation footgun logs the user out of their own CLI.
+- **Standalone menu-bar / ccusage-style external tool.** Rejected: not in the one pane that sees all
+  five agents; Nick wants it in the footer.
+- **Aggressive real-time polling.** Rejected: Codex 403'd on rapid repeat; anti-abuse risk to the
+  user's account.
+- **Ship all five at once, big-bang.** Rejected: only Codex is proven; per-provider PRs let the HUD
+  ship value while unknown endpoints are still being confirmed.
+
+## Fold — author self-pass (folded back into this design)
+
+Struck the casting myself before Temper. Material findings, folded in:
+
+- **F5 (biggest — reshapes the adapter).** I under-evaluated the "shell out to the CLI's own usage
+  command" alternative. Where a CLI exposes a **non-interactive machine-readable usage subcommand**
+  (e.g. `codex usage --json`), that path is *strictly safer* than a direct API call: it sidesteps
+  keychain/auth-file reading (kills C6), token-freshness (kills C1), AND anti-abuse (it IS the CLI's
+  own attributed call, not a second client on the same token). So the adapter is now **two-mode**:
+  prefer `.cliSubcommand`, fall back to `.directAPI` only where no such command exists. New research
+  var **R6: does each CLI expose a non-interactive usage command?** — checked in build step 1
+  alongside R1. This may make the credential-reader unnecessary for some providers entirely.
+- **F1 (anti-abuse is under-counted).** cmux's own API calls (directAPI mode) add request volume to
+  the user's account under a *different* User-Agent than the CLI — providers may flag mismatched-UA
+  or two-client patterns (Codex 403 already showed sensitivity). Mitigation folded in: directAPI
+  mode mimics the CLI's real UA/headers, polls ultra-sparse, and `.cliSubcommand` mode is preferred
+  precisely because it avoids this. Anti-abuse is now a **named owned risk**, not "harmless."
+- **F7 (lifecycle gating).** Poller runs **only when the app is active** and the footer tile is
+  visible or the panel is open. No polling while backgrounded — saves quota-attributed calls and
+  shrinks the anti-abuse surface.
+- **F4 (observation isolation, sharper).** The 90s publish must invalidate **only the leaf tile**,
+  never a parent containing the workspace list / any `LazyVStack`. The panel is popover-mounted
+  (exists only while open), so its updates never touch the sidebar tree. A 90s tick is far below
+  typing frequency, but misplaced observation could still thrash the list — so the store is observed
+  at the tile leaf via a derived Equatable value only.
+- **F2/F3 (active-provider + credits-only rendering).** Active provider = most-recently-focused
+  surface with a detected agent (from the live agent index); tile hidden if none. Tile renders a
+  ring when `usedPercent != nil`, else a compact credits-remaining number — providers differ
+  (window-only, credits-only, or both, like Codex).
+- **F8 (no high-frequency timer).** Reset countdown renders coarse ("3h" / "12m"), recomputed on the
+  90s poll tick — never a 1Hz timer in the footer (typing-latency law).
+- **F6 (absent vs signed-out).** No auth file at all → provider `.notInstalled` → hidden entirely;
+  distinct from `.signedOut` (installed, token gone).
+
+Fold did **not** re-grade the ore (candidate fixed at consent) and does **not** replace Temper —
+same-distribution blindness means the cross-family strike still has to happen.
+
+## Temper — cross-family strike record (2026-07-25)
+
+**Adversary reached:** Grok / xAI (Tesla) — a genuine different-family strike, not a persona.
+Codex, Gemini, Kimi were not drivable non-interactively from the scrubbed cmux shell this session
+(codex shim couldn't resolve its binary; gemini blocked on interactive auth; kimi CLI syntax).
+
+**Verdict: design re-cast (round 1 of ≤3), not invalidated.** Grok's five findings were decisive
+and convergent — all pointing at "you centered the credential-reading poller; center the CLI's own
+usage command instead." Folded back:
+- **F-T1 (fatal):** "cmux never writes" was violated by the preferred CLI-spawn path → invariant
+  re-stated precisely (cmux never refreshes/writes; a CLI it spawns managing its own token is fine).
+- **F-T2 (fatal):** multi-token residency = single point of multi-account takeover → CLI-first path
+  holds no tokens; direct-API residency minimized, consented, excluded from extension/crash surface.
+- **F-T3 (fatal):** "no external-input attack surface" retracted → all parsed I/O treated hostile.
+- **F-T4 (fatal):** UA-mimic is evasion → no background poll, no UA spoofing, on-demand only.
+- **F-T5 (fatal):** simpler alternative (CLI `usage --json` on demand) wins → it is now the core;
+  credential reader demoted to a may-never-build last resort.
+
+**Honesty label:** TEMPERED by **one** genuine cross-family adversary, not the full five-cast. This
+is stronger than a persona-only pass (a real different inductive bias struck and its findings
+reshaped the design) but weaker than a full cast. **Required gate before merge:** a second
+cross-family strike (Codex/GPT + Gemini) on this revised design, run from an environment where those
+CLIs are drivable — the F-T1 CLI-spawn invariant and the hostile-input parsing especially want a
+second bias. This is carried into the Blade plan as a pre-build gate.
+
+## Open variables (no silent TODOs)
+- Exact Claude `oauth/usage` response schema (needs a fresh keychain token).
+- Whether Gemini/Kimi/Grok have any limits endpoint (R2/C2).
+- Multi-account enumeration mechanism per CLI (R5/C5).
+- Final poll interval per provider (R3/C3).
+- Default-on vs default-off at GA.

--- a/docs/crucible/usage-hud/RESEARCH.md
+++ b/docs/crucible/usage-hud/RESEARCH.md
@@ -1,0 +1,68 @@
+# RESEARCH — Multi-provider usage HUD
+
+Verified 2026-07-23 (probe session). "Proven" = observed a live 200 this session.
+"Plausible" = shape of the error implies the route exists. "Unknown" = not reachable yet.
+
+## 1. Attribution machinery (already exists — reuse, don't build)
+- `RestorableAgentKind` (`Sources/RestorableAgentTypes.swift:4`) — enum covers claude/codex/grok/
+  gemini/kimi + more, with `displayName`, `rawValue`.
+- Per-surface identity: `CMUX_WORKSPACE_ID` / `CMUX_SURFACE_ID` injected into every PTY
+  (`TerminalSurface.swift` ~L405). `VaultAgentProcessScanner.swift` buckets live agent processes
+  back to `(workspaceId, surfaceId)`.
+- Hook records at `~/.cmuxterm/<agent>-hook-sessions.json`
+  (`RestorableAgentHookSessionRecord`) store `surfaceId → cwd → transcriptPath` directly.
+- `SharedLiveAgentIndex.swift` — existing `@MainActor` singleton poller with a `DispatchSourceTimer`.
+  **This is the architectural template for the new usage service.**
+- Grep for `tokensUsed|costUsd|quotaRemaining|usageLimit` → **zero** agent-related hits. Greenfield.
+
+## 2. Where limits live
+- **Limits ("tokens left / reset") are ONLY behind provider APIs.** No CLI caches its quota to
+  disk (checked codex logs sqlite, grok models_cache, kimi telemetry — none hold quota).
+- **Local transcripts only yield tokens USED per turn** (Claude JSONL `message.usage`;
+  Codex/Kimi session logs carry token events). Used only for the optional per-window column.
+
+## 3. Provider endpoint matrix
+
+| Provider | Endpoint | Auth source | Status | Notes |
+|---|---|---|---|---|
+| **Codex/ChatGPT** | `GET chatgpt.com/backend-api/codex/usage` | `~/.codex/auth.json` → `tokens.access_token` + header `chatgpt-account-id: tokens.account_id` | **PROVEN 200** | Returns `plan_type`, `rate_limit.primary_window {used_percent, limit_window_seconds:604800, reset_after_seconds, reset_at}`, `secondary_window`, `credits{has_credits,unlimited,overage_limit_reached,balance}`. **Repeated hits → 403 (anti-abuse). Cache + poll sparse.** |
+| **Claude** | `GET api.anthropic.com/api/oauth/usage` (likely) | macOS Keychain service `"Claude Code-credentials"` → `claudeAiOauth.accessToken`; header `anthropic-beta: oauth-2025-04-20` | **Plausible** | Returned 401 (auth), not 404 (route). Token from disk was stale. Needs a fresh keychain token to confirm schema. |
+| **Gemini** | Code Assist `cloudcode-pa.googleapis.com` | `~/.gemini/oauth_creds.json` → `access_token` (expiry_date ms) | **Unknown** | On-disk token was expired (~10.7h). Quota surface unconfirmed. |
+| **Kimi** | base `api.kimi.com/coding/v1` | `~/.kimi/credentials/kimi-code.json` → `access_token` (`expires_at`) | **Unknown** | Token expired. `/users/me`, `/users/me/balance` → 404. Real usage route unknown. |
+| **Grok** | base `cli-chat-proxy.grok.com/v1` | `~/.grok/auth.json` → `<issuer>.key` (818-char) | **Unknown / hardest** | "no auth context" with bearer — may need `x-xai-*` auth, not `Authorization: Bearer`. `/rate_limits`, `/usage` → 404 (nginx). Endpoint may not exist. |
+
+## 4. Token freshness (the crux)
+- On-disk tokens go stale; CLIs refresh in-memory / on-use. Confirmed expired at probe time:
+  Gemini, Kimi, Grok. Codex worked only because it was fresh.
+- **Rotation footgun:** if cmux runs a `refresh_token` grant and the provider rotates the
+  refresh_token (single-use), the on-disk copy is invalidated → **user is logged out of their own
+  CLI.** Therefore cmux must treat all auth files/keychain as **read-only**, never persist a
+  rotated token.
+
+## 4b. STEP-1 CLI USAGE-COMMAND CENSUS (2026-07-25) — the gate result
+
+Dumped every CLI's full subcommand list. **The CLI-first path is mostly a mirage.**
+
+| Provider | Non-interactive usage command? | Evidence |
+|---|---|---|
+| **Claude** | **No** | commands: agents/auth/auto-mode/doctor/gateway/install/mcp/plugin/project/setup-token/ultrareview/update. `/usage` is an in-session slash command, not a CLI subcommand. |
+| **Codex** | **Unconfirmed** | real binary sits behind `cmux-codex-wrapper` shim; couldn't run headless. API endpoint `backend-api/codex/usage` is PROVEN regardless. |
+| **Grok** | **No** | commands: agent/export/import/inspect/leader/login/logout/mcp/memory/models/plugin/sessions/setup/ssh/trace/update/version/worktree. None report quota. |
+| **Kimi** | **No** | commands: login/logout/term/acp/info/export/mcp/plugin/vis/web. None report quota. |
+| **Gemini** | **No** | commands: mcp/extensions/skills/hooks/gemma/query. None report quota. |
+
+**Consequence:** the tempered "CLI-first, cmux never touches a token" core is unavailable for ~all
+providers. Real build must use the **read-only-credential + direct-API path** (Temper's demoted
+last resort) as the PRIMARY path, carrying all of Temper's hardening (F-T2/3/4) on the main line.
+This does NOT reintroduce the rotation footgun (still never write/refresh a token), but it DOES put
+credential-residency + anti-abuse + hostile-input on the main path. Fork surfaced to Nick.
+
+## 5. Open research variables (carried into DESIGN as claims-to-falsify)
+- **R1 (load-bearing):** Does each CLI *persist* its refreshed token to a cmux-readable location
+  (auth file / keychain), or keep it in memory only? Codex: yes (`last_refresh` in auth.json).
+  Claude/Gemini/Kimi/Grok: **unverified.** Decides whether piggyback-freshness is viable per provider.
+- **R2:** Do Grok/Kimi/Gemini expose a usage/limits endpoint at all? (Codex yes, Claude likely.)
+- **R3:** What poll interval avoids anti-abuse (Codex 403'd on rapid repeat)?
+- **R4:** Does refreshing rotate the refresh_token, per provider? (Only relevant if we ever add
+  the optional in-memory-refresh path; default design avoids refresh entirely.)
+- **R5:** Do any CLIs support multiple accounts/profiles, and where is that enumerated?

--- a/docs/crucible/usage-hud/RESEARCH.md
+++ b/docs/crucible/usage-hud/RESEARCH.md
@@ -57,6 +57,96 @@ last resort) as the PRIMARY path, carrying all of Temper's hardening (F-T2/3/4) 
 This does NOT reintroduce the rotation footgun (still never write/refresh a token), but it DOES put
 credential-residency + anti-abuse + hostile-input on the main path. Fork surfaced to Nick.
 
+## 4c. ENDPOINT CONFIRMATION ROUND (2026-07-25, fresh tokens where available)
+
+| Provider | Token persists to disk? (R1) | Usage endpoint | Gauge feasible | Verdict |
+|---|---|---|---|---|
+| **Codex** | ✅ yes | `backend-api/codex/usage` | ✅ rolling window(s) + credits | **SHIP** |
+| **Gemini** | ✅ yes (token was fresh 2d later) | `v1internal:loadCodeAssist` → 200 | ⚠️ account is `standard-tier` **"Unlimited"** — no numeric quota | **label-only** (show tier, no gauge) |
+| **Grok** | ✅ yes (token fresh 2d later) | none found — proxy `/usage,/rate_limits,/me,/account` all 404; `grok.com/rest/rate-limits` 501 (maybe POST, needs web-session auth) | ❌ not with CLI token | **`.unsupported`** pending deeper discovery |
+| **Kimi** | ❓ (token expired 15min ago) | unknown | ❓ | **needs 1 CLI run** to refresh, then probe |
+| **Claude** | ❌ **NO** — keychain token 43 DAYS stale despite live session | endpoint likely exists but needs a live token; **no on-disk usage cache** (`policy-limits.json` is restriction policy, not quota) | ⚠️ blocked | **HARD** — headline provider, see below |
+
+**Key positive:** Codex/Gemini/Grok all persist refreshed tokens to disk → read-only piggyback
+works for them. **Claude is the lone exception** — Claude Code refreshes in-memory and never
+rewrites the keychain item, so read-only piggyback yields a 43-day-stale token. Claude's live
+"tokens left" therefore requires either (a) minting a fresh token from the keychain `refreshToken`
+(rotation-footgun risk — must NOT test unilaterally), or (b) reading `anthropic-ratelimit-unified-*`
+headers off a real `/v1/messages` call (needs a valid token AND burns quota). Both need a live token.
+
+**Net achievable gauge today = Codex only.** Gemini = "Unlimited" label; Grok/Kimi/Claude blocked
+or uncertain. This reshapes what "full 5" can mean — decision surfaced to Nick.
+
+### Deep-discovery closure (2026-07-25, per Nick "discovery first")
+- **Claude — DEAD END for live usage.** Keychain `refreshToken` is **empty** (only an expired
+  accessToken remains); live creds are held by Claude Code's daemon (`daemon-auth-status.json:
+  auth_required`, `authMethod: oauth_token`) / the ACL-locked "Claude Safe Storage" item. `claude
+  auth status --json` returns only `{loggedIn, authMethod, apiProvider}` — no token, no usage, and
+  does NOT refresh the keychain. The "use refresh_token" plan is **not executable**. Readable Claude
+  signals: static `subscriptionType` + `rateLimitTier` (plan/tier) + local transcript burn only.
+- **Grok — no usage route reachable with the CLI token.** Proxy paths 404; `grok.com/rest/rate-limits`
+  is Cloudflare-blocked (403 1010) to the CLI bearer (needs a browser/web session). `.unsupported`.
+- **Kimi — still pending** one `kimi info` run to refresh its token before it can be probed.
+
+**FINAL discovery verdict:** only **Codex** exposes a live "tokens-left" gauge. Realistic HUD shape
+= Codex gauge + universal local **burn** layer (transcript `message.usage`, zero-credential, works
+for every provider) + static plan/tier labels where readable (Claude Max, Gemini Unlimited).
+
+### 4d. CLAUDE SOLVED (2026-07-25) — supersedes the "Claude blocked" verdict
+Claude Code authenticates via the **`CLAUDE_CODE_OAUTH_TOKEN` env var** (a `claude setup-token`,
+long-lived ~1yr, **non-rotating** → zero risk), NOT the stale keychain. `claude auth status --text`
+reveals this. The token is `user:inference`-scoped, so `/api/oauth/usage` + `/api/oauth/profile`
+403 (need `user:profile`) — BUT the usage data rides on **response headers of a real `/v1/messages`
+call**, which only needs `user:inference`:
+
+```
+POST https://api.anthropic.com/v1/messages   (model: claude-haiku-4-5-20251001, max_tokens:1)
+  Authorization: Bearer $CLAUDE_CODE_OAUTH_TOKEN
+  anthropic-beta: oauth-2025-04-20
+→ 200, headers:
+  anthropic-ratelimit-unified-5h-utilization: 0.07   anthropic-ratelimit-unified-5h-reset: <epoch>
+  anthropic-ratelimit-unified-7d-utilization: 0.59   anthropic-ratelimit-unified-7d-reset: <epoch>
+  anthropic-ratelimit-unified-5h-status/7d-status: allowed
+  anthropic-ratelimit-unified-representative-claim: five_hour
+```
+So **Claude = full gauge (5h + weekly utilization + reset).** Cost: ~1 token/poll (a real inference
+call), so poll on-demand + cache only; the probe itself nudges utilization negligibly. `count_tokens`
+does NOT carry these headers — must be `/v1/messages`.
+
+**Updated scorecard: Claude ✅ + Codex ✅ (both full gauges), Gemini = Unlimited (no quota exists),
+Grok = unsupported via CLI token, Kimi = pending one `kimi info` refresh.**
+
+### 4e. GROK SOLVED (2026-07-25) — same inference-header pattern as Claude
+Grok's proxy gates inference on a **`x-grok-client-version`** header (426 without it; header name
+found via `strings ~/.grok/bin/grok`). With it, a minimal responses call returns usage in headers:
+
+```
+POST https://cli-chat-proxy.grok.com/v1/responses   {model:grok-4.5, input:"hi", max_output_tokens:1}
+  Authorization: Bearer <auth.json .key>
+  x-grok-client-version: 0.2.22        (also seen: x-grok-user-id, x-grok-client-identifier, x-grok-deployment-id)
+→ 200, headers:
+  x-ratelimit-limit-tokens: 53000000    x-ratelimit-remaining-tokens: 53000000
+  x-ratelimit-limit-requests: 8300      x-ratelimit-remaining-requests: 8300
+```
+So **Grok = gauge** (tokens + requests remaining/limit; no reset epoch in these headers → show % used,
+not countdown). Cost: 1 minimal inference call per poll → on-demand + cache.
+
+### THE REUSABLE KEY
+Usage lives in the **response headers of a real inference call**, not a dedicated usage endpoint,
+for Claude (`anthropic-ratelimit-unified-*`) and Grok (`x-ratelimit-*`). Codex has a real usage
+endpoint. Kimi almost certainly follows the inference-header pattern too (verify after `kimi info`).
+Design implication: adapters need an "inference-probe" mode (minimal call, read headers, discard body)
+in addition to the "usage-endpoint" mode — both are on-demand + cached (each probe costs ~1 token).
+
+### FINAL SCORECARD (2026-07-25)
+| Provider | Gauge | Source | Cost/poll |
+|---|---|---|---|
+| **Claude** | ✅ 5h + weekly % + reset | `/v1/messages` unified headers, `CLAUDE_CODE_OAUTH_TOKEN` | ~1 token |
+| **Codex** | ✅ window + credits | `backend-api/codex/usage` endpoint | free (throttled) |
+| **Grok** | ✅ tokens + requests remaining | `/v1/responses` `x-ratelimit-*` headers | ~1 token |
+| **Gemini** | — (Unlimited tier) | `loadCodeAssist` (label only) | free |
+| **Kimi** | ❓ pending refresh | likely inference headers | TBD |
+
 ## 5. Open research variables (carried into DESIGN as claims-to-falsify)
 - **R1 (load-bearing):** Does each CLI *persist* its refreshed token to a cmux-readable location
   (auth file / keychain), or keep it in memory only? Codex: yes (`last_refresh` in auth.json).


### PR DESCRIPTION
## What

Adds a multi-provider AI usage HUD to the cmux sidebar footer, next to the help button. A compact tile shows the focused agent provider's utilization; tapping opens a multi-provider panel (Claude, Codex, Grok) with usage bars.

## How it's built

- **`CmuxUsage` package** (`Packages/macOS/CmuxUsage`): value types (`UsageProvider`/`UsageWindow`/`UsageSnapshot`/`UsageFreshness`), per-provider adapters (Codex usage endpoint; Claude + Grok read utilization from undocumented inference response headers), a `UsageFetcher` that maps errors to freshness (never throws to UI), an on-demand `UsageStore` (no background timer — fetch only on user action), and value-driven SwiftUI views (no store held below a list boundary).
- **App wiring**: linked into the `cmux` target; `UsageFooterHost` resolves the active provider (`selectedWorkspace.focusedPanelId` → `SharedLiveAgentIndex` → `RestorableAgentKind`) and hosts the panel. Provider resolution + refresh run **off the body path** (`.task`/tap into `@State`) — the footer is typing-latency-sensitive, so `body` stays side-effect free.
- **Localized** en + ja (14 keys).

## Security posture

Read-only credential access; cmux never writes/refreshes a token. All network bodies, CLI stdout, and auth files are treated as hostile input (strict Codable, size caps, fail-closed on drift). One request per fetch; no background polling. Usage rides undocumented provider response headers — an unversioned side channel that degrades to a label on breakage, never a crash.

## Dogfood findings (already addressed)

- Verified live against real credentials. The panel renders correctly; each adapter degrades correctly on stale/expired/throttled creds.
- **Fixed**: the Claude adapter previously read the OAuth token only from the environment, so a Finder/Dock-launched cmux (no inherited shell env) always showed "signed out". Now falls back env → `~/.claude/.credentials.json` → `~/.claude/.env` (read-only, size-capped, fail-closed). Verified end-to-end by launching via Finder.

## Tests

26 unit tests green (`swift test`), including 6 new synthetic-fixture tests for token resolution (no real tokens).

## Not included / follow-ups

- Kimi adapter (pending a fresh token; near-copy of Grok).
- Optional: distinguish "expired" from "signed out" (401 vs no-cred); consider Codex 403 → rate-limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787679007&installation_model_id=21920&pr_number=8957&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8957&signature=98314f16a5feac1ade603a88ad7bca39335f7f99ea615a6f6f3cf3c8ed169cbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-provider usage HUD in the sidebar footer showing live limits for the focused provider and a panel for Claude, Codex, and Grok. Ships the `CmuxUsage` package and wires it into the app with hardened backoff, i18n, and credential handling from review.

- New Features
  - Sidebar tile next to the help button shows the active provider’s utilization; tap opens a multi-provider panel.
  - `CmuxUsage` package: adapters (Codex usage endpoint; Claude/Grok via inference headers), `UsageFetcher`, `UsageStore` (no background timer), and SwiftUI HUD views; `UsageFooterHost` resolves the active provider off the body path for low typing latency.
  - Supports Claude, Codex, and Grok; hides Gemini (unlimited) and Kimi (pending). Localized (en, ja).

- Bug Fixes
  - Fixed i18n formatting for remaining/reset strings; renders correctly in ja.
  - `UsageStore` now honors provider backoff on `.rateLimited(until:)` and does not burn cache on cancelled fetches.
  - Codex parser degrades structureless responses instead of showing a live empty gauge.
  - Unified, size-capped, fail-closed credential file reads across adapters; Grok auth uses strict Decodable with deterministic selection; env-file token parsing strips trailing comments.
  - 31 tests total.

<sup>Written for commit ac1256cb0c2c04fca7e619c73339aa43376d3148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a macOS sidebar usage HUD supporting Claude, Codex, and Grok.
  * Shows quota gauges with rolling windows, credits, reset timing, and account/status details.
  * Adds a popover for expanded multi-account limits.
  * Usage refresh is user-driven and keeps the last known values during temporary failures.

* **Localization**
  * Added/updated English and Japanese strings for usage labels, window text, reset details, and status messages.

* **Documentation**
  * Added usage HUD design, research, and validation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->