### PR TITLE
fix: coalesce browser rendering and teardown

### DIFF
--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -274,9 +274,6 @@ extension WKWebView {
 
         setFrameSize(nudgedSize)
         needsLayout = true
-        layoutSubtreeIfNeeded()
-        enclosingScrollView?.layoutSubtreeIfNeeded()
-        displayIfNeeded()
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -293,9 +290,6 @@ extension WKWebView {
             }
             self.setFrameSize(originalSize)
             self.needsLayout = true
-            self.layoutSubtreeIfNeeded()
-            self.enclosingScrollView?.layoutSubtreeIfNeeded()
-            self.displayIfNeeded()
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.webview.firstSizedReveal.restore web=\(browserPortalRenderingStateDebugToken(self)) " +

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2404,7 +2404,8 @@ final class WindowBrowserPortal: NSObject {
         in containerView: WindowBrowserSlotView,
         reason: String,
         phase: String,
-        reattachRenderingState: Bool
+        reattachRenderingState: Bool,
+        forceRenderingStateRefresh: Bool
     ) {
         guard !containerView.isHidden else { return }
         guard !containerView.isHostedInspectorDividerDragActive else {
@@ -2448,7 +2449,11 @@ final class WindowBrowserPortal: NSObject {
 
         for webKitSubview in hostedWebKitSubviews {
             if reattachRenderingState {
-                webKitSubview.browserPortalForceRenderingStateRefresh(reason: "\(reason):\(phase)")
+                if forceRenderingStateRefresh {
+                    webKitSubview.browserPortalForceRenderingStateRefresh(reason: "\(reason):\(phase)")
+                } else {
+                    webKitSubview.browserPortalReattachRenderingState(reason: "\(reason):\(phase)")
+                }
             }
             if webKitSubview === webView {
                 webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
@@ -2479,14 +2484,16 @@ final class WindowBrowserPortal: NSObject {
             in: containerView,
             reason: reason,
             phase: "geometry",
-            reattachRenderingState: false
+            reattachRenderingState: false,
+            forceRenderingStateRefresh: false
         )
     }
 
     private func refreshHostedWebViewPresentation(
         _ webView: WKWebView,
         in containerView: WindowBrowserSlotView,
-        reason: String
+        reason: String,
+        forceRenderingStateRefresh: Bool
     ) {
         guard !containerView.isHidden else { return }
         runHostedWebViewRefreshPass(
@@ -2494,7 +2501,8 @@ final class WindowBrowserPortal: NSObject {
             in: containerView,
             reason: reason,
             phase: "presentation",
-            reattachRenderingState: true
+            reattachRenderingState: true,
+            forceRenderingStateRefresh: forceRenderingStateRefresh
         )
     }
 
@@ -3582,7 +3590,8 @@ final class WindowBrowserPortal: NSObject {
                     refreshHostedWebViewPresentation(
                         webView,
                         in: containerView,
-                        reason: refreshReason
+                        reason: refreshReason,
+                        forceRenderingStateRefresh: forcePresentationRefresh
                     )
                 }
             }

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2434,10 +2434,9 @@ final class WindowBrowserPortal: NSObject {
         containerView.needsLayout = true
         containerView.needsDisplay = true
         containerView.setNeedsDisplay(containerView.bounds)
-        let presentationView = webView.cmuxBrowserViewportPresentationView
-        if presentationView !== webView {
-            presentationView.needsLayout = true
-            presentationView.setNeedsDisplay(presentationView.bounds)
+        if let viewportHost =
+            webView.cmuxBrowserViewportPresentationView as? BrowserViewportHostView {
+            viewportHost.invalidateBrowserPortalPresentation()
         }
 
         for webKitSubview in hostedWebKitSubviews {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -3025,10 +3025,11 @@ final class WindowBrowserPortal: NSObject {
         }
 
         // During rapid geometry changes (e.g. divider drag), syncing every web view
-        // on every frame is expensive and causes stuttering.  Each panel's
-        // HostContainerView fires its own geometry callback, so secondary web views
-        // will sync themselves.  Defer the all-sync to coalesce with the next
-        // run-loop turn instead.
+        // on every frame is expensive and causes stuttering. Each panel's
+        // HostContainerView fires its own geometry callback, so the primary entry
+        // is already current. Only schedule the recovery all-sync when another
+        // entry may still need reconciliation.
+        guard primaryWebViewId == nil || entriesByWebViewId.count > 1 else { return }
         scheduleDeferredFullSynchronizeAll()
     }
 

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1829,9 +1829,8 @@ final class WindowBrowserPortal: NSObject {
     }
 
     private struct PendingHostedWebViewRefresh {
-        var generation: UInt64 = 0
-        var asyncWorkItem: DispatchWorkItem?
-        var delayedWorkItem: DispatchWorkItem?
+        let generation: UInt64
+        let workItem: DispatchWorkItem
     }
 
     private var entriesByWebViewId: [ObjectIdentifier: Entry] = [:]
@@ -2007,17 +2006,6 @@ final class WindowBrowserPortal: NSObject {
         hostView.layoutSubtreeIfNeeded()
         synchronizeAllWebViews(excluding: nil, source: "externalGeometry")
 
-        for entry in entriesByWebViewId.values {
-            guard let webView = entry.webView,
-                  let containerView = entry.containerView,
-                  !containerView.isHidden else { continue }
-            guard webView.cmuxBrowserViewportPresentationView.superview === containerView else { continue }
-            invalidateHostedWebViewGeometry(
-                webView,
-                in: containerView,
-                reason: "externalGeometry"
-            )
-        }
     }
 
     @discardableResult
@@ -2461,16 +2449,9 @@ final class WindowBrowserPortal: NSObject {
             webKitSubview.setNeedsDisplay(webKitSubview.bounds)
         }
 
-        containerView.layoutSubtreeIfNeeded()
         for webKitSubview in hostedWebKitSubviews {
-            if let scrollView = webKitSubview.enclosingScrollView {
-                scrollView.layoutSubtreeIfNeeded()
-                scrollView.contentView.layoutSubtreeIfNeeded()
-                scrollView.displayIfNeeded()
-            }
-            webKitSubview.layoutSubtreeIfNeeded()
             if reattachRenderingState {
-                webKitSubview.browserPortalReattachRenderingState(reason: "\(reason):\(phase)")
+                webKitSubview.browserPortalForceRenderingStateRefresh(reason: "\(reason):\(phase)")
             }
             if webKitSubview === webView {
                 webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
@@ -2479,10 +2460,7 @@ final class WindowBrowserPortal: NSObject {
                     relativeTo: window
                 )
             }
-            webKitSubview.displayIfNeeded()
         }
-        containerView.displayIfNeeded()
-        (containerView.window ?? webView.window ?? hostView.window)?.displayIfNeeded()
 #if DEBUG
         cmuxDebugLog(
             "\(reattachRenderingState ? "browser.portal.refresh" : "browser.portal.invalidate") " +
@@ -2493,20 +2471,9 @@ final class WindowBrowserPortal: NSObject {
 #endif
     }
 
-    private func cancelPendingHostedWebViewRefreshes(
-        for webViewId: ObjectIdentifier,
-        keepGeneration: Bool = false
-    ) {
-        guard var pending = pendingHostedWebViewRefreshes[webViewId] else { return }
-        pending.asyncWorkItem?.cancel()
-        pending.delayedWorkItem?.cancel()
-        if keepGeneration {
-            pending.asyncWorkItem = nil
-            pending.delayedWorkItem = nil
-            pendingHostedWebViewRefreshes[webViewId] = pending
-        } else {
-            pendingHostedWebViewRefreshes.removeValue(forKey: webViewId)
-        }
+    private func cancelPendingHostedWebViewRefreshes(for webViewId: ObjectIdentifier) {
+        guard let pending = pendingHostedWebViewRefreshes.removeValue(forKey: webViewId) else { return }
+        pending.workItem.cancel()
     }
 
     private func invalidateHostedWebViewGeometry(
@@ -2531,61 +2498,30 @@ final class WindowBrowserPortal: NSObject {
         guard !containerView.isHidden else { return }
         let webViewId = ObjectIdentifier(webView)
 
-        // Bind/reveal/fullscreen refreshes can stack up during a single layout churn.
-        // Keep only the latest follow-up passes so reattach work does not pile up on
-        // the main thread while browser panes are moving between hosts.
-        cancelPendingHostedWebViewRefreshes(for: webViewId, keepGeneration: true)
-        var pending = pendingHostedWebViewRefreshes[webViewId] ?? PendingHostedWebViewRefresh()
+        // Bind/reveal/fullscreen refreshes can stack up during one layout churn.
+        // Keep only the latest next-turn pass so WebKit reattach work is committed
+        // once, after AppKit has coalesced the current geometry changes.
+        cancelPendingHostedWebViewRefreshes(for: webViewId)
         nextHostedWebViewRefreshGeneration &+= 1
         let generation = nextHostedWebViewRefreshGeneration
-        pending.generation = generation
 
-        runHostedWebViewRefreshPass(
-            webView,
-            in: containerView,
-            reason: reason,
-            phase: "immediate",
-            reattachRenderingState: true
-        )
-
-        let asyncWorkItem = DispatchWorkItem { [weak self, weak webView, weak containerView] in
+        let workItem = DispatchWorkItem { [weak self, weak webView, weak containerView] in
             guard let self, let webView, let containerView else { return }
             guard self.pendingHostedWebViewRefreshes[webViewId]?.generation == generation else { return }
+            self.pendingHostedWebViewRefreshes.removeValue(forKey: webViewId)
             self.runHostedWebViewRefreshPass(
                 webView,
                 in: containerView,
                 reason: reason,
-                phase: "async",
+                phase: "coalesced",
                 reattachRenderingState: true
             )
         }
-        pending.asyncWorkItem = asyncWorkItem
-
-        let delayedWorkItem = DispatchWorkItem { [weak self, weak webView, weak containerView] in
-            guard let self else { return }
-            defer {
-                if var current = self.pendingHostedWebViewRefreshes[webViewId],
-                   current.generation == generation {
-                    current.asyncWorkItem = nil
-                    current.delayedWorkItem = nil
-                    self.pendingHostedWebViewRefreshes[webViewId] = current
-                }
-            }
-            guard let webView, let containerView else { return }
-            guard self.pendingHostedWebViewRefreshes[webViewId]?.generation == generation else { return }
-            self.runHostedWebViewRefreshPass(
-                webView,
-                in: containerView,
-                reason: reason,
-                phase: "delayed",
-                reattachRenderingState: true
-            )
-        }
-        pending.delayedWorkItem = delayedWorkItem
-        pendingHostedWebViewRefreshes[webViewId] = pending
-
-        DispatchQueue.main.async(execute: asyncWorkItem)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03, execute: delayedWorkItem)
+        pendingHostedWebViewRefreshes[webViewId] = PendingHostedWebViewRefresh(
+            generation: generation,
+            workItem: workItem
+        )
+        DispatchQueue.main.async(execute: workItem)
     }
 
     private enum HostedWebViewPresentationUpdateKind {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -3058,9 +3058,9 @@ final class WindowBrowserPortal: NSObject {
             "reason=\(reason) remaining=\(entry.transientRecoveryRetriesRemaining)"
         )
 #endif
-        if entry.transientRecoveryRetriesRemaining > 0 {
-            scheduleDeferredFullSynchronizeAll()
-        }
+        // Schedule once more after consuming the final retry so the next pass
+        // observes exhaustion and hides a still-detached visible entry.
+        scheduleDeferredFullSynchronizeAll()
         return true
     }
 

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -3469,6 +3469,8 @@ final class WindowBrowserPortal: NSObject {
         }
 
         let containerOwnsWebView = webView.superview === containerView
+        let containerOwnsPresentationView =
+            webView.cmuxBrowserViewportPresentationView.superview === containerView
         let containerBounds = containerView.bounds
         let preNormalizeWebFrame = containerOwnsWebView ? webView.frame : .zero
         let inspectorHeightFromInsets = max(0, containerBounds.height - preNormalizeWebFrame.height)
@@ -3591,7 +3593,7 @@ final class WindowBrowserPortal: NSObject {
         )
         let shouldReapplyHostedInspectorPostRefresh =
             presentationUpdateKind == .refresh && requiresRenderingStateReattach
-        if !shouldHide, containerOwnsWebView, presentationUpdateKind != .none {
+        if !shouldHide, containerOwnsPresentationView, presentationUpdateKind != .none {
             if presentationUpdateKind == .refresh &&
                 hostedInspectorAdjustedDuringSync &&
                 !recoveredFromTransientGeometry &&

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -3163,13 +3163,10 @@ final class WindowBrowserPortal: NSObject {
                 anchorView.window == nil &&
                 anchorView.superview != nil
             if isOffWindowReparent {
-                if preserveVisibleDuringTransientDetach(reason: "anchorWindowMismatch.offWindow") {
-                    return
-                }
-                if scheduleTransientDetachRecovery(reason: "anchorWindowMismatch") {
-                    hideContainerView(reason: "anchorWindowMismatch")
-                    return
-                }
+                // A drag reparent can remain off-window beyond the retry budget. Exhaustion
+                // stops polling but must not hide the last valid presentation before rebind.
+                _ = preserveVisibleDuringTransientDetach(reason: "anchorWindowMismatch.offWindow")
+                return
             }
             if preserveVisibleDuringTransientDetach(reason: "anchorWindowMismatch") {
                 return

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2434,6 +2434,11 @@ final class WindowBrowserPortal: NSObject {
         containerView.needsLayout = true
         containerView.needsDisplay = true
         containerView.setNeedsDisplay(containerView.bounds)
+        let presentationView = webView.cmuxBrowserViewportPresentationView
+        if presentationView !== webView {
+            presentationView.needsLayout = true
+            presentationView.setNeedsDisplay(presentationView.bounds)
+        }
 
         for webKitSubview in hostedWebKitSubviews {
             if let scrollView = webKitSubview.enclosingScrollView {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2823,7 +2823,13 @@ final class WindowBrowserPortal: NSObject {
         )
     }
 
-    func bind(webView: WKWebView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
+    func bind(
+        webView: WKWebView,
+        to anchorView: NSView,
+        visibleInUI: Bool,
+        zPriority: Int = 0,
+        forcePresentationRefresh: Bool = false
+    ) {
         guard ensureInstalled() else { return }
 
         let webViewId = ObjectIdentifier(webView)
@@ -2969,7 +2975,7 @@ final class WindowBrowserPortal: NSObject {
         synchronizeWebView(
             withId: webViewId,
             source: "bind",
-            forcePresentationRefresh: didChangeAnchor
+            forcePresentationRefresh: didChangeAnchor || forcePresentationRefresh
         )
         pruneDeadEntries()
     }
@@ -3794,7 +3800,13 @@ enum BrowserWindowPortalRegistry {
         return portal
     }
 
-    static func bind(webView: WKWebView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
+    static func bind(
+        webView: WKWebView,
+        to anchorView: NSView,
+        visibleInUI: Bool,
+        zPriority: Int = 0,
+        forcePresentationRefresh: Bool = false
+    ) {
         guard let window = anchorView.window else { return }
 
         let windowId = ObjectIdentifier(window)
@@ -3806,7 +3818,13 @@ enum BrowserWindowPortalRegistry {
             portalsByWindowId[oldWindowId]?.detachWebView(withId: webViewId)
         }
 
-        nextPortal.bind(webView: webView, to: anchorView, visibleInUI: visibleInUI, zPriority: zPriority)
+        nextPortal.bind(
+            webView: webView,
+            to: anchorView,
+            visibleInUI: visibleInUI,
+            zPriority: zPriority,
+            forcePresentationRefresh: forcePresentationRefresh
+        )
         webViewToWindowId[webViewId] = windowId
         pruneWebViewMappings(for: windowId, validWebViewIds: nextPortal.webViewIds())
         postRegistryDidChange(for: webView)

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -3555,9 +3555,11 @@ final class WindowBrowserPortal: NSObject {
             reasons: refreshReasons
         )
         let shouldReapplyHostedInspectorPostRefresh =
-            presentationUpdateKind == .refresh && requiresRenderingStateReattach
+            presentationUpdateKind == .refresh &&
+            (requiresRenderingStateReattach || forcePresentationRefresh)
         if !shouldHide, containerOwnsPresentationView, presentationUpdateKind != .none {
             if presentationUpdateKind == .refresh &&
+                !forcePresentationRefresh &&
                 hostedInspectorAdjustedDuringSync &&
                 !recoveredFromTransientGeometry &&
                 !requiresRenderingStateReattach {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1808,9 +1808,6 @@ final class WindowBrowserPortal: NSObject {
     private var hasDeferredFullSyncScheduled = false
     private var hasExternalGeometrySyncScheduled = false
     private var geometryObservers: [NSObjectProtocol] = []
-    // Keep generations monotonic even if a pending entry is cleared during hide/detach churn.
-    private var nextHostedWebViewRefreshGeneration: UInt64 = 0
-    private var pendingHostedWebViewRefreshes: [ObjectIdentifier: PendingHostedWebViewRefresh] = [:]
 
     private struct Entry {
         weak var webView: WKWebView?
@@ -1828,10 +1825,6 @@ final class WindowBrowserPortal: NSObject {
         var transientRecoveryRetriesRemaining: Int
     }
 
-    private struct PendingHostedWebViewRefresh {
-        let generation: UInt64
-        let workItem: DispatchWorkItem
-    }
 
     private var entriesByWebViewId: [ObjectIdentifier: Entry] = [:]
     private var webViewByAnchorId: [ObjectIdentifier: ObjectIdentifier] = [:]
@@ -2475,10 +2468,6 @@ final class WindowBrowserPortal: NSObject {
 #endif
     }
 
-    private func cancelPendingHostedWebViewRefreshes(for webViewId: ObjectIdentifier) {
-        guard let pending = pendingHostedWebViewRefreshes.removeValue(forKey: webViewId) else { return }
-        pending.workItem.cancel()
-    }
 
     private func invalidateHostedWebViewGeometry(
         _ webView: WKWebView,
@@ -2500,32 +2489,13 @@ final class WindowBrowserPortal: NSObject {
         reason: String
     ) {
         guard !containerView.isHidden else { return }
-        let webViewId = ObjectIdentifier(webView)
-
-        // Bind/reveal/fullscreen refreshes can stack up during one layout churn.
-        // Keep only the latest next-turn pass so WebKit reattach work is committed
-        // once, after AppKit has coalesced the current geometry changes.
-        cancelPendingHostedWebViewRefreshes(for: webViewId)
-        nextHostedWebViewRefreshGeneration &+= 1
-        let generation = nextHostedWebViewRefreshGeneration
-
-        let workItem = DispatchWorkItem { [weak self, weak webView, weak containerView] in
-            guard let self, let webView, let containerView else { return }
-            guard self.pendingHostedWebViewRefreshes[webViewId]?.generation == generation else { return }
-            self.pendingHostedWebViewRefreshes.removeValue(forKey: webViewId)
-            self.runHostedWebViewRefreshPass(
-                webView,
-                in: containerView,
-                reason: reason,
-                phase: "coalesced",
-                reattachRenderingState: true
-            )
-        }
-        pendingHostedWebViewRefreshes[webViewId] = PendingHostedWebViewRefresh(
-            generation: generation,
-            workItem: workItem
+        runHostedWebViewRefreshPass(
+            webView,
+            in: containerView,
+            reason: reason,
+            phase: "presentation",
+            reattachRenderingState: true
         )
-        DispatchQueue.main.async(execute: workItem)
     }
 
     private enum HostedWebViewPresentationUpdateKind {
@@ -2604,7 +2574,6 @@ final class WindowBrowserPortal: NSObject {
     }
 
     func detachWebView(withId webViewId: ObjectIdentifier) {
-        cancelPendingHostedWebViewRefreshes(for: webViewId)
         guard let entry = entriesByWebViewId.removeValue(forKey: webViewId) else { return }
         if let anchor = entry.anchorView {
             webViewByAnchorId.removeValue(forKey: ObjectIdentifier(anchor))
@@ -2637,7 +2606,6 @@ final class WindowBrowserPortal: NSObject {
         source: String,
         preserveCurrentSuperview: Bool
     ) {
-        cancelPendingHostedWebViewRefreshes(for: webViewId)
         guard let entry = entriesByWebViewId.removeValue(forKey: webViewId) else { return }
         if let anchor = entry.anchorView {
             webViewByAnchorId.removeValue(forKey: ObjectIdentifier(anchor))
@@ -2848,24 +2816,10 @@ final class WindowBrowserPortal: NSObject {
 
     func forceRefreshWebView(withId webViewId: ObjectIdentifier, reason: String) {
         guard ensureInstalled() else { return }
-        let refreshSource = "forceRefresh:\(reason)"
         synchronizeWebView(
             withId: webViewId,
-            source: refreshSource,
+            source: "forceRefresh:\(reason)",
             forcePresentationRefresh: true
-        )
-        guard let entry = entriesByWebViewId[webViewId],
-              let webView = entry.webView,
-              let containerView = entry.containerView,
-              !containerView.isHidden else {
-            return
-        }
-        // Portal-host replacement/fullscreen churn relies on forceRefresh to kick
-        // WebKit even when synchronizeWebView short-circuits or skips its refresh path.
-        refreshHostedWebViewPresentation(
-            webView,
-            in: containerView,
-            reason: refreshSource
         )
     }
 
@@ -3124,7 +3078,6 @@ final class WindowBrowserPortal: NSObject {
         }
         let previousTransientRecoveryReason = entry.transientRecoveryReason
         func hideContainerView(reason: String) {
-            cancelPendingHostedWebViewRefreshes(for: webViewId)
             containerView.setPaneTopChromeHeight(0)
             containerView.setSearchOverlay(nil)
             containerView.setDesignComposer(nil)

--- a/Sources/DockSplitStore+PortalReconcile.swift
+++ b/Sources/DockSplitStore+PortalReconcile.swift
@@ -272,7 +272,7 @@ extension DockSplitStore {
             BrowserWindowPortalRegistry.synchronizeForAnchor(anchorView)
         }
         let isReady = dockBrowserPortalReady(browser)
-        if isReady && (!wasReady || snapshot?.containerHidden == true) {
+        if wasReady && isReady && snapshot?.containerHidden == true {
             BrowserWindowPortalRegistry.refresh(webView: webView, reason: reason)
         }
         return !isReady

--- a/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
+++ b/Sources/Panels/BrowserHiddenWebViewDiscardManager.swift
@@ -240,6 +240,10 @@ final class BrowserHiddenWebViewDiscardManager {
         }
     }
 
+    func shutdown() {
+        stopOnMainActor()
+    }
+
     func markDiscarded(reason: String, now: Date) {
         isDiscardedForMemory = true
         isRestoreNavigationPending = false
@@ -333,6 +337,7 @@ final class BrowserHiddenWebViewDiscardManager {
 
     private func stopOnMainActor() {
         cancel()
+        delegate = nil
         if let policyObserver {
             NotificationCenter.default.removeObserver(policyObserver)
             self.policyObserver = nil

--- a/Sources/Panels/BrowserPanel+AutomationViewport.swift
+++ b/Sources/Panels/BrowserPanel+AutomationViewport.swift
@@ -136,10 +136,6 @@ extension BrowserPanel {
         webView.translatesAutoresizingMaskIntoConstraints = true
         webView.autoresizingMask = [.width, .height]
         webView.cmuxBrowserViewportHostView?.apply(nativeLayout, updateWebView: false)
-        BrowserWindowPortalRegistry.refresh(
-            webView: webView,
-            reason: "attachedInspectorResetAutomationViewport"
-        )
         return true
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5445,8 +5445,9 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func close() {
-        cancelHiddenWebViewDiscard()
+        guard !isClosingWebViewLifecycle else { return }
         isClosingWebViewLifecycle = true
+        hiddenWebViewDiscardManager.shutdown()
         automationNavigationCoordinator.invalidate()
         automationDocumentReadiness.invalidate()
         automationWatchdog.invalidate()
@@ -5475,6 +5476,20 @@ final class BrowserPanel: Panel, ObservableObject {
         webViewDidRequestClose = nil
         detachWebViewObservers()
         faviconTask?.cancel(); faviconTask = nil
+        browserViewportHostRestorationTask?.cancel()
+        browserViewportHostRestorationTask = nil
+        browserViewportHostRestorationPending = false
+
+        let replacement = makeReplacementWebView(
+            profileID: profileID,
+            websiteDataStore: websiteDataStore
+        )
+        shouldRenderWebView = false
+        webViewInstanceID = UUID()
+        hasCommittedDocumentSinceWebViewReplacement = false
+        userStoppedLoadSinceWebViewReplacement = false
+        webView = replacement
+        viewportHostView.installWebView(replacement)
     }
 
     // MARK: - Popup window management

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6698,7 +6698,12 @@ extension BrowserPanel {
             // (`consumeAttachedDeveloperToolsManualCloseIfNeeded`) refuses to
             // run and preserved visible intent can resurrect an inspector the
             // user explicitly closed.
-            resetAutomationViewportForAttachedBrowserInspector()
+            if resetAutomationViewportForAttachedBrowserInspector() {
+                BrowserWindowPortalRegistry.refresh(
+                    webView: webView,
+                    reason: "attachedInspectorPreferenceSync"
+                )
+            }
             setPreferredDeveloperToolsPresentation(.attached)
             developerToolsDetachedOpenGraceDeadline = nil
             if developerToolsLastAttachedHostAt == nil {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5480,6 +5480,9 @@ final class BrowserPanel: Panel, ObservableObject {
         browserViewportHostRestorationTask = nil
         browserViewportHostRestorationPending = false
 
+        // Local inline hosting has no portal registry entry to detach.
+        webView.cmuxBrowserViewportPresentationView.removeFromSuperview()
+
         let replacement = makeReplacementWebView(
             profileID: profileID,
             websiteDataStore: websiteDataStore

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7500,7 +7500,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                 webView: webView,
                 to: portalAnchorView,
                 visibleInUI: coordinator.desiredPortalVisibleInUI,
-                zPriority: coordinator.desiredPortalZPriority
+                zPriority: coordinator.desiredPortalZPriority,
+                forcePresentationRefresh: true
             )
             BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
                 for: webView,
@@ -7533,7 +7534,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     webView: webView,
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
-                    zPriority: coordinator.desiredPortalZPriority
+                    zPriority: coordinator.desiredPortalZPriority,
+                    forcePresentationRefresh: true
                 )
                 BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
                     for: webView,
@@ -7574,7 +7576,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     webView: webView,
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
-                    zPriority: coordinator.desiredPortalZPriority
+                    zPriority: coordinator.desiredPortalZPriority,
+                    forcePresentationRefresh: true
                 )
                 coordinator.lastPortalHostId = hostId
                 coordinator.lastSynchronizedHostGeometryRevision = geometryRevision

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -7502,10 +7502,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 visibleInUI: coordinator.desiredPortalVisibleInUI,
                 zPriority: coordinator.desiredPortalZPriority
             )
-            BrowserWindowPortalRegistry.refresh(
-                webView: webView,
-                reason: "portalHostBind.didMoveToWindow"
-            )
             BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
                 for: webView,
                 height: coordinator.desiredPortalVisibleInUI ? paneTopChromeHeight : 0
@@ -7538,10 +7534,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
                     zPriority: coordinator.desiredPortalZPriority
-                )
-                BrowserWindowPortalRegistry.refresh(
-                    webView: webView,
-                    reason: "portalHostBind.geometryChanged"
                 )
                 BrowserWindowPortalRegistry.updatePaneTopChromeHeight(
                     for: webView,
@@ -7576,19 +7568,13 @@ struct WebViewRepresentable: NSViewRepresentable {
                 previousZPriority != portalZPriority
             if shouldBindNow {
                 Self.installPortalAnchorView(portalAnchorView, in: host)
+                // Registry bind owns the one synchronous rendering-state refresh
+                // after portal host replacement.
                 BrowserWindowPortalRegistry.bind(
                     webView: webView,
                     to: portalAnchorView,
                     visibleInUI: coordinator.desiredPortalVisibleInUI,
                     zPriority: coordinator.desiredPortalZPriority
-                )
-                // Force a rendering-state reattach after portal host replacement
-                // (e.g. after a pane split). Without this, WKWebView can freeze
-                // because _exitInWindow/_enterInWindow are never cycled when the
-                // web view is reparented to a new container during bind.
-                BrowserWindowPortalRegistry.refresh(
-                    webView: webView,
-                    reason: "portalHostBind"
                 )
                 coordinator.lastPortalHostId = hostId
                 coordinator.lastSynchronizedHostGeometryRevision = geometryRevision

--- a/Sources/Panels/BrowserViewportHostView.swift
+++ b/Sources/Panels/BrowserViewportHostView.swift
@@ -12,9 +12,6 @@ import WebKit
 final class BrowserViewportHostView: NSView {
     private(set) weak var webView: WKWebView?
     private(set) var appliedLayout: BrowserViewportLayout?
-#if DEBUG
-    private(set) var browserPortalInvalidationCountForTesting = 0
-#endif
 
     override var isFlipped: Bool { true }
     override var isOpaque: Bool { false }
@@ -60,9 +57,6 @@ final class BrowserViewportHostView: NSView {
     }
 
     func invalidateBrowserPortalPresentation() {
-#if DEBUG
-        browserPortalInvalidationCountForTesting += 1
-#endif
         needsLayout = true
         setNeedsDisplay(bounds)
     }

--- a/Sources/Panels/BrowserViewportHostView.swift
+++ b/Sources/Panels/BrowserViewportHostView.swift
@@ -12,6 +12,9 @@ import WebKit
 final class BrowserViewportHostView: NSView {
     private(set) weak var webView: WKWebView?
     private(set) var appliedLayout: BrowserViewportLayout?
+#if DEBUG
+    private(set) var browserPortalInvalidationCountForTesting = 0
+#endif
 
     override var isFlipped: Bool { true }
     override var isOpaque: Bool { false }
@@ -54,6 +57,14 @@ final class BrowserViewportHostView: NSView {
             appliedLayout = nil
             removeFromSuperview()
         }
+    }
+
+    func invalidateBrowserPortalPresentation() {
+#if DEBUG
+        browserPortalInvalidationCountForTesting += 1
+#endif
+        needsLayout = true
+        setNeedsDisplay(bounds)
     }
 
     @discardableResult

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10022,8 +10022,9 @@ final class Workspace: Identifiable, ObservableObject {
                     BrowserWindowPortalRegistry.synchronizeForAnchor(browserPanel.portalAnchorView)
                 }
                 let isReady = browserPortalReady(for: browserPanel)
-                if isReady,
-                   (!wasReady || BrowserWindowPortalRegistry.debugSnapshot(for: browserPanel.webView)?.containerHidden == true) {
+                if wasReady,
+                   isReady,
+                   BrowserWindowPortalRegistry.debugSnapshot(for: browserPanel.webView)?.containerHidden == true {
                     BrowserWindowPortalRegistry.refresh(
                         webView: browserPanel.webView,
                         reason: reason
@@ -10309,10 +10310,6 @@ final class Workspace: Identifiable, ObservableObject {
                 if anchorReady && !portalReady {
                     BrowserWindowPortalRegistry.synchronizeForAnchor(anchorView)
                     if browserPortalReady(for: browserPanel) {
-                        BrowserWindowPortalRegistry.refresh(
-                            webView: browserPanel.webView,
-                            reason: reason
-                        )
                         didChange = true
                     }
                 } else if anchorReady && snapshot?.containerHidden == true {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3475,7 +3475,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
-    func testSingleEntryAnchorResizeDoesNotScheduleRedundantFullSync() {
+    func testSingleEntryAnchorResizeDoesNotScheduleRedundantFullSync() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
             styleMask: [.titled, .closable],
@@ -3494,22 +3494,29 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         contentView.addSubview(anchor)
         let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
         portal.bind(webView: webView, to: anchor, visibleInUI: true)
-        advanceAnimations()
+        await waitForNextMainTurn()
 
         let conversionCountBeforeResize = anchor.windowConversionCount
         anchor.frame = NSRect(x: 52, y: 30, width: 248, height: 178)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        let conversionCountAfterResize = anchor.windowConversionCount
+        XCTAssertEqual(
+            conversionCountAfterResize - conversionCountBeforeResize,
+            1,
+            "A single hosted browser should synchronize its changed anchor once"
+        )
+
+        await waitForNextMainTurn()
 
         XCTAssertEqual(
-            anchor.windowConversionCount - conversionCountBeforeResize,
-            1,
-            "A single hosted browser should synchronize its changed anchor once without a redundant deferred all-entry pass"
+            anchor.windowConversionCount,
+            conversionCountAfterResize,
+            "A single hosted browser should not receive a redundant deferred all-entry pass"
         )
     }
 
-    func testPortalAnchorResizeDoesNotForceHostedWebViewPresentationRefresh() {
+    func testPortalAnchorResizeDoesNotForceHostedWebViewPresentationRefresh() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
             styleMask: [.titled, .closable],
@@ -3531,7 +3538,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.bind(webView: webView, to: anchor, visibleInUI: true)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        await waitForNextMainTurn()
 
         guard let slot = webView.superview as? WindowBrowserSlotView else {
             XCTFail("Expected browser slot")
@@ -3544,7 +3551,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         anchor.frame = NSRect(x: 52, y: 30, width: 248, height: 178)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        let setNeedsDisplayCountAfterResize = webView.setNeedsDisplayCount
+        let displayCountAfterResize = webView.displayIfNeededCount
+        let reattachCountAfterResize = webView.reattachRenderingStateCount
 
         XCTAssertFalse(slot.isHidden, "Anchor resize should keep the portal-hosted browser visible")
         XCTAssertEqual(slot.frame.origin.x, 52, accuracy: 0.5)
@@ -3552,23 +3561,31 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(slot.frame.size.width, 248, accuracy: 0.5)
         XCTAssertEqual(slot.frame.size.height, 178, accuracy: 0.5)
         XCTAssertGreaterThan(
-            webView.setNeedsDisplayCount,
+            setNeedsDisplayCountAfterResize,
             initialSetNeedsDisplayCount,
             "Pure anchor geometry updates should invalidate the hosted browser for redraw"
         )
         XCTAssertEqual(
-            webView.displayIfNeededCount,
+            displayCountAfterResize,
             initialDisplayCount,
             "Pure anchor geometry updates must not synchronously flush WebKit display"
         )
         XCTAssertEqual(
-            webView.reattachRenderingStateCount,
+            reattachCountAfterResize,
             initialReattachCount,
             "Pure anchor geometry updates should not trigger the WebKit reattach path"
         )
+
+        await waitForNextMainTurn()
+
+        XCTAssertEqual(
+            webView.reattachRenderingStateCount,
+            reattachCountAfterResize,
+            "Pure anchor geometry updates must not enqueue a delayed WebKit reattach"
+        )
     }
 
-    func testActiveViewportAnchorResizeKeepsHostedWebViewAttached() throws {
+    func testActiveViewportAnchorResizeKeepsHostedWebViewAttached() async throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
             styleMask: [.titled, .closable],
@@ -3595,7 +3612,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.bind(webView: webView, to: anchor, visibleInUI: true)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        await waitForNextMainTurn()
 
         XCTAssertTrue(webView.superview === viewportHost)
         guard let slot = viewportHost.superview as? WindowBrowserSlotView else {
@@ -3628,7 +3645,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertTrue(viewportHost.needsDisplay)
     }
 
-    func testExternalSplitResizeDoesNotForceHostedWebViewPresentationRefresh() {
+    func testExternalSplitResizeDoesNotForceHostedWebViewPresentationRefresh() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 360),
             styleMask: [.titled, .closable],
@@ -3673,7 +3690,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.bind(webView: webView, to: anchor, visibleInUI: true)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        await waitForNextMainTurn()
 
         guard let slot = webView.superview as? WindowBrowserSlotView else {
             XCTFail("Expected browser slot")
@@ -3688,7 +3705,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         splitView.setPosition(280, ofDividerAt: 0)
         contentView.layoutSubtreeIfNeeded()
         NotificationCenter.default.post(name: NSSplitView.didResizeSubviewsNotification, object: splitView)
-        advanceAnimations()
+        let displayCountAfterResizeRequest = webView.displayIfNeededCount
+
+        await waitForNextMainTurn()
 
         XCTAssertFalse(slot.isHidden, "App split resize should keep the browser slot visible")
         XCTAssertLessThan(
@@ -3702,9 +3721,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "External split resize should invalidate the hosted browser for redraw"
         )
         XCTAssertEqual(
-            webView.displayIfNeededCount,
+            displayCountAfterResizeRequest,
             initialDisplayCount,
-            "External split resize must not synchronously flush WebKit display"
+            "External split resize request must not synchronously flush WebKit display"
         )
         XCTAssertEqual(
             webView.reattachRenderingStateCount,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2969,8 +2969,12 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         }
     }
 
-    private func drainFormerPresentationRetryWindow() {
-        RunLoop.current.run(until: Date().addingTimeInterval(0.08))
+    private func drainFormerPresentationRetryWindow() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                continuation.resume()
+            }
+        }
     }
 
     private func dropZoneOverlay(in slot: WindowBrowserSlotView, excluding webView: WKWebView) -> NSView? {
@@ -4078,7 +4082,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "A visibility-only reveal refreshes presentation but must not run the enter/exit-window reattach lifecycle, or every tab switch fires page visibilitychange"
         )
 
-        drainFormerPresentationRetryWindow()
+        await drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(
             webView.enterInWindowCount,
@@ -4139,7 +4143,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "A forced refresh should invoke the WebKit deferred-window selector once in the portal sync"
         )
 
-        drainFormerPresentationRetryWindow()
+        await drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, refreshedEnterInWindowCount)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
@@ -4222,7 +4226,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "An explicit refresh must still end deferred WebKit changes after adjusting the inspector divider"
         )
 
-        drainFormerPresentationRetryWindow()
+        await drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, refreshedEnterInWindowCount)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
@@ -4277,7 +4281,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Registry bind should own one synchronous deferred-window refresh"
         )
 
-        drainFormerPresentationRetryWindow()
+        await drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, boundEnterInWindowCount)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, boundEndDeferringCount)
@@ -4348,7 +4352,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Same-anchor host replacement should invoke one synchronous deferred-window refresh"
         )
 
-        drainFormerPresentationRetryWindow()
+        await drainFormerPresentationRetryWindow()
         XCTAssertEqual(webView.viewDidUnhideCount, viewDidUnhideCountAfterRebind)
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
@@ -4439,7 +4443,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Anchor rebind should invoke one synchronous deferred-window refresh"
         )
 
-        drainFormerPresentationRetryWindow()
+        await drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
@@ -4651,7 +4655,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Workspace rebind must not synchronously flush WebKit display"
         )
 
-        drainFormerPresentationRetryWindow()
+        await drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3560,7 +3560,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
-    func testActiveViewportAnchorResizeInvalidatesHostedWebViewWithoutSynchronousDisplay() throws {
+    func testActiveViewportAnchorResizeKeepsHostedWebViewAttached() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
             styleMask: [.titled, .closable],
@@ -3595,8 +3595,6 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             return
         }
 
-        let initialPresentationInvalidationCount =
-            viewportHost.browserPortalInvalidationCountForTesting
         anchor.frame = NSRect(x: 32, y: 20, width: 400, height: 240)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
@@ -3605,11 +3603,21 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(slot.frame.origin.y, 20, accuracy: 0.5)
         XCTAssertEqual(slot.frame.size.width, 400, accuracy: 0.5)
         XCTAssertEqual(slot.frame.size.height, 240, accuracy: 0.5)
-        XCTAssertGreaterThan(
-            viewportHost.browserPortalInvalidationCountForTesting,
-            initialPresentationInvalidationCount,
-            "Geometry sync should request a redraw from the active viewport presentation host"
+        XCTAssertTrue(webView.superview === viewportHost)
+        XCTAssertTrue(viewportHost.superview === slot)
+    }
+
+    func testActiveViewportPresentationInvalidationMarksHostForDeferredLayoutAndDisplay() {
+        let viewportHost = BrowserViewportHostView(
+            frame: NSRect(x: 0, y: 0, width: 320, height: 180)
         )
+        viewportHost.needsLayout = false
+        viewportHost.needsDisplay = false
+
+        viewportHost.invalidateBrowserPortalPresentation()
+
+        XCTAssertTrue(viewportHost.needsLayout)
+        XCTAssertTrue(viewportHost.needsDisplay)
     }
 
     func testExternalSplitResizeDoesNotForceHostedWebViewPresentationRefresh() {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4404,7 +4404,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
     }
 
-    func testVisiblePortalEntryStaysVisibleDuringOffWindowAnchorReparentUntilRebind() {
+    func testVisiblePortalEntryStaysVisibleDuringOffWindowAnchorReparentUntilRebind() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
             styleMask: [.titled, .closable],
@@ -4438,7 +4438,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         anchor.removeFromSuperview()
         offWindowContainer.addSubview(anchor)
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        for _ in 0..<16 {
+            await waitForNextMainTurn()
+        }
 
         XCTAssertTrue(
             webView.superview === slot,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4622,6 +4622,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.bind(webView: webView, to: newAnchor, visibleInUI: true)
         let enterInWindowCountAfterRebind = webView.enterInWindowCount
         let endDeferringCountAfterRebind = webView.endDeferringViewInWindowChangesCount
+        let redrawCountAfterRebind = webView.setNeedsDisplayCount
 
         XCTAssertTrue(
             webView.superview === slot,
@@ -4650,10 +4651,15 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Workspace rebind must not synchronously flush WebKit display"
         )
 
-        await waitForNextMainTurn()
+        drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
+        XCTAssertEqual(
+            webView.setNeedsDisplayCount,
+            redrawCountAfterRebind,
+            "Workspace rebind must not enqueue a delayed presentation invalidation"
+        )
     }
 }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4248,6 +4248,8 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(portal.debugEntryCount(), 1, "Workspace handoff should keep the hidden browser portal entry alive")
 
         let displayCountBeforeRebind = webView.displayIfNeededCount
+        let redrawCountBeforeRebind = webView.setNeedsDisplayCount
+        let reattachCountBeforeRebind = webView.reattachRenderingStateCount
         let newAnchor = NSView(frame: anchorFrame)
         contentView.addSubview(newAnchor)
         portal.bind(webView: webView, to: newAnchor, visibleInUI: true)
@@ -4261,9 +4263,19 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertFalse(slot.isHidden, "Rebinding the workspace browser should reveal the existing portal slot")
         XCTAssertEqual(portal.debugEntryCount(), 1)
         XCTAssertGreaterThan(
+            webView.setNeedsDisplayCount,
+            redrawCountBeforeRebind,
+            "Workspace rebind should invalidate the preserved browser for redraw"
+        )
+        XCTAssertGreaterThan(
+            webView.reattachRenderingStateCount,
+            reattachCountBeforeRebind,
+            "Workspace rebind should repair the preserved browser's rendering state"
+        )
+        XCTAssertEqual(
             webView.displayIfNeededCount,
             displayCountBeforeRebind,
-            "Workspace rebind should refresh the preserved browser without recreating its portal slot"
+            "Workspace rebind must not synchronously flush WebKit display"
         )
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2903,6 +2903,12 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
     private final class TrackingPortalWebView: WKWebView {
         private(set) var displayIfNeededCount = 0
         private(set) var reattachRenderingStateCount = 0
+        private(set) var setNeedsDisplayCount = 0
+
+        override func setNeedsDisplay(_ invalidRect: NSRect) {
+            setNeedsDisplayCount += 1
+            super.setNeedsDisplay(invalidRect)
+        }
 
         override func displayIfNeeded() {
             displayIfNeededCount += 1
@@ -3475,6 +3481,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             return
         }
 
+        let initialSetNeedsDisplayCount = webView.setNeedsDisplayCount
         let initialDisplayCount = webView.displayIfNeededCount
         let initialReattachCount = webView.reattachRenderingStateCount
         anchor.frame = NSRect(x: 52, y: 30, width: 248, height: 178)
@@ -3488,9 +3495,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(slot.frame.size.width, 248, accuracy: 0.5)
         XCTAssertEqual(slot.frame.size.height, 178, accuracy: 0.5)
         XCTAssertGreaterThan(
+            webView.setNeedsDisplayCount,
+            initialSetNeedsDisplayCount,
+            "Pure anchor geometry updates should invalidate the hosted browser for redraw"
+        )
+        XCTAssertEqual(
             webView.displayIfNeededCount,
             initialDisplayCount,
-            "Pure anchor geometry updates should still repaint the hosted browser"
+            "Pure anchor geometry updates must not synchronously flush WebKit display"
         )
         XCTAssertEqual(
             webView.reattachRenderingStateCount,
@@ -3551,6 +3563,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             return
         }
 
+        let initialSetNeedsDisplayCount = webView.setNeedsDisplayCount
         let initialDisplayCount = webView.displayIfNeededCount
         let initialReattachCount = webView.reattachRenderingStateCount
         let initialWidth = slot.frame.width
@@ -3567,9 +3580,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Moving the app split divider should shrink the hosted browser slot"
         )
         XCTAssertGreaterThan(
+            webView.setNeedsDisplayCount,
+            initialSetNeedsDisplayCount,
+            "External split resize should invalidate the hosted browser for redraw"
+        )
+        XCTAssertEqual(
             webView.displayIfNeededCount,
             initialDisplayCount,
-            "External split resize should still repaint the hosted browser"
+            "External split resize must not synchronously flush WebKit display"
         )
         XCTAssertEqual(
             webView.reattachRenderingStateCount,
@@ -3872,6 +3890,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         advanceAnimations()
         let hiddenDisplayCount = webView.displayIfNeededCount
         let hiddenReattachCount = webView.reattachRenderingStateCount
+        let hiddenSetNeedsDisplayCount = webView.setNeedsDisplayCount
 
         portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: true, zPriority: 0)
         portal.synchronizeWebViewForAnchor(anchor)
@@ -3884,9 +3903,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Hiding a portal-hosted browser should not itself trigger the WebKit reattach path"
         )
         XCTAssertGreaterThan(
+            webView.setNeedsDisplayCount,
+            hiddenSetNeedsDisplayCount,
+            "Revealing an existing portal-hosted browser should invalidate WebKit presentation"
+        )
+        XCTAssertEqual(
             webView.displayIfNeededCount,
             hiddenDisplayCount,
-            "Revealing an existing portal-hosted browser should refresh WebKit presentation immediately"
+            "Reveal should let AppKit commit the invalidated frame instead of forcing display synchronously"
         )
         XCTAssertEqual(
             webView.reattachRenderingStateCount,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4154,7 +4154,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, boundEndDeferringCount)
     }
 
-    func testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind() {
+    func testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
             styleMask: [.titled, .closable],
@@ -4196,11 +4196,13 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(portal.debugEntryCount(), 1)
 
         let displayCountBeforeRebind = webView.displayIfNeededCount
+        let enterInWindowCountBeforeRebind = webView.enterInWindowCount
+        let endDeferringCountBeforeRebind = webView.endDeferringViewInWindowChangesCount
         let anchor2 = NSView(frame: anchorFrame)
         contentView.addSubview(anchor2)
         portal.bind(webView: webView, to: anchor2, visibleInUI: true)
-        portal.synchronizeWebViewForAnchor(anchor2)
-        advanceAnimations()
+        let enterInWindowCountAfterRebind = webView.enterInWindowCount
+        let endDeferringCountAfterRebind = webView.endDeferringViewInWindowChangesCount
 
         XCTAssertTrue(webView.superview === slot, "Rebinding after transient anchor removal should reuse the existing portal slot")
         XCTAssertFalse(slot.isHidden)
@@ -4210,6 +4212,21 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             displayCountBeforeRebind,
             "Anchor rebinds should refresh hosted browser presentation even when geometry is unchanged"
         )
+        XCTAssertEqual(
+            enterInWindowCountAfterRebind - enterInWindowCountBeforeRebind,
+            1,
+            "Anchor rebind should invoke one synchronous WebKit window-entry refresh"
+        )
+        XCTAssertEqual(
+            endDeferringCountAfterRebind - endDeferringCountBeforeRebind,
+            1,
+            "Anchor rebind should invoke one synchronous deferred-window refresh"
+        )
+
+        await waitForNextMainTurn()
+
+        XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
+        XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
     }
 
     func testVisiblePortalEntryStaysVisibleDuringOffWindowAnchorReparentUntilRebind() {
@@ -4327,7 +4344,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertTrue(slot.isHidden, "Hiding should immediately hide the existing portal slot")
     }
 
-    func testHiddenPortalEntrySurvivesAnchorRemovalUntilWorkspaceRebind() {
+    func testHiddenPortalEntrySurvivesAnchorRemovalUntilWorkspaceRebind() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
             styleMask: [.titled, .closable],
@@ -4375,12 +4392,13 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         let displayCountBeforeRebind = webView.displayIfNeededCount
         let redrawCountBeforeRebind = webView.setNeedsDisplayCount
-        let reattachCountBeforeRebind = webView.reattachRenderingStateCount
+        let enterInWindowCountBeforeRebind = webView.enterInWindowCount
+        let endDeferringCountBeforeRebind = webView.endDeferringViewInWindowChangesCount
         let newAnchor = NSView(frame: anchorFrame)
         contentView.addSubview(newAnchor)
         portal.bind(webView: webView, to: newAnchor, visibleInUI: true)
-        portal.synchronizeWebViewForAnchor(newAnchor)
-        advanceAnimations()
+        let enterInWindowCountAfterRebind = webView.enterInWindowCount
+        let endDeferringCountAfterRebind = webView.endDeferringViewInWindowChangesCount
 
         XCTAssertTrue(
             webView.superview === slot,
@@ -4393,16 +4411,26 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             redrawCountBeforeRebind,
             "Workspace rebind should invalidate the preserved browser for redraw"
         )
-        XCTAssertGreaterThan(
-            webView.reattachRenderingStateCount,
-            reattachCountBeforeRebind,
-            "Workspace rebind should repair the preserved browser's rendering state"
+        XCTAssertEqual(
+            enterInWindowCountAfterRebind - enterInWindowCountBeforeRebind,
+            1,
+            "Workspace rebind should invoke one synchronous WebKit window-entry refresh"
+        )
+        XCTAssertEqual(
+            endDeferringCountAfterRebind - endDeferringCountBeforeRebind,
+            1,
+            "Workspace rebind should invoke one synchronous deferred-window refresh"
         )
         XCTAssertEqual(
             webView.displayIfNeededCount,
             displayCountBeforeRebind,
             "Workspace rebind must not synchronously flush WebKit display"
         )
+
+        await waitForNextMainTurn()
+
+        XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
+        XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
     }
 }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3560,10 +3560,10 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
-    func testActiveViewportExternalWindowResizeInvalidatesHostedWebViewWithoutSynchronousRefresh() throws {
+    func testActiveViewportAnchorResizeInvalidatesHostedWebViewWithoutSynchronousDisplay() throws {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
-            styleMask: [.titled, .closable, .resizable],
+            styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
         )
@@ -3576,10 +3576,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         }
 
         let anchor = NSView(frame: contentView.bounds.insetBy(dx: 40, dy: 24))
-        anchor.autoresizingMask = [.width, .height]
         contentView.addSubview(anchor)
 
-        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
         let viewportModel = BrowserViewportModel()
         let viewportHost = BrowserViewportHostView(frame: .zero)
         webView.browserViewportModel = viewportModel
@@ -3596,38 +3595,20 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             return
         }
 
-        let initialSlotSize = slot.frame.size
-        let initialSetNeedsDisplayCount = webView.setNeedsDisplayCount
-        let initialDisplayCount = webView.displayIfNeededCount
-        let initialEnterInWindowCount = webView.enterInWindowCount
-        let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
-
-        window.setContentSize(NSSize(width: 620, height: 420))
+        webView.needsDisplay = false
+        webView.scrollView.needsDisplay = false
+        webView.scrollView.contentView.needsDisplay = false
+        anchor.frame = NSRect(x: 32, y: 20, width: 400, height: 240)
         contentView.layoutSubtreeIfNeeded()
-        NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
-        advanceAnimations()
+        portal.synchronizeWebViewForAnchor(anchor)
 
-        XCTAssertGreaterThan(slot.frame.width, initialSlotSize.width)
-        XCTAssertGreaterThan(slot.frame.height, initialSlotSize.height)
-        XCTAssertGreaterThan(
-            webView.setNeedsDisplayCount,
-            initialSetNeedsDisplayCount,
-            "External resize should invalidate a browser nested in its active viewport host"
-        )
-        XCTAssertEqual(
-            webView.displayIfNeededCount,
-            initialDisplayCount,
-            "Active viewport resize must not synchronously flush WebKit display"
-        )
-        XCTAssertEqual(
-            webView.enterInWindowCount,
-            initialEnterInWindowCount,
-            "Active viewport resize should not re-enter the WebKit window"
-        )
-        XCTAssertEqual(
-            webView.endDeferringViewInWindowChangesCount,
-            initialEndDeferringCount,
-            "Active viewport resize should not end deferred WebKit window changes"
+        XCTAssertEqual(slot.frame.origin.x, 32, accuracy: 0.5)
+        XCTAssertEqual(slot.frame.origin.y, 20, accuracy: 0.5)
+        XCTAssertEqual(slot.frame.size.width, 400, accuracy: 0.5)
+        XCTAssertEqual(slot.frame.size.height, 240, accuracy: 0.5)
+        XCTAssertTrue(
+            webView.needsDisplay,
+            "Geometry sync should leave a nested active-viewport browser invalidated for AppKit's next display pass"
         )
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3969,7 +3969,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertFalse(overlay.isHidden, "Restoring visibility should restore the active drop-zone overlay")
     }
 
-    func testPortalRevealRefreshesHostedWebViewWithoutFrameDelta() {
+    func testPortalRevealRefreshesHostedWebViewSynchronouslyOnceWithoutFrameDelta() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
             styleMask: [.titled, .closable],
@@ -4006,7 +4006,8 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: true, zPriority: 0)
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        let revealedEnterInWindowCount = webView.enterInWindowCount
+        let revealedEndDeferringCount = webView.endDeferringViewInWindowChangesCount
 
         XCTAssertGreaterThanOrEqual(hiddenDisplayCount, initialDisplayCount)
         XCTAssertEqual(
@@ -4022,7 +4023,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertGreaterThan(
             webView.setNeedsDisplayCount,
             hiddenSetNeedsDisplayCount,
-            "Revealing an existing portal-hosted browser should invalidate WebKit presentation"
+            "Revealing an existing portal-hosted browser should invalidate WebKit presentation synchronously"
         )
         XCTAssertEqual(
             webView.displayIfNeededCount,
@@ -4034,6 +4035,66 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             hiddenReattachCount,
             "A visibility-only reveal refreshes presentation but must not run the enter/exit-window reattach lifecycle, or every tab switch fires page visibilitychange"
         )
+
+        advanceAnimations()
+
+        XCTAssertEqual(
+            webView.enterInWindowCount,
+            revealedEnterInWindowCount,
+            "Reveal must not enqueue a later duplicate WebKit window-entry repair"
+        )
+        XCTAssertEqual(
+            webView.endDeferringViewInWindowChangesCount,
+            revealedEndDeferringCount,
+            "Reveal must not enqueue a later duplicate deferred-window repair"
+        )
+    }
+
+    func testForcedPortalRefreshRunsSynchronouslyOnce() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        let anchor = NSView(frame: NSRect(x: 40, y: 24, width: 220, height: 160))
+        contentView.addSubview(anchor)
+
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let webViewId = ObjectIdentifier(webView)
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+        let initialEnterInWindowCount = webView.enterInWindowCount
+        let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+
+        portal.forceRefreshWebView(withId: webViewId, reason: "unitTest")
+        let refreshedEnterInWindowCount = webView.enterInWindowCount
+        let refreshedEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+
+        XCTAssertEqual(
+            refreshedEnterInWindowCount - initialEnterInWindowCount,
+            1,
+            "A forced refresh should invoke the WebKit window-entry selector once in the portal sync"
+        )
+        XCTAssertEqual(
+            refreshedEndDeferringCount - initialEndDeferringCount,
+            1,
+            "A forced refresh should invoke the WebKit deferred-window selector once in the portal sync"
+        )
+
+        advanceAnimations()
+
+        XCTAssertEqual(webView.enterInWindowCount, refreshedEnterInWindowCount)
+        XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
     }
 
     func testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind() {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4105,6 +4105,83 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
     }
 
+    func testForcedPortalRefreshBypassesInspectorDividerAdjustmentSkip() async {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        let anchor = NSView(frame: NSRect(x: 40, y: 24, width: 260, height: 180))
+        contentView.addSubview(anchor)
+
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let webViewId = ObjectIdentifier(webView)
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        await waitForNextMainTurn()
+
+        guard let slot = webView.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected browser slot")
+            return
+        }
+        let initialInspectorWidth: CGFloat = 80
+        let preferredInspectorWidth: CGFloat = 120
+        webView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: slot.bounds.width - initialInspectorWidth,
+            height: slot.bounds.height
+        )
+        let inspectorContainer = NSView(
+            frame: NSRect(
+                x: webView.frame.maxX,
+                y: 0,
+                width: initialInspectorWidth,
+                height: slot.bounds.height
+            )
+        )
+        let inspectorView = WKInspectorProbeView(frame: inspectorContainer.bounds)
+        inspectorView.autoresizingMask = [.width, .height]
+        inspectorContainer.addSubview(inspectorView)
+        slot.addSubview(inspectorContainer)
+        slot.onHostedInspectorLayout = nil
+        slot.recordPreferredHostedInspectorWidth(
+            preferredInspectorWidth,
+            containerBounds: slot.bounds
+        )
+        let initialEnterInWindowCount = webView.enterInWindowCount
+        let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+
+        portal.forceRefreshWebView(withId: webViewId, reason: "inspectorRedock")
+        let refreshedEnterInWindowCount = webView.enterInWindowCount
+        let refreshedEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+
+        XCTAssertEqual(inspectorContainer.frame.width, preferredInspectorWidth, accuracy: 0.5)
+        XCTAssertEqual(
+            refreshedEnterInWindowCount - initialEnterInWindowCount,
+            1,
+            "An explicit refresh must still enter WebKit after adjusting the hosted inspector divider"
+        )
+        XCTAssertEqual(
+            refreshedEndDeferringCount - initialEndDeferringCount,
+            1,
+            "An explicit refresh must still end deferred WebKit changes after adjusting the inspector divider"
+        )
+
+        await waitForNextMainTurn()
+
+        XCTAssertEqual(webView.enterInWindowCount, refreshedEnterInWindowCount)
+        XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
+    }
+
     func testRegistryBindOwnsOneSynchronousPresentationRefresh() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2903,6 +2903,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
     private final class TrackingPortalWebView: WKWebView {
         private(set) var displayIfNeededCount = 0
         private(set) var reattachRenderingStateCount = 0
+        private(set) var viewDidUnhideCount = 0
         private(set) var enterInWindowCount = 0
         private(set) var endDeferringViewInWindowChangesCount = 0
         private(set) var setNeedsDisplayCount = 0
@@ -2915,6 +2916,11 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         override func displayIfNeeded() {
             displayIfNeededCount += 1
             super.displayIfNeeded()
+        }
+
+        override func viewDidUnhide() {
+            viewDidUnhideCount += 1
+            reattachRenderingStateCount += 1
         }
 
         @objc(_enterInWindow)
@@ -4278,6 +4284,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             visibleInUI: true
         )
         await waitForNextMainTurn()
+        let viewDidUnhideCountBeforeRebind = webView.viewDidUnhideCount
         let enterInWindowCountBeforeRebind = webView.enterInWindowCount
         let endDeferringCountBeforeRebind = webView.endDeferringViewInWindowChangesCount
 
@@ -4287,9 +4294,15 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             visibleInUI: true,
             forcePresentationRefresh: true
         )
+        let viewDidUnhideCountAfterRebind = webView.viewDidUnhideCount
         let enterInWindowCountAfterRebind = webView.enterInWindowCount
         let endDeferringCountAfterRebind = webView.endDeferringViewInWindowChangesCount
 
+        XCTAssertEqual(
+            viewDidUnhideCountAfterRebind - viewDidUnhideCountBeforeRebind,
+            1,
+            "Same-anchor host replacement should invoke one synchronous AppKit unhide refresh"
+        )
         XCTAssertEqual(
             enterInWindowCountAfterRebind - enterInWindowCountBeforeRebind,
             1,
@@ -4302,6 +4315,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
 
         await waitForNextMainTurn()
+        XCTAssertEqual(webView.viewDidUnhideCount, viewDidUnhideCountAfterRebind)
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
@@ -4339,7 +4353,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         anchor1.removeFromSuperview()
         portal.synchronizeWebViewForAnchor(anchor1)
-        advanceAnimations()
+        for _ in 0..<16 {
+            await waitForNextMainTurn()
+        }
 
         XCTAssertTrue(webView.superview === slot, "Visible browser entries should not detach during transient anchor removal")
         XCTAssertTrue(

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2903,6 +2903,8 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
     private final class TrackingPortalWebView: WKWebView {
         private(set) var displayIfNeededCount = 0
         private(set) var reattachRenderingStateCount = 0
+        private(set) var enterInWindowCount = 0
+        private(set) var endDeferringViewInWindowChangesCount = 0
         private(set) var setNeedsDisplayCount = 0
 
         override func setNeedsDisplay(_ invalidRect: NSRect) {
@@ -2917,11 +2919,13 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         @objc(_enterInWindow)
         func cmuxUnitTestEnterInWindow() {
+            enterInWindowCount += 1
             reattachRenderingStateCount += 1
         }
 
         @objc(_endDeferringViewInWindowChangesSync)
         func cmuxUnitTestEndDeferringViewInWindowChangesSync() {
+            endDeferringViewInWindowChangesCount += 1
             reattachRenderingStateCount += 1
         }
     }
@@ -3928,12 +3932,15 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.synchronizeWebViewForAnchor(anchor)
         advanceAnimations()
         let initialDisplayCount = webView.displayIfNeededCount
-        let initialReattachCount = webView.reattachRenderingStateCount
+        let initialEnterInWindowCount = webView.enterInWindowCount
+        let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
 
         portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: false, zPriority: 0)
         portal.synchronizeWebViewForAnchor(anchor)
         advanceAnimations()
         let hiddenDisplayCount = webView.displayIfNeededCount
+        let hiddenEnterInWindowCount = webView.enterInWindowCount
+        let hiddenEndDeferringCount = webView.endDeferringViewInWindowChangesCount
         let hiddenReattachCount = webView.reattachRenderingStateCount
         let hiddenSetNeedsDisplayCount = webView.setNeedsDisplayCount
 
@@ -3943,9 +3950,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
 
         XCTAssertGreaterThanOrEqual(hiddenDisplayCount, initialDisplayCount)
         XCTAssertEqual(
-            hiddenReattachCount,
-            initialReattachCount,
-            "Hiding a portal-hosted browser should not itself trigger the WebKit reattach path"
+            hiddenEnterInWindowCount,
+            initialEnterInWindowCount,
+            "Hiding a portal-hosted browser should not itself enter the WebKit window"
+        )
+        XCTAssertEqual(
+            hiddenEndDeferringCount,
+            initialEndDeferringCount,
+            "Hiding a portal-hosted browser should not itself end deferred WebKit window changes"
         )
         XCTAssertGreaterThan(
             webView.setNeedsDisplayCount,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3595,7 +3595,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             return
         }
 
-        webView.needsDisplay = false
+        viewportHost.needsDisplay = false
         anchor.frame = NSRect(x: 32, y: 20, width: 400, height: 240)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
@@ -3605,8 +3605,8 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(slot.frame.size.width, 400, accuracy: 0.5)
         XCTAssertEqual(slot.frame.size.height, 240, accuracy: 0.5)
         XCTAssertTrue(
-            webView.needsDisplay,
-            "Geometry sync should leave a nested active-viewport browser invalidated for AppKit's next display pass"
+            viewportHost.needsDisplay,
+            "Geometry sync should invalidate the active viewport presentation host for AppKit's next display pass"
         )
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3595,7 +3595,8 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             return
         }
 
-        viewportHost.needsDisplay = false
+        let initialPresentationInvalidationCount =
+            viewportHost.browserPortalInvalidationCountForTesting
         anchor.frame = NSRect(x: 32, y: 20, width: 400, height: 240)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)
@@ -3604,9 +3605,10 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(slot.frame.origin.y, 20, accuracy: 0.5)
         XCTAssertEqual(slot.frame.size.width, 400, accuracy: 0.5)
         XCTAssertEqual(slot.frame.size.height, 240, accuracy: 0.5)
-        XCTAssertTrue(
-            viewportHost.needsDisplay,
-            "Geometry sync should invalidate the active viewport presentation host for AppKit's next display pass"
+        XCTAssertGreaterThan(
+            viewportHost.browserPortalInvalidationCountForTesting,
+            initialPresentationInvalidationCount,
+            "Geometry sync should request a redraw from the active viewport presentation host"
         )
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2926,6 +2926,17 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         }
     }
 
+    private final class TrackingPortalAnchorView: NSView {
+        private(set) var windowConversionCount = 0
+
+        override func convert(_ rect: NSRect, to view: NSView?) -> NSRect {
+            if view == nil {
+                windowConversionCount += 1
+            }
+            return super.convert(rect, to: view)
+        }
+    }
+
     private final class WKInspectorProbeView: NSView {}
 
     private func realizeWindowLayout(_ window: NSWindow) {
@@ -3449,6 +3460,40 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             webView.frame.width,
             slot.bounds.width,
             "Side-docked inspector should still own part of the slot after pane resize"
+        )
+    }
+
+    func testSingleEntryAnchorResizeDoesNotScheduleRedundantFullSync() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let anchor = TrackingPortalAnchorView(frame: NSRect(x: 40, y: 24, width: 220, height: 160))
+        contentView.addSubview(anchor)
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        advanceAnimations()
+
+        let conversionCountBeforeResize = anchor.windowConversionCount
+        anchor.frame = NSRect(x: 52, y: 30, width: 248, height: 178)
+        contentView.layoutSubtreeIfNeeded()
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+
+        XCTAssertEqual(
+            anchor.windowConversionCount - conversionCountBeforeResize,
+            1,
+            "A single hosted browser should synchronize its changed anchor once without a redundant deferred all-entry pass"
         )
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4154,6 +4154,63 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, boundEndDeferringCount)
     }
 
+    func testRegistrySameAnchorRebindForcesOneSynchronousPresentationRefresh() async {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        realizeWindowLayout(window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        let anchor = NSView(frame: NSRect(x: 40, y: 24, width: 220, height: 160))
+        contentView.addSubview(anchor)
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        defer {
+            BrowserWindowPortalRegistry.detach(webView: webView)
+            window.orderOut(nil)
+            window.close()
+        }
+
+        BrowserWindowPortalRegistry.bind(
+            webView: webView,
+            to: anchor,
+            visibleInUI: true
+        )
+        await waitForNextMainTurn()
+        let enterInWindowCountBeforeRebind = webView.enterInWindowCount
+        let endDeferringCountBeforeRebind = webView.endDeferringViewInWindowChangesCount
+
+        BrowserWindowPortalRegistry.bind(
+            webView: webView,
+            to: anchor,
+            visibleInUI: true,
+            forcePresentationRefresh: true
+        )
+        let enterInWindowCountAfterRebind = webView.enterInWindowCount
+        let endDeferringCountAfterRebind = webView.endDeferringViewInWindowChangesCount
+
+        XCTAssertEqual(
+            enterInWindowCountAfterRebind - enterInWindowCountBeforeRebind,
+            1,
+            "Same-anchor host replacement should invoke one synchronous WebKit window-entry refresh"
+        )
+        XCTAssertEqual(
+            endDeferringCountAfterRebind - endDeferringCountBeforeRebind,
+            1,
+            "Same-anchor host replacement should invoke one synchronous deferred-window refresh"
+        )
+
+        await waitForNextMainTurn()
+
+        XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
+        XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
+    }
+
     func testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4077,9 +4077,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Reveal should let AppKit commit the invalidated frame instead of forcing display synchronously"
         )
         XCTAssertEqual(
-            webView.reattachRenderingStateCount,
-            hiddenReattachCount,
-            "A visibility-only reveal refreshes presentation but must not run the enter/exit-window reattach lifecycle, or every tab switch fires page visibilitychange"
+            revealedEnterInWindowCount,
+            hiddenEnterInWindowCount,
+            "A visibility-only reveal must not explicitly re-enter the WebKit window"
+        )
+        XCTAssertEqual(
+            revealedEndDeferringCount,
+            hiddenEndDeferringCount,
+            "A visibility-only reveal must not explicitly end deferred WebKit window changes"
         )
 
         await drainFormerPresentationRetryWindow()
@@ -4443,13 +4448,19 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Anchor rebind should invoke one synchronous deferred-window refresh"
         )
 
+        // AppKit queues one ordinary display invalidation when the hidden slot is
+        // reattached. Let that framework-owned turn settle before checking that
+        // the portal did not enqueue its former delayed presentation retry.
+        await waitForNextMainTurn()
+        let settledRedrawCountAfterRebind = webView.setNeedsDisplayCount
+
         await drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
         XCTAssertEqual(
             webView.setNeedsDisplayCount,
-            redrawCountAfterRebind,
+            settledRedrawCountAfterRebind,
             "Anchor rebind must not enqueue a delayed presentation invalidation"
         )
     }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3642,7 +3642,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         viewportHost.invalidateBrowserPortalPresentation()
 
         XCTAssertTrue(viewportHost.needsLayout)
-        XCTAssertTrue(viewportHost.needsDisplay)
+        XCTAssertTrue(viewportHost.needsToDraw(viewportHost.bounds))
     }
 
     func testExternalSplitResizeDoesNotForceHostedWebViewPresentationRefresh() async {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4226,7 +4226,6 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         defer {
             BrowserWindowPortalRegistry.detach(webView: webView)
             window.orderOut(nil)
-            window.close()
         }
         let initialEnterInWindowCount = webView.enterInWindowCount
         let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
@@ -4275,7 +4274,6 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         defer {
             BrowserWindowPortalRegistry.detach(webView: webView)
             window.orderOut(nil)
-            window.close()
         }
 
         BrowserWindowPortalRegistry.bind(

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2955,6 +2955,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.25))
     }
 
+    private func waitForNextMainTurn() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
     private func dropZoneOverlay(in slot: WindowBrowserSlotView, excluding webView: WKWebView) -> NSView? {
         let candidates = slot.subviews + (slot.superview?.subviews ?? [])
         return candidates.first(where: {
@@ -3969,7 +3977,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertFalse(overlay.isHidden, "Restoring visibility should restore the active drop-zone overlay")
     }
 
-    func testPortalRevealRefreshesHostedWebViewSynchronouslyOnceWithoutFrameDelta() {
+    func testPortalRevealRefreshesHostedWebViewSynchronouslyOnceWithoutFrameDelta() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
             styleMask: [.titled, .closable],
@@ -3990,14 +3998,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
         portal.bind(webView: webView, to: anchor, visibleInUI: true)
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        await waitForNextMainTurn()
         let initialDisplayCount = webView.displayIfNeededCount
         let initialEnterInWindowCount = webView.enterInWindowCount
         let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
 
         portal.updateEntryVisibility(forWebViewId: ObjectIdentifier(webView), visibleInUI: false, zPriority: 0)
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        await waitForNextMainTurn()
         let hiddenDisplayCount = webView.displayIfNeededCount
         let hiddenEnterInWindowCount = webView.enterInWindowCount
         let hiddenEndDeferringCount = webView.endDeferringViewInWindowChangesCount
@@ -4036,7 +4044,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "A visibility-only reveal refreshes presentation but must not run the enter/exit-window reattach lifecycle, or every tab switch fires page visibilitychange"
         )
 
-        advanceAnimations()
+        await waitForNextMainTurn()
 
         XCTAssertEqual(
             webView.enterInWindowCount,
@@ -4050,7 +4058,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
-    func testForcedPortalRefreshRunsSynchronouslyOnce() {
+    func testForcedPortalRefreshRunsSynchronouslyOnce() async {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
             styleMask: [.titled, .closable],
@@ -4072,7 +4080,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         let webViewId = ObjectIdentifier(webView)
         portal.bind(webView: webView, to: anchor, visibleInUI: true)
         portal.synchronizeWebViewForAnchor(anchor)
-        advanceAnimations()
+        await waitForNextMainTurn()
         let initialEnterInWindowCount = webView.enterInWindowCount
         let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
 
@@ -4091,10 +4099,59 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "A forced refresh should invoke the WebKit deferred-window selector once in the portal sync"
         )
 
-        advanceAnimations()
+        await waitForNextMainTurn()
 
         XCTAssertEqual(webView.enterInWindowCount, refreshedEnterInWindowCount)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
+    }
+
+    func testRegistryBindOwnsOneSynchronousPresentationRefresh() async {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        realizeWindowLayout(window)
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        let anchor = NSView(frame: NSRect(x: 40, y: 24, width: 220, height: 160))
+        contentView.addSubview(anchor)
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        defer {
+            BrowserWindowPortalRegistry.detach(webView: webView)
+            window.orderOut(nil)
+            window.close()
+        }
+        let initialEnterInWindowCount = webView.enterInWindowCount
+        let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+
+        BrowserWindowPortalRegistry.bind(
+            webView: webView,
+            to: anchor,
+            visibleInUI: true
+        )
+        let boundEnterInWindowCount = webView.enterInWindowCount
+        let boundEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+
+        XCTAssertEqual(
+            boundEnterInWindowCount - initialEnterInWindowCount,
+            1,
+            "Registry bind should own one synchronous WebKit window-entry refresh"
+        )
+        XCTAssertEqual(
+            boundEndDeferringCount - initialEndDeferringCount,
+            1,
+            "Registry bind should own one synchronous deferred-window refresh"
+        )
+
+        await waitForNextMainTurn()
+
+        XCTAssertEqual(webView.enterInWindowCount, boundEnterInWindowCount)
+        XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, boundEndDeferringCount)
     }
 
     func testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind() {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -4330,6 +4330,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertEqual(portal.debugEntryCount(), 1)
 
         let displayCountBeforeRebind = webView.displayIfNeededCount
+        let redrawCountBeforeRebind = webView.setNeedsDisplayCount
         let enterInWindowCountBeforeRebind = webView.enterInWindowCount
         let endDeferringCountBeforeRebind = webView.endDeferringViewInWindowChangesCount
         let anchor2 = NSView(frame: anchorFrame)
@@ -4342,9 +4343,14 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertFalse(slot.isHidden)
         XCTAssertEqual(portal.debugEntryCount(), 1)
         XCTAssertGreaterThan(
+            webView.setNeedsDisplayCount,
+            redrawCountBeforeRebind,
+            "Anchor rebind should invalidate hosted browser presentation even when geometry is unchanged"
+        )
+        XCTAssertEqual(
             webView.displayIfNeededCount,
             displayCountBeforeRebind,
-            "Anchor rebinds should refresh hosted browser presentation even when geometry is unchanged"
+            "Anchor rebind must not synchronously flush WebKit display"
         )
         XCTAssertEqual(
             enterInWindowCountAfterRebind - enterInWindowCountBeforeRebind,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3560,6 +3560,77 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testActiveViewportExternalWindowResizeInvalidatesHostedWebViewWithoutSynchronousRefresh() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        realizeWindowLayout(window)
+        let portal = WindowBrowserPortal(window: window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let anchor = NSView(frame: contentView.bounds.insetBy(dx: 40, dy: 24))
+        anchor.autoresizingMask = [.width, .height]
+        contentView.addSubview(anchor)
+
+        let webView = TrackingPortalWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let viewportModel = BrowserViewportModel()
+        let viewportHost = BrowserViewportHostView(frame: .zero)
+        webView.browserViewportModel = viewportModel
+        viewportModel.setViewport(try XCTUnwrap(BrowserViewport(width: 1_280, height: 720)))
+        viewportHost.installWebView(webView)
+        portal.bind(webView: webView, to: anchor, visibleInUI: true)
+        contentView.layoutSubtreeIfNeeded()
+        portal.synchronizeWebViewForAnchor(anchor)
+        advanceAnimations()
+
+        XCTAssertTrue(webView.superview === viewportHost)
+        guard let slot = viewportHost.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected active browser viewport host in a portal slot")
+            return
+        }
+
+        let initialSlotSize = slot.frame.size
+        let initialSetNeedsDisplayCount = webView.setNeedsDisplayCount
+        let initialDisplayCount = webView.displayIfNeededCount
+        let initialEnterInWindowCount = webView.enterInWindowCount
+        let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+
+        window.setContentSize(NSSize(width: 620, height: 420))
+        contentView.layoutSubtreeIfNeeded()
+        NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
+        advanceAnimations()
+
+        XCTAssertGreaterThan(slot.frame.width, initialSlotSize.width)
+        XCTAssertGreaterThan(slot.frame.height, initialSlotSize.height)
+        XCTAssertGreaterThan(
+            webView.setNeedsDisplayCount,
+            initialSetNeedsDisplayCount,
+            "External resize should invalidate a browser nested in its active viewport host"
+        )
+        XCTAssertEqual(
+            webView.displayIfNeededCount,
+            initialDisplayCount,
+            "Active viewport resize must not synchronously flush WebKit display"
+        )
+        XCTAssertEqual(
+            webView.enterInWindowCount,
+            initialEnterInWindowCount,
+            "Active viewport resize should not re-enter the WebKit window"
+        )
+        XCTAssertEqual(
+            webView.endDeferringViewInWindowChangesCount,
+            initialEndDeferringCount,
+            "Active viewport resize should not end deferred WebKit window changes"
+        )
+    }
+
     func testExternalSplitResizeDoesNotForceHostedWebViewPresentationRefresh() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 640, height: 360),

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3596,8 +3596,6 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         }
 
         webView.needsDisplay = false
-        webView.scrollView.needsDisplay = false
-        webView.scrollView.contentView.needsDisplay = false
         anchor.frame = NSRect(x: 32, y: 20, width: 400, height: 240)
         contentView.layoutSubtreeIfNeeded()
         portal.synchronizeWebViewForAnchor(anchor)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2969,6 +2969,10 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         }
     }
 
+    private func drainFormerPresentationRetryWindow() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.08))
+    }
+
     private func dropZoneOverlay(in slot: WindowBrowserSlotView, excluding webView: WKWebView) -> NSView? {
         let candidates = slot.subviews + (slot.superview?.subviews ?? [])
         return candidates.first(where: {
@@ -3711,7 +3715,11 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         splitView.setPosition(280, ofDividerAt: 0)
         contentView.layoutSubtreeIfNeeded()
         NotificationCenter.default.post(name: NSSplitView.didResizeSubviewsNotification, object: splitView)
-        let displayCountAfterResizeRequest = webView.displayIfNeededCount
+        XCTAssertEqual(
+            webView.displayIfNeededCount,
+            initialDisplayCount,
+            "External split resize request must not synchronously flush WebKit display"
+        )
 
         await waitForNextMainTurn()
 
@@ -3727,9 +3735,9 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "External split resize should invalidate the hosted browser for redraw"
         )
         XCTAssertEqual(
-            displayCountAfterResizeRequest,
+            webView.displayIfNeededCount,
             initialDisplayCount,
-            "External split resize request must not synchronously flush WebKit display"
+            "The completed external split resize pass must not flush WebKit display"
         )
         XCTAssertEqual(
             webView.reattachRenderingStateCount,
@@ -4041,6 +4049,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.synchronizeWebViewForAnchor(anchor)
         let revealedEnterInWindowCount = webView.enterInWindowCount
         let revealedEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+        let revealedSetNeedsDisplayCount = webView.setNeedsDisplayCount
 
         XCTAssertGreaterThanOrEqual(hiddenDisplayCount, initialDisplayCount)
         XCTAssertEqual(
@@ -4069,7 +4078,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "A visibility-only reveal refreshes presentation but must not run the enter/exit-window reattach lifecycle, or every tab switch fires page visibilitychange"
         )
 
-        await waitForNextMainTurn()
+        drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(
             webView.enterInWindowCount,
@@ -4080,6 +4089,11 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             webView.endDeferringViewInWindowChangesCount,
             revealedEndDeferringCount,
             "Reveal must not enqueue a later duplicate deferred-window repair"
+        )
+        XCTAssertEqual(
+            webView.setNeedsDisplayCount,
+            revealedSetNeedsDisplayCount,
+            "Reveal must not enqueue a delayed presentation invalidation"
         )
     }
 
@@ -4112,6 +4126,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.forceRefreshWebView(withId: webViewId, reason: "unitTest")
         let refreshedEnterInWindowCount = webView.enterInWindowCount
         let refreshedEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+        let refreshedSetNeedsDisplayCount = webView.setNeedsDisplayCount
 
         XCTAssertEqual(
             refreshedEnterInWindowCount - initialEnterInWindowCount,
@@ -4124,10 +4139,15 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "A forced refresh should invoke the WebKit deferred-window selector once in the portal sync"
         )
 
-        await waitForNextMainTurn()
+        drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, refreshedEnterInWindowCount)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
+        XCTAssertEqual(
+            webView.setNeedsDisplayCount,
+            refreshedSetNeedsDisplayCount,
+            "Forced refresh must not enqueue a delayed presentation invalidation"
+        )
     }
 
     func testForcedPortalRefreshBypassesInspectorDividerAdjustmentSkip() async {
@@ -4188,6 +4208,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.forceRefreshWebView(withId: webViewId, reason: "inspectorRedock")
         let refreshedEnterInWindowCount = webView.enterInWindowCount
         let refreshedEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+        let refreshedSetNeedsDisplayCount = webView.setNeedsDisplayCount
 
         XCTAssertEqual(inspectorContainer.frame.width, preferredInspectorWidth, accuracy: 0.5)
         XCTAssertEqual(
@@ -4201,10 +4222,15 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "An explicit refresh must still end deferred WebKit changes after adjusting the inspector divider"
         )
 
-        await waitForNextMainTurn()
+        drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, refreshedEnterInWindowCount)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, refreshedEndDeferringCount)
+        XCTAssertEqual(
+            webView.setNeedsDisplayCount,
+            refreshedSetNeedsDisplayCount,
+            "Inspector refresh must not enqueue a delayed presentation invalidation"
+        )
     }
 
     func testRegistryBindOwnsOneSynchronousPresentationRefresh() async {
@@ -4229,6 +4255,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         }
         let initialEnterInWindowCount = webView.enterInWindowCount
         let initialEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+        let initialSetNeedsDisplayCount = webView.setNeedsDisplayCount
 
         BrowserWindowPortalRegistry.bind(
             webView: webView,
@@ -4237,6 +4264,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         )
         let boundEnterInWindowCount = webView.enterInWindowCount
         let boundEndDeferringCount = webView.endDeferringViewInWindowChangesCount
+        let boundSetNeedsDisplayCount = webView.setNeedsDisplayCount
 
         XCTAssertEqual(
             boundEnterInWindowCount - initialEnterInWindowCount,
@@ -4249,10 +4277,16 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Registry bind should own one synchronous deferred-window refresh"
         )
 
-        await waitForNextMainTurn()
+        drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, boundEnterInWindowCount)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, boundEndDeferringCount)
+        XCTAssertGreaterThan(boundSetNeedsDisplayCount, initialSetNeedsDisplayCount)
+        XCTAssertEqual(
+            webView.setNeedsDisplayCount,
+            boundSetNeedsDisplayCount,
+            "Registry bind must not enqueue a delayed presentation invalidation"
+        )
     }
 
     func testRegistrySameAnchorRebindForcesOneSynchronousPresentationRefresh() async {
@@ -4285,6 +4319,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         let viewDidUnhideCountBeforeRebind = webView.viewDidUnhideCount
         let enterInWindowCountBeforeRebind = webView.enterInWindowCount
         let endDeferringCountBeforeRebind = webView.endDeferringViewInWindowChangesCount
+        let setNeedsDisplayCountBeforeRebind = webView.setNeedsDisplayCount
 
         BrowserWindowPortalRegistry.bind(
             webView: webView,
@@ -4295,6 +4330,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         let viewDidUnhideCountAfterRebind = webView.viewDidUnhideCount
         let enterInWindowCountAfterRebind = webView.enterInWindowCount
         let endDeferringCountAfterRebind = webView.endDeferringViewInWindowChangesCount
+        let setNeedsDisplayCountAfterRebind = webView.setNeedsDisplayCount
 
         XCTAssertEqual(
             viewDidUnhideCountAfterRebind - viewDidUnhideCountBeforeRebind,
@@ -4312,11 +4348,17 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Same-anchor host replacement should invoke one synchronous deferred-window refresh"
         )
 
-        await waitForNextMainTurn()
+        drainFormerPresentationRetryWindow()
         XCTAssertEqual(webView.viewDidUnhideCount, viewDidUnhideCountAfterRebind)
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
+        XCTAssertGreaterThan(setNeedsDisplayCountAfterRebind, setNeedsDisplayCountBeforeRebind)
+        XCTAssertEqual(
+            webView.setNeedsDisplayCount,
+            setNeedsDisplayCountAfterRebind,
+            "Same-anchor rebind must not enqueue a delayed presentation invalidation"
+        )
     }
 
     func testVisiblePortalEntryHidesWithoutDetachingDuringTransientAnchorRemovalUntilRebind() async {
@@ -4371,6 +4413,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.bind(webView: webView, to: anchor2, visibleInUI: true)
         let enterInWindowCountAfterRebind = webView.enterInWindowCount
         let endDeferringCountAfterRebind = webView.endDeferringViewInWindowChangesCount
+        let redrawCountAfterRebind = webView.setNeedsDisplayCount
 
         XCTAssertTrue(webView.superview === slot, "Rebinding after transient anchor removal should reuse the existing portal slot")
         XCTAssertFalse(slot.isHidden)
@@ -4396,10 +4439,15 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
             "Anchor rebind should invoke one synchronous deferred-window refresh"
         )
 
-        await waitForNextMainTurn()
+        drainFormerPresentationRetryWindow()
 
         XCTAssertEqual(webView.enterInWindowCount, enterInWindowCountAfterRebind)
         XCTAssertEqual(webView.endDeferringViewInWindowChangesCount, endDeferringCountAfterRebind)
+        XCTAssertEqual(
+            webView.setNeedsDisplayCount,
+            redrawCountAfterRebind,
+            "Anchor rebind must not enqueue a delayed presentation invalidation"
+        )
     }
 
     func testVisiblePortalEntryStaysVisibleDuringOffWindowAnchorReparentUntilRebind() async {

--- a/cmuxTests/BrowserPanelViewIdentityTests.swift
+++ b/cmuxTests/BrowserPanelViewIdentityTests.swift
@@ -59,6 +59,24 @@ import Testing
         )
     }
 
+    @Test func closeReleasesLoadedWebViewWhilePanelRemainsRetained() {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let originalWebView = panel.webView
+        let discardManager = panel.hiddenWebViewDiscardManager
+
+        #expect(discardManager.delegate === panel)
+
+        panel.close()
+
+        #expect(discardManager.delegate == nil)
+        #expect(!discardManager.hasScheduledDiscard)
+        #expect(panel.webView !== originalWebView)
+        #expect(panel.webView.url == nil)
+        #expect(originalWebView.navigationDelegate == nil)
+        #expect(originalWebView.uiDelegate == nil)
+        #expect(originalWebView.superview == nil)
+    }
+
     private func waitForOmnibarField(
         panelID: UUID,
         in window: NSWindow,

--- a/cmuxTests/BrowserPanelViewIdentityTests.swift
+++ b/cmuxTests/BrowserPanelViewIdentityTests.swift
@@ -4,6 +4,8 @@ import CmuxAppKitSupportUI
 import Observation
 import SwiftUI
 import Testing
+import WebKit
+import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -74,14 +76,19 @@ import Testing
         window.contentView?.addSubview(slot)
         slot.addSubview(originalPresentationView)
         slot.pinHostedWebView(originalWebView)
+        let loadProbe = BrowserPanelLoadProbe()
+        originalWebView.navigationDelegate = loadProbe
         originalWebView.loadHTMLString("<html><body>loaded</body></html>", baseURL: nil)
         window.makeKeyAndOrderFront(nil)
+        let loadResult = XCTWaiter.wait(for: [loadProbe.didFinish], timeout: 5)
 
         defer {
             window.orderOut(nil)
             window.contentView = nil
         }
 
+        #expect(loadResult == .completed)
+        #expect(loadProbe.error == nil)
         #expect(discardManager.delegate === panel)
         #expect(originalPresentationView.superview === slot)
 
@@ -116,6 +123,29 @@ import Testing
     private func render(_ window: NSWindow) {
         window.displayIfNeeded()
         window.contentView?.layoutSubtreeIfNeeded()
+    }
+}
+
+private final class BrowserPanelLoadProbe: NSObject, WKNavigationDelegate {
+    let didFinish = XCTestExpectation(description: "browser page finished loading")
+    private(set) var error: Error?
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        didFinish.fulfill()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        self.error = error
+        didFinish.fulfill()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        self.error = error
+        didFinish.fulfill()
     }
 }
 

--- a/cmuxTests/BrowserPanelViewIdentityTests.swift
+++ b/cmuxTests/BrowserPanelViewIdentityTests.swift
@@ -59,12 +59,31 @@ import Testing
         )
     }
 
-    @Test func closeReleasesLoadedWebViewWhilePanelRemainsRetained() {
+    @Test func closeReleasesLoadedWebViewFromLocalInlineHostWhilePanelRemainsRetained() {
         let panel = BrowserPanel(workspaceId: UUID())
         let originalWebView = panel.webView
+        let originalPresentationView = originalWebView.cmuxBrowserViewportPresentationView
         let discardManager = panel.hiddenWebViewDiscardManager
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 500),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let slot = WindowBrowserSlotView(frame: window.contentView?.bounds ?? .zero)
+        window.contentView?.addSubview(slot)
+        slot.addSubview(originalPresentationView)
+        slot.pinHostedWebView(originalWebView)
+        originalWebView.loadHTMLString("<html><body>loaded</body></html>", baseURL: nil)
+        window.makeKeyAndOrderFront(nil)
+
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
 
         #expect(discardManager.delegate === panel)
+        #expect(originalPresentationView.superview === slot)
 
         panel.close()
 
@@ -74,6 +93,7 @@ import Testing
         #expect(panel.webView.url == nil)
         #expect(originalWebView.navigationDelegate == nil)
         #expect(originalWebView.uiDelegate == nil)
+        #expect(originalPresentationView.superview == nil)
         #expect(originalWebView.superview == nil)
     }
 

--- a/cmuxTests/BrowserPanelViewIdentityTests.swift
+++ b/cmuxTests/BrowserPanelViewIdentityTests.swift
@@ -5,7 +5,6 @@ import Observation
 import SwiftUI
 import Testing
 import WebKit
-import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -61,7 +60,7 @@ import XCTest
         )
     }
 
-    @Test func closeReleasesLoadedWebViewFromLocalInlineHostWhilePanelRemainsRetained() {
+    @Test func closeReleasesLoadedWebViewFromLocalInlineHostWhilePanelRemainsRetained() async {
         let panel = BrowserPanel(workspaceId: UUID())
         let originalWebView = panel.webView
         let originalPresentationView = originalWebView.cmuxBrowserViewportPresentationView
@@ -78,16 +77,16 @@ import XCTest
         slot.pinHostedWebView(originalWebView)
         let loadProbe = BrowserPanelLoadProbe()
         originalWebView.navigationDelegate = loadProbe
-        originalWebView.loadHTMLString("<html><body>loaded</body></html>", baseURL: nil)
         window.makeKeyAndOrderFront(nil)
-        let loadResult = XCTWaiter.wait(for: [loadProbe.didFinish], timeout: 5)
+        originalWebView.loadHTMLString("<html><body>loaded</body></html>", baseURL: nil)
+        let didCompleteLoad = await waitForWebViewLoad(loadProbe)
 
         defer {
             window.orderOut(nil)
             window.contentView = nil
         }
 
-        #expect(loadResult == .completed)
+        #expect(didCompleteLoad)
         #expect(loadProbe.error == nil)
         #expect(discardManager.delegate === panel)
         #expect(originalPresentationView.superview === slot)
@@ -102,6 +101,20 @@ import XCTest
         #expect(originalWebView.uiDelegate == nil)
         #expect(originalPresentationView.superview == nil)
         #expect(originalWebView.superview == nil)
+    }
+
+    private func waitForWebViewLoad(
+        _ probe: BrowserPanelLoadProbe,
+        timeout: TimeInterval = 5
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if probe.didComplete {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        } while Date() < deadline
+        return probe.didComplete
     }
 
     private func waitForOmnibarField(
@@ -127,16 +140,16 @@ import XCTest
 }
 
 private final class BrowserPanelLoadProbe: NSObject, WKNavigationDelegate {
-    let didFinish = XCTestExpectation(description: "browser page finished loading")
+    private(set) var didComplete = false
     private(set) var error: Error?
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        didFinish.fulfill()
+        didComplete = true
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         self.error = error
-        didFinish.fulfill()
+        didComplete = true
     }
 
     func webView(
@@ -145,7 +158,7 @@ private final class BrowserPanelLoadProbe: NSObject, WKNavigationDelegate {
         withError error: Error
     ) {
         self.error = error
-        didFinish.fulfill()
+        didComplete = true
     }
 }
 

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -92,7 +92,6 @@ struct BrowserPortalFirstRevealScrollTests {
         defer {
             webView.stopLoading()
             window.orderOut(nil)
-            window.close()
         }
 
         #expect(webView.window === window)
@@ -117,7 +116,6 @@ struct BrowserPortalFirstRevealScrollTests {
         defer {
             webView.stopLoading()
             fixture.window.orderOut(nil)
-            fixture.window.close()
         }
 
         #expect(webView.window === fixture.window)
@@ -141,7 +139,6 @@ struct BrowserPortalFirstRevealScrollTests {
         defer {
             webView.stopLoading()
             fixture.window.orderOut(nil)
-            fixture.window.close()
         }
 
         #expect(webView.window === fixture.window)
@@ -161,7 +158,6 @@ struct BrowserPortalFirstRevealScrollTests {
         let fixture = makeWindowFixture()
         defer {
             fixture.window.orderOut(nil)
-            fixture.window.close()
         }
         let webView = RecordingWebView(
             frame: NSRect(x: 0, y: 0, width: 300, height: 180),

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -13,6 +13,12 @@ import WebKit
 struct BrowserPortalFirstRevealScrollTests {
     private final class RecordingWebView: WKWebView {
         var frameSizeCalls: [NSSize] = []
+        private(set) var displayIfNeededCount = 0
+
+        override func displayIfNeeded() {
+            displayIfNeededCount += 1
+            super.displayIfNeeded()
+        }
 
         override func setFrameSize(_ newSize: NSSize) {
             frameSizeCalls.append(newSize)
@@ -199,6 +205,7 @@ struct BrowserPortalFirstRevealScrollTests {
 
         webView.browserPortalPrepareForHiddenHostAdoption()
         #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+        let displayCountBeforeReveal = webView.displayIfNeededCount
 
         BrowserWindowPortalRegistry.bind(webView: webView, to: fixture.anchor, visibleInUI: true)
         BrowserWindowPortalRegistry.synchronizeForAnchor(fixture.anchor)
@@ -212,6 +219,10 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: revealedSize) })
         #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
         #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
+        #expect(
+            webView.displayIfNeededCount == displayCountBeforeReveal,
+            "The one-point first-reveal nudge should invalidate layout without synchronously flushing display."
+        )
         #expect(fixture.window.firstResponder === firstResponder)
 
         webView.frameSizeCalls.removeAll()

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -208,7 +208,6 @@ struct BrowserPortalFirstRevealScrollTests {
         let displayCountBeforeReveal = webView.displayIfNeededCount
 
         BrowserWindowPortalRegistry.bind(webView: webView, to: fixture.anchor, visibleInUI: true)
-        BrowserWindowPortalRegistry.synchronizeForAnchor(fixture.anchor)
 
         let slot = try #require(webView.superview as? WindowBrowserSlotView)
         let revealedSize = slot.bounds.size

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -209,11 +209,20 @@ struct BrowserPortalFirstRevealScrollTests {
 
         BrowserWindowPortalRegistry.bind(webView: webView, to: fixture.anchor, visibleInUI: true)
         BrowserWindowPortalRegistry.synchronizeForAnchor(fixture.anchor)
-        await waitForNextMainTurn()
 
         let slot = try #require(webView.superview as? WindowBrowserSlotView)
         let revealedSize = slot.bounds.size
         let nudgedSize = NSSize(width: revealedSize.width, height: max(1, revealedSize.height - 1))
+
+        #expect(
+            webView.frameSizeCalls.filter { size($0, approximatelyEquals: nudgedSize) }.count == 1,
+            "Portal bind should apply one first-sized nudge synchronously against settled slot bounds."
+        )
+        #expect(
+            size(webView.frame.size, approximatelyEquals: nudgedSize),
+            "The first-sized nudge should remain pending only until the causal next main turn."
+        )
+        await waitForNextMainTurn()
 
         #expect(webView.frameSizeCalls.filter { size($0, approximatelyEquals: nudgedSize) }.count == 1)
         #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: revealedSize) })

--- a/docs/browser-rendering-performance-investigation.md
+++ b/docs/browser-rendering-performance-investigation.md
@@ -62,6 +62,14 @@ The focused regression suite covers:
 5. Discard-manager shutdown clearing its timer and delegate synchronously.
 6. Closing a committed local page while the panel remains retained, including detachment from the local inline host and replacement with an unloaded view.
 
+## CI and build evidence
+
+Final code and test commit `772dacfd9e` was validated on GitHub-hosted macOS:
+
+- [macOS Compatibility run 30210823264](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30210823264) checked out that exact commit and compiled the application and test targets. On macOS 15, the active-viewport, external-split, workspace-rebind, portal-anchor, and single-entry lifecycle regressions all passed. The two arm64 jobs continued into the repository-wide suite until the 60-minute job limit, and the Intel macOS 14 job could not start because that runner class was unavailable under the account spending limit. The run therefore is not presented as a full-suite green result; unrelated suites also reported failures before timeout.
+- [Tagged application build 30213748000](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30213748000) successfully built the exact final code and test commit as `cmux DEV browser-perf-final-772dacf` on macOS 15.
+- [Standard CI run 30210826433](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30210826433) remained pending without creating a job and was canceled after the compatibility and tagged-build paths supplied the available macOS evidence.
+
 ## Measurements
 
 ### Deterministic frame-change probe

--- a/docs/browser-rendering-performance-investigation.md
+++ b/docs/browser-rendering-performance-investigation.md
@@ -68,7 +68,7 @@ The focused regression suite covers:
 
 ## CI and build evidence
 
-Final code and test commit `772dacfd9e` was validated on GitHub-hosted macOS:
+The first complete code-and-test checkpoint, `772dacfd9e`, was validated on GitHub-hosted macOS:
 
 - [macOS Compatibility run 30210823264](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30210823264) checked out that exact commit and compiled the application and test targets. On macOS 15, the active-viewport, external-split, workspace-rebind, portal-anchor, and single-entry lifecycle regressions all passed. The two arm64 jobs continued into the repository-wide suite until the 60-minute job limit, and the Intel macOS 14 job could not start because that runner class was unavailable under the account spending limit. The run therefore is not presented as a full-suite green result; unrelated suites also reported failures before timeout.
 - [Tagged application build 30213748000](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30213748000) successfully built the exact final code and test commit as `cmux DEV browser-perf-final-772dacf` on macOS 15.

--- a/docs/browser-rendering-performance-investigation.md
+++ b/docs/browser-rendering-performance-investigation.md
@@ -1,0 +1,180 @@
+# Embedded Browser Rendering Performance Investigation
+
+## Summary
+
+The embedded browser had four independent lifecycle costs on its main-thread resize path:
+
+1. A portal geometry notification could schedule the same external synchronization twice.
+2. Each synchronization synchronously forced AppKit layout and display through the WebKit container and window hierarchy.
+3. A presentation refresh ran immediately, on the next main-queue turn, and again after 30 ms.
+4. Closing a browser pane stopped WebKit navigation but left discard-manager timers and observers tied to the panel lifecycle.
+
+The change removes the duplicate geometry request, replaces synchronous display flushing with coalesced invalidation, reduces presentation recovery to one latest-wins main-queue pass, skips the deferred all-entry pass when the primary browser is the only portal entry, and synchronously tears down browser-pane lifecycle resources on close.
+
+The measured result is less portal work and better responsiveness in one continuous-resize run. Whole-window AppKit and SwiftUI layout still dominate sustained live resize, so this report does **not** claim that every long animation frame or all historical memory growth is eliminated.
+
+## Scope and environment
+
+- Source baseline: upstream `main` before this change.
+- Test machine: Apple Silicon laptop running macOS 15.7.5.
+- Browser workload: one local, deterministic HTML page with 160 colored bands, continuous vertical scrolling, a changing fixed marker, and `requestAnimationFrame` timing.
+- Resize workloads:
+  - 180 deterministic window-frame changes through the debug automation API.
+  - 10-second continuous Accessibility-driven window resizing while the page scrolled.
+  - A second 220-sample Accessibility run alternating the window by 150 × 90 points.
+- Memory workload: load 12 additional browser surfaces, close them, and sample the attributed process tree for 24 seconds.
+- Profiling: a five-second `sample` capture during continuous resize.
+
+All pages were local fixtures. The report contains no account, browsing-history, host, or user-identifying data.
+
+## Root-cause findings
+
+### 1. Duplicate geometry synchronization
+
+The external geometry callback invalidated the browser portal directly and then queued another invalidation for the same event-loop turn. In a baseline trace, 203 external-geometry callbacks accompanied 180 requested frame changes.
+
+The corrected path has one coalescing boundary. A single primary browser synchronizes immediately from its anchor and no longer schedules a redundant all-entry pass. Multiple-browser and recovery paths retain the deferred full reconciliation.
+
+### 2. Synchronous rendering flushes
+
+The portal called `layoutSubtreeIfNeeded()` and `displayIfNeeded()` across the WebKit view, its container, ancestors, and window after geometry changes. Both APIs are synchronous. Repeating them inside a resize callback makes the pointer or automation request wait for work AppKit could otherwise coalesce.
+
+The corrected geometry path updates frames inside a disabled-animation Core Animation transaction and marks affected views dirty. AppKit performs layout and display on its normal event-loop cadence.
+
+### 3. Repeated presentation recovery
+
+The old recovery helper performed three refreshes: immediate, next-turn, and delayed. This was appropriate as a defensive workaround for stale WebKit hosted layers, but it was also used during ordinary frame churn.
+
+The corrected helper keeps one cancellable, latest-wins next-turn refresh. Reveal, reattach, and transient-recovery paths still request the WebKit rendering-state repair; pure geometry changes only invalidate display.
+
+### 4. Browser-pane close lifecycle
+
+Pane close previously depended on later deinitialization for some cleanup. The discard manager now has a synchronous main-actor shutdown that cancels its timer, clears its delegate, and removes policy and sleep/wake observers. Browser close is idempotent, detaches the old presentation hierarchy from either portal or local inline hosting, clears callbacks and delegates, cancels viewport restoration, and replaces the loaded view with one unloaded view so the panel's non-optional view contract does not retain the old WebContent ownership tree.
+
+## Regression coverage
+
+The focused regression suite covers:
+
+1. One external geometry callback producing one coalesced portal invalidation.
+2. Geometry-only synchronization invalidating direct and active-viewport-hosted browsers without synchronous AppKit display flushes.
+3. Reveal coalescing to one call for each required WebKit rendering-state selector.
+4. Single-browser portal synchronization avoiding a redundant deferred all-entry pass.
+5. Discard-manager shutdown clearing its timer and delegate synchronously.
+6. Closing a committed local page while the panel remains retained, including detachment from the local inline host and replacement with an unloaded view.
+
+## Measurements
+
+### Deterministic frame-change probe
+
+| Metric | Baseline run 1 | Baseline run 2 | Candidate run 1 |
+|---|---:|---:|---:|
+| Idle rAF median / p95 | 17 / 19 ms | 17 / 19 ms | 17 / 19 ms |
+| Resize rAF median / p95 | 15 / 55 ms | 16 / 55 ms | 15 / 55 ms |
+| Resize intervals > 33 ms | 181 | 182 | 181 |
+| Resize RPC median / p95 | 57.868 / 78.623 ms | 58.602 / 80.562 ms | 57.809 / 81.884 ms |
+| App CPU during resize | 1.77% | 1.78% | 1.76% |
+
+This probe deliberately waits for each synchronous `setFrame(display: true)` request. Its approximately 58 ms median is primarily window-server and whole-window layout pacing; it did not distinguish the portal optimization by itself.
+
+### Continuous live resize
+
+Two independently implemented Accessibility resize loops produced directionally different RPC timing but the same central result: portal work fell, rendered-frame behavior improved modestly, and long frames remained because the full window still lays out on every accepted size.
+
+| Metric | Baseline | Candidate |
+|---|---:|---:|
+| Applied samples in 10 s | 216 | 220 |
+| rAF samples | 452 | 501 |
+| rAF median / p95 | 18 / 48 ms | 17 / 46 ms |
+| rAF intervals > 33 ms | 218 | 216 |
+| Browser RPC median / p95 | 425.872 / 539.717 ms | 247.809 / 527.019 ms |
+| App CPU | 2.41% | 2.38% |
+
+A repeated 220-sample run used a slower, synchronous Accessibility command loop. It produced 1,394 baseline and 1,409 candidate rAF samples, a p95 of 58 vs. 57 ms, and 153 vs. 127 intervals over 50 ms. Median browser RPC was 22.482 vs. 23.082 ms. This run showed fewer severe frame stalls, while the slower median RPC demonstrates run-to-run variability and rules out presenting the result as a universal speedup.
+
+### Portal trace counts
+
+| Trace event | Baseline | Candidate before single-entry follow-up | Change |
+|---|---:|---:|---:|
+| Geometry invalidations | 383 | 180 | -53% |
+| Full presentation refreshes | 47 | 2 | -96% |
+| External-geometry callbacks | 203 | 4 | -98% |
+| Deferred all-entry schedule/tick pairs | 193 | 174 | Single-entry follow-up removes the remaining redundant anchor-driven requests |
+
+The candidate still logged 1,239 synchronization results because the benchmark also exercises normal per-anchor synchronization. The important reduction is in duplicate invalidation and forced presentation recovery, not an artificial suppression of required geometry updates.
+
+### Main-thread sample
+
+During a five-second continuous candidate resize:
+
+- 2,034 of 2,766 main-thread samples were below `CmuxMainWindow.setFrame`.
+- 1,499 samples included AppKit layout.
+- 852 samples included SwiftUI `NSHostingView.layout`.
+- Immediate browser-portal synchronization appeared in 31 samples.
+- Deferred browser-portal synchronization appeared in one sample.
+
+These stacks overlap, so the counts are not additive percentages. They establish that remaining live-resize pacing is mostly whole-window layout rather than the removed synchronous WebKit display flush.
+
+### Browser process reclamation
+
+| Metric | Baseline range (2 runs) | Candidate run 1 | Final tagged run |
+|---|---:|---:|---:|
+| WebKit processes after loading surfaces | 15 | 15 | 15 |
+| WebKit processes after close and settle | 4 | 3 | 3 |
+| WebKit footprint loaded | 262.1–266.3 MB | 253.0 MB | 245.2 MB |
+| WebKit footprint settled | 87.4–92.3 MB | 83.2 MB | 78.0 MB |
+| Attributed tree footprint reclaimed | 191.1–196.0 MB | 151.2 MB | 150.0 MB |
+
+Gross reclaimed bytes depend on the loaded starting footprint; the candidate's loaded WebKit footprint was lower, so the smaller gross delta is not evidence of a regression. The bounded signal is that the 12 closed surfaces did not leave 12 WebContent processes alive: both candidate runs returned to three processes and the final tagged run returned to 78.0 MB of WebKit footprint.
+
+A separate final tagged-app probe repeated three cycles of opening and closing eight additional browser surfaces. Every cycle loaded 11 WebKit processes and settled at three. The cycles reclaimed 117.3, 112.3, and 117.2 MB of WebKit footprint; their settled footprints were 41.4, 46.9, and 46.3 MB. All lifecycle assertions passed. These short synthetic tests do not replace a day-long soak for the broad reports in #4188 and #5305.
+
+### Final tagged-app resize validation
+
+The repository's release workflow produced the final test artifact, which was then exercised as an installed app rather than an in-tree executable. Activation, browser loading, scrolling, screenshots, resizing, close, and process reclamation all passed.
+
+| Metric | Deterministic probe | 220-sample live-resize probe |
+|---|---:|---:|
+| rAF median / p95 | 15 / 55 ms | 16 / 55 ms |
+| rAF intervals > 33 ms | 180 of 631 | 227 of 1,519 |
+| Browser RPC median / p95 | 58.691 / 82.571 ms | 22.714 / 59.585 ms |
+| Browser RPC errors | 0 | 0 |
+| App CPU during resize | 1.71% | 1.08% |
+
+The deterministic probe also measured idle rAF at 17 / 19 ms median / p95 and 0.18% app CPU. The live-resize probe applied all 220 requested 150 × 90-point changes and produced a valid 15.5 KB browser-owned PNG.
+
+## Visual validation and capture limitation
+
+The browser automation screenshot API produced valid PNGs during the resize probes (11–16 KB in the scrolling fixture). Screen-level compositor capture on this macOS configuration omitted the hosted WebKit surface and returned black/protected pixels for the browser region. Therefore:
+
+- Browser content, scrolling, and changed rendering were verified through the browser-owned screenshot API and DOM/rAF instrumentation.
+- Direct pixel comparison of a torn intermediate compositor frame was not possible.
+- The evidence supports removing synchronous and repeated refresh work that can destabilize frame pacing; it does not prove that no compositor tear can ever occur.
+
+## Related issue audit
+
+| Item | Current state | Relevance |
+|---|---|---|
+| [#1114](https://github.com/manaflow-ai/cmux/issues/1114) | Open | Direct report of inconsistent browser drag/resize lag. |
+| [#1118](https://github.com/manaflow-ai/cmux/pull/1118) | Open, merge-conflicted | Earlier 270-line throttling approach. The current change uses a smaller coalescing boundary and avoids mouse-event heuristics. |
+| [#4188](https://github.com/manaflow-ai/cmux/issues/4188) | Open | Broad retained-WebKit and helper-process memory report. This change covers browser-pane teardown only. |
+| [#5305](https://github.com/manaflow-ai/cmux/issues/5305) | Open | Broad long-session CPU/memory audit; remains larger than this change. |
+| [#5303](https://github.com/manaflow-ai/cmux/issues/5303) | Closed | Prior browser render loop. Idle CPU remained 0.17–0.19% in this investigation, so that loop did not reproduce. |
+| [#3085](https://github.com/manaflow-ai/cmux/issues/3085) | Open | Ghost WebKit layer across workspaces. The retained portal recovery behavior remains covered; this change does not claim to close it. |
+| [#4287](https://github.com/manaflow-ai/cmux/issues/4287) | Closed, not planned | Blank flash on WebKit reattach. Reveal still receives one explicit rendering-state recovery pass. |
+| [#4539](https://github.com/manaflow-ai/cmux/issues/4539) | Closed | Hidden-browser retention policy. The close cleanup complements, rather than replaces, hidden-surface discard. |
+| [#7895](https://github.com/manaflow-ai/cmux/issues/7895) | Closed | Initial scrollability after first-sized reveal. The one-shot size nudge remains, without synchronous display flushing. |
+
+## API rationale
+
+- [`NSView.displayIfNeeded()`](https://developer.apple.com/documentation/appkit/nsview/displayifneeded()) synchronously displays invalid regions.
+- [`NSView.setNeedsDisplay(_:)`](https://developer.apple.com/documentation/appkit/nsview/setneedsdisplay(_:)) invalidates content for AppKit to display on its normal pass.
+- [`NSView.layoutSubtreeIfNeeded()`](https://developer.apple.com/documentation/appkit/nsview/layoutsubtreeifneeded()) performs pending layout synchronously.
+
+The implementation uses invalidation for ordinary geometry and reserves explicit WebKit rendering-state recovery for lifecycle transitions.
+
+## Remaining risk
+
+- Whole-window SwiftUI/AppKit layout still produces long rAF intervals during aggressive resize.
+- Screen capture cannot directly score intermediate hosted-layer tearing on the test system.
+- The memory probe is bounded and synthetic, not a multi-hour workload with arbitrary websites, media, extensions, or developer tools.
+- Multi-browser portal reconciliation remains intentionally deferred and needs continued regression coverage because it cannot use the single-entry fast path.

--- a/docs/browser-rendering-performance-investigation.md
+++ b/docs/browser-rendering-performance-investigation.md
@@ -9,9 +9,9 @@ The embedded browser had four independent lifecycle costs on its main-thread res
 3. A presentation refresh ran immediately, on the next main-queue turn, and again after 30 ms.
 4. Closing a browser pane stopped WebKit navigation but left discard-manager timers and observers tied to the panel lifecycle.
 
-The change removes the duplicate geometry request, replaces synchronous display flushing with coalesced invalidation, reduces presentation recovery to one latest-wins main-queue pass, skips the deferred all-entry pass when the primary browser is the only portal entry, and synchronously tears down browser-pane lifecycle resources on close.
+The change removes the duplicate geometry request, replaces synchronous display flushing with coalesced invalidation, performs one synchronous presentation repair inside the owning portal synchronization for bind, reveal, and forced-refresh transitions, skips the deferred all-entry pass when the primary browser is the only portal entry, and synchronously tears down browser-pane lifecycle resources on close.
 
-The measured result is less portal work and better responsiveness in one continuous-resize run. Whole-window AppKit and SwiftUI layout still dominate sustained live resize, so this report does **not** claim that every long animation frame or all historical memory growth is eliminated.
+The measured result is less portal work and stable responsiveness across repeated resize probes. Whole-window AppKit and SwiftUI layout still dominate sustained live resize, so this report does **not** claim that every long animation frame or all historical memory growth is eliminated.
 
 ## Scope and environment
 
@@ -33,7 +33,7 @@ All pages were local fixtures. The report contains no account, browsing-history,
 
 The external geometry callback invalidated the browser portal directly and then queued another invalidation for the same event-loop turn. In a baseline trace, 203 external-geometry callbacks accompanied 180 requested frame changes.
 
-The corrected path has one coalescing boundary. A single primary browser synchronizes immediately from its anchor and no longer schedules a redundant all-entry pass. Multiple-browser and recovery paths retain the deferred full reconciliation.
+The corrected path has one coalescing boundary. A single primary browser synchronizes immediately from its anchor and no longer schedules a redundant all-entry pass. Multiple-browser reconciliation remains deferred; lifecycle transitions request presentation recovery through the owning synchronization rather than a second caller-side refresh.
 
 ### 2. Synchronous rendering flushes
 
@@ -45,7 +45,7 @@ The corrected geometry path updates frames inside a disabled-animation Core Anim
 
 The old recovery helper performed three refreshes: immediate, next-turn, and delayed. This was appropriate as a defensive workaround for stale WebKit hosted layers, but it was also used during ordinary frame churn.
 
-The corrected helper keeps one cancellable, latest-wins next-turn refresh. Reveal, reattach, and transient-recovery paths still request the WebKit rendering-state repair; pure geometry changes only invalidate display.
+The corrected helper performs one synchronous presentation repair from the portal synchronization that owns the transition. Reveal, same- and new-anchor rebind, reattach, hosted-inspector adjustment, and explicit force-refresh paths still request the WebKit rendering-state repair exactly once; pure geometry changes only invalidate layout and display.
 
 ### 4. Browser-pane close lifecycle
 
@@ -57,10 +57,14 @@ The focused regression suite covers:
 
 1. One external geometry callback producing one coalesced portal invalidation.
 2. Geometry-only synchronization invalidating direct and active-viewport-hosted browsers without synchronous AppKit display flushes.
-3. Reveal coalescing to one call for each required WebKit rendering-state selector.
-4. Single-browser portal synchronization avoiding a redundant deferred all-entry pass.
-5. Discard-manager shutdown clearing its timer and delegate synchronously.
-6. Closing a committed local page while the panel remains retained, including detachment from the local inline host and replacement with an unloaded view.
+3. Initial bind, reveal, and explicit force refresh producing one synchronous call to each required WebKit rendering-state selector with no next-turn duplicate.
+4. Same- and new-anchor rebinds refreshing a replaced host exactly once.
+5. Hosted-inspector divider adjustment honoring one explicit forced refresh without a caller-side duplicate.
+6. First-sized reveal retaining its one-shot size nudge while presentation recovery remains synchronous.
+7. Single-browser portal synchronization avoiding a redundant deferred all-entry pass.
+8. Bounded transient-anchor recovery hiding a genuinely detached stale slot after exhaustion while preserving an off-window drag reparent until rebind.
+9. Discard-manager shutdown clearing its timer and delegate synchronously.
+10. Closing a committed local page while the panel remains retained, including detachment from the local inline host and replacement with an unloaded view.
 
 ## CI and build evidence
 
@@ -124,31 +128,31 @@ These stacks overlap, so the counts are not additive percentages. They establish
 
 ### Browser process reclamation
 
-| Metric | Baseline range (2 runs) | Candidate run 1 | Final tagged run |
+| Metric | Baseline range (2 runs) | Candidate run 1 | Final reviewed-head run |
 |---|---:|---:|---:|
 | WebKit processes after loading surfaces | 15 | 15 | 15 |
 | WebKit processes after close and settle | 4 | 3 | 3 |
-| WebKit footprint loaded | 262.1–266.3 MB | 253.0 MB | 245.2 MB |
-| WebKit footprint settled | 87.4–92.3 MB | 83.2 MB | 78.0 MB |
-| Attributed tree footprint reclaimed | 191.1–196.0 MB | 151.2 MB | 150.0 MB |
+| WebKit footprint loaded | 262.1–266.3 MB | 253.0 MB | 253.2 MB |
+| WebKit footprint settled | 87.4–92.3 MB | 83.2 MB | 83.3 MB |
+| Attributed tree footprint reclaimed | 191.1–196.0 MB | 151.2 MB | 182.9 MB |
 
-Gross reclaimed bytes depend on the loaded starting footprint; the candidate's loaded WebKit footprint was lower, so the smaller gross delta is not evidence of a regression. The bounded signal is that the 12 closed surfaces did not leave 12 WebContent processes alive: both candidate runs returned to three processes and the final tagged run returned to 78.0 MB of WebKit footprint.
+Gross reclaimed bytes depend on the loaded starting footprint, so the bounded signal is process and settled-footprint behavior rather than the delta alone. The 12 closed surfaces did not leave 12 WebContent processes alive: both candidate runs and the final reviewed-head run returned to three processes; the latest run settled at 83.3 MB of WebKit footprint.
 
-A separate final tagged-app probe repeated three cycles of opening and closing eight additional browser surfaces. Every cycle loaded 11 WebKit processes and settled at three. The cycles reclaimed 117.3, 112.3, and 117.2 MB of WebKit footprint; their settled footprints were 41.4, 46.9, and 46.3 MB. All lifecycle assertions passed. These short synthetic tests do not replace a day-long soak for the broad reports in #4188 and #5305.
+An earlier tagged-app probe repeated three cycles of opening and closing eight additional browser surfaces. Every cycle loaded 11 WebKit processes and settled at three. The cycles reclaimed 117.3, 112.3, and 117.2 MB of WebKit footprint; their settled footprints were 41.4, 46.9, and 46.3 MB. All lifecycle assertions passed. The final reviewed-head probe then repeated the larger 12-surface cycle above. These short synthetic tests do not replace a day-long soak for the broad reports in #4188 and #5305.
 
 ### Final tagged-app resize validation
 
-The repository's release workflow produced the final test artifact, which was then exercised as an installed app rather than an in-tree executable. Activation, browser loading, scrolling, screenshots, resizing, close, and process reclamation all passed.
+The repository's release workflow produced an app from reviewed code-and-test commit `e779b88e3c`, which was then exercised as an installed app rather than an in-tree executable. Activation, browser loading, scrolling, screenshots, resizing, close, and process reclamation all passed.
 
 | Metric | Deterministic probe | 220-sample live-resize probe |
 |---|---:|---:|
-| rAF median / p95 | 15 / 55 ms | 16 / 55 ms |
-| rAF intervals > 33 ms | 180 of 631 | 227 of 1,519 |
-| Browser RPC median / p95 | 58.691 / 82.571 ms | 22.714 / 59.585 ms |
+| rAF median / p95 | 16 / 56 ms | 17 / 54 ms |
+| rAF intervals > 33 ms | 182 of 627 | 222 of 1,525 |
+| Browser RPC median / p95 | 59.030 / 84.691 ms | 23.180 / 60.900 ms |
 | Browser RPC errors | 0 | 0 |
-| App CPU during resize | 1.71% | 1.08% |
+| App CPU during resize | 1.73% | 1.05% |
 
-The deterministic probe also measured idle rAF at 17 / 19 ms median / p95 and 0.18% app CPU. The live-resize probe applied all 220 requested 150 × 90-point changes and produced a valid 15.5 KB browser-owned PNG.
+The deterministic probe also measured idle rAF at 17 / 18 ms median / p95 and 0.19% app CPU. The live-resize probe applied all 220 requested 150 × 90-point changes and produced a valid 15.5 KB browser-owned PNG.
 
 ## Visual validation and capture limitation
 

--- a/docs/browser-rendering-performance-investigation.md
+++ b/docs/browser-rendering-performance-investigation.md
@@ -9,7 +9,7 @@ The embedded browser had four independent lifecycle costs on its main-thread res
 3. A presentation refresh ran immediately, on the next main-queue turn, and again after 30 ms.
 4. Closing a browser pane stopped WebKit navigation but left discard-manager timers and observers tied to the panel lifecycle.
 
-The change removes the duplicate geometry request, replaces synchronous display flushing with coalesced invalidation, performs one synchronous presentation repair inside the owning portal synchronization for bind, reveal, and forced-refresh transitions, skips the deferred all-entry pass when the primary browser is the only portal entry, and synchronously tears down browser-pane lifecycle resources on close.
+The change removes the duplicate geometry request, replaces synchronous display flushing with coalesced invalidation, makes one presentation-update decision inside the owning portal synchronization, forces WebKit rendering-state repair only for explicit host/lifecycle recovery, skips the deferred all-entry pass when the primary browser is the only portal entry, and synchronously tears down browser-pane lifecycle resources on close. A visibility-only reveal invalidates presentation without forcing WebKit's enter/exit-window lifecycle; it reattaches only when a prior WebKit hide/offscreen notification marked that repair necessary.
 
 The measured result is less portal work and stable responsiveness across repeated resize probes. Whole-window AppKit and SwiftUI layout still dominate sustained live resize, so this report does **not** claim that every long animation frame or all historical memory growth is eliminated.
 
@@ -45,7 +45,7 @@ The corrected geometry path updates frames inside a disabled-animation Core Anim
 
 The old recovery helper performed three refreshes: immediate, next-turn, and delayed. This was appropriate as a defensive workaround for stale WebKit hosted layers, but it was also used during ordinary frame churn.
 
-The corrected helper performs one synchronous presentation repair from the portal synchronization that owns the transition. Reveal, same- and new-anchor rebind, reattach, hosted-inspector adjustment, and explicit force-refresh paths still request the WebKit rendering-state repair exactly once; pure geometry changes only invalidate layout and display.
+The corrected helper performs one immediate pass from the portal synchronization that owns the transition. It always coalesces presentation invalidation. Host attachment/rebind and explicit forced refresh invoke the WebKit rendering-state selectors once; an ordinary visibility-only reveal does not explicitly force them, which avoids adding a portal-owned page `visibilitychange` to every tab switch. A reveal after a WebKit hide/offscreen notification still consumes that notification's conditional reattach flag. Pure geometry changes only invalidate layout and display.
 
 ### 4. Browser-pane close lifecycle
 
@@ -57,7 +57,7 @@ The focused regression suite covers:
 
 1. One external geometry callback producing one coalesced portal invalidation.
 2. Geometry-only synchronization invalidating direct and active-viewport-hosted browsers without synchronous AppKit display flushes.
-3. Initial bind, reveal, and explicit force refresh producing one synchronous call to each required WebKit rendering-state selector with no next-turn duplicate.
+3. Host attachment/rebind and explicit force refresh producing one synchronous call to each required WebKit rendering-state selector, while visibility-only reveal invalidates presentation without an explicit `_enterInWindow` or `_endDeferringViewInWindowChangesSync` call; neither path enqueues a next-turn or delayed duplicate.
 4. Same- and new-anchor rebinds refreshing a replaced host exactly once.
 5. Hosted-inspector divider adjustment honoring one explicit forced refresh without a caller-side duplicate.
 6. First-sized reveal retaining its one-shot size nudge while presentation recovery remains synchronous.
@@ -68,11 +68,14 @@ The focused regression suite covers:
 
 ## CI and build evidence
 
-The first complete code-and-test checkpoint, `772dacfd9e`, was validated on GitHub-hosted macOS:
+The final implementation checkpoint, `adba69284e11f52580d6476ed991a3dbd689e828`, and its test-only follow-ups were validated on GitHub-hosted macOS 15:
 
-- [macOS Compatibility run 30210823264](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30210823264) checked out that exact commit and compiled the application and test targets. On macOS 15, the active-viewport, external-split, workspace-rebind, portal-anchor, and single-entry lifecycle regressions all passed. The two arm64 jobs continued into the repository-wide suite until the 60-minute job limit, and the Intel macOS 14 job could not start because that runner class was unavailable under the account spending limit. The run therefore is not presented as a full-suite green result; unrelated suites also reported failures before timeout.
-- [Tagged application build 30213748000](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30213748000) successfully built the exact final code and test commit as `cmux DEV browser-perf-final-772dacf` on macOS 15.
-- [Standard CI run 30210826433](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30210826433) remained pending without creating a job and was canceled after the compatibility and tagged-build paths supplied the available macOS evidence.
+- Run `30408303896` checked out lifecycle-test checkpoint `9a7a7702f3614b2b7fd6f98423f1fe0183beeeb2`; all 31 `BrowserWindowPortalLifecycleTests` passed with 0 failures.
+- Runs `30410242397` and `30410243498` checked out final test checkpoint `c99f4ff41b2328f4b6b590095688c60a2b820654`; all 16 `BrowserPortalFirstRevealScrollTests` and both `BrowserPanelViewIdentityTests` passed.
+- Mutation run `30408307183` checked out intentional mutation checkpoint `50a7f09005a1b8ddd125cca88ea35ef3401a5270`, which restored synchronous `displayIfNeeded()` and a 30 ms presentation invalidation. The same lifecycle suite executed 31 tests and failed 12 assertions, including both synchronous-flush and delayed-retry contracts.
+- Tagged application build `30402994309` successfully built the exact implementation checkpoint as `cmux DEV browser-perf-final-adba692` on macOS 15.
+
+Each clean focused run had a green selected-test step. Its workflow-level conclusion was failure only because the subsequent fork-context result publisher could not create its external record. These are focused contract results, not a claim that the repository-wide suite passed.
 
 ## Measurements
 
@@ -128,35 +131,35 @@ These stacks overlap, so the counts are not additive percentages. They establish
 
 ### Browser process reclamation
 
-| Metric | Baseline range (2 runs) | Candidate run 1 | Final reviewed-head run |
-|---|---:|---:|---:|
-| WebKit processes after loading surfaces | 15 | 15 | 15 |
-| WebKit processes after close and settle | 4 | 3 | 3 |
-| WebKit footprint loaded | 262.1–266.3 MB | 253.0 MB | 253.2 MB |
-| WebKit footprint settled | 87.4–92.3 MB | 83.2 MB | 83.3 MB |
-| Attributed tree footprint reclaimed | 191.1–196.0 MB | 151.2 MB | 182.9 MB |
+| Metric | Baseline range (2 runs) | Candidate run 1 | Reviewed-head run | Rebased validation |
+|---|---:|---:|---:|---:|
+| WebKit processes after loading surfaces | 15 | 15 | 15 | 15 |
+| WebKit processes after close and settle | 4 | 3 | 3 | 3 |
+| WebKit footprint loaded | 262.1–266.3 MB | 253.0 MB | 253.2 MB | 375.3 MB |
+| WebKit footprint settled | 87.4–92.3 MB | 83.2 MB | 83.3 MB | 87.3 MB |
+| Attributed tree footprint reclaimed | 191.1–196.0 MB | 151.2 MB | 182.9 MB | 325.5 MB |
 
-Gross reclaimed bytes depend on the loaded starting footprint, so the bounded signal is process and settled-footprint behavior rather than the delta alone. The 12 closed surfaces did not leave 12 WebContent processes alive: both candidate runs and the final reviewed-head run returned to three processes; the latest run settled at 83.3 MB of WebKit footprint.
+Gross reclaimed bytes depend on the loaded starting footprint, so the bounded signal is process and settled-footprint behavior rather than the delta alone. The 12 closed surfaces did not leave 12 WebContent processes alive: all candidate validations returned to three processes, and the rebased run settled at 87.3 MB of WebKit footprint.
 
-An earlier tagged-app probe repeated three cycles of opening and closing eight additional browser surfaces. Every cycle loaded 11 WebKit processes and settled at three. The cycles reclaimed 117.3, 112.3, and 117.2 MB of WebKit footprint; their settled footprints were 41.4, 46.9, and 46.3 MB. All lifecycle assertions passed. The final reviewed-head probe then repeated the larger 12-surface cycle above. These short synthetic tests do not replace a day-long soak for the broad reports in #4188 and #5305.
+An earlier tagged-app probe repeated three cycles of opening and closing eight additional browser surfaces. Every cycle loaded 11 WebKit processes and settled at three. The cycles reclaimed 117.3, 112.3, and 117.2 MB of WebKit footprint; their settled footprints were 41.4, 46.9, and 46.3 MB. All lifecycle assertions passed. The later probes repeated the larger 12-surface cycle. These short synthetic tests do not replace a day-long soak for the broad reports in #4188 and #5305.
 
 ### Final tagged-app resize validation
 
-The repository's release workflow produced an app from reviewed code-and-test commit `e779b88e3c`, which was then exercised as an installed app rather than an in-tree executable. Activation, browser loading, scrolling, screenshots, resizing, close, and process reclamation all passed.
+Run `30402994309` built exact implementation checkpoint `adba69284e11f52580d6476ed991a3dbd689e828` as `cmux DEV browser-perf-final-adba692` on macOS 15. Its build metadata records that full source ref. The installed artifact was then exercised on Apple Silicon macOS 15.7.5; activation, browser loading, continuous scrolling, browser-owned screenshots, resizing, close, and process reclamation all passed.
 
 | Metric | Deterministic probe | 220-sample live-resize probe |
 |---|---:|---:|
-| rAF median / p95 | 16 / 56 ms | 17 / 54 ms |
-| rAF intervals > 33 ms | 182 of 627 | 222 of 1,525 |
-| Browser RPC median / p95 | 59.030 / 84.691 ms | 23.180 / 60.900 ms |
+| rAF median / p95 | 16 / 56 ms | 16 / 54 ms |
+| rAF intervals > 33 ms | 182 of 634 | 82 of 514 |
+| Browser RPC median / p95 | 60.549 / 84.949 ms | 22.463 / 57.420 ms |
 | Browser RPC errors | 0 | 0 |
-| App CPU during resize | 1.73% | 1.05% |
+| App CPU during resize | 1.63% | 1.03% |
 
-The deterministic probe also measured idle rAF at 17 / 18 ms median / p95 and 0.19% app CPU. The live-resize probe applied all 220 requested 150 × 90-point changes and produced a valid 15.5 KB browser-owned PNG.
+The deterministic probe also measured idle rAF at 17 / 18 ms median / p95 and 0.19% app CPU. The live-resize probe applied all 220 requested 150 × 90-point changes, returned 826 successful responsiveness samples with no errors, and produced a valid 58.7 KB browser-owned PNG. Final rebase validation served the same deterministic fixture over loopback HTTP; fixture loading completed before timing began.
 
 ## Visual validation and capture limitation
 
-The browser automation screenshot API produced valid PNGs during the resize probes (11–16 KB in the scrolling fixture). Screen-level compositor capture on this macOS configuration omitted the hosted WebKit surface and returned black/protected pixels for the browser region. Therefore:
+The browser automation screenshot API produced valid PNGs during the final resize probes (43–59 KB in the scrolling fixture). Screen-level compositor capture on this macOS configuration omitted the hosted WebKit surface and returned black/protected pixels for the browser region. Therefore:
 
 - Browser content, scrolling, and changed rendering were verified through the browser-owned screenshot API and DOM/rAF instrumentation.
 - Direct pixel comparison of a torn intermediate compositor frame was not possible.
@@ -167,12 +170,12 @@ The browser automation screenshot API produced valid PNGs during the resize prob
 | Item | Current state | Relevance |
 |---|---|---|
 | [#1114](https://github.com/manaflow-ai/cmux/issues/1114) | Open | Direct report of inconsistent browser drag/resize lag. |
-| [#1118](https://github.com/manaflow-ai/cmux/pull/1118) | Open, merge-conflicted | Earlier 270-line throttling approach. The current change uses a smaller coalescing boundary and avoids mouse-event heuristics. |
+| [#1118](https://github.com/manaflow-ai/cmux/pull/1118) | Open | Earlier 270-line throttling approach. The current change uses a smaller coalescing boundary and avoids mouse-event heuristics. |
 | [#4188](https://github.com/manaflow-ai/cmux/issues/4188) | Open | Broad retained-WebKit and helper-process memory report. This change covers browser-pane teardown only. |
 | [#5305](https://github.com/manaflow-ai/cmux/issues/5305) | Open | Broad long-session CPU/memory audit; remains larger than this change. |
 | [#5303](https://github.com/manaflow-ai/cmux/issues/5303) | Closed | Prior browser render loop. Idle CPU remained 0.17–0.19% in this investigation, so that loop did not reproduce. |
 | [#3085](https://github.com/manaflow-ai/cmux/issues/3085) | Open | Ghost WebKit layer across workspaces. The retained portal recovery behavior remains covered; this change does not claim to close it. |
-| [#4287](https://github.com/manaflow-ai/cmux/issues/4287) | Closed, not planned | Blank flash on WebKit reattach. Reveal still receives one explicit rendering-state recovery pass. |
+| [#4287](https://github.com/manaflow-ai/cmux/issues/4287) | Closed, not planned | Blank flash on WebKit reattach. Visibility-only reveal avoids a forced rendering-state lifecycle, while notification-driven reattach remains conditional. |
 | [#4539](https://github.com/manaflow-ai/cmux/issues/4539) | Closed | Hidden-browser retention policy. The close cleanup complements, rather than replaces, hidden-surface discard. |
 | [#7895](https://github.com/manaflow-ai/cmux/issues/7895) | Closed | Initial scrollability after first-sized reveal. The one-shot size nudge remains, without synchronous display flushing. |
 
@@ -182,7 +185,7 @@ The browser automation screenshot API produced valid PNGs during the resize prob
 - [`NSView.setNeedsDisplay(_:)`](https://developer.apple.com/documentation/appkit/nsview/setneedsdisplay(_:)) invalidates content for AppKit to display on its normal pass.
 - [`NSView.layoutSubtreeIfNeeded()`](https://developer.apple.com/documentation/appkit/nsview/layoutsubtreeifneeded()) performs pending layout synchronously.
 
-The implementation uses invalidation for ordinary geometry and reserves explicit WebKit rendering-state recovery for lifecycle transitions.
+The implementation uses invalidation for ordinary geometry and visibility-only reveal, conditionally reattaches after WebKit hide/offscreen notifications, and reserves forced rendering-state recovery for explicit host and lifecycle repair.
 
 ## Remaining risk
 


### PR DESCRIPTION
## Summary

### Purpose

Coalesce browser-portal geometry and presentation work without synchronous AppKit/WebKit display flushing, keep one explicit rendering-state repair at lifecycle transitions, skip redundant single-browser reconciliation, and synchronously release browser-pane discard and presentation resources on close. This preserves active viewport, rebind, inspector, reveal, recovery, and teardown behavior while reducing avoidable main-thread work.

Fixes #1114.
Related: #4188, #5305, #3085, #7895.

### Tests

- TDD coverage exercises external geometry coalescing; direct and active-viewport redraw invalidation; single-entry synchronization; initial bind, reveal, forced refresh, same/new-anchor and delayed workspace rebind; hosted-inspector adjustment; first-sized reveal; bounded transient-anchor and off-window recovery; discard-manager shutdown; and loaded local-webview teardown.
- The initial failing lifecycle probe reproduced stale transient-anchor visibility: 6 selected cases ran with 1 assertion failure before the recovery fix.
- macOS Compatibility run `30210823264` compiled the application and test targets at the first complete code-and-test checkpoint. The active-viewport, external-split, workspace-rebind, portal-anchor, and single-entry regressions passed on macOS 15. Repository-wide jobs later reached their time limits, unrelated suites also reported failures, and the Intel macOS 14 job could not start under the account spending limit; this is scoped rather than full-suite-green evidence.
- Tagged application build `30225738150` built reviewed source head `e779b88e3c` successfully on macOS 15. The installed tagged app passed activation, local-page loading, scrolling, browser-owned screenshot capture, deterministic resize, a 220-sample live-resize probe with zero browser RPC errors, and the bounded 12-surface close/reclaim probe.
- Current head `213f48628e` adds causal refresh checks and delayed-workspace-rebind coverage. Its focused lifecycle, first-reveal, and teardown workflows are pending on macOS 15: [run 30323970929](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30323970929), [run 30323971382](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30323971382), and [run 30323971416](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30323971416). They have no observed conclusions yet and are not claimed as passing. Two earlier `df5c4b9063` focused runs ended with workflow exit code 4 instead of reporting an assertion result.

### Metrics

All measurements used local deterministic fixtures on an Apple Silicon macOS 15 system. They are bounded before/after observations, not universal speed claims.

- **Browser process cleanup (12 surfaces):** baseline loaded/settled at 15/4 WebKit processes; reviewed treatment loaded/settled at 15/3, so one fewer process remained after close and the 12 closed surfaces did not leave 12 WebContent processes alive.
- **WebKit footprint:** baseline loaded 262.1–266.3 MB and settled 87.4–92.3 MB; reviewed treatment loaded 253.2 MB and settled 83.3 MB. Loaded footprint was 8.9–13.1 MB lower and settled footprint was 4.1–9.0 MB lower than the two baseline runs.
- **Installed-app resize probe:** deterministic baseline browser RPC median/p95 was 59.030/84.691 ms with 1.73% app CPU; the 220-sample live-resize treatment measured 23.180/60.900 ms with 1.05% app CPU and zero RPC errors. Because the loops differ and repeated runs showed directionally variable timing, these values document the exercised probes rather than establish a general RPC or CPU speedup.
- **Portal trace context:** one measured comparison reduced geometry invalidations from 383 to 180 and full presentation refreshes from 47 to 2. Required per-anchor synchronization remains; the change removes duplicate invalidation and forced recovery rather than suppressing necessary geometry work.

The memory probe is synthetic and short, not a long-session soak. Whole-window SwiftUI/AppKit layout still produces long frames during aggressive resize. Screen-level capture could not score intermediate hosted-layer tearing, so the evidence does not claim that all long frames, historical memory growth, or compositor tearing are eliminated.

### Safety

- Pure geometry changes invalidate layout/display for AppKit's normal pass; they do not synchronously call `displayIfNeeded()` or invoke WebKit recovery.
- Bind, reveal, force-refresh, inspector adjustment, rebind, and recovery transitions retain one explicit rendering-state repair owned by portal synchronization.
- Multi-browser reconciliation remains deferred; only the single-entry redundant all-entry pass is skipped.
- Close is idempotent, cancels viewport restoration, shuts down the discard manager, clears delegates/observers, detaches portal or inline presentation, and replaces a loaded view with an unloaded view while preserving the non-optional panel contract.
- Focused tests observe production state directly; no test-only production counter remains.
- The detailed investigation and claim boundaries are recorded in `docs/browser-rendering-performance-investigation.md`.

## Testing

- Focused lifecycle, viewport, rebind, recovery, first-reveal, discard, and loaded-webview teardown regressions as described above.
- Installed tagged-app local-fixture probe: activation, load, scroll, browser-owned PNG, deterministic resize, 220-sample live resize, close, and process reclamation.
- No project-wide green claim; repository-wide timeouts, unrelated failures, and unavailable Intel capacity are explicitly excluded from the focused proof.

## Demo Video

No video attached. Screen-level capture on the validation system omitted the hosted WebKit surface. Browser-owned PNGs plus DOM, animation-frame, RPC, process, and footprint instrumentation verify the exercised behavior; the capture limitation and claim boundary are documented in the investigation report.

- Video URL or attachment: None

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved
