### PR TITLE
feat: support trackpad pinch zoom in browser panes

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3692,6 +3692,10 @@ final class BrowserPanel: Panel, ObservableObject {
             }
             self.scheduleBrowserViewportHostRestoration(reason: "webViewHierarchyChanged")
         }
+        webView.onMagnificationDelta = { [weak self, weak webView] delta in
+            guard let self, let webView, self.webView === webView else { return }
+            self.handleMagnificationDelta(delta)
+        }
         DiffCommentsBridge.associate(panelId: id, workspaceId: workspaceId, with: webView)
         webView.onMouseBackButton = { [weak self] in
             self?.goBack()
@@ -7206,6 +7210,11 @@ extension BrowserPanel {
     func setPageZoomFactor(_ pageZoom: CGFloat) -> Bool {
         let clamped = max(minPageZoom, min(maxPageZoom, pageZoom))
         return pageZoomMutationHandled(applyPageZoom(clamped))
+    }
+
+    func handleMagnificationDelta(_ delta: CGFloat) {
+        guard delta.isFinite else { return }
+        _ = setPageZoomFactor(webView.pageZoom + delta)
     }
 
     /// Take a snapshot of the web view

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -12,6 +12,7 @@ import WebKit
 final class CmuxWebView: WKWebView {
     var browserViewportModel: BrowserViewportModel?
     var onBrowserViewportHierarchyChanged: (() -> Void)?
+    var onMagnificationDelta: ((CGFloat) -> Void)?
 
     // Some sites/WebKit paths report middle-click link activations as
     // WKNavigationAction.buttonNumber=4 instead of 2. Track a recent local
@@ -247,6 +248,20 @@ final class CmuxWebView: WKWebView {
     override func viewDidMoveToSuperview() {
         super.viewDidMoveToSuperview()
         onBrowserViewportHierarchyChanged?()
+    }
+
+    @discardableResult
+    func handleMagnificationDelta(_ delta: CGFloat) -> Bool {
+        guard let onMagnificationDelta else { return false }
+        onMagnificationDelta(delta)
+        return true
+    }
+
+    override func magnify(with event: NSEvent) {
+        guard handleMagnificationDelta(event.magnification) else {
+            super.magnify(with: event)
+            return
+        }
     }
 
     private final class ContextMenuFallbackBox: NSObject {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -36,17 +36,33 @@ struct BrowserWebViewUserAgentRegressionTests {
     }
 }
 
+private final class TestMagnificationEvent: NSEvent {
+    private let delta: CGFloat
+
+    init(delta: CGFloat) {
+        self.delta = delta
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var magnification: CGFloat { delta }
+}
+
 @MainActor
 final class BrowserPanelTrackpadMagnificationTests: XCTestCase {
-    func testMagnificationDeltaRoutesOnlyToInstalledHandler() {
+    func testMagnifyResponderRoutesOnlyToInstalledHandler() {
         let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let event = TestMagnificationEvent(delta: 0.2)
         var receivedDelta: CGFloat?
 
-        XCTAssertFalse(webView.handleMagnificationDelta(0.2))
+        XCTAssertFalse(webView.handleMagnificationDelta(event.magnification))
 
         webView.onMagnificationDelta = { receivedDelta = $0 }
+        webView.magnify(with: event)
 
-        XCTAssertTrue(webView.handleMagnificationDelta(0.2))
         XCTAssertEqual(receivedDelta, 0.2)
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -36,6 +36,76 @@ struct BrowserWebViewUserAgentRegressionTests {
     }
 }
 
+@MainActor
+final class BrowserPanelTrackpadMagnificationTests: XCTestCase {
+    func testMagnificationDeltaRoutesOnlyToInstalledHandler() {
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        var receivedDelta: CGFloat?
+
+        XCTAssertFalse(webView.handleMagnificationDelta(0.2))
+
+        webView.onMagnificationDelta = { receivedDelta = $0 }
+
+        XCTAssertTrue(webView.handleMagnificationDelta(0.2))
+        XCTAssertEqual(receivedDelta, 0.2)
+    }
+
+    func testMagnificationDeltasAdjustCurrentPageZoomAdditively() throws {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let webView = try XCTUnwrap(panel.webView as? CmuxWebView)
+        _ = panel.setPageZoomFactor(1.0)
+
+        XCTAssertTrue(webView.handleMagnificationDelta(0.3))
+        XCTAssertEqual(panel.currentPageZoomFactor(), 1.3, accuracy: 0.000_001)
+
+        XCTAssertTrue(webView.handleMagnificationDelta(-0.15))
+        XCTAssertEqual(panel.currentPageZoomFactor(), 1.15, accuracy: 0.000_001)
+    }
+
+    func testMagnificationRejectsInvalidDeltasAndUsesExistingZoomLimits() throws {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let webView = try XCTUnwrap(panel.webView as? CmuxWebView)
+        XCTAssertTrue(panel.setPageZoomFactor(1.25))
+
+        for delta in [CGFloat.nan, .infinity, -.infinity] {
+            XCTAssertTrue(webView.handleMagnificationDelta(delta))
+            XCTAssertEqual(panel.currentPageZoomFactor(), 1.25, accuracy: 0.000_001)
+        }
+
+        XCTAssertTrue(panel.setPageZoomFactor(4.9))
+        XCTAssertTrue(webView.handleMagnificationDelta(1.0))
+        XCTAssertEqual(panel.currentPageZoomFactor(), 5.0, accuracy: 0.000_001)
+    }
+
+    func testMagnificationRetainsAutomationViewportRenderLimit() throws {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let webView = try XCTUnwrap(panel.webView as? CmuxWebView)
+        let viewport = try XCTUnwrap(BrowserViewport(width: 4_096, height: 4_096))
+        panel.viewportModel.setViewport(viewport)
+        XCTAssertTrue(panel.setPageZoomFactor(1.4))
+
+        XCTAssertTrue(webView.handleMagnificationDelta(0.1))
+        XCTAssertEqual(panel.currentPageZoomFactor(), 1.4, accuracy: 0.000_001)
+    }
+
+    func testStaleWebViewMagnificationIsIgnoredAfterProfileReplacement() throws {
+        let alternateProfile = try makeTemporaryBrowserPanelProfile(named: "Magnification")
+        defer { _ = BrowserProfileStore.shared.deleteProfile(id: alternateProfile.id) }
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            profileID: BrowserProfileStore.shared.builtInDefaultProfileID
+        )
+        let staleWebView = try XCTUnwrap(panel.webView as? CmuxWebView)
+
+        XCTAssertTrue(panel.switchToProfile(alternateProfile.id))
+        XCTAssertFalse(panel.webView === staleWebView)
+        XCTAssertTrue(panel.setPageZoomFactor(1.25))
+
+        XCTAssertTrue(staleWebView.handleMagnificationDelta(0.5))
+        XCTAssertEqual(panel.currentPageZoomFactor(), 1.25, accuracy: 0.000_001)
+    }
+}
+
 private func drainBrowserPanelMainQueue() {
     let expectation = XCTestExpectation(description: "drain main queue")
     DispatchQueue.main.async {

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -35,6 +35,12 @@ The tests were committed before the implementation and cover:
 4. Preservation of the 4096 × 4096 automation viewport render limit.
 5. Ignoring a stale callback after browser-profile replacement.
 
+## CI evidence
+
+The focused `BrowserPanelTrackpadMagnificationTests` suite passed all five cases on macOS 15 in [compatibility run 30202672962](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202672962). The complete compatibility job continued through the much larger application suite and reached its 60-minute job limit later in unrelated `GhosttySurfaceOverlayTests`; the macOS 14 matrix job started no steps.
+
+The repository's standard [CI run 30202484638](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202484638) stopped in its workflow guard before macOS tests because the compared upstream history changed iOS SwiftPM dependencies without matching `Package.resolved` changes. That pre-existing policy failure is outside this browser-only diff.
+
 ## Tagged application smoke
 
 A tagged macOS application was built from implementation commit `b32f332070` by [workflow run 30202484640](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202484640).

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -27,9 +27,9 @@ Navigation swipes, scrolling, editable focus, popups, and ordinary browser point
 
 ## TDD coverage
 
-The tests were committed before the implementation and cover:
+The zoom-behavior tests were committed failing before the implementation. After implementation, a responder-boundary regression was added to exercise `CmuxWebView.magnify(with:)` directly with a controlled synthetic `NSEvent`. The final focused suite covers:
 
-1. Direct invocation of `CmuxWebView.magnify(with:)` using a controlled synthetic `NSEvent`, including routing only when a handler is installed.
+1. Event-delta routing only when a browser handler is installed.
 2. Positive and negative deltas applied to the current zoom.
 3. Rejection of `NaN` and infinity plus reuse of existing bounds.
 4. Preservation of the 4096 × 4096 automation viewport render limit.
@@ -37,21 +37,21 @@ The tests were committed before the implementation and cover:
 
 ## CI evidence
 
-The focused `BrowserPanelTrackpadMagnificationTests` suite passed all five cases on macOS 15 in [compatibility run 30202672962](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202672962). The full run was not green: other suites later reported failures, and the macOS 15 job was cancelled at its 60-minute limit while `GlobalSearchShortcutSettingsTests` was running. The macOS 14 matrix job reported failure without recording any steps or logs.
+At exact head `dcf0d6bf18`, the focused `BrowserPanelTrackpadMagnificationTests` suite passed all cases on GitHub-hosted macOS 15 in run `30228023992`. The selected-test step was green. The workflow's overall conclusion was failure only because the subsequent result-publishing step could not create its external record from a fork context.
 
-The repository's standard [CI run 30202484638](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202484638) stopped in its workflow guard before macOS tests because the compared upstream history changed iOS SwiftPM dependencies without matching `Package.resolved` changes. That pre-existing policy failure is outside this browser-only diff.
+This was a focused contract run, not a claim that the repository-wide suite passed.
 
 ## Tagged application smoke
 
-A tagged macOS application was built from implementation commit `b32f332070` by [workflow run 30202484640](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202484640).
+Run `30228024007` built exact head `dcf0d6bf18` as the tagged macOS application `cmux DEV pinch-zoom-final-dcf0d6b`.
 
-The application was launched on an Apple Silicon laptop running macOS 15.7.5 against a deterministic local HTML fixture. The smoke used the same `WKWebView.pageZoom` mutation pipeline exposed to the gesture bridge:
+The exact artifact was launched on an Apple Silicon laptop running macOS 15.7.5 against a deterministic local HTML fixture. The smoke used the same `WKWebView.pageZoom` mutation pipeline exposed to the gesture bridge:
 
 | Observation | Reset | Three zoom-in steps | Reset after zoom |
 |---|---:|---:|---:|
 | CSS viewport width | 760 px | 584 px | 760 px |
 | CSS viewport height | 610 px | 469 px | 610 px |
-| Browser-owned PNG size | 17,688 bytes | 19,367 bytes | — |
+| Browser-owned PNG size | 50,781 bytes | 53,987 bytes | — |
 
 All smoke assertions passed:
 

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -37,7 +37,7 @@ The tests were committed before the implementation and cover:
 
 ## CI evidence
 
-The focused `BrowserPanelTrackpadMagnificationTests` suite passed all five cases on macOS 15 in [compatibility run 30202672962](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202672962). The complete compatibility job continued through the much larger application suite and reached its 60-minute job limit later in unrelated `GhosttySurfaceOverlayTests`; the macOS 14 matrix job started no steps.
+The focused `BrowserPanelTrackpadMagnificationTests` suite passed all five cases on macOS 15 in [compatibility run 30202672962](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202672962). The full run was not green: other suites later reported failures, and the macOS 15 job was cancelled at its 60-minute limit while `GlobalSearchShortcutSettingsTests` was running. The macOS 14 matrix job reported failure without recording any steps or logs.
 
 The repository's standard [CI run 30202484638](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202484638) stopped in its workflow guard before macOS tests because the compared upstream history changed iOS SwiftPM dependencies without matching `Package.resolved` changes. That pre-existing policy failure is outside this browser-only diff.
 

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -1,0 +1,79 @@
+# Browser Trackpad Pinch Zoom
+
+## Summary
+
+Browser panes now handle the native AppKit magnification gesture and apply each finite gesture delta to the active `WKWebView.pageZoom`. The gesture uses the same `0.25...5.0` bounds and automation viewport limit as menu- and API-driven page zoom.
+
+The implementation is intentionally narrow:
+
+- `CmuxWebView.magnify(with:)` forwards `NSEvent.magnification` when a browser-panel handler is installed.
+- `BrowserPanel` adds the delta to the current page zoom instead of replacing it, preserving continuous trackpad behavior.
+- Missing handlers fall back to `super.magnify(with:)`.
+- A weak, identity-checked callback prevents a replaced or stale web view from mutating the current browser.
+- Existing zoom validation remains authoritative for non-finite input, zoom bounds, and the 4096 × 4096 automation viewport ceiling.
+
+## Behavior contract
+
+| Input | Result |
+|---|---|
+| Positive magnification delta | Increase the active page zoom additively |
+| Negative magnification delta | Decrease the active page zoom additively |
+| Non-finite delta | Ignore without changing page zoom |
+| Delta beyond supported range | Clamp through the existing `0.25...5.0` zoom path |
+| Magnification after profile/web-view replacement | Ignore the stale view callback |
+| Magnification with no browser handler | Preserve the `WKWebView`/`NSResponder` fallback |
+
+Navigation swipes, scrolling, editable focus, popups, and ordinary browser pointer handling are unchanged because the implementation overrides only AppKit's dedicated magnification responder callback.
+
+## TDD coverage
+
+The tests were committed before the implementation and cover:
+
+1. Callback routing only when a handler is installed.
+2. Positive and negative deltas applied to the current zoom.
+3. Rejection of `NaN` and infinity plus reuse of existing bounds.
+4. Preservation of the 4096 × 4096 automation viewport render limit.
+5. Ignoring a stale callback after browser-profile replacement.
+
+## Tagged application smoke
+
+A tagged macOS application was built from implementation commit `b32f332070` by [workflow run 30202484640](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202484640).
+
+The application was launched on an Apple Silicon laptop running macOS 15.7.5 against a deterministic local HTML fixture. The smoke used the same `WKWebView.pageZoom` mutation pipeline exposed to the gesture bridge:
+
+| Observation | Reset | Three zoom-in steps | Reset after zoom |
+|---|---:|---:|---:|
+| CSS viewport width | 760 px | 584 px | 760 px |
+| CSS viewport height | 610 px | 469 px | 610 px |
+| Browser-owned PNG size | 17,688 bytes | 19,367 bytes | — |
+
+All smoke assertions passed:
+
+- Zooming in reduced the CSS viewport width.
+- Reset restored the original viewport width.
+- The browser-owned PNG changed after zoom.
+
+The before/after PNG SHA-256 values differed; the report omits them because the observable result is the changed rendered image rather than a machine-specific fingerprint.
+
+## Validation boundary
+
+The public Core Graphics event API does not expose a supported way to synthesize a physical trackpad magnification event. The automated evidence therefore divides cleanly:
+
+- Unit coverage proves `magnify(with:)` delegates the event's magnification delta into the panel callback and tests the callback's behavior and safety boundaries.
+- The tagged-app smoke proves the resulting page-zoom mutation changes and restores real WebKit rendering.
+- A literal physical two-finger gesture was not programmatically injected, so the report does not claim HID-level gesture proof.
+
+## Related issues
+
+| Item | Current state | Relevance |
+|---|---|---|
+| [#346](https://github.com/manaflow-ai/cmux/issues/346) | Open | Direct request for browser pinch-to-zoom support. This change implements that browser behavior. |
+| [#1934](https://github.com/manaflow-ai/cmux/issues/1934) | Open | Requests a configurable default zoom. This change does not add a persisted default. |
+
+## API rationale
+
+- [`NSEvent.magnification`](https://developer.apple.com/documentation/appkit/nsevent/magnification) is the amount to add to the current magnification.
+- [`NSResponder.magnify(with:)`](https://developer.apple.com/documentation/appkit/nsresponder/magnify(with:)) receives magnification gestures for the view under the touches.
+- [`WKWebView.pageZoom`](https://developer.apple.com/documentation/webkit/wkwebview/pagezoom) is the existing page-zoom property used by browser controls and automation.
+
+Using the native responder callback avoids scroll-wheel heuristics and keeps one zoom implementation for trackpad, menu, and automation paths.

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -65,7 +65,7 @@ The before/after PNG SHA-256 values differed; the report omits them because the 
 
 The public Core Graphics event API does not expose a supported way to synthesize a physical trackpad magnification event. The automated evidence therefore divides cleanly:
 
-- Unit coverage proves `magnify(with:)` delegates the event's magnification delta into the panel callback and tests the callback's behavior and safety boundaries.
+- Unit coverage proves the optional magnification callback routes deltas into the panel and tests the resulting zoom behavior and safety boundaries; it does not synthesize `NSEvent` or directly exercise `magnify(with:)`.
 - The tagged-app smoke proves the resulting page-zoom mutation changes and restores real WebKit rendering.
 - A literal physical two-finger gesture was not programmatically injected, so the report does not claim HID-level gesture proof.
 

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -37,15 +37,15 @@ The zoom-behavior tests were committed failing before the implementation. After 
 
 ## CI evidence
 
-At validation checkpoint `af4e20fd8b`, the focused `BrowserPanelTrackpadMagnificationTests` suite passed all cases on GitHub-hosted macOS 15 in run `30398095443`. The selected-test step was green. The workflow's overall conclusion was failure only because the subsequent result-publishing step could not create its external record from a fork context.
+At validation checkpoint `2f59a17e5dba3341a2fb5360127ddb90c742be14`, the focused `BrowserPanelTrackpadMagnificationTests` suite passed all 5 cases with 0 failures on GitHub-hosted macOS 15 in run `30408134600`. The selected-test step was green. The workflow's overall conclusion was failure only because the subsequent result-publishing step could not create its external record from a fork context.
 
 This was a focused contract run, not a claim that the repository-wide suite passed.
 
 ## Tagged application smoke
 
-Run `30398107908` built the same validation checkpoint as the tagged macOS application `cmux DEV pinch-zoom-final-af4e20f`.
+Run `30403009110` built exact validation checkpoint `2f59a17e5dba3341a2fb5360127ddb90c742be14` as `cmux DEV pinch-zoom-final-2f59a17` on macOS 15; its build metadata records that full source ref.
 
-The exact artifact was launched on an Apple Silicon laptop running macOS 15.7.5 against a deterministic local HTML fixture. The smoke used the same `WKWebView.pageZoom` mutation pipeline exposed to the gesture bridge:
+The installed artifact was launched on an Apple Silicon laptop running macOS 15.7.5 against a deterministic fixture served over loopback HTTP. The smoke used the same `WKWebView.pageZoom` mutation pipeline exposed to the gesture bridge:
 
 | Observation | Reset | Three zoom-in steps | Reset after zoom |
 |---|---:|---:|---:|

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -29,7 +29,7 @@ Navigation swipes, scrolling, editable focus, popups, and ordinary browser point
 
 The tests were committed before the implementation and cover:
 
-1. Callback routing only when a handler is installed.
+1. Direct invocation of `CmuxWebView.magnify(with:)` using a controlled synthetic `NSEvent`, including routing only when a handler is installed.
 2. Positive and negative deltas applied to the current zoom.
 3. Rejection of `NaN` and infinity plus reuse of existing bounds.
 4. Preservation of the 4096 × 4096 automation viewport render limit.
@@ -65,9 +65,9 @@ The before/after PNG SHA-256 values differed; the report omits them because the 
 
 The public Core Graphics event API does not expose a supported way to synthesize a physical trackpad magnification event. The automated evidence therefore divides cleanly:
 
-- Unit coverage proves the optional magnification callback routes deltas into the panel and tests the resulting zoom behavior and safety boundaries; it does not synthesize `NSEvent` or directly exercise `magnify(with:)`.
-- The tagged-app smoke proves the resulting page-zoom mutation changes and restores real WebKit rendering.
-- A literal physical two-finger gesture was not programmatically injected, so the report does not claim HID-level gesture proof.
+- Unit coverage directly invokes `CmuxWebView.magnify(with:)` with an `NSEvent` test subclass whose magnification delta is controlled, proving that the responder override forwards the event delta into the installed callback.
+- The remaining focused cases test the resulting panel zoom behavior and safety boundaries, and the tagged-app smoke proves that the page-zoom mutation changes and restores real WebKit rendering.
+- A literal physical two-finger gesture was not programmatically injected, so the report does not claim HID-level event-delivery proof.
 
 ## Related issues
 

--- a/docs/browser-trackpad-pinch-zoom.md
+++ b/docs/browser-trackpad-pinch-zoom.md
@@ -37,13 +37,13 @@ The zoom-behavior tests were committed failing before the implementation. After 
 
 ## CI evidence
 
-At exact head `dcf0d6bf18`, the focused `BrowserPanelTrackpadMagnificationTests` suite passed all cases on GitHub-hosted macOS 15 in run `30228023992`. The selected-test step was green. The workflow's overall conclusion was failure only because the subsequent result-publishing step could not create its external record from a fork context.
+At validation checkpoint `af4e20fd8b`, the focused `BrowserPanelTrackpadMagnificationTests` suite passed all cases on GitHub-hosted macOS 15 in run `30398095443`. The selected-test step was green. The workflow's overall conclusion was failure only because the subsequent result-publishing step could not create its external record from a fork context.
 
 This was a focused contract run, not a claim that the repository-wide suite passed.
 
 ## Tagged application smoke
 
-Run `30228024007` built exact head `dcf0d6bf18` as the tagged macOS application `cmux DEV pinch-zoom-final-dcf0d6b`.
+Run `30398107908` built the same validation checkpoint as the tagged macOS application `cmux DEV pinch-zoom-final-af4e20f`.
 
 The exact artifact was launched on an Apple Silicon laptop running macOS 15.7.5 against a deterministic local HTML fixture. The smoke used the same `WKWebView.pageZoom` mutation pipeline exposed to the gesture bridge:
 


### PR DESCRIPTION
## Purpose

Route native AppKit `magnify(with:)` events from browser web views into the existing bounded `WKWebView.pageZoom` path. This fixes #346 without adding persisted default-zoom behavior from #1934.

## Tests

- TDD red: [run 30202672968](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30202672968) compiled the test-only commit and failed because `CmuxWebView` had no magnification handler.
- Current-head behavior proof: [run 30228023992](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30228023992) checked out `dcf0d6bf1876a81080b1907248aea771ea832c8b` and executed all five `BrowserPanelTrackpadMagnificationTests` with 0 failures. The five cases cover direct responder invocation with a controlled synthetic `NSEvent`, positive/negative deltas, non-finite input and bounds, the automation viewport ceiling, and stale callbacks after profile replacement. The workflow's overall failure occurred only afterward in the fork-only results-reporting step because its `GH_TOKEN` was empty; the product build and selected tests succeeded.
- Current-head tagged build: [run 30228024007](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30228024007) checked out the same immutable SHA and completed successfully.
- An additional current-base compatibility attempt reached an unrelated upstream `CmuxSimulator` compile error before selected tests in [run 30227602488](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30227602488); the focused proof above uses the fork's GitHub-hosted macOS lane.

## Metrics

In one installed tagged-app smoke against a deterministic HTML fixture, the reset baseline was a 760 × 610 CSS viewport and a 17,688-byte browser-owned PNG. After three zoom-in steps, treatment was 584 × 469 and 19,367 bytes: a delta of −176 × −141 CSS pixels and +1,679 PNG bytes. Reset returned exactly to 760 × 610 (zero residual viewport delta), and the PNG content changed. These are observable behavior/rendering measurements, not a speed or performance claim.

## Safety

Only AppKit's magnification responder is added. Finite deltas reuse existing `0.25...5.0` clamping and the 4096 × 4096 automation ceiling; stale web-view callbacks are identity-checked, and an uninstalled handler falls back to `super.magnify(with:)`. Scrolling, navigation swipes, pointer handling, editable focus, and popups are unchanged. The synthetic responder test does not claim physical HID event delivery.