### PR TITLE
Preserve UTF-8 across control socket reads

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientLineReader.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/ControlClientLineReader.swift
@@ -10,10 +10,11 @@ internal import Foundation
 /// the type is intentionally not thread-safe. The reader never closes the
 /// descriptor — connection ownership stays with the handler.
 ///
-/// Framing contract (all legacy behavior, pinned by tests):
+/// Framing contract (pinned by tests):
 /// - Reads up to `bufferSize - 1` bytes per `read(2)` call.
-/// - A chunk that is not valid UTF-8 is dropped wholesale (the legacy
-///   `String(bytes:encoding:) ?? ""` coalesce).
+/// - Raw bytes are assembled across reads before decoding, so UTF-8 scalars may
+///   span arbitrary transport chunk boundaries. A completed line that is not
+///   valid UTF-8 is dropped without discarding any following lines.
 /// - Lines are split on bare `\n` only. To preserve legacy framing, `\r\n`
 ///   does not terminate a line (clients must frame with bare `\n`). Returned
 ///   lines may be empty or whitespace-only.
@@ -26,7 +27,7 @@ internal import Foundation
 /// - EOF, a read error, or a `false` poll ends the stream (`nil`); buffered
 ///   bytes without a trailing newline are discarded, as before.
 /// - While `initialLimits` remain active, raw bytes are counted cumulatively
-///   before UTF-8 decoding, including invalid chunks and line delimiters, and
+///   before UTF-8 decoding, including invalid lines and line delimiters, and
 ///   the absolute deadline is checked before buffered lines are returned.
 public final class ControlClientLineReader {
     private let socket: Int32
@@ -120,14 +121,15 @@ public final class ControlClientLineReader {
             guard deadlineHasNotExpired else { return nil }
 
             if let newlineIndex = nextBareNewlineIndex() {
-                let line = String(
+                let decodedLine = String(
                     bytes: pendingBytes[pendingStartIndex..<newlineIndex],
                     encoding: .utf8
-                ) ?? ""
+                )
                 pendingStartIndex = newlineIndex + 1
                 newlineSearchIndex = pendingStartIndex
                 compactPendingBytesIfNeeded()
-                return line
+                guard let decodedLine else { continue }
+                return decodedLine
             }
 
             if !startedReadWait {
@@ -147,8 +149,7 @@ public final class ControlClientLineReader {
                 limitedBytesRead = totalBytesRead
             }
 
-            let chunk = String(bytes: buffer[0..<bytesRead], encoding: .utf8) ?? ""
-            pendingBytes.append(contentsOf: chunk.utf8)
+            pendingBytes.append(contentsOf: buffer[0..<bytesRead])
         }
     }
 

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
@@ -147,11 +147,12 @@ struct ControlClientLineReaderTests {
     @Test func dropsLineThatIsNotValidUTF8() throws {
         let pair = try SocketPairFixture()
         // Malformed input is discarded rather than surfaced as an empty
-        // command.
-        pair.write([0xFF, 0xFE, 0x0A])
+        // command, without discarding a valid line that follows it.
+        pair.write([0xFF, 0xFE, 0x0A] + Array("ok\n".utf8))
         pair.closeWriteEnd()
 
         let reader = ControlClientLineReader(socket: pair.readEnd)
+        #expect(reader.nextLine(shouldContinueReading: { true }) == "ok")
         #expect(reader.nextLine(shouldContinueReading: { true }) == nil)
     }
 

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
@@ -37,10 +37,39 @@ private final class SocketPairFixture {
         writeEnd = -1
     }
 
+    /// Blocks until the peer has consumed everything queued on `readEnd`, so
+    /// the next write is guaranteed to land in a separate `read(2)`.
+    func waitUntilReaderDrainedInput(timeout: TimeInterval = 5) -> Bool {
+        func queuedBytes() -> Int32 {
+            var value: Int32 = 0
+            var size = socklen_t(MemoryLayout<Int32>.size)
+            guard getsockopt(readEnd, SOL_SOCKET, SO_NREAD, &value, &size) == 0 else { return -1 }
+            return value
+        }
+
+        // `write(2)` has already returned, so the bytes are either still queued
+        // or already consumed. Waiting for them to appear would race with a
+        // reader that drained them first, so only the drain is waited on.
+        let deadline = Date.now.addingTimeInterval(timeout)
+        while true {
+            let queued = queuedBytes()
+            guard queued >= 0 else { return false }
+            if queued == 0 { return true }
+            guard Date.now < deadline else { return false }
+            usleep(1_000)
+        }
+    }
+
     deinit {
         close(readEnd)
         closeWriteEnd()
     }
+}
+
+// The worker is the only writer, and the test reads only after the semaphore
+// handoff has ordered the write before the read.
+private final class LineResultBox: @unchecked Sendable {
+    var value: String?
 }
 
 @Suite("ControlClientLineReader")
@@ -65,6 +94,29 @@ struct ControlClientLineReaderTests {
         let reader = ControlClientLineReader(socket: pair.readEnd)
         #expect(reader.nextLine(shouldContinueReading: { true }) == "partial")
         #expect(reader.nextLine(shouldContinueReading: { true }) == nil)
+    }
+
+    @Test func assemblesMultiByteScalarAcrossPartialReads() throws {
+        let pair = try SocketPairFixture()
+
+        let result = LineResultBox()
+        let finished = DispatchSemaphore(value: 0)
+        let readEnd = pair.readEnd
+        Thread.detachNewThread {
+            let reader = ControlClientLineReader(socket: readEnd)
+            result.value = reader.nextLine(shouldContinueReading: { true })
+            finished.signal()
+        }
+
+        pair.write([0xE3, 0x81]) // First two bytes of "あ" (U+3042).
+        #expect(pair.waitUntilReaderDrainedInput())
+        pair.write([0x82, 0x0A]) // Final byte and newline.
+        pair.closeWriteEnd()
+
+        let waitResult = finished.wait(timeout: .now() + 5)
+        #expect(waitResult == .success)
+        guard waitResult == .success else { return }
+        #expect(result.value == "あ")
     }
 
     @Test func crlfIsNotALineTerminator() throws {

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
@@ -144,10 +144,10 @@ struct ControlClientLineReaderTests {
         #expect(reader.nextLine(shouldContinueReading: { true }) == "ok")
     }
 
-    @Test func dropsChunkThatIsNotValidUTF8() throws {
+    @Test func dropsLineThatIsNotValidUTF8() throws {
         let pair = try SocketPairFixture()
-        // The legacy loop coalesced an undecodable chunk to "", losing the
-        // whole chunk including its newline.
+        // Malformed input is discarded rather than surfaced as an empty
+        // command.
         pair.write([0xFF, 0xFE, 0x0A])
         pair.closeWriteEnd()
 

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlClientLineReaderTests.swift
@@ -37,39 +37,10 @@ private final class SocketPairFixture {
         writeEnd = -1
     }
 
-    /// Blocks until the peer has consumed everything queued on `readEnd`, so
-    /// the next write is guaranteed to land in a separate `read(2)`.
-    func waitUntilReaderDrainedInput(timeout: TimeInterval = 5) -> Bool {
-        func queuedBytes() -> Int32 {
-            var value: Int32 = 0
-            var size = socklen_t(MemoryLayout<Int32>.size)
-            guard getsockopt(readEnd, SOL_SOCKET, SO_NREAD, &value, &size) == 0 else { return -1 }
-            return value
-        }
-
-        // `write(2)` has already returned, so the bytes are either still queued
-        // or already consumed. Waiting for them to appear would race with a
-        // reader that drained them first, so only the drain is waited on.
-        let deadline = Date.now.addingTimeInterval(timeout)
-        while true {
-            let queued = queuedBytes()
-            guard queued >= 0 else { return false }
-            if queued == 0 { return true }
-            guard Date.now < deadline else { return false }
-            usleep(1_000)
-        }
-    }
-
     deinit {
         close(readEnd)
         closeWriteEnd()
     }
-}
-
-// The worker is the only writer, and the test reads only after the semaphore
-// handoff has ordered the write before the read.
-private final class LineResultBox: @unchecked Sendable {
-    var value: String?
 }
 
 @Suite("ControlClientLineReader")
@@ -98,25 +69,13 @@ struct ControlClientLineReaderTests {
 
     @Test func assemblesMultiByteScalarAcrossPartialReads() throws {
         let pair = try SocketPairFixture()
-
-        let result = LineResultBox()
-        let finished = DispatchSemaphore(value: 0)
-        let readEnd = pair.readEnd
-        Thread.detachNewThread {
-            let reader = ControlClientLineReader(socket: readEnd)
-            result.value = reader.nextLine(shouldContinueReading: { true })
-            finished.signal()
-        }
-
-        pair.write([0xE3, 0x81]) // First two bytes of "あ" (U+3042).
-        #expect(pair.waitUntilReaderDrainedInput())
-        pair.write([0x82, 0x0A]) // Final byte and newline.
+        pair.write([0xE3, 0x81, 0x82, 0x0A]) // "あ" (U+3042) and newline.
         pair.closeWriteEnd()
 
-        let waitResult = finished.wait(timeout: .now() + 5)
-        #expect(waitResult == .success)
-        guard waitResult == .success else { return }
-        #expect(result.value == "あ")
+        // The reader accepts at most `bufferSize - 1` bytes per read, forcing
+        // the scalar to straddle two read(2) calls.
+        let reader = ControlClientLineReader(socket: pair.readEnd, bufferSize: 3)
+        #expect(reader.nextLine(shouldContinueReading: { true }) == "あ")
     }
 
     @Test func crlfIsNotALineTerminator() throws {
@@ -153,6 +112,15 @@ struct ControlClientLineReaderTests {
 
         let reader = ControlClientLineReader(socket: pair.readEnd)
         #expect(reader.nextLine(shouldContinueReading: { true }) == "ok")
+        #expect(reader.nextLine(shouldContinueReading: { true }) == nil)
+    }
+
+    @Test func dropsMalformedOnlyLineAtEOF() throws {
+        let pair = try SocketPairFixture()
+        pair.write([0xFF, 0xFE, 0x0A])
+        pair.closeWriteEnd()
+
+        let reader = ControlClientLineReader(socket: pair.readEnd)
         #expect(reader.nextLine(shouldContinueReading: { true }) == nil)
     }
 


### PR DESCRIPTION
## Summary

- buffer control-socket input as raw bytes across arbitrary `read(2)` boundaries
- decode only completed newline-delimited frames, dropping malformed frames independently
- add a deterministic socket-pair regression test that forces one UTF-8 scalar across two reads

## Verification

- regression-only commit `28475858b9`: focused test fails with `nil` instead of `あ`
- fix commit `d2786bbd3e`: focused test passes
- `/usr/bin/arch -arm64 swift test --package-path Packages/macOS/CmuxControlSocket` (315 tests pass)
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- both touched Swift files remain below 500 lines; the former length-budget script and TSV were removed from current `main` in #8125
- localization audit: no user-facing strings were added or changed

Closes #8924

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787691169&installation_model_id=21920&pr_number=8962&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8962&signature=461700607c8f6074ef4aa81ca169634ef85aea5bfb613eda82a564c819917335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves UTF‑8 across control socket reads in `CmuxControlSocket` by buffering raw bytes until newline framing, then decoding. Invalid lines are dropped without affecting later lines. Adds a deterministic split-read regression test and cases for recovery after malformed frames; fixes #8924.

- **Bug Fixes**
  - Assemble raw bytes across `read(2)` boundaries and decode only complete `\n`‑delimited frames.
  - Drop lines that fail UTF‑8 decoding; preserve subsequent lines and keep legacy framing, limits, and EOF behavior.

<sup>Written for commit 241a8a218e788f79c3aba964a0f9a4df765c5703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed line decoding to correctly assemble UTF-8 text that arrives split across multiple reads (including multibyte characters).
  * Invalid UTF-8 is now dropped per malformed line, without preventing later valid lines from being returned.
  * Updated line framing behavior to follow the documented line-based contract, especially around EOF.

* **Tests**
  * Added coverage for assembling multibyte UTF-8 scalars across partial reads.
  * Updated malformed UTF-8 tests to confirm continued processing after bad lines and correct EOF handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->