### PR TITLE
Fit main windows after AppKit frame restoration

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1,0 +1,80 @@
+import AppKit
+import CmuxWindowing
+
+@MainActor
+final class MainWindowController: ReleasingWindowController {
+    var onClose: (() -> Void)?
+    var shouldClose: (() -> Bool)?
+    var onFrameRestorationCheckpoint: ((NSWindow) -> Void)?
+
+#if DEBUG
+    private func logWindowEvent(_ event: String, notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        let id = window.identifier?.rawValue ?? "<nil>"
+        cmuxDebugLog(
+            "mainWindow.delegate.\(event) window=\(id) visible=\(window.isVisible ? 1 : 0) mini=\(window.isMiniaturized ? 1 : 0) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0)"
+        )
+    }
+#endif
+
+    override func managedWindowWillClose(_ window: NSWindow) {
+        onClose?()
+    }
+
+    func windowDidExitFullScreen(_ notification: Notification) {
+        handleFrameRestorationCheckpoint("didExitFullScreen", notification: notification)
+    }
+
+    func windowDidDeminiaturize(_ notification: Notification) {
+        handleFrameRestorationCheckpoint("didDeminiaturize", notification: notification)
+    }
+
+#if DEBUG
+    func windowDidMiniaturize(_ notification: Notification) {
+        logWindowEvent("didMiniaturize", notification: notification)
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        logWindowEvent("didBecomeKey", notification: notification)
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        logWindowEvent("didResignKey", notification: notification)
+    }
+
+    func windowDidBecomeMain(_ notification: Notification) {
+        logWindowEvent("didBecomeMain", notification: notification)
+    }
+
+    func windowDidResignMain(_ notification: Notification) {
+        logWindowEvent("didResignMain", notification: notification)
+    }
+#endif
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        let shouldClose = shouldClose?() ?? true
+        if shouldClose {
+            WebViewInspectorTeardown.closeAllInspectors(in: sender)
+        }
+        return shouldClose
+    }
+
+    func windowWillUseStandardFrame(_ window: NSWindow, defaultFrame newFrame: NSRect) -> NSRect {
+        guard window is CmuxMainWindow else { return newFrame }
+        return CmuxMainWindow.standardFrame(forDefaultFrame: newFrame)
+    }
+
+    private func handleFrameRestorationCheckpoint(
+        _ event: String,
+        notification: Notification
+    ) {
+        guard let restoredWindow = notification.object as? NSWindow,
+              restoredWindow === window else {
+            return
+        }
+#if DEBUG
+        logWindowEvent(event, notification: notification)
+#endif
+        onFrameRestorationCheckpoint?(restoredWindow)
+    }
+}

--- a/Sources/AppDelegate+MonitorMemory.swift
+++ b/Sources/AppDelegate+MonitorMemory.swift
@@ -196,9 +196,9 @@ extension AppDelegate {
             window.setFrame(corrected, display: true)
         }
         if visibleFrameFitTopologyChanged {
-            MainWindowVisibleFrameFitRescue().performFitIfNeeded(
-                displays: displays.available,
-                windows: mainWindows
+            fitRestoredMainWindowFramesIfNeeded(
+                windows: mainWindows,
+                displays: displays.available
             )
         }
     }

--- a/Sources/AppDelegate+WindowFrameRestoration.swift
+++ b/Sources/AppDelegate+WindowFrameRestoration.swift
@@ -1,0 +1,22 @@
+import AppKit
+
+extension AppDelegate {
+    /// Reasserts the main-window visible-frame invariant after AppKit restores
+    /// window geometry outside cmux's launch and display-topology restore paths.
+    func fitRestoredMainWindowFramesIfNeeded(
+        windows: [NSWindow]? = nil,
+        displays: [SessionDisplayGeometry]? = nil
+    ) {
+        guard !isTerminatingApp else { return }
+        let candidateWindows = windows ?? mainWindowsForVisibilityController()
+        let availableDisplays = displays ?? currentDisplayGeometries().available
+        MainWindowVisibleFrameFitRescue().performFitIfNeeded(
+            displays: availableDisplays,
+            windows: candidateWindows
+        )
+    }
+
+    func applicationDidUnhide(_ notification: Notification) {
+        fitRestoredMainWindowFramesIfNeeded()
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -579,64 +579,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private final class MainWindowController: ReleasingWindowController {
-        var onClose: (() -> Void)?
-        var shouldClose: (() -> Bool)?
-
-        #if DEBUG
-        private func logWindowEvent(_ event: String, notification: Notification) {
-            guard let window = notification.object as? NSWindow else { return }
-            let id = window.identifier?.rawValue ?? "<nil>"
-            cmuxDebugLog(
-                "mainWindow.delegate.\(event) window=\(id) visible=\(window.isVisible ? 1 : 0) mini=\(window.isMiniaturized ? 1 : 0) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0)"
-            )
-        }
-        #endif
-
-        override func managedWindowWillClose(_ window: NSWindow) {
-            onClose?()
-        }
-
-        #if DEBUG
-        func windowDidDeminiaturize(_ notification: Notification) {
-            logWindowEvent("didDeminiaturize", notification: notification)
-        }
-
-        func windowDidMiniaturize(_ notification: Notification) {
-            logWindowEvent("didMiniaturize", notification: notification)
-        }
-
-        func windowDidBecomeKey(_ notification: Notification) {
-            logWindowEvent("didBecomeKey", notification: notification)
-        }
-
-        func windowDidResignKey(_ notification: Notification) {
-            logWindowEvent("didResignKey", notification: notification)
-        }
-
-        func windowDidBecomeMain(_ notification: Notification) {
-            logWindowEvent("didBecomeMain", notification: notification)
-        }
-
-        func windowDidResignMain(_ notification: Notification) {
-            logWindowEvent("didResignMain", notification: notification)
-        }
-        #endif
-
-        func windowShouldClose(_ sender: NSWindow) -> Bool {
-            let shouldClose = shouldClose?() ?? true
-            if shouldClose {
-                WebViewInspectorTeardown.closeAllInspectors(in: sender)
-            }
-            return shouldClose
-        }
-
-        func windowWillUseStandardFrame(_ window: NSWindow, defaultFrame newFrame: NSRect) -> NSRect {
-            guard window is CmuxMainWindow else { return newFrame }
-            return CmuxMainWindow.standardFrame(forDefaultFrame: newFrame)
-        }
-    }
-
     struct ScriptableMainWindowState {
         let windowId: UUID
         let tabManager: TabManager
@@ -8933,6 +8875,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Keep a strong reference so the window isn't deallocated.
         let controller = MainWindowController(window: window)
+        controller.onFrameRestorationCheckpoint = { [weak self] restoredWindow in
+            self?.fitRestoredMainWindowFramesIfNeeded(windows: [restoredWindow])
+        }
         controller.onClose = { [weak self, weak controller] in
             guard let self, let controller else { return }
             let manager = self.tabManagerFor(windowId: windowId)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A79840020000000000000002 /* AppDelegate+SocketConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79840020000000000000001 /* AppDelegate+SocketConfiguration.swift */; };
 		DCDC1000000000000000C030 /* AppDelegate+WindowDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C031 /* AppDelegate+WindowDock.swift */; };
 		4805E1513D104D02B52A9807 /* AppDelegate+WindowFramePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4085E612770476FA272C012 /* AppDelegate+WindowFramePolicy.swift */; };
+		895500000000000000000005 /* AppDelegate+WindowFrameRestoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895500000000000000000006 /* AppDelegate+WindowFrameRestoration.swift */; };
 		604500100000000000000005 /* AppDelegate+WindowIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604500100000000000000006 /* AppDelegate+WindowIdentity.swift */; };
 		A5FB1207 /* AppDelegate+WorkspaceActionSave.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB1208 /* AppDelegate+WorkspaceActionSave.swift */; };
 		357DF9BBBB0D71C5EE23D997 /* AppDelegate+WorkspaceTodoShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E213BAD49ECD0698B3471B /* AppDelegate+WorkspaceTodoShortcut.swift */; };
@@ -1075,6 +1076,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		87590000000000000000000B /* MainThreadHangSampleRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87590000000000000000000C /* MainThreadHangSampleRunner.swift */; };
 		875900000000000000000003 /* MainThreadHangWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875900000000000000000004 /* MainThreadHangWatchdog.swift */; };
 		875900000000000000000007 /* MainThreadHangWatchdogState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875900000000000000000008 /* MainThreadHangWatchdogState.swift */; };
+		895500000000000000000003 /* MainWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895500000000000000000004 /* MainWindowController.swift */; };
 		2F0C05000000000000000002 /* MainWindowFocusController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C05000000000000000001 /* MainWindowFocusController.swift */; };
 		6512F0C06512F0C06512F002 /* MainWindowFocusRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6512F0C06512F0C06512F001 /* MainWindowFocusRestoreTests.swift */; };
 		B37A00000000000000000005 /* MainWindowFocusTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A00000000000000000006 /* MainWindowFocusTypes.swift */; };
@@ -2547,6 +2549,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A79840020000000000000001 /* AppDelegate+SocketConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+SocketConfiguration.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000C031 /* AppDelegate+WindowDock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WindowDock.swift"; sourceTree = "<group>"; };
 		B4085E612770476FA272C012 /* AppDelegate+WindowFramePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WindowFramePolicy.swift"; sourceTree = "<group>"; };
+		895500000000000000000006 /* AppDelegate+WindowFrameRestoration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WindowFrameRestoration.swift"; sourceTree = "<group>"; };
 		604500100000000000000006 /* AppDelegate+WindowIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WindowIdentity.swift"; sourceTree = "<group>"; };
 		A5FB1208 /* AppDelegate+WorkspaceActionSave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WorkspaceActionSave.swift"; sourceTree = "<group>"; };
 		D7E213BAD49ECD0698B3471B /* AppDelegate+WorkspaceTodoShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WorkspaceTodoShortcut.swift"; sourceTree = "<group>"; };
@@ -3379,6 +3382,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		87590000000000000000000C /* MainThreadHangSampleRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadHangSampleRunner.swift; sourceTree = "<group>"; };
 		875900000000000000000004 /* MainThreadHangWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadHangWatchdog.swift; sourceTree = "<group>"; };
 		875900000000000000000008 /* MainThreadHangWatchdogState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadHangWatchdogState.swift; sourceTree = "<group>"; };
+		895500000000000000000004 /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/MainWindowController.swift; sourceTree = "<group>"; };
 		2F0C05000000000000000001 /* MainWindowFocusController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusController.swift; sourceTree = "<group>"; };
 		6512F0C06512F0C06512F001 /* MainWindowFocusRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusRestoreTests.swift; sourceTree = "<group>"; };
 		B37A00000000000000000006 /* MainWindowFocusTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusTypes.swift; sourceTree = "<group>"; };
@@ -5244,6 +5248,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A6D1F0300000000000000001 /* MainWindowVisibilityController+Lifecycle.swift */,
 				2F0C06000000000000000001 /* MainWindowVisibilityController.swift */,
 				730600020000000000000001 /* MainWindowVisibleFrameFitRescue.swift */,
+				895500000000000000000004 /* MainWindowController.swift */,
 				A6D1F0000000000000000001 /* ReleasingWindowController.swift */,
 				A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */,
 				D35B71010000000000000002 /* StartupBreadcrumbLog.swift */,
@@ -5716,6 +5721,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C65930010000000000000004 /* AppDelegate+CrashSessionSnapshotRemoval.swift */,
 				E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */,
 				A74770010000000000000002 /* AppDelegate+MonitorMemory.swift */,
+				895500000000000000000006 /* AppDelegate+WindowFrameRestoration.swift */,
 				D7AB00000000000000000002 /* AppDelegate+MoveTabToNewWorkspace.swift */,
 				2907A0022907A0022907A002 /* AppDelegate+RecoverableMainWindowRoutes.swift */,
 				797800010000000000000002 /* AppDelegate+RemoteSessionPower.swift */,
@@ -7641,6 +7647,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A79840020000000000000002 /* AppDelegate+SocketConfiguration.swift in Sources */,
 				DCDC1000000000000000C030 /* AppDelegate+WindowDock.swift in Sources */,
 				4805E1513D104D02B52A9807 /* AppDelegate+WindowFramePolicy.swift in Sources */,
+				895500000000000000000005 /* AppDelegate+WindowFrameRestoration.swift in Sources */,
 				604500100000000000000005 /* AppDelegate+WindowIdentity.swift in Sources */,
 				A5FB1207 /* AppDelegate+WorkspaceActionSave.swift in Sources */,
 				357DF9BBBB0D71C5EE23D997 /* AppDelegate+WorkspaceTodoShortcut.swift in Sources */,
@@ -8098,6 +8105,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				87590000000000000000000B /* MainThreadHangSampleRunner.swift in Sources */,
 				875900000000000000000003 /* MainThreadHangWatchdog.swift in Sources */,
 				875900000000000000000007 /* MainThreadHangWatchdogState.swift in Sources */,
+				895500000000000000000003 /* MainWindowController.swift in Sources */,
 				2F0C05000000000000000002 /* MainWindowFocusController.swift in Sources */,
 				B37A00000000000000000005 /* MainWindowFocusTypes.swift in Sources */,
 				A6D1F0300000000000000002 /* MainWindowVisibilityController+Lifecycle.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A1B2C3D4E5F600000000CF01 /* AppDelegateDisplayConfigRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600000000CF02 /* AppDelegateDisplayConfigRestoreTests.swift */; };
 		E3309A09 /* AppDelegateEqualizeSplitsShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A0A /* AppDelegateEqualizeSplitsShortcutTests.swift */; };
 		F5996001A1B2C3D4E5F60001 /* AppDelegateFileExplorerShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5996001A1B2C3D4E5F60002 /* AppDelegateFileExplorerShortcutRoutingTests.swift */; };
+		895500000000000000000001 /* AppDelegateFullScreenFrameRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895500000000000000000002 /* AppDelegateFullScreenFrameRestoreTests.swift */; };
 		2907A0032907A0032907A003 /* AppDelegateIssue2907RoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */; };
 		D6212D0C00000000000000D9 /* AppDelegateMainWindowTestingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C00000000000000DA /* AppDelegateMainWindowTestingSupport.swift */; };
 		D7AB0000000000000000000F /* AppDelegateMoveTabToNewWorkspaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */; };
@@ -2555,6 +2556,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A1B2C3D4E5F600000000CF02 /* AppDelegateDisplayConfigRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateDisplayConfigRestoreTests.swift; sourceTree = "<group>"; };
 		E3309A0A /* AppDelegateEqualizeSplitsShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateEqualizeSplitsShortcutTests.swift; sourceTree = "<group>"; };
 		F5996001A1B2C3D4E5F60002 /* AppDelegateFileExplorerShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateFileExplorerShortcutRoutingTests.swift; sourceTree = "<group>"; };
+		895500000000000000000002 /* AppDelegateFullScreenFrameRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateFullScreenFrameRestoreTests.swift; sourceTree = "<group>"; };
 		2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateIssue2907RoutingTests.swift; sourceTree = "<group>"; };
 		D6212D0C00000000000000DA /* AppDelegateMainWindowTestingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateMainWindowTestingSupport.swift; sourceTree = "<group>"; };
 		D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateMoveTabToNewWorkspaceTests.swift; sourceTree = "<group>"; };
@@ -6478,6 +6480,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					806600000000000000000001 /* SessionRestorableAgentSnapshotPermissionModeTests.swift */,
 					F17F00000000000000000002 /* FullWidthTabPersistenceTests.swift */,
 					FD21AD844E5D4D50A6DFC442 /* AppDelegateWindowFrameReconcileTests.swift */,
+					895500000000000000000002 /* AppDelegateFullScreenFrameRestoreTests.swift */,
 					A1B2C3D4E5F600000000CF02 /* AppDelegateDisplayConfigRestoreTests.swift */,
 					793800000000000000000009 /* AppDelegateOversizedFrameRestoreTests.swift */,
 				B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
@@ -9171,6 +9174,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A1B2C3D4E5F600000000CF01 /* AppDelegateDisplayConfigRestoreTests.swift in Sources */,
 				E3309A09 /* AppDelegateEqualizeSplitsShortcutTests.swift in Sources */,
 				F5996001A1B2C3D4E5F60001 /* AppDelegateFileExplorerShortcutRoutingTests.swift in Sources */,
+				895500000000000000000001 /* AppDelegateFullScreenFrameRestoreTests.swift in Sources */,
 				2907A0032907A0032907A003 /* AppDelegateIssue2907RoutingTests.swift in Sources */,
 				D6212D0C00000000000000D9 /* AppDelegateMainWindowTestingSupport.swift in Sources */,
 				D7AB0000000000000000000F /* AppDelegateMoveTabToNewWorkspaceTests.swift in Sources */,

--- a/cmuxTests/AppDelegateFullScreenFrameRestoreTests.swift
+++ b/cmuxTests/AppDelegateFullScreenFrameRestoreTests.swift
@@ -1,0 +1,49 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+@MainActor
+struct AppDelegateFullScreenFrameRestoreTests {
+    @Test(.enabled(
+        if: NSScreen.screens.contains { $0.visibleFrame.maxY < $0.frame.maxY },
+        "No screen with a visible menu-bar inset is available"
+    ))
+    func exitingNativeFullScreenFitsFullDisplayFrameBelowMenuBar() throws {
+        _ = NSApplication.shared
+        let screen = try #require(NSScreen.screens.first(where: {
+            $0.visibleFrame.maxY < $0.frame.maxY
+        }))
+
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let windowId = appDelegate.createMainWindow(shouldActivate: false)
+        let window = try #require(appDelegate.mainWindow(for: windowId) as? CmuxMainWindow)
+#if DEBUG
+        let previousConfirmationHandler = appDelegate.debugCloseMainWindowConfirmationHandler
+        appDelegate.debugCloseMainWindowConfirmationHandler = { _ in true }
+#endif
+        defer {
+            window.animationBehavior = .none
+            window.orderOut(nil)
+            window.close()
+#if DEBUG
+            appDelegate.debugCloseMainWindowConfirmationHandler = previousConfirmationHandler
+#endif
+        }
+
+        window.setFrame(screen.frame, display: false)
+        #expect(window.frame.maxY > screen.visibleFrame.maxY)
+
+        window.delegate?.windowDidExitFullScreen?(
+            Notification(name: NSWindow.didExitFullScreenNotification, object: window)
+        )
+
+        #expect(screen.visibleFrame.contains(window.frame))
+        #expect(window.frame.maxY <= screen.visibleFrame.maxY)
+    }
+}


### PR DESCRIPTION
## Summary

The external-monitor fixes cover display-topology reconciliation, but they do not run when AppKit restores a live window after native fullscreen. A full-physical-display-height frame therefore survives fullscreen exit and leaves cmux titlebar controls behind the menu bar.

This PR routes AppKit frame-restoration checkpoints through one AppDelegate-owned visible-frame invariant backed by the existing MainWindowVisibleFrameFitCore/MainWindowVisibleFrameFitRescue implementation.

- fit after native fullscreen exit, deminiaturize, and app unhide
- route existing topology reconciliation through the same invariant
- retain launch/session restore fitting and per-monitor geometry behavior unchanged
- extract MainWindowController from the oversized AppDelegate file; both new Swift files stay below 500 lines

## Coverage verdict

| Path | Before this PR | Evidence / result |
| --- | --- | --- |
| Monitor disconnect/reconnect and display topology | Covered | #6913 adds reachability rescue; #7308 strictly fits after trusted topology changes; #7477 restores geometry per monitor configuration |
| Launch/session restore | Covered on main | #8675 strictly fits same-display restored frames; #7477 covers configuration-specific restore |
| Native fullscreen exit with full-display-height restore | **Gap** | No windowDidExitFullScreen geometry handler existed; CmuxMainWindow intentionally preserved a frame with a reachable titlebar slice |
| Sleep/wake | Covered for known drift | #6305 prevents AppKit constrain drift; actual display-parameter changes enter topology reconciliation |
| Menu-bar/top-inset height changes | Covered when screen parameters change | #7308 topology signatures include top inset; this PR also fits on unhide. Per-window `windowDidChangeScreen` is intentionally not a fit trigger because it also fires during interactive cross-display drags. Side/bottom Dock and Stage Manager insets remain intentionally excluded from topology identity |
| cmux programmatic setFrame calls | Covered at their owners | launch/config restore resolves through fitted frames; new-window cascade and display moves already compute visible-frame-safe frames. AppKit lifecycle restoration was the bypass fixed here |

## Release audit

- #6305 first shipped in v0.64.17
- #6913, #7308, and #7477 first shipped in v0.64.18
- latest stable/Homebrew cask v0.64.20 includes those monitor fixes
- #8675 is merged on main but has not shipped in a stable tag yet

Thus a Homebrew v0.64.20 reporter has the monitor fixes, but neither the unreleased same-display launch restore hardening nor this fullscreen-exit safety net.

## Verification

- test-first commit creates a real cmux main window, applies the screen physical frame, fires its actual windowDidExitFullScreen delegate callback, and requires the result to fit visibleFrame
- test file is wired into the cmuxTests target
- pbxproj normalization and test-wiring lint pass
- no local app build/xcodebuild was run, per task constraints

Closes #7746
Likely fixes #8955

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787691466&installation_model_id=21920&pr_number=8963&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8963&signature=0b41259e31f0bdf756cefe30ed7ff4d77f1ba820e097dbbb92d5052931c5ff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fits main windows to the visible screen after `AppKit` restores frames, preventing the titlebar from sitting under the menu bar after exiting native fullscreen. Centralizes fitting in an AppDelegate-owned invariant invoked on fullscreen exit, screen changes, deminiaturize, and app unhide; fixes #8955 and closes #7746.

- **Bug Fixes**
  - Fit on `AppKit` restoration checkpoints (fullscreen exit, deminiaturize, app unhide).
  - Route display-topology reconciliation through the same invariant.
  - Keep launch/session restore and per-monitor geometry unchanged.
  - Add a conditional test verifying fullscreen-exit frames fit below the menu bar.

- **Refactors**
  - Extract `MainWindowController`; add `onFrameRestorationCheckpoint` to trigger fitting.

<sup>Written for commit 8f22c975175b2dd49b3a2f20b5f5ac3f9a59b66b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved main window frame restoration after leaving full screen, ensuring the window is placed within the screen’s visible area (including menu-bar insets).
  * Enhanced visible-frame fitting after screen changes and when the window is unhidden.
* **New Features**
  * Added a main window controller to manage close behavior and provide frame-restoration checkpoint hooks.
* **Tests**
  * Added a full-screen exit restoration test validating the restored window frame stays within the screen’s visible bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->