### PR TITLE
Fix zsh prompt wrap spacer lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -957,6 +957,7 @@ jobs:
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
           python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
+          python3 tests/test_issue_8953_zsh_prompt_wrap_guard.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_claude_hook_stop_last_assistant.py

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -469,8 +469,6 @@ typeset -g _CMUX_CMD_START=0
 typeset -g _CMUX_SHELL_ACTIVITY_LAST=""
 typeset -g _CMUX_TTY_NAME=""
 typeset -g _CMUX_TTY_REPORTED=0
-typeset -g _CMUX_GHOSTTY_SEMANTIC_PATCHED=0
-typeset -g _CMUX_WINCH_GUARD_INSTALLED=0
 typeset -g _CMUX_TMUX_PUSH_SIGNATURE=""
 typeset -g _CMUX_TMUX_PULL_SIGNATURE=""
 typeset -g _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT=${_CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT:-0}
@@ -604,56 +602,6 @@ _cmux_tmux_sync_cmux_environment() {
     fi
 }
 
-_cmux_ensure_ghostty_preexec_strips_both_marks() {
-    local fn_name="$1"
-    (( $+functions[$fn_name] )) || return 0
-
-    local old_strip new_strip updated
-    old_strip=$'PS1=${PS1//$\'%{\\e]133;A;cl=line\\a%}\'}'
-    new_strip=$'PS1=${PS1//$\'%{\\e]133;A;redraw=last;cl=line\\a%}\'}'
-    updated="${functions[$fn_name]}"
-
-    if [[ "$updated" == *"$new_strip"* && "$updated" != *"$old_strip"* ]]; then
-        updated="${updated/$new_strip/$old_strip
-        $new_strip}"
-        functions[$fn_name]="$updated"
-        _CMUX_GHOSTTY_SEMANTIC_PATCHED=1
-        return 0
-    fi
-    if [[ "$updated" == *"$old_strip"* && "$updated" != *"$new_strip"* ]]; then
-        updated="${updated/$old_strip/$old_strip
-        $new_strip}"
-        functions[$fn_name]="$updated"
-        _CMUX_GHOSTTY_SEMANTIC_PATCHED=1
-    fi
-}
-
-_cmux_patch_ghostty_semantic_redraw() {
-    local old_frag new_frag
-    old_frag='133;A;cl=line'
-    new_frag='133;A;redraw=last;cl=line'
-
-    # Patch both deferred and live hook definitions, depending on init timing.
-    if (( $+functions[_ghostty_deferred_init] )); then
-        functions[_ghostty_deferred_init]="${functions[_ghostty_deferred_init]//$old_frag/$new_frag}"
-        _CMUX_GHOSTTY_SEMANTIC_PATCHED=1
-    fi
-    if (( $+functions[_ghostty_precmd] )); then
-        functions[_ghostty_precmd]="${functions[_ghostty_precmd]//$old_frag/$new_frag}"
-        _CMUX_GHOSTTY_SEMANTIC_PATCHED=1
-    fi
-    if (( $+functions[_ghostty_preexec] )); then
-        functions[_ghostty_preexec]="${functions[_ghostty_preexec]//$old_frag/$new_frag}"
-        _CMUX_GHOSTTY_SEMANTIC_PATCHED=1
-    fi
-
-    # Keep legacy + redraw-aware strip lines so prompts created before patching
-    # are still cleared by preexec.
-    _cmux_ensure_ghostty_preexec_strips_both_marks _ghostty_deferred_init
-    _cmux_ensure_ghostty_preexec_strips_both_marks _ghostty_preexec
-}
-_cmux_patch_ghostty_semantic_redraw
-
 _cmux_prepend_job_table_guard_to_function() {
     local fn_name="$1"
     (( $+functions[$fn_name] )) || return 0
@@ -733,47 +681,6 @@ _cmux_patch_ghostty_job_table_guard() {
     _cmux_prepend_job_table_guard_to_function _ghostty_zle_keymap_select
 }
 _cmux_patch_ghostty_job_table_guard
-
-_cmux_prompt_wrap_guard() {
-    local cmd_start="$1"
-    local pwd="$2"
-    [[ -n "$cmd_start" && "$cmd_start" != 0 ]] || return 0
-
-    local cols="${COLUMNS:-0}"
-    (( cols > 0 )) || return 0
-
-    local budget=$(( cols - 24 ))
-    (( budget < 20 )) && budget=20
-    (( ${#pwd} >= budget )) || return 0
-
-    # Keep a spacer line between command output and a wrapped prompt so
-    # resize-driven prompt redraw cannot overwrite the command tail.
-    builtin print -r -- ""
-}
-
-_cmux_install_winch_guard() {
-    (( _CMUX_WINCH_GUARD_INSTALLED )) && return 0
-
-    # Respect user-defined WINCH handlers (function-based or trap-based).
-    local existing_winch_trap=""
-    existing_winch_trap="$(trap -p WINCH 2>/dev/null || true)"
-    if (( $+functions[TRAPWINCH] )) || [[ -n "$existing_winch_trap" ]]; then
-        _CMUX_WINCH_GUARD_INSTALLED=1
-        return 0
-    fi
-
-    TRAPWINCH() {
-        [[ -n "$CMUX_TAB_ID" ]] || return 0
-        [[ -n "$CMUX_PANEL_ID" ]] || return 0
-
-        # Ghostty already marks prompt redraws on SIGWINCH. Writing to the PTY
-        # here grows the screen and makes resize look like a fresh prompt.
-        return 0
-    }
-
-    _CMUX_WINCH_GUARD_INSTALLED=1
-}
-_cmux_install_winch_guard
 
 _cmux_git_resolve_head_path() {
     # Resolve the HEAD file path without invoking git (fast; works for worktrees).
@@ -1778,10 +1685,9 @@ _cmux_preexec() {
 
 _cmux_precmd() {
     local last_status=$?
-    # Handle cases where Ghostty integration initializes after this file. This
-    # is pure function-body patching, so it remains safe under job saturation.
+    # Ghostty integration can initialize after this file, so retry its job-table
+    # guards when each prompt begins.
     _cmux_patch_ghostty_job_table_guard
-    (( _CMUX_GHOSTTY_SEMANTIC_PATCHED )) || _cmux_patch_ghostty_semantic_redraw
     _cmux_stop_git_head_watch
     _cmux_zsh_job_table_saturated && return 0
 
@@ -1820,13 +1726,12 @@ _cmux_precmd() {
         cmd_dur=$(( now - cmd_start ))
     fi
 
-    if (( ! cmux_has_unix_socket )); then
+    if (( cmux_has_unix_socket )); then
+        [[ -n "$CMUX_PANEL_ID" ]] || return 0
+    else
         if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
             _cmux_report_pwd_via_relay "$pwd" && _CMUX_PWD_LAST_PWD="$pwd"
         fi
-    else
-        [[ -n "$CMUX_PANEL_ID" ]] || return 0
-        _cmux_prompt_wrap_guard "$cmd_start" "$pwd"
     fi
 
     _cmux_set_git_active_pwd "$pwd"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1726,12 +1726,12 @@ _cmux_precmd() {
         cmd_dur=$(( now - cmd_start ))
     fi
 
-    if (( cmux_has_unix_socket )); then
-        [[ -n "$CMUX_PANEL_ID" ]] || return 0
-    else
+    if (( ! cmux_has_unix_socket )); then
         if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
             _cmux_report_pwd_via_relay "$pwd" && _CMUX_PWD_LAST_PWD="$pwd"
         fi
+    else
+        [[ -n "$CMUX_PANEL_ID" ]] || return 0
     fi
 
     _cmux_set_git_active_pwd "$pwd"

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -4725,38 +4725,6 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         XCTAssertTrue(output.contains("PREEXEC=0"), output)
     }
 
-    func testGhosttySemanticPatchRetriesAfterDeferredInitCreatesLiveHooks() throws {
-        let output = try runInteractiveZsh(
-            cmuxLoadGhosttyIntegration: true,
-            cmuxLoadShellIntegration: true,
-            command: """
-            _cmux_patch_ghostty_semantic_redraw
-            (( $+functions[_ghostty_deferred_init] )) && _ghostty_deferred_init >/dev/null 2>&1
-            _cmux_patch_ghostty_semantic_redraw
-            print -r -- "PRECMD_BODY=${functions[_ghostty_precmd]}"
-            print -r -- "PREEXEC_BODY=${functions[_ghostty_preexec]}"
-            """
-        )
-
-        XCTAssertTrue(output.contains("PRECMD_BODY="), output)
-        XCTAssertTrue(output.contains("PREEXEC_BODY="), output)
-        XCTAssertTrue(output.contains("133;A;redraw=last;cl=line"), output)
-    }
-
-    func testShellIntegrationWinchGuardDoesNotPrintSpacerLineOnResize() throws {
-        let output = try runInteractiveZsh(
-            cmuxLoadGhosttyIntegration: false,
-            cmuxLoadShellIntegration: true,
-            command: """
-            print -r -- BEFORE
-            TRAPWINCH
-            print -r -- AFTER
-            """
-        )
-
-        XCTAssertEqual(output, "BEFORE\nAFTER", output)
-    }
-
     func testShellIntegrationPreservesStartupTermForThemeSelectionBeforeRestoringManagedTerm() throws {
         let output = try runPromptInteractiveZsh(
             cmuxLoadGhosttyIntegration: false,

--- a/tests/test_issue_8953_zsh_prompt_wrap_guard.py
+++ b/tests/test_issue_8953_zsh_prompt_wrap_guard.py
@@ -108,6 +108,7 @@ def _wait_for_child(pid: int, master_fd: int, output: bytearray) -> int:
             return os.waitstatus_to_exitcode(status)
 
         if not master_open:
+            time.sleep(0.01)
             continue
         readable, _, _ = select.select([master_fd], [], [], 0.2)
         if master_fd not in readable:

--- a/tests/test_issue_8953_zsh_prompt_wrap_guard.py
+++ b/tests/test_issue_8953_zsh_prompt_wrap_guard.py
@@ -40,6 +40,7 @@ KEYBOARD_RESET = b"\x1b[>m\x1b[<8u"
 @dataclass(frozen=True)
 class SessionResult:
     columns: int
+    resized_columns: int
     output: bytes
 
     @property
@@ -178,6 +179,7 @@ def _capture_session(columns: int) -> SessionResult:
             os.chdir(cwd)
             os.execve("/bin/zsh", ["zsh", "-d", "-i"], env)
 
+        resized_columns = columns + 1
         fcntl.ioctl(
             master_fd,
             termios.TIOCSWINSZ,
@@ -192,9 +194,17 @@ def _capture_session(columns: int) -> SessionResult:
         search_from = 0
         child_reaped = False
         try:
-            for command in (b"echo AAA\n", b"echo BBB\n"):
-                search_from = _read_until(master_fd, output, PROMPT_END, search_from)
-                os.write(master_fd, command)
+            search_from = _read_until(master_fd, output, PROMPT_END, search_from)
+            os.write(master_fd, b"echo AAA\n")
+
+            search_from = _read_until(master_fd, output, PROMPT_END, search_from)
+            fcntl.ioctl(
+                master_fd,
+                termios.TIOCSWINSZ,
+                struct.pack("HHHH", 24, resized_columns, 0, 0),
+            )
+            search_from = _read_until(master_fd, output, PROMPT_END, search_from)
+            os.write(master_fd, b"echo BBB\n")
 
             search_from = _read_until(master_fd, output, PROMPT_END, search_from)
             os.write(master_fd, b"exit\n")
@@ -216,7 +226,11 @@ def _capture_session(columns: int) -> SessionResult:
             listener.close()
             server.join(timeout=1.0)
 
-        return SessionResult(columns=columns, output=bytes(output))
+        return SessionResult(
+            columns=columns,
+            resized_columns=resized_columns,
+            output=bytes(output),
+        )
 
 
 def main() -> int:
@@ -240,9 +254,10 @@ def main() -> int:
             failures.append(
                 f"cols={result.columns}: cmux rewrote Ghostty's zsh prompt marker to redraw=last"
             )
-        if result.output.count(GHOSTTY_FRESH_PROMPT) != 3:
+        if result.output.count(GHOSTTY_FRESH_PROMPT) != 4:
             failures.append(
-                f"cols={result.columns}: expected 3 unmodified Ghostty fresh-prompt markers, "
+                f"cols={result.columns}->{result.resized_columns}: expected 4 unmodified Ghostty "
+                "fresh-prompt markers (including the SIGWINCH redraw), "
                 f"saw {result.output.count(GHOSTTY_FRESH_PROMPT)}"
             )
 
@@ -250,7 +265,10 @@ def main() -> int:
         print("FAIL: " + "\nFAIL: ".join(failures))
         return 1
 
-    print("PASS: short zsh prompts emit no spacer rows and retain Ghostty prompt semantics")
+    print(
+        "PASS: short zsh prompts and SIGWINCH redraws emit no spacer rows "
+        "and retain Ghostty prompt semantics"
+    )
     return 0
 
 

--- a/tests/test_issue_8953_zsh_prompt_wrap_guard.py
+++ b/tests/test_issue_8953_zsh_prompt_wrap_guard.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Regression coverage for cmux issue #8953.
+
+Drive the bundled cmux and Ghostty zsh integrations through a real interactive
+PTY.  The prompt deliberately renders only the final path component while the
+working directory is long, matching the issue's config-independent reproducer.
+cmux must not infer prompt wrapping from ``PWD`` or write spacer rows into the
+PTY, and it must preserve Ghostty's zsh prompt markers rather than rewriting
+their redraw semantics.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import pty
+import select
+import shutil
+import signal
+import socket
+import struct
+import tempfile
+import termios
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CMUX_INTEGRATION_DIR = REPO_ROOT / "Resources/shell-integration"
+GHOSTTY_RESOURCES_DIR = REPO_ROOT / "ghostty/src"
+
+PROMPT_END = b"\x1b]133;B\x07"
+GHOSTTY_FRESH_PROMPT = b"\x1b]133;A;cl=line\x07"
+CMUX_REDRAW_PROMPT = b"\x1b]133;A;redraw=last;cl=line\x07"
+KEYBOARD_RESET = b"\x1b[>m\x1b[<8u"
+
+
+@dataclass(frozen=True)
+class SessionResult:
+    columns: int
+    output: bytes
+
+    @property
+    def spacer_count(self) -> int:
+        return self.output.count(KEYBOARD_RESET + b"\r\n")
+
+    @property
+    def prompt_count(self) -> int:
+        return self.output.count(KEYBOARD_RESET)
+
+
+def _serve_socket(listener: socket.socket, stop: threading.Event) -> None:
+    """Drain cmux metadata messages so detached hook clients exit promptly."""
+    while not stop.is_set():
+        try:
+            connection, _ = listener.accept()
+        except (TimeoutError, OSError):
+            continue
+
+        with connection:
+            connection.settimeout(0.2)
+            while True:
+                try:
+                    if not connection.recv(65_536):
+                        break
+                except (TimeoutError, OSError):
+                    break
+
+
+def _read_until(
+    master_fd: int,
+    output: bytearray,
+    marker: bytes,
+    search_from: int,
+    *,
+    timeout: float = 10.0,
+) -> int:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        marker_index = output.find(marker, search_from)
+        if marker_index != -1:
+            return marker_index + len(marker)
+
+        readable, _, _ = select.select([master_fd], [], [], 0.2)
+        if master_fd not in readable:
+            continue
+        try:
+            chunk = os.read(master_fd, 65_536)
+        except OSError as error:
+            raise AssertionError(
+                f"PTY closed before marker {marker!r}; output={bytes(output)!r}"
+            ) from error
+        if not chunk:
+            break
+        output.extend(chunk)
+
+    raise AssertionError(f"timed out waiting for marker {marker!r}; output={bytes(output)!r}")
+
+
+def _wait_for_child(pid: int, master_fd: int, output: bytearray) -> int:
+    deadline = time.monotonic() + 10.0
+    master_open = True
+    while time.monotonic() < deadline:
+        waited_pid, status = os.waitpid(pid, os.WNOHANG)
+        if waited_pid == pid:
+            return os.waitstatus_to_exitcode(status)
+
+        if not master_open:
+            continue
+        readable, _, _ = select.select([master_fd], [], [], 0.2)
+        if master_fd not in readable:
+            continue
+        try:
+            chunk = os.read(master_fd, 65_536)
+        except OSError:
+            master_open = False
+            continue
+        if chunk:
+            output.extend(chunk)
+        else:
+            master_open = False
+
+    os.kill(pid, signal.SIGKILL)
+    os.waitpid(pid, 0)
+    raise AssertionError(f"interactive zsh did not exit; output={bytes(output)!r}")
+
+
+def _capture_session(columns: int) -> SessionResult:
+    with tempfile.TemporaryDirectory(prefix=f"cmux-issue-8953-{columns}-", dir="/tmp") as tmp:
+        root = Path(tmp)
+        home = root / "home"
+        user_zdotdir = root / "minzdot"
+        cwd = home / "cmux-blank-repro/aaaaaaaaaa/bbbbbbbbbb/cccccccccc/dddddddddd"
+        user_zdotdir.mkdir(parents=True)
+        cwd.mkdir(parents=True)
+        (user_zdotdir / ".zshrc").write_text("PROMPT='%1~ '\n", encoding="utf-8")
+
+        assert len(str(cwd)) >= 73, f"fixture cwd is not deep enough: {cwd}"
+
+        socket_path = root / "cmux.sock"
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.set_inheritable(False)
+        listener.bind(str(socket_path))
+        listener.listen()
+        listener.settimeout(0.1)
+
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith(("CMUX_", "GHOSTTY_")) and key not in {"ZDOTDIR", "TMUX"}
+        }
+        env.update(
+            {
+                "HOME": str(home),
+                "SHELL": "/bin/zsh",
+                "TERM": "xterm-256color",
+                "ZDOTDIR": str(CMUX_INTEGRATION_DIR),
+                "CMUX_ZSH_ZDOTDIR": str(user_zdotdir),
+                "CMUX_SHELL_INTEGRATION": "1",
+                "CMUX_SHELL_INTEGRATION_DIR": str(CMUX_INTEGRATION_DIR),
+                "CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION": "1",
+                "GHOSTTY_RESOURCES_DIR": str(GHOSTTY_RESOURCES_DIR),
+                "CMUX_SOCKET_PATH": str(socket_path),
+                "CMUX_TAB_ID": "tab-issue-8953",
+                "CMUX_PANEL_ID": "panel-issue-8953",
+                "CMUX_TEST_FORCE_KEYBOARD_RESET": "1",
+                # Keep command-start timestamps nonzero without waiting for the
+                # real shell clock to advance after startup.
+                "EPOCHSECONDS": "1234567890",
+            }
+        )
+
+        pid, master_fd = pty.fork()
+        if pid == 0:
+            os.chdir(cwd)
+            os.execve("/bin/zsh", ["zsh", "-d", "-i"], env)
+
+        fcntl.ioctl(
+            master_fd,
+            termios.TIOCSWINSZ,
+            struct.pack("HHHH", 24, columns, 0, 0),
+        )
+
+        stop = threading.Event()
+        server = threading.Thread(target=_serve_socket, args=(listener, stop), daemon=True)
+        server.start()
+
+        output = bytearray()
+        search_from = 0
+        child_reaped = False
+        try:
+            for command in (b"echo AAA\n", b"echo BBB\n"):
+                search_from = _read_until(master_fd, output, PROMPT_END, search_from)
+                os.write(master_fd, command)
+
+            search_from = _read_until(master_fd, output, PROMPT_END, search_from)
+            os.write(master_fd, b"exit\n")
+            exit_code = _wait_for_child(pid, master_fd, output)
+            child_reaped = True
+            assert exit_code == 0, f"interactive zsh exited {exit_code}; output={bytes(output)!r}"
+        finally:
+            if not child_reaped:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                try:
+                    os.waitpid(pid, 0)
+                except ChildProcessError:
+                    pass
+            os.close(master_fd)
+            stop.set()
+            listener.close()
+            server.join(timeout=1.0)
+
+        return SessionResult(columns=columns, output=bytes(output))
+
+
+def main() -> int:
+    if shutil.which("zsh") is None:
+        print("SKIP: zsh is not installed")
+        return 0
+
+    results = [_capture_session(columns) for columns in (40, 140)]
+    failures: list[str] = []
+
+    for result in results:
+        if result.prompt_count != 3:
+            failures.append(
+                f"cols={result.columns}: expected 3 cmux prompt cycles, saw {result.prompt_count}"
+            )
+        if result.spacer_count != 0:
+            failures.append(
+                f"cols={result.columns}: cmux wrote {result.spacer_count} spacer newline(s)"
+            )
+        if CMUX_REDRAW_PROMPT in result.output:
+            failures.append(
+                f"cols={result.columns}: cmux rewrote Ghostty's zsh prompt marker to redraw=last"
+            )
+        if result.output.count(GHOSTTY_FRESH_PROMPT) != 3:
+            failures.append(
+                f"cols={result.columns}: expected 3 unmodified Ghostty fresh-prompt markers, "
+                f"saw {result.output.count(GHOSTTY_FRESH_PROMPT)}"
+            )
+
+    if failures:
+        print("FAIL: " + "\nFAIL: ".join(failures))
+        return 1
+
+    print("PASS: short zsh prompts emit no spacer rows and retain Ghostty prompt semantics")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- remove cmux-owned zsh prompt layout heuristics and physical spacer output
- leave Ghostty as the single owner of zsh OSC 133 prompt and resize semantics
- add a real interactive PTY regression for 40- and 140-column panes with a short `%1~` prompt in a deep cwd

## Testing
- regression test fails before the fix with two narrow-pane spacer newlines and passes after the fix
- `zsh -n Resources/shell-integration/.zshenv Resources/shell-integration/cmux-zsh-integration.zsh`
- `python3 tests/test_issue_8953_zsh_prompt_wrap_guard.py`
- `python3 tests/test_ghostty_zsh_job_table_saturation_guard.py`
- `python3 tests/test_issue_6714_zsh_shim_noclobber.py`
- `python3 tests/test_shell_zdotdir_user_override.py`
- `python3 scripts/check-test-determinism.py --strict --roots tests/test_issue_8953_zsh_prompt_wrap_guard.py`

Closes #8953

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787691660&installation_model_id=21920&pr_number=8964&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8964&signature=01a93643fe11d76cb74c009e386fb01d1ce5fb3fb47c24689e5816b3c8f99695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `cmux` from inserting spacer lines on wrapped zsh prompts and removes rewrites of `Ghostty` OSC 133 markers, handing prompt/resize ownership to `Ghostty`. Fixes output being pushed down in narrow panes and covers SIGWINCH redraws. Closes #8953.

- **Bug Fixes**
  - Removed prompt-wrap heuristic, WINCH guard, and semantic redraw patching; `Ghostty` now owns zsh prompt redraws and resize.
  - Stopped rewriting `Ghostty` OSC 133 markers; kept only the job-table saturation guard.
  - Added an interactive PTY regression (40/140 cols) verifying no spacer lines, unmodified markers, and resize ownership; wired into CI and removed obsolete Swift tests.

<sup>Written for commit 1c0d7ca95070ac464e2bfbcb3f344f03f00c3d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zsh prompt rendering across different terminal widths.
  * Prevented unwanted blank spacer lines and prompt redraw issues during shell interactions.
  * Improved working-directory reporting for non-Unix transport connections.

* **Tests**
  * Added end-to-end regression coverage for zsh prompt behavior.
  * Updated continuous integration to run the new regression test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->