### PR TITLE
Fix disabled workspace cwd inheritance

### DIFF
--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -238,7 +238,7 @@ public struct AppSection: View {
                 String(localized: "settings.app.workspaceInheritWorkingDirectory", defaultValue: "Inherit Workspace Working Directory"),
                 subtitle: inheritDir.current
                     ? String(localized: "settings.app.workspaceInheritWorkingDirectory.subtitleOn", defaultValue: "New workspaces start in the focused workspace's working directory.")
-                    : String(localized: "settings.app.workspaceInheritWorkingDirectory.subtitleOff", defaultValue: "New workspaces leave their working directory unset so Ghostty's working-directory setting can apply.")
+                    : String(localized: "settings.app.workspaceInheritWorkingDirectory.subtitleOff", defaultValue: "New workspaces use Ghostty's working-directory setting instead.")
             ) {
                 Toggle("", isOn: Binding(get: { inheritDir.current }, set: { inheritDir.set($0) }))
                     .labelsHidden()

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyWorkingDirectoryResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyWorkingDirectoryResolver.swift
@@ -2,14 +2,17 @@ import Foundation
 
 /// Resolves Ghostty's `working-directory` config value into the concrete path
 /// required by cmux when it must suppress Ghostty's focused-surface inheritance.
-public enum GhosttyWorkingDirectoryResolver {
-    /// Resolves using the current user's home directory and the process cwd.
-    public static func resolve(configuredValue: String?) -> String {
-        resolve(
-            configuredValue: configuredValue,
-            homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
-            processWorkingDirectory: FileManager.default.currentDirectoryPath
-        )
+public struct GhosttyWorkingDirectoryResolver: Sendable {
+    private let homeDirectory: String
+    private let processWorkingDirectory: String
+
+    /// Creates a resolver using the supplied environment paths.
+    public init(
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        processWorkingDirectory: String = FileManager.default.currentDirectoryPath
+    ) {
+        self.homeDirectory = homeDirectory
+        self.processWorkingDirectory = processWorkingDirectory
     }
 
     /// Returns a concrete absolute working directory for a new terminal.
@@ -18,11 +21,7 @@ public enum GhosttyWorkingDirectoryResolver {
     /// runtime config. Embedded surfaces cannot rely on that default when their
     /// creation context would first inherit another surface's live directory,
     /// so cmux resolves those values before passing the surface override.
-    public static func resolve(
-        configuredValue: String?,
-        homeDirectory: String,
-        processWorkingDirectory: String
-    ) -> String {
+    public func resolve(configuredValue: String?) -> String {
         let home = normalizedAbsolutePath(homeDirectory) ?? "/"
         let processDirectory = normalizedAbsolutePath(processWorkingDirectory) ?? home
         guard let configuredValue = normalizedValue(configuredValue) else {
@@ -43,13 +42,13 @@ public enum GhosttyWorkingDirectoryResolver {
         }
     }
 
-    private static func normalizedValue(_ value: String?) -> String? {
+    private func normalizedValue(_ value: String?) -> String? {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private static func normalizedAbsolutePath(_ value: String) -> String? {
+    private func normalizedAbsolutePath(_ value: String) -> String? {
         guard let value = normalizedValue(value), value.hasPrefix("/") else {
             return nil
         }

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyWorkingDirectoryResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyWorkingDirectoryResolver.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Resolves Ghostty's `working-directory` config value into the concrete path
+/// required by cmux when it must suppress Ghostty's focused-surface inheritance.
+public enum GhosttyWorkingDirectoryResolver {
+    /// Resolves using the current user's home directory and the process cwd.
+    public static func resolve(configuredValue: String?) -> String {
+        resolve(
+            configuredValue: configuredValue,
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
+            processWorkingDirectory: FileManager.default.currentDirectoryPath
+        )
+    }
+
+    /// Returns a concrete absolute working directory for a new terminal.
+    ///
+    /// Ghostty normally resolves `home` and `inherit` while finalizing its
+    /// runtime config. Embedded surfaces cannot rely on that default when their
+    /// creation context would first inherit another surface's live directory,
+    /// so cmux resolves those values before passing the surface override.
+    public static func resolve(
+        configuredValue: String?,
+        homeDirectory: String,
+        processWorkingDirectory: String
+    ) -> String {
+        let home = normalizedAbsolutePath(homeDirectory) ?? "/"
+        let processDirectory = normalizedAbsolutePath(processWorkingDirectory) ?? home
+        guard let configuredValue = normalizedValue(configuredValue) else {
+            return home
+        }
+
+        switch configuredValue {
+        case "home":
+            return home
+        case "inherit":
+            return processDirectory
+        default:
+            if configuredValue.hasPrefix("~/") {
+                let relativePath = String(configuredValue.dropFirst(2))
+                return (home as NSString).appendingPathComponent(relativePath)
+            }
+            return normalizedAbsolutePath(configuredValue) ?? home
+        }
+    }
+
+    private static func normalizedValue(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalizedAbsolutePath(_ value: String) -> String? {
+        guard let value = normalizedValue(value), value.hasPrefix("/") else {
+            return nil
+        }
+        return value
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyWorkingDirectoryResolver.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/Config/GhosttyWorkingDirectoryResolver.swift
@@ -8,8 +8,8 @@ public struct GhosttyWorkingDirectoryResolver: Sendable {
 
     /// Creates a resolver using the supplied environment paths.
     public init(
-        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
-        processWorkingDirectory: String = FileManager.default.currentDirectoryPath
+        homeDirectory: String,
+        processWorkingDirectory: String
     ) {
         self.homeDirectory = homeDirectory
         self.processWorkingDirectory = processWorkingDirectory

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyWorkingDirectoryResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyWorkingDirectoryResolverTests.swift
@@ -1,0 +1,46 @@
+import CmuxTerminalCore
+import Testing
+
+@Suite struct GhosttyWorkingDirectoryResolverTests {
+    private let home = "/Users/tester"
+    private let processDirectory = "/Applications/cmux.app"
+
+    @Test(arguments: [nil, "", "  ", "relative/path"] as [String?])
+    func absentOrInvalidValuesFallBackToHome(_ configuredValue: String?) {
+        #expect(resolve(configuredValue) == home)
+    }
+
+    @Test func homeUsesCurrentUserHomeDirectory() {
+        #expect(resolve("home") == home)
+    }
+
+    @Test func inheritUsesProcessWorkingDirectory() {
+        #expect(resolve("inherit") == processDirectory)
+    }
+
+    @Test func tildePathExpandsAgainstCurrentUserHomeDirectory() {
+        #expect(resolve("~/Projects/cmux") == "/Users/tester/Projects/cmux")
+    }
+
+    @Test func absolutePathPassesThrough() {
+        #expect(resolve("/Volumes/Work/cmux") == "/Volumes/Work/cmux")
+    }
+
+    @Test func invalidProcessDirectoryFallsBackToHome() {
+        #expect(
+            GhosttyWorkingDirectoryResolver.resolve(
+                configuredValue: "inherit",
+                homeDirectory: home,
+                processWorkingDirectory: "relative/path"
+            ) == home
+        )
+    }
+
+    private func resolve(_ configuredValue: String?) -> String {
+        GhosttyWorkingDirectoryResolver.resolve(
+            configuredValue: configuredValue,
+            homeDirectory: home,
+            processWorkingDirectory: processDirectory
+        )
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyWorkingDirectoryResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/GhosttyWorkingDirectoryResolverTests.swift
@@ -28,19 +28,17 @@ import Testing
 
     @Test func invalidProcessDirectoryFallsBackToHome() {
         #expect(
-            GhosttyWorkingDirectoryResolver.resolve(
-                configuredValue: "inherit",
+            GhosttyWorkingDirectoryResolver(
                 homeDirectory: home,
                 processWorkingDirectory: "relative/path"
-            ) == home
+            ).resolve(configuredValue: "inherit") == home
         )
     }
 
     private func resolve(_ configuredValue: String?) -> String {
-        GhosttyWorkingDirectoryResolver.resolve(
-            configuredValue: configuredValue,
+        GhosttyWorkingDirectoryResolver(
             homeDirectory: home,
             processWorkingDirectory: processDirectory
-        )
+        ).resolve(configuredValue: configuredValue)
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceCreationWorkingDirectoryPolicy.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceCreationWorkingDirectoryPolicy.swift
@@ -1,13 +1,19 @@
 import Foundation
 
 /// Selects the concrete working directory for a newly created workspace.
-public enum WorkspaceCreationWorkingDirectoryPolicy {
+public struct WorkspaceCreationWorkingDirectoryPolicy: Sendable {
+    private let inheritanceEnabled: Bool
+
+    /// Creates a policy for the current workspace inheritance preference.
+    public init(inheritanceEnabled: Bool) {
+        self.inheritanceEnabled = inheritanceEnabled
+    }
+
     /// Applies workspace-creation precedence without allowing disabled
     /// inheritance to collapse into an ambiguous `nil` terminal override.
-    public static func resolve(
+    public func resolve(
         explicitWorkingDirectory: String?,
         inheritedWorkingDirectory: String?,
-        inheritanceEnabled: Bool,
         defaultWorkingDirectory: @autoclosure () -> String
     ) -> String {
         if let explicitWorkingDirectory = normalized(explicitWorkingDirectory) {
@@ -20,7 +26,7 @@ public enum WorkspaceCreationWorkingDirectoryPolicy {
         return normalized(defaultWorkingDirectory()) ?? "/"
     }
 
-    private static func normalized(_ value: String?) -> String? {
+    private func normalized(_ value: String?) -> String? {
         guard let value else { return nil }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceCreationWorkingDirectoryPolicy.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceCreationWorkingDirectoryPolicy.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Selects the concrete working directory for a newly created workspace.
+public enum WorkspaceCreationWorkingDirectoryPolicy {
+    /// Applies workspace-creation precedence without allowing disabled
+    /// inheritance to collapse into an ambiguous `nil` terminal override.
+    public static func resolve(
+        explicitWorkingDirectory: String?,
+        inheritedWorkingDirectory: String?,
+        inheritanceEnabled: Bool,
+        defaultWorkingDirectory: @autoclosure () -> String
+    ) -> String {
+        if let explicitWorkingDirectory = normalized(explicitWorkingDirectory) {
+            return explicitWorkingDirectory
+        }
+        if inheritanceEnabled,
+           let inheritedWorkingDirectory = normalized(inheritedWorkingDirectory) {
+            return inheritedWorkingDirectory
+        }
+        return normalized(defaultWorkingDirectory()) ?? "/"
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCreationWorkingDirectoryPolicyTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCreationWorkingDirectoryPolicyTests.swift
@@ -25,10 +25,9 @@ import Testing
     }
 
     private func resolve(explicit: String?, inherited: String?, enabled: Bool) -> String {
-        WorkspaceCreationWorkingDirectoryPolicy.resolve(
+        WorkspaceCreationWorkingDirectoryPolicy(inheritanceEnabled: enabled).resolve(
             explicitWorkingDirectory: explicit,
             inheritedWorkingDirectory: inherited,
-            inheritanceEnabled: enabled,
             defaultWorkingDirectory: "/default"
         )
     }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCreationWorkingDirectoryPolicyTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCreationWorkingDirectoryPolicyTests.swift
@@ -1,0 +1,35 @@
+import CmuxWorkspaces
+import Testing
+
+@Suite struct WorkspaceCreationWorkingDirectoryPolicyTests {
+    @Test func explicitDirectoryWins() {
+        #expect(
+            resolve(explicit: "/explicit", inherited: "/inherited", enabled: true)
+                == "/explicit"
+        )
+    }
+
+    @Test func enabledInheritanceUsesSourceDirectory() {
+        #expect(
+            resolve(explicit: nil, inherited: "/inherited", enabled: true)
+                == "/inherited"
+        )
+    }
+
+    @Test func disabledInheritanceUsesConcreteDefault() {
+        #expect(resolve(explicit: nil, inherited: "/inherited", enabled: false) == "/default")
+    }
+
+    @Test func missingInheritedDirectoryUsesConcreteDefault() {
+        #expect(resolve(explicit: nil, inherited: nil, enabled: true) == "/default")
+    }
+
+    private func resolve(explicit: String?, inherited: String?, enabled: Bool) -> String {
+        WorkspaceCreationWorkingDirectoryPolicy.resolve(
+            explicitWorkingDirectory: explicit,
+            inheritedWorkingDirectory: inherited,
+            inheritanceEnabled: enabled,
+            defaultWorkingDirectory: "/default"
+        )
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -155423,13 +155423,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New workspaces leave their working directory unset so Ghostty's working-directory setting can apply."
+            "value": "New workspaces use Ghostty's working-directory setting instead."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "新規ワークスペースの作業ディレクトリを未設定にして、Ghostty の working-directory 設定を適用します。"
+            "value": "新規ワークスペースでは、代わりに Ghostty の working-directory 設定を使用します。"
           }
         }
       }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -479,7 +479,10 @@ class TabManager: ObservableObject {
         panelTitleUpdateCoalescer: NotificationBurstCoalescer? = nil,
         settings: any SettingsWriting = UserDefaultsSettingsClient(defaults: .standard),
         defaultWorkspaceWorkingDirectoryProvider: @escaping () -> String = {
-            GhosttyWorkingDirectoryResolver().resolve(
+            GhosttyWorkingDirectoryResolver(
+                homeDirectory: FileManager.default.homeDirectoryForCurrentUser.path,
+                processWorkingDirectory: FileManager.default.currentDirectoryPath
+            ).resolve(
                 configuredValue: GhosttyConfig.load().workingDirectory
             )
         },

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -479,7 +479,7 @@ class TabManager: ObservableObject {
         panelTitleUpdateCoalescer: NotificationBurstCoalescer? = nil,
         settings: any SettingsWriting = UserDefaultsSettingsClient(defaults: .standard),
         defaultWorkspaceWorkingDirectoryProvider: @escaping () -> String = {
-            GhosttyWorkingDirectoryResolver.resolve(
+            GhosttyWorkingDirectoryResolver().resolve(
                 configuredValue: GhosttyConfig.load().workingDirectory
             )
         },
@@ -1142,10 +1142,11 @@ class TabManager: ObservableObject {
             let nextTabCount = snapshot.tabs.count + 1
             sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
             let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
-            let workingDirectory = WorkspaceCreationWorkingDirectoryPolicy.resolve(
+            let workingDirectory = WorkspaceCreationWorkingDirectoryPolicy(
+                inheritanceEnabled: inheritanceEnabled
+            ).resolve(
                 explicitWorkingDirectory: explicitWorkingDirectory,
                 inheritedWorkingDirectory: snapshot.preferredWorkingDirectory,
-                inheritanceEnabled: inheritanceEnabled,
                 defaultWorkingDirectory: defaultWorkspaceWorkingDirectoryProvider()
             )
             let inheritedConfig = workspaceCreationConfigTemplate(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -392,6 +392,7 @@ class TabManager: ObservableObject {
     /// Typed synchronous settings access (CmuxSettings).
     private let settings: any SettingsWriting
     private let settingsCatalog = SettingCatalog()
+    private let defaultWorkspaceWorkingDirectoryProvider: () -> String
     let workspaceDirectoryCustomizationStore: WorkspaceDirectoryCustomizationStore
     private var lastFocusHistoryIncludesPanesAndTabs: Bool
     let nativeSSHConnectionBroker: NativeSSHConnectionBroker
@@ -477,11 +478,17 @@ class TabManager: ObservableObject {
         gitProbeLimiter: WorkspaceGitMetadataProbeLimiter? = nil,
         panelTitleUpdateCoalescer: NotificationBurstCoalescer? = nil,
         settings: any SettingsWriting = UserDefaultsSettingsClient(defaults: .standard),
+        defaultWorkspaceWorkingDirectoryProvider: @escaping () -> String = {
+            GhosttyWorkingDirectoryResolver.resolve(
+                configuredValue: GhosttyConfig.load().workingDirectory
+            )
+        },
         workspaceDirectoryCustomizationStore: WorkspaceDirectoryCustomizationStore? = nil,
         nativeSSHConnectionBroker: NativeSSHConnectionBroker = NativeSSHConnectionBroker(),
         closeTabWarningDefaults: UserDefaults = .standard
     ) {
         self.settings = settings
+        self.defaultWorkspaceWorkingDirectoryProvider = defaultWorkspaceWorkingDirectoryProvider
         self.workspaceDirectoryCustomizationStore = workspaceDirectoryCustomizationStore ?? WorkspaceDirectoryCustomizationStore()
         let focusHistoryScopeKey = SettingCatalog().app.focusHistoryIncludesPanesAndTabs
         self.lastFocusHistoryIncludesPanesAndTabs = settings.value(for: focusHistoryScopeKey)
@@ -1114,8 +1121,10 @@ class TabManager: ObservableObject {
         // entire creation path. Release ARC can otherwise drop retains early across the
         // helper/insertion chain, which reintroduces use-after-free crashes in optimized builds.
         return withExtendedLifetime((capturedTabs, sourceWorkspace)) {
-            let dir = inheritWorkingDirectory
-                ? implicitWorkingDirectoryForNewWorkspace(from: sourceWorkspace)
+            let inheritanceEnabled = inheritWorkingDirectory
+                && settings.value(for: settingsCatalog.app.workspaceInheritWorkingDirectory)
+            let inheritedWorkingDirectory = inheritanceEnabled
+                ? preferredWorkingDirectoryForNewTab(workspace: sourceWorkspace)
                 : nil
             let fontSizeLineage = inheritedTerminalFontSizeLineageForNewWorkspace(
                 workspace: sourceWorkspace
@@ -1123,7 +1132,7 @@ class TabManager: ObservableObject {
             let snapshot = workspaceCreationSnapshotLite(
                 currentTabs: capturedTabs,
                 currentSelectedTabId: capturedSelectedTabId,
-                preferredWorkingDirectory: dir,
+                preferredWorkingDirectory: inheritedWorkingDirectory,
                 inheritedTerminalFontSizeLineage: fontSizeLineage
             )
             didCaptureWorkspaceCreationSnapshot()
@@ -1133,7 +1142,12 @@ class TabManager: ObservableObject {
             let nextTabCount = snapshot.tabs.count + 1
             sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
             let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
-            let workingDirectory = explicitWorkingDirectory ?? snapshot.preferredWorkingDirectory
+            let workingDirectory = WorkspaceCreationWorkingDirectoryPolicy.resolve(
+                explicitWorkingDirectory: explicitWorkingDirectory,
+                inheritedWorkingDirectory: snapshot.preferredWorkingDirectory,
+                inheritanceEnabled: inheritanceEnabled,
+                defaultWorkingDirectory: defaultWorkspaceWorkingDirectoryProvider()
+            )
             let inheritedConfig = workspaceCreationConfigTemplate(
                 inheritedTerminalFontSizeLineage: snapshot.inheritedTerminalFontSizeLineage
             )

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2242,6 +2242,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE00000000000000000D3A /* WorkspaceCreateWorkingDirectoryAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000D39 /* WorkspaceCreateWorkingDirectoryAliasTests.swift */; };
 		C0DE71450000000000000001 /* WorkspaceCreateWorkingDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE71450000000000000002 /* WorkspaceCreateWorkingDirectoryTests.swift */; };
 		C0DE00000000000000000D34 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000D33 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift */; };
+		E60812C95246E275F29D3C1B /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3084DF49224DFF2DF4C376 /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift */; };
 		281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */; };
 		E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
 		72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */; };
@@ -4528,6 +4529,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE00000000000000000D39 /* WorkspaceCreateWorkingDirectoryAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreateWorkingDirectoryAliasTests.swift; sourceTree = "<group>"; };
 		C0DE71450000000000000002 /* WorkspaceCreateWorkingDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreateWorkingDirectoryTests.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000D33 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreateWorkingDirectoryValidationServiceTests.swift; sourceTree = "<group>"; };
+		9D3084DF49224DFF2DF4C376 /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift; sourceTree = "<group>"; };
 		CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCustomSidebarPullRequestContextTests.swift; sourceTree = "<group>"; };
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
 		B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -6869,6 +6871,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					B8E2A4C1D5F3096871A2B3C4 /* RemoteTmuxNativeMirrorLayoutFuzzTests.swift */,
 					B8E2A4C1D5F3096871A2B4A2 /* RemoteTmuxBonsplitImpositionRenderTests.swift */,
 				08850489C70ECFACA540C2F3 /* WorkspaceTerminalWorkingDirectoryFallbackTests.swift */,
+				9D3084DF49224DFF2DF4C376 /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift */,
 				B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */,
 				4F34462AE2F2EECEF5298031 /* GhosttyOptionAsAltModsTests.swift */,
 				D7C0DE00000000000000A104 /* CmuxWebViewContextMenuLinkCaptureTests.swift */,
@@ -9713,6 +9716,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE00000000000000000D3A /* WorkspaceCreateWorkingDirectoryAliasTests.swift in Sources */,
 				C0DE71450000000000000001 /* WorkspaceCreateWorkingDirectoryTests.swift in Sources */,
 				C0DE00000000000000000D34 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift in Sources */,
+				E60812C95246E275F29D3C1B /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift in Sources */,
 				281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */,
 				72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */,
 				F0ACC0DE0000000000000005 /* WorkspaceForkConversationContextMenuTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2310,6 +2310,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		5B38DFE53BE108F4DA2BDBB7 /* WorkspaceTodoSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */; };
 		39EF42EF23A2F751429718CE /* WorkspaceTodoState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A243534CEB9E9A49B44453 /* WorkspaceTodoState.swift */; };
 		6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */; };
+		B95EC019F70D4F23BD3C8D1D /* WorkspaceWorkingDirectorySpawnUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81464EB0D515022903F26DD8 /* WorkspaceWorkingDirectorySpawnUITests.swift */; };
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
 /* End PBXBuildFile section */
 
@@ -4597,6 +4598,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTodoSnapshotTests.swift; sourceTree = "<group>"; };
 		E9A243534CEB9E9A49B44453 /* WorkspaceTodoState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTodoState.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
+		81464EB0D515022903F26DD8 /* WorkspaceWorkingDirectorySpawnUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceWorkingDirectorySpawnUITests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -4781,6 +4783,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */,
 				FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */,
 				7B5F1A2E9C0D4B6A8E217301 /* BrowserFixtureInteractionUITests.swift */,
+				81464EB0D515022903F26DD8 /* WorkspaceWorkingDirectorySpawnUITests.swift */,
 				8478B0000000000000000001 /* BrowserFixtureSocketTestCase+PendingRequest.swift */,
 				7B5F1A2E9C0D4B6A8E217303 /* BrowserReliabilityRegressionUITests.swift */,
 				8478A0000000000000000001 /* BrowserRecoveryHTTPServer.swift */,
@@ -9133,6 +9136,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */,
 				E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */,
 				F0F0A001A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift in Sources */,
+				B95EC019F70D4F23BD3C8D1D /* WorkspaceWorkingDirectorySpawnUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/cmuxTests/WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift
+++ b/cmuxTests/WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift
@@ -1,0 +1,50 @@
+import CmuxSettings
+import CmuxTerminalCore
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Workspace creation working-directory spawn policy", .serialized)
+struct WorkspaceCreationWorkingDirectorySpawnPolicyTests {
+    @Test("disabled inheritance passes Ghostty's home default to the first terminal")
+    func disabledInheritancePassesGhosttyHomeDefaultToFirstTerminal() throws {
+#if DEBUG
+        let previousOverride = TerminalStartupAppearancePreviewOverride.installed
+        TerminalStartupAppearancePreviewOverride.installed = TerminalStartupAppearancePreviewOverride(
+            loadsRealUserConfig: false,
+            previewConfigContents: { _ in "working-directory = home" }
+        )
+        GhosttyConfig.invalidateLoadCache()
+        defer {
+            TerminalStartupAppearancePreviewOverride.installed = previousOverride
+            GhosttyConfig.invalidateLoadCache()
+        }
+#endif
+
+        let suiteName = "WorkspaceCreationWorkingDirectorySpawnPolicyTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let settings = UserDefaultsSettingsClient(defaults: defaults)
+        settings.set(false, for: SettingCatalog().app.workspaceInheritWorkingDirectory)
+
+        let sourceDirectory = "/tmp/cmux-issue-8741-source-\(UUID().uuidString)"
+        let manager = TabManager(
+            initialWorkingDirectory: sourceDirectory,
+            autoWelcomeIfNeeded: false,
+            settings: settings
+        )
+
+        let workspace = manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let requestedDirectory = try #require(workspace.focusedTerminalPanel?.requestedWorkingDirectory)
+
+        #expect(requestedDirectory == FileManager.default.homeDirectoryForCurrentUser.path)
+        #expect(requestedDirectory != sourceDirectory)
+    }
+}

--- a/cmuxTests/WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift
+++ b/cmuxTests/WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift
@@ -1,5 +1,4 @@
 import CmuxSettings
-import CmuxTerminalCore
 import Foundation
 import Testing
 
@@ -14,19 +13,6 @@ import Testing
 struct WorkspaceCreationWorkingDirectorySpawnPolicyTests {
     @Test("disabled inheritance passes Ghostty's home default to the first terminal")
     func disabledInheritancePassesGhosttyHomeDefaultToFirstTerminal() throws {
-#if DEBUG
-        let previousOverride = TerminalStartupAppearancePreviewOverride.installed
-        TerminalStartupAppearancePreviewOverride.installed = TerminalStartupAppearancePreviewOverride(
-            loadsRealUserConfig: false,
-            previewConfigContents: { _ in "working-directory = home" }
-        )
-        GhosttyConfig.invalidateLoadCache()
-        defer {
-            TerminalStartupAppearancePreviewOverride.installed = previousOverride
-            GhosttyConfig.invalidateLoadCache()
-        }
-#endif
-
         let suiteName = "WorkspaceCreationWorkingDirectorySpawnPolicyTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -35,16 +21,18 @@ struct WorkspaceCreationWorkingDirectorySpawnPolicyTests {
         settings.set(false, for: SettingCatalog().app.workspaceInheritWorkingDirectory)
 
         let sourceDirectory = "/tmp/cmux-issue-8741-source-\(UUID().uuidString)"
+        let ghosttyDefaultDirectory = FileManager.default.homeDirectoryForCurrentUser.path
         let manager = TabManager(
             initialWorkingDirectory: sourceDirectory,
             autoWelcomeIfNeeded: false,
-            settings: settings
+            settings: settings,
+            defaultWorkspaceWorkingDirectoryProvider: { ghosttyDefaultDirectory }
         )
 
         let workspace = manager.addWorkspace(autoWelcomeIfNeeded: false)
         let requestedDirectory = try #require(workspace.focusedTerminalPanel?.requestedWorkingDirectory)
 
-        #expect(requestedDirectory == FileManager.default.homeDirectoryForCurrentUser.path)
+        #expect(requestedDirectory == ghosttyDefaultDirectory)
         #expect(requestedDirectory != sourceDirectory)
     }
 }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -3051,27 +3051,31 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
         }
     }
 
-    func testDisabledInheritanceLeavesNewWorkspaceCwdUnsetForGhosttyConfigFallback() throws {
+    func testDisabledInheritanceUsesGhosttyDefaultForNewWorkspaceCwd() throws {
         try withWorkspaceWorkingDirectoryInheritanceSetting(false) {
             let sourceCwd = "/tmp/cmux-source-\(UUID().uuidString)"
+            let fallbackCwd = "/tmp/cmux-ghostty-default-\(UUID().uuidString)"
             let manager = TabManager(
                 initialWorkingDirectory: sourceCwd,
-                autoWelcomeIfNeeded: false
+                autoWelcomeIfNeeded: false,
+                defaultWorkspaceWorkingDirectoryProvider: { fallbackCwd }
             )
 
             let inserted = manager.addWorkspace(autoWelcomeIfNeeded: false)
 
-            XCTAssertNil(inserted.focusedTerminalPanel?.requestedWorkingDirectory)
-            XCTAssertNotEqual(inserted.currentDirectory, sourceCwd)
+            XCTAssertEqual(inserted.focusedTerminalPanel?.requestedWorkingDirectory, fallbackCwd)
+            XCTAssertEqual(inserted.currentDirectory, fallbackCwd)
         }
     }
 
-    func testExplicitNoInheritanceLeavesNewWorkspaceCwdUnsetWhenGlobalInheritanceEnabled() throws {
+    func testExplicitNoInheritanceUsesGhosttyDefaultWhenGlobalInheritanceEnabled() throws {
         try withWorkspaceWorkingDirectoryInheritanceSetting(nil) {
             let sourceCwd = "/tmp/cmux-source-\(UUID().uuidString)"
+            let fallbackCwd = "/tmp/cmux-ghostty-default-\(UUID().uuidString)"
             let manager = TabManager(
                 initialWorkingDirectory: sourceCwd,
-                autoWelcomeIfNeeded: false
+                autoWelcomeIfNeeded: false,
+                defaultWorkspaceWorkingDirectoryProvider: { fallbackCwd }
             )
 
             let inserted = manager.addWorkspace(
@@ -3079,8 +3083,8 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
                 autoWelcomeIfNeeded: false
             )
 
-            XCTAssertNil(inserted.focusedTerminalPanel?.requestedWorkingDirectory)
-            XCTAssertNotEqual(inserted.currentDirectory, sourceCwd)
+            XCTAssertEqual(inserted.focusedTerminalPanel?.requestedWorkingDirectory, fallbackCwd)
+            XCTAssertEqual(inserted.currentDirectory, fallbackCwd)
         }
     }
 

--- a/cmuxUITests/BrowserFixtureInteractionUITests.swift
+++ b/cmuxUITests/BrowserFixtureInteractionUITests.swift
@@ -42,13 +42,13 @@ class BrowserFixtureSocketTestCase: XCTestCase {
     // MARK: - Launch
 
     @discardableResult
-    func launchApp() throws -> XCUIApplication {
+    func launchApp(additionalLaunchArguments: [String] = []) throws -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments += [
             "-socketControlMode", "allowAll",
             "-AppleLanguages", "(en)",
             "-AppleLocale", "en_US",
-        ]
+        ] + additionalLaunchArguments
         app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
         app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
         app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"

--- a/cmuxUITests/SettingsAppBehaviorUITests.swift
+++ b/cmuxUITests/SettingsAppBehaviorUITests.swift
@@ -38,9 +38,6 @@ import XCTest
 ///     observable after creating ≥2 workspaces and inspecting sidebar
 ///     order; requires workspace scaffolding the fresh UI-test launch
 ///     does not have (CMUX_UI_TEST_MODE skips session restore).
-///   - Inherit CWD effect on a real new workspace (the *subtitle* swap is
-///     TIER 1 below; the actual working-directory inheritance needs a
-///     spawned terminal to inspect, which is a terminal-surface seam).
 ///   - Keep Workspace Open When Closing Last Surface
 ///     (closeWorkspaceOnLastSurfaceShortcut): only observable by closing
 ///     the last surface of a real workspace and checking whether the
@@ -124,7 +121,7 @@ final class SettingsAppBehaviorUITests: SettingsUITestCase {
         static let minimalOff = "Use the standard workspace title bar and controls."
 
         static let inheritOn = "New workspaces start in the focused workspace's working directory."
-        static let inheritOff = "New workspaces leave their working directory unset so Ghostty's working-directory setting can apply."
+        static let inheritOff = "New workspaces use Ghostty's working-directory setting instead."
 
         static let paletteOn = "Cmd+P also matches panel surfaces across workspaces."
         static let paletteOff = "Cmd+P matches workspace rows only."
@@ -207,7 +204,7 @@ final class SettingsAppBehaviorUITests: SettingsUITestCase {
 
         XCTAssertTrue(
             poll(timeout: 4.0) { subtitleText(window, Subtitle.inheritOff).exists },
-            "Disabling inherit should show the unset-working-directory subtitle"
+            "Disabling inherit should show the Ghostty working-directory subtitle"
         )
         XCTAssertTrue(
             poll(timeout: 4.0) { !subtitleText(window, Subtitle.inheritOn).exists },

--- a/cmuxUITests/WorkspaceWorkingDirectorySpawnUITests.swift
+++ b/cmuxUITests/WorkspaceWorkingDirectorySpawnUITests.swift
@@ -33,6 +33,7 @@ final class WorkspaceWorkingDirectorySpawnUITests: BrowserFixtureSocketTestCase 
             ],
             responseTimeout: 12.0
         )
+        let sourceWorkspaceID = try XCTUnwrap(source["workspace_id"] as? String)
         let sourceSurfaceID = try XCTUnwrap(source["surface_id"] as? String)
         let sourceOutput = try XCTUnwrap(
             waitForScreenLine(prefix: "SOURCE_CWD=/", surfaceID: sourceSurfaceID, timeout: 12.0),
@@ -45,7 +46,14 @@ final class WorkspaceWorkingDirectorySpawnUITests: BrowserFixtureSocketTestCase 
             params: ["surface_id": sourceSurfaceID]
         )
         app.activate()
-        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        XCTAssertTrue(
+            waitForFocusedSurface(
+                workspaceID: sourceWorkspaceID,
+                surfaceID: sourceSurfaceID,
+                timeout: 5.0
+            ),
+            "Expected source terminal to become the focused surface"
+        )
 
         let target = try socketResult(
             method: "workspace.create",
@@ -56,7 +64,16 @@ final class WorkspaceWorkingDirectorySpawnUITests: BrowserFixtureSocketTestCase 
             ],
             responseTimeout: 12.0
         )
+        let targetWorkspaceID = try XCTUnwrap(target["workspace_id"] as? String)
         let targetSurfaceID = try XCTUnwrap(target["surface_id"] as? String)
+        let expectedDirectory = try XCTUnwrap(
+            waitForRequestedWorkingDirectory(
+                workspaceID: targetWorkspaceID,
+                surfaceID: targetSurfaceID,
+                timeout: 5.0
+            ),
+            "Expected workspace policy to provide a concrete Ghostty default"
+        )
         let targetOutput = try XCTUnwrap(
             waitForScreenLine(prefix: "SPAWN_CWD=/", surfaceID: targetSurfaceID, timeout: 12.0),
             "Expected new workspace shell to report its spawn cwd"
@@ -64,10 +81,76 @@ final class WorkspaceWorkingDirectorySpawnUITests: BrowserFixtureSocketTestCase 
         let spawnedDirectory = String(targetOutput.dropFirst("SPAWN_CWD=".count))
 
         XCTAssertNotEqual(
-            spawnedDirectory,
+            expectedDirectory,
             sourceDirectory.path,
-            "Disabled workspace cwd inheritance must reach the spawned shell"
+            "Disabled workspace cwd inheritance must choose the Ghostty default"
         )
+        XCTAssertEqual(
+            spawnedDirectory,
+            expectedDirectory,
+            "The concrete Ghostty default must reach the spawned shell"
+        )
+    }
+
+    private func waitForFocusedSurface(
+        workspaceID: String,
+        surfaceID: String,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if currentSurfaceMatches(workspaceID: workspaceID, surfaceID: surfaceID) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        return currentSurfaceMatches(workspaceID: workspaceID, surfaceID: surfaceID)
+    }
+
+    private func currentSurfaceMatches(workspaceID: String, surfaceID: String) -> Bool {
+        guard let envelope = socketEnvelope(
+            method: "surface.current",
+            params: [:],
+            responseTimeout: 2.0
+        ),
+              envelope["ok"] as? Bool == true,
+              let result = envelope["result"] as? [String: Any] else {
+            return false
+        }
+        return result["workspace_id"] as? String == workspaceID
+            && result["surface_id"] as? String == surfaceID
+    }
+
+    private func waitForRequestedWorkingDirectory(
+        workspaceID: String,
+        surfaceID: String,
+        timeout: TimeInterval
+    ) -> String? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let directory = requestedWorkingDirectory(
+                workspaceID: workspaceID,
+                surfaceID: surfaceID
+            ) {
+                return directory
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        return requestedWorkingDirectory(workspaceID: workspaceID, surfaceID: surfaceID)
+    }
+
+    private func requestedWorkingDirectory(workspaceID: String, surfaceID: String) -> String? {
+        guard let envelope = socketEnvelope(
+            method: "surface.list",
+            params: ["workspace_id": workspaceID],
+            responseTimeout: 2.0
+        ), envelope["ok"] as? Bool == true,
+           let result = envelope["result"] as? [String: Any],
+           let surfaces = result["surfaces"] as? [[String: Any]],
+           let surface = surfaces.first(where: { $0["id"] as? String == surfaceID }) else {
+            return nil
+        }
+        return surface["requested_working_directory"] as? String
     }
 
     private func waitForScreenLine(

--- a/cmuxUITests/WorkspaceWorkingDirectorySpawnUITests.swift
+++ b/cmuxUITests/WorkspaceWorkingDirectorySpawnUITests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+
+final class WorkspaceWorkingDirectorySpawnUITests: BrowserFixtureSocketTestCase {
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDown() {
+        super.tearDown()
+        for directory in temporaryDirectories {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        temporaryDirectories = []
+    }
+
+    func testDisabledInheritanceDoesNotReachSpawnedShell() throws {
+        let sourceDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-issue-8741-source-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        temporaryDirectories.append(sourceDirectory)
+
+        let app = try launchApp(additionalLaunchArguments: [
+            "-workspaceInheritWorkingDirectory", "false",
+        ])
+        app.activate()
+
+        let source = try socketResult(
+            method: "workspace.create",
+            params: [
+                "title": "Issue 8741 source",
+                "working_directory": sourceDirectory.path,
+                "initial_command": #"printf 'SOURCE_CWD=%s\n' "$PWD"; sleep 60"#,
+                "focus": true,
+            ],
+            responseTimeout: 12.0
+        )
+        let sourceSurfaceID = try XCTUnwrap(source["surface_id"] as? String)
+        let sourceOutput = try XCTUnwrap(
+            waitForScreenLine(prefix: "SOURCE_CWD=/", surfaceID: sourceSurfaceID, timeout: 12.0),
+            "Expected source shell to report its cwd"
+        )
+        XCTAssertEqual(sourceOutput, "SOURCE_CWD=\(sourceDirectory.path)")
+
+        _ = try socketResult(
+            method: "surface.focus",
+            params: ["surface_id": sourceSurfaceID]
+        )
+        app.activate()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        let target = try socketResult(
+            method: "workspace.create",
+            params: [
+                "title": "Issue 8741 probe",
+                "initial_command": #"printf 'SPAWN_CWD=%s\n' "$PWD"; sleep 60"#,
+                "focus": false,
+            ],
+            responseTimeout: 12.0
+        )
+        let targetSurfaceID = try XCTUnwrap(target["surface_id"] as? String)
+        let targetOutput = try XCTUnwrap(
+            waitForScreenLine(prefix: "SPAWN_CWD=/", surfaceID: targetSurfaceID, timeout: 12.0),
+            "Expected new workspace shell to report its spawn cwd"
+        )
+        let spawnedDirectory = String(targetOutput.dropFirst("SPAWN_CWD=".count))
+
+        XCTAssertNotEqual(
+            spawnedDirectory,
+            sourceDirectory.path,
+            "Disabled workspace cwd inheritance must reach the spawned shell"
+        )
+    }
+
+    private func waitForScreenLine(
+        prefix: String,
+        surfaceID: String,
+        timeout: TimeInterval
+    ) -> String? {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if let line = screenLine(prefix: prefix, surfaceID: surfaceID) {
+                return line
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        } while Date() < deadline
+        return screenLine(prefix: prefix, surfaceID: surfaceID)
+    }
+
+    private func screenLine(prefix: String, surfaceID: String) -> String? {
+        guard let envelope = socketEnvelope(
+            method: "surface.read_text",
+            params: ["surface_id": surfaceID],
+            responseTimeout: 2.0
+        ), envelope["ok"] as? Bool == true,
+           let result = envelope["result"] as? [String: Any],
+           let text = result["text"] as? String else {
+            return nil
+        }
+        return text
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { $0.hasPrefix(prefix) }
+    }
+}

--- a/skills/cmux-settings/references/all-keys.md
+++ b/skills/cmux-settings/references/all-keys.md
@@ -13,7 +13,7 @@ General app preferences from Settings > App.
 | `app.appIcon` | `"automatic"` or `"light"` or `"dark"` | `"automatic"` | Dock and app switcher icon style. |
 | `app.menuBarOnly` | boolean | `false` | Hide the Dock icon and app switcher entry while keeping cmux available from the menu bar. |
 | `app.newWorkspacePlacement` | `"top"` or `"afterCurrent"` or `"end"` | `"afterCurrent"` | Where new workspaces are inserted in the sidebar. |
-| `app.workspaceInheritWorkingDirectory` | boolean | `true` | When true, new workspaces inherit the current workspace working directory. When false, new workspaces leave the working directory unset so Ghostty's working-directory setting can provide the default. |
+| `app.workspaceInheritWorkingDirectory` | boolean | `true` | When true, new workspaces inherit the current workspace working directory. When false, new workspaces use Ghostty's working-directory setting instead. |
 | `app.minimalMode` | boolean | `false` | Hide the workspace title bar and move controls into the sidebar. |
 | `app.keepWorkspaceOpenWhenClosingLastSurface` | boolean | `false` | When true, closing the last surface keeps the workspace open. |
 | `app.focusPaneOnFirstClick` | boolean | `true` | When cmux is inactive, the first click can activate and focus the clicked pane. |

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -434,7 +434,7 @@
         "workspaceInheritWorkingDirectory": {
           "type": "boolean",
           "default": true,
-          "description": "When true, new workspaces inherit the current workspace working directory. When false, new workspaces leave the working directory unset so Ghostty's working-directory setting can provide the default."
+          "description": "When true, new workspaces inherit the current workspace working directory. When false, new workspaces use Ghostty's working-directory setting instead."
         },
         "minimalMode": {
           "type": "boolean",


### PR DESCRIPTION
Summary
- resolve Ghostty working-directory values before creating a workspace when cmux inheritance is disabled
- apply one explicit > inherited > Ghostty-default policy on the shared GUI and CLI creation path
- add model and spawned-shell regression coverage
- update the localized Settings description and config schema wording

Testing
- arch -arm64 /usr/bin/xcrun swift test --filter WorkspaceCreationWorkingDirectoryPolicyTests
- terminal-core resolver typechecked with Swift 6
- project normalization, test wiring, package grouping, Package.resolved policy, JSON, and localization checks
- targeted app and UI tests dispatched through GitHub Actions

Closes #8741

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787692032&installation_model_id=21920&pr_number=8966&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8966&signature=47a46520d9ffb9c6dd4e94401cb3a67cde2afe090cfc79c8f4c008e1459a6153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disabled workspace working-directory inheritance so new workspaces use Ghostty’s working-directory default when inheritance is off, and ensures spawned shells receive the correct cwd. Applies one precedence across GUI and CLI: explicit > inherited (if enabled) > Ghostty default.

- **Bug Fixes**
  - Resolve Ghostty `working-directory` into an absolute path (supports `home`, `inherit`, `~/...`, and absolute paths) via `GhosttyWorkingDirectoryResolver`.
  - Use `WorkspaceCreationWorkingDirectoryPolicy` in `TabManager` to pick the cwd and pass it to terminal spawn; inject `defaultWorkspaceWorkingDirectoryProvider` (derived from `GhosttyConfig.load().workingDirectory`, process cwd, and user home) so GUI and CLI share the same environment.
  - Update Settings subtitle and `cmux.schema.json` description to reflect the behavior.
  - Add unit tests, spawn-policy integration tests, and a socket-driven UI test that verifies the spawned shell uses the Ghostty default (not the source cwd); UI test harness accepts additional launch arguments.

<sup>Written for commit 38994412875c7c7ca3e80a11d31de15ce2de829e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New workspaces now use Ghostty’s configured working directory when working-directory inheritance is disabled.
  * Working-directory selection now consistently prioritizes explicit, inherited, then default locations.
  * Added support for resolving Ghostty values such as `home`, `inherit`, and `~` paths.

* **UI & Documentation**
  * Updated setting descriptions and translations to clarify the new behavior.

* **Tests**
  * Added coverage for working-directory resolution, workspace creation, and terminal spawning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->