### PR TITLE
Fix blank panes after skipped initial layout

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -68,12 +68,21 @@ extension TerminalSurface {
     /// surface even if higher-level layout bookkeeping is momentarily stale.
     public var isRendererPortalVisible: Bool { rendererPortalVisible }
 
-    /// Whether the native surface view and its pane host are both attached to
-    /// the same real presentation window. A hidden bootstrap window is useful
-    /// for starting the PTY, but it cannot safely host the first drawable.
+    /// Whether the native surface view and its pane host have usable drawable
+    /// geometry in the same real presentation window. A hidden bootstrap window
+    /// can start the PTY, and a zero-sized real-window attachment can establish
+    /// ownership, but neither is enough to present a renderer.
     @MainActor
-    private var isRendererPresentationAttachmentReady: Bool {
-        return attachedView?.window != nil && uiWindow != nil
+    private var isRendererPresentationReady: Bool {
+        guard let attachedView,
+              let presentationWindow = uiWindow,
+              attachedView.window === presentationWindow else { return false }
+        let surfaceSize = attachedView.bounds.size
+        let paneSize = paneHost.bounds.size
+        return surfaceSize.width.isFinite && surfaceSize.height.isFinite &&
+            paneSize.width.isFinite && paneSize.height.isFinite &&
+            surfaceSize.width > 1 && surfaceSize.height > 1 &&
+            paneSize.width > 1 && paneSize.height > 1
     }
 
     /// Record the portal visibility transition for reclamation. Called from
@@ -86,12 +95,12 @@ extension TerminalSurface {
     public func setRendererPortalVisible(_ visible: Bool) {
         setRendererPortalVisible(
             visible,
-            attachmentReady: isRendererPresentationAttachmentReady
+            presentationReady: isRendererPresentationReady
         )
     }
 
     @MainActor
-    func setRendererPortalVisible(_ visible: Bool, attachmentReady: Bool) {
+    func setRendererPortalVisible(_ visible: Bool, presentationReady: Bool) {
         let wasVisible = rendererPortalVisible
         rendererPortalVisible = visible
         if !visible {
@@ -103,7 +112,7 @@ extension TerminalSurface {
         // while Ghostty is still occluded; occlusion is lifted only after the
         // native realization enqueue below.
         if visible {
-            ensureRendererPresented(attachmentReady: attachmentReady)
+            ensureRendererPresented(presentationReady: presentationReady)
         }
         // Stamp the last-visible time while visible, and exactly once at the hide
         // transition (the hide moment is the last-visible time). Do NOT re-stamp
@@ -129,16 +138,16 @@ extension TerminalSurface {
     @MainActor
     func rendererRuntimeSurfaceDidCreate() {
         rendererRuntimeSurfaceDidCreate(
-            attachmentReady: isRendererPresentationAttachmentReady
+            presentationReady: isRendererPresentationReady
         )
     }
 
     @MainActor
-    func rendererRuntimeSurfaceDidCreate(attachmentReady: Bool) {
+    func rendererRuntimeSurfaceDidCreate(presentationReady: Bool) {
         rendererPresentationPhase = .awaitingFirstPresentation
         surfaceCallbackContext?.takeUnretainedValue().cancelRendererPresentationRepair()
         guard surface != nil else { return }
-        if rendererPortalVisible, attachmentReady {
+        if rendererPortalVisible, presentationReady {
             rendererPresentationPhase = .presented
             setOcclusion(true)
         } else {
@@ -151,13 +160,14 @@ extension TerminalSurface {
         }
     }
 
-    /// Completes a deferred first presentation after AppKit attaches the pane
-    /// to a real window. Both `attachToView` and the already-attached reconcile
-    /// path call this so portal reparenting cannot strand a released renderer.
+    /// Completes a deferred first presentation after AppKit supplies both a real
+    /// window and usable drawable geometry. Attachment and sizing paths call this
+    /// transition, so a skipped reentrant layout can recover on the next normal
+    /// layout pass without forcing the hosting hierarchy to lay out recursively.
     @MainActor
-    func rendererPresentationAttachmentDidBecomeReady() {
-        guard rendererPortalVisible, isRendererPresentationAttachmentReady else { return }
-        ensureRendererPresented(attachmentReady: true)
+    public func rendererPresentationReadinessDidChange() {
+        guard rendererPortalVisible, isRendererPresentationReady else { return }
+        ensureRendererPresented(presentationReady: true)
     }
 
     /// Release the runtime surface's GPU renderer (Metal swap chain / IOSurface)
@@ -176,7 +186,7 @@ extension TerminalSurface {
         // A visible portal is protected once it is actually attached. Before
         // that point (including the hidden bootstrap window), release is the
         // normalization step that makes first presentation safe and retryable.
-        guard !rendererPortalVisible || !isRendererPresentationAttachmentReady else { return false }
+        guard !rendererPortalVisible || !isRendererPresentationReady else { return false }
         // The reclamation controller is default-on and scans every registered
         // wrapper, so validate the native pointer (registry ownership +
         // liveness) before the C call instead of trusting `surface != nil`.
@@ -208,17 +218,17 @@ extension TerminalSurface {
     @MainActor
     public func ensureRendererPresented() {
         ensureRendererPresented(
-            attachmentReady: isRendererPresentationAttachmentReady
+            presentationReady: isRendererPresentationReady
         )
     }
 
     @MainActor
-    func ensureRendererPresented(attachmentReady: Bool) {
+    func ensureRendererPresented(presentationReady: Bool) {
 #if os(macOS)
-        // `setVisibleInUI(true)` can precede Dock portal reattachment. Do not
-        // realize against a windowless/headless layer and then mirror that
-        // enqueue as a completed presentation.
-        guard attachmentReady else { return }
+        // `setVisibleInUI(true)` can precede portal reattachment or completed
+        // layout. Do not realize against a windowless/headless/zero-sized layer
+        // and then mirror that enqueue as a completed presentation.
+        guard presentationReady else { return }
         guard rendererPresentationPhase != .presented else { return }
         guard let surface = liveSurfaceForGhosttyAccess(reason: "renderer.ensurePresented") else { return }
         let callbackContext = surfaceCallbackContext?.takeUnretainedValue()
@@ -264,15 +274,15 @@ extension TerminalSurface {
     @MainActor
     public func retryRendererPresentationAfterActivity() {
         retryRendererPresentationAfterActivity(
-            attachmentReady: isRendererPresentationAttachmentReady
+            presentationReady: isRendererPresentationReady
         )
     }
 
     @MainActor
-    func retryRendererPresentationAfterActivity(attachmentReady: Bool) {
+    func retryRendererPresentationAfterActivity(presentationReady: Bool) {
         guard rendererPortalVisible,
               hasLiveSurface,
               rendererPresentationPhase != .presented else { return }
-        ensureRendererPresented(attachmentReady: attachmentReady)
+        ensureRendererPresented(presentationReady: presentationReady)
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -111,7 +111,7 @@ extension TerminalSurface {
            let s = liveSurfaceForGhosttyAccess(reason: "reconcileAttachedWindow") {
             ghostty_surface_set_display_id(s, displayID)
         }
-        rendererPresentationAttachmentDidBecomeReady()
+        rendererPresentationReadinessDidChange()
     }
 
     /// Whether the surface model is attached to `view` with a live runtime
@@ -413,7 +413,7 @@ extension TerminalSurface {
                let s = surface {
                 ghostty_surface_set_display_id(s, displayID)
             }
-            rendererPresentationAttachmentDidBecomeReady()
+            rendererPresentationReadinessDidChange()
             return
         }
 
@@ -472,7 +472,7 @@ extension TerminalSurface {
             logDebugEvent("surface.attach.displayId surface=\(id.uuidString.prefix(5)) display=\(displayID)")
 #endif
         }
-        rendererPresentationAttachmentDidBecomeReady()
+        rendererPresentationReadinessDidChange()
     }
 
     @MainActor

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceRendererPresentationTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceRendererPresentationTests.swift
@@ -59,7 +59,7 @@ private func rendererReleaseWasOccluded() -> Bool
 
         surface.paneHost.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         surface.surfaceView.frame = surface.paneHost.bounds
-        surface.rendererPresentationAttachmentDidBecomeReady()
+        surface.rendererPresentationReadinessDidChange()
 
         #expect(surface.isRendererPresented)
         #expect(rendererRealizedCalls() == [false, true])
@@ -71,9 +71,9 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: false)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: false)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -82,13 +82,13 @@ private func rendererReleaseWasOccluded() -> Bool
 
         #expect(rendererRealizedCalls() == [false])
 
-        surface.setRendererPortalVisible(true, attachmentReady: false)
+        surface.setRendererPortalVisible(true, presentationReady: false)
 
         #expect(surface.isRendererPortalVisible)
         #expect(!surface.isRendererPresented)
         #expect(rendererRealizedCalls() == [false])
 
-        surface.ensureRendererPresented(attachmentReady: true)
+        surface.ensureRendererPresented(presentationReady: true)
 
         #expect(surface.isRendererPresented)
         #expect(rendererRealizedCalls() == [false, true])
@@ -100,9 +100,9 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -112,13 +112,13 @@ private func rendererReleaseWasOccluded() -> Bool
         #expect(!surface.isRendererRealized)
         #expect(rendererRealizedCalls() == [false])
 
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
 
         #expect(surface.isRendererPortalVisible)
         #expect(surface.isRendererRealized)
         #expect(rendererRealizedCalls() == [false, true])
 
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
 
         #expect(rendererRealizedCalls() == [false, true])
     }
@@ -129,9 +129,9 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -148,9 +148,9 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -162,7 +162,7 @@ private func rendererReleaseWasOccluded() -> Bool
         #expect(surface.isRendererPresented)
         #expect(rendererRealizedCalls().isEmpty)
 
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
 
         #expect(rendererRealizedCalls().isEmpty)
     }
@@ -173,23 +173,23 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
             resetRendererRealizedTracking()
         }
 
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
 
         #expect(surface.releaseRenderer())
         #expect(!surface.isRendererRealized)
         #expect(rendererRealizedCalls() == [false])
 
-        surface.setRendererPortalVisible(true, attachmentReady: true)
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
 
         #expect(surface.isRendererPresented)
         #expect(rendererRealizedCalls() == [false, true])
@@ -204,9 +204,9 @@ private func rendererReleaseWasOccluded() -> Bool
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
         setRendererRealizedResult(false)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -215,7 +215,7 @@ private func rendererReleaseWasOccluded() -> Bool
 
         beginRendererRealizedTracking(runtimeSurface)
         setRendererRealizedResult(false)
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
 
         #expect(!surface.isRendererPresented)
         #expect(rendererRealizedCalls() == [false])
@@ -224,7 +224,7 @@ private func rendererReleaseWasOccluded() -> Bool
         setRendererRealizedResult(true)
         scheduler.onSchedule = { surfaceID in
             #expect(surfaceID == surface.id)
-            surface.retryRendererPresentationAfterActivity(attachmentReady: true)
+            surface.retryRendererPresentationAfterActivity(presentationReady: true)
         }
         terminalRendererEventCallback(
             callbackContext.toOpaque(),
@@ -253,9 +253,9 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -266,9 +266,9 @@ private func rendererReleaseWasOccluded() -> Bool
         setRendererRealizedResult(false)
         scheduler.onSchedule = { surfaceID in
             #expect(surfaceID == surface.id)
-            surface.retryRendererPresentationAfterActivity(attachmentReady: true)
+            surface.retryRendererPresentationAfterActivity(presentationReady: true)
         }
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
         terminalRendererEventCallback(
             callbackContext.toOpaque(),
             GHOSTTY_RENDERER_EVENT_UPDATE_FRAME_END
@@ -297,9 +297,9 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -308,10 +308,10 @@ private func rendererReleaseWasOccluded() -> Bool
 
         beginRendererRealizedTracking(runtimeSurface)
         setRendererRealizedResult(false)
-        surface.setRendererPortalVisible(true, attachmentReady: true)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         callbackContext.takeUnretainedValue().rendererMailboxDidDrain()
-        surface.retryRendererPresentationAfterActivity(attachmentReady: true)
+        surface.retryRendererPresentationAfterActivity(presentationReady: true)
 
         #expect(!surface.isRendererPresented)
         #expect(rendererRealizedCalls() == [true])
@@ -326,9 +326,9 @@ private func rendererReleaseWasOccluded() -> Bool
         let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
         registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
         beginRendererRealizedTracking(runtimeSurface)
-        surface.setRendererPortalVisible(false, attachmentReady: true)
+        surface.setRendererPortalVisible(false, presentationReady: true)
         surface.installRuntimeSurfaceForTesting(runtimeSurface)
-        surface.rendererRuntimeSurfaceDidCreate(attachmentReady: true)
+        surface.rendererRuntimeSurfaceDidCreate(presentationReady: true)
         defer {
             surface.releaseSurfaceForTesting()
             runtimeSurface.deallocate()
@@ -341,10 +341,10 @@ private func rendererReleaseWasOccluded() -> Bool
         scheduler.onSchedule = { surfaceID in
             #expect(surfaceID == surface.id)
             queuedRepair = {
-                surface.retryRendererPresentationAfterActivity(attachmentReady: true)
+                surface.retryRendererPresentationAfterActivity(presentationReady: true)
             }
         }
-        surface.setRendererPortalVisible(true, attachmentReady: true)
+        surface.setRendererPortalVisible(true, presentationReady: true)
         terminalRendererEventCallback(
             callbackContext.toOpaque(),
             GHOSTTY_RENDERER_EVENT_UPDATE_FRAME_END

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceRendererPresentationTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceRendererPresentationTests.swift
@@ -24,6 +24,47 @@ private func rendererReleaseWasOccluded() -> Bool
 
 @MainActor
 @Suite(.serialized) struct TerminalSurfaceRendererPresentationTests {
+    @Test func visibleRuntimeWaitsForUsableDrawableGeometry() {
+        let registry = TerminalSurfaceRegistry()
+        let surface = makeSurface(registry: registry)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        surface.paneHost.frame = .zero
+        surface.surfaceView.frame = .zero
+        window.contentView?.addSubview(surface.paneHost)
+        surface.attachedView = surface.surfaceView
+
+        let runtimeSurface = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        registry.registerRuntimeSurface(runtimeSurface, ownerId: surface.id)
+        beginRendererRealizedTracking(runtimeSurface)
+        surface.setRendererPortalVisible(true)
+        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+        surface.rendererRuntimeSurfaceDidCreate()
+        defer {
+            surface.releaseSurfaceForTesting()
+            runtimeSurface.deallocate()
+            resetRendererRealizedTracking()
+            window.contentView = nil
+            window.close()
+        }
+
+        #expect(surface.isRendererPortalVisible)
+        #expect(!surface.isRendererPresented)
+        #expect(rendererRealizedCalls() == [false])
+
+        surface.paneHost.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        surface.surfaceView.frame = surface.paneHost.bounds
+        surface.rendererPresentationAttachmentDidBecomeReady()
+
+        #expect(surface.isRendererPresented)
+        #expect(rendererRealizedCalls() == [false, true])
+    }
+
     @Test func firstPresentationWaitsUntilTheSurfaceIsAttachedToARealWindow() {
         let registry = TerminalSurfaceRegistry()
         let surface = makeSurface(registry: registry)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11162,9 +11162,9 @@ final class GhosttySurfaceScrollView: NSView {
         let width = max(0, surfaceView.frame.width)
         let height = surfaceView.frame.height
         guard width > 0, height > 0 else { return false }
+        defer { surfaceView.terminalSurface?.rendererPresentationReadinessDidChange() }
         return surfaceView.pushTargetSurfaceSize(CGSize(width: width, height: height))
     }
-
     private func updateNotificationRingPath() {
         updateOverlayRingPath(
             layer: notificationRingLayer,


### PR DESCRIPTION
## Summary

- require a visible terminal's pane host and native surface to share the same real window and have finite, usable drawable geometry before marking its renderer presented
- retry the deferred first presentation from normal AppKit geometry synchronization, without forcing another SwiftUI/AppKit layout pass
- add behavioral coverage for the zero-sized, real-window-attached state produced when SwiftUI skips a reentrant layout

## Root cause

Renderer creation and real-window attachment were treated as successful presentation. When SwiftUI skipped a reentrant initial layout, a new split/tab could be attached while its pane and drawable remained zero-sized; cmux then marked the renderer presented and had no later state transition to repair it.

## Regression proof

The history intentionally uses two commits:

1. `789b2c1fd5` adds the regression test only. Against the old implementation it fails because the zero-sized renderer is already marked presented and emits no release/realize transition.
2. `1e53bee1c2` adds the fix. `TerminalSurfaceRendererPresentationTests` passes all 10 tests, including the new `[false, true]` release/realize sequence after geometry becomes usable.

## Verification

- `arch -arm64 swift test --filter TerminalSurfaceRendererPresentationTests` builds and reports all 10 tests passing; SwiftPM itself exits nonzero only for the checkout's pre-existing `ghostty-internal.a` artifact-name diagnostic
- direct arm64 Swift Testing bundle run: 10/10 passed, exit 0
- `xcrun swiftc -parse` on all four changed Swift files
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- `git diff --check`
- canonical HQ autoreview: clean, no actionable findings; merge-conflict gate clean against `origin/main`
- all required PR checks green; GitHub reports `MERGEABLE`

The explicitly dispatched full CI run is blocked before macOS/package jobs by an unrelated failure already present on `origin/main`: `workflow-guard-tests` rejects `.github/workflows/cmux-tui-build-package.yml:376` for bare `runs-on: ubuntu-latest`. The PR does not touch workflow files; downstream `linux-preflight`, `tests`, and `ci-status` failures are cascading. Run: https://github.com/manaflow-ai/cmux/actions/runs/30220859303

## Cloud macOS 26 evidence

Direct CUA reproduction was blocked because the GUI-ready cloud runner never became visible on the controller's Tailscale peer list; provisioning timed out and the lease was cancelled: https://github.com/manaflow-ai/cmux-loader/actions/runs/30219832513

## File budget and localization

`Sources/GhosttyTerminalView.swift` remains exactly 12,551 lines and no budget TSV changed. This checkout does not contain `scripts/swift_file_length_budget.py` or `.github/swift-file-length-budget.tsv`, so that requested validator could not run.

No user-facing strings or localized surfaces changed. The localization audit confirmed the diff contains only renderer lifecycle logic and tests, with no additions to `Resources/Localizable.xcstrings` or web message catalogs required.

Closes #8918
