### PR TITLE
Navigate search results with navigate_search, not search (Cmd-G searched for the word "next")

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -524,6 +524,25 @@ func shouldRouteTerminalFontZoomShortcutToGhostty(
         literalChars: literalChars
     ) != nil
 }
+
+/// Ghostty binding actions that move between the results of a search that is
+/// already running.
+///
+/// Ghostty parses a binding action as `action:parameter`, and its two search
+/// actions are not interchangeable:
+///
+/// - `search:<text>` starts a *new* search for `<text>`, replacing any active
+///   one. `search:next` therefore searches for the literal word "next".
+/// - `navigate_search:<previous|next>` steps through the existing results.
+///
+/// These are constants rather than literals at each call site because the two
+/// spellings drifted apart once they were duplicated: the find bar navigated
+/// with `navigate_search:`, while Find Next / Find Previous sent `search:`.
+enum TerminalSearchNavigationAction {
+    static let next = "navigate_search:next"
+    static let previous = "navigate_search:previous"
+}
+
 // Main-actor isolated: TerminalSurface.searchState carries the legacy
 // main-thread-only contract as compiler-enforced isolation after the
 // CmuxTerminal lift; both callers (TabManager, overlay tests) are @MainActor.

--- a/Sources/Find/SurfaceSearchOverlay.swift
+++ b/Sources/Find/SurfaceSearchOverlay.swift
@@ -52,8 +52,8 @@ struct SurfaceSearchOverlay: View {
                     },
                     onReturn: { isShift in
                         let action = isShift
-                            ? "navigate_search:previous"
-                            : "navigate_search:next"
+                            ? TerminalSearchNavigationAction.previous
+                            : TerminalSearchNavigationAction.next
                         onNavigateSearch(action)
                     }
                 )
@@ -85,7 +85,7 @@ struct SurfaceSearchOverlay: View {
                     #if DEBUG
                     cmuxDebugLog("findbar.next surface=\(surfaceId.uuidString.prefix(5))")
                     #endif
-                    onNavigateSearch("navigate_search:next")
+                    onNavigateSearch(TerminalSearchNavigationAction.next)
                 }) {
                     Image(systemName: "chevron.up")
                 }
@@ -96,7 +96,7 @@ struct SurfaceSearchOverlay: View {
                     #if DEBUG
                     cmuxDebugLog("findbar.prev surface=\(surfaceId.uuidString.prefix(5))")
                     #endif
-                    onNavigateSearch("navigate_search:previous")
+                    onNavigateSearch(TerminalSearchNavigationAction.previous)
                 }) {
                     Image(systemName: "chevron.down")
                 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -834,7 +834,7 @@ class TabManager: ObservableObject {
 
     func findNext() {
         if let panel = selectedTerminalPanel {
-            _ = panel.performBindingAction("search:next")
+            _ = panel.performBindingAction(TerminalSearchNavigationAction.next)
             return
         }
 
@@ -843,7 +843,7 @@ class TabManager: ObservableObject {
 
     func findPrevious() {
         if let panel = selectedTerminalPanel {
-            _ = panel.performBindingAction("search:previous")
+            _ = panel.performBindingAction(TerminalSearchNavigationAction.previous)
             return
         }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4467,6 +4467,22 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         )
     }
 
+    func testTerminalSearchNavigationUsesNavigateSearchRatherThanStartingANewSearch() {
+        // Ghostty parses binding actions as `action:parameter`. `search:<text>`
+        // starts a new search for `<text>`, so `search:next` searched the
+        // scrollback for the literal word "next" and discarded the user's query.
+        // Only `navigate_search:<previous|next>` steps through existing results.
+        XCTAssertEqual(TerminalSearchNavigationAction.next, "navigate_search:next")
+        XCTAssertEqual(TerminalSearchNavigationAction.previous, "navigate_search:previous")
+
+        for action in [TerminalSearchNavigationAction.next, TerminalSearchNavigationAction.previous] {
+            XCTAssertTrue(
+                action.hasPrefix("navigate_search:"),
+                "\(action) must navigate existing results; a bare `search:` prefix starts a new search for the parameter text"
+            )
+        }
+    }
+
     func testEscapeDismissingFindOverlayDoesNotLeakEscapeKeyUpToTerminal() {
         _ = NSApplication.shared
 


### PR DESCRIPTION
## Summary

**What changed?** `TabManager.findNext()` / `findPrevious()` now send Ghostty `navigate_search:next` / `navigate_search:previous` instead of `search:next` / `search:previous`.

**Why?** Cmd-G (Find Next) searched the scrollback for the literal word **"next"**, throwing away whatever the user had typed into the find bar. Cmd-Opt-G did the same with "previous".

Ghostty parses a binding action as `action:parameter`, and its two search actions are not interchangeable — from `ghostty +list-actions --docs`:

```
search:
  Start a search for the given text. If the text is empty, then
  the search is canceled. …
  If a previous search is active, it is replaced.

navigate_search:
  Navigate the search results. If there is no active search, this
  is not performed.

  Valid values: `previous`, `next`.
```

So `search:next` means *"start a new search for the text `next`"*. Ghostty was doing exactly what it was asked.

`Sources/Find/SurfaceSearchOverlay.swift` already used `navigate_search:` for the find bar's Return handler and its up/down buttons — which is why those worked and only the keyboard shortcuts were broken. That divergence is the actual root cause: the same action string was duplicated across two files and drifted. This PR hoists both spellings into a single `TerminalSearchNavigationAction` so they cannot drift again, and pins them with a regression test.

### Behavior note for reviewers

`navigate_search` is documented as *"If there is no active search, this is not performed."* After this change, Cmd-G with no active search does nothing, where before it started a bogus search for "next". The Cmd-F path is unaffected — `startSearch()` already recovers `surface.lastSearchNeedle`. Happy to add an explicit "no active search → open the find bar" fallback if you'd prefer that behavior, but it seemed out of scope for the fix.

## Testing

- `testTerminalSearchNavigationUsesNavigateSearchRatherThanStartingANewSearch` added to `GhosttySurfaceOverlayTests`, next to the existing `startOrFocusTerminalSearch` coverage. It pins both action strings and asserts neither carries a bare `search:` prefix.
- All four touched files pass `swiftc -frontend -parse`.
- Root cause confirmed against the Ghostty bundled with cmux 0.64.20 (100) via `ghostty +list-actions --docs` (quoted above).

**Not yet done, and I don't want to claim otherwise:** I have not built the app locally for this change — `scripts/setup.sh` builds GhosttyKit from the ghostty submodule via Zig, which I haven't run. The new test is therefore unverified by an actual test run. Marking this PR as a draft until that and the demo video below are done. If a maintainer's CI picks it up first, that works too.

## Demo Video

Pending — will attach a before/after capture of Cmd-G in a terminal pane before marking this ready for review.

- Video URL or attachment: _pending_

## Checklist

- [ ] I tested the change locally — **not done** (no local GhosttyKit build; see Testing)
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed — happy to add a CHANGELOG entry if that's expected for fixes
- [ ] I requested bot reviews after my latest commit — holding until this leaves draft
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

## Reproduction

1. Open a terminal pane with scrollback.
2. Cmd-F, type any query, Return — matches highlight correctly.
3. Cmd-G.

Before: the search is replaced with a search for `next`. After: advances to the next match.

Environment: cmux 0.64.20 (100) `[14e3400b9]`, bundled Ghostty 1.3.2-HEAD, macOS 26.5.2 (25F84).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787698816&installation_model_id=21920&pr_number=8970&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8970&signature=aa4c99a5e1ac766cd59682dbc32fa5b21dfe05431f528c33d9ebc977c3a7264a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Cmd-G (Find Next) and Cmd-Opt-G (Find Previous) so they navigate existing search results by sending `navigate_search:next`/`navigate_search:previous` instead of starting a new search for the words "next"/"previous". This matches the find bar behavior and prevents replacing the user's query.

- **Bug Fixes**
  - `TabManager.findNext()`/`findPrevious()` now send `navigate_search:next`/`navigate_search:previous`.
  - If no search is active, these shortcuts do nothing (per Ghostty’s contract).

- **Refactors**
  - Hoisted action strings into `TerminalSearchNavigationAction` and reused in `SurfaceSearchOverlay`.
  - Added `testTerminalSearchNavigationUsesNavigateSearchRatherThanStartingANewSearch` to pin the action format.

<sup>Written for commit 42a80fe40b0b3a33e69fef1705341dfe7b810fca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

