### PR TITLE
Release browser suggestion indexes with TabManager

### DIFF
--- a/Sources/Panels/BrowserOmnibarPerformanceSupport.swift
+++ b/Sources/Panels/BrowserOmnibarPerformanceSupport.swift
@@ -215,19 +215,7 @@ struct ContinuousOmnibarSuggestionRefreshClock: OmnibarSuggestionRefreshClock {
     }
 }
 
-private var browserOpenTabSuggestionIndexesByManagerId: [ObjectIdentifier: BrowserOpenTabSuggestionIndex] = [:]
-
 extension TabManager {
-    private var browserOpenTabSuggestionIndex: BrowserOpenTabSuggestionIndex {
-        let managerId = ObjectIdentifier(self)
-        if let index = browserOpenTabSuggestionIndexesByManagerId[managerId] {
-            return index
-        }
-        let index = BrowserOpenTabSuggestionIndex()
-        browserOpenTabSuggestionIndexesByManagerId[managerId] = index
-        return index
-    }
-
     func upsertBrowserOpenTabSuggestion(_ snapshot: BrowserOpenTabSuggestionSnapshot) {
         browserOpenTabSuggestionIndex.upsert(snapshot)
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -183,6 +183,7 @@ class TabManager: ObservableObject {
     /// Stable identifier of the owning macOS window. Used only for opt-in title
     /// templates that expose a WM-matchable per-window token.
     var windowId: UUID?
+    lazy var browserOpenTabSuggestionIndex = BrowserOpenTabSuggestionIndex()
 
     // Wave-4 sub-model (TabManager decomposition): the workspace list, the
     // sidebar group sections, and the selected-workspace id storage live in

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -183,7 +183,7 @@ class TabManager: ObservableObject {
     /// Stable identifier of the owning macOS window. Used only for opt-in title
     /// templates that expose a WM-matchable per-window token.
     var windowId: UUID?
-    lazy var browserOpenTabSuggestionIndex = BrowserOpenTabSuggestionIndex()
+    private(set) lazy var browserOpenTabSuggestionIndex = BrowserOpenTabSuggestionIndex()
 
     // Wave-4 sub-model (TabManager decomposition): the workspace list, the
     // sidebar group sections, and the selected-workspace id storage live in

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B0A501000000000000000001 /* BrowserOmnibarAppKitBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A501000000000000000002 /* BrowserOmnibarAppKitBridge.swift */; };
 		B0A500000000000000000001 /* BrowserOmnibarPerformanceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A500000000000000000002 /* BrowserOmnibarPerformanceSupport.swift */; };
 		C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */; };
+		C2B6A97D1F2E4C71A8B9D011 /* BrowserOpenTabSuggestionIndexLifetimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B6A97D1F2E4C71A8B9D012 /* BrowserOpenTabSuggestionIndexLifetimeTests.swift */; };
 		27DA3BE42CBF4AAFB6DE69C5 /* BrowserOmnibarSubmitSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76D07ED88D244B1B02FAF3C /* BrowserOmnibarSubmitSupport.swift */; };
 		B7380002B7380002B7380002 /* BrowserOmnibarSuggestionClickRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7380001B7380001B7380001 /* BrowserOmnibarSuggestionClickRoutingTests.swift */; };
 		D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
@@ -2961,6 +2962,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B0A501000000000000000002 /* BrowserOmnibarAppKitBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarAppKitBridge.swift; sourceTree = "<group>"; };
 		B0A500000000000000000002 /* BrowserOmnibarPerformanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarPerformanceSupport.swift; sourceTree = "<group>"; };
 		C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarPerformanceSupportTests.swift; sourceTree = "<group>"; };
+		C2B6A97D1F2E4C71A8B9D012 /* BrowserOpenTabSuggestionIndexLifetimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOpenTabSuggestionIndexLifetimeTests.swift; sourceTree = "<group>"; };
 		C76D07ED88D244B1B02FAF3C /* BrowserOmnibarSubmitSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarSubmitSupport.swift; sourceTree = "<group>"; };
 		B7380001B7380001B7380001 /* BrowserOmnibarSuggestionClickRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionClickRoutingTests.swift; sourceTree = "<group>"; };
 		D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionsUITests.swift; sourceTree = "<group>"; };
@@ -7283,6 +7285,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 				A5008380 /* BrowserFindJavaScriptTests.swift */,
 				C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */,
+				C2B6A97D1F2E4C71A8B9D012 /* BrowserOpenTabSuggestionIndexLifetimeTests.swift */,
 				B7380001B7380001B7380001 /* BrowserOmnibarSuggestionClickRoutingTests.swift */,
 				8054BEEF0000000000000002 /* BrowserPanelViewIdentityTests.swift */,
 				C0DEC0DE000000000000F301 /* CommandPaletteEmojiTitleSearchTests.swift */,
@@ -10145,6 +10148,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				BCBC0A0E0000000000000E21 /* BrowserMediaPlaybackAudioActivityTests.swift in Sources */,
 				A85970000000000000000001 /* BrowserNavigableURLPasteTests.swift in Sources */,
 				C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */,
+				C2B6A97D1F2E4C71A8B9D011 /* BrowserOpenTabSuggestionIndexLifetimeTests.swift in Sources */,
 				B7380002B7380002B7380002 /* BrowserOmnibarSuggestionClickRoutingTests.swift in Sources */,
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,
 				D7632003A1B2C3D4E5F60718 /* BrowserPaneFileDropUploadRegressionTests.swift in Sources */,

--- a/cmuxTests/BrowserOpenTabSuggestionIndexLifetimeTests.swift
+++ b/cmuxTests/BrowserOpenTabSuggestionIndexLifetimeTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite struct BrowserOpenTabSuggestionIndexLifetimeTests {
+    @Test func suggestionIndexDeallocatesWithTabManager() {
+        var manager: TabManager? = TabManager(autoWelcomeIfNeeded: false)
+        weak var suggestionIndex: BrowserOpenTabSuggestionIndex?
+        suggestionIndex = manager?.browserOpenTabSuggestionIndex
+
+        #expect(suggestionIndex != nil)
+        manager = nil
+
+        #expect(suggestionIndex == nil)
+    }
+}

--- a/cmuxTests/BrowserOpenTabSuggestionIndexLifetimeTests.swift
+++ b/cmuxTests/BrowserOpenTabSuggestionIndexLifetimeTests.swift
@@ -8,14 +8,25 @@ import Testing
 
 @MainActor
 @Suite struct BrowserOpenTabSuggestionIndexLifetimeTests {
-    @Test func suggestionIndexDeallocatesWithTabManager() {
-        var manager: TabManager? = TabManager(autoWelcomeIfNeeded: false)
-        weak var suggestionIndex: BrowserOpenTabSuggestionIndex?
-        suggestionIndex = manager?.browserOpenTabSuggestionIndex
+    @Test func suggestionIndexesArePerManagerAndDeallocateIndependently() {
+        var firstManager: TabManager? = TabManager(autoWelcomeIfNeeded: false)
+        var secondManager: TabManager? = TabManager(autoWelcomeIfNeeded: false)
+        weak var firstSuggestionIndex: BrowserOpenTabSuggestionIndex?
+        weak var secondSuggestionIndex: BrowserOpenTabSuggestionIndex?
+        firstSuggestionIndex = firstManager?.browserOpenTabSuggestionIndex
+        secondSuggestionIndex = secondManager?.browserOpenTabSuggestionIndex
 
-        #expect(suggestionIndex != nil)
-        manager = nil
+        #expect(firstSuggestionIndex != nil)
+        #expect(secondSuggestionIndex != nil)
+        #expect(firstSuggestionIndex !== secondSuggestionIndex)
 
-        #expect(suggestionIndex == nil)
+        firstManager = nil
+
+        #expect(firstSuggestionIndex == nil)
+        #expect(secondSuggestionIndex != nil)
+
+        secondManager = nil
+
+        #expect(secondSuggestionIndex == nil)
     }
 }


### PR DESCRIPTION
## Purpose

Bind each browser open-tab suggestion index to its owning `TabManager`, so the index is released with that manager instead of remaining in a process-global map.

## Tests

`BrowserOpenTabSuggestionIndexLifetimeTests.suggestionIndexDeallocatesWithTabManager` observes the index through a weak reference across one `TabManager` lifecycle. On the test-only commit, review confirmed the process-global map makes the final deallocation expectation fail consistently. Project test wiring passes `scripts/lint-pbxproj-test-wiring.sh`. An immutable focused macOS 15 run for implementation commit `96b1dd724a` is pending at https://github.com/usr-bin-roygbiv/cmux/actions/runs/30326434496.

## Metrics

Baseline: one observed index remains strongly retained after one initialized `TabManager` lifecycle. Treatment: zero observed indexes remain after manager release, a delta of -1 retained index per completed initialized-manager lifecycle in the focused one-manager sample. This is lifecycle/count evidence only; no byte or timing savings are claimed.

## Safety

Suggestion matching, ranking, and browser UI behavior are unchanged. The change is limited to moving index ownership onto `TabManager`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of open-tab suggestion indexing when a browser tab manager is released.
  * Prevented the open-tab suggestion index from lingering after its associated tab manager is deallocated.
* **Tests**
  * Added a new test suite verifying the open-tab suggestion index is released when the tab manager is deallocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->