### PR TITLE
Reuse verified artifacts across TUI publishers

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -373,7 +373,7 @@ jobs:
     name: verify Linux package entrypoints (${{ matrix.architecture }})
     needs: package
     if: ${{ inputs.package_npm || inputs.package_pypi }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/cmux-tui-release-cut.yml
+++ b/.github/workflows/cmux-tui-release-cut.yml
@@ -151,19 +151,25 @@ jobs:
       - name: Dispatch release workflows
         # The tag push above was made with the default GITHUB_TOKEN, which
         # never triggers other workflows' tag-push events. Dispatch the
-        # release workflows explicitly against the new tag. This keeps registry
-        # OIDC identities on their top-level workflow files and binds provenance
-        # to the exact immutable release commit. Failed runs retain that ref.
+        # build/package workflow explicitly against the new tag. That workflow
+        # builds and verifies every package once, then dispatches the top-level
+        # registry workflows with its artifact run ID. The registry OIDC
+        # identities therefore stay on their existing workflow files without
+        # rebuilding the same binaries for each registry.
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          gh workflow run cmux-tui-release.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f version="$VERSION"
-          gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f version="$VERSION"
-          gh workflow run tui-publish-npm.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f version="$VERSION" -f confirm_tui_cmux=true
+          gh workflow run cmux-tui-release.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$TAG" \
+            -f version="$VERSION" \
+            -f publish_npm=true \
+            -f publish_pypi=true \
+            -f confirm_tui_cmux=true
           {
-            echo "- Dispatched cmux-tui-release.yml on $TAG"
-            echo "- Dispatched npm and PyPI publishers on $TAG"
+            echo "- Dispatched one build/package run on $TAG"
+            echo "- npm and PyPI will reuse that run's verified artifacts"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -1,8 +1,8 @@
 name: cmux-tui release binaries
 
-# Builds the cmux-tui TUI binary for every distribution target (npm/PyPI `cmux`).
-# Manual dispatch or cmux-tui tag builds upload one artifact per target so the
-# npm/PyPI wrapper-packaging jobs can bundle them.
+# Builds and verifies the cmux-tui distribution artifacts once. A coordinated
+# stable release can then dispatch the npm and PyPI publishers with this run's
+# artifact ID, avoiding identical rebuilds in each registry workflow.
 on:
   workflow_dispatch:
     inputs:
@@ -10,6 +10,21 @@ on:
         description: "TUI package version to build, for example 0.1.0"
         required: true
         type: string
+      publish_npm:
+        description: "Publish the verified npm artifacts after the build"
+        required: true
+        default: false
+        type: boolean
+      publish_pypi:
+        description: "Publish the verified PyPI artifacts after the build"
+        required: true
+        default: false
+        type: boolean
+      confirm_tui_cmux:
+        description: "Set true only for the coordinated npm cmux TUI publish"
+        required: true
+        default: false
+        type: boolean
   push:
     tags:
       - "cmux-tui-v*"
@@ -33,6 +48,9 @@ jobs:
         id: version
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
+          PUBLISH_NPM: ${{ inputs.publish_npm }}
+          PUBLISH_PYPI: ${{ inputs.publish_pypi }}
+          CONFIRM_TUI_CMUX: ${{ inputs.confirm_tui_cmux }}
         run: |
           set -euo pipefail
           if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
@@ -41,12 +59,27 @@ jobs:
               exit 1
             }
             version="${GITHUB_REF_NAME#cmux-tui-v}"
+            if [[ -n "$DISPATCH_VERSION" && "$DISPATCH_VERSION" != "$version" ]]; then
+              echo "workflow_dispatch version $DISPATCH_VERSION does not match tag version $version" >&2
+              exit 1
+            fi
           else
             version="$DISPATCH_VERSION"
             [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
               echo "workflow_dispatch version must match X.Y.Z" >&2
               exit 1
             }
+          fi
+
+          if [[ "$PUBLISH_NPM" == "true" || "$PUBLISH_PYPI" == "true" ]]; then
+            if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
+              echo "Registry publishing requires a cmux-tui-vX.Y.Z tag ref." >&2
+              exit 1
+            fi
+          fi
+          if [[ "$PUBLISH_NPM" == "true" && "$CONFIRM_TUI_CMUX" != "true" ]]; then
+            echo "npm publishing requires confirm_tui_cmux=true." >&2
+            exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -60,3 +93,45 @@ jobs:
       package_npm: true
       package_pypi: true
       include_windows: true
+
+  dispatch-publishers:
+    name: dispatch verified artifacts to registries
+    if: ${{ inputs.publish_npm || inputs.publish_pypi }}
+    needs: build-package
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ github.ref_name }}
+      VERSION: ${{ inputs.version }}
+      ARTIFACT_RUN_ID: ${{ github.run_id }}
+      PUBLISH_NPM: ${{ inputs.publish_npm }}
+      PUBLISH_PYPI: ${{ inputs.publish_pypi }}
+    steps:
+      - name: Dispatch registry publishers
+        run: |
+          set -euo pipefail
+          if [[ "$PUBLISH_NPM" == "true" ]]; then
+            gh workflow run tui-publish-npm.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" \
+              -f version="$VERSION" \
+              -f artifact_run_id="$ARTIFACT_RUN_ID" \
+              -f confirm_tui_cmux=true
+          fi
+          if [[ "$PUBLISH_PYPI" == "true" ]]; then
+            gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" \
+              -f version="$VERSION" \
+              -f artifact_run_id="$ARTIFACT_RUN_ID"
+          fi
+          {
+            echo "### Registry publishing"
+            echo
+            echo "- Verified artifact run: $ARTIFACT_RUN_ID"
+            if [[ "$PUBLISH_NPM" == "true" ]]; then
+              echo "- Dispatched npm publisher"
+            fi
+            if [[ "$PUBLISH_PYPI" == "true" ]]; then
+              echo "- Dispatched PyPI publisher"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cmux-tui-release.yml
+++ b/.github/workflows/cmux-tui-release.yml
@@ -49,34 +49,23 @@ jobs:
         env:
           DISPATCH_VERSION: ${{ inputs.version }}
           PUBLISH_NPM: ${{ inputs.publish_npm }}
-          PUBLISH_PYPI: ${{ inputs.publish_pypi }}
           CONFIRM_TUI_CMUX: ${{ inputs.confirm_tui_cmux }}
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-            [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "tag must match cmux-tui-vX.Y.Z" >&2
-              exit 1
-            }
-            version="${GITHUB_REF_NAME#cmux-tui-v}"
-            if [[ -n "$DISPATCH_VERSION" && "$DISPATCH_VERSION" != "$version" ]]; then
-              echo "workflow_dispatch version $DISPATCH_VERSION does not match tag version $version" >&2
-              exit 1
-            fi
-          else
-            version="$DISPATCH_VERSION"
-            [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
-              echo "workflow_dispatch version must match X.Y.Z" >&2
-              exit 1
-            }
+          if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
+            echo "Stable artifacts require a cmux-tui-vX.Y.Z tag ref." >&2
+            exit 1
+          fi
+          [[ "$GITHUB_REF_NAME" =~ ^cmux-tui-v[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "tag must match cmux-tui-vX.Y.Z" >&2
+            exit 1
+          }
+          version="${GITHUB_REF_NAME#cmux-tui-v}"
+          if [[ -n "$DISPATCH_VERSION" && "$DISPATCH_VERSION" != "$version" ]]; then
+            echo "workflow_dispatch version $DISPATCH_VERSION does not match tag version $version" >&2
+            exit 1
           fi
 
-          if [[ "$PUBLISH_NPM" == "true" || "$PUBLISH_PYPI" == "true" ]]; then
-            if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
-              echo "Registry publishing requires a cmux-tui-vX.Y.Z tag ref." >&2
-              exit 1
-            fi
-          fi
           if [[ "$PUBLISH_NPM" == "true" && "$CONFIRM_TUI_CMUX" != "true" ]]; then
             echo "npm publishing requires confirm_tui_cmux=true." >&2
             exit 1

--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -7,6 +7,10 @@ on:
         description: "TUI package version to publish, for example 0.1.0"
         required: true
         type: string
+      artifact_run_id:
+        description: "Successful cmux-tui release run containing verified packages"
+        required: true
+        type: string
       confirm_tui_cmux:
         description: "Set true only for the coordinated npm cmux TUI publish"
         required: true
@@ -28,6 +32,7 @@ jobs:
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 5
     permissions:
+      actions: read
       contents: read
     outputs:
       release_sha: ${{ steps.release.outputs.release_sha }}
@@ -74,24 +79,67 @@ jobs:
             echo "release_sha=$release_sha"
           } >> "$GITHUB_OUTPUT"
 
-  build-package:
-    needs: validate-version
-    permissions:
-      contents: read
-    uses: ./.github/workflows/cmux-tui-build-package.yml
-    with:
-      version: ${{ inputs.version }}
-      package_npm: true
-      package_pypi: false
-      include_windows: false
-      checkout_ref: ${{ needs.validate-version.outputs.release_sha }}
+      - name: Require successful verified artifact run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
+          RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_RUN_ID" =~ ^[0-9]+$ ]] || {
+            echo "artifact_run_id must be a GitHub Actions run ID" >&2
+            exit 1
+          }
+
+          artifact_path=".github/workflows/cmux-tui-release.yml"
+          artifact_status=""
+          artifact_conclusion=""
+          release_sha="$RELEASE_SHA"
+          for _ in {1..24}; do
+            IFS=$'\t' read -r actual_path artifact_head_sha artifact_head_branch artifact_status artifact_conclusion <<<"$(
+              gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ARTIFACT_RUN_ID" \
+                --jq '[.path, .head_sha, .head_branch, .status, (.conclusion // "")] | @tsv'
+            )"
+            if [[ "$actual_path" != "$artifact_path" ]]; then
+              echo "artifact run $ARTIFACT_RUN_ID came from $actual_path, expected $artifact_path" >&2
+              exit 1
+            fi
+            if [[ "$artifact_head_sha" != "$release_sha" ]]; then
+              echo "artifact run commit $artifact_head_sha does not match release commit $release_sha" >&2
+              exit 1
+            fi
+            if [[ "$artifact_head_branch" != "$RELEASE_TAG" ]]; then
+              echo "artifact run ref $artifact_head_branch does not match release tag $RELEASE_TAG" >&2
+              exit 1
+            fi
+            if [[ "$artifact_status" == "completed" ]]; then
+              break
+            fi
+            case "$artifact_status" in
+              queued|in_progress|pending|waiting|requested)
+                sleep 5
+                ;;
+              *)
+                echo "artifact run $ARTIFACT_RUN_ID has unexpected status $artifact_status" >&2
+                exit 1
+                ;;
+            esac
+          done
+          if [[ "$artifact_status" != "completed" ]]; then
+            echo "artifact run $ARTIFACT_RUN_ID did not complete in time" >&2
+            exit 1
+          fi
+          if [[ "$artifact_conclusion" != "success" ]]; then
+            echo "artifact run $ARTIFACT_RUN_ID concluded $artifact_conclusion" >&2
+            exit 1
+          fi
 
   publish:
-    needs:
-      - validate-version
-      - build-package
+    needs: validate-version
     runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
     permissions:
+      actions: read
       contents: read
       id-token: write
     environment:
@@ -114,6 +162,8 @@ jobs:
         with:
           name: npm-packages
           path: dist
+          run-id: ${{ inputs.artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Restore npm package executable modes
         run: |

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -7,6 +7,10 @@ on:
         description: "TUI package version to publish, for example 0.1.0"
         required: true
         type: string
+      artifact_run_id:
+        description: "Successful cmux-tui release run containing verified packages"
+        required: true
+        type: string
 
 permissions: {}
 
@@ -19,6 +23,7 @@ jobs:
     name: validate release source
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
+      actions: read
       contents: read
     outputs:
       release_sha: ${{ steps.release.outputs.release_sha }}
@@ -65,22 +70,67 @@ jobs:
             echo "release_sha=$release_sha"
           } >> "$GITHUB_OUTPUT"
 
-  build-package:
-    needs: validate-version
-    permissions:
-      contents: read
-    uses: ./.github/workflows/cmux-tui-build-package.yml
-    with:
-      version: ${{ inputs.version }}
-      package_npm: false
-      package_pypi: true
-      include_windows: false
-      checkout_ref: ${{ needs.validate-version.outputs.release_sha }}
+      - name: Require successful verified artifact run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact_run_id }}
+          RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_RUN_ID" =~ ^[0-9]+$ ]] || {
+            echo "artifact_run_id must be a GitHub Actions run ID" >&2
+            exit 1
+          }
+
+          artifact_path=".github/workflows/cmux-tui-release.yml"
+          artifact_status=""
+          artifact_conclusion=""
+          release_sha="$RELEASE_SHA"
+          for _ in {1..24}; do
+            IFS=$'\t' read -r actual_path artifact_head_sha artifact_head_branch artifact_status artifact_conclusion <<<"$(
+              gh api "repos/$GITHUB_REPOSITORY/actions/runs/$ARTIFACT_RUN_ID" \
+                --jq '[.path, .head_sha, .head_branch, .status, (.conclusion // "")] | @tsv'
+            )"
+            if [[ "$actual_path" != "$artifact_path" ]]; then
+              echo "artifact run $ARTIFACT_RUN_ID came from $actual_path, expected $artifact_path" >&2
+              exit 1
+            fi
+            if [[ "$artifact_head_sha" != "$release_sha" ]]; then
+              echo "artifact run commit $artifact_head_sha does not match release commit $release_sha" >&2
+              exit 1
+            fi
+            if [[ "$artifact_head_branch" != "$RELEASE_TAG" ]]; then
+              echo "artifact run ref $artifact_head_branch does not match release tag $RELEASE_TAG" >&2
+              exit 1
+            fi
+            if [[ "$artifact_status" == "completed" ]]; then
+              break
+            fi
+            case "$artifact_status" in
+              queued|in_progress|pending|waiting|requested)
+                sleep 5
+                ;;
+              *)
+                echo "artifact run $ARTIFACT_RUN_ID has unexpected status $artifact_status" >&2
+                exit 1
+                ;;
+            esac
+          done
+          if [[ "$artifact_status" != "completed" ]]; then
+            echo "artifact run $ARTIFACT_RUN_ID did not complete in time" >&2
+            exit 1
+          fi
+          if [[ "$artifact_conclusion" != "success" ]]; then
+            echo "artifact run $ARTIFACT_RUN_ID concluded $artifact_conclusion" >&2
+            exit 1
+          fi
 
   publish:
-    needs: build-package
+    needs: validate-version
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
+      actions: read
       contents: read
       id-token: write
     environment:
@@ -92,6 +142,8 @@ jobs:
         with:
           name: pypi-wheels
           path: dist
+          run-id: ${{ inputs.artifact_run_id }}
+          github-token: ${{ github.token }}
 
       - name: Trusted publisher setup note
         run: |

--- a/cmux-tui/dist/RELEASING-TUI.md
+++ b/cmux-tui/dist/RELEASING-TUI.md
@@ -93,23 +93,30 @@ Use `.github/workflows/cmux-tui-release-cut.yml` from `main`.
   `main` HEAD, and pushes that tag.
 - The tag is pushed with the default `GITHUB_TOKEN`, and GitHub suppresses
   workflow triggers for token-created events, so the release-cut workflow then
-  explicitly dispatches `cmux-tui-release.yml` (build + package) and
-  both registry publishers against the new tag. The npm dispatch sets
-  `confirm_tui_cmux=true`. A manual `git push origin cmux-tui-vX.Y.Z` from a
-  developer machine still fires the build and PyPI tag triggers directly, but
-  npm remains manual-dispatch only.
+  explicitly dispatches `cmux-tui-release.yml` against the new tag with npm and
+  PyPI publishing enabled.
+- `cmux-tui-release.yml` builds every target once, creates both registries'
+  packages, and runs the Linux compatibility matrix. After those jobs pass, it
+  dispatches both top-level publishers with its own artifact run ID. This keeps
+  the configured trusted-publisher identities while avoiding registry-specific
+  rebuilds.
+- A manual `git push origin cmux-tui-vX.Y.Z` runs the artifact workflow without
+  publishing. Use the release-cut workflow for a coordinated stable release.
 
 ## Publishing
 
-PyPI publishing can run from `cmux-tui-vX.Y.Z` tags or manual dispatch.
+Both registry workflows are manual-dispatch only. They require the ID of a
+successful `cmux-tui-release.yml` run on the exact release tag. Each publisher
+checks the source workflow, tag, commit, and conclusion before downloading its
+package artifact. It never rebuilds the binaries. This also lets a failed
+publisher retry reuse the already verified artifacts.
 
-npm publishing is manual dispatch only and requires `confirm_tui_cmux=true`.
-The platform packages are published first, then the `cmux` launcher.
+npm additionally requires `confirm_tui_cmux=true`. The platform packages are
+published first, then the `cmux` launcher.
 
-Each publisher runs its generated Linux entrypoint packages across the
-supported glibc and musl distribution matrix on x86_64 and ARM64 before its
-publish job starts. A compatibility regression therefore blocks writes to that
-registry.
+The shared artifact run exercises the generated npm and PyPI entrypoints across
+the supported glibc and musl distribution matrix on x86_64 and ARM64. A
+compatibility regression therefore blocks both registry dispatches.
 
 The npm launcher publish deliberately does not pass `--tag`: when the TUI
 version is greater than `0.8.3`, this coordinated release takes over the npm

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -8,7 +8,7 @@ def workflow(name: str) -> str:
     return (ROOT / ".github" / "workflows" / name).read_text()
 
 
-def test_stable_registry_publishers_are_exact_tag_bound() -> None:
+def test_stable_registry_publishers_are_exact_tag_and_artifact_bound() -> None:
     for name, environment in (
         ("tui-publish-npm.yml", "npm-tui"),
         ("tui-publish-pypi.yml", "pypi-tui"),
@@ -19,7 +19,16 @@ def test_stable_registry_publishers_are_exact_tag_bound() -> None:
         assert 'if [[ "$GITHUB_REF" != "$expected_ref" ]]' in text
         assert 'git rev-parse "refs/tags/$tag^{commit}"' in text
         assert 'if [[ "$release_sha" != "$GITHUB_SHA" ]]' in text
-        assert "checkout_ref: ${{ needs.validate-version.outputs.release_sha }}" in text
+        assert "artifact_run_id:" in text
+        assert "required: true" in text
+        assert '[[ "$ARTIFACT_RUN_ID" =~ ^[0-9]+$ ]]' in text
+        assert 'artifact_path=".github/workflows/cmux-tui-release.yml"' in text
+        assert 'if [[ "$artifact_head_sha" != "$release_sha" ]]' in text
+        assert 'if [[ "$artifact_conclusion" != "success" ]]' in text
+        assert "actions: read" in text
+        assert "run-id: ${{ inputs.artifact_run_id }}" in text
+        assert "github-token: ${{ github.token }}" in text
+        assert "uses: ./.github/workflows/cmux-tui-build-package.yml" not in text
         assert f"name: {environment}" in text
 
 
@@ -42,10 +51,29 @@ def test_nightly_build_is_pinned_to_its_provenance_commit() -> None:
     assert "checkout_ref: ${{ needs.version.outputs.head_sha }}" in text
 
 
-def test_release_cut_dispatches_top_level_publishers_at_the_tagged_main_commit() -> None:
+def test_stable_release_builds_and_tests_once_before_dispatching_publishers() -> None:
     release_cut = workflow("cmux-tui-release-cut.yml")
+    release = workflow("cmux-tui-release.yml")
+    npm = workflow("tui-publish-npm.yml")
+    pypi = workflow("tui-publish-pypi.yml")
+
     assert "ref: ${{ github.sha }}" in release_cut
-    assert 'gh workflow run tui-publish-npm.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"' in release_cut
-    assert 'gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"' in release_cut
+    assert release_cut.count("gh workflow run cmux-tui-release.yml") == 1
+    assert "gh workflow run tui-publish-npm.yml" not in release_cut
+    assert "gh workflow run tui-publish-pypi.yml" not in release_cut
+    assert "-f publish_npm=true" in release_cut
+    assert "-f publish_pypi=true" in release_cut
+    assert "-f confirm_tui_cmux=true" in release_cut
+
+    stable_workflows = (release, npm, pypi)
+    reusable_build = "uses: ./.github/workflows/cmux-tui-build-package.yml"
+    assert sum(text.count(reusable_build) for text in stable_workflows) == 1
+    assert "publish_npm:" in release
+    assert "publish_pypi:" in release
+    assert "needs: build-package" in release
+    assert 'gh workflow run tui-publish-npm.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"' in release
+    assert 'gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"' in release
+    assert '-f artifact_run_id="$ARTIFACT_RUN_ID"' in release
+
     for name in ("tui-publish-npm.yml", "tui-publish-pypi.yml"):
         assert "workflow_call:" not in workflow(name)

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -70,6 +70,8 @@ def test_stable_release_builds_and_tests_once_before_dispatching_publishers() ->
     assert sum(text.count(reusable_build) for text in stable_workflows) == 1
     assert "publish_npm:" in release
     assert "publish_pypi:" in release
+    assert 'if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]' in release
+    assert "Stable artifacts require a cmux-tui-vX.Y.Z tag ref." in release
     assert "needs: build-package" in release
     assert 'gh workflow run tui-publish-npm.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"' in release
     assert 'gh workflow run tui-publish-pypi.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"' in release


### PR DESCRIPTION
## Summary
- Build and verify stable TUI packages once, then pass that artifact run to npm and PyPI.
- Require publishers to validate the source workflow, tag, commit, and successful conclusion.
- Route Linux package gates through the configured Linux runner pool.

## Efficiency
- Reduce target builds per stable release from 13 to 5.
- Reduce Linux package verification jobs from 6 to 2.
- Reuse verified artifacts for publisher retries.

## Testing
- `actionlint` on all changed workflows
- `python3 -m pytest -q tests/test_tui_publish_workflow_security.py tests/test_tui_npm_package_artifact.py`
- `bash tests/test_ci_self_hosted_guard.sh`
- Regression guard committed before the implementation fix

## Task
- Keep cmux TUI CI/CD efficient and avoid rerunning work that has already passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787704257&installation_model_id=21920&pr_number=8973&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8973&signature=55eb5e4771ae6d9a347ee2287ade807f5fdbe5463408b7668a0f8a4b3544f06c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build and verify `cmux-tui` once per tagged release, then reuse those verified artifacts for both `npm` and `PyPI`. Publishers now require the release run’s `artifact_run_id` and validate the workflow path, tag, commit, and success before downloading.

- New Features
  - Centralized build produces all targets once and passes its `artifact_run_id` to registry publishers.
  - `tui-publish-npm.yml` and `tui-publish-pypi.yml` no longer build; they download from the verified run after checking path/tag/commit/conclusion.
  - `cmux-tui-release.yml` enforces tag-only (`cmux-tui-vX.Y.Z`), validates input version against the tag, gates `npm` on `confirm_tui_cmux=true`, and can dispatch both publishers.
  - `cmux-tui-release-cut.yml` dispatches one build with `publish_npm/publish_pypi=true`; registries reuse its artifacts. Linux checks use `vars.LINUX_RUNNER`. Docs and tests updated.

- Efficiency
  - Reduce target builds per stable release from 13 to 5.
  - Reduce Linux verification jobs from 6 to 2.
  - Publisher retries reuse the already verified artifacts.

<sup>Written for commit 01406005a6c4b84f0c900918388264350a16e650. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Streamlined releases by dispatching a single coordinated build/package flow and then conditionally publishing to npm and PyPI.
  * Added stronger gating and validation so publishing is tied to a specific successful release build artifact and matching tag/version.
  * Introduced explicit inputs to control publishing behavior (including an npm confirmation flag).
  * Improved Linux package builds with configurable runner selection and a fallback.

* **Tests**
  * Hardened workflow security tests to enforce artifact/tag coupling, permissions, and correct dispatch behavior.
  * Added coverage to ensure stable release builds/tests run exactly once before publishing dispatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->