### PR TITLE
perf: optimize prompt detector hot paths

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PromptDetection/PromptLineTurnDetector.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PromptDetection/PromptLineTurnDetector.swift
@@ -39,19 +39,16 @@ public struct PromptLineTurnDetector: Sendable {
     }
 
     private static let maximumLogicalLineBytes = 4_096
-    private static let maximumCSIParameterBytes = 12
 
     private let configuration: PromptLineTurnDetectionConfiguration
     private let maximumWaitingPromptLineByteCount: Int
     private let promptVisibleByteCount: Int
     private var phase: Phase = .stable(.seekingInitialPrompt)
     private var controlSequence: ControlSequence = .none
-    /// CSI parameter/intermediate bytes of the sequence being parsed, so the
-    /// terminator can distinguish line-rewriting controls (CSI 2K, CSI 1G)
-    /// from inert ones (SGR, cursor shifts). Overlong sequences are treated
-    /// as inert rather than growing the buffer.
-    private var csiParameterBytes: [UInt8] = []
-    private var csiParameterOverflowed = false
+    /// CSI parameter/intermediate byte count, saturated at two. The first byte
+    /// is retained only for the exactly-one-byte G/K forms handled below.
+    private var csiFirstParameterByte: UInt8 = 0
+    private var csiParameterByteCount: UInt8 = 0
     private var logicalLine: [UInt8] = []
     private var logicalLineOverflowed = false
     /// Visible bytes currently in `logicalLine`, maintained incrementally so
@@ -122,12 +119,7 @@ public struct PromptLineTurnDetector: Sendable {
                printableBytesCannotChangeState {
                 // Skip the rest of the printable run without state machine
                 // work; only control bytes below can change detection state.
-                var cursor = index + 1
-                while cursor < bytes.endIndex {
-                    let next = bytes[cursor]
-                    if next < 0x20 || next == 0x7F { break }
-                    cursor += 1
-                }
+                let cursor = Self.firstNonPrintableByteIndex(in: bytes, from: index)
                 unstoredLineByteCount += cursor - index
                 index = cursor
                 continue
@@ -135,6 +127,53 @@ public struct PromptLineTurnDetector: Sendable {
             consume(byte)
             index += 1
         }
+    }
+
+    /// Returns the first C0 control or DEL byte at or after `startIndex`.
+    /// Eight-byte probes keep ordinary PTY output close to memcpy cost while
+    /// the scalar tail preserves the exact logical-line boundary semantics.
+    @inline(__always)
+    static func firstNonPrintableByteIndex(
+        in bytes: UnsafeBufferPointer<UInt8>,
+        from startIndex: Int
+    ) -> Int {
+        precondition(startIndex >= bytes.startIndex && startIndex <= bytes.endIndex)
+        guard let baseAddress = bytes.baseAddress else { return bytes.endIndex }
+
+        var index = startIndex
+        while index + MemoryLayout<UInt64>.size <= bytes.endIndex {
+            let word = UnsafeRawPointer(baseAddress.advanced(by: index))
+                .loadUnaligned(as: UInt64.self)
+            if wordContainsNonPrintableByte(word) { break }
+            index += MemoryLayout<UInt64>.size
+        }
+        while index < bytes.endIndex {
+            let byte = bytes[index]
+            if byte < 0x20 || byte == 0x7F { break }
+            index += 1
+        }
+        return index
+    }
+
+    @inline(__always)
+    private static func wordContainsNonPrintableByte(_ word: UInt64) -> Bool {
+        let highBits: UInt64 = 0x8080_8080_8080_8080
+        let repeatedOnes: UInt64 = 0x0101_0101_0101_0101
+        let repeatedSpaces: UInt64 = 0x2020_2020_2020_2020
+        let repeatedDeletes: UInt64 = 0x7F7F_7F7F_7F7F_7F7F
+        let containsC0Control = ((word &- repeatedSpaces) & ~word & highBits) != 0
+        let deleteCandidates = word ^ repeatedDeletes
+        let containsDelete = ((deleteCandidates &- repeatedOnes) & ~deleteCandidates & highBits) != 0
+        return containsC0Control || containsDelete
+    }
+
+    @inline(__always)
+    static func firstByteDisqualifiesWaitingPrompt(
+        in line: [UInt8],
+        promptFirstByte: UInt8
+    ) -> Bool {
+        guard let firstByte = line.first else { return false }
+        return firstByte != promptFirstByte
     }
 
     /// Confirms a prompt boundary after its debounce interval elapsed.
@@ -196,6 +235,12 @@ public struct PromptLineTurnDetector: Sendable {
     private var lineCannotBecomeWaitingPrompt: Bool {
         if logicalLineOverflowed || unstoredLineByteCount > 0 { return true }
         if logicalLine.count > maximumWaitingPromptLineByteCount { return true }
+        if Self.firstByteDisqualifiesWaitingPrompt(
+            in: logicalLine,
+            promptFirstByte: configuration.promptBytes[0]
+        ) {
+            return true
+        }
         return !configuration.waitingPromptLineBytes.contains { $0.starts(with: logicalLine) }
     }
 
@@ -209,13 +254,19 @@ public struct PromptLineTurnDetector: Sendable {
             }
             return
         case .csi:
-            if (0x40...0x7E).contains(byte) {
+            if byte >= 0x40 && byte <= 0x7E {
                 controlSequence = .none
                 handleCSITerminator(byte)
-            } else if csiParameterBytes.count < Self.maximumCSIParameterBytes {
-                csiParameterBytes.append(byte)
             } else {
-                csiParameterOverflowed = true
+                switch csiParameterByteCount {
+                case 0:
+                    csiFirstParameterByte = byte
+                    csiParameterByteCount = 1
+                case 1:
+                    csiParameterByteCount = 2
+                default:
+                    break
+                }
             }
             return
         case .osc:
@@ -235,8 +286,8 @@ public struct PromptLineTurnDetector: Sendable {
         switch byte {
         case 0x1B:
             controlSequence = .escape
-            csiParameterBytes.removeAll(keepingCapacity: true)
-            csiParameterOverflowed = false
+            csiFirstParameterByte = 0
+            csiParameterByteCount = 0
         case 0x0A, 0x0D:
             invalidatePendingPrompt()
             handleLineBoundary()
@@ -316,6 +367,15 @@ public struct PromptLineTurnDetector: Sendable {
             }
             return
         }
+        if Self.firstByteDisqualifiesWaitingPrompt(
+            in: logicalLine,
+            promptFirstByte: configuration.promptBytes[0]
+        ) {
+            if visibleByteCount > 0 {
+                markOutputObserved()
+            }
+            return
+        }
         guard configuration.waitingPromptLineBytes.contains(logicalLine),
               case .stable(let stablePhase) = phase else {
             if !configuration.waitingPromptLineBytes.contains(where: { $0.starts(with: logicalLine) }),
@@ -355,21 +415,22 @@ public struct PromptLineTurnDetector: Sendable {
     /// stays inert because the detector does not track cursor columns.
     private mutating func handleCSITerminator(_ terminator: UInt8) {
         defer {
-            csiParameterBytes.removeAll(keepingCapacity: true)
-            csiParameterOverflowed = false
+            csiFirstParameterByte = 0
+            csiParameterByteCount = 0
         }
-        guard !csiParameterOverflowed else { return }
         switch terminator {
         case UInt8(ascii: "G"):
-            guard csiParameterBytes.isEmpty ||
-                csiParameterBytes == [UInt8(ascii: "1")] ||
-                csiParameterBytes == [UInt8(ascii: "0")] else {
+            guard csiParameterByteCount == 0 ||
+                (csiParameterByteCount == 1 &&
+                    (csiFirstParameterByte == UInt8(ascii: "0") ||
+                        csiFirstParameterByte == UInt8(ascii: "1"))) else {
                 return
             }
             invalidatePendingPrompt()
             resetLogicalLine()
         case UInt8(ascii: "K"):
-            guard csiParameterBytes == [UInt8(ascii: "2")] else { return }
+            guard csiParameterByteCount == 1,
+                  csiFirstParameterByte == UInt8(ascii: "2") else { return }
             invalidatePendingPrompt()
             resetLogicalLine()
         default:

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/PromptLineTurnDetectorTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/PromptLineTurnDetectorTests.swift
@@ -82,6 +82,22 @@ struct PromptLineTurnDetectorTests {
         #expect(detector.pendingConfirmation == nil)
     }
 
+    @Test("A multi-byte CSI G preserves the echoed submission until its line boundary")
+    func multiByteCSIGPreservesSubmissionState() throws {
+        var detector = readyDetector()
+
+        detector.consume(Data("explain\u{1B}[12G\r\n".utf8))
+        #expect(detector.submissionCount == 1)
+        #expect(detector.pendingConfirmation == nil)
+
+        detector.consume(Data("answer\r\n".utf8))
+        #expect(detector.pendingConfirmation == nil)
+
+        detector.consume(Data(">>> ".utf8))
+        let confirmation = try #require(detector.pendingConfirmation)
+        #expect(detector.confirm(confirmation) == 1)
+    }
+
     @Test("Prompt text inside an OSC title is ignored")
     func oscPayloadCannotCompleteTurn() throws {
         var detector = readyDetector()
@@ -259,6 +275,62 @@ struct PromptLineTurnDetectorTests {
 
         let confirmation = try #require(detector.pendingConfirmation)
         #expect(detector.confirm(confirmation) == 1)
+    }
+
+    @Test("First byte rejects impossible waiting prompt lines")
+    func firstByteRejectsImpossibleWaitingPrompts() {
+        let promptFirstByte = UInt8(ascii: ">")
+        #expect(
+            !PromptLineTurnDetector.firstByteDisqualifiesWaitingPrompt(
+                in: [],
+                promptFirstByte: promptFirstByte
+            )
+        )
+        #expect(
+            !PromptLineTurnDetector.firstByteDisqualifiesWaitingPrompt(
+                in: [promptFirstByte],
+                promptFirstByte: promptFirstByte
+            )
+        )
+        #expect(
+            PromptLineTurnDetector.firstByteDisqualifiesWaitingPrompt(
+                in: [UInt8(ascii: "x")],
+                promptFirstByte: promptFirstByte
+            )
+        )
+    }
+
+    @Test("Printable-run scanning stops exactly at control bytes")
+    func printableRunScanningStopsAtControls() {
+        let controlBytes = Array(UInt8(0x00)...UInt8(0x1F)) + [UInt8(0x7F)]
+        for controlByte in controlBytes {
+            for printableCount in [0, 1, 7, 8, 15, 16, 19] {
+                let bytes = [UInt8(0x00)]
+                    + Array(repeating: UInt8(ascii: "x"), count: printableCount)
+                    + [controlByte, 0x80, 0xFF]
+                bytes.withUnsafeBufferPointer { buffer in
+                    #expect(
+                        PromptLineTurnDetector.firstNonPrintableByteIndex(
+                            in: buffer,
+                            from: 1
+                        ) == printableCount + 1,
+                        "control byte: \(controlByte), printable count: \(printableCount)"
+                    )
+                }
+            }
+        }
+
+        let printableBytes = [UInt8(0x00)]
+            + Array(repeating: UInt8(ascii: "x"), count: 19)
+            + [0x20, 0x7E, 0x80, 0xFF]
+        printableBytes.withUnsafeBufferPointer { buffer in
+            #expect(
+                PromptLineTurnDetector.firstNonPrintableByteIndex(
+                    in: buffer,
+                    from: 1
+                ) == buffer.endIndex
+            )
+        }
     }
 
     private func readyDetector() -> PromptLineTurnDetector {


### PR DESCRIPTION
## Purpose

Speed up raw PTY prompt detection by scanning printable runs eight bytes at a time, rejecting lines whose first byte cannot begin a configured prompt before searching prompt patterns, and retaining only the compact CSI state needed for supported `G` and `K` rewrites.

## Tests

- Added focused regressions for exact C0/DEL scan boundaries, first-byte prompt rejection, and inert multi-byte `CSI G` behavior.
- TDD: the test-only current-base build failed because the new hot-path helpers were absent; after implementation, `PromptLineTurnDetectorTests` passed 21/21 with Swift 6.0.3.
- Generic [macOS Compatibility run 30228368833](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30228368833) tested exact head `a27362208189c14216ba8b6eaa0291f1752b7448`, but both macOS 15 jobs failed in the repository-wide unit step while compiling unrelated `CmuxSimulator` code before detector tests; the inspected job reported unavailable `posix_spawn_file_actions_addchdir`. The Intel job acquired no runner and produced no steps.
- Immutable focused [run 30326486404](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30326486404) was dispatched for exact head `a27362208189c14216ba8b6eaa0291f1752b7448` with the automatic macOS runner, video disabled, and a 60-minute bound; result pending.

## Metrics

In a paired 14-sample ANSI-throughput fixture, baseline was 253,184 lines/s and treatment was 285,152 lines/s, a +12.63% delta. In the same paired context, CSI-handler samples were 0.050× baseline (-95%), terminal-tee samples were 0.6025× baseline (-39.75%), and presents per million lines were 0.726× baseline. These measurements cover the combined three-change treatment on a synthetic ANSI workload; they do not attribute the gain to any single optimization or claim end-to-end user latency.

## Safety

Observable detection behavior is unchanged: vector scanning stops exactly at C0/DEL, only impossible first bytes take the early rejection, and compact CSI state preserves bare/`0`/`1` `G` plus `2K` rewrites while keeping multi-byte parameters inert. The diff is limited to the detector and its focused tests. A complete base-to-head privacy scan found no private paths, host or account identifiers, session text, or harness artifacts. One-shot review reconciliation found no inline findings, and CodeRabbit reported no actionable comments; remaining automated checks are external gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prompt detection when terminal output includes multi-byte control sequences.
  - Prevented invalid prompt candidates from being considered, improving turn-state accuracy.
  - Improved handling of control characters and line-rewrite sequences.

- **Performance**
  - Faster processing of printable terminal output, especially for larger PTY data chunks.

- **Tests**
  - Added coverage for prompt validation, control-character scanning, and multi-byte terminal sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->