### PR TITLE
Avoid grapheme scans for bounded scrollback

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -64,6 +64,9 @@ enum SessionPersistencePolicy {
 
     static func truncatedScrollback(_ text: String?) -> String? {
         guard let text, !text.isEmpty else { return nil }
+        if text.utf8.count <= maxScrollbackCharactersPerTerminal {
+            return text
+        }
         if text.count <= maxScrollbackCharactersPerTerminal {
             return text
         }

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -675,6 +675,33 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testTruncatedScrollbackPreservesValuesAtOrBelowCharacterLimit() {
+        let maxChars = SessionPersistencePolicy.maxScrollbackCharactersPerTerminal
+        let exactASCII = String(repeating: "x", count: maxChars)
+        let exactUnicode = String(repeating: "🙂", count: maxChars)
+
+        XCTAssertNil(SessionPersistencePolicy.truncatedScrollback(nil))
+        XCTAssertNil(SessionPersistencePolicy.truncatedScrollback(""))
+        XCTAssertEqual(SessionPersistencePolicy.truncatedScrollback(exactASCII), exactASCII)
+        XCTAssertGreaterThan(exactUnicode.utf8.count, maxChars)
+        XCTAssertEqual(SessionPersistencePolicy.truncatedScrollback(exactUnicode), exactUnicode)
+    }
+
+    func testTruncatedScrollbackReturnsExactCharacterSuffixForOversizedValues() {
+        let maxChars = SessionPersistencePolicy.maxScrollbackCharactersPerTerminal
+        let retainedASCII = String(repeating: "x", count: maxChars)
+        let retainedUnicode = String(repeating: "e\u{301}", count: maxChars)
+
+        XCTAssertEqual(
+            SessionPersistencePolicy.truncatedScrollback("discarded" + retainedASCII),
+            retainedASCII
+        )
+        XCTAssertEqual(
+            SessionPersistencePolicy.truncatedScrollback("discarded" + retainedUnicode),
+            retainedUnicode
+        )
+    }
+
     func testTruncatedScrollbackAvoidsLeadingPartialANSICSISequence() {
         let maxChars = SessionPersistencePolicy.maxScrollbackCharactersPerTerminal
         let source = "\u{001B}[31m"


### PR DESCRIPTION
## Summary

- Skip a full `String.count` pass when retained scrollback is already within the persistence limit by UTF-8 length.
- Preserve the existing character-based truncation behavior for larger and multi-byte values.

## Purpose

Session persistence checks retained scrollback on every snapshot. This adds a UTF-8 length gate so bounded values return before the grapheme-cluster count, while values above the byte gate continue through the existing character-count and ANSI-safe suffix path.

## Tests

- Current-base resource regression: **RED** — at test-only commit `0858f160e98477af7c26cf0bd96ac27046c501b2`, the focused gate assertion failed because under-limit scrollback still reached the grapheme-cluster count.
- Treatment resource regression: **GREEN** — at PR head `5c5b407bd5d70030bd51d618d069ef371ecc4915`, the same structural assertion found the UTF-8 gate before the existing character-count path.
- Broad hosted run: https://github.com/usr-bin-roygbiv/cmux/actions/runs/30323866674 compiled and executed `SessionPersistenceTests`. All three relevant truncation tests passed. The 142-test class run ended with 20 unrelated Hermes/restorable-agent failures, so it is supporting evidence rather than a clean overall gate.
- Immutable-head narrow runs dispatched for clean proof:
  - bounded ASCII/Unicode behavior: https://github.com/usr-bin-roygbiv/cmux/actions/runs/30325376686
  - oversized composed-Unicode suffix: https://github.com/usr-bin-roygbiv/cmux/actions/runs/30325376689
  - ANSI-safe truncation boundary: https://github.com/usr-bin-roygbiv/cmux/actions/runs/30325376720

## Metrics

- Baseline: non-empty inputs at or below 400,000 UTF-8 bytes execute one explicit `String.count` pass.
- Treatment: the same inputs execute zero explicit `String.count` passes; delta **-1 pass (-100%) per qualifying call**.
- Sample context: the broader four-change terminal candidate measured 14 paired samples at 253,184 lines/s baseline and 285,152 lines/s treatment, +12.63% aggregate throughput.
- Claim boundary: there is no isolated timing result for this slice; the throughput result is context only and is not attributed to this change.

## Safety

The UTF-8 gate is conservative: a string with at most 400,000 UTF-8 bytes cannot exceed 400,000 characters. Inputs above the byte gate retain the existing character-count, Unicode suffix, and ANSI-safe truncation behavior. Scope is limited to `SessionPersistencePolicy` and its focused tests.

## Demo Video

N/A — no user-facing UI or behavior changes.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] Immutable-head narrow macOS runs completed cleanly
- [x] I added or updated focused behavior tests
- [x] Docs/changelog are not needed for this internal performance change
- [ ] Bot review comments are resolved
- [x] No human review comments are pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrollback truncation for multi-byte and non-ASCII text by basing truncation decisions on UTF-8 byte length rather than character count.
  * Preserves original content when it matches the configured limit, and truncates only when the limit is exceeded.
* **Tests**
  * Added test coverage for nil/empty inputs, exact-limit behavior (including Unicode cases), and correct suffix truncation for oversized content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->