### PR TITLE
Avoid terminal snapshot encoding copies

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5257,8 +5257,8 @@ class TerminalController {
         guard let ptr = text.text, text.text_len > 0 else {
             return ""
         }
-        let rawData = Data(bytes: ptr, count: Int(text.text_len))
-        return String(decoding: rawData, as: UTF8.self)
+        let bytes = UnsafeRawBufferPointer(start: ptr, count: Int(text.text_len))
+        return Self.decodeTerminalText(bytes)
     }
 
     private func readTerminalTextBase64(terminalPanel: TerminalPanel, includeScrollback: Bool = false, lineLimit: Int? = nil) -> String {
@@ -5271,23 +5271,25 @@ class TerminalController {
         ) else {
             return "ERROR: Terminal surface not found"
         }
-        switch Self.terminalTextPayload(
+        return Self.terminalTextBase64Response(
             from: snapshot,
             includeScrollback: includeScrollback,
             lineLimit: lineLimit
-        ) {
-        case .success(let payload):
-            return "OK \(payload.base64)"
-        case .failure(let error):
-            return "ERROR: \(error.message)"
-        }
+        )
     }
 
-    nonisolated static func terminalTextPayload(
+    nonisolated static func decodeTerminalText(_ bytes: UnsafeRawBufferPointer) -> String {
+        // Ghostty owns this buffer until `ghostty_surface_free_text`. String's
+        // decoder consumes it synchronously and returns owned storage, so no
+        // Data copy is needed while the pointer is alive.
+        String(decoding: bytes, as: UTF8.self)
+    }
+
+    nonisolated static func terminalTextOutput(
         from snapshot: TerminalTextRawSnapshot,
         includeScrollback: Bool,
         lineLimit: Int?
-    ) -> Result<TerminalTextPayload, TerminalTextPayloadError> {
+    ) -> Result<String, TerminalTextPayloadError> {
         let output: String
         if includeScrollback {
             var candidates: [String] = []
@@ -5328,8 +5330,42 @@ class TerminalController {
             output = viewport
         }
 
-        let base64 = output.data(using: .utf8)?.base64EncodedString() ?? ""
-        return .success(TerminalTextPayload(text: output, base64: base64))
+        return .success(output)
+    }
+
+    nonisolated static func terminalTextPayload(
+        from snapshot: TerminalTextRawSnapshot,
+        includeScrollback: Bool,
+        lineLimit: Int?
+    ) -> Result<TerminalTextPayload, TerminalTextPayloadError> {
+        switch terminalTextOutput(
+            from: snapshot,
+            includeScrollback: includeScrollback,
+            lineLimit: lineLimit
+        ) {
+        case .success(let output):
+            let base64 = output.data(using: .utf8)?.base64EncodedString() ?? ""
+            return .success(TerminalTextPayload(text: output, base64: base64))
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    nonisolated static func terminalTextBase64Response(
+        from snapshot: TerminalTextRawSnapshot,
+        includeScrollback: Bool,
+        lineLimit: Int?
+    ) -> String {
+        switch terminalTextPayload(
+            from: snapshot,
+            includeScrollback: includeScrollback,
+            lineLimit: lineLimit
+        ) {
+        case .success(let payload):
+            return "OK \(payload.base64)"
+        case .failure(let error):
+            return "ERROR: \(error.message)"
+        }
     }
 
     nonisolated private static func terminalTextCandidateScore(_ text: String) -> (lines: Int, bytes: Int) {
@@ -5579,21 +5615,18 @@ class TerminalController {
         includeScrollback: Bool = false,
         lineLimit: Int? = nil
     ) -> String? {
-        let response = readTerminalTextBase64(
-            terminalPanel: terminalPanel,
-            includeScrollback: includeScrollback,
-            lineLimit: lineLimit
-        )
-        guard response.hasPrefix("OK ") else { return nil }
-        let base64 = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
-        if base64.isEmpty {
-            return ""
-        }
-        guard let data = Data(base64Encoded: base64),
-              let decoded = String(data: data, encoding: .utf8) else {
+        guard terminalPanel.surface.liveSurfaceForGhosttyAccess(reason: "readPlainTerminalTextForSnapshot") != nil,
+              let snapshot = readTerminalTextRawSnapshot(
+                  terminalPanel: terminalPanel,
+                  includeScrollback: includeScrollback
+              ) else {
             return nil
         }
-        return decoded
+        return try? Self.terminalTextOutput(
+            from: snapshot,
+            includeScrollback: includeScrollback,
+            lineLimit: lineLimit
+        ).get()
     }
 
     func readTerminalTextForSnapshot(

--- a/cmuxTests/TerminalControllerTerminalTextTests.swift
+++ b/cmuxTests/TerminalControllerTerminalTextTests.swift
@@ -34,4 +34,80 @@ final class TerminalControllerTerminalTextTests: XCTestCase {
         XCTAssertEqual(payload.base64, Data("three\nfour\nfive".utf8).base64EncodedString())
     }
 
+    func testTerminalTextOutputReturnsPlainViewportWithoutEncodingRoundTrip() throws {
+        let result = TerminalController.terminalTextOutput(
+            from: TerminalController.TerminalTextRawSnapshot(
+                viewport: "prompt λ\nresult ✓",
+                screen: nil,
+                history: nil,
+                active: nil
+            ),
+            includeScrollback: false,
+            lineLimit: 1
+        )
+
+        XCTAssertEqual(try result.get(), "result ✓")
+    }
+
+    func testTerminalTextBase64ResponsePreservesSocketBytes() {
+        let response = TerminalController.terminalTextBase64Response(
+            from: TerminalController.TerminalTextRawSnapshot(
+                viewport: "prompt λ\nresult ✓",
+                screen: nil,
+                history: nil,
+                active: nil
+            ),
+            includeScrollback: false,
+            lineLimit: nil
+        )
+
+        XCTAssertEqual(response, "OK cHJvbXB0IM67CnJlc3VsdCDinJM=")
+    }
+
+    func testTerminalTextOutputAndBase64ResponsePreserveEmptyText() throws {
+        let snapshot = TerminalController.TerminalTextRawSnapshot(
+            viewport: "",
+            screen: nil,
+            history: nil,
+            active: nil
+        )
+
+        XCTAssertEqual(
+            try TerminalController.terminalTextOutput(
+                from: snapshot,
+                includeScrollback: false,
+                lineLimit: nil
+            ).get(),
+            ""
+        )
+        XCTAssertEqual(
+            TerminalController.terminalTextBase64Response(
+                from: snapshot,
+                includeScrollback: false,
+                lineLimit: nil
+            ),
+            "OK "
+        )
+    }
+
+    func testDecodeTerminalTextReadsBorrowedSelectionBytes() {
+        let bytes = Array("selected λ".utf8)
+
+        let decoded = bytes.withUnsafeBytes { buffer in
+            TerminalController.decodeTerminalText(buffer)
+        }
+
+        XCTAssertEqual(decoded, "selected λ")
+    }
+
+    func testDecodeTerminalTextPreservesInvalidUTF8ReplacementSemantics() {
+        let bytes: [UInt8] = [0x66, 0x80, 0x6f]
+
+        let decoded = bytes.withUnsafeBytes { buffer in
+            TerminalController.decodeTerminalText(buffer)
+        }
+
+        XCTAssertEqual(decoded, "f\u{FFFD}o")
+    }
+
 }


### PR DESCRIPTION
## Purpose

Avoid redundant terminal snapshot text copies by decoding Ghostty's borrowed bytes directly and returning formatted plain snapshot text without a UTF-8/Base64 round trip. Socket Base64 output remains unchanged.

## Tests

- `TerminalControllerTerminalTextTests`: plain viewport tailing, socket Base64 bytes, empty output, borrowed-buffer UTF-8 decoding, and invalid UTF-8 replacement semantics.
- Red: [focused macOS run 30323866685](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30323866685) compiled the test-only commit `ab786afd59` and failed in the selected test target because `TerminalController` lacked `terminalTextOutput`, `terminalTextBase64Response`, and `decodeTerminalText`. This is the intended current-base regression failure, not an infrastructure failure.
- Green: [focused macOS run 30326238465](https://github.com/usr-bin-roygbiv/cmux/actions/runs/30326238465) targets immutable implementation head `ab66ffffe0`; external runner result pending.

## Metrics

Current-base structural count per invocation:

- Non-empty Ghostty selection: 1 explicit `Data(bytes:)` buffer copy -> 0 (delta -1 copy per selection).
- Direct plain snapshot after formatting: 4 encode/decode steps (UTF-8 encode, Base64 encode, Base64 decode, UTF-8 decode) -> 0 (delta -4 steps per snapshot).

These are source/control-flow counts against upstream `main`, not timing or aggregate-throughput claims. Socket responses retain their required Base64 encoding.

## Safety

Snapshot selection, line limiting, empty text, Unicode, and invalid UTF-8 replacement behavior are covered. Borrowed Ghostty bytes are decoded synchronously before `ghostty_surface_free_text`, and the socket response format is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text decoding, including support for borrowed UTF-8 selection data and consistent handling of invalid characters.
  * Improved terminal snapshot and viewport text retrieval, including empty viewport handling.
  * Preserved correct plain-text and base64 response formats for terminal content.

* **Tests**
  * Added coverage for viewport output, base64 responses, empty content, and UTF-8 decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->