### PR TITLE
Display-link occlusion replay (unproven; parity with main — do not merge for perf)

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -43,17 +43,22 @@ extension TerminalSurface {
         }
     }
 
-    /// Applies the occlusion state to the runtime surface (deduplicated).
+    /// Applies the occlusion state to the runtime surface.
     ///
     /// The desired value is recorded even when there is no runtime surface yet,
     /// so `createSurface` can replay it. Without that, a `false` pushed while the
     /// surface was still nil is lost and Ghostty keeps its default
     /// `visible = true`, leaving the surface's `CVDisplayLink` free to run at the
     /// display refresh rate for a pane that is not on screen.
+    ///
+    /// Deliberately NOT deduplicated. Ghostty's renderer starts the display link
+    /// from `setFocus(true)` without consulting its own visibility, so a repeated
+    /// `false` here is what stops a link that a focus event restarted behind our
+    /// back. Suppressing those repeats measurably leaks links (7 running vs 1 on
+    /// main for the same workload).
     public func setOcclusion(_ visible: Bool) {
         desiredOcclusionVisible = visible
         guard let surface = surface else { return }
-        guard appliedOcclusionVisible != visible else { return }
         appliedOcclusionVisible = visible
         ghostty_surface_set_occlusion(surface, visible)
     }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -43,10 +43,29 @@ extension TerminalSurface {
         }
     }
 
-    /// Applies the occlusion state to the runtime surface.
+    /// Applies the occlusion state to the runtime surface (deduplicated).
+    ///
+    /// The desired value is recorded even when there is no runtime surface yet,
+    /// so `createSurface` can replay it. Without that, a `false` pushed while the
+    /// surface was still nil is lost and Ghostty keeps its default
+    /// `visible = true`, leaving the surface's `CVDisplayLink` free to run at the
+    /// display refresh rate for a pane that is not on screen.
     public func setOcclusion(_ visible: Bool) {
+        desiredOcclusionVisible = visible
         guard let surface = surface else { return }
+        guard appliedOcclusionVisible != visible else { return }
+        appliedOcclusionVisible = visible
         ghostty_surface_set_occlusion(surface, visible)
+    }
+
+    /// Pushes `desiredOcclusionVisible` onto a freshly created runtime surface,
+    /// bypassing the dedupe cache (a new runtime surface starts from Ghostty's
+    /// own `visible = true` default, so the cache from the previous one cannot be
+    /// trusted). Called from `createSurface`.
+    @MainActor
+    func replayDesiredOcclusionToRuntime() {
+        appliedOcclusionVisible = nil
+        setOcclusion(desiredOcclusionVisible)
     }
 
     /// Whether this surface currently holds realized GPU renderer resources.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -328,6 +328,9 @@ extension TerminalSurface {
         pendingSocketInputQueue.removeAll(keepingCapacity: false)
         pendingSocketInputBytes = 0
         desiredFocusState = false
+        // The next runtime surface starts from Ghostty's own default, so drop the
+        // applied cache and let `createSurface` replay `desiredOcclusionVisible`.
+        appliedOcclusionVisible = nil
 
         guard let surfaceToFree else {
             callbackContext?.release()
@@ -629,6 +632,14 @@ extension TerminalSurface {
         // surface converges with any focus changes that happened while the
         // surface was being initialized.
         ghostty_surface_set_focus(createdSurface, desiredFocusState)
+
+        // Same convergence for occlusion. A hidden pane's `setOcclusion(false)`
+        // usually lands before its runtime surface exists (background workspaces
+        // create surfaces lazily), and Ghostty's renderer defaults to
+        // `visible = true` and only reacts to transitions, so without this replay
+        // the surface stays "visible" to Ghostty forever and keeps its
+        // CVDisplayLink ticking at the display refresh rate off screen.
+        replayDesiredOcclusionToRuntime()
 
         flushPendingSocketInputIfNeeded()
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -286,6 +286,24 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// state unless the workspace focus path requests it.
     var desiredFocusState: Bool = false
 
+    /// Portal-visibility state cmux wants Ghostty to have, tracked independently
+    /// of whether a runtime surface exists yet.
+    ///
+    /// Surfaces for background workspaces are created lazily, long after the
+    /// portal has already marked the view hidden, so the `false` push lands on a
+    /// nil runtime surface and is lost. Ghostty's renderer thread defaults to
+    /// `visible = true` and only reacts to transitions, so a lost `false` leaves
+    /// it believing the surface is on screen forever. Combined with a focused
+    /// surface that keeps its `CVDisplayLink` running, that is a display-refresh
+    /// -rate wakeup for a surface nobody can see. `createSurface` replays this
+    /// exactly like `desiredFocusState`.
+    var desiredOcclusionVisible: Bool = true
+
+    /// Last occlusion value actually handed to the live runtime surface, used to
+    /// dedupe redundant pushes. Reset on runtime teardown so a recreated surface
+    /// always re-receives the desired state instead of trusting a stale cache.
+    var appliedOcclusionVisible: Bool?
+
     /// Bumped after every completed runtime clipboard read.
     public internal(set) var clipboardReadGeneration = 0
 #if DEBUG

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceOcclusionReplayTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceOcclusionReplayTests.swift
@@ -1,0 +1,119 @@
+import AppKit
+import CmuxTerminalCore
+import Foundation
+import GhosttyKit
+import Testing
+@testable import CmuxTerminal
+
+@_silgen_name("cmux_test_ghostty_renderer_realized_begin")
+private func beginOcclusionTracking(_ surface: UnsafeMutableRawPointer)
+
+@_silgen_name("cmux_test_ghostty_renderer_realized_reset")
+private func resetOcclusionTracking()
+
+@_silgen_name("cmux_test_ghostty_occlusion_visible")
+private func ghosttyOcclusionVisible() -> Bool
+
+/// Ghostty's renderer thread starts every surface at `visible = true` and only
+/// reacts to visibility *transitions*. A surface that Ghostty believes is
+/// visible keeps its `CVDisplayLink` free to run at the display refresh rate,
+/// waking its renderer thread ~120x/sec for a pane nobody can see.
+///
+/// cmux creates surfaces for background workspaces lazily, so the portal's
+/// `setOcclusion(false)` routinely lands while the runtime surface is still nil.
+/// These tests pin that such a request is not lost.
+@MainActor
+@Suite(.serialized) struct TerminalSurfaceOcclusionReplayTests {
+    @Test func occlusionRequestedBeforeRuntimeExistsReachesGhosttyOnCreation() {
+        let surface = makeSurface()
+        let runtime = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        beginOcclusionTracking(runtime)
+        defer {
+            surface.releaseSurfaceForTesting()
+            runtime.deallocate()
+            resetOcclusionTracking()
+        }
+
+        // The portal hides the pane before its runtime surface has been created.
+        surface.setOcclusion(false)
+        #expect(ghosttyOcclusionVisible(), "no runtime surface yet, so Ghostty cannot have been told")
+
+        // Runtime surface comes up later; createSurface replays the desired state.
+        surface.installRuntimeSurfaceForTesting(runtime)
+        surface.replayDesiredOcclusionToRuntime()
+
+        #expect(!ghosttyOcclusionVisible(), "hidden pane must reach Ghostty as occluded")
+    }
+
+    @Test func visibleSurfaceIsNotOccludedByTheReplay() {
+        let surface = makeSurface()
+        let runtime = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        beginOcclusionTracking(runtime)
+        defer {
+            surface.releaseSurfaceForTesting()
+            runtime.deallocate()
+            resetOcclusionTracking()
+        }
+
+        surface.setOcclusion(true)
+        surface.installRuntimeSurfaceForTesting(runtime)
+        surface.replayDesiredOcclusionToRuntime()
+
+        #expect(ghosttyOcclusionVisible(), "an on-screen pane must not be occluded by the replay")
+    }
+
+    @Test func recreatedRuntimeSurfaceRelearnsOcclusion() {
+        let surface = makeSurface()
+        let first = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        let second = UnsafeMutableRawPointer.allocate(byteCount: 8, alignment: 8)
+        defer {
+            surface.releaseSurfaceForTesting()
+            first.deallocate()
+            second.deallocate()
+            resetOcclusionTracking()
+        }
+
+        beginOcclusionTracking(first)
+        surface.installRuntimeSurfaceForTesting(first)
+        surface.setOcclusion(false)
+        #expect(!ghosttyOcclusionVisible())
+
+        // A replacement runtime surface starts from Ghostty's visible default, so
+        // the dedupe cache from the previous one must not suppress the re-push.
+        resetOcclusionTracking()
+        beginOcclusionTracking(second)
+        surface.installRuntimeSurfaceForTesting(second)
+        surface.replayDesiredOcclusionToRuntime()
+
+        #expect(!ghosttyOcclusionVisible(), "recreated surface must relearn that it is hidden")
+    }
+
+    private func makeSurface() -> TerminalSurface {
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
+        return TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            dependencies: TerminalSurfaceRuntimeDependencies(
+                registry: FakeSurfaceRegistry(),
+                engine: FakeTerminalEngine(),
+                viewProvider: FakeTerminalSurfaceViewProvider(surfaceView: nativeView, paneHost: paneHost),
+                spawnPolicy: FakeSpawnPolicyProvider(),
+                byteTee: FakeTerminalByteTee(),
+                rendererRealization: FakeRendererRealizationScheduler(),
+                hibernationRecorder: FakeHibernationRecorder(),
+                runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
+                restoreSpawnScheduler: TerminalSurfaceRestoreSpawnScheduler(interSpawnDelay: .zero),
+                runtimeFilesystem: TerminalSurfaceRuntimeFilesystem(
+                    claudeCommandShimTemporaryDirectory: URL(fileURLWithPath: "/tmp/cmux-terminal-tests", isDirectory: true),
+                    installClaudeCommandShim: { _, _, _ in nil },
+                    isExecutableFile: { _ in false }
+                ),
+                sessionPortBase: 40_000,
+                sessionPortRangeSize: 100,
+                scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"
+            )
+        )
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -70,6 +70,10 @@ bool cmux_test_ghostty_renderer_release_was_occluded(void) {
     return cmux_test_renderer_release_was_occluded;
 }
 
+bool cmux_test_ghostty_occlusion_visible(void) {
+    return cmux_test_renderer_occlusion_visible;
+}
+
 bool ghostty_surface_clear_selection(void *surface) {
     (void)surface;
     return false;

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -81,5 +81,6 @@ uint32_t cmux_test_ghostty_renderer_realized_call_count(void);
 bool cmux_test_ghostty_renderer_realized_call_value(uint32_t index);
 void cmux_test_ghostty_renderer_realized_set_result(bool result);
 bool cmux_test_ghostty_renderer_release_was_occluded(void);
+bool cmux_test_ghostty_occlusion_visible(void);
 
 #endif

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8004,7 +8004,6 @@ final class GhosttySurfaceScrollView: NSView {
     private static let scrollToBottomThreshold: CGFloat = 5.0
     private var isActive = true
     private var lastFocusRefreshAt: CFTimeInterval = 0
-    private var lastRequestedPortalOcclusionVisible: Bool?
     private var activeDropZone: DropZone?
     private var pendingDropZone: DropZone?
     private var sessionContentWidthPresentation = SessionContentWidthPresentation.disabled
@@ -9724,10 +9723,13 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.setVisibleInUI(visible)
         isHidden = !visible
         surfaceView.terminalSurface?.setRendererPortalVisible(visible)
-        if wasVisible != visible, lastRequestedPortalOcclusionVisible != visible {
-            lastRequestedPortalOcclusionVisible = visible
-            surfaceView.terminalSurface?.setOcclusion(visible)
-        }
+        // Hand the authoritative portal state to the surface on every call.
+        // `TerminalSurface.setOcclusion` dedupes and records the value for replay
+        // across runtime surface recreation. Gating here on the view's own
+        // previous value dropped the push whenever the view had already been
+        // marked hidden before its runtime surface existed, which left Ghostty on
+        // its `visible = true` default and its CVDisplayLink running off screen.
+        surfaceView.terminalSurface?.setOcclusion(visible)
 #if DEBUG
         if wasVisible != visible {
             let transition = "\(wasVisible ? 1 : 0)->\(visible ? 1 : 0)"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9723,13 +9723,16 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.setVisibleInUI(visible)
         isHidden = !visible
         surfaceView.terminalSurface?.setRendererPortalVisible(visible)
-        // Hand the authoritative portal state to the surface on every call.
-        // `TerminalSurface.setOcclusion` dedupes and records the value for replay
-        // across runtime surface recreation. Gating here on the view's own
-        // previous value dropped the push whenever the view had already been
-        // marked hidden before its runtime surface existed, which left Ghostty on
-        // its `visible = true` default and its CVDisplayLink running off screen.
-        surfaceView.terminalSurface?.setOcclusion(visible)
+        // Only push on a real transition. `visibleInUI` starts `true` for every
+        // view, and a pane that is never mounted is never corrected, so an
+        // unconditional push here would tell Ghostty that off-screen panes are
+        // visible and *start* their CVDisplayLinks (measured: 9 running links of
+        // 10 surfaces vs 0 on main). `TerminalSurface.setOcclusion` records the
+        // value even when the runtime surface does not exist yet and replays it
+        // on creation, which is what keeps a hide from being lost.
+        if wasVisible != visible {
+            surfaceView.terminalSurface?.setOcclusion(visible)
+        }
 #if DEBUG
         if wasVisible != visible {
             let transition = "\(wasVisible ? 1 : 0)->\(visible ? 1 : 0)"


### PR DESCRIPTION
## What I measured

Profiled the running `cmux.app` 0.64.20 with `sample` (370 threads) while the session was locked, so nothing was on screen:

| | |
|---|---|
| Ghostty surfaces | 64 |
| CVDisplayLinks **running** | **25** |
| Renderer threads awake | **24** |
| Correct number with nothing visible | **0** |

A CoreVideo display-link IO thread exists only while the link is created, and a running one parks in `CVDisplayLink::waitUntil` at the display refresh rate, so thread count is an exact proxy (`created == running` in every sample). Awake renderer threads correlated one-to-one with running links; the other 37 renderer threads sat idle in `kevent64`.

Each of those threads wakes ~120x/sec for a pane nobody can see, and the wakeup work is dominated by `zig_os_log_with_type` -> `_os_log_impl_flatten_and_send` -> `voucher_activity_trace_v_2` -> `_dlock_wait`, so they also serialize on the libtrace lock and feed `logd` (measured at 26% CPU). That amplification is https://github.com/manaflow-ai/cmux/issues/8919; this PR removes the wakeups driving it. Related: https://github.com/manaflow-ai/cmux/issues/8564.

## Root cause

Ghostty's renderer starts every surface at `focused = true` / `visible = true`, starts the CVDisplayLink unconditionally in `loopEnter`, and afterwards only reacts to *transitions*. The link runs while `visible && focused`.

cmux drives both, but only occlusion was lossy:

- `createSurface` replays `desiredFocusState` but **never replayed occlusion**.
- Surfaces for background workspaces are created lazily, so the portal's `setOcclusion(false)` typically lands while `surface` is still `nil`, and `guard let surface else { return }` drops it.
- `GhosttySurfaceScrollView.setVisibleInUI` then cached in `lastRequestedPortalOcclusionVisible` that it had already asked for "hidden", so nothing re-sent it.

Ghostty therefore believed the pane was visible for the rest of the surface's life; once anything focused it, the display link ran forever.

## Fix

Mirrors the existing focus-replay pattern:

- `TerminalSurface.desiredOcclusionVisible` records the wanted state even with no runtime surface.
- `TerminalSurface.appliedOcclusionVisible` dedupes against what the *live* surface was actually told, cleared on runtime teardown so a recreated surface relearns it.
- `createSurface` calls `replayDesiredOcclusionToRuntime()` right after the focus replay.
- `GhosttySurfaceScrollView` drops its duplicate cache and defers deduping to the surface.

## A regression I introduced and backed out

My first attempt also made `setVisibleInUI` push occlusion unconditionally, on the theory that the view layer held authoritative state. It does not: `visibleInUI` starts `true` on every `GhosttyNSView` and a pane that is never mounted is never corrected. Measured with an identical scripted workload (launch, create 4 workspaces focused, cycle, send input):

| build | surfaces | display links running |
|---|---|---|
| `main` (baseline) | 6 | **0** |
| first attempt | 10 | **9** |
| this PR (corrected) | 9 | **0** |

Second commit restores the transition guard. The lost-hide fix does not depend on the push being unconditional.

## Verification status — read before merging

- **Proven:** the lost pre-creation occlusion push is fixed (unit tests below), and this branch does not start links that `main` leaves stopped (table above).
- **Not yet proven end-to-end:** I could not reproduce the original 25-link leak in a controlled build. The leak needs a surface to become first responder, and this Mac's session was locked for the whole session, so no surface ever took interactive focus and both `main` and this branch measured 0. The real confirmation is running this build in a normal multi-workspace session and re-counting.

Count on any build with:

```
sample <pid> 3 -file /tmp/s.txt && grep -c 'CVDisplayLink' /tmp/s.txt
```

Expected: roughly the number of panes actually on screen and focused, not the number of workspaces ever visited.

## Tests

`Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceOcclusionReplayTests.swift` asserts the real `ghostty_surface_set_occlusion` value through the existing runtime stub (new `cmux_test_ghostty_occlusion_visible()` accessor):

- pre-creation `setOcclusion(false)` reaches Ghostty when the runtime surface appears
- a visible pane is not occluded by the replay
- a recreated runtime surface relearns that it is hidden

Red/green verified locally by neutering the implementation: tests 1 and 3 fail, test 2 (the no-regression case) stays green. Kept as one commit because the test needs the new seam to compile, so a test-only commit would fail to build rather than fail its assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal visibility and occlusion state becoming out of sync after runtime surfaces are recreated or resumed.
  * Ensured hidden terminal panes remain hidden and visible panes are correctly restored.
  * Prevented stale visibility state from suppressing necessary updates.

* **Tests**
  * Added coverage for occlusion replay during surface creation, transitions, and recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->