### PR TITLE
docs: fix outdated Xcode/macOS/Rust prerequisites in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-- macOS 26+
-- Xcode 26+ (see `.xcode-version` for the exact pinned version)
+- macOS 15.6+ (required to run Xcode 26)
+- Xcode 26.0 (pinned in `.xcode-version` and enforced by `scripts/check-pbxproj.sh` in CI)
 - [Zig](https://ziglang.org/) (install via `brew install zig`)
 - [Rust](https://rustup.rs/)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,10 @@
 
 ## Prerequisites
 
-- macOS 14+
-- Xcode 15+
+- macOS 26+
+- Xcode 26+ (see `.xcode-version` for the exact pinned version)
 - [Zig](https://ziglang.org/) (install via `brew install zig`)
+- [Rust](https://rustup.rs/)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- CONTRIBUTING.md listed macOS 14+ / Xcode 15+ as prerequisites and didn't mention Rust
- \`.xcode-version\` pins Xcode 26 (enforced by \`scripts/check-pbxproj.sh\` as a CI guard on \`objectVersion\`), and \`scripts/setup.sh\` requires Rust to be installed
- Updated the prerequisites section to match what setup.sh actually checks for, so new contributors don't hit build errors from an outdated toolchain

## Test plan
- [x] Doc-only change, no build/test impact

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787707400&installation_model_id=21920&pr_number=8982&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8982&signature=4e99b9adfc41da4d64ec7fac2883e61aa12e211f446d4324358d7f9e5b269422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CONTRIBUTING prerequisites to match the current toolchain. Replace macOS 14+/Xcode 15+ with macOS 15.6+ and Xcode 26.0 (pinned in `.xcode-version` and enforced by `scripts/check-pbxproj.sh`), and add Rust to avoid setup errors.

<sup>Written for commit 5974cbddd739092b60f2fa6234ca9d4cf03d304f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated developer environment prerequisites: macOS now requires 15.6+ and the minimum supported Xcode version is now 26.0.
  * Added guidance to use the project’s pinned Xcode version.
  * Noted that CI enforces the required Xcode version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->