### PR TITLE
Fix TUI frame shrink race during drawing

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -3265,6 +3265,8 @@ pub struct App {
     sidebar_plugin_retry_at: Option<Instant>,
     sidebar_width_override: Option<u16>,
     machine_sidebar_width_override: Option<u16>,
+    /// Host grid used to compute the cached sidebar and pane rectangles.
+    pub(crate) frame_layout_size: Option<(u16, u16)>,
     /// Pane region of the current frame (screen minus sidebar/status).
     pub content_area: Rect,
     /// Clickable regions of the current frame, rebuilt by the renderers.
@@ -4354,6 +4356,7 @@ pub fn run_with_machine_updates(
         sidebar_plugin_retry_at: None,
         sidebar_width_override: None,
         machine_sidebar_width_override: None,
+        frame_layout_size: None,
         content_area: Rect::default(),
         hits: Vec::new(),
         tab_scroll: HashMap::new(),
@@ -5908,8 +5911,9 @@ impl App {
     /// Refresh the tree snapshot, recompute the active screen's layout
     /// (each pane's border box eats one cell on every side), and push
     /// content sizes to surfaces.
-    fn sync_layout(&mut self, size: (u16, u16)) {
+    pub(crate) fn sync_layout(&mut self, size: (u16, u16)) {
         let (width, height) = size;
+        self.frame_layout_size = Some(size);
         self.sidebar_layout = if self.surface_only.is_some() {
             SidebarLayout {
                 content: Rect { x: 0, y: 0, width, height },
@@ -19831,6 +19835,7 @@ mod tests {
             sidebar_plugin_retry_at: None,
             sidebar_width_override: None,
             machine_sidebar_width_override: None,
+            frame_layout_size: None,
             content_area: Rect::default(),
             hits: Vec::new(),
             tab_scroll: HashMap::new(),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -11804,6 +11804,16 @@ mod tests {
     }
 
     #[test]
+    fn draw_survives_host_shrinking_after_layout_sync() {
+        let mux = Mux::new("host-shrink-draw-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.sync_layout((80, 25));
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+    }
+
+    #[test]
     fn panic_restore_waits_for_a_concurrent_stdout_owner() {
         let lock = Arc::new(StdoutLock::new(()));
         let (held_tx, held_rx) = std::sync::mpsc::sync_channel(1);

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -33,6 +33,10 @@ pub(crate) use scrollbar::{
 pub fn draw(app: &mut App, frame: &mut Frame) {
     app.reset_frame_cursor_spec();
     let area = frame.area();
+    let frame_size = (area.width, area.height);
+    if app.frame_layout_size.is_some_and(|layout_size| layout_size != frame_size) {
+        app.sync_layout(frame_size);
+    }
     if area.height == 0 {
         return;
     }


### PR DESCRIPTION
## Summary

- track the host grid used to compute cached pane and sidebar rectangles
- resynchronize layout from the actual Ratatui frame when the host size changes between the pre-draw size query and frame creation
- add a regression that reproduces the Ratatui `index outside of buffer` panic when the backend shrinks by one row

## Regression sequence

Commit 1 adds the failing test and reproduces an access at `(0, 24)` against an `80x24` buffer after layout was computed for `80x25`.

Commit 2 recomputes the layout from `Frame::area()` before any renderer uses cached rectangles.

## Verification

- `cargo +1.97.1 test -p cmux-tui draw_survives_host_shrinking_after_layout_sync -- --nocapture`
- `cargo +1.97.1 fmt --all -- --check`
- `cargo +1.97.1 build -p cmux-tui`

One pre-existing selection test fails identically on the test-only parent commit and the fixed commit; it is unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787726462&installation_model_id=21920&pr_number=8996&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8996&signature=068d2b396a73af4c3036c09a48ae452d79b0b3432b9c8d7ca1962635d4a5d128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a TUI layout race when the terminal shrinks between sizing and draw. Prevents the `ratatui` "index outside of buffer" panic and stabilizes drawing during rapid resizes.

- Bug Fixes
  - Store the last layout grid on `App` as `frame_layout_size` to validate cached pane/sidebar rects.
  - On draw, resync layout from `Frame::area()` when it differs from the cached size.
  - Add a regression test covering the 80x25 → 80x24 shrink case.

<sup>Written for commit c8d7c18fe13431d18a4de84eb932b58fe37ccd61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI rendering when the terminal window is resized smaller.
  * Prevented drawing failures caused by mismatches between cached layout dimensions and the current terminal frame size.
  * Added regression coverage to ensure the interface remains stable after host layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->