### PR TITLE
CI: verify TUI ARM64 packages on native runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,8 +1,9 @@
 self-hosted-runner:
   labels:
     # Active default lives in the MACOS_RUNNER_15 / MACOS_RUNNER_26 /
-    # MACOS_RUNNER_IOS / LINUX_RUNNER repo variables; these are the literal
-    # labels referenced as fallbacks or as manual workflow_dispatch choices.
+    # MACOS_RUNNER_IOS / LINUX_RUNNER / LINUX_ARM64_RUNNER repo variables;
+    # these are the literal labels referenced as fallbacks or as manual
+    # workflow_dispatch choices.
     # See docs/ci-runners.md.
     - blacksmith-6vcpu-macos-15
     - blacksmith-6vcpu-macos-26

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -373,16 +373,21 @@ jobs:
     name: verify Linux package entrypoints (${{ matrix.architecture }})
     needs: package
     if: ${{ inputs.package_npm || inputs.package_pypi }}
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        architecture:
-          - x64
-          - arm64
+        include:
+          - architecture: x64
+            runner: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+          # Run ARM64 containers on native hardware. QEMU registration is not
+          # persistent on every third-party x64 runner and can disappear
+          # between setup and the package smoke test.
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
     env:
       PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
     steps:
@@ -398,12 +403,6 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
-
-      - name: Set up ARM64 emulation
-        if: matrix.architecture == 'arm64'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-        with:
-          platforms: arm64
 
       - name: Download npm package archive
         if: inputs.package_npm

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -387,7 +387,7 @@ jobs:
           # persistent on every third-party x64 runner and can disappear
           # between setup and the package smoke test.
           - architecture: arm64
-            runner: ubuntu-24.04-arm
+            runner: ${{ vars.LINUX_ARM64_RUNNER || 'ubuntu-24.04-arm' }} # github-hosted-required: package smoke tests need native ARM64 execution
     env:
       PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
     steps:

--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -8,6 +8,7 @@ that takes effect on the next workflow run.
 | Variable            | Used by                                                    | Active value                | Fallback baked into the workflow |
 | ------------------- | ---------------------------------------------------------- | --------------------------- | -------------------------------- |
 | `LINUX_RUNNER`      | every Linux job (`ci.yml` web/typecheck/db, presence, cloud-vm, nightly/ios decide jobs, claude, homebrew, tmux fuzz) | `blacksmith-4vcpu-ubuntu-2404` | `warp-ubuntu-latest-x64-4x`   |
+| `LINUX_ARM64_RUNNER` | native ARM64 package entrypoint verification              | `ubuntu-24.04-arm`          | `ubuntu-24.04-arm`               |
 | `MACOS_RUNNER_15`   | universal Release app builds: nightly, stable release, `release-ghostty-cli-helper`, most macOS defaults | `tart-macos-15` | `warp-macos-15-arm64-6x`         |
 | `MACOS_RUNNER_DUAL_XCODE` | `swift-package-tests` (SDK 15 release helper, then SDK 26 package tests) | `blacksmith-6vcpu-macos-15` | `blacksmith-6vcpu-macos-15` |
 | `MACOS_RUNNER_26`   | macOS 26 compatibility jobs                                | `blacksmith-6vcpu-macos-26` | `blacksmith-6vcpu-macos-26`      |
@@ -47,6 +48,7 @@ fleet recovers.
 
 ```bash
 gh variable set LINUX_RUNNER          --repo manaflow-ai/cmux -b blacksmith-4vcpu-ubuntu-2404
+gh variable set LINUX_ARM64_RUNNER    --repo manaflow-ai/cmux -b ubuntu-24.04-arm
 gh variable set MACOS_RUNNER_15         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
 gh variable set MACOS_RUNNER_DUAL_XCODE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
 gh variable set MACOS_RUNNER_26         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26


### PR DESCRIPTION
The cmux-tui-v0.9.7 release built every artifact, then failed twice before package execution because QEMU registration disappeared on the x64 Blacksmith runner.

This routes the ARM64 package smoke test to GitHub native ubuntu-24.04-arm hardware and keeps x64 verification on the configured Linux runner. The release-source parent remains the exact v0.9.7 commit so a new immutable patch tag can rebuild the same TUI source with repaired verification.

Failure: https://github.com/manaflow-ai/cmux/actions/runs/30265382547/job/89978220642

Verification: CI plus a cmux-tui-v0.9.8 release artifact run after merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787747933&installation_model_id=21920&pr_number=9004&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9004&signature=3353a9677f2a757514e740664fd9412f8e2379f45eddd7f732ea14d7f55a1dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes TUI ARM64 package verification to native ARM runners to stabilize smoke tests and avoid QEMU flakiness. x64 verification stays on the configured Linux runner.

- **Bug Fixes**
  - Use a per-arch matrix with explicit runners: x64 uses `vars.LINUX_RUNNER` (fallback `blacksmith-4vcpu-ubuntu-2404`); ARM64 uses `vars.LINUX_ARM64_RUNNER` (fallback `ubuntu-24.04-arm`).
  - Remove the ARM64 QEMU emulation setup step.

<sup>Written for commit ea467c0f71e86459f292391bf3627ec047cc5efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux package verification for ARM64 by pinning the ARM64 checks to the correct runner.
  * Removed ARM64 emulation from the test flow so verification runs directly on native ARM64 infrastructure.
  * Continued validation of published npm and PyPI packages across supported Linux architectures.
* **Documentation**
  * Added documentation for the `LINUX_ARM64_RUNNER` variable and updated “break-glass” runner-switch instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->