### PR TITLE
Fix Bash Shell Integration Printing `cannot overwrite existing file` Under Noclobber (#6714)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -957,6 +957,7 @@ jobs:
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
           python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
+          python3 tests/test_issue_6714_bash_shim_noclobber.py
           python3 tests/test_issue_8953_zsh_prompt_wrap_guard.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -334,7 +334,13 @@ _cmux_install_cli_command_shim() {
         else
             printf 'exec "%s" "$@"\n' "$escaped_wrapper"
         fi
-    } >"$shim_path" 2>/dev/null || return 0
+    # Use bash's explicit clobber redirection (>|) so cmux always refreshes its
+    # own generated shim, even when the user's interactive bash has `noclobber`
+    # set. A plain `>` is refused under noclobber and prints `cannot overwrite
+    # existing file` on startup (the writer runs again from the _cmux_fix_path
+    # prompt hook after the shim already exists), and `|| return 0` then leaves
+    # the shim stale. Mirrors the zsh fix in #6815. See issue #6714.
+    } >|"$shim_path" 2>/dev/null || return 0
     /bin/chmod 0700 "$shim_path" >/dev/null 2>&1 || return 0
 
     if [[ "$command_name" == "claude" ]]; then

--- a/tests/test_issue_6714_bash_shim_noclobber.py
+++ b/tests/test_issue_6714_bash_shim_noclobber.py
@@ -60,9 +60,19 @@ INTEGRATION = REPO_ROOT / "Resources/shell-integration/cmux-bash-integration.bas
 # source time), so the only writes are our two explicit calls. The prompt hooks
 # the integration registers never fire under `bash -c` (non-interactive, no
 # prompt), keeping the scenario focused on the shim writer.
+#
+# Sourcing is deliberately *not* stderr-suppressed: with the clean environment
+# below the integration sources silently, so any initialization noise is a real
+# signal and must fail the test rather than hide behind `2>/dev/null`. The
+# explicit `declare -F` guard then fails loudly (exit 90) if the shim writer is
+# missing, so a broken driver can never look like a passing scenario.
 DRIVER = r"""
 set -o noclobber
-source "$CMUX_BASH_INTEGRATION" 2>/dev/null
+source "$CMUX_BASH_INTEGRATION"
+if ! declare -F _cmux_install_cli_command_shim >/dev/null 2>&1; then
+    printf '%s\n' 'driver: _cmux_install_cli_command_shim undefined after sourcing' >&2
+    exit 90
+fi
 export TMPDIR="$CMUX_TEST_TMPDIR"
 export CMUX_SURFACE_ID="$CMUX_TEST_SURFACE_ID"
 _cmux_install_cli_command_shim claude "$CMUX_TEST_WRAPPER_A"
@@ -116,6 +126,14 @@ def test_bash_shim_refresh_is_silent_and_refreshes_under_noclobber() -> None:
             f"\nexit={proc.returncode}"
             f"\n--- driver stdout ---\n{proc.stdout}"
             f"\n--- driver stderr ---\n{proc.stderr}"
+        )
+
+        # Fail fast on a broken driver: a non-zero exit means sourcing or the
+        # `declare -F` precondition failed, so nothing below would be testing
+        # the scenario we think it is.
+        assert proc.returncode == 0, (
+            "driver did not complete cleanly; the noclobber scenario never ran"
+            + debug
         )
 
         # The reported symptom: bash refuses to clobber the existing shim and

--- a/tests/test_issue_6714_bash_shim_noclobber.py
+++ b/tests/test_issue_6714_bash_shim_noclobber.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Regression coverage for the bash half of
+https://github.com/manaflow-ai/cmux/issues/6714.
+
+The zsh half was fixed in #6815. The identical defect still exists in the bash
+integration: when a user enables ``set -o noclobber`` in their interactive bash,
+cmux's shell integration prints a spurious error on startup::
+
+    cmux-bash-integration.bash: line 281: \
+        /var/folders/.../T/cmux-cli-shims/<surface-id>/claude: \
+        cannot overwrite existing file
+
+Root cause: ``Resources/shell-integration/cmux-bash-integration.bash`` writes a
+per-surface CLI shim with a plain ``>`` redirection::
+
+    } >"$shim_path" 2>/dev/null || return 0
+
+``_cmux_install_cli_command_shim`` runs more than once per shell (once at source
+time via the top-level ``_cmux_install_cli_wrapper claude`` call, and again from
+the ``_cmux_fix_path`` prompt hook). The second write targets a shim that
+already exists, so under ``noclobber`` bash refuses to overwrite the file. The
+``2>/dev/null`` does not suppress the message, because the no-clobber failure is
+reported by the shell's redirection machinery on the compound-command redirect
+itself rather than by anything running inside the group.
+
+The failure is not merely cosmetic: ``|| return 0`` then *skips* the write, so
+the shim is also left stale and keeps pointing at the wrapper path captured by
+the first write.
+
+The fix is bash's explicit clobber redirection (``>|``) for this cmux-owned
+generated file, which overwrites regardless of the user's global ``noclobber``
+setting -- the same operator the zsh integration adopted in #6815.
+
+This test drives the *actual* integration file through real bash with
+``noclobber`` enabled and asserts that a second shim write is silent **and**
+actually refreshes the shim contents. It is deterministic (no PTY, no sleeps,
+no network) and locale-pinned so the assertions do not depend on bash's message
+wording.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION = REPO_ROOT / "Resources/shell-integration/cmux-bash-integration.bash"
+
+# Drive the real shim writer twice under noclobber. The first call creates the
+# shim; the second must overwrite the existing file (cmux owns it) without
+# tripping noclobber. We embed two *different* wrapper paths so we can prove the
+# second write actually refreshed the file rather than silently no-op'ing.
+#
+# Sourcing the integration with no CMUX_SHELL_INTEGRATION_DIR makes the
+# top-level `_cmux_install_cli_wrapper claude` early-return (no shim written at
+# source time), so the only writes are our two explicit calls. The prompt hooks
+# the integration registers never fire under `bash -c` (non-interactive, no
+# prompt), keeping the scenario focused on the shim writer.
+DRIVER = r"""
+set -o noclobber
+source "$CMUX_BASH_INTEGRATION" 2>/dev/null
+export TMPDIR="$CMUX_TEST_TMPDIR"
+export CMUX_SURFACE_ID="$CMUX_TEST_SURFACE_ID"
+_cmux_install_cli_command_shim claude "$CMUX_TEST_WRAPPER_A"
+_cmux_install_cli_command_shim claude "$CMUX_TEST_WRAPPER_B"
+"""
+
+
+def _run_driver(tmp: Path) -> subprocess.CompletedProcess[str]:
+    # Two distinct wrapper paths so the shim content differs between writes.
+    wrapper_a = tmp / "wrapper-a"
+    wrapper_b = tmp / "wrapper-b"
+    wrapper_a.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    wrapper_b.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    wrapper_a.chmod(0o755)
+    wrapper_b.chmod(0o755)
+
+    # Clean env: drop ambient CMUX_* so nothing the integration reads leaks in,
+    # and explicitly disable the socket path so sourcing stays quiet.
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CMUX")}
+    env.update(
+        {
+            "LC_ALL": "C",
+            "LANG": "C",
+            "CMUX_BASH_INTEGRATION": str(INTEGRATION),
+            "CMUX_TEST_TMPDIR": str(tmp),
+            "CMUX_TEST_SURFACE_ID": "issue-6714-bash-shim",
+            "CMUX_TEST_WRAPPER_A": str(wrapper_a),
+            "CMUX_TEST_WRAPPER_B": str(wrapper_b),
+            # Keep sourcing side-effect-free: no socket sends.
+            "CMUX_SOCKET_PATH": "",
+        }
+    )
+
+    return subprocess.run(
+        ["bash", "--noprofile", "--norc", "-c", DRIVER],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_bash_shim_refresh_is_silent_and_refreshes_under_noclobber() -> None:
+    assert INTEGRATION.exists(), f"missing integration file: {INTEGRATION}"
+
+    with tempfile.TemporaryDirectory(prefix="cmux-6714-bash-") as td:
+        tmp = Path(td)
+        proc = _run_driver(tmp)
+        debug = (
+            f"\nexit={proc.returncode}"
+            f"\n--- driver stdout ---\n{proc.stdout}"
+            f"\n--- driver stderr ---\n{proc.stderr}"
+        )
+
+        # The reported symptom: bash refuses to clobber the existing shim and
+        # prints `cannot overwrite existing file` from the shim writer.
+        assert "cannot overwrite" not in proc.stderr.lower(), (
+            "cmux printed a noclobber 'cannot overwrite existing file' error while "
+            "refreshing its own generated shim" + debug
+        )
+        # Locale-independent guard: no error should be attributed to the
+        # integration file at all (the noclobber failure carries its path).
+        assert "cmux-bash-integration.bash" not in proc.stderr, (
+            "the bash integration reported an error to stderr while refreshing the "
+            "shim" + debug
+        )
+
+        shim_path = tmp / "cmux-cli-shims" / "issue-6714-bash-shim" / "claude"
+        assert shim_path.exists(), f"shim was not created at {shim_path}" + debug
+        assert os.access(shim_path, os.X_OK), (
+            f"shim is not executable: {shim_path}" + debug
+        )
+
+        # The second write must have actually overwritten the shim: under the
+        # bug, noclobber makes the redirect fail and `|| return 0` skips the
+        # write, so the shim still embeds wrapper A. With the fix it embeds B.
+        contents = shim_path.read_text(encoding="utf-8")
+        wrapper_b = str(tmp / "wrapper-b")
+        wrapper_a = str(tmp / "wrapper-a")
+        assert f'cmux_wrapper="{wrapper_b}"' in contents, (
+            "cmux did not refresh its generated shim on the second write under "
+            f"noclobber (expected wrapper {wrapper_b!r}).\n--- shim ---\n{contents}"
+            + debug
+        )
+        assert f'cmux_wrapper="{wrapper_a}"' not in contents, (
+            "stale wrapper path from the first write survived the refresh.\n"
+            f"--- shim ---\n{contents}" + debug
+        )
+
+
+if __name__ == "__main__":
+    test_bash_shim_refresh_is_silent_and_refreshes_under_noclobber()
+    print("PASS: cmux refreshes its bash CLI shim silently under noclobber")

--- a/tests/test_issue_6714_bash_shim_noclobber.py
+++ b/tests/test_issue_6714_bash_shim_noclobber.py
@@ -68,7 +68,10 @@ INTEGRATION = REPO_ROOT / "Resources/shell-integration/cmux-bash-integration.bas
 # missing, so a broken driver can never look like a passing scenario.
 DRIVER = r"""
 set -o noclobber
-source "$CMUX_BASH_INTEGRATION"
+if ! source "$CMUX_BASH_INTEGRATION"; then
+    printf '%s\n' 'driver: sourcing the integration returned non-zero' >&2
+    exit 91
+fi
 if ! declare -F _cmux_install_cli_command_shim >/dev/null 2>&1; then
     printf '%s\n' 'driver: _cmux_install_cli_command_shim undefined after sourcing' >&2
     exit 90


### PR DESCRIPTION
## Problem

The zsh half of #6714 was fixed in #6815. The identical defect is still present in the **bash** integration.

With `set -o noclobber` in an interactive bash, every cmux shell prints:

```
cmux-bash-integration.bash: line 281: /var/folders/.../T/cmux-cli-shims/<surface-id>/claude: cannot overwrite existing file
```

`_cmux_install_cli_command_shim` runs more than once per shell — once at source time via the top-level `_cmux_install_cli_wrapper claude`, and again from the `_cmux_fix_path` prompt hook. The second write targets a shim that already exists, and a plain `>` is refused under `noclobber`. The `2>/dev/null` does not suppress it, because the failure is reported by the shell's redirection machinery on the compound-command redirect itself rather than by anything running inside the group.

**This is not only cosmetic.** The failed redirect trips `|| return 0`, so the write is skipped entirely and the shim is left stale — it keeps pointing at the wrapper path captured by the first write:

```
$ # second write under noclobber, before this PR
cmux-bash-integration.bash: line 281: .../cmux-cli-shims/smoke/claude: cannot overwrite existing file
$ grep -m1 cmux_wrapper= .../cmux-cli-shims/smoke/claude
cmux_wrapper=".../wa"      # still wrapper A — the refresh to B never happened
```

## Fix

Use bash's explicit clobber redirection `>|` for this cmux-owned generated file, so it overwrites regardless of the user's global `noclobber` setting. This is exactly the operator the zsh integration adopted in #6815.

```diff
-    } >"$shim_path" 2>/dev/null || return 0
+    } >|"$shim_path" 2>/dev/null || return 0
```

## Tests

Adds `tests/test_issue_6714_bash_shim_noclobber.py`, mirroring `test_issue_6714_zsh_shim_noclobber.py`: it drives the real integration file through bash with `noclobber` enabled, writing the shim twice with two different wrapper paths, and asserts the second write is **silent** *and* **actually refreshes** the shim contents. Deterministic — no PTY, no sleeps, no network — and locale-pinned so assertions don't depend on bash's message wording. Wired into `ci.yml` next to the zsh test.

Two-commit red/green per the repo's regression-test policy:

- `dbaf658` adds the test only — fails on `main` with `cannot overwrite existing file`
- `49de225` adds the fix — test passes

Verified locally: new bash test **red → green**, existing zsh test still **green**, and `bash -n` / `zsh -n` clean on both integration files.

## Note on #7030

I opened #7030 back in June for this, covering bash *and* zsh. The zsh half landed independently via #6815, and that branch is now ~2000 commits behind `main`. This PR supersedes it — cut fresh from current `main`, bash-only, with the regression test the zsh fix set the precedent for. I'll close #7030 in favor of this one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787756151&installation_model_id=21920&pr_number=9006&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9006&signature=3fea117a78cb53196c90c7a8c3fa26b7b5d2d260d792f072fcea1c15730588ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bash shell integration under `set -o noclobber` so CLI shims refresh without errors or stale paths. Uses bash `>|` to overwrite cmux-generated shims safely.

- **Bug Fixes**
  - Write shims with `>|` in Resources/shell-integration/cmux-bash-integration.bash to prevent “cannot overwrite existing file” and ensure refresh; mirrors the zsh fix in #6815 for #6714.
  - Add and harden tests/test_issue_6714_bash_shim_noclobber.py: run under `noclobber` with no stderr suppression; abort on non-zero source status (exit 91) and guard missing writer via `declare -F` (exit 90); assert the second write is silent and updates the shim; enable in CI.

<sup>Written for commit 41252e4ccd93c44aab663975b30b00d0a344c6f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLI shim installation in interactive Bash sessions when `noclobber` is enabled, ensuring shim refresh reliably updates existing shims without errors or overwrite warnings.

* **Tests**
  * Added a new regression test covering shim refresh under `set -o noclobber`, including validation that the shim file is updated as expected.
  * Updated CI to run this new test as part of the existing CLI no-socket regression suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->