### PR TITLE
fix(socket): treat surface.focus as explicit main-panel focus intent

### DIFF
--- a/Sources/TerminalController+ControlSidebarContext3.swift
+++ b/Sources/TerminalController+ControlSidebarContext3.swift
@@ -98,7 +98,7 @@ extension TerminalController {
               tab.surfaceIdFromPanelId(panelID) != nil else {
             return false
         }
-        tabManager.focusSurface(tabId: tab.id, surfaceId: panelID)
+        controlFocusMainAreaPanel(surfaceOrPanelID: panelID, in: tab, tabManager: tabManager)
         return true
     }
 

--- a/Sources/TerminalController+ControlSurfaceContext.swift
+++ b/Sources/TerminalController+ControlSurfaceContext.swift
@@ -10,6 +10,50 @@ extension TerminalController {
     nonisolated static var terminalSurfaceUnavailableSocketError: String {
         "ERROR: \(terminalSurfaceUnavailableMessage)"
     }
+
+    /// The single seam every socket/CLI focus request into the main area goes
+    /// through: v2 `surface.focus`, v1 `focus_surface`, v1
+    /// `focus_surface_by_panel`, and the remote-tmux pane focus.
+    ///
+    /// Recording main-panel intent is what makes the focus stick. While the
+    /// right sidebar owns the intent, `allowsTerminalKeyboardFocus` refuses
+    /// every main-area terminal, so `TerminalPanel.focus()` drops the request
+    /// and the command still answers success. A click records the same intent
+    /// via `noteMainPanelKeyboardFocusIntent`; an explicit focus request naming
+    /// a surface is no less deliberate.
+    ///
+    /// Deliberately not folded into `Workspace.focusPanel`: that fires on
+    /// internal and UI-driven focus changes too (split creation, restore,
+    /// detach, drag), where stealing the intent from the sidebar would be wrong.
+    func controlFocusMainAreaPanel(
+        surfaceOrPanelID: UUID,
+        in workspace: Workspace,
+        tabManager: TabManager
+    ) {
+        // Fail closed on an id this workspace does not own. Falling back to the
+        // raw id would take the intent off the sidebar and then no-op in
+        // `focusPanel` — the same silent-success bug this seam exists to remove.
+        guard let panelID = tabManager.panelId(forSurfaceOrPanelId: surfaceOrPanelID, in: workspace) else {
+            return
+        }
+        let window = AppDelegate.shared?.mainWindowContainingWorkspace(workspace.id)
+        AppDelegate.shared?.noteMainPanelKeyboardFocusIntent(
+            workspaceId: workspace.id,
+            panelId: panelID,
+            in: window
+        )
+        // Reopening the intent gate is not enough on its own. `TerminalPanel.focus()`
+        // focuses with `respectForeignFirstResponder: true`, so a sidebar host that
+        // holds first responder keeps the keyboard even once the gate allows the
+        // terminal through. Make it resign, exactly as `right_sidebar hide` does on
+        // its way back to the terminal.
+        if let window,
+           let responder = window.firstResponder,
+           AppDelegate.shared?.isRightSidebarFocusResponder(responder, in: window) == true {
+            window.makeFirstResponder(nil)
+        }
+        workspace.focusPanel(panelID)
+    }
 }
 
 /// The surface-domain witnesses are the byte-faithful bodies of the former
@@ -297,7 +341,7 @@ extension TerminalController: ControlSurfaceContext {
             tabManager.selectWorkspace(ws)
         }
         if ws.panels[surfaceID] != nil {
-            ws.focusPanel(surfaceID)
+            controlFocusMainAreaPanel(surfaceOrPanelID: surfaceID, in: ws, tabManager: tabManager)
         } else if ws.containsDockPanel(surfaceID) {
             revealDockForFocus(tabManager: tabManager)
             ws.dockSplit.focusPanel(surfaceID)

--- a/Sources/TerminalController+RemoteTmuxControlMutations.swift
+++ b/Sources/TerminalController+RemoteTmuxControlMutations.swift
@@ -47,7 +47,11 @@ extension TerminalController {
         // The wrapper is the mirror's real Bonsplit tab. Selecting it makes the
         // projected TerminalPanelView visible; mirror.activePaneId drives which
         // inner hosted view receives its `isFocused` responder state.
-        workspace.focusPanel(location.containerPanelID)
+        controlFocusMainAreaPanel(
+            surfaceOrPanelID: location.containerPanelID,
+            in: workspace,
+            tabManager: tabManager
+        )
         return true
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12204,7 +12204,7 @@ class TerminalController {
             if let uuid = UUID(uuidString: trimmed),
                tab.panels[uuid] != nil {
                 guard tab.surfaceIdFromPanelId(uuid) != nil else { return }
-                tabManager.focusSurface(tabId: tab.id, surfaceId: uuid)
+                controlFocusMainAreaPanel(surfaceOrPanelID: uuid, in: tab, tabManager: tabManager)
                 success = true
                 return
             }
@@ -12213,7 +12213,11 @@ class TerminalController {
                 let panels = orderedPanels(in: tab)
                 guard index < panels.count else { return }
                 guard tab.surfaceIdFromPanelId(panels[index].id) != nil else { return }
-                tabManager.focusSurface(tabId: tab.id, surfaceId: panels[index].id)
+                controlFocusMainAreaPanel(
+                    surfaceOrPanelID: panels[index].id,
+                    in: tab,
+                    tabManager: tabManager
+                )
                 success = true
             }
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1823,6 +1823,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5001226 /* SocketControlMode+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001225 /* SocketControlMode+Display.swift */; };
 		F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 		C510C1E00000000000000002 /* SocketOperationTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C510C1E00000000000000001 /* SocketOperationTelemetry.swift */; };
+		901190119011901190119002 /* SocketSurfaceFocusIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901190119011901190119001 /* SocketSurfaceFocusIntentTests.swift */; };
 		A5001230 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A5001231 /* Sparkle */; };
 		A6AC72050000000000000001 /* SpinnerCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC72050000000000000002 /* SpinnerCard.swift */; };
 		A6AC72090000000000000001 /* SpinnerEnergy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC72090000000000000002 /* SpinnerEnergy.swift */; };
@@ -4122,6 +4123,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001225 /* SocketControlMode+Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SocketControlMode+Display.swift"; sourceTree = "<group>"; };
 		F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 			C510C1E00000000000000001 /* SocketOperationTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketOperationTelemetry.swift; sourceTree = "<group>"; };
+		901190119011901190119001 /* SocketSurfaceFocusIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketSurfaceFocusIntentTests.swift; sourceTree = "<group>"; };
 		A6AC72050000000000000002 /* SpinnerCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerCard.swift; sourceTree = "<group>"; };
 		A6AC72090000000000000002 /* SpinnerEnergy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerEnergy.swift; sourceTree = "<group>"; };
 		5B11E5A100000000000000A2 /* SpinnerGalleryDebugWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerGalleryDebugWindowController.swift; sourceTree = "<group>"; };
@@ -6563,6 +6565,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */,
 				4E6A6F5C1D2B4980A1234567 /* AppDelegateSurfaceShortcutRoutingTests.swift */,
 				6512F0C06512F0C06512F001 /* MainWindowFocusRestoreTests.swift */,
+				901190119011901190119001 /* SocketSurfaceFocusIntentTests.swift */,
 				C3467AB10000000000000002 /* ShortcutWhenClauseTests.swift */,
 				5330A0025330A0025330A002 /* TextBoxInlineAttachmentRenderingTests.swift */,
 				C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */,
@@ -9643,6 +9646,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5830CA11BAC0000000000002 /* SocketCallbackAwaiterMainThreadTests.swift in Sources */,
 				A7984AD10000000000000001 /* SocketConfigurationLifecycleTests.swift in Sources */,
 						F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
+				901190119011901190119002 /* SocketSurfaceFocusIntentTests.swift in Sources */,
 				F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */,
 				797800040000000000000001 /* SSHDeepSleepReattachTests.swift in Sources */,
 				8410A0020000000000000002 /* SSHForegroundAuthenticationMarkerCleanupTests.swift in Sources */,

--- a/cmuxTests/SocketSurfaceFocusIntentTests.swift
+++ b/cmuxTests/SocketSurfaceFocusIntentTests.swift
@@ -1,0 +1,175 @@
+import AppKit
+import CmuxControlSocket
+import CmuxTerminal
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// A socket focus request naming a main-area surface silently did nothing while
+/// the right sidebar owned the keyboard-focus intent, and still answered
+/// `.focused` — so callers could not detect the failure.
+///
+/// `allowsTerminalFocus` refuses every main-area panel under `.rightSidebar`
+/// intent and `TerminalPanel.focus()` bails on that gate, while no socket path
+/// cleared the intent. Asserting the resolution alone is worthless here: that
+/// return value was already lying. Each test asserts the terminal actually owns
+/// first responder afterwards.
+@MainActor
+@Suite(.serialized)
+struct SocketSurfaceFocusIntentTests {
+    @Test func v2SurfaceFocusTakesKeyboardBackFromRightSidebar() throws {
+        let harness = try FocusHarness()
+        defer { harness.tearDown() }
+
+        harness.giveRightSidebarTheKeyboard()
+
+        let resolution = TerminalController.shared.controlSurfaceFocus(
+            routing: ControlRoutingSelectors(
+                hasWindowIDParam: true,
+                windowID: harness.windowId,
+                groupID: nil,
+                workspaceID: harness.workspace.id,
+                surfaceID: harness.panelId,
+                paneID: nil
+            ),
+            surfaceID: harness.panelId
+        )
+
+        #expect(resolution == .focused(
+            windowID: harness.windowId,
+            workspaceID: harness.workspace.id,
+            surfaceID: harness.panelId
+        ))
+        harness.expectTerminalOwnsKeyboard(entrypoint: "surface.focus")
+    }
+
+    @Test func v1FocusSurfaceByPanelTakesKeyboardBackFromRightSidebar() throws {
+        let harness = try FocusHarness()
+        defer { harness.tearDown() }
+
+        let previousActiveManager = TerminalController.shared.activeTabManagerForCallerNotification()
+        TerminalController.shared.setActiveTabManager(harness.manager)
+        defer { TerminalController.shared.setActiveTabManager(previousActiveManager) }
+
+        harness.giveRightSidebarTheKeyboard()
+
+        #expect(TerminalController.shared.controlSidebarFocusSurfaceByPanel(panelID: harness.panelId))
+        harness.expectTerminalOwnsKeyboard(entrypoint: "focus_surface_by_panel")
+    }
+
+    /// A real main window with a real Ghostty surface, so first-responder
+    /// assertions exercise the actual focus gate rather than a stub.
+    @MainActor
+    private struct FocusHarness {
+        let appDelegate: AppDelegate
+        let windowId: UUID
+        let window: NSWindow
+        let manager: TabManager
+        let workspace: Workspace
+        let panelId: UUID
+        let terminalPanel: TerminalPanel
+        let terminalView: GhosttyNSView
+        let sidebarResponder = RightSidebarKeyboardFocusView(
+            frame: NSRect(x: 0, y: 0, width: 24, height: 24)
+        )
+
+        init() throws {
+            appDelegate = try #require(AppDelegate.shared)
+            windowId = appDelegate.createMainWindow()
+            window = try #require(appDelegate.windowForMainWindowId(windowId))
+            manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            workspace = try #require(manager.selectedWorkspace)
+            panelId = try #require(workspace.focusedPanelId)
+            terminalPanel = try #require(workspace.terminalPanel(for: panelId))
+            terminalView = try #require(Self.surfaceView(in: terminalPanel.hostedView))
+
+            window.makeKeyAndOrderFront(nil)
+            window.displayIfNeeded()
+            terminalPanel.hostedView.setVisibleInUI(true)
+            terminalPanel.hostedView.setActive(true)
+            terminalPanel.hostedView.moveFocus()
+            Self.waitUntil(timeout: 1.0) { terminalPanel.hostedView.isSurfaceViewFirstResponder() }
+            #expect(
+                terminalPanel.hostedView.isSurfaceViewFirstResponder(),
+                "Expected the main terminal to own first responder before the sidebar takes it"
+            )
+        }
+
+        /// Mirrors clicking into the Dock: a real sidebar responder takes first
+        /// responder and the sidebar becomes the focus-intent owner.
+        ///
+        /// The responder has to genuinely own the keyboard. Merely clearing first
+        /// responder would let the terminal back in through
+        /// `respectForeignFirstResponder`, a path the live app never takes, and the
+        /// test would pass against a fix that does not actually work.
+        func giveRightSidebarTheKeyboard() {
+            (window.contentView?.superview ?? window.contentView)?.addSubview(sidebarResponder)
+            sidebarResponder.registerWithKeyboardFocusCoordinatorIfNeeded()
+            #expect(window.makeFirstResponder(sidebarResponder), "Expected the sidebar responder to take the keyboard")
+            appDelegate.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
+
+            #expect(
+                !appDelegate.allowsTerminalKeyboardFocus(
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    in: window
+                ),
+                "Precondition: the right sidebar must own the focus intent"
+            )
+            #expect(!terminalPanel.hostedView.isSurfaceViewFirstResponder())
+        }
+
+        func expectTerminalOwnsKeyboard(entrypoint: String) {
+            #expect(
+                appDelegate.allowsTerminalKeyboardFocus(
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    in: window
+                ),
+                "\(entrypoint) must hand the keyboard-focus intent back to the main panel"
+            )
+            Self.waitUntil(timeout: 1.0) {
+                terminalPanel.hostedView.isSurfaceViewFirstResponder() && window.firstResponder === terminalView
+            }
+            #expect(
+                window.firstResponder === terminalView,
+                "\(entrypoint) reported success, so the terminal must actually own first responder"
+            )
+        }
+
+        func tearDown() {
+            sidebarResponder.removeFromSuperview()
+            let originalConfirmationHandler = appDelegate.debugCloseMainWindowConfirmationHandler
+            appDelegate.debugCloseMainWindowConfirmationHandler = { _ in true }
+            defer { appDelegate.debugCloseMainWindowConfirmationHandler = originalConfirmationHandler }
+            window.animationBehavior = .none
+            window.orderOut(nil)
+            window.close()
+            Self.waitUntil(timeout: 1.0) {
+                AppDelegate.shared?.windowForMainWindowId(windowId) == nil || !window.isVisible
+            }
+        }
+
+        private static func surfaceView(in hostedView: GhosttySurfaceScrollView) -> GhosttyNSView? {
+            var stack: [NSView] = [hostedView]
+            while let current = stack.popLast() {
+                if let surfaceView = current as? GhosttyNSView {
+                    return surfaceView
+                }
+                stack.append(contentsOf: current.subviews)
+            }
+            return nil
+        }
+
+        private static func waitUntil(timeout: TimeInterval, condition: () -> Bool) {
+            let deadline = Date(timeIntervalSinceNow: timeout)
+            while !condition(), Date() < deadline {
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`surface.focus` on a main-workspace surface silently does nothing while the right sidebar owns the keyboard-focus intent — and still answers `.focused`, so callers can't tell.

At `main` (357edfe5d): `allowsTerminalFocus` refuses main-area panels while `intent` is `.rightSidebar` (`MainWindowFocusController.swift:175`), `TerminalPanel.focus()` bails on that gate (`Panels/TerminalPanel.swift:628`), and every caller of `noteMainPanelKeyboardFocusIntent` is a pointer or keyboard path — nothing on the socket path clears the intent. `controlSurfaceFocus` returns `.focused(...)` either way.

This records the intent before focusing, as a click does. It also makes the branches symmetric: the Dock branch just below already sets sidebar intent via `revealDockForFocus`.

**Repro:** focus a Dock surface, then `cmux rpc surface.focus '{"surface_id":"<main-area terminal>"}'` → returns `.focused`, keyboard stays in the Dock.

**Why I care:** an approval pane in the Dock that focuses itself, then can't hand the keyboard back. The only release-build workaround is `right_sidebar hide`, which closes the user's whole sidebar. ⇧⌘E hits a clean path (`toggleRightSidebarOrTerminalFocus`) but it's keyboard/menu only.

## Testing

**I couldn't build this — I'm on Linux, this is an AppKit target. Please verify before merging.** Flagging that instead of ticking the box.

- `swiftc -parse` clean on the modified file (Swift 6.1 container); a broken control file exits non-zero, so the check is live. Syntax only — no type checking without AppKit.
- Window resolution is copied verbatim from `revealDockForFocus`. If `v2ResolveWindowId` yields nothing, `keyboardFocusCoordinator(for:)` returns nil and the call no-ops — failure mode is today's behaviour.

Open question for you: is "socket focus overrides sidebar focus" the policy you want? If you'd rather it be opt-in per request, I'll rework it. Happy to add a test if you point me at the target — I'd rather not add one I can't run.

## Demo Video

None — can't run a build. Repro above is CLI-only.

## Checklist

- [ ] I tested the change locally — **no, see Testing**
- [ ] I added or updated tests — happy to, with a pointer
- [ ] I updated docs/changelog — n/a
- [x] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787768958&installation_model_id=21920&pr_number=9011&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9011&signature=892995064354f718ac0e67d9cd755cc94a2accdccff1b11bc719d9905eee9348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `surface.focus` and all v1/remote‑tmux focus paths set main‑panel keyboard-focus intent and make the right sidebar resign first responder so the keyboard actually moves to the requested panel.

- **Bug Fixes**
  - Routes v2 `surface.focus`, v1 `focus_surface`/`focus_surface_by_panel` (by id or index), and remote‑tmux pane focus through one seam: `controlFocusMainAreaPanel`.
  - Records main‑panel intent via `noteMainPanelKeyboardFocusIntent` and, if the right sidebar owns first responder, makes it resign before focusing.
  - Scopes intent to the workspace’s window via `mainWindowContainingWorkspace`; no‑op if the window can’t be resolved.
  - Adds `SocketSurfaceFocusIntentTests` using a real right‑sidebar responder; asserts the terminal actually becomes first responder for v2 and v1 paths.

<sup>Written for commit 72239d34b6a7c7c753bc499642fbaf488995fa9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard-focus routing so main-area terminal surfaces reliably regain first-responder focus when focus is triggered via terminal surface controls, sidebar-to-main panel focus, and remote tmux mirror panels.
  * Explicit main-area focus requests are now recorded consistently, avoiding interference from right-sidebar focus behavior.
* **Tests**
  * Added keyboard-focus intent tests (sidebar-to-main and panel-based paths) that verify first-responder ownership restoration using a real window and terminal surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->