### PR TITLE
Fix mobile feature flag isolation warning

### DIFF
--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -3,7 +3,7 @@ import Observation
 import PostHog
 import os
 
-struct CmuxFeatureFlagDefinition: Identifiable, Equatable {
+nonisolated struct CmuxFeatureFlagDefinition: Identifiable, Equatable, Sendable {
     var id: String { key }
 
     let key: String
@@ -51,9 +51,9 @@ final class CmuxFeatureFlags {
     #endif
     private static let agentChatUIDefault = false
     #if DEBUG
-    private static let mobileWorkspaceChangesDefault = true
+    private nonisolated static let mobileWorkspaceChangesDefault = true
     #else
-    private static let mobileWorkspaceChangesDefault = false
+    private nonisolated static let mobileWorkspaceChangesDefault = false
     #endif
     private static let sidebarWorkspaceAgentSpinnerDefault = false
     private static let simulatorDefault = true
@@ -95,7 +95,7 @@ final class CmuxFeatureFlags {
     // Mac-side flag turns the whole feature off end to end. Release builds
     // keep it off until the PostHog flag enables it; DEBUG keeps it on for
     // dogfood.
-    static let mobileWorkspaceChangesFlag = CmuxFeatureFlagDefinition(
+    nonisolated static let mobileWorkspaceChangesFlag = CmuxFeatureFlagDefinition(
         key: "mobile-workspace-changes-enabled-release",
         title: String(
             localized: "featureFlags.mobileWorkspaceChanges.title",


### PR DESCRIPTION
## Summary

- mark the immutable feature-flag definition as nonisolated and Sendable
- expose the mobile workspace flag definition and fallback as immutable off-main values
- keep the mutable feature-flag store MainActor-isolated

Unblocks the speculative merge gate for https://github.com/manaflow-ai/cmux/pull/8850.

## Testing

- tagged cloud build: https://github.com/manaflow-ai/cmux/actions/runs/30301889950
- verified the build log contains no `mobileWorkspaceChangesFlag` actor-isolation warning
- no behavior-level regression test added because this is a compiler-warning regression and source-shape tests are prohibited

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787775926&installation_model_id=21920&pr_number=9013&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9013&signature=6afd71245bf65d1e66d1ab34e271cc83ac3f83dbc9dab239fb4c82b7413fddd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Swift concurrency actor-isolation warning for the mobile workspace feature flag. Removes the `mobileWorkspaceChangesFlag` warning and unblocks the merge for #8850.

- Bug Fixes
  - Marked `CmuxFeatureFlagDefinition` as nonisolated and `Sendable`.
  - Made `mobileWorkspaceChangesFlag` and its defaults nonisolated `static let`.
  - Kept the mutable feature-flag store `MainActor`-isolated; no behavior changes.

<sup>Written for commit 355bb3f386b736c84844f1def5bc8edf43255fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved feature-flag access across execution contexts without changing available flags or their values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->