### PR TITLE
Fix saved layout surface ordering

### DIFF
--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -110,13 +110,6 @@ extension Workspace {
 
         guard !surfaces.isEmpty else { return }
 
-        // Layouts are declarative, so materialize their surfaces by appending in
-        // config order. Restore the interactive "next to current" policy as soon
-        // as this pane is populated.
-        let interactiveNewTabPosition = bonsplitController.configuration.newTabPosition
-        bonsplitController.configuration.newTabPosition = .end
-        defer { bonsplitController.configuration.newTabPosition = interactiveNewTabPosition }
-
         let firstSurface = surfaces[0]
         if let placeholderPanelId = existingPanelIds.first {
             configureExistingSurface(
@@ -128,6 +121,13 @@ extension Workspace {
                 pendingSetup: &pendingSetup
             )
         }
+
+        // The first surface either reuses or replaces the pane's placeholder.
+        // Append only the remaining declarative surfaces in config order, then
+        // restore the interactive "next to current" policy immediately.
+        let interactiveNewTabPosition = bonsplitController.configuration.newTabPosition
+        bonsplitController.configuration.newTabPosition = .end
+        defer { bonsplitController.configuration.newTabPosition = interactiveNewTabPosition }
 
         for surfaceIndex in 1..<surfaces.count {
             createNewSurface(

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -110,34 +110,34 @@ extension Workspace {
 
         guard !surfaces.isEmpty else { return }
 
-        var orderedPanelIds: [UUID] = []
+        // Layouts are declarative, so materialize their surfaces by appending in
+        // config order. Restore the interactive "next to current" policy as soon
+        // as this pane is populated.
+        let interactiveNewTabPosition = bonsplitController.configuration.newTabPosition
+        bonsplitController.configuration.newTabPosition = .end
+        defer { bonsplitController.configuration.newTabPosition = interactiveNewTabPosition }
+
         let firstSurface = surfaces[0]
         if let placeholderPanelId = existingPanelIds.first {
-            if let panelId = configureExistingSurface(
+            configureExistingSurface(
                 panelId: placeholderPanelId,
                 inPane: paneId,
                 surface: firstSurface,
                 baseCwd: baseCwd,
                 focusPanelId: &focusPanelId,
                 pendingSetup: &pendingSetup
-            ) {
-                orderedPanelIds.append(panelId)
-            }
+            )
         }
 
         for surfaceIndex in 1..<surfaces.count {
-            if let panelId = createNewSurface(
+            createNewSurface(
                 inPane: paneId,
                 surface: surfaces[surfaceIndex],
                 baseCwd: baseCwd,
                 focusPanelId: &focusPanelId,
                 pendingSetup: &pendingSetup
-            ) {
-                orderedPanelIds.append(panelId)
-            }
+            )
         }
-
-        applyDeclaredSurfaceOrder(orderedPanelIds, inPane: paneId)
     }
 
     /// Consumes the workspace-level setup command on the first terminal surface it
@@ -165,7 +165,7 @@ extension Workspace {
         baseCwd: String,
         focusPanelId: inout UUID?,
         pendingSetup: inout String?
-    ) -> UUID? {
+    ) {
         switch surface.type {
         case .terminal where surface.cwd != nil || surface.env != nil:
             // Placeholder can't change cwd/env — replace it
@@ -182,9 +182,7 @@ extension Workspace {
                 if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
                     sendInputWhenReady(input, to: panel)
                 }
-                return panel.id
             }
-            return nil
 
         case .terminal:
             if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
@@ -193,7 +191,6 @@ extension Workspace {
                let terminal = terminalPanel(for: panelId) {
                 sendInputWhenReady(input, to: terminal)
             }
-            return panelId
 
         case .browser:
             let url = surface.url.flatMap { URL(string: $0) }
@@ -206,9 +203,7 @@ extension Workspace {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                return panel.id
             }
-            return nil
 
         case .project:
             if let panel = newProjectSurface(
@@ -219,9 +214,7 @@ extension Workspace {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                return panel.id
             }
-            return nil
         }
     }
 
@@ -231,7 +224,7 @@ extension Workspace {
         baseCwd: String,
         focusPanelId: inout UUID?,
         pendingSetup: inout String?
-    ) -> UUID? {
+    ) {
         switch surface.type {
         case .terminal:
             let resolvedCwd = CmuxConfigStore.resolveCwd(surface.cwd, relativeTo: baseCwd)
@@ -246,9 +239,7 @@ extension Workspace {
                 if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
                     sendInputWhenReady(input, to: panel)
                 }
-                return panel.id
             }
-            return nil
 
         case .browser:
             let url = surface.url.flatMap { URL(string: $0) }
@@ -260,9 +251,7 @@ extension Workspace {
             ) {
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                return panel.id
             }
-            return nil
 
         case .project:
             if let panel = newProjectSurface(
@@ -272,37 +261,7 @@ extension Workspace {
             ) {
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                return panel.id
             }
-            return nil
-        }
-    }
-
-    /// Reconciles Bonsplit's interactive insertion policy with the declarative
-    /// order owned by the layout, without changing the user's new-tab behavior.
-    private func applyDeclaredSurfaceOrder(_ panelIds: [UUID], inPane paneId: PaneID) {
-        let selectedTabId = bonsplitController.selectedTab(inPane: paneId)?.id
-        let focusedPaneId = bonsplitController.focusedPaneId
-        var didReorder = false
-
-        for (targetIndex, panelId) in panelIds.enumerated() {
-            guard let tabId = surfaceIdFromPanelId(panelId) else { continue }
-            let tabs = bonsplitController.tabs(inPane: paneId)
-            guard let currentIndex = tabs.firstIndex(where: { $0.id == tabId }),
-                  currentIndex != targetIndex else {
-                continue
-            }
-            _ = bonsplitController.reorderTab(tabId, toIndex: targetIndex)
-            didReorder = true
-        }
-
-        guard didReorder else { return }
-        if let selectedTabId,
-           bonsplitController.tabs(inPane: paneId).contains(where: { $0.id == selectedTabId }) {
-            bonsplitController.selectTab(selectedTabId)
-        }
-        if let focusedPaneId, bonsplitController.focusedPaneId != focusedPaneId {
-            bonsplitController.focusPane(focusedPaneId)
         }
     }
 

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -110,27 +110,34 @@ extension Workspace {
 
         guard !surfaces.isEmpty else { return }
 
+        var orderedPanelIds: [UUID] = []
         let firstSurface = surfaces[0]
         if let placeholderPanelId = existingPanelIds.first {
-            configureExistingSurface(
+            if let panelId = configureExistingSurface(
                 panelId: placeholderPanelId,
                 inPane: paneId,
                 surface: firstSurface,
                 baseCwd: baseCwd,
                 focusPanelId: &focusPanelId,
                 pendingSetup: &pendingSetup
-            )
+            ) {
+                orderedPanelIds.append(panelId)
+            }
         }
 
         for surfaceIndex in 1..<surfaces.count {
-            createNewSurface(
+            if let panelId = createNewSurface(
                 inPane: paneId,
                 surface: surfaces[surfaceIndex],
                 baseCwd: baseCwd,
                 focusPanelId: &focusPanelId,
                 pendingSetup: &pendingSetup
-            )
+            ) {
+                orderedPanelIds.append(panelId)
+            }
         }
+
+        applyDeclaredSurfaceOrder(orderedPanelIds, inPane: paneId)
     }
 
     /// Consumes the workspace-level setup command on the first terminal surface it
@@ -158,7 +165,7 @@ extension Workspace {
         baseCwd: String,
         focusPanelId: inout UUID?,
         pendingSetup: inout String?
-    ) {
+    ) -> UUID? {
         switch surface.type {
         case .terminal where surface.cwd != nil || surface.env != nil:
             // Placeholder can't change cwd/env — replace it
@@ -175,7 +182,9 @@ extension Workspace {
                 if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
                     sendInputWhenReady(input, to: panel)
                 }
+                return panel.id
             }
+            return nil
 
         case .terminal:
             if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
@@ -184,6 +193,7 @@ extension Workspace {
                let terminal = terminalPanel(for: panelId) {
                 sendInputWhenReady(input, to: terminal)
             }
+            return panelId
 
         case .browser:
             let url = surface.url.flatMap { URL(string: $0) }
@@ -196,7 +206,9 @@ extension Workspace {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
+                return panel.id
             }
+            return nil
 
         case .project:
             if let panel = newProjectSurface(
@@ -207,7 +219,9 @@ extension Workspace {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
+                return panel.id
             }
+            return nil
         }
     }
 
@@ -217,7 +231,7 @@ extension Workspace {
         baseCwd: String,
         focusPanelId: inout UUID?,
         pendingSetup: inout String?
-    ) {
+    ) -> UUID? {
         switch surface.type {
         case .terminal:
             let resolvedCwd = CmuxConfigStore.resolveCwd(surface.cwd, relativeTo: baseCwd)
@@ -232,7 +246,9 @@ extension Workspace {
                 if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
                     sendInputWhenReady(input, to: panel)
                 }
+                return panel.id
             }
+            return nil
 
         case .browser:
             let url = surface.url.flatMap { URL(string: $0) }
@@ -244,7 +260,9 @@ extension Workspace {
             ) {
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
+                return panel.id
             }
+            return nil
 
         case .project:
             if let panel = newProjectSurface(
@@ -254,7 +272,37 @@ extension Workspace {
             ) {
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
+                return panel.id
             }
+            return nil
+        }
+    }
+
+    /// Reconciles Bonsplit's interactive insertion policy with the declarative
+    /// order owned by the layout, without changing the user's new-tab behavior.
+    private func applyDeclaredSurfaceOrder(_ panelIds: [UUID], inPane paneId: PaneID) {
+        let selectedTabId = bonsplitController.selectedTab(inPane: paneId)?.id
+        let focusedPaneId = bonsplitController.focusedPaneId
+        var didReorder = false
+
+        for (targetIndex, panelId) in panelIds.enumerated() {
+            guard let tabId = surfaceIdFromPanelId(panelId) else { continue }
+            let tabs = bonsplitController.tabs(inPane: paneId)
+            guard let currentIndex = tabs.firstIndex(where: { $0.id == tabId }),
+                  currentIndex != targetIndex else {
+                continue
+            }
+            _ = bonsplitController.reorderTab(tabId, toIndex: targetIndex)
+            didReorder = true
+        }
+
+        guard didReorder else { return }
+        if let selectedTabId,
+           bonsplitController.tabs(inPane: paneId).contains(where: { $0.id == selectedTabId }) {
+            bonsplitController.selectTab(selectedTabId)
+        }
+        if let focusedPaneId, bonsplitController.focusedPaneId != focusedPaneId {
+            bonsplitController.focusPane(focusedPaneId)
         }
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2268,6 +2268,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE71450000000000000001 /* WorkspaceCreateWorkingDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE71450000000000000002 /* WorkspaceCreateWorkingDirectoryTests.swift */; };
 		C0DE00000000000000000D34 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000D33 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift */; };
 		E60812C95246E275F29D3C1B /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3084DF49224DFF2DF4C376 /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift */; };
+		901000010000000000000001 /* WorkspaceCustomLayoutOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 901000010000000000000002 /* WorkspaceCustomLayoutOrderTests.swift */; };
 		281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */; };
 		E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
 		72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */; };
@@ -4581,6 +4582,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE71450000000000000002 /* WorkspaceCreateWorkingDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreateWorkingDirectoryTests.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000D33 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreateWorkingDirectoryValidationServiceTests.swift; sourceTree = "<group>"; };
 		9D3084DF49224DFF2DF4C376 /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift; sourceTree = "<group>"; };
+		901000010000000000000002 /* WorkspaceCustomLayoutOrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCustomLayoutOrderTests.swift; sourceTree = "<group>"; };
 		CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCustomSidebarPullRequestContextTests.swift; sourceTree = "<group>"; };
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
 		B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -6750,6 +6752,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F0ACC0DE0000000000000006 /* WorkspaceForkConversationContextMenuTests.swift */,
 				71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
 				CE74DFAC5946F9C2EEDBE577 /* WorkspaceCustomSidebarPullRequestContextTests.swift */,
+				901000010000000000000002 /* WorkspaceCustomLayoutOrderTests.swift */,
 				C0DE71450000000000000002 /* WorkspaceCreateWorkingDirectoryTests.swift */,
 				C0DE71450000000000000004 /* InMemoryWorkspaceCreateIdempotencyStore.swift */,
 				C0DE00000000000000000D39 /* WorkspaceCreateWorkingDirectoryAliasTests.swift */,
@@ -9821,6 +9824,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE71450000000000000001 /* WorkspaceCreateWorkingDirectoryTests.swift in Sources */,
 				C0DE00000000000000000D34 /* WorkspaceCreateWorkingDirectoryValidationServiceTests.swift in Sources */,
 				E60812C95246E275F29D3C1B /* WorkspaceCreationWorkingDirectorySpawnPolicyTests.swift in Sources */,
+				901000010000000000000001 /* WorkspaceCustomLayoutOrderTests.swift in Sources */,
 				281F3AEA52379AF45C5C1189 /* WorkspaceCustomSidebarPullRequestContextTests.swift in Sources */,
 				72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */,
 				F0ACC0DE0000000000000005 /* WorkspaceForkConversationContextMenuTests.swift in Sources */,

--- a/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
+++ b/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized) struct WorkspaceCustomLayoutOrderTests {
+    @Test(arguments: [0, 1, 2, 3])
+    func allTerminalSurfacesPreserveDeclaredOrder(focusedIndex: Int) throws {
+        let names = ["AAA", "BBB", "CCC", "DDD"]
+        let surfaces = names.enumerated().map { index, name in
+            CmuxSurfaceDefinition(type: .terminal, name: name, focus: index == focusedIndex)
+        }
+
+        let workspace = Workspace()
+        workspace.applyCustomLayout(
+            .pane(CmuxPaneDefinition(surfaces: surfaces)),
+            baseCwd: NSTemporaryDirectory()
+        )
+
+        let snapshot = try Self.surfaceSnapshot(in: workspace)
+        #expect(snapshot.titles == names)
+        #expect(snapshot.selectedTitle == names[focusedIndex])
+    }
+
+    @Test(arguments: [0, 1, 2])
+    func mixedTerminalAndBrowserSurfacesPreserveDeclaredOrder(focusedIndex: Int) throws {
+        let names = ["Shell", "Docs", "Logs"]
+        let surfaces = [
+            CmuxSurfaceDefinition(type: .terminal, name: names[0], focus: focusedIndex == 0),
+            CmuxSurfaceDefinition(
+                type: .browser,
+                name: names[1],
+                url: "https://example.com",
+                focus: focusedIndex == 1
+            ),
+            CmuxSurfaceDefinition(type: .terminal, name: names[2], focus: focusedIndex == 2),
+        ]
+
+        let workspace = Workspace()
+        workspace.applyCustomLayout(
+            .pane(CmuxPaneDefinition(surfaces: surfaces)),
+            baseCwd: NSTemporaryDirectory()
+        )
+
+        let snapshot = try Self.surfaceSnapshot(in: workspace)
+        #expect(snapshot.titles == names)
+        #expect(snapshot.selectedTitle == names[focusedIndex])
+    }
+
+    private static func surfaceSnapshot(in workspace: Workspace) throws -> (titles: [String], selectedTitle: String?) {
+        let paneId = try #require(workspace.bonsplitController.allPaneIds.first)
+        let titles = workspace.bonsplitController.tabs(inPane: paneId).map(\.title)
+        let selectedTitle = workspace.bonsplitController.selectedTab(inPane: paneId)?.title
+        return (titles, selectedTitle)
+    }
+}

--- a/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
+++ b/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
@@ -1,3 +1,4 @@
+import Bonsplit
 import Foundation
 import Testing
 
@@ -34,7 +35,7 @@ import Testing
             CmuxSurfaceDefinition(
                 type: .browser,
                 name: names[0],
-                url: "https://example.com",
+                url: nil,
                 focus: focusedIndex == 0
             ),
             CmuxSurfaceDefinition(type: .terminal, name: names[1], focus: focusedIndex == 1),
@@ -52,9 +53,10 @@ import Testing
         #expect(snapshot.selectedTitle == names[focusedIndex])
     }
 
-    @Test
-    func layoutApplicationRestoresInteractiveNewTabPlacement() throws {
+    @Test(arguments: [NewTabPosition.current, .end])
+    func layoutApplicationRestoresInteractiveNewTabPlacement(initialPlacement: NewTabPosition) throws {
         let workspace = Workspace()
+        workspace.bonsplitController.configuration.newTabPosition = initialPlacement
         workspace.applyCustomLayout(
             .pane(CmuxPaneDefinition(surfaces: [
                 CmuxSurfaceDefinition(type: .terminal, name: "AAA"),
@@ -68,15 +70,24 @@ import Testing
         let layoutTabIds = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
         try #require(layoutTabIds.count == 3)
 
+        switch (initialPlacement, workspace.bonsplitController.configuration.newTabPosition) {
+        case (.current, .current), (.end, .end):
+            break
+        default:
+            Issue.record("Layout application did not restore the initial new-tab placement")
+        }
+
         let newPanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: false))
         let newTabId = try #require(workspace.surfaceIdFromPanelId(newPanel.id))
+        let expectedTabIds: [TabID]
+        switch initialPlacement {
+        case .current:
+            expectedTabIds = [layoutTabIds[0], layoutTabIds[1], newTabId, layoutTabIds[2]]
+        case .end:
+            expectedTabIds = [layoutTabIds[0], layoutTabIds[1], layoutTabIds[2], newTabId]
+        }
 
-        #expect(workspace.bonsplitController.tabs(inPane: paneId).map(\.id) == [
-            layoutTabIds[0],
-            layoutTabIds[1],
-            newTabId,
-            layoutTabIds[2],
-        ])
+        #expect(workspace.bonsplitController.tabs(inPane: paneId).map(\.id) == expectedTabIds)
         #expect(workspace.bonsplitController.selectedTab(inPane: paneId)?.id == layoutTabIds[1])
     }
 

--- a/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
+++ b/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
@@ -29,15 +29,15 @@ import Testing
 
     @Test(arguments: [0, 1, 2])
     func mixedTerminalAndBrowserSurfacesPreserveDeclaredOrder(focusedIndex: Int) throws {
-        let names = ["Shell", "Docs", "Logs"]
+        let names = ["Docs", "Shell", "Logs"]
         let surfaces = [
-            CmuxSurfaceDefinition(type: .terminal, name: names[0], focus: focusedIndex == 0),
             CmuxSurfaceDefinition(
                 type: .browser,
-                name: names[1],
+                name: names[0],
                 url: "https://example.com",
-                focus: focusedIndex == 1
+                focus: focusedIndex == 0
             ),
+            CmuxSurfaceDefinition(type: .terminal, name: names[1], focus: focusedIndex == 1),
             CmuxSurfaceDefinition(type: .terminal, name: names[2], focus: focusedIndex == 2),
         ]
 
@@ -66,7 +66,7 @@ import Testing
 
         let paneId = try #require(workspace.bonsplitController.allPaneIds.first)
         let layoutTabIds = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
-        #expect(layoutTabIds.count == 3)
+        try #require(layoutTabIds.count == 3)
 
         let newPanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: false))
         let newTabId = try #require(workspace.surfaceIdFromPanelId(newPanel.id))

--- a/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
+++ b/cmuxTests/WorkspaceCustomLayoutOrderTests.swift
@@ -52,6 +52,34 @@ import Testing
         #expect(snapshot.selectedTitle == names[focusedIndex])
     }
 
+    @Test
+    func layoutApplicationRestoresInteractiveNewTabPlacement() throws {
+        let workspace = Workspace()
+        workspace.applyCustomLayout(
+            .pane(CmuxPaneDefinition(surfaces: [
+                CmuxSurfaceDefinition(type: .terminal, name: "AAA"),
+                CmuxSurfaceDefinition(type: .terminal, name: "BBB", focus: true),
+                CmuxSurfaceDefinition(type: .terminal, name: "CCC"),
+            ])),
+            baseCwd: NSTemporaryDirectory()
+        )
+
+        let paneId = try #require(workspace.bonsplitController.allPaneIds.first)
+        let layoutTabIds = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
+        #expect(layoutTabIds.count == 3)
+
+        let newPanel = try #require(workspace.newTerminalSurface(inPane: paneId, focus: false))
+        let newTabId = try #require(workspace.surfaceIdFromPanelId(newPanel.id))
+
+        #expect(workspace.bonsplitController.tabs(inPane: paneId).map(\.id) == [
+            layoutTabIds[0],
+            layoutTabIds[1],
+            newTabId,
+            layoutTabIds[2],
+        ])
+        #expect(workspace.bonsplitController.selectedTab(inPane: paneId)?.id == layoutTabIds[1])
+    }
+
     private static func surfaceSnapshot(in workspace: Workspace) throws -> (titles: [String], selectedTitle: String?) {
         let paneId = try #require(workspace.bonsplitController.allPaneIds.first)
         let titles = workspace.bonsplitController.tabs(inPane: paneId).map(\.title)


### PR DESCRIPTION
## Summary

- preserve the declared surface array order when applying saved workspace layouts
- keep focus selection independent from surface placement
- preserve interactive single-tab placement behavior
- add all-terminal and mixed terminal/browser regression coverage across every focused position

Fixes https://github.com/manaflow-ai/cmux/issues/9010

## Testing

- test-only commit: focused GitHub Actions run failed with the reported reversed tail: https://github.com/manaflow-ai/cmux/actions/runs/30315318043
- final focused GitHub Actions run passed: https://github.com/manaflow-ai/cmux/actions/runs/30318231856
- manual full CI: https://github.com/manaflow-ai/cmux/actions/runs/30318238012 failed only on the pre-existing strict determinism finding in cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift:95; linux-preflight, tests, and ci-status were downstream cascades
- `./scripts/lint-pbxproj-test-wiring.sh`
- `./scripts/check-pbxproj.sh`
- `python3 scripts/check-package-resolved-policy.py`

## Demo Video

- Not recorded. This is a deterministic model-ordering fix covered by behavior tests. The requested app build is deferred until explicit approval.

## Checklist

- [x] I added or updated tests for behavior changes
- [x] No user-facing strings changed
- [x] All required PR checks are green
- [x] All substantive code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787789493&installation_model_id=21920&pr_number=9018&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9018&signature=a415b69c286297b31c486cc7a49bcefd08b5e4597b1070872cf2c4b4466cd7a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes saved layout tab ordering by appending remaining surfaces in declared order after the first placeholder replacement, then restoring the interactive new‑tab policy. Focus selection stays intact and single‑tab insertion order after layout matches the user’s setting. Fixes #9010.

- **Bug Fixes**
  - Append only remaining surfaces with newTabPosition temporarily set to .end, then restore the prior policy.
  - Keep the previously selected tab and focused pane after applying the layout.
  - Add serialized tests for terminal-only and mixed layouts across focused positions, and for restoring new‑tab placement (current and end).

<sup>Written for commit 812fbb594750126a93698cc1ca9ea87438456956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores the original custom workspace tab-position behavior after populating panes, ensuring consistent tab ordering.
  * Preserves custom pane tab title order and the correct focused/selected tab, including after adding new terminal tabs.

* **Tests**
  * Added serialized, main-thread UI tests covering custom pane tab ordering, focus/selection behavior, and expected insertion index for newly added terminal tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
