### PR TITLE
Treat incomplete Pi runs as errors, not completions

### DIFF
--- a/CLI/CMUXCLI+PiExtensionSourcePart1.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart1.swift
@@ -14,8 +14,15 @@ type HookExtra = Record<string, unknown>;
 
 interface PendingCompletion {
   lastAssistantMessage?: string;
-  notificationType: string;
+  stopReason: string;
+  errorMessage?: string;
   turnId: string;
+}
+
+interface AssistantOutcome {
+  message?: string;
+  stopReason: string;
+  errorMessage?: string;
 }
 
 interface SessionState {
@@ -237,18 +244,29 @@ function textFromContent(content: unknown): string | null {
   return parts.join("\n") || null;
 }
 
-function lastAssistantMessage(event: unknown): string | undefined {
+function lastAssistantOutcome(event: unknown): AssistantOutcome {
+  const eventStopReason = firstString(objectValue(event, ["stopReason", "reason", "terminationReason"]));
   const messagesValue = objectValue(event, ["messages"]);
   const messages = Array.isArray(messagesValue) ? messagesValue : [];
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (!message || typeof message !== "object") continue;
-    const typed = message as { role?: unknown; content?: unknown };
+    const typed = message as {
+      role?: unknown;
+      content?: unknown;
+      stopReason?: unknown;
+      stop_reason?: unknown;
+      errorMessage?: unknown;
+      error_message?: unknown;
+    };
     if (typed.role !== "assistant") continue;
-    const text = firstString(textFromContent(typed.content));
-    if (text) return text;
+    return {
+      message: firstString(textFromContent(typed.content)) || undefined,
+      stopReason: firstString(typed.stopReason, typed.stop_reason, eventStopReason) || "stop",
+      errorMessage: firstString(typed.errorMessage, typed.error_message) || undefined,
+    };
   }
-  return undefined;
+  return { stopReason: eventStopReason || "stop" };
 }
 
 function sessionIdFrom(ctx: ExtensionContext): string | null {

--- a/CLI/CMUXCLI+PiExtensionSourcePart2.swift
+++ b/CLI/CMUXCLI+PiExtensionSourcePart2.swift
@@ -227,15 +227,40 @@ function sendFeed(eventName: "PreToolUse" | "PostToolUse", ctx: ExtensionContext
 function publishPendingCompletion(ctx: ExtensionContext, sessionId: string): void {
   const completion = settleTurn(sessionId);
   if (!completion) return;
+
+  const stopPayload: HookExtra = {
+    last_assistant_message: completion.lastAssistantMessage,
+    terminationReason: completion.stopReason,
+    turn_id: completion.turnId,
+  };
+
+  if (completion.stopReason === "aborted") {
+    // User cancellation is idle, not a successful completion worth notifying about.
+    stopPayload.cmux_notification_routed = true;
+    sendHook("stop", ctx, stopPayload);
+    return;
+  }
+
+  if (completion.stopReason === "length" || completion.stopReason === "error") {
+    // Stop first so the error notification remains the final visible lifecycle state.
+    // Always suppress the generic Stop fallback, which would misreport this as completed.
+    stopPayload.cmux_notification_routed = true;
+    sendHook("stop", ctx, stopPayload);
+    sendHook("notification", ctx, {
+      message: completion.stopReason === "length"
+        ? "Model stopped because it reached the maximum output token limit. The response may be incomplete."
+        : completion.errorMessage || "Pi stopped with an error before completing the task.",
+      turn_id: completion.turnId,
+      notification: { type: "error" },
+    });
+    return;
+  }
+
   const notificationRouted = sendHook("notification", ctx, {
     message: completion.lastAssistantMessage || "Task completed",
     turn_id: completion.turnId,
-    notification: { type: completion.notificationType },
+    notification: { type: "completed" },
   });
-  const stopPayload: HookExtra = {
-    last_assistant_message: completion.lastAssistantMessage,
-    turn_id: completion.turnId,
-  };
   if (notificationRouted) stopPayload.cmux_notification_routed = true;
   sendHook("stop", ctx, stopPayload);
 }
@@ -274,11 +299,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     const sessionId = sessionIdFrom(ctx);
     if (!sessionId) return;
     const state = stateFor(sessionId);
-    const message = lastAssistantMessage(event);
+    const outcome = lastAssistantOutcome(event);
     // Preserve the latest low-level result until Pi confirms no automatic work remains.
     state.pendingCompletion = {
-      lastAssistantMessage: message || state.pendingCompletion?.lastAssistantMessage,
-      notificationType: firstString(objectValue(event, ["stopReason", "reason", "terminationReason"])) || "completed",
+      lastAssistantMessage: outcome.message || state.pendingCompletion?.lastAssistantMessage,
+      stopReason: outcome.stopReason,
+      errorMessage: outcome.errorMessage,
       turnId: currentTurnId(sessionId, event),
     };
     // Older Pi versions do not emit agent_settled, so retain their established completion behavior.

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -368,6 +368,72 @@ completionCount += 2;
 if (await completionHookCount() !== completionCount) throw new Error("settlement did not attempt failed notification and stop");
 await handlers.get("agent_settled")({}, notificationFailureCtx);
 if (await completionHookCount() !== completionCount) throw new Error("failed notification was retried after duplicate settlement");
+const lengthCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-length"; }
+  }
+};
+await handlers.get("session_start")({}, lengthCtx);
+await handlers.get("before_agent_start")({ prompt: "produce a long answer" }, lengthCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [{
+    role: "assistant",
+    content: [{ type: "text", text: "partial answer" }],
+    stopReason: "length"
+  }]
+}, lengthCtx);
+if (await completionHookCount() !== completionCount) throw new Error("length-capped agent emitted completion before settlement");
+await handlers.get("agent_settled")({}, lengthCtx);
+completionCount += 2;
+if (await completionHookCount() !== completionCount) throw new Error("length-capped settlement did not emit notification and stop");
+await handlers.get("session_shutdown")({ reason: "quit" }, lengthCtx);
+if (await completionHookCount() !== completionCount) throw new Error("length-capped shutdown emitted a duplicate stop");
+const errorCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-error"; }
+  }
+};
+await handlers.get("session_start")({}, errorCtx);
+await handlers.get("before_agent_start")({ prompt: "trigger a provider error" }, errorCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [{
+    role: "assistant",
+    content: [],
+    stopReason: "error",
+    errorMessage: "Provider unavailable"
+  }]
+}, errorCtx);
+if (await completionHookCount() !== completionCount) throw new Error("failed agent emitted completion before settlement");
+await handlers.get("agent_settled")({}, errorCtx);
+completionCount += 2;
+if (await completionHookCount() !== completionCount) throw new Error("failed settlement did not emit notification and stop");
+await handlers.get("session_shutdown")({ reason: "quit" }, errorCtx);
+if (await completionHookCount() !== completionCount) throw new Error("failed shutdown emitted a duplicate stop");
+const abortedCtx = {
+  cwd: "/tmp/pi-project",
+  isIdle() { return true; },
+  sessionManager: {
+    getSessionId() { return "pi-session-aborted"; }
+  }
+};
+await handlers.get("session_start")({}, abortedCtx);
+await handlers.get("before_agent_start")({ prompt: "cancel this response" }, abortedCtx);
+completionCount = await completionHookCount();
+await handlers.get("agent_end")({
+  messages: [{ role: "assistant", content: [], stopReason: "aborted" }]
+}, abortedCtx);
+if (await completionHookCount() !== completionCount) throw new Error("aborted agent emitted completion before settlement");
+await handlers.get("agent_settled")({}, abortedCtx);
+completionCount += 1;
+if (await completionHookCount() !== completionCount) throw new Error("aborted settlement did not emit one stop");
+await handlers.get("session_shutdown")({ reason: "quit" }, abortedCtx);
+if (await completionHookCount() !== completionCount) throw new Error("aborted shutdown emitted a duplicate stop");
 process.argv.splice(
   0,
   process.argv.length,
@@ -482,6 +548,9 @@ if (await completionHookCount() !== completionCount) throw new Error("malformed 
             "set", "get", "clear",
             "set", "get", "clear",
             "set", "get",
+            "set", "get", "clear",
+            "set", "get", "clear",
+            "set", "get", "clear",
             "set", "get",
             "set", "get",
             "set", "get",
@@ -506,6 +575,16 @@ if (await completionHookCount() !== completionCount) throw new Error("malformed 
             ]
             if completion_events != ["Notification", "Stop"]:
                 print(f"FAIL: completion hooks were out of order for {session_id}: {completion_events!r}")
+                return 1
+        for session_id in ["pi-session-length", "pi-session-error"]:
+            failure_events = [
+                payload.get("hook_event_name")
+                for payload in payloads
+                if payload.get("session_id") == session_id
+                and payload.get("hook_event_name") in {"Notification", "Stop"}
+            ]
+            if failure_events != ["Stop", "Notification"]:
+                print(f"FAIL: unsuccessful hooks were out of order for {session_id}: {failure_events!r}")
                 return 1
         if not any(payload.get("session_id") == "pi-session-test" for payload in payloads):
             print(f"FAIL: extension did not pass session id, got {payloads!r}")
@@ -542,6 +621,104 @@ if (await completionHookCount() !== completionCount) throw new Error("malformed 
                 "FAIL: failed Pi completion notification still suppressed native notification fallback, "
                 f"got {fallback_stop_payload!r}"
             )
+            return 1
+        length_notification_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-length"
+                and payload.get("hook_event_name") == "Notification"
+            ),
+            None,
+        )
+        length_notification = (
+            length_notification_payload.get("notification")
+            if isinstance(length_notification_payload, dict)
+            else None
+        )
+        if not isinstance(length_notification, dict) or length_notification.get("type") != "error":
+            print(f"FAIL: length-capped Pi response was reported as completed: {length_notification_payload!r}")
+            return 1
+        if "maximum output token limit" not in str(length_notification_payload.get("message")):
+            print(f"FAIL: length-capped Pi notification did not explain the incomplete response: {length_notification_payload!r}")
+            return 1
+        length_stop_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-length"
+                and payload.get("hook_event_name") == "Stop"
+            ),
+            None,
+        )
+        if (
+            length_stop_payload is None
+            or length_stop_payload.get("terminationReason") != "length"
+            or length_stop_payload.get("cmux_notification_routed") is not True
+        ):
+            print(f"FAIL: length-capped Pi stop did not preserve its incomplete outcome: {length_stop_payload!r}")
+            return 1
+        error_notification_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-error"
+                and payload.get("hook_event_name") == "Notification"
+            ),
+            None,
+        )
+        error_notification = (
+            error_notification_payload.get("notification")
+            if isinstance(error_notification_payload, dict)
+            else None
+        )
+        if (
+            not isinstance(error_notification, dict)
+            or error_notification.get("type") != "error"
+            or error_notification_payload.get("message") != "Provider unavailable"
+        ):
+            print(f"FAIL: failed Pi response was reported as completed: {error_notification_payload!r}")
+            return 1
+        error_stop_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-error"
+                and payload.get("hook_event_name") == "Stop"
+            ),
+            None,
+        )
+        if (
+            error_stop_payload is None
+            or error_stop_payload.get("terminationReason") != "error"
+            or error_stop_payload.get("cmux_notification_routed") is not True
+        ):
+            print(f"FAIL: failed Pi stop did not preserve its error outcome: {error_stop_payload!r}")
+            return 1
+        aborted_events = [
+            payload.get("hook_event_name")
+            for payload in payloads
+            if payload.get("session_id") == "pi-session-aborted"
+            and payload.get("hook_event_name") in {"Notification", "Stop"}
+        ]
+        if aborted_events != ["Stop"]:
+            print(f"FAIL: aborted Pi response emitted a completion notification: {aborted_events!r}")
+            return 1
+        aborted_stop_payload = next(
+            (
+                payload
+                for payload in payloads
+                if payload.get("session_id") == "pi-session-aborted"
+                and payload.get("hook_event_name") == "Stop"
+            ),
+            None,
+        )
+        if (
+            aborted_stop_payload is None
+            or aborted_stop_payload.get("terminationReason") != "aborted"
+            or aborted_stop_payload.get("cmux_notification_routed") is not True
+        ):
+            print(f"FAIL: aborted Pi stop did not preserve its outcome: {aborted_stop_payload!r}")
             return 1
         legacy_stop_payload = next(
             (


### PR DESCRIPTION
## Summary

- read Pi's final assistant `stopReason` and `errorMessage` instead of assuming every settled run completed successfully
- report output-limit and provider failures as errors, with the failure notification left as the final visible lifecycle state
- suppress completion notifications for user-aborted runs while still marking the session idle
- preserve the existing completion path and legacy Pi compatibility

## Validation

- `python3 -m py_compile tests/test_pi_extension_install.py`
- `git diff --check`
- generated-extension runtime regression harness: failed before the fix with `notification.type: "completed"`; passed after the fix
- `tests/test_pi_extension_install.py`: passed with the generated extension and a focused fake installer CLI

Tagged app build was not run because this machine has Xcode 16.2 while the repository is pinned to Xcode 26.x. The focused test exercises the generated TypeScript extension end to end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787792838&installation_model_id=21920&pr_number=9021&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9021&signature=757987b43bc6efba7bc7b4da2774712e4aea18a8dae95007e9633ad8400aaf14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat incomplete Pi runs as errors instead of successful completions. Output-limit and provider failures now show error notifications; aborted runs no longer emit completion notifications.

- **Bug Fixes**
  - Parse assistant outcome (`stopReason`, `errorMessage`) and preserve the last message.
  - For `length` and `error`: emit `stop` first (with `terminationReason` and `cmux_notification_routed`), then an error `notification`.
  - For `aborted`: emit only `stop` and mark the session idle; no completion notification.
  - Preserve legacy completion behavior for Pi versions without `agent_settled`.
  - Added tests for length-capped, provider error, and aborted flows, verifying hook order and payloads.

<sup>Written for commit 35036a56d4f086154372442a2df2faf53592f447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

