### PR TITLE
Fix cmux-tui scrollback truncation

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/lib.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/lib.rs
@@ -50,9 +50,9 @@ pub use surface::{
     AttachFrame, AttachFrameReceiver, AttachStream, BrowserAttachState, BrowserFrame,
     BrowserFrameStream, BrowserSource, BrowserStatus, CLEAR_HISTORY_FALLBACK_UNREPRESENTABLE_ERROR,
     CLEAR_HISTORY_FALLBACK_WRITE_TIMEOUT_ERROR, CLEAR_HISTORY_PRESERVATION_ERROR,
-    CLEAR_HISTORY_STREAM_TIMEOUT_ERROR, ClearHistoryDelivery, ClearHistoryFailure, DefaultColors,
-    RenderAttachFrame, RenderAttachStream, Surface, SurfaceKind, SurfaceOptions,
-    SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
+    CLEAR_HISTORY_STREAM_TIMEOUT_ERROR, ClearHistoryDelivery, ClearHistoryFailure,
+    DEFAULT_SCROLLBACK_LIMIT_BYTES, DefaultColors, RenderAttachFrame, RenderAttachStream, Surface,
+    SurfaceKind, SurfaceOptions, SurfaceRenderFrame, TerminalColors, TerminalHostConnectionState,
 };
 pub use workspace_registry::{
     FrontendProjection, ProjectionCommit, RegistryCommit, RegistryEvent, RegistrySnapshot,

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -34,6 +34,8 @@ use crate::browser::{BrowserResizeWaiter, BrowserSurface, PendingBrowserResize};
 use crate::terminal_host_protocol::{FLAG_COLORS_FOLLOW, Frame, MessageKind, PROTOCOL_VERSION};
 use cmux_tui_cdp::BrowserMode;
 
+pub const DEFAULT_SCROLLBACK_LIMIT_BYTES: usize = 50_000_000;
+
 /// How to spawn surface children.
 #[derive(Debug, Clone)]
 pub struct SurfaceOptions {
@@ -45,6 +47,7 @@ pub struct SurfaceOptions {
     pub term: String,
     pub cols: u16,
     pub rows: u16,
+    /// Maximum retained scrollback backing storage in bytes.
     pub scrollback: usize,
     /// Extra environment for children (e.g. CMUX_TUI_SOCKET).
     pub extra_env: Vec<(String, String)>,
@@ -83,7 +86,7 @@ impl Default for SurfaceOptions {
                 .unwrap_or_else(|_| "xterm-256color".into()),
             cols: 80,
             rows: 24,
-            scrollback: 10_000,
+            scrollback: DEFAULT_SCROLLBACK_LIMIT_BYTES,
             extra_env: Vec::new(),
             chrome_binary: None,
             cdp_url: None,
@@ -3143,9 +3146,7 @@ mod tests {
             Terminal::new(options.cols, options.rows, options.scrollback, Callbacks::default())
                 .unwrap();
         for line in 0..20_000 {
-            terminal.vt_write(
-                format!("omp-history-{line:05} {}\r\n", "x".repeat(64)).as_bytes(),
-            );
+            terminal.vt_write(format!("omp-history-{line:05} {}\r\n", "x".repeat(64)).as_bytes());
         }
 
         let scrollback = terminal.plain_text().unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -3136,6 +3136,23 @@ fn terminal_scroll_position(term: &Terminal) -> (u64, bool) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn default_scrollback_retains_long_agent_transcript() {
+        let options = SurfaceOptions::default();
+        let mut terminal =
+            Terminal::new(options.cols, options.rows, options.scrollback, Callbacks::default())
+                .unwrap();
+        for line in 0..20_000 {
+            terminal.vt_write(
+                format!("omp-history-{line:05} {}\r\n", "x".repeat(64)).as_bytes(),
+            );
+        }
+
+        let scrollback = terminal.plain_text().unwrap();
+        assert!(scrollback.contains("omp-history-00000"));
+        assert!(scrollback.contains("omp-history-19999"));
+    }
+
     #[derive(Clone, Default)]
     struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2587,6 +2587,46 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn resolver_without_scrollback_preserves_file_configured_limit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_ghostty_bin = std::env::var_os("GHOSTTY_BIN");
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let old_xdg_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        let root = std::env::temp_dir().join(format!(
+            "cmux-tui-ghostty-scrollback-fallback-{}-{}",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let ghostty_dir = root.join("ghostty");
+        let binary = root.join("ghostty-config-helper");
+        std::fs::create_dir_all(&ghostty_dir).unwrap();
+        std::fs::write(ghostty_dir.join("config"), "scrollback-limit = 8_000_000\n").unwrap();
+        std::fs::write(
+            &binary,
+            "#!/bin/sh\nprintf 'background = #272822\\nforeground = #fdfff1\\n'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o700)).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe {
+            std::env::set_var("GHOSTTY_BIN", &binary);
+            std::env::remove_var("CMUX_MUX_CONFIG");
+            std::env::set_var("XDG_CONFIG_HOME", &root);
+        }
+
+        let config = load();
+
+        restore_env_var("GHOSTTY_BIN", old_ghostty_bin);
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        restore_env_var("XDG_CONFIG_HOME", old_xdg_config_home);
+        let _ = std::fs::remove_dir_all(root);
+        assert_eq!(config.scrollback_limit_bytes(), 8_000_000);
+    }
+
     #[test]
     fn fallback_theme_selection_matches_ghostty_first_theme_wins() {
         let dir = std::env::temp_dir().join(format!(

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2134,21 +2134,29 @@ fn parse_color(s: &str) -> Option<Color> {
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
 fn ghostty_defaults() -> GhosttyApplicationDefaults {
-    let parsed = resolved_ghostty_defaults()
-        .or_else(|| {
-            let text = platform::ghostty_config_paths()
-                .iter()
-                .find_map(|path| std::fs::read_to_string(path).ok())?;
-            Some(GhosttyApplicationDefaults {
-                colors: parse_ghostty_defaults(&text),
-                scrollback_limit_bytes: parse_scrollback_limit_bytes(&text),
-            })
-        })
-        .unwrap_or_default();
+    let parsed = if let Some(mut resolved) = resolved_ghostty_defaults() {
+        if resolved.scrollback_limit_bytes.is_none() {
+            resolved.scrollback_limit_bytes =
+                ghostty_file_defaults().and_then(|defaults| defaults.scrollback_limit_bytes);
+        }
+        resolved
+    } else {
+        ghostty_file_defaults().unwrap_or_default()
+    };
     GhosttyApplicationDefaults {
         colors: resolve_ghostty_application_defaults(parsed.colors),
         ..parsed
     }
+}
+
+fn ghostty_file_defaults() -> Option<GhosttyApplicationDefaults> {
+    let text = platform::ghostty_config_paths()
+        .iter()
+        .find_map(|path| std::fs::read_to_string(path).ok())?;
+    Some(GhosttyApplicationDefaults {
+        colors: parse_ghostty_defaults(&text),
+        scrollback_limit_bytes: parse_scrollback_limit_bytes(&text),
+    })
 }
 
 fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultColors {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -125,10 +125,10 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use cmux_tui_core::BrowserMode;
 use cmux_tui_core::SidebarPluginOptions;
-use cmux_tui_core::SurfaceOptions;
 use cmux_tui_core::TRANSPORT_SAFE_CAPTURE_MEGAPIXELS;
 use cmux_tui_core::platform;
 use cmux_tui_core::{CursorShape, DefaultColors, Rgb};
+use cmux_tui_core::{DEFAULT_SCROLLBACK_LIMIT_BYTES, SurfaceOptions};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
@@ -1681,6 +1681,7 @@ pub struct Config {
     pub terminal_defaults: DefaultColors,
     pub cursor_style: Option<CursorShape>,
     pub cursor_blink: Option<bool>,
+    scrollback_limit_bytes: Option<usize>,
     pub chrome: ChromeMode,
     pub tabs: Tabs,
     pub sidebar: Sidebar,
@@ -1710,6 +1711,10 @@ pub struct ThemeOverrides {
 }
 
 impl Config {
+    pub fn scrollback_limit_bytes(&self) -> usize {
+        self.scrollback_limit_bytes.unwrap_or(DEFAULT_SCROLLBACK_LIMIT_BYTES)
+    }
+
     pub fn apply_chrome_defaults(&mut self, chrome: ChromeTheme) {
         if !self.theme_overrides.selection {
             self.theme.selection_bg = chrome.selection_bg;
@@ -1729,8 +1734,10 @@ pub struct SidebarPluginConfig {
 pub fn load() -> Config {
     let mut config = Config::default();
 
-    let defaults = ghostty_defaults();
+    let ghostty = ghostty_defaults();
+    let defaults = ghostty.colors;
     config.terminal_defaults = defaults;
+    config.scrollback_limit_bytes = ghostty.scrollback_limit_bytes;
     if let Some(bg) = defaults.selection_bg {
         config.theme.selection_bg = Color::Rgb(bg.r, bg.g, bg.b);
         config.theme_overrides.selection = true;
@@ -2126,16 +2133,22 @@ fn parse_color(s: &str) -> Option<Color> {
 
 /// The user's relevant Ghostty settings with non-optional application defaults
 /// resolved for values that the low-level terminal otherwise leaves unset.
-fn ghostty_defaults() -> DefaultColors {
+fn ghostty_defaults() -> GhosttyApplicationDefaults {
     let parsed = resolved_ghostty_defaults()
         .or_else(|| {
             let text = platform::ghostty_config_paths()
                 .iter()
                 .find_map(|path| std::fs::read_to_string(path).ok())?;
-            Some(parse_ghostty_defaults(&text))
+            Some(GhosttyApplicationDefaults {
+                colors: parse_ghostty_defaults(&text),
+                scrollback_limit_bytes: parse_scrollback_limit_bytes(&text),
+            })
         })
         .unwrap_or_default();
-    resolve_ghostty_application_defaults(parsed)
+    GhosttyApplicationDefaults {
+        colors: resolve_ghostty_application_defaults(parsed.colors),
+        ..parsed
+    }
 }
 
 fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultColors {
@@ -2147,31 +2160,62 @@ fn resolve_ghostty_application_defaults(mut defaults: DefaultColors) -> DefaultC
     defaults
 }
 
+#[derive(Default)]
+struct GhosttyApplicationDefaults {
+    colors: DefaultColors,
+    scrollback_limit_bytes: Option<usize>,
+}
+
 /// Ask Ghostty to resolve its configuration so cmux-tui inherits precisely the
-/// same theme-loading behavior as the graphical terminal. A failed or slow
-/// invocation is deliberately ignored; startup then uses the file fallback.
-fn resolved_ghostty_defaults() -> Option<DefaultColors> {
+/// same settings as the graphical terminal. A failed or slow invocation is
+/// deliberately ignored; startup then uses the file fallback.
+fn resolved_ghostty_defaults() -> Option<GhosttyApplicationDefaults> {
     resolved_ghostty_defaults_from(&platform::ghostty_installations())
 }
 
 fn resolved_ghostty_defaults_from(
     installations: &[platform::GhosttyInstallation],
-) -> Option<DefaultColors> {
+) -> Option<GhosttyApplicationDefaults> {
     installations.iter().find_map(|installation| {
-        let text = run_ghostty_show_config(installation)?;
-        let defaults = parse_resolved_ghostty_defaults(&text);
-        // `+show-config` serializes Ghostty's effective application defaults,
-        // including both colors. An executable that exits successfully but
-        // emits no resolved config (for example a packaging stub) is not a
-        // usable resolver and must not suppress later pinned candidates.
-        (defaults.fg.is_some() && defaults.bg.is_some()).then_some(defaults)
+        let text = run_ghostty_show_config(installation, false)?;
+        let colors = parse_resolved_ghostty_defaults(&text);
+        // `+show-config` serializes Ghostty's effective application colors.
+        // An executable that exits successfully but emits no resolved config
+        // (for example a packaging stub) is not a usable resolver and must
+        // not suppress later pinned candidates.
+        (colors.fg.is_some() && colors.bg.is_some()).then(|| {
+            let scrollback_limit_bytes = parse_scrollback_limit_bytes(&text).or_else(|| {
+                run_ghostty_show_config(installation, true)
+                    .as_deref()
+                    .and_then(parse_scrollback_limit_bytes)
+            });
+            GhosttyApplicationDefaults { colors, scrollback_limit_bytes }
+        })
     })
 }
 
-fn run_ghostty_show_config(installation: &platform::GhosttyInstallation) -> Option<String> {
+fn parse_scrollback_limit_bytes(text: &str) -> Option<usize> {
+    text.lines()
+        .filter_map(|line| {
+            let (key, value) = line.trim().split_once('=')?;
+            (key.trim() == "scrollback-limit")
+                .then(|| value.trim().trim_matches('"').replace('_', "").parse::<usize>().ok())
+                .flatten()
+        })
+        .last()
+}
+
+fn run_ghostty_show_config(
+    installation: &platform::GhosttyInstallation,
+    show_defaults: bool,
+) -> Option<String> {
     let mut command = Command::new(&installation.binary);
+    command.arg("+show-config");
+    if show_defaults {
+        command.arg("--default");
+    }
     command
-        .args(["+show-config", "--no-pager"])
+        .arg("--no-pager")
         .env_remove("GHOSTTY_RESOURCES_DIR")
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
@@ -2435,6 +2479,20 @@ mod tests {
     }
 
     #[test]
+    fn parses_ghostty_scrollback_limit_with_later_valid_entry_wins() {
+        assert_eq!(
+            parse_scrollback_limit_bytes(
+                "scrollback-limit = 4_000_000\n\
+                 scrollback-limit = invalid\n\
+                 scrollback-limit = 50_000_000\n"
+            ),
+            Some(50_000_000)
+        );
+        assert_eq!(parse_scrollback_limit_bytes("scrollback-limit = -1\n"), None);
+        assert_eq!(Config::default().scrollback_limit_bytes(), DEFAULT_SCROLLBACK_LIMIT_BYTES);
+    }
+
+    #[test]
     fn parses_resolved_ghostty_show_config_output() {
         let defaults = parse_resolved_ghostty_defaults(
             "# Ghostty resolved configuration\n\
@@ -2485,10 +2543,10 @@ mod tests {
         .unwrap();
         std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o700)).unwrap();
 
-        let output = run_ghostty_show_config(&platform::GhosttyInstallation {
-            binary,
-            resources_dir: Some(resources.clone()),
-        })
+        let output = run_ghostty_show_config(
+            &platform::GhosttyInstallation { binary, resources_dir: Some(resources.clone()) },
+            false,
+        )
         .unwrap();
         assert!(output.contains(&format!("resource-path = {}", resources.display())));
         let defaults = parse_resolved_ghostty_defaults(&output);
@@ -2513,10 +2571,9 @@ mod tests {
         std::fs::write(&broken, "#!/bin/sh\nexit 0\n").unwrap();
         std::fs::write(
             &working,
-            "#!/bin/sh\nprintf 'background = #272822\\nforeground = #fdfff1\\n'\n",
+            "#!/bin/sh\nif [ \"$2\" = \"--default\" ]; then\n  printf 'scrollback-limit = 4000000\\n'\nelse\n  printf 'background = #272822\\nforeground = #fdfff1\\n'\nfi\n",
         )
         .unwrap();
-        std::fs::set_permissions(&broken, std::fs::Permissions::from_mode(0o700)).unwrap();
         std::fs::set_permissions(&working, std::fs::Permissions::from_mode(0o700)).unwrap();
 
         let defaults = resolved_ghostty_defaults_from(&[
@@ -2524,8 +2581,9 @@ mod tests {
             platform::GhosttyInstallation { binary: working, resources_dir: None },
         ])
         .unwrap();
-        assert_eq!(defaults.bg, Some(Rgb { r: 0x27, g: 0x28, b: 0x22 }));
-        assert_eq!(defaults.fg, Some(Rgb { r: 0xfd, g: 0xff, b: 0xf1 }));
+        assert_eq!(defaults.colors.bg, Some(Rgb { r: 0x27, g: 0x28, b: 0x22 }));
+        assert_eq!(defaults.colors.fg, Some(Rgb { r: 0xfd, g: 0xff, b: 0xf1 }));
+        assert_eq!(defaults.scrollback_limit_bytes, Some(4_000_000));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -985,6 +985,7 @@ fn run_server(
 
     let mut surface_options = SurfaceOptions::default();
     config::apply_browser_to_surface_options(&config, &mut surface_options);
+    surface_options.scrollback = config.scrollback_limit_bytes();
     if let Some(term) = args.term {
         surface_options.term = term;
     }


### PR DESCRIPTION
## Summary

- raise cmux-tui's standalone fallback from Ghostty's low-level 10,000-byte default to the 50,000,000-byte application capacity
- resolve `scrollback-limit` from the user's effective Ghostty configuration, including the installed Ghostty version's default when the user has no explicit override
- pass the resolved byte limit into every locally created terminal surface

## Root cause

`SurfaceOptions` used `10_000` as `max_scrollback`. Ghostty measures that field in bytes, not rows, so agent transcripts were discarded after a very small amount of output.

## Related work

#7616 changes the native macOS app's managed default and is not a duplicate: this PR fixes the Rust cmux-tui terminal implementation and follows the user's Ghostty setting.

## Tests

- `cargo +1.97.1 test -p cmux-tui-core default_scrollback_retains_long_agent_transcript -- --nocapture`
- `cargo +1.97.1 test -p cmux-tui parses_ghostty_scrollback_limit_with_later_valid_entry_wins -- --nocapture`
- `cargo +1.97.1 test -p cmux-tui unusable_packaged_ghostty_resolver_falls_through -- --nocapture`
- `cargo +1.97.1 check -p cmux-tui --all-targets`
- `cargo +1.97.1 build --release -p cmux-tui`

The regression test is committed separately before the fix so CI shows the failure and recovery.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787796024&installation_model_id=21920&pr_number=9022&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9022&signature=89711096f806a14c1cdd9958dd090f85f8bd28de0dcb5c7fe74f2c95a60ea47e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scrollback truncation in `cmux-tui` by inheriting Ghostty’s `scrollback-limit` (including file-configured fallback) and raising the built-in default to 50,000,000 bytes. Long agent output now persists across all local terminal surfaces.

- **Bug Fixes**
  - Resolve `scrollback-limit` via `+show-config`; when missing, keep the value from Ghostty config files, and when unset, use `--default`.
  - Apply the resolved limit to every local terminal surface at startup.
  - Add tests for long scrollback retention, `scrollback-limit` parsing, and preserving file-configured limits; ignore unusable resolvers.

<sup>Written for commit 42455c3e1ce0146167a8a2f132e60cbd8926ef24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable terminal scrollback capacity, measured in bytes.
  * The app now honors Ghostty’s `scrollback-limit` when provided (with safe fallback to the default when unavailable).
  * Increased the default scrollback capacity to better preserve longer terminal and agent transcripts.

* **Bug Fixes**
  * Reduced the chance of losing earlier output during long sessions by retaining more scrollback data by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->