### PR TITLE
Stop reentrant focus storms (#8843)

### DIFF
--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
@@ -8,18 +8,23 @@
 public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     private let deliver: @MainActor @Sendable (Payload) -> Void
     private let schedule: @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void
-    private let scheduleAfterCircuitBreaker: @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void
     private let maxCoalescedDeliveries: Int
     private let maxConsecutiveBoundedFlushes: Int
+    private let maxConsecutiveCircuitDeliveries: Int
+    private let maxCircuitBreakerRecoveryDeliveries: Int
+    private let belongsToSameCircuit: @MainActor @Sendable (Payload, Payload) -> Bool
     private let onDrainBoundExceeded: @MainActor @Sendable (Payload) -> Void
     private let onCircuitBreakerTripped: @MainActor @Sendable (Payload) -> Void
 
     private var pending: Payload?
     private var flushScheduled = false
-    private var circuitBreakerFlushScheduled = false
     private var circuitBreakerOpen = false
     private var isDelivering = false
     private var consecutiveBoundedFlushes = 0
+    private var circuitDeliveryReference: Payload?
+    private var consecutiveCircuitDeliveries = 0
+    private var circuitBreakerReference: Payload?
+    private var circuitBreakerRecoveryDeliveriesRemaining = 0
 
     /// Creates a focus-broadcast coalescer.
     ///
@@ -29,9 +34,18 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     ///   - maxConsecutiveBoundedFlushes: Upper bound on consecutive flushes that
     ///     hit ``maxCoalescedDeliveries`` before the still-pending payload is moved
     ///     to the circuit-breaker scheduler. Values below one are clamped to one.
+    ///   - maxConsecutiveCircuitDeliveries: Upper bound on deliveries for payloads
+    ///     that belong to the same logical feedback circuit, including deferred
+    ///     emits that arrive after the active delivery stack has unwound. Defaults
+    ///     to `maxCoalescedDeliveries * maxConsecutiveBoundedFlushes`.
+    ///   - maxCircuitBreakerRecoveryDeliveries: Upper bound on retained same-circuit
+    ///     payloads delivered after the circuit breaker trips. Defaults to
+    ///     `maxCoalescedDeliveries`, so legitimate finite convergence can publish a
+    ///     final payload while non-converging feedback remains bounded.
+    ///   - belongsToSameCircuit: Returns whether two payloads belong to the same
+    ///     logical feedback circuit. Payloads in different circuits are treated as
+    ///     new external work and close any open breaker.
     ///   - schedule: Schedules deferred main-actor flush work.
-    ///   - scheduleAfterCircuitBreaker: Schedules one retained-payload recovery
-    ///     after the circuit breaker trips. Defaults to ``schedule``.
     ///   - onDrainBoundExceeded: Called with the still-pending payload when a
     ///     flush hits ``maxCoalescedDeliveries`` and defers to another turn.
     ///   - onCircuitBreakerTripped: Called with the retained pending payload when
@@ -40,16 +54,32 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     public init(
         maxCoalescedDeliveries: Int = 8,
         maxConsecutiveBoundedFlushes: Int = 4,
+        maxConsecutiveCircuitDeliveries: Int? = nil,
+        maxCircuitBreakerRecoveryDeliveries: Int? = nil,
+        belongsToSameCircuit: @escaping @MainActor @Sendable (Payload, Payload) -> Bool = { _, _ in false },
         schedule: @escaping @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void,
-        scheduleAfterCircuitBreaker: (@MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void)? = nil,
         onDrainBoundExceeded: @escaping @MainActor @Sendable (Payload) -> Void = { _ in },
         onCircuitBreakerTripped: @escaping @MainActor @Sendable (Payload) -> Void = { _ in },
         deliver: @escaping @MainActor @Sendable (Payload) -> Void
     ) {
-        self.maxCoalescedDeliveries = max(1, maxCoalescedDeliveries)
-        self.maxConsecutiveBoundedFlushes = max(1, maxConsecutiveBoundedFlushes)
+        let coalescedDeliveryLimit = max(1, maxCoalescedDeliveries)
+        let boundedFlushLimit = max(1, maxConsecutiveBoundedFlushes)
+        let defaultCircuitDeliveryLimit: Int
+        if coalescedDeliveryLimit > Int.max / boundedFlushLimit {
+            defaultCircuitDeliveryLimit = Int.max
+        } else {
+            defaultCircuitDeliveryLimit = coalescedDeliveryLimit * boundedFlushLimit
+        }
+
+        self.maxCoalescedDeliveries = coalescedDeliveryLimit
+        self.maxConsecutiveBoundedFlushes = boundedFlushLimit
+        self.maxConsecutiveCircuitDeliveries = max(1, maxConsecutiveCircuitDeliveries ?? defaultCircuitDeliveryLimit)
+        self.maxCircuitBreakerRecoveryDeliveries = max(
+            0,
+            maxCircuitBreakerRecoveryDeliveries ?? coalescedDeliveryLimit
+        )
+        self.belongsToSameCircuit = belongsToSameCircuit
         self.schedule = schedule
-        self.scheduleAfterCircuitBreaker = scheduleAfterCircuitBreaker ?? schedule
         self.onDrainBoundExceeded = onDrainBoundExceeded
         self.onCircuitBreakerTripped = onCircuitBreakerTripped
         self.deliver = deliver
@@ -59,15 +89,21 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     ///
     /// This method never delivers synchronously. If delivery is already in
     /// progress, the payload is recorded for the active drain loop instead of
-    /// recursively scheduling more work. If the circuit breaker is open, only an
-    /// external emit closes it and schedules immediate work; synchronous emits from
-    /// recovery delivery remain pending without rescheduling the loop.
+    /// recursively scheduling more work. If the circuit breaker is open, payloads
+    /// in the same circuit are allowed only through the bounded recovery budget;
+    /// payloads from a different circuit close the breaker and schedule normally.
     public func emit(_ payload: Payload) {
+        let isSameBreakerCircuit = isSameCircuit(as: circuitBreakerReference, payload)
         pending = payload
         if isDelivering { return }
         if circuitBreakerOpen {
-            circuitBreakerOpen = false
-            consecutiveBoundedFlushes = 0
+            guard isSameBreakerCircuit else {
+                closeCircuitBreakerForExternalPayload()
+                scheduleImmediateFlush()
+                return
+            }
+            scheduleCircuitBreakerRecoveryIfPossible()
+            return
         }
         scheduleImmediateFlush()
     }
@@ -98,15 +134,20 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
                 if consecutiveBoundedFlushes >= maxConsecutiveBoundedFlushes {
                     pending = next
                     hitCircuitBreaker = true
-                    circuitBreakerOpen = true
-                    consecutiveBoundedFlushes = 0
-                    onCircuitBreakerTripped(next)
+                    tripCircuitBreaker(with: next)
                 } else {
                     pending = next
                 }
                 break
             }
+            if shouldTripForConsecutiveCircuitDelivery(next) {
+                pending = next
+                hitCircuitBreaker = true
+                tripCircuitBreaker(with: next)
+                break
+            }
             deliver(next)
+            recordCircuitDelivery(next)
         }
 
         isDelivering = false
@@ -115,7 +156,7 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
         }
         if pending != nil {
             if hitCircuitBreaker {
-                scheduleCircuitBreakerFlush()
+                scheduleCircuitBreakerRecoveryIfPossible()
             } else {
                 scheduleImmediateFlush()
             }
@@ -124,17 +165,24 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
 
     private func flushCircuitBreakerRecovery() {
         guard let next = pending else {
-            circuitBreakerOpen = false
-            consecutiveBoundedFlushes = 0
+            return
+        }
+        guard circuitBreakerRecoveryDeliveriesRemaining > 0 else {
             return
         }
         pending = nil
+        circuitBreakerRecoveryDeliveriesRemaining -= 1
         isDelivering = true
         deliver(next)
+        recordCircuitDelivery(next)
         isDelivering = false
         consecutiveBoundedFlushes = 0
-        if pending == nil {
-            circuitBreakerOpen = false
+        guard let remaining = pending else { return }
+        if isSameCircuit(as: circuitBreakerReference, remaining) {
+            scheduleCircuitBreakerRecoveryIfPossible()
+        } else {
+            closeCircuitBreakerForExternalPayload()
+            scheduleImmediateFlush()
         }
     }
 
@@ -146,13 +194,54 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
         }
     }
 
-    private func scheduleCircuitBreakerFlush() {
-        guard !circuitBreakerFlushScheduled else { return }
-        circuitBreakerFlushScheduled = true
-        scheduleAfterCircuitBreaker { @Sendable [weak self] in
-            guard let self else { return }
-            self.circuitBreakerFlushScheduled = false
-            self.flush()
+    private func scheduleCircuitBreakerRecoveryIfPossible() {
+        guard circuitBreakerRecoveryDeliveriesRemaining > 0 else {
+            pending = nil
+            return
         }
+        scheduleImmediateFlush()
+    }
+
+    private func tripCircuitBreaker(with payload: Payload) {
+        circuitBreakerOpen = true
+        circuitBreakerReference = payload
+        circuitBreakerRecoveryDeliveriesRemaining = maxCircuitBreakerRecoveryDeliveries
+        consecutiveBoundedFlushes = 0
+        onCircuitBreakerTripped(payload)
+    }
+
+    private func closeCircuitBreakerForExternalPayload() {
+        circuitBreakerOpen = false
+        circuitBreakerReference = nil
+        circuitBreakerRecoveryDeliveriesRemaining = 0
+        consecutiveBoundedFlushes = 0
+        resetCircuitDeliveryTracking()
+    }
+
+    private func shouldTripForConsecutiveCircuitDelivery(_ payload: Payload) -> Bool {
+        guard let reference = circuitDeliveryReference,
+              belongsToSameCircuit(reference, payload) else {
+            return false
+        }
+        return consecutiveCircuitDeliveries >= maxConsecutiveCircuitDeliveries
+    }
+
+    private func recordCircuitDelivery(_ payload: Payload) {
+        if isSameCircuit(as: circuitDeliveryReference, payload) {
+            consecutiveCircuitDeliveries += 1
+        } else {
+            circuitDeliveryReference = payload
+            consecutiveCircuitDeliveries = 1
+        }
+    }
+
+    private func resetCircuitDeliveryTracking() {
+        circuitDeliveryReference = nil
+        consecutiveCircuitDeliveries = 0
+    }
+
+    private func isSameCircuit(as reference: Payload?, _ payload: Payload) -> Bool {
+        guard let reference else { return false }
+        return belongsToSameCircuit(reference, payload)
     }
 }

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
@@ -17,6 +17,7 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     private var pending: Payload?
     private var flushScheduled = false
     private var circuitBreakerFlushScheduled = false
+    private var circuitBreakerOpen = false
     private var isDelivering = false
     private var consecutiveBoundedFlushes = 0
 
@@ -29,8 +30,8 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     ///     hit ``maxCoalescedDeliveries`` before the still-pending payload is moved
     ///     to the circuit-breaker scheduler. Values below one are clamped to one.
     ///   - schedule: Schedules deferred main-actor flush work.
-    ///   - scheduleAfterCircuitBreaker: Schedules continuation work after the
-    ///     circuit breaker trips. Defaults to ``schedule``.
+    ///   - scheduleAfterCircuitBreaker: Schedules one retained-payload recovery
+    ///     after the circuit breaker trips. Defaults to ``schedule``.
     ///   - onDrainBoundExceeded: Called with the still-pending payload when a
     ///     flush hits ``maxCoalescedDeliveries`` and defers to another turn.
     ///   - onCircuitBreakerTripped: Called with the retained pending payload when
@@ -58,10 +59,16 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     ///
     /// This method never delivers synchronously. If delivery is already in
     /// progress, the payload is recorded for the active drain loop instead of
-    /// recursively scheduling more work.
+    /// recursively scheduling more work. If the circuit breaker is open, only an
+    /// external emit closes it and schedules immediate work; synchronous emits from
+    /// recovery delivery remain pending without rescheduling the loop.
     public func emit(_ payload: Payload) {
         pending = payload
         if isDelivering { return }
+        if circuitBreakerOpen {
+            circuitBreakerOpen = false
+            consecutiveBoundedFlushes = 0
+        }
         scheduleImmediateFlush()
     }
 
@@ -72,6 +79,10 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     public func flush() {
         flushScheduled = false
         guard !isDelivering else { return }
+        if circuitBreakerOpen {
+            flushCircuitBreakerRecovery()
+            return
+        }
         isDelivering = true
 
         var iterations = 0
@@ -87,6 +98,7 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
                 if consecutiveBoundedFlushes >= maxConsecutiveBoundedFlushes {
                     pending = next
                     hitCircuitBreaker = true
+                    circuitBreakerOpen = true
                     consecutiveBoundedFlushes = 0
                     onCircuitBreakerTripped(next)
                 } else {
@@ -107,6 +119,22 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
             } else {
                 scheduleImmediateFlush()
             }
+        }
+    }
+
+    private func flushCircuitBreakerRecovery() {
+        guard let next = pending else {
+            circuitBreakerOpen = false
+            consecutiveBoundedFlushes = 0
+            return
+        }
+        pending = nil
+        isDelivering = true
+        deliver(next)
+        isDelivering = false
+        consecutiveBoundedFlushes = 0
+        if pending == nil {
+            circuitBreakerOpen = false
         }
     }
 

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
@@ -8,6 +8,7 @@
 public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     private let deliver: @MainActor @Sendable (Payload) -> Void
     private let schedule: @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void
+    private let scheduleAfterCircuitBreaker: @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void
     private let maxCoalescedDeliveries: Int
     private let maxConsecutiveBoundedFlushes: Int
     private let onDrainBoundExceeded: @MainActor @Sendable (Payload) -> Void
@@ -15,6 +16,7 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
 
     private var pending: Payload?
     private var flushScheduled = false
+    private var circuitBreakerFlushScheduled = false
     private var isDelivering = false
     private var consecutiveBoundedFlushes = 0
 
@@ -24,19 +26,21 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     ///   - maxCoalescedDeliveries: Upper bound on deliveries performed by a single
     ///     flush. Values below one are clamped to one.
     ///   - maxConsecutiveBoundedFlushes: Upper bound on consecutive flushes that
-    ///     hit ``maxCoalescedDeliveries`` before the last pending payload gets one
-    ///     final reconciliation delivery and the re-entrant continuation is
-    ///     dropped. Values below one are clamped to one.
+    ///     hit ``maxCoalescedDeliveries`` before the still-pending payload is moved
+    ///     to the circuit-breaker scheduler. Values below one are clamped to one.
     ///   - schedule: Schedules deferred main-actor flush work.
+    ///   - scheduleAfterCircuitBreaker: Schedules continuation work after the
+    ///     circuit breaker trips. Defaults to ``schedule``.
     ///   - onDrainBoundExceeded: Called with the still-pending payload when a
     ///     flush hits ``maxCoalescedDeliveries`` and defers to another turn.
-    ///   - onCircuitBreakerTripped: Called with the final reconciled payload when
+    ///   - onCircuitBreakerTripped: Called with the retained pending payload when
     ///     a non-converging cycle reaches ``maxConsecutiveBoundedFlushes``.
     ///   - deliver: Delivers one pending payload.
     public init(
         maxCoalescedDeliveries: Int = 8,
         maxConsecutiveBoundedFlushes: Int = 4,
         schedule: @escaping @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void,
+        scheduleAfterCircuitBreaker: (@MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void)? = nil,
         onDrainBoundExceeded: @escaping @MainActor @Sendable (Payload) -> Void = { _ in },
         onCircuitBreakerTripped: @escaping @MainActor @Sendable (Payload) -> Void = { _ in },
         deliver: @escaping @MainActor @Sendable (Payload) -> Void
@@ -44,6 +48,7 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
         self.maxCoalescedDeliveries = max(1, maxCoalescedDeliveries)
         self.maxConsecutiveBoundedFlushes = max(1, maxConsecutiveBoundedFlushes)
         self.schedule = schedule
+        self.scheduleAfterCircuitBreaker = scheduleAfterCircuitBreaker ?? schedule
         self.onDrainBoundExceeded = onDrainBoundExceeded
         self.onCircuitBreakerTripped = onCircuitBreakerTripped
         self.deliver = deliver
@@ -57,11 +62,7 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     public func emit(_ payload: Payload) {
         pending = payload
         if isDelivering { return }
-        if flushScheduled { return }
-        flushScheduled = true
-        schedule { @Sendable [weak self] in
-            self?.flush()
-        }
+        scheduleImmediateFlush()
     }
 
     /// Delivers pending payloads in a bounded drain.
@@ -75,6 +76,7 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
 
         var iterations = 0
         var hitDeliveryBound = false
+        var hitCircuitBreaker = false
         while let next = pending {
             pending = nil
             iterations += 1
@@ -83,12 +85,9 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
                 consecutiveBoundedFlushes += 1
                 onDrainBoundExceeded(next)
                 if consecutiveBoundedFlushes >= maxConsecutiveBoundedFlushes {
-                    pending = nil
+                    pending = next
+                    hitCircuitBreaker = true
                     consecutiveBoundedFlushes = 0
-                    deliver(next)
-                    // Preserve the latest focus once before tripping, then drop
-                    // only the continuation emitted by a non-converging observer.
-                    pending = nil
                     onCircuitBreakerTripped(next)
                 } else {
                     pending = next
@@ -102,11 +101,30 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
         if !hitDeliveryBound {
             consecutiveBoundedFlushes = 0
         }
-        if pending != nil, !flushScheduled {
-            flushScheduled = true
-            schedule { @Sendable [weak self] in
-                self?.flush()
+        if pending != nil {
+            if hitCircuitBreaker {
+                scheduleCircuitBreakerFlush()
+            } else {
+                scheduleImmediateFlush()
             }
+        }
+    }
+
+    private func scheduleImmediateFlush() {
+        guard !flushScheduled else { return }
+        flushScheduled = true
+        schedule { @Sendable [weak self] in
+            self?.flush()
+        }
+    }
+
+    private func scheduleCircuitBreakerFlush() {
+        guard !circuitBreakerFlushScheduled else { return }
+        circuitBreakerFlushScheduled = true
+        scheduleAfterCircuitBreaker { @Sendable [weak self] in
+            guard let self else { return }
+            self.circuitBreakerFlushScheduled = false
+            self.flush()
         }
     }
 }

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
@@ -1,0 +1,106 @@
+/// Coalesces and bounds main-actor focus broadcasts.
+///
+/// The coalescer is payload-agnostic: callers provide the scheduler, delivery
+/// closure, and diagnostics. This keeps the re-entrancy/circuit-breaker policy
+/// testable in the package while leaving app-specific notification wiring at the
+/// composition edge.
+@MainActor
+public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
+    private let deliver: @MainActor @Sendable (Payload) -> Void
+    private let schedule: @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void
+    private let maxCoalescedDeliveries: Int
+    private let maxConsecutiveBoundedFlushes: Int
+    private let onDrainBoundExceeded: @MainActor @Sendable (Payload) -> Void
+    private let onCircuitBreakerTripped: @MainActor @Sendable (Payload) -> Void
+
+    private var pending: Payload?
+    private var flushScheduled = false
+    private var isDelivering = false
+    private var consecutiveBoundedFlushes = 0
+
+    /// Creates a focus-broadcast coalescer.
+    ///
+    /// - Parameters:
+    ///   - maxCoalescedDeliveries: Upper bound on deliveries performed by a single
+    ///     flush. Values below one are clamped to one.
+    ///   - maxConsecutiveBoundedFlushes: Upper bound on consecutive flushes that
+    ///     hit ``maxCoalescedDeliveries`` before the last pending payload is
+    ///     dropped. Values below one are clamped to one.
+    ///   - schedule: Schedules deferred main-actor flush work.
+    ///   - onDrainBoundExceeded: Called with the still-pending payload when a
+    ///     flush hits ``maxCoalescedDeliveries`` and defers to another turn.
+    ///   - onCircuitBreakerTripped: Called with the dropped payload when a
+    ///     non-converging cycle reaches ``maxConsecutiveBoundedFlushes``.
+    ///   - deliver: Delivers one pending payload.
+    public init(
+        maxCoalescedDeliveries: Int = 8,
+        maxConsecutiveBoundedFlushes: Int = 4,
+        schedule: @escaping @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void,
+        onDrainBoundExceeded: @escaping @MainActor @Sendable (Payload) -> Void = { _ in },
+        onCircuitBreakerTripped: @escaping @MainActor @Sendable (Payload) -> Void = { _ in },
+        deliver: @escaping @MainActor @Sendable (Payload) -> Void
+    ) {
+        self.maxCoalescedDeliveries = max(1, maxCoalescedDeliveries)
+        self.maxConsecutiveBoundedFlushes = max(1, maxConsecutiveBoundedFlushes)
+        self.schedule = schedule
+        self.onDrainBoundExceeded = onDrainBoundExceeded
+        self.onCircuitBreakerTripped = onCircuitBreakerTripped
+        self.deliver = deliver
+    }
+
+    /// Records a payload for asynchronous, coalesced delivery.
+    ///
+    /// This method never delivers synchronously. If delivery is already in
+    /// progress, the payload is recorded for the active drain loop instead of
+    /// recursively scheduling more work.
+    public func emit(_ payload: Payload) {
+        pending = payload
+        if isDelivering { return }
+        if flushScheduled { return }
+        flushScheduled = true
+        schedule { @Sendable [weak self] in
+            self?.flush()
+        }
+    }
+
+    /// Delivers pending payloads in a bounded drain.
+    ///
+    /// Most callers should not call this directly; it is public so app-target
+    /// wrappers and tests can drive an injected scheduler deterministically.
+    public func flush() {
+        flushScheduled = false
+        guard !isDelivering else { return }
+        isDelivering = true
+
+        var iterations = 0
+        var hitDeliveryBound = false
+        while let next = pending {
+            pending = nil
+            iterations += 1
+            if iterations > maxCoalescedDeliveries {
+                pending = next
+                hitDeliveryBound = true
+                consecutiveBoundedFlushes += 1
+                onDrainBoundExceeded(next)
+                if consecutiveBoundedFlushes >= maxConsecutiveBoundedFlushes {
+                    pending = nil
+                    consecutiveBoundedFlushes = 0
+                    onCircuitBreakerTripped(next)
+                }
+                break
+            }
+            deliver(next)
+        }
+
+        isDelivering = false
+        if !hitDeliveryBound {
+            consecutiveBoundedFlushes = 0
+        }
+        if pending != nil, !flushScheduled {
+            flushScheduled = true
+            schedule { @Sendable [weak self] in
+                self?.flush()
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
+++ b/Packages/macOS/CmuxNotifications/Sources/CmuxNotifications/FocusSurfaceBroadcastCoalescer.swift
@@ -24,13 +24,14 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
     ///   - maxCoalescedDeliveries: Upper bound on deliveries performed by a single
     ///     flush. Values below one are clamped to one.
     ///   - maxConsecutiveBoundedFlushes: Upper bound on consecutive flushes that
-    ///     hit ``maxCoalescedDeliveries`` before the last pending payload is
+    ///     hit ``maxCoalescedDeliveries`` before the last pending payload gets one
+    ///     final reconciliation delivery and the re-entrant continuation is
     ///     dropped. Values below one are clamped to one.
     ///   - schedule: Schedules deferred main-actor flush work.
     ///   - onDrainBoundExceeded: Called with the still-pending payload when a
     ///     flush hits ``maxCoalescedDeliveries`` and defers to another turn.
-    ///   - onCircuitBreakerTripped: Called with the dropped payload when a
-    ///     non-converging cycle reaches ``maxConsecutiveBoundedFlushes``.
+    ///   - onCircuitBreakerTripped: Called with the final reconciled payload when
+    ///     a non-converging cycle reaches ``maxConsecutiveBoundedFlushes``.
     ///   - deliver: Delivers one pending payload.
     public init(
         maxCoalescedDeliveries: Int = 8,
@@ -78,14 +79,19 @@ public final class FocusSurfaceBroadcastCoalescer<Payload: Sendable> {
             pending = nil
             iterations += 1
             if iterations > maxCoalescedDeliveries {
-                pending = next
                 hitDeliveryBound = true
                 consecutiveBoundedFlushes += 1
                 onDrainBoundExceeded(next)
                 if consecutiveBoundedFlushes >= maxConsecutiveBoundedFlushes {
                     pending = nil
                     consecutiveBoundedFlushes = 0
+                    deliver(next)
+                    // Preserve the latest focus once before tripping, then drop
+                    // only the continuation emitted by a non-converging observer.
+                    pending = nil
                     onCircuitBreakerTripped(next)
+                } else {
+                    pending = next
                 }
                 break
             }

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
@@ -7,16 +7,28 @@ struct FocusSurfaceBroadcastCoalescerTests {
     @MainActor
     private final class ManualScheduler {
         private(set) var pending: [@MainActor @Sendable () -> Void] = []
+        private(set) var circuitBreakerPending: [@MainActor @Sendable () -> Void] = []
 
         func append(_ work: @escaping @MainActor @Sendable () -> Void) {
             pending.append(work)
         }
 
+        func appendCircuitBreaker(_ work: @escaping @MainActor @Sendable () -> Void) {
+            circuitBreakerPending.append(work)
+        }
+
         var count: Int { pending.count }
+        var circuitBreakerCount: Int { circuitBreakerPending.count }
 
         func runAll() {
             let work = pending
             pending.removeAll()
+            for unit in work { unit() }
+        }
+
+        func runAllCircuitBreaker() {
+            let work = circuitBreakerPending
+            circuitBreakerPending.removeAll()
             for unit in work { unit() }
         }
     }
@@ -92,6 +104,7 @@ struct FocusSurfaceBroadcastCoalescerTests {
             maxCoalescedDeliveries: 2,
             maxConsecutiveBoundedFlushes: 4,
             schedule: { scheduler.append($0) },
+            scheduleAfterCircuitBreaker: { scheduler.appendCircuitBreaker($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
             onCircuitBreakerTripped: { tripped.append($0) },
             deliver: { payload in
@@ -113,13 +126,64 @@ struct FocusSurfaceBroadcastCoalescerTests {
         }
 
         #expect(scheduler.count == 0)
+        #expect(scheduler.circuitBreakerCount == 1)
         #expect(turns == 4)
-        // The breaker preserves the latest requested focus once before dropping
-        // the re-entrant continuation that would otherwise keep rescheduling.
-        #expect(delivered.count == 9)
+        #expect(delivered.count == 8)
         #expect(delivered.last == 8843)
         #expect(boundExceeded == [8843, 8843, 8843, 8843])
         #expect(tripped == [8843])
         #expect(reentryBudget > 0)
+    }
+
+    @Test("the circuit breaker retains pending focus for a throttled continuation")
+    func circuitBreakerRetainsPendingPayloadForThrottledContinuation() {
+        let scheduler = ManualScheduler()
+        var delivered: [Int] = []
+        var boundExceeded: [Int] = []
+        var tripped: [Int] = []
+        let relay = CoalescerRelay<Int>()
+
+        let coalescer = FocusSurfaceBroadcastCoalescer<Int>(
+            maxCoalescedDeliveries: 1,
+            maxConsecutiveBoundedFlushes: 1,
+            schedule: { scheduler.append($0) },
+            scheduleAfterCircuitBreaker: { scheduler.appendCircuitBreaker($0) },
+            onDrainBoundExceeded: { boundExceeded.append($0) },
+            onCircuitBreakerTripped: { tripped.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                if payload == 1 {
+                    relay.emit(2)
+                } else if payload == 2 {
+                    relay.emit(3)
+                }
+            }
+        )
+        relay.coalescer = coalescer
+
+        coalescer.emit(1)
+        scheduler.runAll()
+
+        #expect(delivered == [1])
+        #expect(boundExceeded == [2])
+        #expect(tripped == [2])
+        #expect(scheduler.count == 0)
+        #expect(scheduler.circuitBreakerCount == 1)
+
+        scheduler.runAllCircuitBreaker()
+
+        #expect(delivered == [1, 2])
+        #expect(boundExceeded == [2, 3])
+        #expect(tripped == [2, 3])
+        #expect(scheduler.count == 0)
+        #expect(scheduler.circuitBreakerCount == 1)
+
+        scheduler.runAllCircuitBreaker()
+
+        #expect(delivered == [1, 2, 3])
+        #expect(boundExceeded == [2, 3])
+        #expect(tripped == [2, 3])
+        #expect(scheduler.count == 0)
+        #expect(scheduler.circuitBreakerCount == 0)
     }
 }

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
@@ -1,0 +1,122 @@
+import Testing
+@testable import CmuxNotifications
+
+@MainActor
+@Suite("Focus surface broadcast coalescer")
+struct FocusSurfaceBroadcastCoalescerTests {
+    @MainActor
+    private final class ManualScheduler {
+        private(set) var pending: [@MainActor @Sendable () -> Void] = []
+
+        func append(_ work: @escaping @MainActor @Sendable () -> Void) {
+            pending.append(work)
+        }
+
+        var count: Int { pending.count }
+
+        func runAll() {
+            let work = pending
+            pending.removeAll()
+            for unit in work { unit() }
+        }
+    }
+
+    /// Safe because the relay is main-actor isolated and every captured test
+    /// delivery closure is also `@MainActor`.
+    @MainActor
+    private final class CoalescerRelay<Payload: Sendable>: @unchecked Sendable {
+        var coalescer: FocusSurfaceBroadcastCoalescer<Payload>?
+
+        func emit(_ payload: Payload) {
+            coalescer?.emit(payload)
+        }
+    }
+
+    @Test("emits asynchronously and coalesces to the latest payload")
+    func emitDefersAndCoalesces() {
+        let scheduler = ManualScheduler()
+        var delivered: [Int] = []
+        let coalescer = FocusSurfaceBroadcastCoalescer<Int>(
+            schedule: { scheduler.append($0) },
+            deliver: { delivered.append($0) }
+        )
+
+        coalescer.emit(1)
+        coalescer.emit(2)
+        coalescer.emit(3)
+
+        #expect(delivered.isEmpty)
+        #expect(scheduler.count == 1)
+
+        scheduler.runAll()
+        #expect(delivered == [3])
+    }
+
+    @Test("finite re-entrant cycles drain without dropping the final payload")
+    func finiteReentrantCycleDrains() {
+        let scheduler = ManualScheduler()
+        var delivered: [Int] = []
+        let relay = CoalescerRelay<Int>()
+        var reEmitsRemaining = 2
+
+        let coalescer = FocusSurfaceBroadcastCoalescer<Int>(
+            maxCoalescedDeliveries: 8,
+            schedule: { scheduler.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                if reEmitsRemaining > 0 {
+                    reEmitsRemaining -= 1
+                    relay.emit(7)
+                }
+            }
+        )
+        relay.coalescer = coalescer
+
+        coalescer.emit(0)
+        scheduler.runAll()
+
+        #expect(delivered == [0, 7, 7])
+        #expect(scheduler.count == 0)
+    }
+
+    @Test("non-converging re-entrant cycles trip the circuit breaker")
+    func nonConvergingReentrantCycleTripsCircuitBreaker() {
+        let scheduler = ManualScheduler()
+        var delivered: [Int] = []
+        var boundExceeded: [Int] = []
+        var tripped: [Int] = []
+        let relay = CoalescerRelay<Int>()
+        var reentryBudget = 1_000
+
+        let coalescer = FocusSurfaceBroadcastCoalescer<Int>(
+            maxCoalescedDeliveries: 2,
+            maxConsecutiveBoundedFlushes: 4,
+            schedule: { scheduler.append($0) },
+            onDrainBoundExceeded: { boundExceeded.append($0) },
+            onCircuitBreakerTripped: { tripped.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                if reentryBudget > 0 {
+                    reentryBudget -= 1
+                    relay.emit(8843)
+                }
+            }
+        )
+        relay.coalescer = coalescer
+
+        coalescer.emit(0)
+
+        var turns = 0
+        while scheduler.count > 0 && turns < 12 {
+            turns += 1
+            scheduler.runAll()
+        }
+
+        #expect(scheduler.count == 0)
+        #expect(turns == 4)
+        #expect(delivered.count == 8)
+        #expect(boundExceeded == [8843, 8843, 8843, 8843])
+        #expect(tripped == [8843])
+        #expect(reentryBudget > 0)
+    }
+}

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
@@ -133,10 +133,19 @@ struct FocusSurfaceBroadcastCoalescerTests {
         #expect(boundExceeded == [8843, 8843, 8843, 8843])
         #expect(tripped == [8843])
         #expect(reentryBudget > 0)
+
+        scheduler.runAllCircuitBreaker()
+
+        #expect(scheduler.count == 0)
+        #expect(scheduler.circuitBreakerCount == 0)
+        #expect(delivered.count == 9)
+        #expect(delivered.last == 8843)
+        #expect(boundExceeded == [8843, 8843, 8843, 8843])
+        #expect(tripped == [8843])
     }
 
-    @Test("the circuit breaker retains pending focus for a throttled continuation")
-    func circuitBreakerRetainsPendingPayloadForThrottledContinuation() {
+    @Test("the circuit breaker recovery stops re-entrant rescheduling")
+    func circuitBreakerRecoveryStopsReentrantRescheduling() {
         let scheduler = ManualScheduler()
         var delivered: [Int] = []
         var boundExceeded: [Int] = []
@@ -173,16 +182,19 @@ struct FocusSurfaceBroadcastCoalescerTests {
         scheduler.runAllCircuitBreaker()
 
         #expect(delivered == [1, 2])
-        #expect(boundExceeded == [2, 3])
-        #expect(tripped == [2, 3])
+        #expect(boundExceeded == [2])
+        #expect(tripped == [2])
         #expect(scheduler.count == 0)
-        #expect(scheduler.circuitBreakerCount == 1)
+        #expect(scheduler.circuitBreakerCount == 0)
 
-        scheduler.runAllCircuitBreaker()
+        coalescer.emit(4)
+        #expect(scheduler.count == 1)
+        #expect(scheduler.circuitBreakerCount == 0)
+        scheduler.runAll()
 
-        #expect(delivered == [1, 2, 3])
-        #expect(boundExceeded == [2, 3])
-        #expect(tripped == [2, 3])
+        #expect(delivered == [1, 2, 4])
+        #expect(boundExceeded == [2])
+        #expect(tripped == [2])
         #expect(scheduler.count == 0)
         #expect(scheduler.circuitBreakerCount == 0)
     }

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
@@ -4,31 +4,24 @@ import Testing
 @MainActor
 @Suite("Focus surface broadcast coalescer")
 struct FocusSurfaceBroadcastCoalescerTests {
+    private struct TestPayload: Equatable, Sendable {
+        let transaction: Int
+        let value: Int
+    }
+
     @MainActor
     private final class ManualScheduler {
         private(set) var pending: [@MainActor @Sendable () -> Void] = []
-        private(set) var circuitBreakerPending: [@MainActor @Sendable () -> Void] = []
 
         func append(_ work: @escaping @MainActor @Sendable () -> Void) {
             pending.append(work)
         }
 
-        func appendCircuitBreaker(_ work: @escaping @MainActor @Sendable () -> Void) {
-            circuitBreakerPending.append(work)
-        }
-
         var count: Int { pending.count }
-        var circuitBreakerCount: Int { circuitBreakerPending.count }
 
         func runAll() {
             let work = pending
             pending.removeAll()
-            for unit in work { unit() }
-        }
-
-        func runAllCircuitBreaker() {
-            let work = circuitBreakerPending
-            circuitBreakerPending.removeAll()
             for unit in work { unit() }
         }
     }
@@ -94,30 +87,32 @@ struct FocusSurfaceBroadcastCoalescerTests {
     @Test("non-converging re-entrant cycles trip the circuit breaker")
     func nonConvergingReentrantCycleTripsCircuitBreaker() {
         let scheduler = ManualScheduler()
-        var delivered: [Int] = []
-        var boundExceeded: [Int] = []
-        var tripped: [Int] = []
-        let relay = CoalescerRelay<Int>()
+        var delivered: [TestPayload] = []
+        var boundExceeded: [TestPayload] = []
+        var tripped: [TestPayload] = []
+        let relay = CoalescerRelay<TestPayload>()
+        let reentryTarget = TestPayload(transaction: 1, value: 8843)
         var reentryBudget = 1_000
 
-        let coalescer = FocusSurfaceBroadcastCoalescer<Int>(
+        let coalescer = FocusSurfaceBroadcastCoalescer<TestPayload>(
             maxCoalescedDeliveries: 2,
             maxConsecutiveBoundedFlushes: 4,
+            maxCircuitBreakerRecoveryDeliveries: 2,
+            belongsToSameCircuit: { $0.transaction == $1.transaction },
             schedule: { scheduler.append($0) },
-            scheduleAfterCircuitBreaker: { scheduler.appendCircuitBreaker($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
             onCircuitBreakerTripped: { tripped.append($0) },
             deliver: { payload in
                 delivered.append(payload)
                 if reentryBudget > 0 {
                     reentryBudget -= 1
-                    relay.emit(8843)
+                    relay.emit(reentryTarget)
                 }
             }
         )
         relay.coalescer = coalescer
 
-        coalescer.emit(0)
+        coalescer.emit(TestPayload(transaction: 1, value: 0))
 
         var turns = 0
         while scheduler.count > 0 && turns < 12 {
@@ -126,76 +121,105 @@ struct FocusSurfaceBroadcastCoalescerTests {
         }
 
         #expect(scheduler.count == 0)
-        #expect(scheduler.circuitBreakerCount == 1)
-        #expect(turns == 4)
-        #expect(delivered.count == 8)
-        #expect(delivered.last == 8843)
-        #expect(boundExceeded == [8843, 8843, 8843, 8843])
-        #expect(tripped == [8843])
+        #expect(turns == 6)
+        #expect(delivered.count == 10)
+        #expect(delivered.last == reentryTarget)
+        #expect(boundExceeded == Array(repeating: reentryTarget, count: 4))
+        #expect(tripped == [reentryTarget])
         #expect(reentryBudget > 0)
-
-        scheduler.runAllCircuitBreaker()
-
-        #expect(scheduler.count == 0)
-        #expect(scheduler.circuitBreakerCount == 0)
-        #expect(delivered.count == 9)
-        #expect(delivered.last == 8843)
-        #expect(boundExceeded == [8843, 8843, 8843, 8843])
-        #expect(tripped == [8843])
     }
 
-    @Test("the circuit breaker recovery stops re-entrant rescheduling")
-    func circuitBreakerRecoveryStopsReentrantRescheduling() {
+    @Test("circuit-breaker recovery can publish a finite final payload")
+    func circuitBreakerRecoveryPublishesFiniteFinalPayload() {
         let scheduler = ManualScheduler()
-        var delivered: [Int] = []
-        var boundExceeded: [Int] = []
-        var tripped: [Int] = []
-        let relay = CoalescerRelay<Int>()
+        var delivered: [TestPayload] = []
+        var boundExceeded: [TestPayload] = []
+        var tripped: [TestPayload] = []
+        let relay = CoalescerRelay<TestPayload>()
 
-        let coalescer = FocusSurfaceBroadcastCoalescer<Int>(
+        let first = TestPayload(transaction: 1, value: 1)
+        let second = TestPayload(transaction: 1, value: 2)
+        let final = TestPayload(transaction: 1, value: 3)
+        let external = TestPayload(transaction: 2, value: 4)
+
+        let coalescer = FocusSurfaceBroadcastCoalescer<TestPayload>(
             maxCoalescedDeliveries: 1,
             maxConsecutiveBoundedFlushes: 1,
+            maxCircuitBreakerRecoveryDeliveries: 2,
+            belongsToSameCircuit: { $0.transaction == $1.transaction },
             schedule: { scheduler.append($0) },
-            scheduleAfterCircuitBreaker: { scheduler.appendCircuitBreaker($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
             onCircuitBreakerTripped: { tripped.append($0) },
             deliver: { payload in
                 delivered.append(payload)
-                if payload == 1 {
-                    relay.emit(2)
-                } else if payload == 2 {
-                    relay.emit(3)
+                if payload == first {
+                    relay.emit(second)
+                } else if payload == second {
+                    relay.emit(final)
                 }
             }
         )
         relay.coalescer = coalescer
 
-        coalescer.emit(1)
-        scheduler.runAll()
+        coalescer.emit(first)
+        while scheduler.count > 0 {
+            scheduler.runAll()
+        }
 
-        #expect(delivered == [1])
-        #expect(boundExceeded == [2])
-        #expect(tripped == [2])
+        #expect(delivered == [first, second, final])
+        #expect(boundExceeded == [second])
+        #expect(tripped == [second])
         #expect(scheduler.count == 0)
-        #expect(scheduler.circuitBreakerCount == 1)
 
-        scheduler.runAllCircuitBreaker()
-
-        #expect(delivered == [1, 2])
-        #expect(boundExceeded == [2])
-        #expect(tripped == [2])
-        #expect(scheduler.count == 0)
-        #expect(scheduler.circuitBreakerCount == 0)
-
-        coalescer.emit(4)
+        coalescer.emit(external)
         #expect(scheduler.count == 1)
-        #expect(scheduler.circuitBreakerCount == 0)
         scheduler.runAll()
 
-        #expect(delivered == [1, 2, 4])
-        #expect(boundExceeded == [2])
-        #expect(tripped == [2])
+        #expect(delivered == [first, second, final, external])
         #expect(scheduler.count == 0)
-        #expect(scheduler.circuitBreakerCount == 0)
+    }
+
+    @Test("same-circuit deferred feedback is bounded across scheduler turns")
+    func sameCircuitDeferredFeedbackTripsAcrossTurns() {
+        let scheduler = ManualScheduler()
+        var delivered: [TestPayload] = []
+        var tripped: [TestPayload] = []
+        let relay = CoalescerRelay<TestPayload>()
+        let initial = TestPayload(transaction: 1, value: 0)
+        let feedback = TestPayload(transaction: 1, value: 7)
+        var deferredFeedbackBudget = 1_000
+
+        let coalescer = FocusSurfaceBroadcastCoalescer<TestPayload>(
+            maxCoalescedDeliveries: 8,
+            maxConsecutiveBoundedFlushes: 4,
+            maxConsecutiveCircuitDeliveries: 3,
+            maxCircuitBreakerRecoveryDeliveries: 2,
+            belongsToSameCircuit: { $0.transaction == $1.transaction },
+            schedule: { scheduler.append($0) },
+            onCircuitBreakerTripped: { tripped.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                guard deferredFeedbackBudget > 0 else { return }
+                deferredFeedbackBudget -= 1
+                scheduler.append {
+                    relay.emit(feedback)
+                }
+            }
+        )
+        relay.coalescer = coalescer
+
+        coalescer.emit(initial)
+
+        var turns = 0
+        while scheduler.count > 0 && turns < 20 {
+            turns += 1
+            scheduler.runAll()
+        }
+
+        #expect(scheduler.count == 0)
+        #expect(turns == 11)
+        #expect(delivered == [initial, feedback, feedback, feedback, feedback])
+        #expect(tripped == [feedback])
+        #expect(deferredFeedbackBudget > 0)
     }
 }

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/FocusSurfaceBroadcastCoalescerTests.swift
@@ -114,7 +114,10 @@ struct FocusSurfaceBroadcastCoalescerTests {
 
         #expect(scheduler.count == 0)
         #expect(turns == 4)
-        #expect(delivered.count == 8)
+        // The breaker preserves the latest requested focus once before dropping
+        // the re-entrant continuation that would otherwise keep rescheduling.
+        #expect(delivered.count == 9)
+        #expect(delivered.last == 8843)
         #expect(boundExceeded == [8843, 8843, 8843, 8843])
         #expect(tripped == [8843])
         #expect(reentryBudget > 0)

--- a/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
+++ b/Packages/macOS/CmuxNotifications/Tests/CmuxNotificationsTests/NotificationDismissalModelTests.swift
@@ -43,7 +43,7 @@ private final class FakeHost: NotificationDismissalHosting {
 
     func panelId(forSurfaceOrPanelId surfaceId: UUID, in workspaceId: UUID) -> UUID? {
         detailedLookupCount += 1
-        panelIdsBySurface[surfaceId] ?? surfaceId
+        return panelIdsBySurface[surfaceId] ?? surfaceId
     }
 
     func storeHasDismissibleState(workspaceId: UUID) -> Bool {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2834,9 +2834,10 @@ struct ContentView: View {
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDidFocusSurface)) { notification in
             guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
                   tabId == tabManager.selectedTabId else { return }
+            let focusTransactionId = notification.userInfo?[GhosttyNotificationKey.focusTransactionId] as? UUID
             refreshTmuxWorkspacePaneWindowOverlay(in: observedWindow)
             completeWorkspaceHandoffIfNeeded(focusedTabId: tabId, reason: "focus")
-            attemptCommandPaletteFocusRestoreIfNeeded()
+            attemptCommandPaletteFocusRestoreIfNeeded(focusTransactionId: focusTransactionId)
             scheduleTitlebarTextRefresh()
         })
 
@@ -9501,7 +9502,7 @@ struct ContentView: View {
         attemptCommandPaletteFocusRestoreIfNeeded()
     }
 
-    private func attemptCommandPaletteFocusRestoreIfNeeded() {
+    private func attemptCommandPaletteFocusRestoreIfNeeded(focusTransactionId: UUID? = nil) {
         guard !isCommandPalettePresented else { return }
         guard let target = commandPaletteFocusRestoreCoordinator.pendingTarget else { return }
         guard let targetWorkspace = tabManager.tabs.first(where: { $0.id == target.workspaceId }) else {
@@ -9523,7 +9524,8 @@ struct ContentView: View {
             target.workspaceId,
             surfaceId: target.panelId,
             suppressFlash: true,
-            dismissRestoredUnreadOnResume: true
+            dismissRestoredUnreadOnResume: true,
+            focusTransactionId: focusTransactionId ?? UUID()
         )
 
         guard let context = focusedPanelContext,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2866,8 +2866,10 @@ struct ContentView: View {
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .ghosttyDidBecomeFirstResponderSurface)) { notification in
             guard let tabId = notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
                   tabId == tabManager.selectedTabId else { return }
+            let focusTransactionId = notification.userInfo?[GhosttyNotificationKey.focusTransactionId] as? UUID
+                ?? tabManager.selectedWorkspace?.activeFocusTransactionId
             completeWorkspaceHandoffIfNeeded(focusedTabId: tabId, reason: "first_responder")
-            attemptCommandPaletteFocusRestoreIfNeeded()
+            attemptCommandPaletteFocusRestoreIfNeeded(focusTransactionId: focusTransactionId)
         })
 
         view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: .browserDidBecomeFirstResponderWebView)) { notification in

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -1,4 +1,11 @@
 import Foundation
+import OSLog
+import CmuxNotifications
+
+nonisolated private let focusSurfaceBroadcasterLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "FocusSurfaceBroadcaster"
+)
 
 /// Coalesces and defers `.ghosttyDidFocusSurface` focus broadcasts so that emitting
 /// one mid-mutation can never synchronously re-enter the focus/selection path.
@@ -14,7 +21,8 @@ import Foundation
 /// (`Workspace.isApplyingTabSelection`) is *per-instance*, a cycle that bounces
 /// through SwiftUI body re-evaluation and across different `Workspace` instances
 /// (command-palette focus restore + cross-workspace handoff) was unbounded. That is
-/// the 426s main-thread hang in https://github.com/manaflow-ai/cmux/issues/5100.
+/// the re-entrant SwiftUI/AppKit layout loop reported in
+/// https://github.com/manaflow-ai/cmux/issues/8843.
 ///
 /// ## Contract
 ///
@@ -72,21 +80,11 @@ final class FocusSurfaceBroadcaster {
 #if DEBUG
             cmuxDebugLog(message)
 #endif
-            NSLog("%@", message)
+            focusSurfaceBroadcasterLogger.error("\(message, privacy: .public)")
         }
     )
 
-    private let deliver: @MainActor (FocusSurfacePayload) -> Void
-    private let schedule: @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void
-    private let maxCoalescedDeliveries: Int
-    private let maxConsecutiveBoundedFlushes: Int
-    private let onDrainBoundExceeded: @MainActor (FocusSurfacePayload) -> Void
-    private let onCircuitBreakerTripped: @MainActor (FocusSurfacePayload) -> Void
-
-    private var pending: FocusSurfacePayload?
-    private var flushScheduled = false
-    private var isDelivering = false
-    private var consecutiveBoundedFlushes = 0
+    private let coalescer: FocusSurfaceBroadcastCoalescer<FocusSurfacePayload>
 
     /// Creates a broadcaster.
     ///
@@ -109,14 +107,14 @@ final class FocusSurfaceBroadcaster {
     init(
         maxCoalescedDeliveries: Int = 8,
         maxConsecutiveBoundedFlushes: Int = 4,
-        schedule: @escaping @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void = { work in
+        schedule: @escaping @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void = { work in
             DispatchQueue.main.async {
                 MainActor.assumeIsolated { work() }
             }
         },
-        onDrainBoundExceeded: @escaping @MainActor (FocusSurfacePayload) -> Void = { _ in },
-        onCircuitBreakerTripped: @escaping @MainActor (FocusSurfacePayload) -> Void = { _ in },
-        deliver: @escaping @MainActor (FocusSurfacePayload) -> Void = { payload in
+        onDrainBoundExceeded: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { _ in },
+        onCircuitBreakerTripped: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { _ in },
+        deliver: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { payload in
             NotificationCenter.default.post(
                 name: .ghosttyDidFocusSurface,
                 object: nil,
@@ -128,12 +126,14 @@ final class FocusSurfaceBroadcaster {
             )
         }
     ) {
-        self.maxCoalescedDeliveries = max(1, maxCoalescedDeliveries)
-        self.maxConsecutiveBoundedFlushes = max(1, maxConsecutiveBoundedFlushes)
-        self.schedule = schedule
-        self.onDrainBoundExceeded = onDrainBoundExceeded
-        self.onCircuitBreakerTripped = onCircuitBreakerTripped
-        self.deliver = deliver
+        self.coalescer = FocusSurfaceBroadcastCoalescer(
+            maxCoalescedDeliveries: maxCoalescedDeliveries,
+            maxConsecutiveBoundedFlushes: maxConsecutiveBoundedFlushes,
+            schedule: schedule,
+            onDrainBoundExceeded: onDrainBoundExceeded,
+            onCircuitBreakerTripped: onCircuitBreakerTripped,
+            deliver: deliver
+        )
     }
 
     /// Records a focus broadcast for asynchronous, coalesced delivery.
@@ -143,15 +143,7 @@ final class FocusSurfaceBroadcaster {
     /// progress (an observer re-entered during a flush), the payload is recorded for
     /// the active drain loop instead of scheduling another flush.
     func emit(_ payload: FocusSurfacePayload) {
-        pending = payload
-        // A re-entrant emit during delivery hands the payload to the running drain
-        // loop; scheduling another flush here would re-introduce the storm.
-        if isDelivering { return }
-        if flushScheduled { return }
-        flushScheduled = true
-        schedule { @Sendable [weak self] in
-            self?.flush()
-        }
+        coalescer.emit(payload)
     }
 
     /// Delivers the pending broadcast(s) on the main queue.
@@ -160,50 +152,6 @@ final class FocusSurfaceBroadcaster {
     /// spin forever. Exposed (non-private) so tests can run the scheduled flush
     /// deterministically.
     func flush() {
-        flushScheduled = false
-        // Defensive: never run nested deliveries even if a flush is somehow scheduled
-        // while one is already draining.
-        guard !isDelivering else { return }
-        isDelivering = true
-
-        var iterations = 0
-        var hitDeliveryBound = false
-        while let next = pending {
-            pending = nil
-            iterations += 1
-            if iterations > maxCoalescedDeliveries {
-                // Re-entrancy did not converge within this turn. Keep the latest
-                // payload for now and let the post-loop reschedule continue it on
-                // a fresh runloop turn. If this keeps happening across turns, the
-                // circuit breaker below drops the payload rather than letting a
-                // SwiftUI/AppKit layout storm run indefinitely.
-                pending = next
-                hitDeliveryBound = true
-                consecutiveBoundedFlushes += 1
-                onDrainBoundExceeded(next)
-                if consecutiveBoundedFlushes >= maxConsecutiveBoundedFlushes {
-                    pending = nil
-                    consecutiveBoundedFlushes = 0
-                    onCircuitBreakerTripped(next)
-                }
-                break
-            }
-            deliver(next)
-        }
-
-        isDelivering = false
-        if !hitDeliveryBound {
-            consecutiveBoundedFlushes = 0
-        }
-        // A delivery (or `onDrainBoundExceeded`) may have left a payload pending —
-        // either because the per-turn bound tripped, or because a re-entrant emit
-        // raced the `isDelivering` window and returned without scheduling. Schedule
-        // one more flush for finite cycles; non-converging cycles are cleared above.
-        if pending != nil, !flushScheduled {
-            flushScheduled = true
-            schedule { @Sendable [weak self] in
-                self?.flush()
-            }
-        }
+        coalescer.flush()
     }
 }

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -35,8 +35,9 @@ nonisolated private let focusSurfaceBroadcasterLogger = Logger(
 ///   loop (at most ``maxCoalescedDeliveries`` deliveries per turn). If the cycle has
 ///   not settled within that bound, the still-pending payload is carried to a fresh
 ///   scheduled flush. Consecutive bounded turns are capped by
-///   ``maxConsecutiveBoundedFlushes`` so a non-converging observer cycle cannot keep
-///   a SwiftUI/AppKit layout storm alive indefinitely.
+///   ``maxConsecutiveBoundedFlushes``; after that the pending payload is retained
+///   but moved to a delayed continuation so a non-converging observer cycle cannot
+///   monopolize SwiftUI/AppKit layout work.
 ///
 /// The type is fully testable without AppKit: inject ``deliver`` to capture
 /// broadcasts, and inject ``schedule`` to drive flushes deterministically.
@@ -63,9 +64,15 @@ final class FocusSurfaceBroadcaster {
     ///
     /// Posts the real `.ghosttyDidFocusSurface` notification and logs (DEBUG builds)
     /// whenever the bounded drain trips, and logs when the cross-turn circuit
-    /// breaker trips after reconciling the latest pending payload once, so a future
-    /// re-entrancy regression is observable instead of a silent hours-long hang.
+    /// breaker trips and moves the pending payload onto a delayed continuation, so
+    /// a future re-entrancy regression is observable instead of a silent hours-long
+    /// hang.
     static let shared = FocusSurfaceBroadcaster(
+        scheduleAfterCircuitBreaker: { work in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                MainActor.assumeIsolated { work() }
+            }
+        },
         onDrainBoundExceeded: { payload in
 #if DEBUG
             cmuxDebugLog(
@@ -97,11 +104,14 @@ final class FocusSurfaceBroadcaster {
     ///     circuit breaker for a non-converging focus observer loop.
     ///   - schedule: Schedules deferred flush work on the main queue. Defaults to
     ///     `DispatchQueue.main.async`. Injected by tests to flush deterministically.
+    ///   - scheduleAfterCircuitBreaker: Schedules continuation work after the
+    ///     cross-turn circuit breaker trips. The shared runtime broadcaster uses a
+    ///     delayed continuation to stop tight loops from monopolizing the main actor.
     ///   - onDrainBoundExceeded: Invoked with the still-pending payload when a flush
     ///     hits ``maxCoalescedDeliveries`` and defers the remainder to a follow-up
     ///     flush. Used for structured logging of a non-converging focus cycle.
-    ///   - onCircuitBreakerTripped: Invoked with the final reconciled payload when
-    ///     the cross-turn circuit breaker stops a non-converging cycle.
+    ///   - onCircuitBreakerTripped: Invoked with the retained pending payload when
+    ///     the cross-turn circuit breaker rate-limits a non-converging cycle.
     ///   - deliver: Performs the actual broadcast. Defaults to posting
     ///     `.ghosttyDidFocusSurface`. Injected by tests to capture deliveries.
     init(
@@ -112,6 +122,7 @@ final class FocusSurfaceBroadcaster {
                 MainActor.assumeIsolated { work() }
             }
         },
+        scheduleAfterCircuitBreaker: (@MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void)? = nil,
         onDrainBoundExceeded: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { _ in },
         onCircuitBreakerTripped: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { _ in },
         deliver: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { payload in
@@ -130,6 +141,7 @@ final class FocusSurfaceBroadcaster {
             maxCoalescedDeliveries: maxCoalescedDeliveries,
             maxConsecutiveBoundedFlushes: maxConsecutiveBoundedFlushes,
             schedule: schedule,
+            scheduleAfterCircuitBreaker: scheduleAfterCircuitBreaker,
             onDrainBoundExceeded: onDrainBoundExceeded,
             onCircuitBreakerTripped: onCircuitBreakerTripped,
             deliver: deliver

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -26,9 +26,9 @@ import Foundation
 ///   pending payload instead of recursing; the active flush drains it in a bounded
 ///   loop (at most ``maxCoalescedDeliveries`` deliveries per turn). If the cycle has
 ///   not settled within that bound, the still-pending payload is carried to a fresh
-///   scheduled flush rather than delivered synchronously or dropped — so work stays
-///   bounded per runloop turn (the app keeps responding) while the final selection is
-///   never lost. A notification-driven focus cycle can therefore no longer hang.
+///   scheduled flush. Consecutive bounded turns are capped by
+///   ``maxConsecutiveBoundedFlushes`` so a non-converging observer cycle cannot keep
+///   a SwiftUI/AppKit layout storm alive indefinitely.
 ///
 /// The type is fully testable without AppKit: inject ``deliver`` to capture
 /// broadcasts, and inject ``schedule`` to drive flushes deterministically.
@@ -54,8 +54,9 @@ final class FocusSurfaceBroadcaster {
     /// The app-wide broadcaster used by ``Workspace`` to emit focus broadcasts.
     ///
     /// Posts the real `.ghosttyDidFocusSurface` notification and logs (DEBUG builds)
-    /// whenever the bounded drain trips, so a future re-entrancy regression is
-    /// observable instead of a silent hang.
+    /// whenever the bounded drain trips, and logs/drops the pending payload when the
+    /// cross-turn circuit breaker trips, so a future re-entrancy regression is
+    /// observable instead of a silent hours-long hang.
     static let shared = FocusSurfaceBroadcaster(
         onDrainBoundExceeded: { payload in
 #if DEBUG
@@ -64,17 +65,28 @@ final class FocusSurfaceBroadcaster {
                 "panel=\(payload.panelId.uuidString.prefix(5)) explicit=\(payload.explicitFocusIntent ? 1 : 0)"
             )
 #endif
+        },
+        onCircuitBreakerTripped: { payload in
+            let message = "focus.broadcast.circuitBreaker.tripped workspace=\(payload.workspaceId.uuidString.prefix(5)) " +
+                "panel=\(payload.panelId.uuidString.prefix(5)) explicit=\(payload.explicitFocusIntent ? 1 : 0)"
+#if DEBUG
+            cmuxDebugLog(message)
+#endif
+            NSLog("%@", message)
         }
     )
 
     private let deliver: @MainActor (FocusSurfacePayload) -> Void
     private let schedule: @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void
     private let maxCoalescedDeliveries: Int
+    private let maxConsecutiveBoundedFlushes: Int
     private let onDrainBoundExceeded: @MainActor (FocusSurfacePayload) -> Void
+    private let onCircuitBreakerTripped: @MainActor (FocusSurfacePayload) -> Void
 
     private var pending: FocusSurfacePayload?
     private var flushScheduled = false
     private var isDelivering = false
+    private var consecutiveBoundedFlushes = 0
 
     /// Creates a broadcaster.
     ///
@@ -82,21 +94,28 @@ final class FocusSurfaceBroadcaster {
     ///   - maxCoalescedDeliveries: Upper bound on deliveries performed by a single
     ///     flush. Caps a re-entrant focus cycle so it can never hang. Defaults to 8,
     ///     matching `Workspace.applyTabSelection`'s existing per-instance drain bound.
+    ///   - maxConsecutiveBoundedFlushes: Upper bound on consecutive scheduled flushes
+    ///     that are allowed to hit ``maxCoalescedDeliveries``. This is the runtime
+    ///     circuit breaker for a non-converging focus observer loop.
     ///   - schedule: Schedules deferred flush work on the main queue. Defaults to
     ///     `DispatchQueue.main.async`. Injected by tests to flush deterministically.
     ///   - onDrainBoundExceeded: Invoked with the still-pending payload when a flush
     ///     hits ``maxCoalescedDeliveries`` and defers the remainder to a follow-up
     ///     flush. Used for structured logging of a non-converging focus cycle.
+    ///   - onCircuitBreakerTripped: Invoked with the last pending payload when the
+    ///     cross-turn circuit breaker drops it to stop a non-converging cycle.
     ///   - deliver: Performs the actual broadcast. Defaults to posting
     ///     `.ghosttyDidFocusSurface`. Injected by tests to capture deliveries.
     init(
         maxCoalescedDeliveries: Int = 8,
+        maxConsecutiveBoundedFlushes: Int = 4,
         schedule: @escaping @MainActor (@escaping @MainActor @Sendable () -> Void) -> Void = { work in
             DispatchQueue.main.async {
                 MainActor.assumeIsolated { work() }
             }
         },
         onDrainBoundExceeded: @escaping @MainActor (FocusSurfacePayload) -> Void = { _ in },
+        onCircuitBreakerTripped: @escaping @MainActor (FocusSurfacePayload) -> Void = { _ in },
         deliver: @escaping @MainActor (FocusSurfacePayload) -> Void = { payload in
             NotificationCenter.default.post(
                 name: .ghosttyDidFocusSurface,
@@ -110,8 +129,10 @@ final class FocusSurfaceBroadcaster {
         }
     ) {
         self.maxCoalescedDeliveries = max(1, maxCoalescedDeliveries)
+        self.maxConsecutiveBoundedFlushes = max(1, maxConsecutiveBoundedFlushes)
         self.schedule = schedule
         self.onDrainBoundExceeded = onDrainBoundExceeded
+        self.onCircuitBreakerTripped = onCircuitBreakerTripped
         self.deliver = deliver
     }
 
@@ -146,28 +167,38 @@ final class FocusSurfaceBroadcaster {
         isDelivering = true
 
         var iterations = 0
+        var hitDeliveryBound = false
         while let next = pending {
             pending = nil
             iterations += 1
             if iterations > maxCoalescedDeliveries {
-                // Re-entrancy did not converge within this turn. Don't hang
-                // (delivering synchronously forever) and don't drop the focus
-                // update: keep the latest payload and let the post-loop reschedule
-                // continue it on a fresh runloop turn. Work stays bounded *per turn*
-                // (so the app keeps responding) while still settling on the final
-                // selection.
+                // Re-entrancy did not converge within this turn. Keep the latest
+                // payload for now and let the post-loop reschedule continue it on
+                // a fresh runloop turn. If this keeps happening across turns, the
+                // circuit breaker below drops the payload rather than letting a
+                // SwiftUI/AppKit layout storm run indefinitely.
                 pending = next
+                hitDeliveryBound = true
+                consecutiveBoundedFlushes += 1
                 onDrainBoundExceeded(next)
+                if consecutiveBoundedFlushes >= maxConsecutiveBoundedFlushes {
+                    pending = nil
+                    consecutiveBoundedFlushes = 0
+                    onCircuitBreakerTripped(next)
+                }
                 break
             }
             deliver(next)
         }
 
         isDelivering = false
+        if !hitDeliveryBound {
+            consecutiveBoundedFlushes = 0
+        }
         // A delivery (or `onDrainBoundExceeded`) may have left a payload pending —
         // either because the per-turn bound tripped, or because a re-entrant emit
         // raced the `isDelivering` window and returned without scheduling. Schedule
-        // one more flush so the final focus selection is never stranded.
+        // one more flush for finite cycles; non-converging cycles are cleared above.
         if pending != nil, !flushScheduled {
             flushScheduled = true
             schedule { @Sendable [weak self] in

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -35,9 +35,10 @@ nonisolated private let focusSurfaceBroadcasterLogger = Logger(
 ///   loop (at most ``maxCoalescedDeliveries`` deliveries per turn). If the cycle has
 ///   not settled within that bound, the still-pending payload is carried to a fresh
 ///   scheduled flush. Consecutive bounded turns are capped by
-///   ``maxConsecutiveBoundedFlushes``; after that the pending payload is retained
-///   but moved to a delayed continuation so a non-converging observer cycle cannot
-///   monopolize SwiftUI/AppKit layout work.
+///   ``maxConsecutiveBoundedFlushes``; after that the pending payload gets one
+///   delayed recovery delivery and the breaker stays open until a new external
+///   focus emit arrives, so a non-converging observer cycle cannot monopolize
+///   SwiftUI/AppKit layout work.
 ///
 /// The type is fully testable without AppKit: inject ``deliver`` to capture
 /// broadcasts, and inject ``schedule`` to drive flushes deterministically.
@@ -64,8 +65,8 @@ final class FocusSurfaceBroadcaster {
     ///
     /// Posts the real `.ghosttyDidFocusSurface` notification and logs (DEBUG builds)
     /// whenever the bounded drain trips, and logs when the cross-turn circuit
-    /// breaker trips and moves the pending payload onto a delayed continuation, so
-    /// a future re-entrancy regression is observable instead of a silent hours-long
+    /// breaker trips and moves the pending payload onto a delayed recovery, so a
+    /// future re-entrancy regression is observable instead of a silent hours-long
     /// hang.
     static let shared = FocusSurfaceBroadcaster(
         scheduleAfterCircuitBreaker: { work in
@@ -106,7 +107,7 @@ final class FocusSurfaceBroadcaster {
     ///     `DispatchQueue.main.async`. Injected by tests to flush deterministically.
     ///   - scheduleAfterCircuitBreaker: Schedules continuation work after the
     ///     cross-turn circuit breaker trips. The shared runtime broadcaster uses a
-    ///     delayed continuation to stop tight loops from monopolizing the main actor.
+    ///     delayed recovery to stop tight loops from monopolizing the main actor.
     ///   - onDrainBoundExceeded: Invoked with the still-pending payload when a flush
     ///     hits ``maxCoalescedDeliveries`` and defers the remainder to a follow-up
     ///     flush. Used for structured logging of a non-converging focus cycle.

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -62,9 +62,9 @@ final class FocusSurfaceBroadcaster {
     /// The app-wide broadcaster used by ``Workspace`` to emit focus broadcasts.
     ///
     /// Posts the real `.ghosttyDidFocusSurface` notification and logs (DEBUG builds)
-    /// whenever the bounded drain trips, and logs/drops the pending payload when the
-    /// cross-turn circuit breaker trips, so a future re-entrancy regression is
-    /// observable instead of a silent hours-long hang.
+    /// whenever the bounded drain trips, and logs when the cross-turn circuit
+    /// breaker trips after reconciling the latest pending payload once, so a future
+    /// re-entrancy regression is observable instead of a silent hours-long hang.
     static let shared = FocusSurfaceBroadcaster(
         onDrainBoundExceeded: { payload in
 #if DEBUG
@@ -100,8 +100,8 @@ final class FocusSurfaceBroadcaster {
     ///   - onDrainBoundExceeded: Invoked with the still-pending payload when a flush
     ///     hits ``maxCoalescedDeliveries`` and defers the remainder to a follow-up
     ///     flush. Used for structured logging of a non-converging focus cycle.
-    ///   - onCircuitBreakerTripped: Invoked with the last pending payload when the
-    ///     cross-turn circuit breaker drops it to stop a non-converging cycle.
+    ///   - onCircuitBreakerTripped: Invoked with the final reconciled payload when
+    ///     the cross-turn circuit breaker stops a non-converging cycle.
     ///   - deliver: Performs the actual broadcast. Defaults to posting
     ///     `.ghosttyDidFocusSurface`. Injected by tests to capture deliveries.
     init(

--- a/Sources/FocusSurfaceBroadcaster.swift
+++ b/Sources/FocusSurfaceBroadcaster.swift
@@ -52,12 +52,20 @@ final class FocusSurfaceBroadcaster {
         let panelId: UUID
         /// Whether the focus change reflects explicit user intent.
         let explicitFocusIntent: Bool
+        /// Stable identity for one logical focus transaction and its feedback.
+        let transactionId: UUID
 
         /// Creates a payload describing a focused surface.
-        init(workspaceId: UUID, panelId: UUID, explicitFocusIntent: Bool) {
+        init(
+            workspaceId: UUID,
+            panelId: UUID,
+            explicitFocusIntent: Bool,
+            transactionId: UUID = UUID()
+        ) {
             self.workspaceId = workspaceId
             self.panelId = panelId
             self.explicitFocusIntent = explicitFocusIntent
+            self.transactionId = transactionId
         }
     }
 
@@ -65,26 +73,23 @@ final class FocusSurfaceBroadcaster {
     ///
     /// Posts the real `.ghosttyDidFocusSurface` notification and logs (DEBUG builds)
     /// whenever the bounded drain trips, and logs when the cross-turn circuit
-    /// breaker trips and moves the pending payload onto a delayed recovery, so a
+    /// breaker trips and moves the pending payload onto bounded recovery, so a
     /// future re-entrancy regression is observable instead of a silent hours-long
     /// hang.
     static let shared = FocusSurfaceBroadcaster(
-        scheduleAfterCircuitBreaker: { work in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                MainActor.assumeIsolated { work() }
-            }
-        },
         onDrainBoundExceeded: { payload in
 #if DEBUG
             cmuxDebugLog(
                 "focus.broadcast.drain.exceeded workspace=\(payload.workspaceId.uuidString.prefix(5)) " +
-                "panel=\(payload.panelId.uuidString.prefix(5)) explicit=\(payload.explicitFocusIntent ? 1 : 0)"
+                "panel=\(payload.panelId.uuidString.prefix(5)) tx=\(payload.transactionId.uuidString.prefix(5)) " +
+                "explicit=\(payload.explicitFocusIntent ? 1 : 0)"
             )
 #endif
         },
         onCircuitBreakerTripped: { payload in
             let message = "focus.broadcast.circuitBreaker.tripped workspace=\(payload.workspaceId.uuidString.prefix(5)) " +
-                "panel=\(payload.panelId.uuidString.prefix(5)) explicit=\(payload.explicitFocusIntent ? 1 : 0)"
+                "panel=\(payload.panelId.uuidString.prefix(5)) tx=\(payload.transactionId.uuidString.prefix(5)) " +
+                "explicit=\(payload.explicitFocusIntent ? 1 : 0)"
 #if DEBUG
             cmuxDebugLog(message)
 #endif
@@ -103,11 +108,12 @@ final class FocusSurfaceBroadcaster {
     ///   - maxConsecutiveBoundedFlushes: Upper bound on consecutive scheduled flushes
     ///     that are allowed to hit ``maxCoalescedDeliveries``. This is the runtime
     ///     circuit breaker for a non-converging focus observer loop.
+    ///   - maxConsecutiveCircuitDeliveries: Upper bound on deliveries for the same
+    ///     focus transaction, including feedback deferred to later main-queue turns.
+    ///   - maxCircuitBreakerRecoveryDeliveries: Upper bound on retained same-transaction
+    ///     payloads delivered after the breaker trips.
     ///   - schedule: Schedules deferred flush work on the main queue. Defaults to
     ///     `DispatchQueue.main.async`. Injected by tests to flush deterministically.
-    ///   - scheduleAfterCircuitBreaker: Schedules continuation work after the
-    ///     cross-turn circuit breaker trips. The shared runtime broadcaster uses a
-    ///     delayed recovery to stop tight loops from monopolizing the main actor.
     ///   - onDrainBoundExceeded: Invoked with the still-pending payload when a flush
     ///     hits ``maxCoalescedDeliveries`` and defers the remainder to a follow-up
     ///     flush. Used for structured logging of a non-converging focus cycle.
@@ -118,12 +124,13 @@ final class FocusSurfaceBroadcaster {
     init(
         maxCoalescedDeliveries: Int = 8,
         maxConsecutiveBoundedFlushes: Int = 4,
+        maxConsecutiveCircuitDeliveries: Int? = nil,
+        maxCircuitBreakerRecoveryDeliveries: Int? = nil,
         schedule: @escaping @MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void = { work in
             DispatchQueue.main.async {
                 MainActor.assumeIsolated { work() }
             }
         },
-        scheduleAfterCircuitBreaker: (@MainActor @Sendable (@escaping @MainActor @Sendable () -> Void) -> Void)? = nil,
         onDrainBoundExceeded: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { _ in },
         onCircuitBreakerTripped: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { _ in },
         deliver: @escaping @MainActor @Sendable (FocusSurfacePayload) -> Void = { payload in
@@ -134,6 +141,7 @@ final class FocusSurfaceBroadcaster {
                     GhosttyNotificationKey.tabId: payload.workspaceId,
                     GhosttyNotificationKey.surfaceId: payload.panelId,
                     GhosttyNotificationKey.explicitFocusIntent: payload.explicitFocusIntent,
+                    GhosttyNotificationKey.focusTransactionId: payload.transactionId,
                 ]
             )
         }
@@ -141,8 +149,10 @@ final class FocusSurfaceBroadcaster {
         self.coalescer = FocusSurfaceBroadcastCoalescer(
             maxCoalescedDeliveries: maxCoalescedDeliveries,
             maxConsecutiveBoundedFlushes: maxConsecutiveBoundedFlushes,
+            maxConsecutiveCircuitDeliveries: maxConsecutiveCircuitDeliveries,
+            maxCircuitBreakerRecoveryDeliveries: maxCircuitBreakerRecoveryDeliveries,
+            belongsToSameCircuit: { $0.transactionId == $1.transactionId },
             schedule: schedule,
-            scheduleAfterCircuitBreaker: scheduleAfterCircuitBreaker,
             onDrainBoundExceeded: onDrainBoundExceeded,
             onCircuitBreakerTripped: onCircuitBreakerTripped,
             deliver: deliver

--- a/Sources/GhosttyTerminalAppearance.swift
+++ b/Sources/GhosttyTerminalAppearance.swift
@@ -91,6 +91,7 @@ enum GhosttyNotificationKey {
     static let tabId = "ghostty.tabId"
     static let surfaceId = "ghostty.surfaceId"
     static let explicitFocusIntent = "ghostty.explicitFocusIntent"
+    static let focusTransactionId = "ghostty.focusTransactionId"
     static let title = "ghostty.title"
     static let sourceSurfaceIdentifier = "ghostty.sourceSurfaceIdentifier"
     static let backgroundColor = "ghostty.backgroundColor"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3285,6 +3285,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     var suppressingReparentFocus: Bool = false
     var tabId: UUID?
     var selectionTranslationHostView: NSView?
+    var firstResponderFocusTransactionId: UUID?
     var onFocus: (() -> Void)?
     var onTriggerFlash: (() -> Void)?
     var backgroundColor: NSColor?
@@ -5161,13 +5162,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             }
 #endif
             if let terminalSurface {
+                var userInfo: [AnyHashable: Any] = [
+                    GhosttyNotificationKey.tabId: terminalSurface.tabId,
+                    GhosttyNotificationKey.surfaceId: terminalSurface.id,
+                ]
+                if let firstResponderFocusTransactionId {
+                    userInfo[GhosttyNotificationKey.focusTransactionId] = firstResponderFocusTransactionId
+                }
                 NotificationCenter.default.post(
                     name: .ghosttyDidBecomeFirstResponderSurface,
                     object: nil,
-                    userInfo: [
-                        GhosttyNotificationKey.tabId: terminalSurface.tabId,
-                        GhosttyNotificationKey.surfaceId: terminalSurface.id,
-                    ]
+                    userInfo: userInfo
                 )
             }
             terminalSurface?.recordExternalFocusState(true)
@@ -8010,6 +8015,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var sessionContentWidthPresentation = SessionContentWidthPresentation.disabled
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
+    private var pendingAutomaticFirstResponderFocusTransactionId: UUID?
     private var pendingSuppressedFirstResponderFocusReapply = false
     // Hidden/tiny focus retry is bounded by layout/visibility signals, not a timer loop.
 
@@ -9856,7 +9862,8 @@ final class GhosttySurfaceScrollView: NSView {
     func moveFocus(
         from previous: GhosttySurfaceScrollView? = nil,
         delay: TimeInterval? = nil,
-        respectForeignFirstResponder: Bool = false
+        respectForeignFirstResponder: Bool = false,
+        focusTransactionId: UUID? = nil
     ) {
 #if DEBUG
         let surfaceShort = String(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil")
@@ -9894,6 +9901,11 @@ final class GhosttySurfaceScrollView: NSView {
             guard self.canRequestSurfaceFirstResponder(in: window, reason: "moveFocus") else { return }
             if let previous, previous !== self {
                 _ = previous.surfaceView.resignFirstResponder()
+            }
+            let previousFocusTransactionId = self.surfaceView.firstResponderFocusTransactionId
+            self.surfaceView.firstResponderFocusTransactionId = focusTransactionId
+            defer {
+                self.surfaceView.firstResponderFocusTransactionId = previousFocusTransactionId
             }
             let result = window.makeFirstResponder(self.surfaceView)
 #if DEBUG
@@ -10062,7 +10074,8 @@ final class GhosttySurfaceScrollView: NSView {
     func ensureFocus(
         for tabId: UUID,
         surfaceId: UUID,
-        respectForeignFirstResponder: Bool = true
+        respectForeignFirstResponder: Bool = true,
+        focusTransactionId: UUID? = nil
     ) {
         let hasUsablePortalGeometry: Bool = {
             let size = bounds.size
@@ -10079,7 +10092,10 @@ final class GhosttySurfaceScrollView: NSView {
                 "reason=not_visible"
             )
 #endif
-            scheduleAutomaticFirstResponderApply(reason: "ensureFocus.notVisible")
+            scheduleAutomaticFirstResponderApply(
+                reason: "ensureFocus.notVisible",
+                focusTransactionId: focusTransactionId
+            )
             return
         }
         guard !isHiddenForFocus, hasUsablePortalGeometry else {
@@ -10090,7 +10106,10 @@ final class GhosttySurfaceScrollView: NSView {
                 "frame=\(String(format: "%.1fx%.1f", bounds.width, bounds.height))"
             )
 #endif
-            scheduleAutomaticFirstResponderApply(reason: "ensureFocus.hiddenOrTiny")
+            scheduleAutomaticFirstResponderApply(
+                reason: "ensureFocus.hiddenOrTiny",
+                focusTransactionId: focusTransactionId
+            )
             return
         }
 
@@ -10133,7 +10152,10 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
                 return
             }
-            let result = window.makeFirstResponder(surfaceView)
+            let result = makeSurfaceViewFirstResponder(
+                in: window,
+                focusTransactionId: focusTransactionId
+            )
 #if DEBUG
             cmuxDebugLog(
                 "focus.ensure.dock.apply surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") " +
@@ -10149,7 +10171,10 @@ final class GhosttySurfaceScrollView: NSView {
         guard let delegate = AppDelegate.shared,
               let tabManager = delegate.tabManagerFor(tabId: tabId) ?? delegate.tabManager,
               tabManager.selectedTabId == tabId else {
-            scheduleAutomaticFirstResponderApply(reason: "ensureFocus.inactiveTab")
+            scheduleAutomaticFirstResponderApply(
+                reason: "ensureFocus.inactiveTab",
+                focusTransactionId: focusTransactionId
+            )
             return
         }
 
@@ -10158,13 +10183,19 @@ final class GhosttySurfaceScrollView: NSView {
               let paneId = tab.bonsplitController.allPaneIds.first(where: { paneId in
                   tab.bonsplitController.tabs(inPane: paneId).contains(where: { $0.id == tabIdForSurface })
               }) else {
-            scheduleAutomaticFirstResponderApply(reason: "ensureFocus.missingPane")
+            scheduleAutomaticFirstResponderApply(
+                reason: "ensureFocus.missingPane",
+                focusTransactionId: focusTransactionId
+            )
             return
         }
 
         guard tab.bonsplitController.selectedTab(inPane: paneId)?.id == tabIdForSurface,
               tab.bonsplitController.focusedPaneId == paneId else {
-            scheduleAutomaticFirstResponderApply(reason: "ensureFocus.unfocusedPane")
+            scheduleAutomaticFirstResponderApply(
+                reason: "ensureFocus.unfocusedPane",
+                focusTransactionId: focusTransactionId
+            )
             return
         }
 
@@ -10222,7 +10253,10 @@ final class GhosttySurfaceScrollView: NSView {
             }
             window.makeKeyAndOrderFront(nil)
         }
-        let result = window.makeFirstResponder(surfaceView)
+        let result = makeSurfaceViewFirstResponder(
+            in: window,
+            focusTransactionId: focusTransactionId
+        )
 #if DEBUG
         cmuxDebugLog(
             "focus.ensure.apply surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") " +
@@ -10232,10 +10266,25 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
 
         if !isSurfaceViewFirstResponder() {
-            scheduleAutomaticFirstResponderApply(reason: "ensureFocus.afterMakeFirstResponder")
+            scheduleAutomaticFirstResponderApply(
+                reason: "ensureFocus.afterMakeFirstResponder",
+                focusTransactionId: focusTransactionId
+            )
         } else {
             reassertTerminalSurfaceFocus(reason: "ensureFocus.afterMakeFirstResponder")
         }
+    }
+
+    private func makeSurfaceViewFirstResponder(
+        in window: NSWindow,
+        focusTransactionId: UUID?
+    ) -> Bool {
+        let previousFocusTransactionId = surfaceView.firstResponderFocusTransactionId
+        surfaceView.firstResponderFocusTransactionId = focusTransactionId
+        defer {
+            surfaceView.firstResponderFocusTransactionId = previousFocusTransactionId
+        }
+        return window.makeFirstResponder(surfaceView)
     }
 
     func yieldTerminalSurfaceFocusForForeignResponder(reason: String) {
@@ -10310,7 +10359,10 @@ final class GhosttySurfaceScrollView: NSView {
                 "frame=\(String(format: "%.1fx%.1f", bounds.width, bounds.height))"
             )
 #endif
-            scheduleAutomaticFirstResponderApply(reason: "clearSuppressReparentFocus.hiddenOrTiny")
+            scheduleAutomaticFirstResponderApply(
+                reason: "clearSuppressReparentFocus.hiddenOrTiny",
+                focusTransactionId: surfaceView.firstResponderFocusTransactionId
+            )
             return
         }
         if !surfaceOwnsFirstResponder && !isSurfaceViewFirstResponder() {
@@ -10331,7 +10383,10 @@ final class GhosttySurfaceScrollView: NSView {
 
     fileprivate func scheduleSuppressedFirstResponderFocusReapply(reason: String) {
         pendingSuppressedFirstResponderFocusReapply = true
-        scheduleAutomaticFirstResponderApply(reason: reason)
+        scheduleAutomaticFirstResponderApply(
+            reason: reason,
+            focusTransactionId: surfaceView.firstResponderFocusTransactionId
+        )
     }
 
     fileprivate func cancelSuppressedFirstResponderFocusReapply() {
@@ -10359,7 +10414,10 @@ final class GhosttySurfaceScrollView: NSView {
               AppDelegate.shared?.isCommandPaletteEffectivelyVisible(for: window) != true else {
             return
         }
-        scheduleAutomaticFirstResponderApply(reason: reason)
+        scheduleAutomaticFirstResponderApply(
+            reason: reason,
+            focusTransactionId: surfaceView.firstResponderFocusTransactionId
+        )
     }
 
     /// Returns true if the terminal's actual Ghostty surface view is (or contains) the window first responder.
@@ -10422,20 +10480,31 @@ final class GhosttySurfaceScrollView: NSView {
         guard canRequestSurfaceFirstResponder(in: window, reason: reason) else {
             return false
         }
-        return window.makeFirstResponder(surfaceView)
+        return makeSurfaceViewFirstResponder(
+            in: window,
+            focusTransactionId: surfaceView.firstResponderFocusTransactionId
+        )
     }
 
-    private func scheduleAutomaticFirstResponderApply(reason: String) {
+    private func scheduleAutomaticFirstResponderApply(
+        reason: String,
+        focusTransactionId: UUID? = nil
+    ) {
+        if let focusTransactionId {
+            pendingAutomaticFirstResponderFocusTransactionId = focusTransactionId
+        }
         guard !pendingAutomaticFirstResponderApply else { return }
         pendingAutomaticFirstResponderApply = true
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.pendingAutomaticFirstResponderApply = false
+            let focusTransactionId = self.pendingAutomaticFirstResponderFocusTransactionId
+            self.pendingAutomaticFirstResponderFocusTransactionId = nil
 #if DEBUG
             let surfaceShort = String(self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil")
             cmuxDebugLog("find.applyFirstResponder.defer surface=\(surfaceShort) reason=\(reason)")
 #endif
-            self.applyFirstResponderIfNeeded()
+            self.applyFirstResponderIfNeeded(focusTransactionId: focusTransactionId)
         }
     }
 
@@ -10461,7 +10530,10 @@ final class GhosttySurfaceScrollView: NSView {
             )
 #endif
             pendingSuppressedFirstResponderFocusReapply = true
-            scheduleAutomaticFirstResponderApply(reason: "\(reason).hiddenOrTiny")
+            scheduleAutomaticFirstResponderApply(
+                reason: "\(reason).hiddenOrTiny",
+                focusTransactionId: surfaceView.firstResponderFocusTransactionId
+            )
             return false
         }
 
@@ -10500,7 +10572,7 @@ final class GhosttySurfaceScrollView: NSView {
         terminalSurface.forceRefresh(reason: "focus.surface.\(reason)")
     }
 
-    private func applyFirstResponderIfNeeded() {
+    private func applyFirstResponderIfNeeded(focusTransactionId: UUID? = nil) {
         let hasUsablePortalGeometry: Bool = {
             let size = bounds.size
             return size.width > 1 && size.height > 1
@@ -10582,7 +10654,10 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
         cmuxDebugLog("find.applyFirstResponder APPLY surface=\(surfaceShort) prevFirstResponder=\(String(describing: window.firstResponder))")
 #endif
-        window.makeFirstResponder(surfaceView)
+        _ = makeSurfaceViewFirstResponder(
+            in: window,
+            focusTransactionId: focusTransactionId
+        )
         if isSurfaceViewFirstResponder() {
             reassertTerminalSurfaceFocus(reason: "applyFirstResponder.afterMakeFirstResponder")
         }

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -590,17 +590,25 @@ final class TerminalPanel: Panel, ObservableObject {
 #endif
 
     func focus() {
+        focus(focusTransactionId: nil)
+    }
+
+    func focus(focusTransactionId: UUID?) {
         if isAgentHibernated {
             _ = requestAgentHibernationResume(focus: true)
             return
         }
-        focusTerminalSurface(respectForeignFirstResponder: true)
+        focusTerminalSurface(
+            respectForeignFirstResponder: true,
+            focusTransactionId: focusTransactionId
+        )
     }
 
     @discardableResult
     private func focusTerminalSurface(
         respectForeignFirstResponder: Bool,
-        clearTextBoxHideArm: Bool = true
+        clearTextBoxHideArm: Bool = true,
+        focusTransactionId: UUID? = nil
     ) -> Bool {
         if clearTextBoxHideArm {
             shouldHideTextBoxOnNextEscape = false
@@ -637,7 +645,8 @@ final class TerminalPanel: Panel, ObservableObject {
         hostedView.ensureFocus(
             for: workspaceId,
             surfaceId: id,
-            respectForeignFirstResponder: respectForeignFirstResponder
+            respectForeignFirstResponder: respectForeignFirstResponder,
+            focusTransactionId: focusTransactionId
         )
         return true
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3360,7 +3360,8 @@ class TabManager: ObservableObject {
         surfaceId: UUID? = nil,
         suppressFlash: Bool = false,
         focusIntent: PanelFocusIntent? = nil,
-        dismissRestoredUnreadOnResume: Bool? = nil
+        dismissRestoredUnreadOnResume: Bool? = nil,
+        focusTransactionId: UUID? = nil
     ) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         let targetPanelId = surfaceId.flatMap { panelId(forSurfaceOrPanelId: $0, in: tab) }
@@ -3389,9 +3390,9 @@ class TabManager: ObservableObject {
         if let surfaceId {
             let focusPanelId = targetPanelId ?? surfaceId
             if !suppressFlash {
-                focusSurface(tabId: tabId, surfaceId: focusPanelId)
+                focusSurface(tabId: tabId, surfaceId: focusPanelId, focusTransactionId: focusTransactionId)
             } else {
-                tab.focusPanel(focusPanelId, focusIntent: focusIntent)
+                tab.focusPanel(focusPanelId, focusIntent: focusIntent, focusTransactionId: focusTransactionId)
             }
             if let dismissalContext {
                 _ = notificationDismissal.dismissNotification(
@@ -3438,9 +3439,12 @@ class TabManager: ObservableObject {
         return true
     }
 
-    func focusSurface(tabId: UUID, surfaceId: UUID) {
+    func focusSurface(tabId: UUID, surfaceId: UUID, focusTransactionId: UUID? = nil) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
-        tab.focusPanel(panelId(forSurfaceOrPanelId: surfaceId, in: tab) ?? surfaceId)
+        tab.focusPanel(
+            panelId(forSurfaceOrPanelId: surfaceId, in: tab) ?? surfaceId,
+            focusTransactionId: focusTransactionId
+        )
     }
 
     func panelId(forSurfaceOrPanelId surfaceOrPanelId: UUID, in workspace: Workspace) -> UUID? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3491,6 +3491,7 @@ final class Workspace: Identifiable, ObservableObject {
         let reassertAppKitFocus: Bool
         let focusIntent: PanelFocusIntent?
         let resumeHibernatedAgent: Bool?
+        let focusTransactionId: UUID?
         let previousTerminalHostedView: GhosttySurfaceScrollView?
     }
     /// The coalesced pending tab-selection request; stored in the
@@ -9233,7 +9234,8 @@ final class Workspace: Identifiable, ObservableObject {
         _ panelId: UUID,
         previousHostedView: GhosttySurfaceScrollView? = nil,
         trigger: FocusPanelTrigger = .standard,
-        focusIntent: PanelFocusIntent? = nil
+        focusIntent: PanelFocusIntent? = nil,
+        focusTransactionId: UUID? = nil
     ) {
         guard !remoteTmuxMirrorInterceptsFocusPanel(panelId, previousHostedView: previousHostedView, trigger: trigger, focusIntent: focusIntent) else { return }
         markExplicitFocusIntent(on: panelId)
@@ -9303,6 +9305,7 @@ final class Workspace: Identifiable, ObservableObject {
                     inPane: targetPaneId,
                     reassertAppKitFocus: false,
                     focusIntent: activationIntent,
+                    focusTransactionId: focusTransactionId,
                     previousTerminalHostedView: previousTerminalHostedView
                 )
             }
@@ -9341,6 +9344,7 @@ final class Workspace: Identifiable, ObservableObject {
                 reassertAppKitFocus: !shouldSuppressReentrantRefocus,
                 focusIntent: activationIntent,
                 resumeHibernatedAgent: true,
+                focusTransactionId: focusTransactionId,
                 previousTerminalHostedView: previousTerminalHostedView
             )
         }
@@ -11099,6 +11103,7 @@ extension Workspace: BonsplitDelegate {
         reassertAppKitFocus: Bool = true,
         focusIntent: PanelFocusIntent? = nil,
         resumeHibernatedAgent: Bool? = nil,
+        focusTransactionId: UUID? = nil,
         previousTerminalHostedView: GhosttySurfaceScrollView? = nil
     ) {
         guard !remoteTmuxMirrorMutations.suppressesFocusActivation else { return }
@@ -11108,6 +11113,7 @@ extension Workspace: BonsplitDelegate {
             reassertAppKitFocus: reassertAppKitFocus,
             focusIntent: focusIntent,
             resumeHibernatedAgent: resumeHibernatedAgent,
+            focusTransactionId: focusTransactionId,
             previousTerminalHostedView: previousTerminalHostedView
         )
         guard !isApplyingTabSelection else { return }
@@ -11128,6 +11134,7 @@ extension Workspace: BonsplitDelegate {
                 reassertAppKitFocus: request.reassertAppKitFocus,
                 focusIntent: request.focusIntent,
                 resumeHibernatedAgent: request.resumeHibernatedAgent,
+                focusTransactionId: request.focusTransactionId,
                 previousTerminalHostedView: request.previousTerminalHostedView
             )
         }
@@ -11150,6 +11157,7 @@ extension Workspace: BonsplitDelegate {
         reassertAppKitFocus: Bool,
         focusIntent: PanelFocusIntent?,
         resumeHibernatedAgent: Bool?,
+        focusTransactionId: UUID?,
         previousTerminalHostedView: GhosttySurfaceScrollView?
     ) {
         let previousFocusedPanelId = focusedPanelId
@@ -11322,12 +11330,13 @@ extension Workspace: BonsplitDelegate {
         // synchronously) so the `@Published` mutations above settle before any
         // observer runs, and so a notification-driven focus cycle (command-palette
         // restore + cross-workspace handoff) cannot synchronously re-enter
-        // applyTabSelectionNow and hang the main thread. See issue #5100.
+        // applyTabSelectionNow and hang the main thread. See issue #8843.
         FocusSurfaceBroadcaster.shared.emit(
             FocusSurfaceBroadcaster.FocusSurfacePayload(
                 workspaceId: self.id,
                 panelId: panelId,
-                explicitFocusIntent: explicitFocusIntent
+                explicitFocusIntent: explicitFocusIntent,
+                transactionId: focusTransactionId ?? UUID()
             )
         )
         publishCmuxFocusedSelection(paneId: focusedPane, surfaceId: panelId, origin: "bonsplit_selection")

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3500,6 +3500,7 @@ final class Workspace: Identifiable, ObservableObject {
         get { surfaceRegistry.pendingTabSelection }
         set { surfaceRegistry.pendingTabSelection = newValue }
     }
+    private(set) var activeFocusTransactionId: UUID?
     private var isReconcilingFocusState = false
     private var focusReconcileScheduled = false
 #if DEBUG
@@ -9238,13 +9239,15 @@ final class Workspace: Identifiable, ObservableObject {
         focusTransactionId: UUID? = nil
     ) {
         guard !remoteTmuxMirrorInterceptsFocusPanel(panelId, previousHostedView: previousHostedView, trigger: trigger, focusIntent: focusIntent) else { return }
+        let effectiveFocusTransactionId = focusTransactionId ?? activeFocusTransactionId
         markExplicitFocusIntent(on: panelId)
 #if DEBUG
         let pane = bonsplitController.focusedPaneId?.id.uuidString.prefix(5) ?? "nil"
         let triggerLabel = trigger == .terminalFirstResponder ? "firstResponder" : "standard"
-        cmuxDebugLog("focus.panel panel=\(panelId.uuidString.prefix(5)) pane=\(pane) trigger=\(triggerLabel)")
+        let transactionLabel = effectiveFocusTransactionId.map { String($0.uuidString.prefix(5)) } ?? "nil"
+        cmuxDebugLog("focus.panel panel=\(panelId.uuidString.prefix(5)) pane=\(pane) trigger=\(triggerLabel) tx=\(transactionLabel)")
         AppDelegate.shared?.focusLog.append(
-            "Workspace.focusPanel panelId=\(panelId.uuidString) focusedPane=\(pane) trigger=\(triggerLabel)"
+            "Workspace.focusPanel panelId=\(panelId.uuidString) focusedPane=\(pane) trigger=\(triggerLabel) transactionId=\(transactionLabel)"
         )
 #endif
         guard let tabId = surfaceIdFromPanelId(panelId) else { return }
@@ -9305,7 +9308,7 @@ final class Workspace: Identifiable, ObservableObject {
                     inPane: targetPaneId,
                     reassertAppKitFocus: false,
                     focusIntent: activationIntent,
-                    focusTransactionId: focusTransactionId,
+                    focusTransactionId: effectiveFocusTransactionId,
                     previousTerminalHostedView: previousTerminalHostedView
                 )
             }
@@ -9344,7 +9347,7 @@ final class Workspace: Identifiable, ObservableObject {
                 reassertAppKitFocus: !shouldSuppressReentrantRefocus,
                 focusIntent: activationIntent,
                 resumeHibernatedAgent: true,
-                focusTransactionId: focusTransactionId,
+                focusTransactionId: effectiveFocusTransactionId,
                 previousTerminalHostedView: previousTerminalHostedView
             )
         }
@@ -11107,13 +11110,14 @@ extension Workspace: BonsplitDelegate {
         previousTerminalHostedView: GhosttySurfaceScrollView? = nil
     ) {
         guard !remoteTmuxMirrorMutations.suppressesFocusActivation else { return }
+        let effectiveFocusTransactionId = focusTransactionId ?? activeFocusTransactionId
         pendingTabSelection = PendingTabSelectionRequest(
             tabId: tabId,
             pane: pane,
             reassertAppKitFocus: reassertAppKitFocus,
             focusIntent: focusIntent,
             resumeHibernatedAgent: resumeHibernatedAgent,
-            focusTransactionId: focusTransactionId,
+            focusTransactionId: effectiveFocusTransactionId,
             previousTerminalHostedView: previousTerminalHostedView
         )
         guard !isApplyingTabSelection else { return }
@@ -11160,6 +11164,12 @@ extension Workspace: BonsplitDelegate {
         focusTransactionId: UUID?,
         previousTerminalHostedView: GhosttySurfaceScrollView?
     ) {
+        let transactionId = focusTransactionId ?? UUID()
+        let previousActiveFocusTransactionId = activeFocusTransactionId
+        activeFocusTransactionId = transactionId
+        defer {
+            activeFocusTransactionId = previousActiveFocusTransactionId
+        }
         let previousFocusedPanelId = focusedPanelId
         let previousPresentedDirectory = presentedCurrentDirectory
         let previousCurrentDirectory = currentDirectory
@@ -11336,7 +11346,7 @@ extension Workspace: BonsplitDelegate {
                 workspaceId: self.id,
                 panelId: panelId,
                 explicitFocusIntent: explicitFocusIntent,
-                transactionId: focusTransactionId ?? UUID()
+                transactionId: transactionId
             )
         )
         publishCmuxFocusedSelection(paneId: focusedPane, surfaceId: panelId, origin: "bonsplit_selection")

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11277,7 +11277,8 @@ extension Workspace: BonsplitDelegate {
         activatePanel(
             panel,
             focusIntent: activationIntent,
-            reassertAppKitFocus: reassertAppKitFocus
+            reassertAppKitFocus: reassertAppKitFocus,
+            focusTransactionId: transactionId
         )
         let focusIntentAllowsBrowserOmnibarAutofocus =
             explicitFocusIntent ||
@@ -11306,7 +11307,8 @@ extension Workspace: BonsplitDelegate {
 #endif
                     terminalPanel.hostedView.moveFocus(
                         from: previousTerminalHostedView,
-                        respectForeignFirstResponder: true
+                        respectForeignFirstResponder: true,
+                        focusTransactionId: transactionId
                     )
                 }
 #if DEBUG
@@ -11316,7 +11318,11 @@ extension Workspace: BonsplitDelegate {
                     "tab=\(selectedTabId.uuid.uuidString.prefix(5)) intent=\(String(describing: activationIntent))"
                 )
 #endif
-                terminalPanel.hostedView.ensureFocus(for: id, surfaceId: panelId)
+                terminalPanel.hostedView.ensureFocus(
+                    for: id,
+                    surfaceId: panelId,
+                    focusTransactionId: transactionId
+                )
             }
         }
 
@@ -11364,14 +11370,15 @@ extension Workspace: BonsplitDelegate {
     private func activatePanel(
         _ panel: any Panel,
         focusIntent: PanelFocusIntent,
-        reassertAppKitFocus: Bool
+        reassertAppKitFocus: Bool,
+        focusTransactionId: UUID? = nil
     ) {
         if let terminalPanel = panel as? TerminalPanel {
             let shouldFocusTerminalSurface = shouldMoveTerminalSurfaceFocus(for: focusIntent)
             terminalPanel.surface.setFocus(shouldFocusTerminalSurface)
             terminalPanel.hostedView.setActive(true)
             if reassertAppKitFocus && shouldFocusTerminalSurface {
-                terminalPanel.focus()
+                terminalPanel.focus(focusTransactionId: focusTransactionId)
             }
             return
         }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -301,7 +301,11 @@ struct WorkspaceContentView: View {
                             // indicator and where keyboard input/flash-focus actually lands.
                             guard isWorkspaceInputActive else { return }
                             guard workspace.panels[panel.id] != nil else { return }
-                            workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
+                            workspace.focusPanel(
+                                panel.id,
+                                trigger: .terminalFirstResponder,
+                                focusTransactionId: workspace.activeFocusTransactionId
+                            )
                         },
                         onRequestPanelFocus: {
                             guard isWorkspaceInputActive else { return }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -53,9 +53,9 @@ struct cmuxApp: App {
     /// injected into AppDelegate and the auth-consuming services.
     private let authComposition: MacAuthComposition
     @StateObject private var tabManager: TabManager
-    @StateObject private var notificationStore = TerminalNotificationStore.shared
-    @StateObject var closedItemHistoryStore = ClosedItemHistoryStore.shared
-    @StateObject private var sidebarState = SidebarState()
+    @StateObject private var notificationStore: TerminalNotificationStore
+    @StateObject var closedItemHistoryStore: ClosedItemHistoryStore
+    @StateObject private var sidebarState: SidebarState
     @State private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
     @AppStorage(TitlebarControlsStyle.storageKey) private var titlebarControlsStyle = TitlebarControlsStyle.defaultRawValue
@@ -64,7 +64,7 @@ struct cmuxApp: App {
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
     @AppStorage(BrowserToolbarAccessorySpacingDebugSettings.key) private var browserToolbarAccessorySpacingRaw = BrowserToolbarAccessorySpacingDebugSettings.defaultSpacing
     @State private var browserFocusModeMenuRevision = 0
-    @StateObject var focusHistoryMenuInvalidator = FocusHistoryMenuInvalidator()
+    @StateObject var focusHistoryMenuInvalidator: FocusHistoryMenuInvalidator
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     private var browserToolbarAccessorySpacing: Int {
         BrowserToolbarAccessorySpacingDebugSettings.resolved(browserToolbarAccessorySpacingRaw)
@@ -119,6 +119,10 @@ struct cmuxApp: App {
             backupTimestamp: secretMigrationTimestamp
         )
         let authComposition = MacAuthComposition()
+        let notificationStore = TerminalNotificationStore.shared
+        let closedItemHistoryStore = ClosedItemHistoryStore.shared
+        let sidebarState = SidebarState()
+        let focusHistoryMenuInvalidator = FocusHistoryMenuInvalidator()
         self.authComposition = authComposition
 
         // If invoked with CLI-style arguments (e.g. `cmux hooks setup`), exec the
@@ -191,10 +195,15 @@ struct cmuxApp: App {
         KeyboardShortcutSettings.settingsFileStore.applyDeferredManagedDefaultSideEffects()
         StartupBreadcrumbLog.append("app.init.keyboardShortcuts.sideEffectsApplied")
         StartupBreadcrumbLog.append("app.init.tabManager.begin")
-        _tabManager = StateObject(wrappedValue: TabManager(
+        let tabManager = TabManager(
             workspaceDirectoryCustomizationStore: workspaceDirectoryCustomizationStore,
             nativeSSHConnectionBroker: TerminalController.shared.nativeSSHConnectionBroker
-        ))
+        )
+        _tabManager = StateObject(wrappedValue: tabManager)
+        _notificationStore = StateObject(wrappedValue: notificationStore)
+        _closedItemHistoryStore = StateObject(wrappedValue: closedItemHistoryStore)
+        _sidebarState = StateObject(wrappedValue: sidebarState)
+        _focusHistoryMenuInvalidator = StateObject(wrappedValue: focusHistoryMenuInvalidator)
         StartupBreadcrumbLog.append("app.init.tabManager.complete")
         // Migrate legacy and old-format socket mode values to the new enum.
         if let stored = defaults.string(forKey: SocketControlSettings.appStorageKey) {

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -204,6 +204,7 @@ struct FocusSurfaceBroadcasterTests {
         let scheduler = ManualScheduler()
         var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        var tripped: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         let relay = BroadcasterRelay()
         let reentryTarget = Self.payload(8843)
         var reentryBudget = 1_000
@@ -212,6 +213,7 @@ struct FocusSurfaceBroadcasterTests {
             maxCoalescedDeliveries: 2,
             schedule: { scheduler.append($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
+            onCircuitBreakerTripped: { tripped.append($0) },
             deliver: { payload in
                 delivered.append(payload)
                 if reentryBudget > 0 {
@@ -235,16 +237,24 @@ struct FocusSurfaceBroadcasterTests {
             "A self-sustaining focus cycle must not be able to enqueue another flush forever."
         )
         #expect(
-            turns <= 4,
-            "The circuit breaker should trip after a small number of consecutive bounded turns, got \(turns)."
+            turns == 4,
+            "The circuit breaker should trip after four consecutive bounded turns, got \(turns)."
         )
         #expect(
-            delivered.count <= 8,
-            "The cycle delivered \(delivered.count) focus broadcasts before tripping."
+            delivered.count == 9,
+            "The cycle should reconcile the latest pending focus once before tripping; got \(delivered.count)."
         )
         #expect(
-            boundExceeded.count <= 4,
-            "The cycle exceeded the per-turn bound \(boundExceeded.count) times before tripping."
+            delivered.last == reentryTarget,
+            "The circuit breaker must not drop the latest requested focus payload."
+        )
+        #expect(
+            boundExceeded.count == 4,
+            "The cycle should exceed the per-turn bound four times before tripping; got \(boundExceeded.count)."
+        )
+        #expect(
+            tripped == [reentryTarget],
+            "The circuit breaker should report the final reconciled payload once."
         )
         #expect(
             reentryBudget > 0,

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -277,5 +277,21 @@ struct FocusSurfaceBroadcasterTests {
             reentryBudget > 0,
             "The test must stop because the circuit breaker tripped, not because the synthetic re-entry budget ran dry."
         )
+
+        scheduler.runAllCircuitBreaker()
+
+        #expect(
+            scheduler.count == 0,
+            "The delayed recovery must not restart an immediate self-sustaining focus cycle."
+        )
+        #expect(
+            scheduler.circuitBreakerCount == 0,
+            "The circuit breaker should remain open after a re-entrant recovery emit until an external focus event arrives."
+        )
+        #expect(
+            delivered.count == 9,
+            "The delayed recovery should deliver the retained focus payload exactly once."
+        )
+        #expect(delivered.last == reentryTarget)
     }
 }

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -13,26 +13,30 @@ import Testing
 /// `.ghosttyDidFocusSurface` *synchronously* while `@Published` selection state was
 /// mid-mutation. The Combine `.onReceive` subscriber in `ContentView` received it on
 /// the posting thread and synchronously re-entered the focus path
-/// (`attemptCommandPaletteFocusRestoreIfNeeded` → `TabManager.focusTab` →
-/// `Workspace.focusPanel` → `applyTabSelectionNow` → post again). The only guard
+/// (`attemptCommandPaletteFocusRestoreIfNeeded` -> `TabManager.focusTab` ->
+/// `Workspace.focusPanel` -> `applyTabSelectionNow` -> post again). The only guard
 /// (`Workspace.isApplyingTabSelection`) is per-instance, so a cycle that bounced
 /// through SwiftUI body re-evaluation and across workspace instances was unbounded,
 /// matching the hours-long SwiftUI/AppKit layout loop in issue #8843.
 ///
 /// ``FocusSurfaceBroadcaster`` is the fix seam: emitting a focus broadcast is now
-/// deferred + coalesced and a re-entrant emit during delivery is drained in a bounded
-/// loop instead of recursing. These tests exercise that contract directly, without
-/// AppKit, by injecting a manual scheduler and capturing deliveries.
+/// deferred + coalesced, same-transaction feedback is bounded across scheduler turns,
+/// and a re-entrant emit during delivery is drained in a bounded loop instead of
+/// recursing. These tests exercise that contract directly, without AppKit, by
+/// injecting a manual scheduler and capturing deliveries.
 @MainActor
 @Suite("Focus surface broadcaster re-entrancy")
 struct FocusSurfaceBroadcasterTests {
 
-    /// Distinct payloads; the `explicitFocusIntent` flag just varies for identity.
-    private static func payload(_ seed: Int) -> FocusSurfaceBroadcaster.FocusSurfacePayload {
+    private static func payload(
+        _ seed: Int,
+        transactionId: UUID = UUID()
+    ) -> FocusSurfaceBroadcaster.FocusSurfacePayload {
         FocusSurfaceBroadcaster.FocusSurfacePayload(
             workspaceId: UUID(),
             panelId: UUID(),
-            explicitFocusIntent: seed.isMultiple(of: 2)
+            explicitFocusIntent: seed.isMultiple(of: 2),
+            transactionId: transactionId
         )
     }
 
@@ -41,30 +45,18 @@ struct FocusSurfaceBroadcasterTests {
     @MainActor
     private final class ManualScheduler {
         private(set) var pending: [@MainActor @Sendable () -> Void] = []
-        private(set) var circuitBreakerPending: [@MainActor @Sendable () -> Void] = []
 
         func append(_ work: @escaping @MainActor @Sendable () -> Void) {
             pending.append(work)
         }
 
-        func appendCircuitBreaker(_ work: @escaping @MainActor @Sendable () -> Void) {
-            circuitBreakerPending.append(work)
-        }
-
         var count: Int { pending.count }
-        var circuitBreakerCount: Int { circuitBreakerPending.count }
 
         /// Runs every currently-queued flush. Clears the queue first so re-entrant
         /// scheduling during a run is observable via ``count``.
         func runAll() {
             let work = pending
             pending.removeAll()
-            for unit in work { unit() }
-        }
-
-        func runAllCircuitBreaker() {
-            let work = circuitBreakerPending
-            circuitBreakerPending.removeAll()
             for unit in work { unit() }
         }
     }
@@ -125,14 +117,43 @@ struct FocusSurfaceBroadcasterTests {
         #expect(delivered == [third])
     }
 
+    @Test("default delivery posts the focus transaction id")
+    func defaultDeliveryPostsFocusTransactionId() {
+        let scheduler = ManualScheduler()
+        let transactionId = UUID()
+        let payload = Self.payload(1, transactionId: transactionId)
+        var postedUserInfo: [AnyHashable: Any]?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .ghosttyDidFocusSurface,
+            object: nil,
+            queue: nil
+        ) { notification in
+            postedUserInfo = notification.userInfo
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let broadcaster = FocusSurfaceBroadcaster(
+            schedule: { scheduler.append($0) }
+        )
+
+        broadcaster.emit(payload)
+        scheduler.runAll()
+
+        #expect(postedUserInfo?[GhosttyNotificationKey.tabId] as? UUID == payload.workspaceId)
+        #expect(postedUserInfo?[GhosttyNotificationKey.surfaceId] as? UUID == payload.panelId)
+        #expect(postedUserInfo?[GhosttyNotificationKey.explicitFocusIntent] as? Bool == payload.explicitFocusIntent)
+        #expect(postedUserInfo?[GhosttyNotificationKey.focusTransactionId] as? UUID == transactionId)
+    }
+
     @Test("a re-entrant emit is bounded per turn, never recurses, and never hangs")
     func reentrantEmitIsBoundedPerTurn() {
         let scheduler = ManualScheduler()
         var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         let relay = BroadcasterRelay()
-        let reentryTarget = Self.payload(99)
-        // Simulates the .onReceive → focusTab → applyTabSelectionNow → emit cycle:
+        let transactionId = UUID()
+        let reentryTarget = Self.payload(99, transactionId: transactionId)
+        // Simulates the .onReceive -> focusTab -> applyTabSelectionNow -> emit cycle:
         // every delivery re-focuses, far more often than the per-turn bound allows.
         var reentryBudget = 100
 
@@ -151,7 +172,7 @@ struct FocusSurfaceBroadcasterTests {
         )
         relay.broadcaster = broadcaster
 
-        broadcaster.emit(Self.payload(0))
+        broadcaster.emit(Self.payload(0, transactionId: transactionId))
 
         // The first flush delivers at most the bound, then defers the rest instead
         // of recursing `reentryBudget` deep (the un-fixed behavior delivers 101 in a
@@ -165,7 +186,7 @@ struct FocusSurfaceBroadcasterTests {
         var turns = 1
         while scheduler.count > 0 {
             turns += 1
-            #expect(turns < 1000)       // converges — not an infinite cross-turn loop
+            #expect(turns < 1000)       // converges, not an infinite cross-turn loop
             if turns >= 1000 { break }
             let before = delivered.count
             scheduler.runAll()
@@ -184,8 +205,9 @@ struct FocusSurfaceBroadcasterTests {
         let scheduler = ManualScheduler()
         var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         let relay = BroadcasterRelay()
-        let finalTarget = Self.payload(7)
-        // The observer re-focuses the same target a couple of times, then stops —
+        let transactionId = UUID()
+        let finalTarget = Self.payload(7, transactionId: transactionId)
+        // The observer re-focuses the same target a couple of times, then stops -
         // the realistic case where focus restore eventually converges.
         var reEmitsRemaining = 2
 
@@ -202,7 +224,7 @@ struct FocusSurfaceBroadcasterTests {
         )
         relay.broadcaster = broadcaster
 
-        broadcaster.emit(Self.payload(0))
+        broadcaster.emit(Self.payload(0, transactionId: transactionId))
         scheduler.runAll()
 
         // Initial delivery + two convergent re-emits, then quiescent.
@@ -218,13 +240,14 @@ struct FocusSurfaceBroadcasterTests {
         var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         var tripped: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         let relay = BroadcasterRelay()
-        let reentryTarget = Self.payload(8843)
+        let transactionId = UUID()
+        let reentryTarget = Self.payload(8843, transactionId: transactionId)
         var reentryBudget = 1_000
 
         let broadcaster = FocusSurfaceBroadcaster(
             maxCoalescedDeliveries: 2,
+            maxCircuitBreakerRecoveryDeliveries: 2,
             schedule: { scheduler.append($0) },
-            scheduleAfterCircuitBreaker: { scheduler.appendCircuitBreaker($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
             onCircuitBreakerTripped: { tripped.append($0) },
             deliver: { payload in
@@ -237,7 +260,7 @@ struct FocusSurfaceBroadcasterTests {
         )
         relay.broadcaster = broadcaster
 
-        broadcaster.emit(Self.payload(0))
+        broadcaster.emit(Self.payload(0, transactionId: transactionId))
 
         var turns = 0
         while scheduler.count > 0 && turns < 12 {
@@ -250,20 +273,16 @@ struct FocusSurfaceBroadcasterTests {
             "A self-sustaining focus cycle must not be able to enqueue immediate flushes forever."
         )
         #expect(
-            scheduler.circuitBreakerCount == 1,
-            "The still-pending focus payload should be retained on the circuit-breaker scheduler."
+            turns == 6,
+            "The circuit breaker plus recovery should stop after six turns, got \(turns)."
         )
         #expect(
-            turns == 4,
-            "The circuit breaker should trip after four consecutive bounded turns, got \(turns)."
-        )
-        #expect(
-            delivered.count == 8,
-            "The cycle delivered \(delivered.count) immediate focus broadcasts before tripping."
+            delivered.count == 10,
+            "The cycle delivered \(delivered.count) focus broadcasts before stopping."
         )
         #expect(
             delivered.last == reentryTarget,
-            "The immediate drain should still settle on the latest requested focus payload."
+            "The drain should still settle on the latest requested focus payload."
         )
         #expect(
             boundExceeded.count == 4,
@@ -275,23 +294,50 @@ struct FocusSurfaceBroadcasterTests {
         )
         #expect(
             reentryBudget > 0,
-            "The test must stop because the circuit breaker tripped, not because the synthetic re-entry budget ran dry."
+            "The test must stop because the circuit breaker tripped, not because the synthetic budget ran dry."
         )
+    }
 
-        scheduler.runAllCircuitBreaker()
+    @Test("same-transaction deferred feedback is bounded across scheduler turns")
+    func sameTransactionDeferredFeedbackTripsAcrossTurns() {
+        let scheduler = ManualScheduler()
+        var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        var tripped: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        let relay = BroadcasterRelay()
+        let transactionId = UUID()
+        let initial = Self.payload(0, transactionId: transactionId)
+        let feedback = Self.payload(7, transactionId: transactionId)
+        var deferredFeedbackBudget = 1_000
 
-        #expect(
-            scheduler.count == 0,
-            "The delayed recovery must not restart an immediate self-sustaining focus cycle."
+        let broadcaster = FocusSurfaceBroadcaster(
+            maxCoalescedDeliveries: 8,
+            maxConsecutiveCircuitDeliveries: 3,
+            maxCircuitBreakerRecoveryDeliveries: 2,
+            schedule: { scheduler.append($0) },
+            onCircuitBreakerTripped: { tripped.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                guard deferredFeedbackBudget > 0 else { return }
+                deferredFeedbackBudget -= 1
+                scheduler.append {
+                    relay.emit(feedback)
+                }
+            }
         )
-        #expect(
-            scheduler.circuitBreakerCount == 0,
-            "The circuit breaker should remain open after a re-entrant recovery emit until an external focus event arrives."
-        )
-        #expect(
-            delivered.count == 9,
-            "The delayed recovery should deliver the retained focus payload exactly once."
-        )
-        #expect(delivered.last == reentryTarget)
+        relay.broadcaster = broadcaster
+
+        broadcaster.emit(initial)
+
+        var turns = 0
+        while scheduler.count > 0 && turns < 20 {
+            turns += 1
+            scheduler.runAll()
+        }
+
+        #expect(scheduler.count == 0)
+        #expect(turns == 11)
+        #expect(delivered == [initial, feedback, feedback, feedback, feedback])
+        #expect(tripped == [feedback])
+        #expect(deferredFeedbackBudget > 0)
     }
 }

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -184,4 +184,56 @@ struct FocusSurfaceBroadcasterTests {
         #expect(delivered.last == finalTarget)
         #expect(scheduler.count == 0)
     }
+
+    @Test("a non-converging re-entrant cycle trips instead of rescheduling forever")
+    func nonConvergingReentrantCycleTripsCircuitBreaker() {
+        let scheduler = ManualScheduler()
+        var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
+        var broadcaster: FocusSurfaceBroadcaster!
+        let reentryTarget = Self.payload(8843)
+        var reentryBudget = 1_000
+
+        broadcaster = FocusSurfaceBroadcaster(
+            maxCoalescedDeliveries: 2,
+            schedule: { scheduler.append($0) },
+            onDrainBoundExceeded: { boundExceeded.append($0) },
+            deliver: { payload in
+                delivered.append(payload)
+                if reentryBudget > 0 {
+                    reentryBudget -= 1
+                    broadcaster.emit(reentryTarget)
+                }
+            }
+        )
+
+        broadcaster.emit(Self.payload(0))
+
+        var turns = 0
+        while scheduler.count > 0 && turns < 12 {
+            turns += 1
+            scheduler.runAll()
+        }
+
+        #expect(
+            scheduler.count == 0,
+            "A self-sustaining focus cycle must not be able to enqueue another flush forever."
+        )
+        #expect(
+            turns <= 4,
+            "The circuit breaker should trip after a small number of consecutive bounded turns, got \(turns)."
+        )
+        #expect(
+            delivered.count <= 8,
+            "The cycle delivered \(delivered.count) focus broadcasts before tripping."
+        )
+        #expect(
+            boundExceeded.count <= 4,
+            "The cycle exceeded the per-turn bound \(boundExceeded.count) times before tripping."
+        )
+        #expect(
+            reentryBudget > 0,
+            "The test must stop because the circuit breaker tripped, not because the synthetic re-entry budget ran dry."
+        )
+    }
 }

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -41,18 +41,30 @@ struct FocusSurfaceBroadcasterTests {
     @MainActor
     private final class ManualScheduler {
         private(set) var pending: [@MainActor @Sendable () -> Void] = []
+        private(set) var circuitBreakerPending: [@MainActor @Sendable () -> Void] = []
 
         func append(_ work: @escaping @MainActor @Sendable () -> Void) {
             pending.append(work)
         }
 
+        func appendCircuitBreaker(_ work: @escaping @MainActor @Sendable () -> Void) {
+            circuitBreakerPending.append(work)
+        }
+
         var count: Int { pending.count }
+        var circuitBreakerCount: Int { circuitBreakerPending.count }
 
         /// Runs every currently-queued flush. Clears the queue first so re-entrant
         /// scheduling during a run is observable via ``count``.
         func runAll() {
             let work = pending
             pending.removeAll()
+            for unit in work { unit() }
+        }
+
+        func runAllCircuitBreaker() {
+            let work = circuitBreakerPending
+            circuitBreakerPending.removeAll()
             for unit in work { unit() }
         }
     }
@@ -212,6 +224,7 @@ struct FocusSurfaceBroadcasterTests {
         let broadcaster = FocusSurfaceBroadcaster(
             maxCoalescedDeliveries: 2,
             schedule: { scheduler.append($0) },
+            scheduleAfterCircuitBreaker: { scheduler.appendCircuitBreaker($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
             onCircuitBreakerTripped: { tripped.append($0) },
             deliver: { payload in
@@ -234,19 +247,23 @@ struct FocusSurfaceBroadcasterTests {
 
         #expect(
             scheduler.count == 0,
-            "A self-sustaining focus cycle must not be able to enqueue another flush forever."
+            "A self-sustaining focus cycle must not be able to enqueue immediate flushes forever."
+        )
+        #expect(
+            scheduler.circuitBreakerCount == 1,
+            "The still-pending focus payload should be retained on the circuit-breaker scheduler."
         )
         #expect(
             turns == 4,
             "The circuit breaker should trip after four consecutive bounded turns, got \(turns)."
         )
         #expect(
-            delivered.count == 9,
-            "The cycle should reconcile the latest pending focus once before tripping; got \(delivered.count)."
+            delivered.count == 8,
+            "The cycle delivered \(delivered.count) immediate focus broadcasts before tripping."
         )
         #expect(
             delivered.last == reentryTarget,
-            "The circuit breaker must not drop the latest requested focus payload."
+            "The immediate drain should still settle on the latest requested focus payload."
         )
         #expect(
             boundExceeded.count == 4,

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -115,6 +115,7 @@ struct FocusSurfaceBroadcasterTests {
 
         broadcaster = FocusSurfaceBroadcaster(
             maxCoalescedDeliveries: 8,
+            maxConsecutiveBoundedFlushes: 1_000,
             schedule: { scheduler.append($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
             deliver: { payload in

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -128,6 +128,10 @@ struct FocusSurfaceBroadcasterTests {
             object: nil,
             queue: nil
         ) { notification in
+            guard notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID == payload.workspaceId,
+                  notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID == payload.panelId else {
+                return
+            }
             postedUserInfo = notification.userInfo
         }
         defer { NotificationCenter.default.removeObserver(observer) }

--- a/cmuxTests/FocusSurfaceBroadcasterTests.swift
+++ b/cmuxTests/FocusSurfaceBroadcasterTests.swift
@@ -7,7 +7,7 @@ import Testing
 @testable import cmux
 #endif
 
-/// Regression coverage for the focus-broadcast re-entrancy hang (issue #5100).
+/// Regression coverage for the focus-broadcast re-entrancy loop (issue #8843).
 ///
 /// Production symptom: `Workspace.applyTabSelectionNow` posted
 /// `.ghosttyDidFocusSurface` *synchronously* while `@Published` selection state was
@@ -16,8 +16,8 @@ import Testing
 /// (`attemptCommandPaletteFocusRestoreIfNeeded` → `TabManager.focusTab` →
 /// `Workspace.focusPanel` → `applyTabSelectionNow` → post again). The only guard
 /// (`Workspace.isApplyingTabSelection`) is per-instance, so a cycle that bounced
-/// through SwiftUI body re-evaluation and across workspace instances was unbounded —
-/// a 426s main-thread hang.
+/// through SwiftUI body re-evaluation and across workspace instances was unbounded,
+/// matching the hours-long SwiftUI/AppKit layout loop in issue #8843.
 ///
 /// ``FocusSurfaceBroadcaster`` is the fix seam: emitting a focus broadcast is now
 /// deferred + coalesced and a re-entrant emit during delivery is drained in a bounded
@@ -54,6 +54,17 @@ struct FocusSurfaceBroadcasterTests {
             let work = pending
             pending.removeAll()
             for unit in work { unit() }
+        }
+    }
+
+    /// Safe because the relay is main-actor isolated and every captured test
+    /// delivery closure is also `@MainActor`.
+    @MainActor
+    private final class BroadcasterRelay: @unchecked Sendable {
+        var broadcaster: FocusSurfaceBroadcaster?
+
+        func emit(_ payload: FocusSurfaceBroadcaster.FocusSurfacePayload) {
+            broadcaster?.emit(payload)
         }
     }
 
@@ -107,13 +118,13 @@ struct FocusSurfaceBroadcasterTests {
         let scheduler = ManualScheduler()
         var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
-        var broadcaster: FocusSurfaceBroadcaster!
+        let relay = BroadcasterRelay()
         let reentryTarget = Self.payload(99)
         // Simulates the .onReceive → focusTab → applyTabSelectionNow → emit cycle:
         // every delivery re-focuses, far more often than the per-turn bound allows.
         var reentryBudget = 100
 
-        broadcaster = FocusSurfaceBroadcaster(
+        let broadcaster = FocusSurfaceBroadcaster(
             maxCoalescedDeliveries: 8,
             maxConsecutiveBoundedFlushes: 1_000,
             schedule: { scheduler.append($0) },
@@ -122,10 +133,11 @@ struct FocusSurfaceBroadcasterTests {
                 delivered.append(payload)
                 if reentryBudget > 0 {
                     reentryBudget -= 1
-                    broadcaster.emit(reentryTarget)
+                    relay.emit(reentryTarget)
                 }
             }
         )
+        relay.broadcaster = broadcaster
 
         broadcaster.emit(Self.payload(0))
 
@@ -159,23 +171,24 @@ struct FocusSurfaceBroadcasterTests {
     func reentrantEmitConvergesToFinalSelection() {
         let scheduler = ManualScheduler()
         var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
-        var broadcaster: FocusSurfaceBroadcaster!
+        let relay = BroadcasterRelay()
         let finalTarget = Self.payload(7)
         // The observer re-focuses the same target a couple of times, then stops —
         // the realistic case where focus restore eventually converges.
         var reEmitsRemaining = 2
 
-        broadcaster = FocusSurfaceBroadcaster(
+        let broadcaster = FocusSurfaceBroadcaster(
             maxCoalescedDeliveries: 8,
             schedule: { scheduler.append($0) },
             deliver: { payload in
                 delivered.append(payload)
                 if reEmitsRemaining > 0 {
                     reEmitsRemaining -= 1
-                    broadcaster.emit(finalTarget)
+                    relay.emit(finalTarget)
                 }
             }
         )
+        relay.broadcaster = broadcaster
 
         broadcaster.emit(Self.payload(0))
         scheduler.runAll()
@@ -191,11 +204,11 @@ struct FocusSurfaceBroadcasterTests {
         let scheduler = ManualScheduler()
         var delivered: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
         var boundExceeded: [FocusSurfaceBroadcaster.FocusSurfacePayload] = []
-        var broadcaster: FocusSurfaceBroadcaster!
+        let relay = BroadcasterRelay()
         let reentryTarget = Self.payload(8843)
         var reentryBudget = 1_000
 
-        broadcaster = FocusSurfaceBroadcaster(
+        let broadcaster = FocusSurfaceBroadcaster(
             maxCoalescedDeliveries: 2,
             schedule: { scheduler.append($0) },
             onDrainBoundExceeded: { boundExceeded.append($0) },
@@ -203,10 +216,11 @@ struct FocusSurfaceBroadcasterTests {
                 delivered.append(payload)
                 if reentryBudget > 0 {
                     reentryBudget -= 1
-                    broadcaster.emit(reentryTarget)
+                    relay.emit(reentryTarget)
                 }
             }
         )
+        relay.broadcaster = broadcaster
 
         broadcaster.emit(Self.payload(0))
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -4889,6 +4889,24 @@ final class WorkspaceTerminalFocusRecoveryTests: XCTestCase {
         }
         defer { NotificationCenter.default.removeObserver(token) }
 
+        var sawFirstResponderNotification = false
+        var observedFirstResponderTransactions: [UUID] = []
+        let firstResponderToken = NotificationCenter.default.addObserver(
+            forName: .ghosttyDidBecomeFirstResponderSurface,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID == workspace.id,
+                  notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID == leftPanel.id else {
+                return
+            }
+            sawFirstResponderNotification = true
+            if let transactionId = notification.userInfo?[GhosttyNotificationKey.focusTransactionId] as? UUID {
+                observedFirstResponderTransactions.append(transactionId)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(firstResponderToken) }
+
         let transactionId = UUID()
         window.makeFirstResponder(nil)
         workspace.applyTabSelection(
@@ -4902,6 +4920,15 @@ final class WorkspaceTerminalFocusRecoveryTests: XCTestCase {
             firstResponderFeedbackCount,
             0,
             "Expected AppKit first-responder focus to feed back through workspace.focusPanel"
+        )
+        XCTAssertTrue(
+            sawFirstResponderNotification,
+            "Expected the terminal first-responder notification to be posted for the focused panel"
+        )
+        XCTAssertEqual(
+            observedFirstResponderTransactions.last,
+            transactionId,
+            "Terminal first-responder notifications should carry the active focus transaction"
         )
         XCTAssertEqual(
             observedTransactions.last,

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -4822,6 +4822,94 @@ final class WorkspaceTerminalFocusRecoveryTests: XCTestCase {
         )
     }
 
+    func testTerminalFirstResponderFeedbackPreservesActiveFocusTransaction() {
+        let originalAppDelegate = AppDelegate.shared
+        let appDelegate = originalAppDelegate ?? AppDelegate()
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let originalTabManager = appDelegate.tabManager
+        let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+        AppDelegate.shared = appDelegate
+        appDelegate.tabManager = manager
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            appDelegate.tabManager = originalTabManager
+            AppDelegate.shared = originalAppDelegate
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let leftPanelId = workspace.focusedPanelId,
+              let leftPanel = workspace.terminalPanel(for: leftPanelId),
+              let rightPanel = workspace.newTerminalSplit(from: leftPanelId, orientation: .horizontal),
+              let leftPaneId = workspace.paneId(forPanelId: leftPanel.id),
+              let leftTabId = workspace.surfaceIdFromPanelId(leftPanel.id) else {
+            XCTFail("Expected split terminal panels")
+            return
+        }
+
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        leftPanel.hostedView.frame = NSRect(x: 0, y: 0, width: 180, height: 220)
+        rightPanel.hostedView.frame = NSRect(x: 180, y: 0, width: 180, height: 220)
+        contentView.addSubview(leftPanel.hostedView)
+        contentView.addSubview(rightPanel.hostedView)
+        leftPanel.hostedView.setVisibleInUI(true)
+        rightPanel.hostedView.setVisibleInUI(true)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        leftPanel.hostedView.layoutSubtreeIfNeeded()
+        rightPanel.hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        FocusSurfaceBroadcaster.shared.flush()
+
+        var firstResponderFeedbackCount = 0
+        leftPanel.hostedView.setFocusHandler {
+            firstResponderFeedbackCount += 1
+            workspace.focusPanel(leftPanel.id, trigger: .terminalFirstResponder)
+        }
+
+        var observedTransactions: [UUID] = []
+        let token = NotificationCenter.default.addObserver(
+            forName: .ghosttyDidFocusSurface,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard notification.userInfo?[GhosttyNotificationKey.tabId] as? UUID == workspace.id,
+                  notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID == leftPanel.id,
+                  let transactionId = notification.userInfo?[GhosttyNotificationKey.focusTransactionId] as? UUID else {
+                return
+            }
+            observedTransactions.append(transactionId)
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let transactionId = UUID()
+        window.makeFirstResponder(nil)
+        workspace.applyTabSelection(
+            tabId: leftTabId,
+            inPane: leftPaneId,
+            focusTransactionId: transactionId
+        )
+        FocusSurfaceBroadcaster.shared.flush()
+
+        XCTAssertGreaterThan(
+            firstResponderFeedbackCount,
+            0,
+            "Expected AppKit first-responder focus to feed back through workspace.focusPanel"
+        )
+        XCTAssertEqual(
+            observedTransactions.last,
+            transactionId,
+            "Terminal first-responder feedback should stay in the active focus transaction instead of starting a new circuit"
+        )
+    }
+
     func testTerminalClickRecoversSplitActiveStateWhenFocusCallbackIsSuppressed() {
         let workspace = Workspace()
         guard let leftPanelId = workspace.focusedPanelId,


### PR DESCRIPTION
Summary:
- Add a deterministic cross-turn circuit breaker to the focus broadcast path so a non-converging focus observer cycle is logged and stopped instead of rescheduling forever.
- Key focus feedback by explicit focus transaction IDs propagated through ContentView -> TabManager -> Workspace, so deferred same-transaction feedback is bounded without asyncAfter or wall-clock recovery.
- Preserve the active focus transaction through AppKit terminal-first-responder / Bonsplit feedback, including feedback callbacks that historically called workspace.focusPanel(..., trigger: .terminalFirstResponder) without a transaction.
- Post focusTransactionId on .ghosttyDidBecomeFirstResponderSurface and carry it through terminal moveFocus/ensureFocus/deferred first-responder paths, so ContentView no longer has to rely on the scoped activeFocusTransactionId fallback after applyTabSelectionNow returns.
- Keep the reusable coalescing/circuit-breaker state machine in CmuxNotifications; app code only owns NotificationCenter delivery, transaction propagation, and structured diagnostics.
- Initialize root StateObject stores through wrapped-value locals in cmuxApp.init so AppDelegate wiring no longer reads StateObject values before SwiftUI installs them.

Review comments addressed:
- Filtered the FocusSurfaceBroadcasterTests NotificationCenter observer by both workspaceId and panelId to avoid cross-suite notification interference.
- Added transaction propagation to .ghosttyDidBecomeFirstResponderSurface and covered it in the terminal first-responder regression test.

Tests:
- swift test in Packages/macOS/CmuxNotifications
- xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-issue-8843-comments -only-testing:cmuxTests/WorkspaceTerminalFocusRecoveryTests/testTerminalFirstResponderFeedbackPreservesActiveFocusTransaction build-for-testing -quiet
- ./scripts/lint-pbxproj-test-wiring.sh
- python3 scripts/check-package-resolved-policy.py
- python3 scripts/check-workspace-package-groups.py --check
- git diff --check
- ./scripts/reload.sh --tag issue-8843
- python3 scripts/swift_warning_budget.py --log /tmp/cmux-reload-issue-8843.log

Notes:
- Local app-hosted cmux-unit test execution was attempted with test-without-building; it reached Testing started and then idled waiting for Xcode workers until interrupted after 94 seconds before any assertion output. The focused build-for-testing completed successfully.

Fixes #8843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved focus broadcast coalescing to safely handle non-converging re-entrant focus loops with bounded per-turn and consecutive delivery limits.
  * Added circuit-breaker behavior with recovery to ensure controlled delivery of pending focus events.
  * Focus transactions now propagate via focusTransactionId, improving command-palette focus restore and ensuring consistent transaction scoping.
* **Diagnostics**
  * Added structured logging for circuit-breaker trip/recovery and debug visibility into bounded delivery behavior.
* **Tests**
  * Expanded coalescing and circuit-breaker regression coverage, including transaction-scoped re-entrant scenarios and ordering/bounding assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->