### PR TITLE
Fix sticky workspace identity leaking into Cmd+N

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator+DeletionConfirmation.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator+DeletionConfirmation.swift
@@ -110,7 +110,7 @@ extension WorkspaceGroupCoordinator {
                     initialBrowserTransparentBackground: false,
                     inheritWorkingDirectory: true,
                     select: true,
-                    shouldApplyWorkspaceDirectoryCustomization: true
+                    workspaceDirectoryCustomizationMode: .trackDirectory
                 )
             }
             let countBefore = model.tabs.count

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
@@ -130,7 +130,8 @@ public final class WorkspaceGroupCoordinator<Tab: WorkspaceTabRepresenting> {
         title: String? = nil,
         initialBrowserURL: URL? = nil,
         initialBrowserOmnibarVisible: Bool = true,
-        initialBrowserTransparentBackground: Bool = false, shouldApplyWorkspaceDirectoryCustomization: Bool = true
+        initialBrowserTransparentBackground: Bool = false,
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode = .trackDirectory
     ) -> Tab? {
         guard let host else { return nil }
         // nil resolves to the stored global default at call time, matching the
@@ -147,7 +148,8 @@ public final class WorkspaceGroupCoordinator<Tab: WorkspaceTabRepresenting> {
             initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
             initialBrowserTransparentBackground: initialBrowserTransparentBackground,
             inheritWorkingDirectory: cwd == nil,
-            select: select, shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+            select: select,
+            workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
         )
         model.assignGroup(workspaceId: newWorkspace.id, groupId: groupId)
         placeWithinGroup(

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupHosting.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupHosting.swift
@@ -29,7 +29,7 @@ public protocol WorkspaceGroupHosting<Tab>: WorkspaceOrderHosting {
         select: Bool
     ) -> Tab
     /// Creates a member workspace for `createWorkspaceInGroup`, preserving the
-    /// initial-surface options and sticky-customization eligibility.
+    /// initial-surface options and directory-customization tracking mode.
     func createWorkspaceForGroup(
         title: String?,
         workingDirectory: String?,
@@ -39,7 +39,7 @@ public protocol WorkspaceGroupHosting<Tab>: WorkspaceOrderHosting {
         initialBrowserTransparentBackground: Bool,
         inheritWorkingDirectory: Bool,
         select: Bool,
-        shouldApplyWorkspaceDirectoryCustomization: Bool
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode
     ) -> Tab
     /// Closes a member workspace during group deletion (legacy
     /// `closeWorkspace(_:recordHistory:)`, including its teardown chain).

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceDirectoryCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceDirectoryCustomization.swift
@@ -21,11 +21,3 @@ public struct WorkspaceDirectoryCustomization: Codable, Equatable, Sendable {
         customTitle == nil && customColor == nil
     }
 }
-
-/// How a freshly-created workspace participates in directory customization.
-public enum WorkspaceDirectoryCustomizationCreationMode: Equatable, Sendable {
-    /// Do not associate the workspace with a directory customization record.
-    case disabled
-    /// Track the workspace directory so later user title/color changes persist.
-    case trackDirectory
-}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceDirectoryCustomization.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceDirectoryCustomization.swift
@@ -21,3 +21,11 @@ public struct WorkspaceDirectoryCustomization: Codable, Equatable, Sendable {
         customTitle == nil && customColor == nil
     }
 }
+
+/// How a freshly-created workspace participates in directory customization.
+public enum WorkspaceDirectoryCustomizationCreationMode: Equatable, Sendable {
+    /// Do not associate the workspace with a directory customization record.
+    case disabled
+    /// Track the workspace directory so later user title/color changes persist.
+    case trackDirectory
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceDirectoryCustomizationCreationMode.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Customization/WorkspaceDirectoryCustomizationCreationMode.swift
@@ -1,0 +1,7 @@
+/// How a freshly-created workspace participates in directory customization.
+public enum WorkspaceDirectoryCustomizationCreationMode: Equatable, Sendable {
+    /// Do not associate the workspace with a directory customization record.
+    case disabled
+    /// Track the workspace directory so later user title/color changes persist.
+    case trackDirectory
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -69,7 +69,7 @@ final class StubGroupHost: WorkspaceGroupHosting {
         initialBrowserTransparentBackground: Bool,
         inheritWorkingDirectory: Bool,
         select: Bool,
-        shouldApplyWorkspaceDirectoryCustomization: Bool
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode
     ) -> CoordinatorStubTab {
         let tab = CoordinatorStubTab(currentDirectory: workingDirectory ?? "/tmp")
         model.tabs.append(tab)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7347,7 +7347,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             title: title,
             initialBrowserURL: url,
             initialBrowserOmnibarVisible: false,
-            initialBrowserTransparentBackground: true, shouldApplyWorkspaceDirectoryCustomization: false,
+            initialBrowserTransparentBackground: true,
+            workspaceDirectoryCustomizationMode: .disabled,
             focusInitialBrowserAddressBarOnCreate: false,
             createdWorkspaceHandler: { workspace in
                 createdWorkspace = workspace
@@ -7396,7 +7397,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         title: String? = nil,
         initialBrowserURL: URL? = nil,
         initialBrowserOmnibarVisible: Bool = true,
-        initialBrowserTransparentBackground: Bool = false, shouldApplyWorkspaceDirectoryCustomization: Bool = true,
+        initialBrowserTransparentBackground: Bool = false,
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode = .trackDirectory,
         focusInitialBrowserAddressBarOnCreate: Bool = true,
         createdWorkspaceHandler: ((Workspace) -> Void)? = nil
     ) -> Bool {
@@ -7438,8 +7440,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                         title: title,
                         initialSurface: .browser,
                         initialBrowserURL: initialBrowserURL,
-                        initialBrowserOmnibarVisible: initialBrowserOmnibarVisible, initialBrowserTransparentBackground: initialBrowserTransparentBackground,
-                        shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+                        initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
+                        initialBrowserTransparentBackground: initialBrowserTransparentBackground,
+                        workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
                     )
                     closeInitialWorkspaceIfNeeded(
                         initialWorkspaceId: initialWorkspace?.id,
@@ -7486,8 +7489,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 initialSurface: initialSurface,
                 title: title,
                 initialBrowserURL: initialBrowserURL,
-                initialBrowserOmnibarVisible: initialBrowserOmnibarVisible, initialBrowserTransparentBackground: initialBrowserTransparentBackground,
-                shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+                initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
+                initialBrowserTransparentBackground: initialBrowserTransparentBackground,
+                workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
             ) else {
                 return false
             }
@@ -7504,8 +7508,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 title: title,
                 initialSurface: initialSurface,
                 initialBrowserURL: initialBrowserURL,
-                initialBrowserOmnibarVisible: initialBrowserOmnibarVisible, initialBrowserTransparentBackground: initialBrowserTransparentBackground,
-                shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+                initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
+                initialBrowserTransparentBackground: initialBrowserTransparentBackground,
+                workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
             )
             createdWorkspaceHandler?(workspace)
             if initialSurface == .browser, focusInitialBrowserAddressBarOnCreate {
@@ -7519,7 +7524,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             initialSurface: initialSurface,
             initialBrowserURL: initialBrowserURL,
             initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
-            initialBrowserTransparentBackground: initialBrowserTransparentBackground, shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization,
+            initialBrowserTransparentBackground: initialBrowserTransparentBackground,
+            workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode,
             event: event,
             debugSource: debugSource
         ) {
@@ -8302,7 +8308,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         initialSurface: NewWorkspaceInitialSurface = .terminal,
         initialBrowserURL: URL? = nil,
         initialBrowserOmnibarVisible: Bool = true,
-        initialBrowserTransparentBackground: Bool = false, shouldApplyWorkspaceDirectoryCustomization: Bool = true,
+        initialBrowserTransparentBackground: Bool = false,
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode = .trackDirectory,
         shouldBringToFront: Bool = false,
         event: NSEvent? = nil,
         debugSource: String = "unspecified"
@@ -8357,7 +8364,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 initialBrowserURL: initialBrowserURL,
                 initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
                 initialBrowserTransparentBackground: initialBrowserTransparentBackground,
-                select: true, shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+                select: true,
+                workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
             )
         } else if workingDirectory != nil || initialTerminalInput != nil {
             workspace = context.tabManager.addWorkspace(
@@ -8365,10 +8373,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 workingDirectory: workingDirectory,
                 initialTerminalInput: initialTerminalInput,
                 select: true,
-                autoWelcomeIfNeeded: initialTerminalInput == nil, shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+                autoWelcomeIfNeeded: initialTerminalInput == nil,
+                workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
             )
         } else if title != nil {
-            workspace = context.tabManager.addWorkspace(title: title, select: true, shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization)
+            workspace = context.tabManager.addWorkspace(
+                title: title,
+                select: true,
+                workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
+            )
         } else {
             workspace = context.tabManager.addTab(select: true)
         }

--- a/Sources/CmuxConfigExecutor+WorkspaceLaunch.swift
+++ b/Sources/CmuxConfigExecutor+WorkspaceLaunch.swift
@@ -153,7 +153,7 @@ extension CmuxConfigExecutor {
             titleSource: .auto,
             workingDirectory: resolvedCwd,
             workspaceEnvironment: wsDef.env ?? [:],
-            shouldApplyWorkspaceDirectoryCustomization: false
+            workspaceDirectoryCustomizationMode: .disabled
         )
         tabManager.setCustomTitle(tabId: newWorkspace.id, title: workspaceName, source: .auto)
         if let color = wsDef.color {

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -303,7 +303,8 @@ final class RemoteTmuxController {
         let workspace = tabManager.addWorkspace(
             title: sessionName, titleSource: .auto,
             select: false,
-            autoWelcomeIfNeeded: false, shouldApplyWorkspaceDirectoryCustomization: false
+            autoWelcomeIfNeeded: false,
+            workspaceDirectoryCustomizationMode: .disabled
         )
         workspace.isRemoteTmuxMirror = true
         workspace.remoteTmuxWindowOrderSync = { [weak self, weak workspace] orderedPanelIds, verification in

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -80,7 +80,7 @@ extension TabManager {
 
             applyCreationChromeInheritance(to: newWorkspace, from: sourceWorkspace ?? capturedTabs.first)
             newWorkspace.owningTabManager = self
-            applyWorkspaceDirectoryCustomization(
+            trackWorkspaceDirectoryCustomization(
                 to: newWorkspace,
                 rootDirectory: workingDirectory,
                 explicitTitle: title,

--- a/Sources/TabManager+WorkspaceDirectoryCustomization.swift
+++ b/Sources/TabManager+WorkspaceDirectoryCustomization.swift
@@ -11,8 +11,8 @@ extension TabManager {
         )
     }
 
-    /// Applies sticky identity to a newly-created workspace. A user-owned creation title wins.
-    func applyWorkspaceDirectoryCustomization(
+    /// Tracks a fresh workspace's root so future user-owned title/color changes persist.
+    func trackWorkspaceDirectoryCustomization(
         to workspace: Workspace,
         rootDirectory: String?,
         explicitTitle: String?,
@@ -23,18 +23,6 @@ extension TabManager {
         )
         guard let directoryKey else { return }
         workspace.customizationDirectory = directoryKey
-
-        if let customization = workspaceDirectoryCustomizationStore.customization(
-            for: directoryKey
-        ) {
-            if (explicitTitle == nil || explicitTitleSource == .auto),
-               let customTitle = customization.customTitle {
-                workspace.setCustomTitle(customTitle)
-            }
-            if let customColor = customization.customColor {
-                workspace.setCustomColor(customColor)
-            }
-        }
 
         if let explicitTitle {
             workspace.setCustomTitle(explicitTitle, source: explicitTitleSource)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1111,7 +1111,7 @@ class TabManager: ObservableObject {
         autoWelcomeIfNeeded: Bool = true,
         autoRefreshMetadata: Bool = true,
         normalizeWorkspaceGroupsAfterInsert: Bool = true,
-        shouldApplyWorkspaceDirectoryCustomization: Bool = true,
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode = .trackDirectory,
         allowTextBoxFocusDefault: Bool = true
     ) -> Workspace {
         let sourceWorkspace = selectedWorkspace
@@ -1194,8 +1194,8 @@ class TabManager: ObservableObject {
                 from: sourceWorkspace ?? capturedTabs.first
             )
             newWorkspace.owningTabManager = self
-            if shouldApplyWorkspaceDirectoryCustomization {
-                applyWorkspaceDirectoryCustomization(
+            if workspaceDirectoryCustomizationMode == .trackDirectory {
+                trackWorkspaceDirectoryCustomization(
                     to: newWorkspace,
                     rootDirectory: workingDirectory,
                     explicitTitle: title,
@@ -1850,7 +1850,8 @@ class TabManager: ObservableObject {
         title: String? = nil,
         initialBrowserURL: URL? = nil,
         initialBrowserOmnibarVisible: Bool = true,
-        initialBrowserTransparentBackground: Bool = false, shouldApplyWorkspaceDirectoryCustomization: Bool = true
+        initialBrowserTransparentBackground: Bool = false,
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode = .trackDirectory
     ) -> Workspace? {
         workspaceGrouping.createWorkspaceInGroup(
             groupId: groupId,
@@ -1861,7 +1862,8 @@ class TabManager: ObservableObject {
             title: title,
             initialBrowserURL: initialBrowserURL,
             initialBrowserOmnibarVisible: initialBrowserOmnibarVisible,
-            initialBrowserTransparentBackground: initialBrowserTransparentBackground, shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+            initialBrowserTransparentBackground: initialBrowserTransparentBackground,
+            workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
         )
     }
 
@@ -1962,7 +1964,8 @@ class TabManager: ObservableObject {
         initialBrowserOmnibarVisible: Bool,
         initialBrowserTransparentBackground: Bool,
         inheritWorkingDirectory: Bool,
-        select: Bool, shouldApplyWorkspaceDirectoryCustomization: Bool
+        select: Bool,
+        workspaceDirectoryCustomizationMode: WorkspaceDirectoryCustomizationCreationMode
     ) -> Workspace {
         addWorkspace(
             title: title,
@@ -1973,7 +1976,8 @@ class TabManager: ObservableObject {
             initialBrowserTransparentBackground: initialBrowserTransparentBackground,
             inheritWorkingDirectory: inheritWorkingDirectory,
             select: select,
-            autoWelcomeIfNeeded: false, shouldApplyWorkspaceDirectoryCustomization: shouldApplyWorkspaceDirectoryCustomization
+            autoWelcomeIfNeeded: false,
+            workspaceDirectoryCustomizationMode: workspaceDirectoryCustomizationMode
         )
     }
 
@@ -4185,7 +4189,7 @@ class TabManager: ObservableObject {
             workingDirectory: entry.snapshot.currentDirectory,
             select: false,
             autoWelcomeIfNeeded: false,
-            shouldApplyWorkspaceDirectoryCustomization: false
+            workspaceDirectoryCustomizationMode: .disabled
         )
         let restoredPanelIds = workspace.restoreSessionSnapshot(entry.snapshot, excludingStableIdentities: excludedStableIdentities)
         guard !entry.snapshot.hasRestorablePanels || !restoredPanelIds.isEmpty else {
@@ -6060,7 +6064,7 @@ extension TabManager {
                 nativeSSHConnectionBroker: nativeSSHConnectionBroker
             )
             fallback.owningTabManager = self
-            applyWorkspaceDirectoryCustomization(to: fallback, rootDirectory: nil, explicitTitle: nil, explicitTitleSource: .auto)
+            trackWorkspaceDirectoryCustomization(to: fallback, rootDirectory: nil, explicitTitle: nil, explicitTitleSource: .auto)
             wireClosedBrowserTracking(for: fallback)
             newTabs.append(fallback)
         }

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -268,7 +268,18 @@ struct WorkspaceRecoveryTests {
         var snapshot = try #require(sourceManager.selectedWorkspace).sessionSnapshot(includeScrollback: false)
         snapshot.customTitle = "Failed Restore Label"
         snapshot.customTitleSource = .user
-        snapshot.panels = []
+        var panelSnapshot = try #require(snapshot.panels.first)
+        panelSnapshot.type = .markdown
+        panelSnapshot.terminal = nil
+        panelSnapshot.browser = nil
+        panelSnapshot.markdown = nil
+        panelSnapshot.filePreview = nil
+        panelSnapshot.rightSidebarTool = nil
+        snapshot.panels = [panelSnapshot]
+        snapshot.layout = .pane(SessionPaneLayoutSnapshot(
+            panelIds: [panelSnapshot.id],
+            selectedPanelId: panelSnapshot.id
+        ))
         let entry = ClosedWorkspaceHistoryEntry(
             workspaceId: UUID(),
             windowId: nil,

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -319,6 +319,58 @@ struct WorkspaceRecoveryTests {
     }
 
     @Test
+    func freshWorkspaceCreationDoesNotAdoptStickyDirectoryIdentityFromInheritedCwd() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appending(path: "cmux-sticky-cmdn-\(UUID().uuidString)", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let directory = directoryURL.path
+        let fixture = try makeCustomizationStore()
+        defer { fixture.defaults.removePersistentDomain(forName: fixture.suiteName) }
+        let store = fixture.store
+        let manager = TabManager(
+            initialWorkingDirectory: directory,
+            autoWelcomeIfNeeded: false,
+            workspaceDirectoryCustomizationStore: store
+        )
+        let sourceWorkspace = try #require(manager.selectedWorkspace)
+
+        #expect(manager.setCustomTitle(
+            tabId: sourceWorkspace.id,
+            title: "MY WORKSPACE"
+        ))
+        manager.applyWorkspaceColor(
+            "#AABBCC",
+            toWorkspaceIds: [sourceWorkspace.id]
+        )
+        #expect(
+            store.customization(for: directory) ==
+                WorkspaceDirectoryCustomization(
+                    customTitle: "MY WORKSPACE",
+                    customColor: "#AABBCC"
+                )
+        )
+
+        let generated = manager.addWorkspace(select: false)
+        #expect(generated.title == "Terminal 2")
+        #expect(generated.currentDirectory == directory)
+        #expect(generated.customTitle == nil)
+        #expect(generated.customColor == nil)
+
+        let explicitlyNamed = manager.addWorkspace(
+            title: "Explicit Fresh",
+            workingDirectory: directory,
+            inheritWorkingDirectory: false,
+            select: false
+        )
+        #expect(explicitlyNamed.customTitle == "Explicit Fresh")
+        #expect(explicitlyNamed.customColor == nil)
+    }
+
+    @Test
     func createRenameAndColorChangesShareOneStickyDirectoryRecord() throws {
         let directory = "/tmp/sticky-project"
         let fixture = try makeCustomizationStore()

--- a/cmuxTests/WorkspaceRecoveryTests.swift
+++ b/cmuxTests/WorkspaceRecoveryTests.swift
@@ -254,7 +254,7 @@ struct WorkspaceRecoveryTests {
             workingDirectory: directory,
             select: false
         )
-        #expect(generated.customTitle == "Sticky Label")
+        #expect(generated.customTitle == "Generated Title")
         #expect(fixture.store.customization(for: directory)?.customTitle == "Sticky Label")
     }
     @Test
@@ -282,13 +282,20 @@ struct WorkspaceRecoveryTests {
 
         #expect(!destinationManager.restoreClosedWorkspace(entry))
         #expect(fixture.store.customization(for: directory)?.customTitle == "Existing Label")
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        fixture.store.setCustomTitle("Home Label", for: home)
-        let rootlessManager = TabManager(autoWelcomeIfNeeded: false, workspaceDirectoryCustomizationStore: fixture.store)
+        let defaultDirectory = "/tmp/failed-history-default-root"
+        fixture.store.setCustomTitle("Home Label", for: defaultDirectory)
+        let rootlessManager = TabManager(
+            autoWelcomeIfNeeded: false,
+            defaultWorkspaceWorkingDirectoryProvider: { defaultDirectory },
+            workspaceDirectoryCustomizationStore: fixture.store
+        )
         let rootlessWorkspace = try #require(rootlessManager.selectedWorkspace)
         #expect(rootlessWorkspace.customTitle == nil)
         rootlessManager.setTabColor(tabId: rootlessWorkspace.id, color: "#123456")
-        #expect(fixture.store.customization(for: home) == WorkspaceDirectoryCustomization(customTitle: "Home Label", customColor: nil))
+        #expect(
+            fixture.store.customization(for: defaultDirectory) ==
+                WorkspaceDirectoryCustomization(customTitle: "Home Label", customColor: "#123456")
+        )
     }
 
     @Test
@@ -385,8 +392,9 @@ struct WorkspaceRecoveryTests {
             workspaceDirectoryCustomizationStore: store
         )
         let firstWorkspace = try #require(firstManager.selectedWorkspace)
-        #expect(firstWorkspace.customTitle == "Original Label")
-        #expect(firstWorkspace.customColor == "#112233")
+        #expect(firstWorkspace.customTitle == nil)
+        #expect(firstWorkspace.customColor == nil)
+        #expect(firstWorkspace.customizationDirectory == store.directoryKey(for: directory))
 
         firstWorkspace.currentDirectory = "/tmp/sticky-project/subdirectory"
         #expect(firstManager.setCustomTitle(
@@ -394,12 +402,25 @@ struct WorkspaceRecoveryTests {
             title: "Renamed Label"
         ))
         firstManager.setTabColor(tabId: firstWorkspace.id, color: "#AABBCC")
+        #expect(
+            store.customization(for: directory) ==
+                WorkspaceDirectoryCustomization(
+                    customTitle: "Renamed Label",
+                    customColor: "#AABBCC"
+                )
+        )
+        var staleSnapshot = firstWorkspace.sessionSnapshot(includeScrollback: false)
+        staleSnapshot.customTitle = "Stale Snapshot Label"
+        staleSnapshot.customColor = "#112233"
 
         let secondManager = TabManager(
-            initialWorkingDirectory: directory,
             autoWelcomeIfNeeded: false,
             workspaceDirectoryCustomizationStore: store
         )
+        secondManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [staleSnapshot]
+        ))
         let secondWorkspace = try #require(secondManager.selectedWorkspace)
         #expect(secondWorkspace.customTitle == "Renamed Label")
         #expect(secondWorkspace.customColor == "#AABBCC")
@@ -413,6 +434,10 @@ struct WorkspaceRecoveryTests {
             autoWelcomeIfNeeded: false,
             workspaceDirectoryCustomizationStore: store
         )
+        clearedManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [secondWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
         let clearedWorkspace = try #require(clearedManager.selectedWorkspace)
         #expect(clearedWorkspace.customTitle == nil)
         #expect(clearedWorkspace.customColor == nil)
@@ -423,10 +448,13 @@ struct WorkspaceRecoveryTests {
             source: .auto
         ))
         let afterAutomaticRename = TabManager(
-            initialWorkingDirectory: directory,
             autoWelcomeIfNeeded: false,
             workspaceDirectoryCustomizationStore: store
         )
+        afterAutomaticRename.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [clearedWorkspace.sessionSnapshot(includeScrollback: false)]
+        ))
         #expect(afterAutomaticRename.selectedWorkspace?.customTitle == nil)
     }
 
@@ -508,13 +536,23 @@ struct WorkspaceRecoveryTests {
             select: false
         )
         #expect(explicitlyNamed.customTitle == "CLI Label")
-        #expect(explicitlyNamed.customColor == "#445566")
+        #expect(explicitlyNamed.customColor == nil)
+        #expect(
+            store.customization(for: directory) ==
+                WorkspaceDirectoryCustomization(
+                    customTitle: "CLI Label",
+                    customColor: "#445566"
+                )
+        )
 
         let laterManager = TabManager(
-            initialWorkingDirectory: directory,
             autoWelcomeIfNeeded: false,
             workspaceDirectoryCustomizationStore: store
         )
+        laterManager.restoreSessionSnapshot(SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: 0,
+            workspaces: [explicitlyNamed.sessionSnapshot(includeScrollback: false)]
+        ))
         #expect(laterManager.selectedWorkspace?.customTitle == "CLI Label")
         #expect(laterManager.selectedWorkspace?.customColor == "#445566")
     }


### PR DESCRIPTION
## Summary
- add a regression test for fresh workspace creation inheriting cwd without inheriting sticky title/color
- split fresh directory tracking from restore/recovery sticky identity application
- keep restore/recovery reconciliation as the only path that reads stored directory customizations

## Verification
- ./scripts/reload.sh --tag issue-9027-sticky-cmdn
- swift test --package-path Packages/macOS/CmuxWorkspaces
- ./scripts/lint-pbxproj-test-wiring.sh
- python3 scripts/swift_warning_budget.py --log /tmp/cmux-reload-issue-9027-sticky-cmdn.log

Fixes #9027

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787809500&installation_model_id=21920&pr_number=9031&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9031&signature=34e8649f3c3ae53ebab43b810d5e42bc7336c45068c66e6e8f385df83e02b848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent sticky directory identity (title/color) from leaking into new workspaces (e.g., Cmd+N). New workspaces can inherit the CWD but start with a clean title and color; only restore/recovery reads and applies saved customizations. Fixes #9027.

- **Bug Fixes**
  - Fresh workspaces now only track their directory; they do not read stored title/color.
  - Restore/recovery is the sole path that reads and applies saved customizations, overriding stale snapshot values.
  - Added regression coverage for Cmd+N inheritance and made the failed-restore customization test deterministic.

- **Refactors**
  - Replaced `shouldApplyWorkspaceDirectoryCustomization` with `WorkspaceDirectoryCustomizationCreationMode` (`.disabled` | `.trackDirectory`) and moved it to its own file.
  - Renamed `applyWorkspaceDirectoryCustomization` to `trackWorkspaceDirectoryCustomization`.
  - Updated creation APIs and `WorkspaceGroupHosting` to use the new mode; default is `.trackDirectory`, with `.disabled` used for remote tmux and config-driven launches.

<sup>Written for commit 1d3d90e641291634ca9ce0de4640a8db1b8e7fda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added directory customization creation modes for new workspaces (enabled via a new mode enum).
  * Workspaces can now track their directory for persistent title/color changes, or opt out when appropriate.
* **Bug Fixes**
  * Fixed cases where newly created or restored workspaces could incorrectly inherit previously stored directory titles and colors.
  * Improved consistency of customization behavior across workspace creation paths (including restore/remote mirror scenarios).
* **Tests**
  * Updated and expanded workspace recovery coverage to match the new mode-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->