### PR TITLE
iOS: preserve terminal scroll position across mid-stream verified replays

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -200,7 +200,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         private var composerMounted = false
         private var activeViewportPolicy: MobileTerminalOutputViewportPolicy = .natural
         private let verifiedReplayState = VerifiedTerminalReplayStateMachine()
-        private var pendingReplayViewportAnchor: VerifiedReplayViewportAnchor?
+        private var pendingReplayViewportAnchor: VerifiedReplayCapturedViewportAnchor?
         /// Serializes the natural-grid viewport reports and their echoes. One
         /// detached Task per report (the previous shape) let Task scheduling
         /// scramble the send order AND let the echo of an old keyboard-up
@@ -499,7 +499,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             let capturedViewportAnchor =
                 await surfaceView.captureVerifiedReplayViewportAnchor()
             guard !Task.isCancelled else { return }
-            let replayViewportAnchor: VerifiedReplayViewportAnchor?
+            let replayViewportAnchor: VerifiedReplayCapturedViewportAnchor?
             if frame.anchor == .screen, frame.activeScreen == .primary {
                 if let capturedViewportAnchor {
                     pendingReplayViewportAnchor = capturedViewportAnchor
@@ -577,7 +577,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         private func finishVerifiedReplay(
             transactionID: UInt64,
             observed: MobileTerminalRenderGridFrame?,
-            viewportAnchor: VerifiedReplayViewportAnchor?,
+            viewportAnchor: VerifiedReplayCapturedViewportAnchor?,
             chunk: MobileTerminalOutputChunk,
             surfaceView: GhosttySurfaceView,
             store: CMUXMobileShellStore

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -200,6 +200,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         private var composerMounted = false
         private var activeViewportPolicy: MobileTerminalOutputViewportPolicy = .natural
         private let verifiedReplayState = VerifiedTerminalReplayStateMachine()
+        private var pendingReplayViewportAnchor: VerifiedReplayViewportAnchor?
         /// Serializes the natural-grid viewport reports and their echoes. One
         /// detached Task per report (the previous shape) let Task scheduling
         /// scramble the send order AND let the echo of an old keyboard-up
@@ -427,6 +428,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             outputTask?.cancel()
             outputTask = nil
             verifiedReplayState.invalidate()
+            pendingReplayViewportAnchor = nil
             liveFontTask?.cancel()
             liveFontTask = nil
             viewportReportScheduler?.cancel()
@@ -494,6 +496,20 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 return
             }
 
+            let capturedViewportAnchor =
+                await surfaceView.captureVerifiedReplayViewportAnchor()
+            guard !Task.isCancelled else { return }
+            let replayViewportAnchor: VerifiedReplayViewportAnchor?
+            if frame.anchor == .screen, frame.activeScreen == .primary {
+                if let capturedViewportAnchor {
+                    pendingReplayViewportAnchor = capturedViewportAnchor
+                }
+                replayViewportAnchor = pendingReplayViewportAnchor
+            } else {
+                pendingReplayViewportAnchor = nil
+                replayViewportAnchor = nil
+            }
+
             let frozen = await surfaceView.freezeVerifiedReplayPresentation(
                 transactionID: transaction.id
             )
@@ -531,9 +547,10 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                     ?? surfaceView.terminalConfigTheme.cursor
             )
             guard !Task.isCancelled else { return }
-            finishVerifiedReplay(
+            await finishVerifiedReplay(
                 transactionID: transaction.id,
                 observed: observed,
+                viewportAnchor: replayViewportAnchor,
                 chunk: chunk,
                 surfaceView: surfaceView,
                 store: store
@@ -560,10 +577,11 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         private func finishVerifiedReplay(
             transactionID: UInt64,
             observed: MobileTerminalRenderGridFrame?,
+            viewportAnchor: VerifiedReplayViewportAnchor?,
             chunk: MobileTerminalOutputChunk,
             surfaceView: GhosttySurfaceView,
             store: CMUXMobileShellStore
-        ) {
+        ) async {
             switch verifiedReplayState.complete(
                 transactionID: transactionID,
                 observedFrame: observed
@@ -578,6 +596,14 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                         streamToken: chunk.streamToken
                     )
                     return
+                }
+                // The ready fence is tied to the exact verification render.
+                // Re-presenting a restored viewport before reveal would replace
+                // that renderer identity and can keep the replay frozen forever.
+                // Reveal first, then let the normal draw pump render the restore.
+                if let viewportAnchor,
+                   await surfaceView.restoreVerifiedReplayViewportAnchor(viewportAnchor) {
+                    pendingReplayViewportAnchor = nil
                 }
                 store.terminalOutputDidProcess(
                     surfaceID: surfaceID,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -587,6 +587,19 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 observedFrame: observed
             ) {
             case .reveal:
+                if let viewportAnchor {
+                    let restored = await surfaceView.restoreVerifiedReplayViewportAnchor(
+                        viewportAnchor
+                    )
+                    guard !Task.isCancelled else { return }
+                    if restored {
+                        pendingReplayViewportAnchor = nil
+                        // Restore and re-fence happen under render suppression,
+                        // so the renderer identity cannot change before reveal.
+                        _ = await surfaceView.presentRestoredVerifiedReplayViewport()
+                        guard !Task.isCancelled else { return }
+                    }
+                }
                 guard surfaceView.revealVerifiedReplayPresentation(
                     transactionID: transactionID
                 ) else {
@@ -596,14 +609,6 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                         streamToken: chunk.streamToken
                     )
                     return
-                }
-                // The ready fence is tied to the exact verification render.
-                // Re-presenting a restored viewport before reveal would replace
-                // that renderer identity and can keep the replay frozen forever.
-                // Reveal first, then let the normal draw pump render the restore.
-                if let viewportAnchor,
-                   await surfaceView.restoreVerifiedReplayViewportAnchor(viewportAnchor) {
-                    pendingReplayViewportAnchor = nil
                 }
                 store.terminalOutputDidProcess(
                     surfaceID: surfaceID,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -496,20 +496,6 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                 return
             }
 
-            let capturedViewportAnchor =
-                await surfaceView.captureVerifiedReplayViewportAnchor()
-            guard !Task.isCancelled else { return }
-            let replayViewportAnchor: VerifiedReplayCapturedViewportAnchor?
-            if frame.anchor == .screen, frame.activeScreen == .primary {
-                if let capturedViewportAnchor {
-                    pendingReplayViewportAnchor = capturedViewportAnchor
-                }
-                replayViewportAnchor = pendingReplayViewportAnchor
-            } else {
-                pendingReplayViewportAnchor = nil
-                replayViewportAnchor = nil
-            }
-
             let frozen = await surfaceView.freezeVerifiedReplayPresentation(
                 transactionID: transaction.id
             )
@@ -527,6 +513,22 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             guard resized else {
                 requestVerifiedReplayReset(transactionID: transaction.id, chunk: chunk, store: store)
                 return
+            }
+
+            // Capture reads the post-reflow scrollbar, so Ghostty's resize pin
+            // remap is authoritative and anchor math never sees reflow as append drift.
+            let capturedViewportAnchor =
+                await surfaceView.captureVerifiedReplayViewportAnchor()
+            guard !Task.isCancelled else { return }
+            let replayViewportAnchor: VerifiedReplayCapturedViewportAnchor?
+            if frame.anchor == .screen, frame.activeScreen == .primary {
+                if let capturedViewportAnchor {
+                    pendingReplayViewportAnchor = capturedViewportAnchor
+                }
+                replayViewportAnchor = pendingReplayViewportAnchor
+            } else {
+                pendingReplayViewportAnchor = nil
+                replayViewportAnchor = nil
             }
 
             if !chunk.data.isEmpty || chunk.terminalConfigTheme != nil {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
@@ -9,19 +9,47 @@ extension GhosttySurfaceView {
     /// screens libghostty turns this into mouse-wheel bytes; the mirror is
     /// display-only and drops those bytes, so the authoritative Mac response
     /// remains the visible update for TUIs.
+    ///
+    /// The flush-site generation bump happens on the main actor before this
+    /// enqueue. Because restore claims and user viewport mutations share
+    /// `outputQueue`, FIFO ordering makes a pre-restore gesture visible to the
+    /// claim and applies a post-restore gesture afterward; no gate lock spans a
+    /// Ghostty call, and scrolling never takes Ghostty locks on the main actor.
     func applyLocalScrollbackScroll(lines: Double, col: Int, row: Int) {
         guard lines != 0, let surface else { return }
         let displayScale = window?.windowScene?.screen.scale ?? traitCollection.displayScale
-        let scale = max(Double(displayScale), 1)
-        let size = ghostty_surface_size(surface)
-        let cellWidthPt = max(Double(size.cell_width_px) / scale, 1)
-        let cellHeightPt = max(Double(size.cell_height_px) / scale, 1)
-        let posX = (Double(max(0, col)) + 0.5) * cellWidthPt
-        let posY = (Double(max(0, row)) + 0.5) * cellHeightPt
-        ghostty_surface_mouse_pos(surface, posX, posY, GHOSTTY_MODS_NONE)
-        ghostty_surface_mouse_scroll(surface, 0, lines, 0)
-        drawForWakeup()
-        scheduleVisibleArtifactCountUpdate()
+        let operation = LocalScrollbackSurfaceOperation(
+            surface: surface,
+            generation: surfaceGeneration
+        )
+        let workQueue = outputQueue
+        workQueue.async { [weak self] in
+            let scale = max(Double(displayScale), 1)
+            let size = ghostty_surface_size(operation.surface)
+            let cellWidthPt = max(Double(size.cell_width_px) / scale, 1)
+            let cellHeightPt = max(Double(size.cell_height_px) / scale, 1)
+            let posX = (Double(max(0, col)) + 0.5) * cellWidthPt
+            let posY = (Double(max(0, row)) + 0.5) * cellHeightPt
+            ghostty_surface_mouse_pos(operation.surface, posX, posY, GHOSTTY_MODS_NONE)
+            ghostty_surface_mouse_scroll(operation.surface, 0, lines, 0)
+            Task { @MainActor [weak self] in
+                guard let self,
+                      self.surface == operation.surface,
+                      self.surfaceGeneration == operation.generation else {
+                    return
+                }
+                self.drawForWakeup()
+                self.scheduleVisibleArtifactCountUpdate()
+            }
+        }
     }
+}
+
+/// One generation-bound pointer used only on its serial Ghostty surface queue.
+private nonisolated struct LocalScrollbackSurfaceOperation: @unchecked Sendable {
+    // Safety: the surface stays owned by GhosttySurfaceView, and every C call
+    // using this pointer is enqueued on that generation's serial output queue.
+    let surface: ghostty_surface_t
+    let generation: UInt64
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+LocalScrollbackScroll.swift
@@ -11,35 +11,62 @@ extension GhosttySurfaceView {
     /// remains the visible update for TUIs.
     ///
     /// The flush-site generation bump happens on the main actor before this
-    /// enqueue. Because restore claims and user viewport mutations share
-    /// `outputQueue`, FIFO ordering makes a pre-restore gesture visible to the
-    /// claim and applies a post-restore gesture afterward; no gate lock spans a
-    /// Ghostty call, and scrolling never takes Ghostty locks on the main actor.
+    /// enqueue. Restore claims and user viewport batches share `outputQueue`, so
+    /// FIFO ordering makes a pre-restore gesture visible to the claim and applies
+    /// a post-restore gesture afterward. Deltas accumulated during an in-flight
+    /// batch apply as one follow-up batch; obsolete intermediate deltas are
+    /// merged, never replayed. No gate lock spans a Ghostty call, and scrolling
+    /// never takes Ghostty locks on the main actor.
     func applyLocalScrollbackScroll(lines: Double, col: Int, row: Int) {
-        guard lines != 0, let surface else { return }
+        guard lines != 0 else { return }
+        pendingLocalScrollLines += lines
+        pendingLocalScrollCell = (col, row)
+        pumpLocalScrollbackScroll()
+    }
+
+    private func pumpLocalScrollbackScroll() {
+        guard !localScrollApplyInFlight,
+              pendingLocalScrollLines != 0,
+              let surface else {
+            return
+        }
+        let lines = pendingLocalScrollLines
+        let cell = pendingLocalScrollCell
+        pendingLocalScrollLines = 0
+        let interactionGeneration = viewportRestoreGate.withLock { $0.interactionGeneration }
+        localScrollApplyInFlight = true
         let displayScale = window?.windowScene?.screen.scale ?? traitCollection.displayScale
         let operation = LocalScrollbackSurfaceOperation(
             surface: surface,
             generation: surfaceGeneration
         )
         let workQueue = outputQueue
+        let gate = viewportRestoreGate
         workQueue.async { [weak self] in
             let scale = max(Double(displayScale), 1)
             let size = ghostty_surface_size(operation.surface)
             let cellWidthPt = max(Double(size.cell_width_px) / scale, 1)
             let cellHeightPt = max(Double(size.cell_height_px) / scale, 1)
-            let posX = (Double(max(0, col)) + 0.5) * cellWidthPt
-            let posY = (Double(max(0, row)) + 0.5) * cellHeightPt
+            let posX = (Double(max(0, cell.col)) + 0.5) * cellWidthPt
+            let posY = (Double(max(0, cell.row)) + 0.5) * cellHeightPt
             ghostty_surface_mouse_pos(operation.surface, posX, posY, GHOSTTY_MODS_NONE)
             ghostty_surface_mouse_scroll(operation.surface, 0, lines, 0)
+            gate.withLock {
+                $0.appliedInteractionGeneration = max(
+                    $0.appliedInteractionGeneration,
+                    interactionGeneration
+                )
+            }
             Task { @MainActor [weak self] in
-                guard let self,
-                      self.surface == operation.surface,
+                guard let self else { return }
+                self.localScrollApplyInFlight = false
+                guard self.surface == operation.surface,
                       self.surfaceGeneration == operation.generation else {
                     return
                 }
                 self.drawForWakeup()
                 self.scheduleVisibleArtifactCountUpdate()
+                self.pumpLocalScrollbackScroll()
             }
         }
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
@@ -55,6 +55,7 @@ extension GhosttySurfaceView {
         if let pending = pendingVerifiedReplayViewportAnchorRestore,
            now - pending.startedAt >= Self.visibleSnapshotTimeout {
             pendingVerifiedReplayViewportAnchorRestore = nil
+            viewportRestoreGate.withLock { $0.activeRestoreTicket = nil }
             pending.continuation.resume(returning: false)
         }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
@@ -44,6 +44,20 @@ extension GhosttySurfaceView {
             pending.continuation.resume(returning: nil)
         }
 
+        // Viewport anchoring is best-effort; a timeout must not replace an
+        // otherwise healthy surface or turn replay into another recovery loop.
+        if let pending = pendingVerifiedReplayViewportAnchorCapture,
+           now - pending.startedAt >= Self.visibleSnapshotTimeout {
+            pendingVerifiedReplayViewportAnchorCapture = nil
+            pending.continuation.resume(returning: nil)
+        }
+
+        if let pending = pendingVerifiedReplayViewportAnchorRestore,
+           now - pending.startedAt >= Self.visibleSnapshotTimeout {
+            pendingVerifiedReplayViewportAnchorRestore = nil
+            pending.continuation.resume(returning: false)
+        }
+
         if let pending = pendingCopyableTextRead,
            now - pending.startedAt >= Self.copyableTextTimeout {
             pendingCopyableTextRead = nil

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+RenderRecovery.swift
@@ -251,6 +251,7 @@ extension GhosttySurfaceView {
         surfaceGeneration &+= 1
         outputQueueGeneration &+= 1
         outputQueue = GhosttySurfaceWorkQueue(generation: outputQueueGeneration)
+        resetScrollStateForSurfaceReplacement()
         scrollToBottomInFlight = false
         bridge = GhosttySurfaceBridge()
         bridge.attach(to: self)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -28,17 +28,12 @@ extension GhosttySurfaceView {
             workQueue.async {
                 var scrollbar = ghostty_surface_scrollbar_s()
                 let anchor: VerifiedReplayViewportAnchor?
-                if ghostty_surface_scrollbar(operation.surface, &scrollbar),
-                   scrollbar.offset < scrollbar.total {
-                    let rowsAfterOffset = scrollbar.total - scrollbar.offset
-                    if scrollbar.len < rowsAfterOffset {
-                        anchor = VerifiedReplayViewportAnchor(
-                            rowsFromBottom: rowsAfterOffset - scrollbar.len,
-                            totalRows: scrollbar.total
-                        )
-                    } else {
-                        anchor = nil
-                    }
+                if ghostty_surface_scrollbar(operation.surface, &scrollbar) {
+                    anchor = VerifiedReplayViewportAnchor(
+                        scrollbarTotal: scrollbar.total,
+                        offset: scrollbar.offset,
+                        len: scrollbar.len
+                    )
                 } else {
                     anchor = nil
                 }
@@ -94,7 +89,7 @@ extension GhosttySurfaceView {
                 } ?? false
                 if readPostReplay {
                     MobileDebugLog.anchormux(
-                        "verified_replay.viewport_restore preTotal=\(anchor.totalRows) preRowsFromBottom=\(anchor.rowsFromBottom) postTotal=\(postReplay.total) postOffset=\(postReplay.offset) postLen=\(postReplay.len) targetTop=\(targetTopRow.map(String.init) ?? "nil") restored=\(restored)"
+                        "verified_replay.viewport_restore preTotal=\(anchor.totalRows) preTopDistance=\(anchor.topRowDistanceFromBottom) postTotal=\(postReplay.total) postOffset=\(postReplay.offset) postLen=\(postReplay.len) targetTop=\(targetTopRow.map(String.init) ?? "nil") restored=\(restored)"
                     )
                 }
                 Task { @MainActor [weak self] in

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -14,6 +14,107 @@ extension GhosttySurfaceView {
         hasPresentedContents
     }
 
+    /// Captures a content-relative viewport anchor on the serial surface queue.
+    ///
+    /// - Returns: The anchor when the viewport is above bottom; otherwise `nil`.
+    public func captureVerifiedReplayViewportAnchor() async -> VerifiedReplayViewportAnchor? {
+        guard let surface, !isDismantled else { return nil }
+        let operation = VerifiedReplayViewportSurfaceOperation(
+            surface: surface,
+            generation: surfaceGeneration
+        )
+        let workQueue = outputQueue
+        return await withCheckedContinuation { continuation in
+            workQueue.async {
+                var scrollbar = ghostty_surface_scrollbar_s()
+                let anchor: VerifiedReplayViewportAnchor?
+                if ghostty_surface_scrollbar(operation.surface, &scrollbar),
+                   scrollbar.offset < scrollbar.total {
+                    let rowsAfterOffset = scrollbar.total - scrollbar.offset
+                    if scrollbar.len < rowsAfterOffset {
+                        anchor = VerifiedReplayViewportAnchor(
+                            rowsFromBottom: rowsAfterOffset - scrollbar.len,
+                            totalRows: scrollbar.total
+                        )
+                    } else {
+                        anchor = nil
+                    }
+                } else {
+                    anchor = nil
+                }
+                Task { @MainActor [weak self] in
+                    guard let self,
+                          self.surface == operation.surface,
+                          self.surfaceGeneration == operation.generation,
+                          !self.isDismantled else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    continuation.resume(returning: anchor)
+                }
+            }
+        }
+    }
+
+    /// Restores a verified-replay viewport anchor on the serial surface queue.
+    ///
+    /// - Parameter anchor: The content-relative position captured before replay.
+    /// - Returns: `true` when Ghostty accepted the revision-matched target row.
+    @discardableResult
+    public func restoreVerifiedReplayViewportAnchor(
+        _ anchor: VerifiedReplayViewportAnchor
+    ) async -> Bool {
+        guard let surface, !isDismantled else { return false }
+        let operation = VerifiedReplayViewportSurfaceOperation(
+            surface: surface,
+            generation: surfaceGeneration
+        )
+        let workQueue = outputQueue
+        return await withCheckedContinuation { continuation in
+            workQueue.async {
+                var postReplay = ghostty_surface_scrollbar_s()
+                let readPostReplay = ghostty_surface_scrollbar(
+                    operation.surface,
+                    &postReplay
+                )
+                let targetTopRow = readPostReplay
+                    ? anchor.targetTopRow(
+                        postReplayTotalRows: postReplay.total,
+                        postReplayVisibleRows: postReplay.len
+                    )
+                    : nil
+                var restoredScrollbar = ghostty_surface_scrollbar_s()
+                let restored = targetTopRow.map {
+                    ghostty_surface_scroll_to_row_if_revision(
+                        operation.surface,
+                        $0,
+                        postReplay.row_space_revision,
+                        &restoredScrollbar
+                    )
+                } ?? false
+                if readPostReplay {
+                    MobileDebugLog.anchormux(
+                        "verified_replay.viewport_restore preTotal=\(anchor.totalRows) preRowsFromBottom=\(anchor.rowsFromBottom) postTotal=\(postReplay.total) postOffset=\(postReplay.offset) postLen=\(postReplay.len) targetTop=\(targetTopRow.map(String.init) ?? "nil") restored=\(restored)"
+                    )
+                }
+                Task { @MainActor [weak self] in
+                    guard let self,
+                          self.surface == operation.surface,
+                          self.surfaceGeneration == operation.generation,
+                          !self.isDismantled else {
+                        continuation.resume(returning: false)
+                        return
+                    }
+                    if restored {
+                        self.needsDraw = true
+                        self.scheduleVisibleArtifactCountUpdate()
+                    }
+                    continuation.resume(returning: restored)
+                }
+            }
+        }
+    }
+
     /// Retains an immutable copy of the last presented pixels and cursor above
     /// the live renderer while a replacement grid is replayed and verified.
     @discardableResult
@@ -330,5 +431,13 @@ extension GhosttySurfaceView {
         )
     }
 
+}
+
+/// One generation-bound pointer used only on its serial Ghostty surface queue.
+private nonisolated struct VerifiedReplayViewportSurfaceOperation: @unchecked Sendable {
+    // Safety: the surface stays owned by GhosttySurfaceView, and every C call
+    // using this pointer is enqueued on that generation's serial output queue.
+    let surface: ghostty_surface_t
+    let generation: UInt64
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -115,22 +115,27 @@ extension GhosttySurfaceView {
                         postReplayVisibleRows: postReplay.len
                     )
                     : nil
-                var restoredScrollbar = ghostty_surface_scrollbar_s()
-                let restored: Bool
-                if clock.withLock({ $0 }) != captured.interactionGeneration {
-                    MobileDebugLog.anchormux(
-                        "verified_replay.viewport_restore.skipped reason=user_interaction_late"
-                    )
-                    restored = false
-                } else {
-                    restored = targetTopRow.map {
+                let postReplayRevision = postReplay.row_space_revision
+                let restored = clock.withLock { generation -> Bool in
+                    guard generation == captured.interactionGeneration else {
+                        return false
+                    }
+                    var restoredScrollbar = ghostty_surface_scrollbar_s()
+                    return targetTopRow.map {
                         ghostty_surface_scroll_to_row_if_revision(
                             operation.surface,
                             $0,
-                            postReplay.row_space_revision,
+                            postReplayRevision,
                             &restoredScrollbar
                         )
                     } ?? false
+                }
+                if !restored,
+                   targetTopRow != nil,
+                   clock.withLock({ $0 }) != captured.interactionGeneration {
+                    MobileDebugLog.anchormux(
+                        "verified_replay.viewport_restore.skipped reason=user_interaction_late"
+                    )
                 }
                 if readPostReplay {
                     MobileDebugLog.anchormux(
@@ -297,6 +302,23 @@ extension GhosttySurfaceView {
         // zero-sized first target is correctly rejected by its size guard.
         guard !Task.isCancelled, !isDismantled, window != nil else { return nil }
         return makeVerifiedReplayBlankFrozenPresentation()
+    }
+
+    /// Renders the just-restored viewport behind the frozen presentation
+    /// and re-arms the ready fence to that frame, so reveal exposes the
+    /// restored position instead of the replay's bottom reset. Render
+    /// suppression is still active here, so no other frame can replace the
+    /// renderer identity between this present and the reveal.
+    @discardableResult
+    public func presentRestoredVerifiedReplayViewport() async -> Bool {
+        guard verifiedReplayFrozenTransactionID != nil,
+              verifiedReplayReadyTransactionID == verifiedReplayFrozenTransactionID else {
+            return false
+        }
+        return await submitVerifiedReplayRenderAndWait(
+            read: nil,
+            rearmReadyFenceOnPresent: true
+        ) != nil
     }
 
     /// Removes the retained last-good pixels only for the transaction that
@@ -504,7 +526,7 @@ extension GhosttySurfaceView {
         ) else {
             return
         }
-        if pending.observedFrame != nil,
+        if pending.observedFrame != nil || pending.rearmReadyFenceOnPresent,
            let transactionID = verifiedReplayFrozenTransactionID {
             verifiedReplayReadyFence = pending.fence
             verifiedReplayReadyTransactionID = transactionID

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -10,7 +10,7 @@ import UIKit
 public struct VerifiedReplayCapturedViewportAnchor: Equatable, Sendable {
     /// The content-relative viewport position captured before replay.
     public let anchor: VerifiedReplayViewportAnchor
-    /// The user viewport generation that must still match before restoration.
+    /// The applied user viewport generation reflected by the captured anchor.
     public let interactionGeneration: UInt64
 }
 
@@ -41,9 +41,9 @@ extension GhosttySurfaceView {
                 var scrollbar = ghostty_surface_scrollbar_s()
                 let captured: VerifiedReplayCapturedViewportAnchor?
                 if ghostty_surface_scrollbar(operation.surface, &scrollbar) {
-                    // Label after the snapshot so a concurrent scroll can only
-                    // make the generation newer, causing a safe skipped restore.
-                    let interactionGeneration = gate.withLock { $0.interactionGeneration }
+                    let interactionGeneration = gate.withLock {
+                        $0.appliedInteractionGeneration
+                    }
                     captured = VerifiedReplayViewportAnchor(
                         scrollbarTotal: scrollbar.total,
                         offset: scrollbar.offset,

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -32,28 +32,30 @@ extension GhosttySurfaceView {
             generation: surfaceGeneration
         )
         let workQueue = outputQueue
+        let gate = viewportRestoreGate
         return await withCheckedContinuation { continuation in
-            let interactionGeneration = userViewportInteractionClock.withLock { $0 }
             let operationID = registerPendingVerifiedReplayViewportAnchorCapture(
                 continuation: continuation
             )
             workQueue.async {
                 var scrollbar = ghostty_surface_scrollbar_s()
-                let anchor: VerifiedReplayViewportAnchor?
+                let captured: VerifiedReplayCapturedViewportAnchor?
                 if ghostty_surface_scrollbar(operation.surface, &scrollbar) {
-                    anchor = VerifiedReplayViewportAnchor(
+                    // Label after the snapshot so a concurrent scroll can only
+                    // make the generation newer, causing a safe skipped restore.
+                    let interactionGeneration = gate.withLock { $0.interactionGeneration }
+                    captured = VerifiedReplayViewportAnchor(
                         scrollbarTotal: scrollbar.total,
                         offset: scrollbar.offset,
                         len: scrollbar.len
-                    )
+                    ).map {
+                        VerifiedReplayCapturedViewportAnchor(
+                            anchor: $0,
+                            interactionGeneration: interactionGeneration
+                        )
+                    }
                 } else {
-                    anchor = nil
-                }
-                let captured = anchor.map {
-                    VerifiedReplayCapturedViewportAnchor(
-                        anchor: $0,
-                        interactionGeneration: interactionGeneration
-                    )
+                    captured = nil
                 }
                 Task { @MainActor [weak self] in
                     guard let self else { return }
@@ -98,7 +100,7 @@ extension GhosttySurfaceView {
             generation: surfaceGeneration
         )
         let workQueue = outputQueue
-        let clock = userViewportInteractionClock
+        let gate = viewportRestoreGate
         return await withCheckedContinuation { continuation in
             let operationID = registerPendingVerifiedReplayViewportAnchorRestore(
                 continuation: continuation
@@ -116,23 +118,28 @@ extension GhosttySurfaceView {
                     )
                     : nil
                 let postReplayRevision = postReplay.row_space_revision
-                let restored = clock.withLock { generation -> Bool in
-                    guard generation == captured.interactionGeneration else {
+                let claimed = gate.withLock { state -> Bool in
+                    guard state.activeRestoreTicket == operationID,
+                          state.interactionGeneration == captured.interactionGeneration else {
                         return false
                     }
-                    var restoredScrollbar = ghostty_surface_scrollbar_s()
-                    return targetTopRow.map {
+                    state.activeRestoreTicket = nil
+                    return true
+                }
+                var restoredScrollbar = ghostty_surface_scrollbar_s()
+                // A gesture between the claim and C call composes with the
+                // restored frozen viewport, so this unlocked window is benign.
+                let restored = claimed
+                    ? (targetTopRow.map {
                         ghostty_surface_scroll_to_row_if_revision(
                             operation.surface,
                             $0,
                             postReplayRevision,
                             &restoredScrollbar
                         )
-                    } ?? false
-                }
-                if !restored,
-                   targetTopRow != nil,
-                   clock.withLock({ $0 }) != captured.interactionGeneration {
+                    } ?? false)
+                    : false
+                if !claimed, targetTopRow != nil {
                     MobileDebugLog.anchormux(
                         "verified_replay.viewport_restore.skipped reason=user_interaction_late"
                     )
@@ -210,6 +217,7 @@ extension GhosttySurfaceView {
             startedAt: CACurrentMediaTime(),
             continuation: continuation
         )
+        viewportRestoreGate.withLock { $0.activeRestoreTicket = operationID }
         ensureSurfaceOperationDeadlinePump()
         return operationID
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -6,6 +6,14 @@ import GhosttyKit
 import QuartzCore
 import UIKit
 
+/// A replay viewport anchor paired with the user-interaction state at capture.
+public struct VerifiedReplayCapturedViewportAnchor: Equatable, Sendable {
+    /// The content-relative viewport position captured before replay.
+    public let anchor: VerifiedReplayViewportAnchor
+    /// The user viewport generation that must still match before restoration.
+    public let interactionGeneration: UInt64
+}
+
 @MainActor
 extension GhosttySurfaceView {
     nonisolated static func requiresVerifiedReplayPresentedDrain(
@@ -17,7 +25,7 @@ extension GhosttySurfaceView {
     /// Captures a content-relative viewport anchor on the serial surface queue.
     ///
     /// - Returns: The anchor when the viewport is above bottom; otherwise `nil`.
-    public func captureVerifiedReplayViewportAnchor() async -> VerifiedReplayViewportAnchor? {
+    public func captureVerifiedReplayViewportAnchor() async -> VerifiedReplayCapturedViewportAnchor? {
         guard let surface, !isDismantled else { return nil }
         let operation = VerifiedReplayViewportSurfaceOperation(
             surface: surface,
@@ -25,6 +33,10 @@ extension GhosttySurfaceView {
         )
         let workQueue = outputQueue
         return await withCheckedContinuation { continuation in
+            let interactionGeneration = userViewportInteractionGeneration
+            let operationID = registerPendingVerifiedReplayViewportAnchorCapture(
+                continuation: continuation
+            )
             workQueue.async {
                 var scrollbar = ghostty_surface_scrollbar_s()
                 let anchor: VerifiedReplayViewportAnchor?
@@ -37,15 +49,27 @@ extension GhosttySurfaceView {
                 } else {
                     anchor = nil
                 }
+                let captured = anchor.map {
+                    VerifiedReplayCapturedViewportAnchor(
+                        anchor: $0,
+                        interactionGeneration: interactionGeneration
+                    )
+                }
                 Task { @MainActor [weak self] in
-                    guard let self,
-                          self.surface == operation.surface,
+                    guard let self else { return }
+                    guard self.surface == operation.surface,
                           self.surfaceGeneration == operation.generation,
                           !self.isDismantled else {
-                        continuation.resume(returning: nil)
+                        self.completePendingVerifiedReplayViewportAnchorCapture(
+                            id: operationID,
+                            returning: nil
+                        )
                         return
                     }
-                    continuation.resume(returning: anchor)
+                    self.completePendingVerifiedReplayViewportAnchorCapture(
+                        id: operationID,
+                        returning: captured
+                    )
                 }
             }
         }
@@ -57,15 +81,27 @@ extension GhosttySurfaceView {
     /// - Returns: `true` when Ghostty accepted the revision-matched target row.
     @discardableResult
     public func restoreVerifiedReplayViewportAnchor(
-        _ anchor: VerifiedReplayViewportAnchor
+        _ captured: VerifiedReplayCapturedViewportAnchor
     ) async -> Bool {
+        // A replay may finish after newer scroll or typing intent; restoring
+        // its stale anchor would undo that user-driven viewport position.
+        guard userViewportInteractionGeneration == captured.interactionGeneration else {
+            MobileDebugLog.anchormux(
+                "verified_replay.viewport_restore.skipped reason=user_interaction"
+            )
+            return false
+        }
         guard let surface, !isDismantled else { return false }
+        let anchor = captured.anchor
         let operation = VerifiedReplayViewportSurfaceOperation(
             surface: surface,
             generation: surfaceGeneration
         )
         let workQueue = outputQueue
         return await withCheckedContinuation { continuation in
+            let operationID = registerPendingVerifiedReplayViewportAnchorRestore(
+                continuation: continuation
+            )
             workQueue.async {
                 var postReplay = ghostty_surface_scrollbar_s()
                 let readPostReplay = ghostty_surface_scrollbar(
@@ -93,21 +129,89 @@ extension GhosttySurfaceView {
                     )
                 }
                 Task { @MainActor [weak self] in
-                    guard let self,
-                          self.surface == operation.surface,
+                    guard let self else { return }
+                    guard self.surface == operation.surface,
                           self.surfaceGeneration == operation.generation,
                           !self.isDismantled else {
-                        continuation.resume(returning: false)
+                        self.completePendingVerifiedReplayViewportAnchorRestore(
+                            id: operationID,
+                            returning: false
+                        )
                         return
                     }
                     if restored {
                         self.needsDraw = true
                         self.scheduleVisibleArtifactCountUpdate()
                     }
-                    continuation.resume(returning: restored)
+                    self.completePendingVerifiedReplayViewportAnchorRestore(
+                        id: operationID,
+                        returning: restored
+                    )
                 }
             }
         }
+    }
+
+    private func registerPendingVerifiedReplayViewportAnchorCapture(
+        continuation: CheckedContinuation<VerifiedReplayCapturedViewportAnchor?, Never>
+    ) -> UInt64 {
+        let operationID = makeSurfaceOperationID()
+        if let existing = pendingVerifiedReplayViewportAnchorCapture {
+            pendingVerifiedReplayViewportAnchorCapture = nil
+            existing.continuation.resume(returning: nil)
+        }
+        pendingVerifiedReplayViewportAnchorCapture = PendingVerifiedReplayViewportAnchorCapture(
+            id: operationID,
+            startedAt: CACurrentMediaTime(),
+            continuation: continuation
+        )
+        ensureSurfaceOperationDeadlinePump()
+        return operationID
+    }
+
+    @discardableResult
+    private func completePendingVerifiedReplayViewportAnchorCapture(
+        id: UInt64,
+        returning anchor: VerifiedReplayCapturedViewportAnchor?
+    ) -> Bool {
+        guard let pending = pendingVerifiedReplayViewportAnchorCapture,
+              pending.id == id else {
+            return false
+        }
+        pendingVerifiedReplayViewportAnchorCapture = nil
+        pending.continuation.resume(returning: anchor)
+        return true
+    }
+
+    private func registerPendingVerifiedReplayViewportAnchorRestore(
+        continuation: CheckedContinuation<Bool, Never>
+    ) -> UInt64 {
+        let operationID = makeSurfaceOperationID()
+        if let existing = pendingVerifiedReplayViewportAnchorRestore {
+            pendingVerifiedReplayViewportAnchorRestore = nil
+            existing.continuation.resume(returning: false)
+        }
+        pendingVerifiedReplayViewportAnchorRestore = PendingVerifiedReplayViewportAnchorRestore(
+            id: operationID,
+            startedAt: CACurrentMediaTime(),
+            continuation: continuation
+        )
+        ensureSurfaceOperationDeadlinePump()
+        return operationID
+    }
+
+    @discardableResult
+    private func completePendingVerifiedReplayViewportAnchorRestore(
+        id: UInt64,
+        returning result: Bool
+    ) -> Bool {
+        guard let pending = pendingVerifiedReplayViewportAnchorRestore,
+              pending.id == id else {
+            return false
+        }
+        pendingVerifiedReplayViewportAnchorRestore = nil
+        pending.continuation.resume(returning: result)
+        return true
     }
 
     /// Retains an immutable copy of the last presented pixels and cursor above

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplay.swift
@@ -33,7 +33,7 @@ extension GhosttySurfaceView {
         )
         let workQueue = outputQueue
         return await withCheckedContinuation { continuation in
-            let interactionGeneration = userViewportInteractionGeneration
+            let interactionGeneration = userViewportInteractionClock.withLock { $0 }
             let operationID = registerPendingVerifiedReplayViewportAnchorCapture(
                 continuation: continuation
             )
@@ -98,6 +98,7 @@ extension GhosttySurfaceView {
             generation: surfaceGeneration
         )
         let workQueue = outputQueue
+        let clock = userViewportInteractionClock
         return await withCheckedContinuation { continuation in
             let operationID = registerPendingVerifiedReplayViewportAnchorRestore(
                 continuation: continuation
@@ -115,14 +116,22 @@ extension GhosttySurfaceView {
                     )
                     : nil
                 var restoredScrollbar = ghostty_surface_scrollbar_s()
-                let restored = targetTopRow.map {
-                    ghostty_surface_scroll_to_row_if_revision(
-                        operation.surface,
-                        $0,
-                        postReplay.row_space_revision,
-                        &restoredScrollbar
+                let restored: Bool
+                if clock.withLock({ $0 }) != captured.interactionGeneration {
+                    MobileDebugLog.anchormux(
+                        "verified_replay.viewport_restore.skipped reason=user_interaction_late"
                     )
-                } ?? false
+                    restored = false
+                } else {
+                    restored = targetTopRow.map {
+                        ghostty_surface_scroll_to_row_if_revision(
+                            operation.surface,
+                            $0,
+                            postReplay.row_space_revision,
+                            &restoredScrollbar
+                        )
+                    } ?? false
+                }
                 if readPostReplay {
                     MobileDebugLog.anchormux(
                         "verified_replay.viewport_restore preTotal=\(anchor.totalRows) preTopDistance=\(anchor.topRowDistanceFromBottom) postTotal=\(postReplay.total) postOffset=\(postReplay.offset) postLen=\(postReplay.len) targetTop=\(targetTopRow.map(String.init) ?? "nil") restored=\(restored)"

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplaySubmission.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+VerifiedReplaySubmission.swift
@@ -7,7 +7,8 @@ import QuartzCore
 @MainActor
 extension GhosttySurfaceView {
     func submitVerifiedReplayRenderAndWait(
-        read: VerifiedReplaySurfaceRead?
+        read: VerifiedReplaySurfaceRead?,
+        rearmReadyFenceOnPresent: Bool = false
     ) async -> VerifiedReplayPresentedSubmission? {
         guard let surface,
               !isDismantled,
@@ -45,6 +46,7 @@ extension GhosttySurfaceView {
                     read: read,
                     fence: fence,
                     observedFrame: nil,
+                    rearmReadyFenceOnPresent: rearmReadyFenceOnPresent,
                     continuation: continuation
                 )
             )

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -8,6 +8,7 @@ import GhosttyKit
 import OSLog
 import Synchronization
 import UIKit
+import os
 
 private let log = Logger(subsystem: "ai.manaflow.cmux.ios", category: "ghostty.surface")
 
@@ -218,7 +219,18 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             || pendingVerifiedReplayViewportAnchorRestore != nil
             || pendingCopyableTextRead != nil || pendingVerifiedReplayPresentation != nil
     }
-    private(set) var userViewportInteractionGeneration: UInt64 = 0
+    /// User viewport-interaction clock. Incremented on the main actor at
+    /// every user-driven viewport mutation; read inside output-queue blocks
+    /// immediately before a viewport-mutating C call so a stale restore
+    /// enqueued before a newer gesture cannot overwrite it.
+    nonisolated let userViewportInteractionClock =
+        OSAllocatedUnfairLock<UInt64>(initialState: 0)
+    var userViewportInteractionGeneration: UInt64 {
+        userViewportInteractionClock.withLock { $0 }
+    }
+    func bumpUserViewportInteractionGeneration() {
+        userViewportInteractionClock.withLock { $0 &+= 1 }
+    }
     private static let scrollMechanicsContentHeight: CGFloat = 1_000_000
     private var scrollMechanicsIsRecentering = false
     private var lastScrollMechanicsOffsetY: CGFloat?
@@ -1759,7 +1771,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let lines = pendingScrollLines
         let cell = pendingScrollCell
         pendingScrollLines = 0
-        userViewportInteractionGeneration &+= 1
+        bumpUserViewportInteractionGeneration()
         if scrollPresentationAuthority.appliesLocally {
             applyLocalScrollbackScroll(lines: lines, col: cell.col, row: cell.row)
         }
@@ -2396,7 +2408,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// because it runs after everything already queued, so key-repeat during a
     /// stall never fans out into one lock-taking queue item per event.
     func enqueueScrollToBottom() {
-        userViewportInteractionGeneration &+= 1
+        bumpUserViewportInteractionGeneration()
         guard let surface, !scrollToBottomInFlight else { return }
         scrollToBottomInFlight = true
         let generation = surfaceGeneration
@@ -2774,7 +2786,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// only explicit user input does (plus the one-time initial-output scroll
     /// in `scrollInitialOutputToBottomIfNeeded`).
     private func handleUserProducedInput() {
-        userViewportInteractionGeneration &+= 1
+        bumpUserViewportInteractionGeneration()
         resetCursorBlink()
         // A flick still decelerating would fight the snap: deltas already in
         // `pendingScrollLines` flush on the display-link frame AFTER the snap

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -219,11 +219,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             || pendingVerifiedReplayViewportAnchorRestore != nil
             || pendingCopyableTextRead != nil || pendingVerifiedReplayPresentation != nil
     }
-    /// Viewport-restore gate. The lock is held only for field reads/writes —
-    /// NEVER across a Ghostty C call — so a main-actor generation bump can
-    /// never wait on the renderer lock. The ticket lets the deadline pump and
-    /// recovery invalidate a queued restore whose continuation already
-    /// resumed, so a late-running queue block cannot scroll after reveal.
+    /// Viewport-restore gate. All user viewport mutations and restores are
+    /// serialized on `outputQueue`; the generation orders gesture versus
+    /// restore across the main-to-queue boundary. The lock is held only for
+    /// field reads and writes, never across a Ghostty C call. The ticket revokes
+    /// a timed-out restore whose queued block has not yet claimed it.
     nonisolated struct ViewportRestoreGate {
         var interactionGeneration: UInt64 = 0
         var activeRestoreTicket: UInt64?

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -193,6 +193,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     var pendingOutputApply: PendingSurfaceOperation?
     var pendingGeometryApply: PendingSurfaceOperation?
     var pendingVisibleSnapshot: PendingVisibleSnapshot?
+    var pendingVerifiedReplayViewportAnchorCapture: PendingVerifiedReplayViewportAnchorCapture?
+    var pendingVerifiedReplayViewportAnchorRestore: PendingVerifiedReplayViewportAnchorRestore?
     var pendingCopyableTextRead: PendingCopyableTextRead?
     var pendingVerifiedReplayPresentation: PendingVerifiedReplayPresentation?
     /// Quiet-frame countdown for local visible-path detection. Output, geometry,
@@ -212,8 +214,11 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
     private var hasPendingSurfaceOperationDeadline: Bool {
         pendingOutputApply != nil || pendingGeometryApply != nil || pendingVisibleSnapshot != nil
+            || pendingVerifiedReplayViewportAnchorCapture != nil
+            || pendingVerifiedReplayViewportAnchorRestore != nil
             || pendingCopyableTextRead != nil || pendingVerifiedReplayPresentation != nil
     }
+    private(set) var userViewportInteractionGeneration: UInt64 = 0
     private static let scrollMechanicsContentHeight: CGFloat = 1_000_000
     private var scrollMechanicsIsRecentering = false
     private var lastScrollMechanicsOffsetY: CGFloat?
@@ -1754,6 +1759,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         let lines = pendingScrollLines
         let cell = pendingScrollCell
         pendingScrollLines = 0
+        userViewportInteractionGeneration &+= 1
         if scrollPresentationAuthority.appliesLocally {
             applyLocalScrollbackScroll(lines: lines, col: cell.col, row: cell.row)
         }
@@ -2199,6 +2205,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             pending.continuation.resume(returning: result)
             completed = true
         }
+        if let pending = pendingVerifiedReplayViewportAnchorCapture {
+            pendingVerifiedReplayViewportAnchorCapture = nil
+            pending.continuation.resume(returning: nil)
+            completed = true
+        }
+        if let pending = pendingVerifiedReplayViewportAnchorRestore {
+            pendingVerifiedReplayViewportAnchorRestore = nil
+            pending.continuation.resume(returning: false)
+            completed = true
+        }
         if let pending = pendingVerifiedReplayPresentation {
             pendingVerifiedReplayPresentation = nil
             pending.continuation.resume(returning: nil)
@@ -2380,6 +2396,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// because it runs after everything already queued, so key-repeat during a
     /// stall never fans out into one lock-taking queue item per event.
     func enqueueScrollToBottom() {
+        userViewportInteractionGeneration &+= 1
         guard let surface, !scrollToBottomInFlight else { return }
         scrollToBottomInFlight = true
         let generation = surfaceGeneration
@@ -2757,6 +2774,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// only explicit user input does (plus the one-time initial-output scroll
     /// in `scrollInitialOutputToBottomIfNeeded`).
     private func handleUserProducedInput() {
+        userViewportInteractionGeneration &+= 1
         resetCursorBlink()
         // A flick still decelerating would fight the snap: deltas already in
         // `pendingScrollLines` flush on the display-link frame AFTER the snap
@@ -3959,6 +3977,22 @@ nonisolated struct PendingVisibleSnapshot {
     let id: UInt64
     let startedAt: CFTimeInterval
     let continuation: CheckedContinuation<(text: String, columns: Int)?, Never>
+}
+
+/// One verified-replay viewport-anchor capture awaiting output-queue completion
+/// or its skip-only display-link deadline.
+nonisolated struct PendingVerifiedReplayViewportAnchorCapture {
+    let id: UInt64
+    let startedAt: CFTimeInterval
+    let continuation: CheckedContinuation<VerifiedReplayCapturedViewportAnchor?, Never>
+}
+
+/// One verified-replay viewport-anchor restore awaiting output-queue completion
+/// or its skip-only display-link deadline.
+nonisolated struct PendingVerifiedReplayViewportAnchorRestore {
+    let id: UInt64
+    let startedAt: CFTimeInterval
+    let continuation: CheckedContinuation<Bool, Never>
 }
 
 /// One "View as Text" read awaiting output-queue completion or deadline.

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -219,13 +219,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             || pendingVerifiedReplayViewportAnchorRestore != nil
             || pendingCopyableTextRead != nil || pendingVerifiedReplayPresentation != nil
     }
-    /// Viewport-restore gate. All user viewport mutations and restores are
-    /// serialized on `outputQueue`; the generation orders gesture versus
-    /// restore across the main-to-queue boundary. The lock is held only for
-    /// field reads and writes, never across a Ghostty C call. The ticket revokes
-    /// a timed-out restore whose queued block has not yet claimed it.
+    /// Viewport-restore gate. `interactionGeneration` records user intent
+    /// bumped on the main actor, while `appliedInteractionGeneration` records
+    /// what `outputQueue` has applied. Anchors use the applied value at snapshot
+    /// time and remain restorable only while intent equals that label, so a
+    /// gesture whose batch has not reached the queue voids the anchor. The lock
+    /// is held only for field reads and writes, never across a Ghostty C call.
+    /// The ticket revokes a timed-out restore whose queued block has not claimed it.
     nonisolated struct ViewportRestoreGate {
         var interactionGeneration: UInt64 = 0
+        var appliedInteractionGeneration: UInt64 = 0
         var activeRestoreTicket: UInt64?
     }
     nonisolated let viewportRestoreGate =
@@ -1759,6 +1762,16 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// Coalesced native scroll forwarded to the Mac once per display-link frame.
     private var pendingScrollLines: Double = 0
     private var pendingScrollCell: (col: Int, row: Int) = (0, 0)
+    var pendingLocalScrollLines: Double = 0
+    var pendingLocalScrollCell: (col: Int, row: Int) = (0, 0)
+    var localScrollApplyInFlight = false
+
+    /// Drops scroll work tied to a surface generation that will no longer run.
+    func resetScrollStateForSurfaceReplacement() {
+        pendingScrollLines = 0
+        pendingLocalScrollLines = 0
+        localScrollApplyInFlight = false
+    }
 
     /// Map a touch point to a grid cell (shared effective grid with the Mac), so
     /// alt-screen mouse-wheel reports at the cell under the finger.
@@ -2415,13 +2428,21 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// stall never fans out into one lock-taking queue item per event.
     func enqueueScrollToBottom() {
         bumpUserViewportInteractionGeneration()
+        let interactionGeneration = viewportRestoreGate.withLock { $0.interactionGeneration }
         guard let surface, !scrollToBottomInFlight else { return }
         scrollToBottomInFlight = true
         let generation = surfaceGeneration
         let action = "scroll_to_bottom"
+        let gate = viewportRestoreGate
         outputQueue.async { [weak self] in
             action.withCString { pointer in
                 _ = ghostty_surface_binding_action(surface, pointer, UInt(action.utf8.count))
+            }
+            gate.withLock {
+                $0.appliedInteractionGeneration = max(
+                    $0.appliedInteractionGeneration,
+                    interactionGeneration
+                )
             }
             DispatchQueue.main.async {
                 // Generation-guarded like the `processOutput` completion: a
@@ -2689,6 +2710,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     func disposeSurface() {
         stopDisplayLink()
         cancelRenderPipelineRecoveryResumeTimer()
+        resetScrollStateForSurfaceReplacement()
         guard let surface else { return }
         GhosttySurfaceView.unregister(surface: surface)
         self.surface = nil
@@ -2800,6 +2822,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         // pending deltas and freeze the scroll mechanics at the current offset
         // (kill-deceleration idiom) so typed input lands at the bottom.
         pendingScrollLines = 0
+        pendingLocalScrollLines = 0
         scrollMechanicsView.setContentOffset(scrollMechanicsView.contentOffset, animated: false)
         enqueueScrollToBottom()
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -219,10 +219,9 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             || pendingVerifiedReplayViewportAnchorRestore != nil
             || pendingCopyableTextRead != nil || pendingVerifiedReplayPresentation != nil
     }
-    /// User viewport-interaction clock. Incremented on the main actor at
-    /// every user-driven viewport mutation; read inside output-queue blocks
-    /// immediately before a viewport-mutating C call so a stale restore
-    /// enqueued before a newer gesture cannot overwrite it.
+    /// User viewport-interaction clock. Its lock is held across at most one
+    /// viewport-scroll C call, so a main-actor bump blocks only for that call
+    /// and no path acquires Ghostty's lock before this clock.
     nonisolated let userViewportInteractionClock =
         OSAllocatedUnfairLock<UInt64>(initialState: 0)
     var userViewportInteractionGeneration: UInt64 {

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -219,16 +219,22 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             || pendingVerifiedReplayViewportAnchorRestore != nil
             || pendingCopyableTextRead != nil || pendingVerifiedReplayPresentation != nil
     }
-    /// User viewport-interaction clock. Its lock is held across at most one
-    /// viewport-scroll C call, so a main-actor bump blocks only for that call
-    /// and no path acquires Ghostty's lock before this clock.
-    nonisolated let userViewportInteractionClock =
-        OSAllocatedUnfairLock<UInt64>(initialState: 0)
+    /// Viewport-restore gate. The lock is held only for field reads/writes —
+    /// NEVER across a Ghostty C call — so a main-actor generation bump can
+    /// never wait on the renderer lock. The ticket lets the deadline pump and
+    /// recovery invalidate a queued restore whose continuation already
+    /// resumed, so a late-running queue block cannot scroll after reveal.
+    nonisolated struct ViewportRestoreGate {
+        var interactionGeneration: UInt64 = 0
+        var activeRestoreTicket: UInt64?
+    }
+    nonisolated let viewportRestoreGate =
+        OSAllocatedUnfairLock<ViewportRestoreGate>(initialState: .init())
     var userViewportInteractionGeneration: UInt64 {
-        userViewportInteractionClock.withLock { $0 }
+        viewportRestoreGate.withLock { $0.interactionGeneration }
     }
     func bumpUserViewportInteractionGeneration() {
-        userViewportInteractionClock.withLock { $0 &+= 1 }
+        viewportRestoreGate.withLock { $0.interactionGeneration &+= 1 }
     }
     private static let scrollMechanicsContentHeight: CGFloat = 1_000_000
     private var scrollMechanicsIsRecentering = false
@@ -2223,6 +2229,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         if let pending = pendingVerifiedReplayViewportAnchorRestore {
             pendingVerifiedReplayViewportAnchorRestore = nil
+            viewportRestoreGate.withLock { $0.activeRestoreTicket = nil }
             pending.continuation.resume(returning: false)
             completed = true
         }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/PendingVerifiedReplayPresentation.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/PendingVerifiedReplayPresentation.swift
@@ -29,6 +29,7 @@ nonisolated struct PendingVerifiedReplayPresentation: @unchecked Sendable {
     let read: VerifiedReplaySurfaceRead?
     var fence: VerifiedReplayPresentationFence
     var observedFrame: MobileTerminalRenderGridFrame?
+    var rearmReadyFenceOnPresent: Bool = false
     let continuation: CheckedContinuation<VerifiedReplayPresentedSubmission?, Never>
 }
 #endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
@@ -1,32 +1,36 @@
 /// A content-relative viewport position captured before a verified replay.
 public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
-    /// The number of rows between the viewport bottom and the content bottom.
-    public let rowsFromBottom: UInt64
+    /// The number of rows between the viewport top and the content bottom.
+    public let topRowDistanceFromBottom: UInt64
     /// The total row-space size when the viewport was captured.
     public let totalRows: UInt64
 
-    /// Creates a viewport anchor from an authoritative scrollbar snapshot.
+    /// Creates a viewport anchor from content-relative row-space values.
     ///
     /// - Parameters:
-    ///   - rowsFromBottom: Rows between the viewport bottom and content bottom.
+    ///   - topRowDistanceFromBottom: Rows from the viewport top to content bottom.
     ///   - totalRows: Total row-space size at capture time.
-    public init(rowsFromBottom: UInt64, totalRows: UInt64) {
-        self.rowsFromBottom = rowsFromBottom
+    public init(topRowDistanceFromBottom: UInt64, totalRows: UInt64) {
+        self.topRowDistanceFromBottom = topRowDistanceFromBottom
         self.totalRows = totalRows
     }
 
     /// Creates an anchor when a scrollbar snapshot is above the content bottom.
     ///
+    /// `len` is excluded from the anchor so visible-row flicker cannot
+    /// accumulate across replays.
+    ///
     /// - Parameters:
     ///   - scrollbarTotal: Total row-space size at capture time.
     ///   - offset: Top visible row at capture time.
     ///   - len: Number of visible rows at capture time.
+    /// - Returns: An anchor above bottom, or `nil` at or below bottom.
     public init?(scrollbarTotal: UInt64, offset: UInt64, len: UInt64) {
         guard offset < scrollbarTotal else { return nil }
         let rowsAfterOffset = scrollbarTotal - offset
         guard len < rowsAfterOffset else { return nil }
         self.init(
-            rowsFromBottom: rowsAfterOffset - len,
+            topRowDistanceFromBottom: rowsAfterOffset,
             totalRows: scrollbarTotal
         )
     }
@@ -45,7 +49,7 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
         postReplayTotalRows: UInt64,
         postReplayVisibleRows: UInt64
     ) -> UInt64? {
-        guard rowsFromBottom > 0 else { return nil }
+        guard topRowDistanceFromBottom > 0 else { return nil }
 
         let maximumTopRow = postReplayTotalRows > postReplayVisibleRows
             ? postReplayTotalRows - postReplayVisibleRows
@@ -54,9 +58,10 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
             ? postReplayTotalRows - totalRows
             : 0
 
-        guard rowsFromBottom <= maximumTopRow else { return 0 }
-        let topRowBeforeDrift = maximumTopRow - rowsFromBottom
+        guard topRowDistanceFromBottom <= postReplayTotalRows else { return 0 }
+        let topRowBeforeDrift = postReplayTotalRows - topRowDistanceFromBottom
         guard drift <= topRowBeforeDrift else { return 0 }
-        return topRowBeforeDrift - drift
+        let idealTop = topRowBeforeDrift - drift
+        return min(idealTop, maximumTopRow)
     }
 }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
@@ -1,0 +1,46 @@
+/// A content-relative viewport position captured before a verified replay.
+public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
+    /// The number of rows between the viewport bottom and the content bottom.
+    public let rowsFromBottom: UInt64
+    /// The total row-space size when the viewport was captured.
+    public let totalRows: UInt64
+
+    /// Creates a viewport anchor from an authoritative scrollbar snapshot.
+    ///
+    /// - Parameters:
+    ///   - rowsFromBottom: Rows between the viewport bottom and content bottom.
+    ///   - totalRows: Total row-space size at capture time.
+    public init(rowsFromBottom: UInt64, totalRows: UInt64) {
+        self.rowsFromBottom = rowsFromBottom
+        self.totalRows = totalRows
+    }
+
+    /// Computes the post-replay top row that preserves the captured content.
+    ///
+    /// Growth in the row space is treated as replay drift and canceled out so
+    /// the same absolute content remains visible. If a scrollback cap hides
+    /// that growth, the calculation naturally preserves distance from bottom.
+    ///
+    /// - Parameters:
+    ///   - postReplayTotalRows: Total row-space size after replay.
+    ///   - postReplayVisibleRows: Number of rows visible after replay.
+    /// - Returns: The clamped target top row, or `nil` for natural bottom follow.
+    public func targetTopRow(
+        postReplayTotalRows: UInt64,
+        postReplayVisibleRows: UInt64
+    ) -> UInt64? {
+        guard rowsFromBottom > 0 else { return nil }
+
+        let maximumTopRow = postReplayTotalRows > postReplayVisibleRows
+            ? postReplayTotalRows - postReplayVisibleRows
+            : 0
+        let drift = postReplayTotalRows > totalRows
+            ? postReplayTotalRows - totalRows
+            : 0
+
+        guard rowsFromBottom <= maximumTopRow else { return 0 }
+        let topRowBeforeDrift = maximumTopRow - rowsFromBottom
+        guard drift <= topRowBeforeDrift else { return 0 }
+        return topRowBeforeDrift - drift
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/VerifiedReplayViewportAnchor.swift
@@ -15,6 +15,22 @@ public struct VerifiedReplayViewportAnchor: Equatable, Sendable {
         self.totalRows = totalRows
     }
 
+    /// Creates an anchor when a scrollbar snapshot is above the content bottom.
+    ///
+    /// - Parameters:
+    ///   - scrollbarTotal: Total row-space size at capture time.
+    ///   - offset: Top visible row at capture time.
+    ///   - len: Number of visible rows at capture time.
+    public init?(scrollbarTotal: UInt64, offset: UInt64, len: UInt64) {
+        guard offset < scrollbarTotal else { return nil }
+        let rowsAfterOffset = scrollbarTotal - offset
+        guard len < rowsAfterOffset else { return nil }
+        self.init(
+            rowsFromBottom: rowsAfterOffset - len,
+            totalRows: scrollbarTotal
+        )
+    }
+
     /// Computes the post-replay top row that preserves the captured content.
     ///
     /// Growth in the row space is treated as replay drift and canceled out so

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
@@ -63,42 +63,61 @@ struct VerifiedReplayViewportAnchorTests {
 
     @Test("an at-bottom viewport follows replay output naturally")
     func atBottomDoesNotRestore() {
-        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 0, totalRows: 100)
+        let anchor = VerifiedReplayViewportAnchor(
+            scrollbarTotal: 100,
+            offset: 80,
+            len: 20
+        )
 
-        #expect(anchor.targetTopRow(postReplayTotalRows: 120, postReplayVisibleRows: 20) == nil)
+        #expect(anchor == nil)
     }
 
     @Test("an unchanged row space restores the prior top row")
     func plainRestore() {
-        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 30, totalRows: 100)
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 50,
+            totalRows: 100
+        )
 
         #expect(anchor.targetTopRow(postReplayTotalRows: 100, postReplayVisibleRows: 20) == 50)
     }
 
     @Test("row-space growth keeps the same content visible")
     func driftGrowthKeepsContent() {
-        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 30, totalRows: 100)
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 50,
+            totalRows: 100
+        )
 
         #expect(anchor.targetTopRow(postReplayTotalRows: 115, postReplayVisibleRows: 20) == 50)
     }
 
     @Test("a capped row space preserves distance from bottom")
     func cappedHistoryDegradesToDistanceFromBottom() {
-        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 30, totalRows: 200)
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 55,
+            totalRows: 200
+        )
 
         #expect(anchor.targetTopRow(postReplayTotalRows: 200, postReplayVisibleRows: 25) == 145)
     }
 
     @Test("a distance beyond available history clamps to the top")
     func distanceBeyondHistoryClampsToTop() {
-        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 100, totalRows: 150)
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 110,
+            totalRows: 150
+        )
 
         #expect(anchor.targetTopRow(postReplayTotalRows: 50, postReplayVisibleRows: 10) == 0)
     }
 
     @Test("a viewport longer than the post-replay row space clamps to zero")
     func rowSpaceShorterThanViewportClampsToZero() {
-        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 1, totalRows: 10)
+        let anchor = VerifiedReplayViewportAnchor(
+            topRowDistanceFromBottom: 11,
+            totalRows: 10
+        )
 
         #expect(anchor.targetTopRow(postReplayTotalRows: 5, postReplayVisibleRows: 10) == 0)
     }
@@ -106,7 +125,7 @@ struct VerifiedReplayViewportAnchorTests {
     @Test("extreme values do not underflow or overflow")
     func extremeValuesDoNotWrap() {
         let anchor = VerifiedReplayViewportAnchor(
-            rowsFromBottom: UInt64.max,
+            topRowDistanceFromBottom: UInt64.max,
             totalRows: 0
         )
 

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
@@ -4,6 +4,63 @@ import Testing
 
 @Suite("Verified replay viewport anchor")
 struct VerifiedReplayViewportAnchorTests {
+    @Test("visible-row flicker does not accumulate across replay cycles")
+    func lenFlickerDoesNotAccumulateAcrossReplayCycles() throws {
+        let totalRows: UInt64 = 4_053
+        let initialOffset: UInt64 = 3_990
+        var offset = initialOffset
+
+        for _ in 0..<10 {
+            let anchor = try #require(
+                VerifiedReplayViewportAnchor(
+                    scrollbarTotal: totalRows,
+                    offset: offset,
+                    len: 54
+                )
+            )
+            offset = try #require(
+                anchor.targetTopRow(
+                    postReplayTotalRows: totalRows,
+                    postReplayVisibleRows: 53
+                )
+            )
+
+            #expect(offset == initialOffset)
+        }
+    }
+
+    @Test("scrollbar derivation distinguishes bottom from above-bottom")
+    func scrollbarDerivation() throws {
+        #expect(
+            VerifiedReplayViewportAnchor(
+                scrollbarTotal: 100,
+                offset: 80,
+                len: 20
+            ) == nil
+        )
+        #expect(
+            VerifiedReplayViewportAnchor(
+                scrollbarTotal: 100,
+                offset: 80,
+                len: 21
+            ) == nil
+        )
+
+        let anchor = try #require(
+            VerifiedReplayViewportAnchor(
+                scrollbarTotal: 100,
+                offset: 79,
+                len: 20
+            )
+        )
+        #expect(
+            anchor.targetTopRow(
+                postReplayTotalRows: 100,
+                postReplayVisibleRows: 20
+            ) == 79
+        )
+    }
+
     @Test("an at-bottom viewport follows replay output naturally")
     func atBottomDoesNotRestore() {
         let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 0, totalRows: 100)

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/VerifiedReplayViewportAnchorTests.swift
@@ -1,0 +1,63 @@
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@Suite("Verified replay viewport anchor")
+struct VerifiedReplayViewportAnchorTests {
+    @Test("an at-bottom viewport follows replay output naturally")
+    func atBottomDoesNotRestore() {
+        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 0, totalRows: 100)
+
+        #expect(anchor.targetTopRow(postReplayTotalRows: 120, postReplayVisibleRows: 20) == nil)
+    }
+
+    @Test("an unchanged row space restores the prior top row")
+    func plainRestore() {
+        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 30, totalRows: 100)
+
+        #expect(anchor.targetTopRow(postReplayTotalRows: 100, postReplayVisibleRows: 20) == 50)
+    }
+
+    @Test("row-space growth keeps the same content visible")
+    func driftGrowthKeepsContent() {
+        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 30, totalRows: 100)
+
+        #expect(anchor.targetTopRow(postReplayTotalRows: 115, postReplayVisibleRows: 20) == 50)
+    }
+
+    @Test("a capped row space preserves distance from bottom")
+    func cappedHistoryDegradesToDistanceFromBottom() {
+        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 30, totalRows: 200)
+
+        #expect(anchor.targetTopRow(postReplayTotalRows: 200, postReplayVisibleRows: 25) == 145)
+    }
+
+    @Test("a distance beyond available history clamps to the top")
+    func distanceBeyondHistoryClampsToTop() {
+        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 100, totalRows: 150)
+
+        #expect(anchor.targetTopRow(postReplayTotalRows: 50, postReplayVisibleRows: 10) == 0)
+    }
+
+    @Test("a viewport longer than the post-replay row space clamps to zero")
+    func rowSpaceShorterThanViewportClampsToZero() {
+        let anchor = VerifiedReplayViewportAnchor(rowsFromBottom: 1, totalRows: 10)
+
+        #expect(anchor.targetTopRow(postReplayTotalRows: 5, postReplayVisibleRows: 10) == 0)
+    }
+
+    @Test("extreme values do not underflow or overflow")
+    func extremeValuesDoNotWrap() {
+        let anchor = VerifiedReplayViewportAnchor(
+            rowsFromBottom: UInt64.max,
+            totalRows: 0
+        )
+
+        #expect(
+            anchor.targetTopRow(
+                postReplayTotalRows: UInt64.max,
+                postReplayVisibleRows: 0
+            ) == 0
+        )
+    }
+}


### PR DESCRIPTION
Fixes the iOS bug where scrolling up in a terminal while an agent streams output snaps the viewport back to the bottom after a few seconds.

Under screen-anchored render grids (https://github.com/manaflow-ai/cmux/pull/8860) the phone owns a local Ghostty mirror. Event-lane deltas and scrollback-free fulls preserve a history-pinned viewport, but authoritative replay RPC responses (hydrating fulls) apply through the verified-replay path with a full terminal reset (`ESC[2J`/`ESC[3J`), which wipes local scrollback and destroys the viewport pin. During heavy agent output these replays fire every few seconds (delta chain breaks from shed frames on the bounded event queue, replay barriers), so a scrolled-up user is repeatedly yanked to the bottom.

Fix: capture a content-relative viewport anchor (distance from bottom plus row-space total, from `ghostty_surface_scrollbar`) before each verified replay, and restore it after the replay reveals via `ghostty_surface_scroll_to_row_if_revision`. Row-space growth during the replay is canceled out so the same content stays visible; when a scrollback cap hides growth the restore degrades to distance-from-bottom. Restore runs only for screen-anchored primary-screen replays (alt-screen TUIs and v1 viewport-mirror clients keep current behavior), and the anchor is retained across failed-verification retries so a keep-frozen retry cannot lose the user's place. All C calls run on the serial surface queue with generation guards, and the read-revision-then-scroll pair executes in one queue block so the revision cannot go stale.

Restore is placed after reveal rather than interposing a re-present before it: the verified-replay ready fence is tied to the exact verification render, and replacing that renderer identity pre-reveal risks a permanent keep-frozen/replay loop. Cost is a one-frame bottom flash on replay, logged via `verified_replay.viewport_restore` for dogfood evidence.

Commit 1 adds the restore-math tests only (red), commit 2 adds the implementation (green). A live-libghostty integration test is not practical in this package (unit-level rigs only); the restore math is fully unit-tested (7 cases including drift, cap degradation, clamping, and overflow bounds) and the integration path is covered by dogfood.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787810965&installation_model_id=21920&pr_number=9032&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9032&signature=4bac90e0db2d8402e16297959cc108bcb9ee180e1c67b22fec1d5f07581d9158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the iOS terminal from snapping to bottom when you scroll up during streaming. Viewport stays fixed across mid‑stream verified replays on primary‑screen, screen‑anchored grids, with a race‑safe capture/restore and a pre‑reveal fence re‑arm so there’s no bottom flash.

- **Bug Fixes**
  - Capture a content‑relative anchor from the scrollbar (excludes visible‑row `len`) on the surface queue before replay; persist across verification retries and clear on remount.
  - Gate restore with a user‑interaction generation clock and a single restore ticket; skip if the user scrolled or typed since capture, invalidate queued restores on deadline/recovery, and hold the clock during the revision‑matched scroll.
  - Present the restored viewport under render suppression and re‑arm the ready fence, so reveal shows the restored position without a flash.
  - Coalesce and serialize local scrollback gestures on the same output queue with generation guards; update the applied interaction generation after scroll and drop work on surface replacement.
  - Add display‑link timeouts for anchor capture/restore to avoid wedges and cancel tickets on timeout.
  - Natural bottom‑follow at bottom; clamps when history or viewport shrinks. Scope: primary‑screen, screen‑anchored grids only; alt‑screen TUIs and v1 viewport‑mirror clients unchanged.
  - Logged under `verified_replay.viewport_restore`. Tests: 9 cases covering the len 54→53 flicker regression, bottom detection, clamping, and extreme values.

<sup>Written for commit 80acfc027e2fa1348270b01c49ca133a172c79b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserves and restores the terminal’s verified-replay viewport using a new viewport anchor model, with async capture/restore and a restored-viewport presentation option.

* **Bug Fixes**
  * Prevents stale cross-frame/after-remount restoration by clearing pending anchor state when surface/frame conditions change.
  * Improves restoration readiness behavior to better handle rearm signaling.
  * Adds best-effort timeouts for anchor capture/restore to avoid stuck recovery paths.

* **Tests**
  * Adds coverage for repeated replay stability, bottom-follow handling, and clamping across edge cases (including extreme values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->