### PR TITLE
Unbreak workflow-guard-tests: poll for quarantine recovery instead of fixed sleep

### DIFF
--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -92,13 +92,22 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         }
         #expect(captureStartCount == 1)
 
-        try? await ContinuousClock().sleep(for: .milliseconds(40))
-        do {
-            let captured = try await evaluator.captureVisibleViewport(from: webView)
-            #expect(captured === expected)
-        } catch {
-            Issue.record("Expected capture to recover after quarantine: \(error)")
+        // The quarantine window expires on wall-clock time (`cleanupTimeout`),
+        // so poll until the evaluator accepts a new capture instead of
+        // assuming a fixed delay is long enough on a loaded CI host.
+        var recovered: NSImage?
+        for _ in 0..<400 {
+            do {
+                recovered = try await evaluator.captureVisibleViewport(from: webView)
+                break
+            } catch {
+                try? await ContinuousClock().sleep(for: .milliseconds(5))
+            }
         }
+        if recovered == nil {
+            Issue.record("Expected capture to recover after quarantine")
+        }
+        #expect(recovered === expected)
         #expect(captureStartCount == 2)
 
         firstCompletion?(.success(expected))


### PR DESCRIPTION
Main's `workflow-guard-tests` is red since https://github.com/manaflow-ai/cmux/commit/4f6a19d68d landed: `droppedVisibleCaptureCallbackRecoversAfterBoundedQuarantine` in `cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift` uses a fixed 40ms sleep-then-assert, which the test-determinism gate flags. Because `linux-preflight` and `tests` depend on the guard job, every PR's merge gate currently fails (seen on https://github.com/manaflow-ai/cmux/actions/runs/30333575979).

This replaces the fixed sleep with a bounded poll: retry `captureVisibleViewport` (blocked attempts throw `CancellationError` without starting a capture) until the wall-clock quarantine window expires, then assert the recovered image and that exactly one new capture started. Same assertions, no fixed-delay assumption on a loaded CI host.

`python3 scripts/check-test-determinism.py`: 0 findings after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787811445&installation_model_id=21920&pr_number=9035&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9035&signature=3c4e99c35a47a52036f56f365f6bee9263a3608fe6d0814f001c9a06e3b1ee90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the fixed 40ms sleep in `droppedVisibleCaptureCallbackRecoversAfterBoundedQuarantine` with a bounded poll to make quarantine recovery deterministic and get `workflow-guard-tests` green again.

- **Bug Fixes**
  - Poll `captureVisibleViewport` every 5ms until the quarantine window expires; ignore `CancellationError` from blocked attempts.
  - Keep assertions: the recovered image matches `expected`, and exactly one new capture starts.
  - Removes fixed-delay timing; the test determinism check passes.

<sup>Written for commit faa3a61da1df0ecb49f542cbbcdd6acbc9384455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated visual capture validation by polling for recovery after temporary capture unavailability.
  * Added clearer failure handling when recovery does not occur within the expected timeframe.
  * No user-facing product behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->