### PR TITLE
Fix Dock agent-finished notification rings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,7 @@ jobs:
             -destination "platform=macOS" \
             CMUX_SKIP_ZIG_BUILD=1 \
             -only-testing:cmuxTests/AgentNotificationRegressionTests \
+            -only-testing:cmuxTests/DockNotificationAttentionTests \
             -only-testing:cmuxTests/ClaudeHookLifecycleCleanupTests \
             -only-testing:cmuxTests/ClaudeHookLiveDeliveryTargetTests \
             -only-testing:cmuxTests/ClaudeHookPIDAuthenticationTests \

--- a/Sources/AppDelegate+DockAttentionRouting.swift
+++ b/Sources/AppDelegate+DockAttentionRouting.swift
@@ -41,7 +41,6 @@ extension AppDelegate {
         if DockSplitStore.routeAttentionFlash(
             panelID: panelID,
             reason: reason,
-            requiresSplit: requiresSplit,
             shouldFocus: shouldFocus
         ) {
             return true

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -120,88 +120,9 @@ struct DockPanelView: View {
     }
 }
 
-/// Renders the Dock's Bonsplit tree, reusing `PanelContentView` so Dock
-/// terminals and browsers render identically to main-area panes.
-private struct DockSplitContentView: View {
-    let store: DockSplitStore
-    let appearance: PanelAppearance
-    let windowAppearance: WindowAppearanceSnapshot
-    let rightSidebarOwnsInputFocus: Bool
-    let unreadPanelIDs: Set<UUID>
-
-    /// Portal z-priority for Dock-hosted terminal/browser surfaces. Kept low so
-    /// Dock surfaces never overlay main-area surfaces.
-    private static let portalPriority = 1
-
-    var body: some View {
-        BonsplitView(controller: store.bonsplitController) { tab, paneId in
-            dockContent(tab: tab, paneId: paneId)
-        } emptyPane: { paneId in
-            DockEmptyPaneView(
-                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
-            )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
-        }
-    }
-
-    @ViewBuilder
-    private func dockContent(tab: Bonsplit.Tab, paneId: PaneID) -> some View {
-        if let panel = store.panel(for: tab.id) {
-            let isFocused = store.panelIsActiveInVisibleDockPane(panel.id) && rightSidebarOwnsInputFocus
-            let isSelectedInPane = store.bonsplitController.selectedTab(inPane: paneId)?.id == tab.id
-            let isVisibleInUI = store.panelIsSelectedInVisibleDockPane(panel.id)
-            let isSplit = store.bonsplitController.allPaneIds.count > 1
-            PanelContentView(
-                panel: panel,
-                workspaceId: store.workspaceId,
-                paneId: paneId,
-                isFocused: isFocused,
-                isSelectedInPane: isSelectedInPane,
-                isVisibleInUI: isVisibleInUI,
-                allowsPointerInput: isVisibleInUI,
-                portalPriority: Self.portalPriority,
-                isSplit: isSplit,
-                appearance: appearance,
-                windowAppearance: windowAppearance,
-                customSidebarTabManager: nil,
-                hasUnreadNotification: unreadPanelIDs.contains(panel.id),
-                terminalAgentContext: "",
-                paneOwnershipOverride: isVisibleInUI,
-                terminalPaneOwnershipResolver: {
-                    guard store.paneId(forPanelId: panel.id)?.id == paneId.id else { return false }
-                    return store.panelIsSelectedInVisibleDockPane(panel.id)
-                },
-                onFocus: {
-                    store.bonsplitController.focusPane(paneId)
-                    store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
-                },
-                onRequestPanelFocus: {
-                    store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
-                    store.focusPanel(panel.id)
-                },
-                onResumeAgentHibernation: {
-                    _ = store.resumeAgentHibernation(panelId: panel.id, focus: true)
-                },
-                onAutoResumeAgentHibernation: {
-                    _ = store.resumeAgentHibernation(panelId: panel.id, focus: false)
-                },
-                onTriggerFlash: {}
-            )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
-        } else {
-            DockEmptyPaneView(
-                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
-                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
-            )
-            .onTapGesture { store.bonsplitController.focusPane(paneId) }
-        }
-    }
-}
-
 /// Shown in an empty Dock pane (initial empty Dock, or a freshly split pane).
 /// Offers the same in-app create affordances as the tab-bar split buttons.
-private struct DockEmptyPaneView: View {
+struct DockEmptyPaneView: View {
     let onNewTerminal: () -> Void
     let onNewBrowser: () -> Void
 

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -19,6 +19,7 @@ struct DockPanelView: View {
     /// exclusive (the main pane dims its ring when this is true).
     var rightSidebarOwnsInputFocus: Bool = false
 
+    @EnvironmentObject private var sidebarUnread: SidebarUnreadModel
     @State private var appearanceConfig = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "dock.initial")
     @State private var visibilityHostId = UUID()
 
@@ -69,6 +70,12 @@ struct DockPanelView: View {
 
     @ViewBuilder
     private var content: some View {
+        let unreadPanelIDs = Set(store.panels.keys.filter {
+            sidebarUnread.hasVisibleNotificationIndicator(
+                forWorkspaceId: store.workspaceId,
+                surfaceId: $0
+            )
+        })
         if let trustRequest = store.trustRequest {
             DockTrustView(request: trustRequest) {
                 store.trustAndReload()
@@ -80,7 +87,8 @@ struct DockPanelView: View {
                 store: store,
                 appearance: appearance,
                 windowAppearance: windowAppearance,
-                rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus
+                rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus,
+                unreadPanelIDs: unreadPanelIDs
             )
         }
     }
@@ -93,6 +101,7 @@ private struct DockSplitContentView: View {
     let appearance: PanelAppearance
     let windowAppearance: WindowAppearanceSnapshot
     let rightSidebarOwnsInputFocus: Bool
+    let unreadPanelIDs: Set<UUID>
 
     /// Portal z-priority for Dock-hosted terminal/browser surfaces. Kept low so
     /// Dock surfaces never overlay main-area surfaces.
@@ -130,7 +139,7 @@ private struct DockSplitContentView: View {
                 appearance: appearance,
                 windowAppearance: windowAppearance,
                 customSidebarTabManager: nil,
-                hasUnreadNotification: false,
+                hasUnreadNotification: unreadPanelIDs.contains(panel.id),
                 terminalAgentContext: "",
                 paneOwnershipOverride: isVisibleInUI,
                 terminalPaneOwnershipResolver: {

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -20,6 +20,7 @@ struct DockPanelView: View {
     var rightSidebarOwnsInputFocus: Bool = false
 
     @State private var appearanceConfig = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "dock.initial")
+    @State private var appearanceRevision: UInt = 0
     @State private var unreadProjection: DockUnreadPanelProjection
     @State private var visibilityHostId = UUID()
 
@@ -97,6 +98,7 @@ struct DockPanelView: View {
     private func refreshAppearance(reason: String) {
         let next = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "dock.\(reason)")
         appearanceConfig = next
+        appearanceRevision &+= 1
         store.applyGhosttyChrome(from: next)
     }
 
@@ -112,6 +114,7 @@ struct DockPanelView: View {
             DockSplitContentView(
                 store: store,
                 appearance: appearance,
+                appearanceRevision: appearanceRevision,
                 windowAppearance: windowAppearance,
                 rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus,
                 unreadPanelIDs: unreadProjection.unreadPanelIDs

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -1,9 +1,7 @@
 import AppKit
 import Bonsplit
-import Combine
 import CmuxAppKitSupportUI
 import CmuxTerminal
-import Observation
 import SwiftUI
 
 /// Right-sidebar Dock. Renders the window's own Dock `BonsplitController` tree
@@ -119,96 +117,6 @@ struct DockPanelView: View {
                 unreadPanelIDs: unreadProjection.unreadPanelIDs
             )
         }
-    }
-}
-
-/// Narrows the app-wide unread model to this Dock before updating its Bonsplit
-/// subtree. Hidden Docks clear once, then ignore unrelated notification churn.
-@MainActor
-@Observable
-final class DockUnreadPanelProjection {
-    private(set) var unreadPanelIDs: Set<UUID> = []
-
-    @ObservationIgnored private let workspaceID: UUID
-    @ObservationIgnored private var panelIDs: Set<UUID> = []
-    @ObservationIgnored private var isActive = false
-    @ObservationIgnored private var unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey>
-    @ObservationIgnored private var focusedReadIndicatorByWorkspaceID: [UUID: UUID]
-    @ObservationIgnored private var unreadSubscription: AnyCancellable?
-
-    init(
-        source: SidebarUnreadModel,
-        workspaceID: UUID,
-        panelIDs: Set<UUID>,
-        isActive: Bool
-    ) {
-        self.workspaceID = workspaceID
-        self.panelIDs = panelIDs
-        self.isActive = isActive
-        unreadSurfaceKeys = source.unreadSurfaceKeys
-        focusedReadIndicatorByWorkspaceID = source.focusedReadIndicatorByWorkspaceId
-        refresh()
-        unreadSubscription = source.$unreadSurfaceKeys.combineLatest(
-            source.$focusedReadIndicatorByWorkspaceId
-        ).sink { [weak self] unreadSurfaceKeys, focusedReadIndicatorByWorkspaceID in
-            // Both publishers are main-actor-owned and publish synchronously
-            // from SidebarUnreadModel.apply().
-            MainActor.assumeIsolated {
-                self?.receive(
-                    unreadSurfaceKeys: unreadSurfaceKeys,
-                    focusedReadIndicatorByWorkspaceID: focusedReadIndicatorByWorkspaceID
-                )
-            }
-        }
-    }
-
-    func updateContext(panelIDs: Set<UUID>, isActive: Bool) {
-        guard self.panelIDs != panelIDs || self.isActive != isActive else { return }
-        self.panelIDs = panelIDs
-        self.isActive = isActive
-        refresh()
-    }
-
-    private func receive(
-        unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey>,
-        focusedReadIndicatorByWorkspaceID: [UUID: UUID]
-    ) {
-        self.unreadSurfaceKeys = unreadSurfaceKeys
-        self.focusedReadIndicatorByWorkspaceID = focusedReadIndicatorByWorkspaceID
-        refresh()
-    }
-
-    private func refresh() {
-        let nextUnreadPanelIDs: Set<UUID>
-        if isActive {
-            let focusedReadPanelID = focusedReadIndicatorByWorkspaceID[workspaceID]
-            nextUnreadPanelIDs = Set(panelIDs.filter { panelID in
-                unreadSurfaceKeys.contains(
-                    SidebarSurfaceUnreadKey(workspaceId: workspaceID, surfaceId: panelID)
-                ) || focusedReadPanelID == panelID
-            })
-        } else {
-            nextUnreadPanelIDs = []
-        }
-        guard unreadPanelIDs != nextUnreadPanelIDs else { return }
-        unreadPanelIDs = nextUnreadPanelIDs
-    }
-}
-
-private struct DockUnreadProjectionContextBridge: View {
-    let projection: DockUnreadPanelProjection
-    let panelIDs: Set<UUID>
-    let isActive: Bool
-
-    var body: some View {
-        Color.clear
-            .onAppear { projection.updateContext(panelIDs: panelIDs, isActive: isActive) }
-            .onChange(of: panelIDs) { _, panelIDs in
-                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
-            }
-            .onChange(of: isActive) { _, isActive in
-                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
-            }
     }
 }
 

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -3,6 +3,7 @@ import Bonsplit
 import Combine
 import CmuxAppKitSupportUI
 import CmuxTerminal
+import Observation
 import SwiftUI
 
 /// Right-sidebar Dock. Renders the window's own Dock `BonsplitController` tree
@@ -19,10 +20,9 @@ struct DockPanelView: View {
     /// dims its focus ring when false so Dock and main-pane focus are mutually
     /// exclusive (the main pane dims its ring when this is true).
     var rightSidebarOwnsInputFocus: Bool = false
-    private let unreadSource: SidebarUnreadModel
 
     @State private var appearanceConfig = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "dock.initial")
-    @State private var unreadPanelIDs: Set<UUID> = []
+    @State private var unreadProjection: DockUnreadPanelProjection
     @State private var visibilityHostId = UUID()
 
     @MainActor
@@ -41,7 +41,12 @@ struct DockPanelView: View {
         self.rootDirectory = rootDirectory
         self.windowAppearance = windowAppearance
         self.rightSidebarOwnsInputFocus = rightSidebarOwnsInputFocus
-        self.unreadSource = unreadSource
+        _unreadProjection = State(initialValue: DockUnreadPanelProjection(
+            source: unreadSource,
+            workspaceID: store.workspaceId,
+            panelIDs: Set(store.panels.keys),
+            isActive: isSidebarVisible && mode == .dock
+        ))
     }
 
     private var appearance: PanelAppearance {
@@ -56,12 +61,10 @@ struct DockPanelView: View {
                 .frame(width: 1, height: 1)
         )
         .background(
-            DockUnreadProjectionBridge(
-                sidebarUnread: unreadSource,
-                workspaceID: store.workspaceId,
+            DockUnreadProjectionContextBridge(
+                projection: unreadProjection,
                 panelIDs: Set(store.panels.keys),
-                isActive: isSidebarVisible && mode == .dock,
-                unreadPanelIDs: $unreadPanelIDs
+                isActive: isSidebarVisible && mode == .dock
             )
             .frame(width: 0, height: 0)
         )
@@ -113,7 +116,7 @@ struct DockPanelView: View {
                 appearance: appearance,
                 windowAppearance: windowAppearance,
                 rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus,
-                unreadPanelIDs: unreadPanelIDs
+                unreadPanelIDs: unreadProjection.unreadPanelIDs
             )
         }
     }
@@ -121,41 +124,61 @@ struct DockPanelView: View {
 
 /// Narrows the app-wide unread model to this Dock before updating its Bonsplit
 /// subtree. Hidden Docks clear once, then ignore unrelated notification churn.
-private struct DockUnreadProjectionBridge: View {
-    let sidebarUnread: SidebarUnreadModel
-    let workspaceID: UUID
-    let panelIDs: Set<UUID>
-    let isActive: Bool
-    @Binding var unreadPanelIDs: Set<UUID>
+@MainActor
+@Observable
+final class DockUnreadPanelProjection {
+    private(set) var unreadPanelIDs: Set<UUID> = []
 
-    var body: some View {
-        Color.clear
-            .onAppear { refresh() }
-            .onChange(of: panelIDs) { _, _ in refresh() }
-            .onChange(of: isActive) { _, _ in refresh() }
-            .onReceive(
-                sidebarUnread.$unreadSurfaceKeys.combineLatest(
-                    sidebarUnread.$focusedReadIndicatorByWorkspaceId
-                )
-            ) { unreadSurfaceKeys, focusedReadIndicatorByWorkspaceID in
-                update(
+    @ObservationIgnored private let workspaceID: UUID
+    @ObservationIgnored private var panelIDs: Set<UUID> = []
+    @ObservationIgnored private var isActive = false
+    @ObservationIgnored private var unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey>
+    @ObservationIgnored private var focusedReadIndicatorByWorkspaceID: [UUID: UUID]
+    @ObservationIgnored private var unreadSubscription: AnyCancellable?
+
+    init(
+        source: SidebarUnreadModel,
+        workspaceID: UUID,
+        panelIDs: Set<UUID>,
+        isActive: Bool
+    ) {
+        self.workspaceID = workspaceID
+        self.panelIDs = panelIDs
+        self.isActive = isActive
+        unreadSurfaceKeys = source.unreadSurfaceKeys
+        focusedReadIndicatorByWorkspaceID = source.focusedReadIndicatorByWorkspaceId
+        refresh()
+        unreadSubscription = source.$unreadSurfaceKeys.combineLatest(
+            source.$focusedReadIndicatorByWorkspaceId
+        ).sink { [weak self] unreadSurfaceKeys, focusedReadIndicatorByWorkspaceID in
+            // Both publishers are main-actor-owned and publish synchronously
+            // from SidebarUnreadModel.apply().
+            MainActor.assumeIsolated {
+                self?.receive(
                     unreadSurfaceKeys: unreadSurfaceKeys,
                     focusedReadIndicatorByWorkspaceID: focusedReadIndicatorByWorkspaceID
                 )
             }
+        }
     }
 
-    private func refresh() {
-        update(
-            unreadSurfaceKeys: sidebarUnread.unreadSurfaceKeys,
-            focusedReadIndicatorByWorkspaceID: sidebarUnread.focusedReadIndicatorByWorkspaceId
-        )
+    func updateContext(panelIDs: Set<UUID>, isActive: Bool) {
+        guard self.panelIDs != panelIDs || self.isActive != isActive else { return }
+        self.panelIDs = panelIDs
+        self.isActive = isActive
+        refresh()
     }
 
-    private func update(
+    private func receive(
         unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey>,
         focusedReadIndicatorByWorkspaceID: [UUID: UUID]
     ) {
+        self.unreadSurfaceKeys = unreadSurfaceKeys
+        self.focusedReadIndicatorByWorkspaceID = focusedReadIndicatorByWorkspaceID
+        refresh()
+    }
+
+    private func refresh() {
         let nextUnreadPanelIDs: Set<UUID>
         if isActive {
             let focusedReadPanelID = focusedReadIndicatorByWorkspaceID[workspaceID]
@@ -169,6 +192,23 @@ private struct DockUnreadProjectionBridge: View {
         }
         guard unreadPanelIDs != nextUnreadPanelIDs else { return }
         unreadPanelIDs = nextUnreadPanelIDs
+    }
+}
+
+private struct DockUnreadProjectionContextBridge: View {
+    let projection: DockUnreadPanelProjection
+    let panelIDs: Set<UUID>
+    let isActive: Bool
+
+    var body: some View {
+        Color.clear
+            .onAppear { projection.updateContext(panelIDs: panelIDs, isActive: isActive) }
+            .onChange(of: panelIDs) { _, panelIDs in
+                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
+            }
+            .onChange(of: isActive) { _, isActive in
+                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
+            }
     }
 }
 

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import Combine
 import CmuxAppKitSupportUI
 import CmuxTerminal
 import SwiftUI
@@ -18,10 +19,30 @@ struct DockPanelView: View {
     /// dims its focus ring when false so Dock and main-pane focus are mutually
     /// exclusive (the main pane dims its ring when this is true).
     var rightSidebarOwnsInputFocus: Bool = false
+    private let unreadSource: SidebarUnreadModel
 
-    @EnvironmentObject private var sidebarUnread: SidebarUnreadModel
     @State private var appearanceConfig = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "dock.initial")
+    @State private var unreadPanelIDs: Set<UUID> = []
     @State private var visibilityHostId = UUID()
+
+    @MainActor
+    init(
+        store: DockSplitStore,
+        isSidebarVisible: Bool,
+        mode: RightSidebarMode,
+        rootDirectory: String?,
+        windowAppearance: WindowAppearanceSnapshot,
+        rightSidebarOwnsInputFocus: Bool = false,
+        unreadSource: SidebarUnreadModel
+    ) {
+        self.store = store
+        self.isSidebarVisible = isSidebarVisible
+        self.mode = mode
+        self.rootDirectory = rootDirectory
+        self.windowAppearance = windowAppearance
+        self.rightSidebarOwnsInputFocus = rightSidebarOwnsInputFocus
+        self.unreadSource = unreadSource
+    }
 
     private var appearance: PanelAppearance {
         PanelAppearance.fromConfig(appearanceConfig)
@@ -33,6 +54,16 @@ struct DockPanelView: View {
         .background(
             DockKeyboardFocusBridge(store: store)
                 .frame(width: 1, height: 1)
+        )
+        .background(
+            DockUnreadProjectionBridge(
+                sidebarUnread: unreadSource,
+                workspaceID: store.workspaceId,
+                panelIDs: Set(store.panels.keys),
+                isActive: isSidebarVisible && mode == .dock,
+                unreadPanelIDs: $unreadPanelIDs
+            )
+            .frame(width: 0, height: 0)
         )
         .accessibilityIdentifier("DockPanel")
         .onAppear {
@@ -70,12 +101,6 @@ struct DockPanelView: View {
 
     @ViewBuilder
     private var content: some View {
-        let unreadPanelIDs = Set(store.panels.keys.filter {
-            sidebarUnread.hasVisibleNotificationIndicator(
-                forWorkspaceId: store.workspaceId,
-                surfaceId: $0
-            )
-        })
         if let trustRequest = store.trustRequest {
             DockTrustView(request: trustRequest) {
                 store.trustAndReload()
@@ -91,6 +116,59 @@ struct DockPanelView: View {
                 unreadPanelIDs: unreadPanelIDs
             )
         }
+    }
+}
+
+/// Narrows the app-wide unread model to this Dock before updating its Bonsplit
+/// subtree. Hidden Docks clear once, then ignore unrelated notification churn.
+private struct DockUnreadProjectionBridge: View {
+    let sidebarUnread: SidebarUnreadModel
+    let workspaceID: UUID
+    let panelIDs: Set<UUID>
+    let isActive: Bool
+    @Binding var unreadPanelIDs: Set<UUID>
+
+    var body: some View {
+        Color.clear
+            .onAppear { refresh() }
+            .onChange(of: panelIDs) { _, _ in refresh() }
+            .onChange(of: isActive) { _, _ in refresh() }
+            .onReceive(
+                sidebarUnread.$unreadSurfaceKeys.combineLatest(
+                    sidebarUnread.$focusedReadIndicatorByWorkspaceId
+                )
+            ) { unreadSurfaceKeys, focusedReadIndicatorByWorkspaceID in
+                update(
+                    unreadSurfaceKeys: unreadSurfaceKeys,
+                    focusedReadIndicatorByWorkspaceID: focusedReadIndicatorByWorkspaceID
+                )
+            }
+    }
+
+    private func refresh() {
+        update(
+            unreadSurfaceKeys: sidebarUnread.unreadSurfaceKeys,
+            focusedReadIndicatorByWorkspaceID: sidebarUnread.focusedReadIndicatorByWorkspaceId
+        )
+    }
+
+    private func update(
+        unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey>,
+        focusedReadIndicatorByWorkspaceID: [UUID: UUID]
+    ) {
+        let nextUnreadPanelIDs: Set<UUID>
+        if isActive {
+            let focusedReadPanelID = focusedReadIndicatorByWorkspaceID[workspaceID]
+            nextUnreadPanelIDs = Set(panelIDs.filter { panelID in
+                unreadSurfaceKeys.contains(
+                    SidebarSurfaceUnreadKey(workspaceId: workspaceID, surfaceId: panelID)
+                ) || focusedReadPanelID == panelID
+            })
+        } else {
+            nextUnreadPanelIDs = []
+        }
+        guard unreadPanelIDs != nextUnreadPanelIDs else { return }
+        unreadPanelIDs = nextUnreadPanelIDs
     }
 }
 

--- a/Sources/DockSplitContentView.swift
+++ b/Sources/DockSplitContentView.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Bonsplit
+import Foundation
+import SwiftUI
+
+/// Renders the Dock's Bonsplit tree, reusing `PanelContentView` so Dock
+/// terminals and browsers render identically to main-area panes.
+struct DockSplitContentView: View {
+    let store: DockSplitStore
+    let appearance: PanelAppearance
+    let windowAppearance: WindowAppearanceSnapshot
+    let rightSidebarOwnsInputFocus: Bool
+    let unreadPanelIDs: Set<UUID>
+
+    /// Portal z-priority for Dock-hosted terminal/browser surfaces. Kept low so
+    /// Dock surfaces never overlay main-area surfaces.
+    private static let portalPriority = 1
+
+    var body: some View {
+        BonsplitView(controller: store.bonsplitController) { tab, paneId in
+            dockContent(tab: tab, paneId: paneId)
+        } emptyPane: { paneId in
+            DockEmptyPaneView(
+                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
+                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+            )
+            .onTapGesture { store.bonsplitController.focusPane(paneId) }
+        }
+    }
+
+    func panelContentView(panel: any Panel, tabID: UUID, paneId: PaneID) -> PanelContentView {
+        let isFocused = store.panelIsActiveInVisibleDockPane(panel.id) && rightSidebarOwnsInputFocus
+        let isSelectedInPane = store.bonsplitController.selectedTab(inPane: paneId)?.id == tabID
+        let isVisibleInUI = store.panelIsSelectedInVisibleDockPane(panel.id)
+        let isSplit = store.bonsplitController.allPaneIds.count > 1
+        return PanelContentView(
+            panel: panel,
+            workspaceId: store.workspaceId,
+            paneId: paneId,
+            isFocused: isFocused,
+            isSelectedInPane: isSelectedInPane,
+            isVisibleInUI: isVisibleInUI,
+            allowsPointerInput: isVisibleInUI,
+            portalPriority: Self.portalPriority,
+            isSplit: isSplit,
+            appearance: appearance,
+            windowAppearance: windowAppearance,
+            customSidebarTabManager: nil,
+            hasUnreadNotification: unreadPanelIDs.contains(panel.id),
+            terminalAgentContext: "",
+            paneOwnershipOverride: isVisibleInUI,
+            terminalPaneOwnershipResolver: {
+                guard store.paneId(forPanelId: panel.id)?.id == paneId.id else { return false }
+                return store.panelIsSelectedInVisibleDockPane(panel.id)
+            },
+            onFocus: {
+                store.bonsplitController.focusPane(paneId)
+                store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
+            },
+            onRequestPanelFocus: {
+                store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
+                store.focusPanel(panel.id)
+            },
+            onResumeAgentHibernation: {
+                _ = store.resumeAgentHibernation(panelId: panel.id, focus: true)
+            },
+            onAutoResumeAgentHibernation: {
+                _ = store.resumeAgentHibernation(panelId: panel.id, focus: false)
+            },
+            onTriggerFlash: {}
+        )
+    }
+
+    @ViewBuilder
+    private func dockContent(tab: Bonsplit.Tab, paneId: PaneID) -> some View {
+        if let panel = store.panel(for: tab.id) {
+            panelContentView(panel: panel, tabID: tab.id, paneId: paneId)
+                .onTapGesture { store.bonsplitController.focusPane(paneId) }
+        } else {
+            DockEmptyPaneView(
+                onNewTerminal: { _ = store.newSurface(kind: .terminal, inPane: paneId, focus: true) },
+                onNewBrowser: { _ = store.newSurface(kind: .browser, inPane: paneId, focus: true) }
+            )
+            .onTapGesture { store.bonsplitController.focusPane(paneId) }
+        }
+    }
+}

--- a/Sources/DockSplitContentView.swift
+++ b/Sources/DockSplitContentView.swift
@@ -1,5 +1,5 @@
-import AppKit
 import Bonsplit
+import CmuxAppKitSupportUI
 import Foundation
 import SwiftUI
 
@@ -8,13 +8,10 @@ import SwiftUI
 struct DockSplitContentView: View {
     let store: DockSplitStore
     let appearance: PanelAppearance
+    let appearanceRevision: UInt
     let windowAppearance: WindowAppearanceSnapshot
     let rightSidebarOwnsInputFocus: Bool
     let unreadPanelIDs: Set<UUID>
-
-    /// Portal z-priority for Dock-hosted terminal/browser surfaces. Kept low so
-    /// Dock surfaces never overlay main-area surfaces.
-    private static let portalPriority = 1
 
     var body: some View {
         BonsplitView(controller: store.bonsplitController) { tab, paneId in
@@ -28,57 +25,25 @@ struct DockSplitContentView: View {
         }
     }
 
-    func panelContentView(panel: any Panel, tabID: TabID, paneId: PaneID) -> PanelContentView {
-        let isFocused = store.panelIsActiveInVisibleDockPane(panel.id) && rightSidebarOwnsInputFocus
-        let isSelectedInPane = store.bonsplitController.selectedTab(inPane: paneId)?.id == tabID
-        let isVisibleInUI = store.panelIsSelectedInVisibleDockPane(panel.id)
-        let isSplit = store.bonsplitController.allPaneIds.count > 1
-        return PanelContentView(
+    func panelView(panel: any Panel, tabID: TabID, paneID: PaneID) -> DockSplitPanelContentView {
+        DockSplitPanelContentView(
+            store: store,
             panel: panel,
-            workspaceId: store.workspaceId,
-            paneId: paneId,
-            isFocused: isFocused,
-            isSelectedInPane: isSelectedInPane,
-            isVisibleInUI: isVisibleInUI,
-            allowsPointerInput: isVisibleInUI,
-            portalPriority: Self.portalPriority,
-            isSplit: isSplit,
+            tabID: tabID,
+            paneID: paneID,
             appearance: appearance,
+            appearanceRevision: appearanceRevision,
             windowAppearance: windowAppearance,
-            customSidebarTabManager: nil,
-            hasUnreadNotification: unreadPanelIDs.contains(panel.id),
-            terminalAgentContext: "",
-            paneOwnershipOverride: isVisibleInUI,
-            terminalPaneOwnershipResolver: {
-                guard store.paneId(forPanelId: panel.id)?.id == paneId.id else { return false }
-                return store.panelIsSelectedInVisibleDockPane(panel.id)
-            },
-            onFocus: {
-                store.focusPanelFromDockInteraction(
-                    panel.id,
-                    window: NSApp.keyWindow ?? NSApp.mainWindow
-                )
-            },
-            onRequestPanelFocus: {
-                store.focusPanelFromDockInteraction(
-                    panel.id,
-                    window: NSApp.keyWindow ?? NSApp.mainWindow
-                )
-            },
-            onResumeAgentHibernation: {
-                _ = store.resumeAgentHibernation(panelId: panel.id, focus: true)
-            },
-            onAutoResumeAgentHibernation: {
-                _ = store.resumeAgentHibernation(panelId: panel.id, focus: false)
-            },
-            onTriggerFlash: {}
+            rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus,
+            hasUnreadNotification: unreadPanelIDs.contains(panel.id)
         )
     }
 
     @ViewBuilder
     private func dockContent(tab: Bonsplit.Tab, paneId: PaneID) -> some View {
         if let panel = store.panel(for: tab.id) {
-            panelContentView(panel: panel, tabID: tab.id, paneId: paneId)
+            panelView(panel: panel, tabID: tab.id, paneID: paneId)
+                .equatable()
                 .onTapGesture { store.bonsplitController.focusPane(paneId) }
         } else {
             DockEmptyPaneView(

--- a/Sources/DockSplitContentView.swift
+++ b/Sources/DockSplitContentView.swift
@@ -28,7 +28,7 @@ struct DockSplitContentView: View {
         }
     }
 
-    func panelContentView(panel: any Panel, tabID: UUID, paneId: PaneID) -> PanelContentView {
+    func panelContentView(panel: any Panel, tabID: TabID, paneId: PaneID) -> PanelContentView {
         let isFocused = store.panelIsActiveInVisibleDockPane(panel.id) && rightSidebarOwnsInputFocus
         let isSelectedInPane = store.bonsplitController.selectedTab(inPane: paneId)?.id == tabID
         let isVisibleInUI = store.panelIsSelectedInVisibleDockPane(panel.id)

--- a/Sources/DockSplitPanelContentView.swift
+++ b/Sources/DockSplitPanelContentView.swift
@@ -1,0 +1,120 @@
+import AppKit
+import Bonsplit
+import CmuxAppKitSupportUI
+import SwiftUI
+
+/// Isolates one Dock panel behind an immutable render snapshot so unread
+/// changes for another keep-alive tab do not update this panel's AppKit host.
+struct DockSplitPanelContentView: View, Equatable {
+    private struct RenderSnapshot: Equatable {
+        let storeID: ObjectIdentifier
+        let workspaceID: UUID
+        let panelID: UUID
+        let panelType: PanelType
+        let tabID: TabID
+        let paneID: PaneID
+        let rightSidebarOwnsInputFocus: Bool
+        let hasUnreadNotification: Bool
+        let appearanceRevision: UInt
+    }
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.renderSnapshot == rhs.renderSnapshot
+    }
+
+    let store: DockSplitStore
+    let panel: any Panel
+    let tabID: TabID
+    let paneID: PaneID
+    let appearance: PanelAppearance
+    let windowAppearance: WindowAppearanceSnapshot
+    let rightSidebarOwnsInputFocus: Bool
+    let hasUnreadNotification: Bool
+
+    private let renderSnapshot: RenderSnapshot
+
+    init(
+        store: DockSplitStore,
+        panel: any Panel,
+        tabID: TabID,
+        paneID: PaneID,
+        appearance: PanelAppearance,
+        appearanceRevision: UInt,
+        windowAppearance: WindowAppearanceSnapshot,
+        rightSidebarOwnsInputFocus: Bool,
+        hasUnreadNotification: Bool
+    ) {
+        self.store = store
+        self.panel = panel
+        self.tabID = tabID
+        self.paneID = paneID
+        self.appearance = appearance
+        self.windowAppearance = windowAppearance
+        self.rightSidebarOwnsInputFocus = rightSidebarOwnsInputFocus
+        self.hasUnreadNotification = hasUnreadNotification
+        // Dock stores admit only terminal/browser panels; neither shared branch
+        // consumes `windowAppearance`, so it is intentionally outside this key.
+        renderSnapshot = RenderSnapshot(
+            storeID: ObjectIdentifier(store),
+            workspaceID: store.workspaceId,
+            panelID: panel.id,
+            panelType: panel.panelType,
+            tabID: tabID,
+            paneID: paneID,
+            rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus,
+            hasUnreadNotification: hasUnreadNotification,
+            appearanceRevision: appearanceRevision
+        )
+    }
+
+    var body: some View {
+        panelContentView()
+    }
+
+    func panelContentView() -> PanelContentView {
+        let isFocused = store.panelIsActiveInVisibleDockPane(panel.id) && rightSidebarOwnsInputFocus
+        let isSelectedInPane = store.bonsplitController.selectedTab(inPane: paneID)?.id == tabID
+        let isVisibleInUI = store.panelIsSelectedInVisibleDockPane(panel.id)
+        let isSplit = store.bonsplitController.allPaneIds.count > 1
+        return PanelContentView(
+            panel: panel,
+            workspaceId: store.workspaceId,
+            paneId: paneID,
+            isFocused: isFocused,
+            isSelectedInPane: isSelectedInPane,
+            isVisibleInUI: isVisibleInUI,
+            allowsPointerInput: isVisibleInUI,
+            portalPriority: 1,
+            isSplit: isSplit,
+            appearance: appearance,
+            windowAppearance: windowAppearance,
+            customSidebarTabManager: nil,
+            hasUnreadNotification: hasUnreadNotification,
+            terminalAgentContext: "",
+            paneOwnershipOverride: isVisibleInUI,
+            terminalPaneOwnershipResolver: {
+                guard store.paneId(forPanelId: panel.id)?.id == paneID.id else { return false }
+                return store.panelIsSelectedInVisibleDockPane(panel.id)
+            },
+            onFocus: {
+                store.focusPanelFromDockInteraction(
+                    panel.id,
+                    window: NSApp.keyWindow ?? NSApp.mainWindow
+                )
+            },
+            onRequestPanelFocus: {
+                store.focusPanelFromDockInteraction(
+                    panel.id,
+                    window: NSApp.keyWindow ?? NSApp.mainWindow
+                )
+            },
+            onResumeAgentHibernation: {
+                _ = store.resumeAgentHibernation(panelId: panel.id, focus: true)
+            },
+            onAutoResumeAgentHibernation: {
+                _ = store.resumeAgentHibernation(panelId: panel.id, focus: false)
+            },
+            onTriggerFlash: {}
+        )
+    }
+}

--- a/Sources/DockSplitStore+AttentionRouting.swift
+++ b/Sources/DockSplitStore+AttentionRouting.swift
@@ -10,7 +10,6 @@ extension DockSplitStore {
     static func routeAttentionFlash(
         panelID: UUID,
         reason: WorkspaceAttentionFlashReason,
-        requiresSplit: Bool = false,
         shouldFocus: Bool = false
     ) -> Bool {
         guard let dock = liveStores.first(where: { $0.containsPanel(panelID) }),
@@ -20,11 +19,6 @@ extension DockSplitStore {
         }
         if shouldFocus {
             dock.focusPanel(panelID)
-        }
-        if requiresSplit,
-           dock.bonsplitController.allPaneIds.count <= 1,
-           dock.panels.count <= 1 {
-            return true
         }
         panel.triggerFlash(reason: reason)
         return true

--- a/Sources/DockUnreadPanelProjection.swift
+++ b/Sources/DockUnreadPanelProjection.swift
@@ -1,0 +1,94 @@
+import Combine
+import Foundation
+import Observation
+import SwiftUI
+
+/// Narrows the app-wide unread model to this Dock before updating its Bonsplit
+/// subtree. Hidden Docks clear once, then ignore unrelated notification churn.
+@MainActor
+@Observable
+final class DockUnreadPanelProjection {
+    private(set) var unreadPanelIDs: Set<UUID> = []
+
+    @ObservationIgnored private let workspaceID: UUID
+    @ObservationIgnored private var panelIDs: Set<UUID> = []
+    @ObservationIgnored private var isActive = false
+    @ObservationIgnored private var unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey>
+    @ObservationIgnored private var focusedReadIndicatorByWorkspaceID: [UUID: UUID]
+    @ObservationIgnored private var unreadSubscription: AnyCancellable?
+
+    init(
+        source: SidebarUnreadModel,
+        workspaceID: UUID,
+        panelIDs: Set<UUID>,
+        isActive: Bool
+    ) {
+        self.workspaceID = workspaceID
+        self.panelIDs = panelIDs
+        self.isActive = isActive
+        unreadSurfaceKeys = source.unreadSurfaceKeys
+        focusedReadIndicatorByWorkspaceID = source.focusedReadIndicatorByWorkspaceId
+        refresh()
+        unreadSubscription = source.$unreadSurfaceKeys.combineLatest(
+            source.$focusedReadIndicatorByWorkspaceId
+        ).sink { [weak self] unreadSurfaceKeys, focusedReadIndicatorByWorkspaceID in
+            // Both publishers are main-actor-owned and publish synchronously
+            // from SidebarUnreadModel.apply().
+            MainActor.assumeIsolated {
+                self?.receive(
+                    unreadSurfaceKeys: unreadSurfaceKeys,
+                    focusedReadIndicatorByWorkspaceID: focusedReadIndicatorByWorkspaceID
+                )
+            }
+        }
+    }
+
+    func updateContext(panelIDs: Set<UUID>, isActive: Bool) {
+        guard self.panelIDs != panelIDs || self.isActive != isActive else { return }
+        self.panelIDs = panelIDs
+        self.isActive = isActive
+        refresh()
+    }
+
+    private func receive(
+        unreadSurfaceKeys: Set<SidebarSurfaceUnreadKey>,
+        focusedReadIndicatorByWorkspaceID: [UUID: UUID]
+    ) {
+        self.unreadSurfaceKeys = unreadSurfaceKeys
+        self.focusedReadIndicatorByWorkspaceID = focusedReadIndicatorByWorkspaceID
+        refresh()
+    }
+
+    private func refresh() {
+        let nextUnreadPanelIDs: Set<UUID>
+        if isActive {
+            let focusedReadPanelID = focusedReadIndicatorByWorkspaceID[workspaceID]
+            nextUnreadPanelIDs = Set(panelIDs.filter { panelID in
+                unreadSurfaceKeys.contains(
+                    SidebarSurfaceUnreadKey(workspaceId: workspaceID, surfaceId: panelID)
+                ) || focusedReadPanelID == panelID
+            })
+        } else {
+            nextUnreadPanelIDs = []
+        }
+        guard unreadPanelIDs != nextUnreadPanelIDs else { return }
+        unreadPanelIDs = nextUnreadPanelIDs
+    }
+}
+
+struct DockUnreadProjectionContextBridge: View {
+    let projection: DockUnreadPanelProjection
+    let panelIDs: Set<UUID>
+    let isActive: Bool
+
+    var body: some View {
+        Color.clear
+            .onAppear { projection.updateContext(panelIDs: panelIDs, isActive: isActive) }
+            .onChange(of: panelIDs) { _, panelIDs in
+                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
+            }
+            .onChange(of: isActive) { _, isActive in
+                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
+            }
+    }
+}

--- a/Sources/DockUnreadPanelProjection.swift
+++ b/Sources/DockUnreadPanelProjection.swift
@@ -1,7 +1,6 @@
 import Combine
 import Foundation
 import Observation
-import SwiftUI
 
 /// Narrows the app-wide unread model to this Dock before updating its Bonsplit
 /// subtree. Hidden Docks clear once, then ignore unrelated notification churn.
@@ -73,22 +72,5 @@ final class DockUnreadPanelProjection {
         }
         guard unreadPanelIDs != nextUnreadPanelIDs else { return }
         unreadPanelIDs = nextUnreadPanelIDs
-    }
-}
-
-struct DockUnreadProjectionContextBridge: View {
-    let projection: DockUnreadPanelProjection
-    let panelIDs: Set<UUID>
-    let isActive: Bool
-
-    var body: some View {
-        Color.clear
-            .onAppear { projection.updateContext(panelIDs: panelIDs, isActive: isActive) }
-            .onChange(of: panelIDs) { _, panelIDs in
-                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
-            }
-            .onChange(of: isActive) { _, isActive in
-                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
-            }
     }
 }

--- a/Sources/DockUnreadProjectionContextBridge.swift
+++ b/Sources/DockUnreadProjectionContextBridge.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// Synchronizes a Dock's changing panel and visibility context into its unread projection.
+struct DockUnreadProjectionContextBridge: View {
+    let projection: DockUnreadPanelProjection
+    let panelIDs: Set<UUID>
+    let isActive: Bool
+
+    var body: some View {
+        Color.clear
+            .onAppear { projection.updateContext(panelIDs: panelIDs, isActive: isActive) }
+            .onChange(of: panelIDs) { _, panelIDs in
+                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
+            }
+            .onChange(of: isActive) { _, isActive in
+                projection.updateContext(panelIDs: panelIDs, isActive: isActive)
+            }
+    }
+}

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -424,7 +424,8 @@ struct RightSidebarPanelView: View {
                 mode: fileExplorerState.mode,
                 rootDirectory: nil,
                 windowAppearance: windowAppearance,
-                rightSidebarOwnsInputFocus: fileExplorerState.rightSidebarOwnsInputFocus
+                rightSidebarOwnsInputFocus: fileExplorerState.rightSidebarOwnsInputFocus,
+                unreadSource: TerminalNotificationStore.shared.sidebarUnread
             )
             .id("dock.window.\(dock.workspaceId.uuidString)")
         } else {

--- a/Sources/Workspace+ForkAgentConversationAvailability.swift
+++ b/Sources/Workspace+ForkAgentConversationAvailability.swift
@@ -90,8 +90,17 @@ extension Workspace {
     }
 
     func resolveForkAgentConversationContextMenuAvailability(
+        forPanelId panelId: UUID
+    ) async {
+        await resolveForkAgentConversationContextMenuAvailability(
+            forPanelId: panelId,
+            liveAgentIndex: .shared
+        )
+    }
+
+    func resolveForkAgentConversationContextMenuAvailability(
         forPanelId panelId: UUID,
-        liveAgentIndex: SharedLiveAgentIndex = .shared
+        liveAgentIndex: SharedLiveAgentIndex
     ) async {
         let selection = forkAgentConversationContextMenuOpenSelection(
             forPanelId: panelId,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -842,6 +842,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D86840000000000000000001 /* DockSessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86840000000000000000002 /* DockSessionPersistenceTests.swift */; };
 		D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81390010000000000000002 /* DockShortcutRoutingTests.swift */; };
 		D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */; };
+		904090409040904090409043 /* DockSplitContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409044 /* DockSplitContentView.swift */; };
 		DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */; };
 		8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */; };
 		DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */; };
@@ -3201,6 +3202,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D86840000000000000000002 /* DockSessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSessionPersistenceTests.swift; sourceTree = "<group>"; };
 		D81390010000000000000002 /* DockShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSocketLifecycleTests.swift; sourceTree = "<group>"; };
+		904090409040904090409044 /* DockSplitContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitContentView.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Appearance.swift"; sourceTree = "<group>"; };
 		8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+AttentionRouting.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+CloseConfirmation.swift"; sourceTree = "<group>"; };
@@ -6402,6 +6404,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D81390020000000000000002 /* DockSplitStore+ShortcutCommands.swift */,
 				DCDC1000000000000000C001 /* AppDelegate+DockSurfaceMove.swift */,
 				DCDC1000000000000000C021 /* DockScope.swift */,
+				904090409040904090409044 /* DockSplitContentView.swift */,
 				DCDC1000000000000000C031 /* AppDelegate+WindowDock.swift */,
 				D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */,
 				DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */,
@@ -8104,6 +8107,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */,
 				DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */,
 				DCDC1000000000000000C020 /* DockScope.swift in Sources */,
+				904090409040904090409043 /* DockSplitContentView.swift in Sources */,
 				DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */,
 				8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */,
 				DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -863,6 +863,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DCDC1000000000000000B00D /* DockSurfaceKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00E /* DockSurfaceKind.swift */; };
 		D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */; };
 		DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B010 /* DockTrustRequest.swift */; };
+		904090409040904090409041 /* DockUnreadPanelProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409042 /* DockUnreadPanelProjection.swift */; };
 		D86860000000000000000001 /* DockWorkingDirectoryInheritanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */; };
 		D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */; };
 		D75280040000000000000001 /* DynamicTracingSignpostInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */; };
@@ -3221,6 +3222,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DCDC1000000000000000B00E /* DockSurfaceKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSurfaceKind.swift; sourceTree = "<group>"; };
 		D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTerminalReattachTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B010 /* DockTrustRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTrustRequest.swift; sourceTree = "<group>"; };
+		904090409040904090409042 /* DockUnreadPanelProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockUnreadPanelProjection.swift; sourceTree = "<group>"; };
 		D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockWorkingDirectoryInheritanceTests.swift; sourceTree = "<group>"; };
 		D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOverlayRoutingPolicy.swift; sourceTree = "<group>"; };
 		D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTracingSignpostInterval.swift; sourceTree = "<group>"; };
@@ -6390,6 +6392,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B008 /* DockConfigResolution.swift */,
 				DCDC1000000000000000B00A /* DockControlDefinition.swift */,
 				D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */,
+				904090409040904090409042 /* DockUnreadPanelProjection.swift */,
 				DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */,
 				8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */,
 				DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */,
@@ -8121,6 +8124,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC0000000000000000A001 /* DockSplitStore.swift in Sources */,
 				DCDC1000000000000000B00D /* DockSurfaceKind.swift in Sources */,
 				DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */,
+				904090409040904090409041 /* DockUnreadPanelProjection.swift in Sources */,
 				D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */,
 				D75280040000000000000001 /* DynamicTracingSignpostInterval.swift in Sources */,
 				A7206C010000000000000001 /* EffectiveAppearanceObservation.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -847,6 +847,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81390010000000000000002 /* DockShortcutRoutingTests.swift */; };
 		D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */; };
 		904090409040904090409043 /* DockSplitContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409044 /* DockSplitContentView.swift */; };
+		904090409040904090409047 /* DockSplitPanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409048 /* DockSplitPanelContentView.swift */; };
 		DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */; };
 		8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */; };
 		DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */; };
@@ -3229,6 +3230,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D81390010000000000000002 /* DockShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSocketLifecycleTests.swift; sourceTree = "<group>"; };
 		904090409040904090409044 /* DockSplitContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitContentView.swift; sourceTree = "<group>"; };
+		904090409040904090409048 /* DockSplitPanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitPanelContentView.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B012 /* DockSplitStore+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Appearance.swift"; sourceTree = "<group>"; };
 		8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+AttentionRouting.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B022 /* DockSplitStore+CloseConfirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+CloseConfirmation.swift"; sourceTree = "<group>"; };
@@ -6440,6 +6442,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B008 /* DockConfigResolution.swift */,
 				DCDC1000000000000000B00A /* DockControlDefinition.swift */,
 				D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */,
+				904090409040904090409048 /* DockSplitPanelContentView.swift */,
 				904090409040904090409046 /* DockUnreadProjectionContextBridge.swift */,
 				904090409040904090409042 /* DockUnreadPanelProjection.swift */,
 				DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */,
@@ -8175,6 +8178,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */,
 				DCDC1000000000000000C020 /* DockScope.swift in Sources */,
 				904090409040904090409043 /* DockSplitContentView.swift in Sources */,
+				904090409040904090409047 /* DockSplitPanelContentView.swift in Sources */,
 				DCDC1000000000000000B011 /* DockSplitStore+Appearance.swift in Sources */,
 				8777D0038777D0038777D003 /* DockSplitStore+AttentionRouting.swift in Sources */,
 				DCDC1000000000000000B021 /* DockSplitStore+CloseConfirmation.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -870,6 +870,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */; };
 		DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B010 /* DockTrustRequest.swift */; };
 		904090409040904090409041 /* DockUnreadPanelProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409042 /* DockUnreadPanelProjection.swift */; };
+		904090409040904090409045 /* DockUnreadProjectionContextBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904090409040904090409046 /* DockUnreadProjectionContextBridge.swift */; };
 		D86860000000000000000001 /* DockWorkingDirectoryInheritanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */; };
 		D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */; };
 		D75280040000000000000001 /* DynamicTracingSignpostInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */; };
@@ -3251,6 +3252,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTerminalReattachTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B010 /* DockTrustRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTrustRequest.swift; sourceTree = "<group>"; };
 		904090409040904090409042 /* DockUnreadPanelProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockUnreadPanelProjection.swift; sourceTree = "<group>"; };
+		904090409040904090409046 /* DockUnreadProjectionContextBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockUnreadProjectionContextBridge.swift; sourceTree = "<group>"; };
 		D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockWorkingDirectoryInheritanceTests.swift; sourceTree = "<group>"; };
 		D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOverlayRoutingPolicy.swift; sourceTree = "<group>"; };
 		D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTracingSignpostInterval.swift; sourceTree = "<group>"; };
@@ -6438,6 +6440,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B008 /* DockConfigResolution.swift */,
 				DCDC1000000000000000B00A /* DockControlDefinition.swift */,
 				D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */,
+				904090409040904090409046 /* DockUnreadProjectionContextBridge.swift */,
 				904090409040904090409042 /* DockUnreadPanelProjection.swift */,
 				DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */,
 				8777D0048777D0048777D004 /* DockSplitStore+AttentionRouting.swift */,
@@ -8193,6 +8196,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000B00D /* DockSurfaceKind.swift in Sources */,
 				DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */,
 				904090409040904090409041 /* DockUnreadPanelProjection.swift in Sources */,
+				904090409040904090409045 /* DockUnreadProjectionContextBridge.swift in Sources */,
 				D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */,
 				D75280040000000000000001 /* DynamicTracingSignpostInterval.swift in Sources */,
 				A7206C010000000000000001 /* EffectiveAppearanceObservation.swift in Sources */,

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -4,7 +4,6 @@ import Combine
 import CmuxControlSocket
 import CmuxTerminal
 import Foundation
-import SwiftUI
 import Testing
 
 #if canImport(cmux_DEV)
@@ -404,85 +403,62 @@ struct DockNotificationAttentionTests {
         #expect(panel.flashReasons == [.notificationArrival])
     }
 
-    @Test("A single-pane Dock renders its unread notification ring")
-    func singlePaneDockRendersUnreadNotificationRing() async throws {
-        let defaultsSuite = "DockNotificationAttentionTests.\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: defaultsSuite))
-        defer { defaults.removePersistentDomain(forName: defaultsSuite) }
-        defaults.set(true, forKey: NotificationPaneRingSettings.enabledKey)
-
-        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
-        dock.hasLoadedConfiguration = true
-        let panel = TerminalPanel(
-            workspaceId: dock.workspaceId,
-            runtimeSpawnPolicy: .pacedSessionRestore
-        )
-        try dock.seedRuntimeParityPanel(panel)
-        dock.setVisibleInUI(true)
-
+    @Test("Dock unread projection is scoped to active Dock panels")
+    func dockUnreadProjectionIsScopedToActiveDockPanels() {
+        let workspaceID = UUID()
+        let firstPanelID = UUID()
+        let secondPanelID = UUID()
+        let foreignPanelID = UUID()
         let unread = SidebarUnreadModel()
+        let projection = DockUnreadPanelProjection(
+            source: unread,
+            workspaceID: workspaceID,
+            panelIDs: [firstPanelID, secondPanelID],
+            isActive: true
+        )
+
         unread.apply(
-            totalUnreadCount: 1,
+            totalUnreadCount: 2,
             summaries: [:],
             unreadSurfaceKeys: [
-                SidebarSurfaceUnreadKey(workspaceId: dock.workspaceId, surfaceId: panel.id),
+                SidebarSurfaceUnreadKey(workspaceId: workspaceID, surfaceId: firstPanelID),
+                SidebarSurfaceUnreadKey(workspaceId: UUID(), surfaceId: foreignPanelID),
             ],
             focusedReadIndicatorByWorkspaceId: [:],
             manualUnreadWorkspaceIds: []
         )
+        #expect(projection.unreadPanelIDs == [firstPanelID])
 
-        let hostingView = NSHostingView(
-            rootView: DockPanelView(
-                store: dock,
-                isSidebarVisible: true,
-                mode: .dock,
-                rootDirectory: nil,
-                windowAppearance: .rightSidebarPanelViewTestDefault,
-                unreadSource: unread
-            )
-            .defaultAppStorage(defaults)
+        unread.apply(
+            totalUnreadCount: 1,
+            summaries: [:],
+            unreadSurfaceKeys: [],
+            focusedReadIndicatorByWorkspaceId: [workspaceID: secondPanelID],
+            manualUnreadWorkspaceIds: []
         )
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 300),
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
+        #expect(projection.unreadPanelIDs == [secondPanelID])
+
+        projection.updateContext(
+            panelIDs: [firstPanelID, secondPanelID],
+            isActive: false
         )
-        window.contentView = hostingView
-        window.orderBack(nil)
-        defer {
-            window.orderOut(nil)
-            window.close()
-        }
+        #expect(projection.unreadPanelIDs.isEmpty)
 
-        let ringBecameVisible = await waitForVisibleNotificationRing(
-            on: panel,
-            hostingView: hostingView,
-            window: window
+        unread.apply(
+            totalUnreadCount: 1,
+            summaries: [:],
+            unreadSurfaceKeys: [
+                SidebarSurfaceUnreadKey(workspaceId: workspaceID, surfaceId: firstPanelID),
+            ],
+            focusedReadIndicatorByWorkspaceId: [:],
+            manualUnreadWorkspaceIds: []
         )
+        #expect(projection.unreadPanelIDs.isEmpty)
 
-        let ring = panel.hostedView.debugNotificationRingState()
-        #expect(ringBecameVisible)
-        #expect(!ring.isHidden)
-        #expect(ring.opacity > 0)
-    }
-
-    private func waitForVisibleNotificationRing(
-        on panel: TerminalPanel,
-        hostingView: NSView,
-        window: NSWindow
-    ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
-        repeat {
-            hostingView.layoutSubtreeIfNeeded()
-            window.displayIfNeeded()
-            let ring = panel.hostedView.debugNotificationRingState()
-            if !ring.isHidden, ring.opacity > 0 {
-                return true
-            }
-            await Task.yield()
-        } while clock.now < deadline
-        return false
+        projection.updateContext(
+            panelIDs: [firstPanelID, secondPanelID],
+            isActive: true
+        )
+        #expect(projection.unreadPanelIDs == [firstPanelID])
     }
 }

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -4,6 +4,7 @@ import Combine
 import CmuxControlSocket
 import CmuxTerminal
 import Foundation
+import SwiftUI
 import Testing
 
 #if canImport(cmux_DEV)
@@ -195,6 +196,16 @@ struct DockRuntimeParityTests {
                 requiresSplit: false,
                 shouldFocus: false
             )
+            workspace.triggerNotificationFocusFlash(
+                panelId: workspacePanel.id,
+                requiresSplit: true,
+                shouldFocus: false
+            )
+            workspace.triggerNotificationFocusFlash(
+                panelId: globalPanel.id,
+                requiresSplit: true,
+                shouldFocus: false
+            )
             manager.workspaceTriggerNotificationDismissFlash(
                 workspaceId: workspace.id,
                 panelId: workspacePanel.id
@@ -214,11 +225,84 @@ struct DockRuntimeParityTests {
 
             let expected: [WorkspaceAttentionFlashReason] = [
                 .notificationArrival,
+                .notificationArrival,
                 .notificationDismiss,
                 .unreadIndicatorDismiss,
             ]
             #expect(workspacePanel.flashReasons == expected)
             #expect(globalPanel.flashReasons == expected)
+        }
+    }
+
+    @Test("A single-pane Dock renders its unread notification ring")
+    func singlePaneDockRendersUnreadNotificationRing() async throws {
+        try await withAppContext { _, _, workspace, _ in
+            let defaults = UserDefaults.standard
+            let previousRingSetting = defaults.object(forKey: NotificationPaneRingSettings.enabledKey)
+            defer {
+                if let previousRingSetting {
+                    defaults.set(previousRingSetting, forKey: NotificationPaneRingSettings.enabledKey)
+                } else {
+                    defaults.removeObject(forKey: NotificationPaneRingSettings.enabledKey)
+                }
+            }
+            defaults.set(true, forKey: NotificationPaneRingSettings.enabledKey)
+
+            let dock = workspace.dockSplit
+            dock.hasLoadedConfiguration = true
+            let panel = TerminalPanel(
+                workspaceId: workspace.id,
+                runtimeSpawnPolicy: .pacedSessionRestore
+            )
+            try dock.seedRuntimeParityPanel(panel)
+            dock.setVisibleInUI(true)
+
+            let unread = SidebarUnreadModel()
+            unread.apply(
+                totalUnreadCount: 1,
+                summaries: [:],
+                unreadSurfaceKeys: [
+                    SidebarSurfaceUnreadKey(workspaceId: dock.workspaceId, surfaceId: panel.id),
+                ],
+                focusedReadIndicatorByWorkspaceId: [:],
+                manualUnreadWorkspaceIds: []
+            )
+
+            let hostingView = NSHostingView(
+                rootView: DockPanelView(
+                    store: dock,
+                    isSidebarVisible: true,
+                    mode: .dock,
+                    rootDirectory: nil,
+                    windowAppearance: .rightSidebarPanelViewTestDefault
+                )
+                .environmentObject(unread)
+            )
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 360, height: 300),
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.contentView = hostingView
+            window.orderBack(nil)
+            defer {
+                window.orderOut(nil)
+                window.close()
+            }
+
+            for _ in 0..<10 {
+                hostingView.layoutSubtreeIfNeeded()
+                window.displayIfNeeded()
+                if !panel.hostedView.debugNotificationRingState().isHidden {
+                    break
+                }
+                await Task.yield()
+            }
+
+            let ring = panel.hostedView.debugNotificationRingState()
+            #expect(!ring.isHidden)
+            #expect(ring.opacity > 0)
         }
     }
 

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -386,15 +386,18 @@ struct DockRuntimeParityTests {
 @MainActor
 @Suite("Dock notification attention", .serialized)
 struct DockNotificationAttentionTests {
-    @Test("Single-pane Dock attention routes without a workspace split gate")
-    func singlePaneDockAttentionRoutesWithoutWorkspaceSplitGate() throws {
+    @Test("Single-pane Dock attention bypasses workspace split gating")
+    func singlePaneDockAttentionBypassesWorkspaceSplitGating() throws {
         let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
         let panel = DockRuntimeParityPanel(title: "Dock")
         try dock.seedRuntimeParityPanel(panel)
 
-        let routed = DockSplitStore.routeAttentionFlash(
+        let appDelegate = try #require(AppDelegate.shared, "Expected app-host AppDelegate")
+        let routed = appDelegate.routeNotificationAttentionFlash(
+            workspaceID: dock.workspaceId,
             panelID: panel.id,
-            reason: .notificationArrival
+            reason: .notificationArrival,
+            requiresSplit: true
         )
 
         #expect(routed)

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -459,4 +459,21 @@ struct DockNotificationAttentionTests {
         )
         #expect(projection.unreadPanelIDs == [firstPanelID])
     }
+
+    @Test("Dock panel content receives projected unread state")
+    func dockPanelContentReceivesProjectedUnreadState() throws {
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let panel = DockRuntimeParityPanel(title: "Dock")
+        let paneID = try dock.seedRuntimeParityPanel(panel)
+        let tabID = try #require(dock.surfaceIdFromPanelId(panel.id))
+        let content = DockSplitContentView(
+            store: dock,
+            appearance: .fromConfig(WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "test.dock.unread")),
+            windowAppearance: .rightSidebarPanelViewTestDefault,
+            rightSidebarOwnsInputFocus: false,
+            unreadPanelIDs: [panel.id]
+        )
+
+        #expect(content.panelContentView(panel: panel, tabID: tabID, paneId: paneID).hasUnreadNotification)
+    }
 }

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -122,6 +122,25 @@ struct DockRuntimeParityTests {
         for await _ in readiness { break }
     }
 
+    private func waitForVisibleNotificationRing(
+        on panel: TerminalPanel,
+        hostingView: NSView,
+        window: NSWindow
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        repeat {
+            hostingView.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+            let ring = panel.hostedView.debugNotificationRingState()
+            if !ring.isHidden, ring.opacity > 0 {
+                return true
+            }
+            await Task.yield()
+        } while clock.now < deadline
+        return false
+    }
+
     private func withAppContext(
         _ body: @MainActor (AppDelegate, TabManager, Workspace, UUID) async throws -> Void
     ) async throws {
@@ -291,16 +310,14 @@ struct DockRuntimeParityTests {
                 window.close()
             }
 
-            for _ in 0..<10 {
-                hostingView.layoutSubtreeIfNeeded()
-                window.displayIfNeeded()
-                if !panel.hostedView.debugNotificationRingState().isHidden {
-                    break
-                }
-                await Task.yield()
-            }
+            let ringBecameVisible = await waitForVisibleNotificationRing(
+                on: panel,
+                hostingView: hostingView,
+                window: window
+            )
 
             let ring = panel.hostedView.debugNotificationRingState()
+            #expect(ringBecameVisible)
             #expect(!ring.isHidden)
             #expect(ring.opacity > 0)
         }

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -386,18 +386,15 @@ struct DockRuntimeParityTests {
 @MainActor
 @Suite("Dock notification attention", .serialized)
 struct DockNotificationAttentionTests {
-    @Test("Single-pane Dock attention bypasses workspace split gating")
-    func singlePaneDockAttentionBypassesWorkspaceSplitGating() throws {
+    @Test("Single-pane Dock attention routes without a workspace split gate")
+    func singlePaneDockAttentionRoutesWithoutWorkspaceSplitGate() throws {
         let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
         let panel = DockRuntimeParityPanel(title: "Dock")
         try dock.seedRuntimeParityPanel(panel)
 
-        let appDelegate = try #require(AppDelegate.shared, "Expected app-host AppDelegate")
-        let routed = appDelegate.routeNotificationAttentionFlash(
-            workspaceID: dock.workspaceId,
+        let routed = DockSplitStore.routeAttentionFlash(
             panelID: panel.id,
-            reason: .notificationArrival,
-            requiresSplit: true
+            reason: .notificationArrival
         )
 
         #expect(routed)

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -122,25 +122,6 @@ struct DockRuntimeParityTests {
         for await _ in readiness { break }
     }
 
-    private func waitForVisibleNotificationRing(
-        on panel: TerminalPanel,
-        hostingView: NSView,
-        window: NSWindow
-    ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
-        repeat {
-            hostingView.layoutSubtreeIfNeeded()
-            window.displayIfNeeded()
-            let ring = panel.hostedView.debugNotificationRingState()
-            if !ring.isHidden, ring.opacity > 0 {
-                return true
-            }
-            await Task.yield()
-        } while clock.now < deadline
-        return false
-    }
-
     private func withAppContext(
         _ body: @MainActor (AppDelegate, TabManager, Workspace, UUID) async throws -> Void
     ) async throws {
@@ -215,16 +196,6 @@ struct DockRuntimeParityTests {
                 requiresSplit: false,
                 shouldFocus: false
             )
-            workspace.triggerNotificationFocusFlash(
-                panelId: workspacePanel.id,
-                requiresSplit: true,
-                shouldFocus: false
-            )
-            workspace.triggerNotificationFocusFlash(
-                panelId: globalPanel.id,
-                requiresSplit: true,
-                shouldFocus: false
-            )
             manager.workspaceTriggerNotificationDismissFlash(
                 workspaceId: workspace.id,
                 panelId: workspacePanel.id
@@ -244,82 +215,11 @@ struct DockRuntimeParityTests {
 
             let expected: [WorkspaceAttentionFlashReason] = [
                 .notificationArrival,
-                .notificationArrival,
                 .notificationDismiss,
                 .unreadIndicatorDismiss,
             ]
             #expect(workspacePanel.flashReasons == expected)
             #expect(globalPanel.flashReasons == expected)
-        }
-    }
-
-    @Test("A single-pane Dock renders its unread notification ring")
-    func singlePaneDockRendersUnreadNotificationRing() async throws {
-        try await withAppContext { _, _, workspace, _ in
-            let defaults = UserDefaults.standard
-            let previousRingSetting = defaults.object(forKey: NotificationPaneRingSettings.enabledKey)
-            defer {
-                if let previousRingSetting {
-                    defaults.set(previousRingSetting, forKey: NotificationPaneRingSettings.enabledKey)
-                } else {
-                    defaults.removeObject(forKey: NotificationPaneRingSettings.enabledKey)
-                }
-            }
-            defaults.set(true, forKey: NotificationPaneRingSettings.enabledKey)
-
-            let dock = workspace.dockSplit
-            dock.hasLoadedConfiguration = true
-            let panel = TerminalPanel(
-                workspaceId: workspace.id,
-                runtimeSpawnPolicy: .pacedSessionRestore
-            )
-            try dock.seedRuntimeParityPanel(panel)
-            dock.setVisibleInUI(true)
-
-            let unread = SidebarUnreadModel()
-            unread.apply(
-                totalUnreadCount: 1,
-                summaries: [:],
-                unreadSurfaceKeys: [
-                    SidebarSurfaceUnreadKey(workspaceId: dock.workspaceId, surfaceId: panel.id),
-                ],
-                focusedReadIndicatorByWorkspaceId: [:],
-                manualUnreadWorkspaceIds: []
-            )
-
-            let hostingView = NSHostingView(
-                rootView: DockPanelView(
-                    store: dock,
-                    isSidebarVisible: true,
-                    mode: .dock,
-                    rootDirectory: nil,
-                    windowAppearance: .rightSidebarPanelViewTestDefault
-                )
-                .environmentObject(unread)
-            )
-            let window = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 360, height: 300),
-                styleMask: [.borderless],
-                backing: .buffered,
-                defer: false
-            )
-            window.contentView = hostingView
-            window.orderBack(nil)
-            defer {
-                window.orderOut(nil)
-                window.close()
-            }
-
-            let ringBecameVisible = await waitForVisibleNotificationRing(
-                on: panel,
-                hostingView: hostingView,
-                window: window
-            )
-
-            let ring = panel.hostedView.debugNotificationRingState()
-            #expect(ringBecameVisible)
-            #expect(!ring.isHidden)
-            #expect(ring.opacity > 0)
         }
     }
 
@@ -481,5 +381,113 @@ struct DockRuntimeParityTests {
             let readResult = try #require(readEnvelope["result"] as? [String: Any])
             #expect(readResult["surface_id"] as? String == workspaceTerminal.id.uuidString)
         }
+    }
+}
+
+@MainActor
+@Suite("Dock notification attention", .serialized)
+struct DockNotificationAttentionTests {
+    @Test("Single-pane Dock attention bypasses workspace split gating")
+    func singlePaneDockAttentionBypassesWorkspaceSplitGating() throws {
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let panel = DockRuntimeParityPanel(title: "Dock")
+        try dock.seedRuntimeParityPanel(panel)
+
+        let routed = AppDelegate().routeNotificationAttentionFlash(
+            workspaceID: dock.workspaceId,
+            panelID: panel.id,
+            reason: .notificationArrival,
+            requiresSplit: true
+        )
+
+        #expect(routed)
+        #expect(panel.flashReasons == [.notificationArrival])
+    }
+
+    @Test("A single-pane Dock renders its unread notification ring")
+    func singlePaneDockRendersUnreadNotificationRing() async throws {
+        let defaults = UserDefaults.standard
+        let previousRingSetting = defaults.object(forKey: NotificationPaneRingSettings.enabledKey)
+        defer {
+            if let previousRingSetting {
+                defaults.set(previousRingSetting, forKey: NotificationPaneRingSettings.enabledKey)
+            } else {
+                defaults.removeObject(forKey: NotificationPaneRingSettings.enabledKey)
+            }
+        }
+        defaults.set(true, forKey: NotificationPaneRingSettings.enabledKey)
+
+        let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        dock.hasLoadedConfiguration = true
+        let panel = TerminalPanel(
+            workspaceId: dock.workspaceId,
+            runtimeSpawnPolicy: .pacedSessionRestore
+        )
+        try dock.seedRuntimeParityPanel(panel)
+        dock.setVisibleInUI(true)
+
+        let unread = SidebarUnreadModel()
+        unread.apply(
+            totalUnreadCount: 1,
+            summaries: [:],
+            unreadSurfaceKeys: [
+                SidebarSurfaceUnreadKey(workspaceId: dock.workspaceId, surfaceId: panel.id),
+            ],
+            focusedReadIndicatorByWorkspaceId: [:],
+            manualUnreadWorkspaceIds: []
+        )
+
+        let hostingView = NSHostingView(
+            rootView: DockPanelView(
+                store: dock,
+                isSidebarVisible: true,
+                mode: .dock,
+                rootDirectory: nil,
+                windowAppearance: .rightSidebarPanelViewTestDefault
+            )
+            .environmentObject(unread)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        window.orderBack(nil)
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let ringBecameVisible = await waitForVisibleNotificationRing(
+            on: panel,
+            hostingView: hostingView,
+            window: window
+        )
+
+        let ring = panel.hostedView.debugNotificationRingState()
+        #expect(ringBecameVisible)
+        #expect(!ring.isHidden)
+        #expect(ring.opacity > 0)
+    }
+
+    private func waitForVisibleNotificationRing(
+        on panel: TerminalPanel,
+        hostingView: NSView,
+        window: NSWindow
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        repeat {
+            hostingView.layoutSubtreeIfNeeded()
+            window.displayIfNeeded()
+            let ring = panel.hostedView.debugNotificationRingState()
+            if !ring.isHidden, ring.opacity > 0 {
+                return true
+            }
+            await Task.yield()
+        } while clock.now < deadline
+        return false
     }
 }

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -468,7 +468,7 @@ struct DockNotificationAttentionTests {
         let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
         let panel = DockRuntimeParityPanel(title: "Dock")
         let paneID = try dock.seedRuntimeParityPanel(panel)
-        let tabID = try #require(dock.surfaceIdFromPanelId(panel.id))
+        let tabID = try #require(dock.surfaceId(forPanelId: panel.id))
         let content = DockSplitContentView(
             store: dock,
             appearance: .fromConfig(WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "test.dock.unread")),

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -437,9 +437,9 @@ struct DockNotificationAttentionTests {
                 isSidebarVisible: true,
                 mode: .dock,
                 rootDirectory: nil,
-                windowAppearance: .rightSidebarPanelViewTestDefault
+                windowAppearance: .rightSidebarPanelViewTestDefault,
+                unreadSource: unread
             )
-            .environmentObject(unread)
             .defaultAppStorage(defaults)
         )
         let window = NSWindow(

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -392,7 +392,8 @@ struct DockNotificationAttentionTests {
         let panel = DockRuntimeParityPanel(title: "Dock")
         try dock.seedRuntimeParityPanel(panel)
 
-        let routed = AppDelegate().routeNotificationAttentionFlash(
+        let appDelegate = try #require(AppDelegate.shared, "Expected app-host AppDelegate")
+        let routed = appDelegate.routeNotificationAttentionFlash(
             workspaceID: dock.workspaceId,
             panelID: panel.id,
             reason: .notificationArrival,

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -386,15 +386,18 @@ struct DockRuntimeParityTests {
 @MainActor
 @Suite("Dock notification attention", .serialized)
 struct DockNotificationAttentionTests {
-    @Test("Single-pane Dock attention routes without a workspace split gate")
-    func singlePaneDockAttentionRoutesWithoutWorkspaceSplitGate() throws {
+    @Test("Single-pane Dock attention bypasses workspace split gating")
+    func singlePaneDockAttentionBypassesWorkspaceSplitGating() throws {
         let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
         let panel = DockRuntimeParityPanel(title: "Dock")
         try dock.seedRuntimeParityPanel(panel)
 
-        let routed = DockSplitStore.routeAttentionFlash(
+        let appDelegate = try #require(AppDelegate.shared, "Expected app-host AppDelegate")
+        let routed = appDelegate.routeNotificationAttentionFlash(
+            workspaceID: dock.workspaceId,
             panelID: panel.id,
-            reason: .notificationArrival
+            reason: .notificationArrival,
+            requiresSplit: true
         )
 
         #expect(routed)
@@ -469,11 +472,26 @@ struct DockNotificationAttentionTests {
         let content = DockSplitContentView(
             store: dock,
             appearance: .fromConfig(WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "test.dock.unread")),
+            appearanceRevision: 0,
             windowAppearance: .rightSidebarPanelViewTestDefault,
             rightSidebarOwnsInputFocus: false,
             unreadPanelIDs: [panel.id]
         )
 
-        #expect(content.panelContentView(panel: panel, tabID: tabID, paneId: paneID).hasUnreadNotification)
+        let unreadPanelView = content.panelView(panel: panel, tabID: tabID, paneID: paneID)
+        let readContent = DockSplitContentView(
+            store: dock,
+            appearance: content.appearance,
+            appearanceRevision: 0,
+            windowAppearance: content.windowAppearance,
+            rightSidebarOwnsInputFocus: false,
+            unreadPanelIDs: []
+        )
+        let readPanelView = readContent.panelView(panel: panel, tabID: tabID, paneID: paneID)
+
+        #expect(unreadPanelView.panelContentView().hasUnreadNotification)
+        #expect(unreadPanelView != readPanelView)
+        let otherUnreadContent = DockSplitContentView(store: dock, appearance: content.appearance, appearanceRevision: 0, windowAppearance: content.windowAppearance, rightSidebarOwnsInputFocus: false, unreadPanelIDs: [UUID()])
+        #expect(readPanelView == otherUnreadContent.panelView(panel: panel, tabID: tabID, paneID: paneID))
     }
 }

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -406,15 +406,9 @@ struct DockNotificationAttentionTests {
 
     @Test("A single-pane Dock renders its unread notification ring")
     func singlePaneDockRendersUnreadNotificationRing() async throws {
-        let defaults = UserDefaults.standard
-        let previousRingSetting = defaults.object(forKey: NotificationPaneRingSettings.enabledKey)
-        defer {
-            if let previousRingSetting {
-                defaults.set(previousRingSetting, forKey: NotificationPaneRingSettings.enabledKey)
-            } else {
-                defaults.removeObject(forKey: NotificationPaneRingSettings.enabledKey)
-            }
-        }
+        let defaultsSuite = "DockNotificationAttentionTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsSuite))
+        defer { defaults.removePersistentDomain(forName: defaultsSuite) }
         defaults.set(true, forKey: NotificationPaneRingSettings.enabledKey)
 
         let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
@@ -446,6 +440,7 @@ struct DockNotificationAttentionTests {
                 windowAppearance: .rightSidebarPanelViewTestDefault
             )
             .environmentObject(unread)
+            .defaultAppStorage(defaults)
         )
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 300),

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -386,18 +386,15 @@ struct DockRuntimeParityTests {
 @MainActor
 @Suite("Dock notification attention", .serialized)
 struct DockNotificationAttentionTests {
-    @Test("Single-pane Dock attention bypasses workspace split gating")
-    func singlePaneDockAttentionBypassesWorkspaceSplitGating() throws {
+    @Test("Single-pane Dock attention routes without AppDelegate global state")
+    func singlePaneDockAttentionRoutesWithoutAppDelegateGlobalState() throws {
         let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
         let panel = DockRuntimeParityPanel(title: "Dock")
         try dock.seedRuntimeParityPanel(panel)
 
-        let appDelegate = try #require(AppDelegate.shared, "Expected app-host AppDelegate")
-        let routed = appDelegate.routeNotificationAttentionFlash(
-            workspaceID: dock.workspaceId,
+        let routed = DockSplitStore.routeAttentionFlash(
             panelID: panel.id,
-            reason: .notificationArrival,
-            requiresSplit: true
+            reason: .notificationArrival
         )
 
         #expect(routed)

--- a/cmuxTests/DockRuntimeParityTests.swift
+++ b/cmuxTests/DockRuntimeParityTests.swift
@@ -386,15 +386,18 @@ struct DockRuntimeParityTests {
 @MainActor
 @Suite("Dock notification attention", .serialized)
 struct DockNotificationAttentionTests {
-    @Test("Single-pane Dock attention routes without AppDelegate global state")
-    func singlePaneDockAttentionRoutesWithoutAppDelegateGlobalState() throws {
+    @Test("Single-pane Dock attention bypasses workspace split gating")
+    func singlePaneDockAttentionBypassesWorkspaceSplitGating() throws {
         let dock = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
         let panel = DockRuntimeParityPanel(title: "Dock")
         try dock.seedRuntimeParityPanel(panel)
 
-        let routed = DockSplitStore.routeAttentionFlash(
+        let appDelegate = try #require(AppDelegate.shared, "Expected app-host AppDelegate")
+        let routed = appDelegate.routeNotificationAttentionFlash(
+            workspaceID: dock.workspaceId,
             panelID: panel.id,
-            reason: .notificationArrival
+            reason: .notificationArrival,
+            requiresSplit: true
         )
 
         #expect(routed)


### PR DESCRIPTION
## Summary

- render Dock terminal unread rings from a Dock-scoped projection of the shared notification state
- preserve notification-arrival flashes for single-pane workspace and global Docks instead of applying the workspace-only split fallback
- isolate each keep-alive Dock panel behind an immutable `.equatable()` render snapshot so another panel's unread change does not update every terminal host
- gate the stable Dock routing and projection regressions in the non-tolerant notification CI lane

Closes #9040

## Root cause

Dock notification ownership and unread publication already worked, but `DockPanelView` hard-coded `hasUnreadNotification` to `false`. Dock attention routing also applied a workspace-only `requiresSplit` fallback, silently consuming notification-arrival flashes for single-pane Docks even though Docks have no tab-strip fallback.

## Architecture

`DockUnreadPanelProjection` is a main-actor, per-Dock projection. It observes only the shared per-surface unread and focused-read inputs, filters them to the active Dock panel IDs, equality-guards its immutable output set, and avoids scanning panels while the Dock is hidden. Only that value snapshot crosses into the Bonsplit subtree.

`DockSplitPanelContentView` gives each keep-alive panel its own immutable equality key. An unread change for one Dock panel therefore updates that panel's shared `PanelContentView` path without calling every sibling terminal's AppKit host update. Appearance changes still cross the boundary through an explicit revision.

The existing global unread source is injected explicitly at the right-sidebar composition point; no new broad environment-object dependency was added below the Dock layout boundary. `SidebarUnreadModel` is still a legacy `ObservableObject`/`@Published` owner, so the projection intentionally confines one Combine subscription to that adapter seam and exposes an `@Observable` value snapshot downstream. Migrating the shared unread owner to Observation is broader behavior-affecting work and is not part of this Dock regression fix.

## Verification

- final manually dispatched CI: https://github.com/manaflow-ai/cmux/actions/runs/30363847747 — green
- focused `Run notification routing regressions` step: green
- all app-host shards, Swift package tests, `tests-build-and-lag`, warning-budget validation, and Release build: green
- `git diff --check`
- `python3 scripts/check-sidebar-lazy-layout.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- `./tests/test_ci_self_hosted_guard.sh`
- `./scripts/check-pbxproj.sh`
- no local Xcode build, Swift test, dev build, or dogfood build was run, per task instructions
- `scripts/swift_file_length_budget.py` and `.github/swift-file-length-budget.tsv` are absent from both the base checkout and this branch; the new Swift files are 19–120 lines, the expanded regression file is 497 lines, and `.github/swift-warning-budget.tsv` is unchanged

## Regression proof

The branch retains a test-only commit before the production fix, but no red CI proof was established: that test-only broad app-host shard stopped after its XCTest summary before the new Swift Testing cases emitted terminal results.

The final stable suite covers:

- the app-level notification attention route with `requiresSplit: true` reaching a single-pane Dock and emitting `.notificationArrival`
- Dock panel composition forwarding unread state to panel content
- exclusion of unread state from foreign workspaces
- the focused-read indicator
- hidden-Dock suppression
- reactivation reconciliation
- per-panel equality changing for that panel's unread state while remaining equal for another panel's unread state

An attempted AppKit-hosted real Ghostty rendering assertion crashed inside the test harness after SwiftUI view-time publishing warnings. It was removed rather than presenting unstable coverage as proof. This PR therefore claims stable routing/projection/composition behavior coverage, not an end-to-end pixel/render assertion.

## Review triage

Canonical autoreview found no actionable code defect and reported the patch correct. The cmux policy tail's private-helper-type and Combine-boundary heuristics were consciously rejected: the nested render snapshot is a closed value key owned solely by its enclosing view, while the single cancellable adapts the pre-existing `SidebarUnreadModel: ObservableObject` source into the new `@Observable` owner.

A fresh CodeRabbit review on the final HEAD completed with no actionable comments. Its generic pre-merge rubric concerns were also rejected with concrete ownership evidence: rebuilding Dock panel IDs occurs only on Dock lifecycle/context invalidation, not per keystroke; caching them would introduce a second mutable source of truth; and this app-specific lifecycle adapter is not a broad package domain suitable for a new micro-package. Cursor Bugbot's repeated comments are billing-limit notices, not code findings.

## CI warning repair

The CI gate exposed an existing Swift actor-isolation warning in `Workspace+ForkAgentConversationAvailability.swift`. The default `.shared` argument was replaced with the file's existing forwarding-overload pattern; runtime behavior is unchanged and no warning budget was raised.

## Localization

No user-facing strings changed; no localization catalog updates are required.

## Demo

Not recorded because this task explicitly prohibits local and dogfood builds.

## Checklist

- [x] Fix is scoped to Dock notification rendering and routing
- [x] Behavior-level regression coverage added
- [x] No user-facing strings added
- [x] No Swift budget TSV changed
- [x] Required CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unread indicators for Dock panels, synchronized with sidebar notification and focus state.
  * Improved Dock split-pane rendering, including empty-pane actions for creating terminals or browsers.
  * Added more consistent Dock panel focus, appearance, and hibernation interactions.

* **Bug Fixes**
  * Improved notification attention routing so Dock panels reliably flash and focus when appropriate.

* **Tests**
  * Added regression coverage for Dock notification routing, unread indicators, and split-pane rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
