### PR TITLE
Fix Dock terminal cwd inheritance from Ghostty reports

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ReportedWorkingDirectory.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ReportedWorkingDirectory.swift
@@ -8,8 +8,7 @@ extension TerminalSurface {
     /// - Parameter directory: The working directory reported by Ghostty.
     @MainActor
     public func recordReportedWorkingDirectory(_ directory: String) {
-        let normalized = directory.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalized.isEmpty, normalized != reportedWorkingDirectory else { return }
-        reportedWorkingDirectory = normalized
+        guard !directory.isEmpty, directory != reportedWorkingDirectory else { return }
+        reportedWorkingDirectory = directory
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ReportedWorkingDirectory.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ReportedWorkingDirectory.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension TerminalSurface {
+    /// Records the latest working directory emitted by this surface's shell integration.
+    ///
+    /// Empty reports do not erase the last usable directory.
+    ///
+    /// - Parameter directory: The working directory reported by Ghostty.
+    @MainActor
+    public func recordReportedWorkingDirectory(_ directory: String) {
+        let normalized = directory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty, normalized != reportedWorkingDirectory else { return }
+        reportedWorkingDirectory = normalized
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ReportedWorkingDirectory.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+ReportedWorkingDirectory.swift
@@ -3,12 +3,13 @@ import Foundation
 extension TerminalSurface {
     /// Records the latest working directory emitted by this surface's shell integration.
     ///
-    /// Empty reports do not erase the last usable directory.
+    /// An empty report clears the directory, matching Ghostty's OSC 7 reset semantics.
     ///
     /// - Parameter directory: The working directory reported by Ghostty.
     @MainActor
     public func recordReportedWorkingDirectory(_ directory: String) {
-        guard !directory.isEmpty, directory != reportedWorkingDirectory else { return }
-        reportedWorkingDirectory = directory
+        let reportedDirectory = directory.isEmpty ? nil : directory
+        guard reportedDirectory != reportedWorkingDirectory else { return }
+        reportedWorkingDirectory = reportedDirectory
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -165,7 +165,7 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// The working directory requested at construction, if any.
     public var requestedWorkingDirectory: String? { workingDirectory }
 
-    /// The latest non-empty working directory reported by Ghostty shell integration.
+    /// The working directory reported by Ghostty shell integration, or nil after a reset.
     @Published public internal(set) var reportedWorkingDirectory: String?
     /// Where the surface participates in focus routing. Mutable so a live
     /// surface can move between the workspace area and the right-sidebar dock

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -12,9 +12,7 @@ internal import CMUXDebugLog
 /// reclamation state.
 ///
 /// Lifted verbatim from `Sources/GhosttyTerminalView.swift`; the legacy
-/// reach-ups into `GhosttyApp.shared` / `TerminalController.shared` /
-/// `MobileTerminalByteTee.shared` / `RendererRealizationController.shared` /
-/// `AgentHibernationController.shared` are inverted through the seams in
+/// reach-ups into app-owned singletons are inverted through the seams in
 /// ``TerminalSurfaceRuntimeDependencies``.
 ///
 /// Isolation: the model keeps the legacy main-thread-only contract. Members
@@ -167,6 +165,8 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// The working directory requested at construction, if any.
     public var requestedWorkingDirectory: String? { workingDirectory }
 
+    /// The latest non-empty working directory reported by Ghostty shell integration.
+    @Published public internal(set) var reportedWorkingDirectory: String?
     /// Where the surface participates in focus routing. Mutable so a live
     /// surface can move between the workspace area and the right-sidebar dock
     /// without being recreated (preserving its process). Always mutate through

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -476,7 +476,7 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         self.surfaceContext = context
         self.configTemplate = configTemplate
         self.lastKnownFontSizeLineage = configTemplate?.fontSizeLineage
-        self.workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.workingDirectory = workingDirectory.flatMap { $0.isEmpty ? nil : $0 }
         self.portOrdinal = portOrdinal
         self.initialCommand = initialCommand.flatMap {
             $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -560,10 +560,12 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// Moves this surface between focus-routing placements (workspace ↔
     /// right-sidebar dock) and keeps the surface registry's record in sync.
     /// Used when a live terminal is dragged across containers so it is not
-    /// recreated. No-op when the placement is unchanged.
+    /// recreated. Clears placement-owned directory state so a prior Dock tenure
+    /// cannot outrank the incoming container's directory. No-op when unchanged.
     @MainActor
     public func setFocusPlacement(_ placement: TerminalSurfaceFocusPlacement) {
         guard focusPlacement != placement else { return }
+        reportedWorkingDirectory = nil
         focusPlacement = placement
         registry.updateFocusPlacement(id: id, placement)
     }

--- a/Sources/DockSplitStore+WorkingDirectory.swift
+++ b/Sources/DockSplitStore+WorkingDirectory.swift
@@ -10,9 +10,11 @@ extension DockSplitStore {
     /// Returns the best current directory owned by a Dock terminal.
     ///
     /// Local terminals prefer the shell integration report owned by their
-    /// surface, then fall back to foreground-process inspection. Remote terminals
-    /// must keep their transferred remote directory because their local process
-    /// is only the relay.
+    /// surface, then fall back to foreground-process inspection. A restored
+    /// agent that is still auto-resuming retains the pre-report candidate order
+    /// so an early shell-home report cannot bypass its cwd rescue state. Remote
+    /// terminals must keep their transferred remote directory because their
+    /// local process is only the relay.
     func terminalWorkingDirectory(for sourcePanelId: UUID) -> String? {
         guard let terminal = panels[sourcePanelId] as? TerminalPanel else { return nil }
         let transfer = detachedSurfaceTransfersByPanelId[sourcePanelId]
@@ -23,12 +25,16 @@ extension DockSplitStore {
                 terminal.requestedWorkingDirectory,
             ])
         }
-        return TerminalWorkingDirectoryResolver.firstAvailable([
-            terminal.surface.reportedWorkingDirectory,
+        let existingCandidates = [
             terminalWorkingDirectoryResolver.liveForegroundProcessWorkingDirectory(for: terminal),
             terminal.directory,
             transfer?.directory,
             terminal.requestedWorkingDirectory,
-        ])
+        ]
+        let reportedDirectory = terminal.surface.reportedWorkingDirectory
+        if restoredAgentLifecycle.resumeStatesByPanelId[sourcePanelId] == .autoResumeCommandRunning {
+            return TerminalWorkingDirectoryResolver.firstAvailable(existingCandidates + [reportedDirectory])
+        }
+        return TerminalWorkingDirectoryResolver.firstAvailable([reportedDirectory] + existingCandidates)
     }
 }

--- a/Sources/DockSplitStore+WorkingDirectory.swift
+++ b/Sources/DockSplitStore+WorkingDirectory.swift
@@ -9,10 +9,10 @@ extension DockSplitStore {
 
     /// Returns the best current directory owned by a Dock terminal.
     ///
-    /// Local terminals prefer the foreground process because the Dock does not
-    /// receive main-workspace cwd reports. Remote terminals must keep their
-    /// transferred remote directory because their local foreground process is
-    /// only the relay.
+    /// Local terminals prefer the shell integration report owned by their
+    /// surface, then fall back to foreground-process inspection. Remote terminals
+    /// must keep their transferred remote directory because their local process
+    /// is only the relay.
     func terminalWorkingDirectory(for sourcePanelId: UUID) -> String? {
         guard let terminal = panels[sourcePanelId] as? TerminalPanel else { return nil }
         let transfer = detachedSurfaceTransfersByPanelId[sourcePanelId]
@@ -24,6 +24,7 @@ extension DockSplitStore {
             ])
         }
         return TerminalWorkingDirectoryResolver.firstAvailable([
+            terminal.surface.reportedWorkingDirectory,
             terminalWorkingDirectoryResolver.liveForegroundProcessWorkingDirectory(for: terminal),
             terminal.directory,
             transfer?.directory,

--- a/Sources/DockSplitStore+WorkingDirectory.swift
+++ b/Sources/DockSplitStore+WorkingDirectory.swift
@@ -33,8 +33,10 @@ extension DockSplitStore {
         ]
         let reportedDirectory = terminal.surface.reportedWorkingDirectory
         if restoredAgentLifecycle.resumeStatesByPanelId[sourcePanelId] == .autoResumeCommandRunning {
-            return TerminalWorkingDirectoryResolver.firstAvailable(existingCandidates + [reportedDirectory])
+            return TerminalWorkingDirectoryResolver.firstAvailable(existingCandidates)
+                ?? reportedDirectory.flatMap { $0.isEmpty ? nil : $0 }
         }
-        return TerminalWorkingDirectoryResolver.firstAvailable([reportedDirectory] + existingCandidates)
+        return reportedDirectory.flatMap { $0.isEmpty ? nil : $0 }
+            ?? TerminalWorkingDirectoryResolver.firstAvailable(existingCandidates)
     }
 }

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -638,11 +638,9 @@ final class DockSplitStore: BonsplitDelegate {
         let inheritedDirectory = settings.value(for: settingsCatalog.app.workspaceInheritWorkingDirectory)
             ? sourcePanelId.flatMap { inheritedLocalTerminalWorkingDirectory(for: $0) }
             : nil
-        return TerminalWorkingDirectoryResolver.firstAvailable([
-            requestedWorkingDirectory,
-            inheritedDirectory,
-            baseDirectory,
-        ]) ?? baseDirectory
+        if let requestedDirectory = TerminalWorkingDirectoryResolver.normalized(requestedWorkingDirectory) { return requestedDirectory }
+        if let inheritedDirectory, !inheritedDirectory.isEmpty { return inheritedDirectory }
+        return baseDirectory
     }
 
     // MARK: - Config loading

--- a/Sources/GhosttyCurrentDirectoryActionDispatcher.swift
+++ b/Sources/GhosttyCurrentDirectoryActionDispatcher.swift
@@ -30,8 +30,16 @@ final class GhosttyCurrentDirectoryActionDispatcher {
             )
         self.replayBoundaryContinuation = replayBoundaryContinuation
         self.ordinaryContinuation = ordinaryContinuation
-        let resolvedDelivery: Delivery = delivery ?? { action in
-            Self.deliver(action)
+        let resolvedDelivery: Delivery
+        if let delivery {
+            resolvedDelivery = { action in
+                Self.recordReportedWorkingDirectory(action)
+                delivery(action)
+            }
+        } else {
+            resolvedDelivery = { action in
+                Self.deliver(action)
+            }
         }
         Task { @MainActor in
             for await action in replayBoundaryStream {
@@ -89,6 +97,7 @@ final class GhosttyCurrentDirectoryActionDispatcher {
         ) == true || action.replayBoundaryGeneration != nil {
             return
         }
+        recordReportedWorkingDirectory(action)
         guard let tabId = surfaceView.tabId,
               let surfaceId = action.terminalSurface?.id else { return }
         AppDelegate.shared?.tabManagerFor(tabId: tabId)?.updateReportedSurfaceDirectory(
@@ -96,6 +105,12 @@ final class GhosttyCurrentDirectoryActionDispatcher {
             surfaceId: surfaceId,
             directory: action.directory
         )
+    }
+
+    @MainActor
+    private static func recordReportedWorkingDirectory(_ action: GhosttyCurrentDirectoryAction) {
+        guard action.replayBoundaryGeneration == nil else { return }
+        action.terminalSurface?.recordReportedWorkingDirectory(action.directory)
     }
 
     private static func stableHash(_ value: String) -> UInt64 {

--- a/Sources/GhosttyCurrentDirectoryActionDispatcher.swift
+++ b/Sources/GhosttyCurrentDirectoryActionDispatcher.swift
@@ -109,8 +109,10 @@ final class GhosttyCurrentDirectoryActionDispatcher {
 
     @MainActor
     private static func recordReportedWorkingDirectory(_ action: GhosttyCurrentDirectoryAction) {
-        guard action.replayBoundaryGeneration == nil else { return }
-        action.terminalSurface?.recordReportedWorkingDirectory(action.directory)
+        guard action.replayBoundaryGeneration == nil,
+              let terminalSurface = action.terminalSurface,
+              terminalSurface.focusPlacement == .rightSidebarDock else { return }
+        terminalSurface.recordReportedWorkingDirectory(action.directory)
     }
 
     private static func stableHash(_ value: String) -> UInt64 {

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -156,7 +156,7 @@ struct DockWorkingDirectoryInheritanceTests {
         }
     }
 
-    @Test("Ghostty PWD reports preserve path whitespace")
+    @Test("Ghostty PWD reports preserve path whitespace and reset on empty")
     @MainActor
     func reportedDirectoryPreservesPathWhitespace() async throws {
         try await withDock(inheritanceEnabled: true) { store, rootPane, root, _ in
@@ -173,8 +173,71 @@ struct DockWorkingDirectoryInheritanceTests {
             sourcePanel.surface.recordReportedWorkingDirectory(reportedDirectory.path)
 
             #expect(sourcePanel.surface.reportedWorkingDirectory == reportedDirectory.path)
-            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+            let newPanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                sourcePanelId: sourcePanelId,
+                focus: true
+            ))
             #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == reportedDirectory.path)
+
+            sourcePanel.surface.recordReportedWorkingDirectory("")
+
+            #expect(sourcePanel.surface.reportedWorkingDirectory == nil)
+            let fallbackPanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                sourcePanelId: sourcePanelId,
+                focus: true
+            ))
+            #expect(try terminalPanel(in: store, panelId: fallbackPanelId).requestedWorkingDirectory == root.path)
+        }
+    }
+
+    @Test("Workspace-owned PWD report does not poison later Dock inheritance")
+    @MainActor
+    func workspaceReportDoesNotPoisonDockInheritance() async throws {
+        let resolver = TerminalWorkingDirectoryResolver(liveDirectoryProvider: { _ in nil })
+        try await withDock(
+            inheritanceEnabled: true,
+            terminalWorkingDirectoryResolver: resolver
+        ) { store, rootPane, root, sourceDirectory in
+            let sourcePanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: sourceDirectory.path,
+                focus: true
+            ))
+            let sourcePanel = try terminalPanel(in: store, panelId: sourcePanelId)
+            sourcePanel.surface.setFocusPlacement(.workspace)
+            defer { sourcePanel.surface.setFocusPlacement(.rightSidebarDock) }
+
+            await confirmation("workspace PWD report delivered") { delivered in
+                var wasDelivered = false
+                let dispatcher = GhosttyCurrentDirectoryActionDispatcher { _ in
+                    wasDelivered = true
+                    delivered()
+                }
+                dispatcher.enqueue(
+                    directory: root.path,
+                    authoritativeGeometry: nil,
+                    surfaceView: sourcePanel.hostedView.surfaceView,
+                    terminalSurface: sourcePanel.surface
+                )
+                for _ in 0..<10 where !wasDelivered {
+                    await Task.yield()
+                }
+            }
+
+            #expect(sourcePanel.surface.reportedWorkingDirectory == nil)
+            sourcePanel.surface.setFocusPlacement(.rightSidebarDock)
+            let newPanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                sourcePanelId: sourcePanelId,
+                focus: true
+            ))
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == sourceDirectory.path)
         }
     }
 

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -156,6 +156,52 @@ struct DockWorkingDirectoryInheritanceTests {
         }
     }
 
+    @Test("Ghostty PWD reports preserve path whitespace")
+    @MainActor
+    func reportedDirectoryPreservesPathWhitespace() async throws {
+        try await withDock(inheritanceEnabled: true) { store, rootPane, root, _ in
+            let sourcePanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: root.path,
+                focus: true
+            ))
+            let sourcePanel = try terminalPanel(in: store, panelId: sourcePanelId)
+            let reportedDirectory = root.appending(path: "Reported Directory ", directoryHint: .isDirectory)
+            try FileManager.default.createDirectory(at: reportedDirectory, withIntermediateDirectories: true)
+
+            sourcePanel.surface.recordReportedWorkingDirectory(reportedDirectory.path)
+
+            #expect(sourcePanel.surface.reportedWorkingDirectory == reportedDirectory.path)
+        }
+    }
+
+    @Test("Restored agent live cwd outranks a stale Ghostty report")
+    @MainActor
+    func restoredAgentLiveDirectoryOutranksStaleReport() async throws {
+        var liveDirectory: String?
+        let resolver = TerminalWorkingDirectoryResolver(liveDirectoryProvider: { _ in liveDirectory })
+        try await withDock(
+            inheritanceEnabled: true,
+            terminalWorkingDirectoryResolver: resolver
+        ) { store, rootPane, root, sourceDirectory in
+            let sourcePanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: root.path,
+                focus: true
+            ))
+            let sourcePanel = try terminalPanel(in: store, panelId: sourcePanelId)
+            sourcePanel.surface.recordReportedWorkingDirectory(root.path)
+            store.restoredAgentLifecycle.resumeStatesByPanelId[sourcePanelId] = .autoResumeCommandRunning
+            liveDirectory = sourceDirectory.path
+
+            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == sourceDirectory.path)
+        }
+    }
+
     @Test("Remote Dock directory is not inherited by a new local terminal")
     @MainActor
     func remoteDirectoryDoesNotBecomeLocalStartupDirectory() async throws {

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -13,8 +13,8 @@ import Testing
 struct DockWorkingDirectoryInheritanceTests {
     @Test("New terminal surface inherits the selected Dock terminal directory")
     @MainActor
-    func newSurfaceInheritsSelectedTerminalDirectory() throws {
-        try withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
+    func newSurfaceInheritsSelectedTerminalDirectory() async throws {
+        try await withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
             let sourcePanelId = try #require(store.newSurface(
                 kind: .terminal,
                 inPane: rootPane,
@@ -32,8 +32,8 @@ struct DockWorkingDirectoryInheritanceTests {
 
     @Test("Programmatic Dock split inherits its source terminal directory")
     @MainActor
-    func newSplitInheritsSourceTerminalDirectory() throws {
-        try withDock(inheritanceEnabled: true) { store, rootPane, _, sourceDirectory in
+    func newSplitInheritsSourceTerminalDirectory() async throws {
+        try await withDock(inheritanceEnabled: true) { store, rootPane, _, sourceDirectory in
             let sourcePanelId = try #require(store.newSurface(
                 kind: .terminal,
                 inPane: rootPane,
@@ -55,8 +55,8 @@ struct DockWorkingDirectoryInheritanceTests {
 
     @Test("Interactive Dock split inherits the original pane terminal directory")
     @MainActor
-    func interactiveSplitInheritsOriginalPaneTerminalDirectory() throws {
-        try withDock(inheritanceEnabled: true) { store, rootPane, _, sourceDirectory in
+    func interactiveSplitInheritsOriginalPaneTerminalDirectory() async throws {
+        try await withDock(inheritanceEnabled: true) { store, rootPane, _, sourceDirectory in
             _ = try #require(store.newSurface(
                 kind: .terminal,
                 inPane: rootPane,
@@ -79,8 +79,8 @@ struct DockWorkingDirectoryInheritanceTests {
 
     @Test("Disabled inheritance starts new Dock terminals in the workspace root")
     @MainActor
-    func disabledInheritanceUsesWorkspaceRoot() throws {
-        try withDock(inheritanceEnabled: false) { store, rootPane, root, sourceDirectory in
+    func disabledInheritanceUsesWorkspaceRoot() async throws {
+        try await withDock(inheritanceEnabled: false) { store, rootPane, root, sourceDirectory in
             _ = try #require(store.newSurface(
                 kind: .terminal,
                 inPane: rootPane,
@@ -96,10 +96,10 @@ struct DockWorkingDirectoryInheritanceTests {
 
     @Test("Live foreground-process directory wins over the Dock terminal startup directory")
     @MainActor
-    func liveDirectoryWinsOverRequestedDirectory() throws {
+    func liveDirectoryWinsOverRequestedDirectory() async throws {
         var liveDirectory: String?
         let resolver = TerminalWorkingDirectoryResolver(liveDirectoryProvider: { _ in liveDirectory })
-        try withDock(
+        try await withDock(
             inheritanceEnabled: true,
             terminalWorkingDirectoryResolver: resolver
         ) { store, rootPane, root, sourceDirectory in
@@ -117,10 +117,49 @@ struct DockWorkingDirectoryInheritanceTests {
         }
     }
 
+    @Test("Ghostty PWD report drives Dock terminal inheritance")
+    @MainActor
+    func reportedDirectoryDrivesNewTerminalInheritance() async throws {
+        let resolver = TerminalWorkingDirectoryResolver(liveDirectoryProvider: { _ in nil })
+        try await withDock(
+            inheritanceEnabled: true,
+            terminalWorkingDirectoryResolver: resolver
+        ) { store, rootPane, root, sourceDirectory in
+            let sourcePanelId = try #require(store.newSurface(
+                kind: .terminal,
+                inPane: rootPane,
+                workingDirectory: root.path,
+                focus: true
+            ))
+            let sourcePanel = try terminalPanel(in: store, panelId: sourcePanelId)
+
+            await confirmation("PWD report delivered") { delivered in
+                var wasDelivered = false
+                let dispatcher = GhosttyCurrentDirectoryActionDispatcher { action in
+                    guard action.directory == sourceDirectory.path else { return }
+                    wasDelivered = true
+                    delivered()
+                }
+                dispatcher.enqueue(
+                    directory: sourceDirectory.path,
+                    authoritativeGeometry: nil,
+                    surfaceView: sourcePanel.hostedView.surfaceView,
+                    terminalSurface: sourcePanel.surface
+                )
+                for _ in 0..<10 where !wasDelivered {
+                    await Task.yield()
+                }
+            }
+
+            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == sourceDirectory.path)
+        }
+    }
+
     @Test("Remote Dock directory is not inherited by a new local terminal")
     @MainActor
-    func remoteDirectoryDoesNotBecomeLocalStartupDirectory() throws {
-        try withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
+    func remoteDirectoryDoesNotBecomeLocalStartupDirectory() async throws {
+        try await withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
             let sourcePanelId = try #require(store.newSurface(
                 kind: .terminal,
                 inPane: rootPane,
@@ -144,8 +183,8 @@ struct DockWorkingDirectoryInheritanceTests {
 
     @Test("Explicit Dock terminal directory overrides inherited directory")
     @MainActor
-    func explicitDirectoryOverridesInheritance() throws {
-        try withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
+    func explicitDirectoryOverridesInheritance() async throws {
+        try await withDock(inheritanceEnabled: true) { store, rootPane, root, sourceDirectory in
             let explicitDirectory = root.appending(path: "Explicit", directoryHint: .isDirectory)
             try FileManager.default.createDirectory(at: explicitDirectory, withIntermediateDirectories: true)
             _ = try #require(store.newSurface(
@@ -170,8 +209,8 @@ struct DockWorkingDirectoryInheritanceTests {
     private func withDock(
         inheritanceEnabled: Bool,
         terminalWorkingDirectoryResolver: TerminalWorkingDirectoryResolver = TerminalWorkingDirectoryResolver(),
-        _ body: (DockSplitStore, PaneID, URL, URL) throws -> Void
-    ) throws {
+        _ body: (DockSplitStore, PaneID, URL, URL) async throws -> Void
+    ) async throws {
         let root = URL.temporaryDirectory.appending(
             path: "cmux-dock-cwd-\(UUID().uuidString)",
             directoryHint: .isDirectory
@@ -197,7 +236,7 @@ struct DockWorkingDirectoryInheritanceTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try body(store, rootPane, root, sourceDirectory)
+        try await body(store, rootPane, root, sourceDirectory)
     }
 
     @MainActor

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -194,9 +194,9 @@ struct DockWorkingDirectoryInheritanceTests {
         }
     }
 
-    @Test("Workspace-owned PWD report does not poison later Dock inheritance")
+    @Test("Dock PWD cache invalidates across a workspace round trip")
     @MainActor
-    func workspaceReportDoesNotPoisonDockInheritance() async throws {
+    func dockReportInvalidatesAcrossWorkspaceRoundTrip() async throws {
         let resolver = TerminalWorkingDirectoryResolver(liveDirectoryProvider: { _ in nil })
         try await withDock(
             inheritanceEnabled: true,
@@ -209,8 +209,12 @@ struct DockWorkingDirectoryInheritanceTests {
                 focus: true
             ))
             let sourcePanel = try terminalPanel(in: store, panelId: sourcePanelId)
+            sourcePanel.surface.recordReportedWorkingDirectory(root.path)
+            #expect(sourcePanel.surface.reportedWorkingDirectory == root.path)
+
             sourcePanel.surface.setFocusPlacement(.workspace)
             defer { sourcePanel.surface.setFocusPlacement(.rightSidebarDock) }
+            #expect(sourcePanel.surface.reportedWorkingDirectory == nil)
 
             await confirmation("workspace PWD report delivered") { delivered in
                 var wasDelivered = false

--- a/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
+++ b/cmuxTests/DockWorkingDirectoryInheritanceTests.swift
@@ -173,6 +173,8 @@ struct DockWorkingDirectoryInheritanceTests {
             sourcePanel.surface.recordReportedWorkingDirectory(reportedDirectory.path)
 
             #expect(sourcePanel.surface.reportedWorkingDirectory == reportedDirectory.path)
+            let newPanelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+            #expect(try terminalPanel(in: store, panelId: newPanelId).requestedWorkingDirectory == reportedDirectory.path)
         }
     }
 


### PR DESCRIPTION
## Summary
- retain each terminal surface’s latest non-empty Ghostty PWD report independently of its layout container
- prefer the surface-owned report when resolving a new local Dock terminal’s working directory
- preserve remote Dock provenance and foreground-process fallback behavior

## Regression coverage
- enqueue a real Ghostty current-directory action for a Dock terminal
- force foreground-process cwd lookup to return nil
- verify the next Dock terminal inherits the reported directory
- test and fix are separate commits for red/green history

## Validation
- package lockfile policy guard passed
- Xcode test wiring guard passed
- no local xcodebuild or XCUITest run, per task instructions
- scripts/swift_file_length_budget.py is not present on this checkout; TerminalSurface.swift remains at its original 711 lines and the new Swift file is 15 lines

Closes #9041

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787823387&installation_model_id=21920&pr_number=9048&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9048&signature=57e2cf3a157e92e4dda3f88c73d8e627b0a144ed80cc40caeaf2f83f55398b6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dock terminal working directory inheritance by caching each surface’s last Ghostty PWD report and preferring it for new local Dock terminals, while preserving exact path bytes. Keeps remote provenance and restored‑agent ordering so live cwd can outrank stale reports. Closes #9041.

- **Bug Fixes**
  - Added per‑surface `reportedWorkingDirectory` with `recordReportedWorkingDirectory(_:)`; empty clears, duplicates ignored, and path whitespace/bytes preserved (including for requested/inherited directories).
  - `GhosttyCurrentDirectoryActionDispatcher` records the PWD on the owning surface before delivery (including custom delivery), only when the surface is in the Dock, and skips replay‑boundary events — keeping the Dock cwd cache authoritative.
  - Clearing `reportedWorkingDirectory` on focus placement changes (workspace ↔ Dock) so workspace reports never leak into the Dock cache.
  - Updated `DockSplitStore` inheritance: prefer surface `reportedWorkingDirectory` → live foreground process → existing/startup dir; during restored‑agent auto‑resume, live cwd retains priority over early/stale reports; remote transfer directories remain unchanged.

<sup>Written for commit 6158f077e40ca2a1b47ecf61586ce2e880d9b67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terminal sessions now record and expose the latest non-empty working directory from shell integration.
  - Dock terminal inheritance can consider the reported directory, with priority that adapts to auto-resume scenarios.
- **Bug Fixes**
  - Empty and unchanged directory reports are ignored (clearing state on empty).
  - Reported paths preserve whitespace, and remote terminal directory behavior remains correct.
  - Working-directory reporting is handled on the main thread for delivered events.
- **Tests**
  - Updated inheritance tests to async/await and added coverage for PWD-driven Dock inheritance and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->