### PR TITLE
Add MiniMax provider to agent-chat registry

### DIFF
--- a/agent-chat/catalog.ts
+++ b/agent-chat/catalog.ts
@@ -38,7 +38,7 @@ export interface AgentModelProviderCatalog {
 export interface AgentModelCatalogPayload {
   schemaVersion: 1;
   updatedAt: string;
-  providers: Partial<Record<"claude" | "codex" | "gemini", AgentModelProviderCatalog>>;
+  providers: Partial<Record<"claude" | "codex" | "gemini" | "minimax", AgentModelProviderCatalog>>;
 }
 
 interface PersistedCatalog {
@@ -55,7 +55,7 @@ interface CatalogStoreOptions {
   now?: () => number;
 }
 
-const PROVIDERS = ["claude", "codex", "gemini"] as const;
+const PROVIDERS = ["claude", "codex", "gemini", "minimax"] as const;
 const DEFAULT_URL = "https://cmux.com/api/agent-models";
 const DEFAULT_CACHE = `${homedir()}/.cache/cmux-agent-chat/models.json`;
 export const AGENT_MODEL_CATALOG_TTL_MS = 60 * 60_000;

--- a/agent-chat/server.ts
+++ b/agent-chat/server.ts
@@ -133,6 +133,10 @@ const GEMINI_MODELS = [
   { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
   { value: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite" },
 ];
+const MINIMAX_MODELS = [
+  { value: "MiniMax-M3", label: "MiniMax M3" },
+  { value: "MiniMax-M2.7", label: "MiniMax M2.7" },
+];
 
 function geminiCatalogModels(): { value: string; label: string; description?: string }[] {
   const remote = agentModelCatalog.provider("gemini");
@@ -142,6 +146,16 @@ function geminiCatalogModels(): { value: string; label: string; description?: st
 
 function geminiDefaultModel(): string | undefined {
   return agentModelCatalog.provider("gemini")?.defaultModel ?? (agentModelCatalog.hasPayload ? undefined : "gemini-3.1-pro-preview");
+}
+
+function minimaxCatalogModels(): { value: string; label: string; description?: string }[] {
+  const remote = agentModelCatalog.provider("minimax");
+  if (remote) return remote.models.map((model) => ({ value: model.id, label: model.label, description: model.description }));
+  return agentModelCatalog.hasPayload ? [] : MINIMAX_MODELS;
+}
+
+function minimaxDefaultModel(): string | undefined {
+  return agentModelCatalog.provider("minimax")?.defaultModel ?? (agentModelCatalog.hasPayload ? undefined : "MiniMax-M3");
 }
 
 const PROVIDERS: ProviderDef[] = [
@@ -158,6 +172,15 @@ const PROVIDERS: ProviderDef[] = [
     installCommand: "npm i -g @google/gemini-cli",
     models: geminiCatalogModels(),
     defaultModel: geminiDefaultModel(),
+  },
+  {
+    id: "minimax",
+    label: "MiniMax",
+    adapter: "acp",
+    cmd: ["minimax", "--acp"],
+    autoApproveArgs: ["--yolo"],
+    models: minimaxCatalogModels(),
+    defaultModel: minimaxDefaultModel(),
   },
 ];
 
@@ -270,15 +293,21 @@ function broadcastSessions() {
 
 function syncCatalogProviderDefs() {
   const gemini = PROVIDERS.find((provider) => provider.id === "gemini");
-  if (!gemini) return;
-  gemini.models = geminiCatalogModels();
-  gemini.defaultModel = geminiDefaultModel();
+  if (gemini) {
+    gemini.models = geminiCatalogModels();
+    gemini.defaultModel = geminiDefaultModel();
+  }
+  const minimax = PROVIDERS.find((provider) => provider.id === "minimax");
+  if (minimax) {
+    minimax.models = minimaxCatalogModels();
+    minimax.defaultModel = minimaxDefaultModel();
+  }
 }
 
 async function applyAgentModelCatalog() {
   syncCatalogProviderDefs();
   const cwd = process.env.CMUX_AGENT_UI_CWD ?? DEFAULT_CWD;
-  const providers = ["claude", "codex", "gemini"];
+  const providers = ["claude", "codex", "gemini", "minimax"];
   const options = new Map<string, SessionOption[]>();
   await Promise.all(providers.map(async (provider) => {
     optionCatalog.delete(provider);

--- a/agent-chat/test/catalog.test.ts
+++ b/agent-chat/test/catalog.test.ts
@@ -33,6 +33,13 @@ const payload = {
         defaultServiceTier: "priority",
       }],
     },
+    minimax: {
+      defaultModel: "MiniMax-M3",
+      models: [
+        { id: "MiniMax-M3", label: "MiniMax M3", contextWindow: 1000000, supportsOneMillion: true },
+        { id: "MiniMax-M2.7", label: "MiniMax M2.7", contextWindow: 204800 },
+      ],
+    },
   },
 } as const;
 
@@ -41,6 +48,9 @@ test("catalog validation, provider merges, persistence, and ETag", async () => {
   const parsed = validateAgentModelCatalog(payload);
   expect(parsed.providers.claude?.models).toHaveLength(1);
   expect(parsed.providers.claude?.defaultModel).toBe("claude-new");
+  expect(parsed.providers.minimax?.models).toHaveLength(2);
+  expect(parsed.providers.minimax?.defaultModel).toBe("MiniMax-M3");
+  expect(parsed.providers.minimax?.models[0]?.supportsOneMillion).toBe(true);
 
   const acp = mergeAcpModelOption(
     { id: "model", label: "Model", kind: "select", value: "binary-current", choices: [{ value: "binary-listed", label: "Binary Listed" }] },

--- a/agent-chat/test/e2e.ts
+++ b/agent-chat/test/e2e.ts
@@ -4,7 +4,7 @@
 const PORT = Number(process.env.CMUX_AGENT_UI_PORT ?? 7739);
 const providersToTest = Bun.argv.slice(2).length
   ? Bun.argv.slice(2)
-  : ["claude", "codex", "opencode", "pi", "gemini"];
+  : ["claude", "codex", "opencode", "pi", "gemini", "minimax"];
 
 const TIMEOUT_MS = Number(process.env.E2E_TIMEOUT_MS ?? 180_000);
 


### PR DESCRIPTION
Reason: Add MiniMax provider and target models (MiniMax-M3, MiniMax-M2.7) to the agent-chat registry, which previously only accepted Claude, Codex, and Gemini.

## Changes

- **catalog.ts**: Add `"minimax"` to the `PROVIDERS` list and the `AgentModelCatalogPayload.providers` type so the remote model catalog validates and accepts MiniMax model entries.
- **server.ts**: Add a `minimax` `ProviderDef` (ACP adapter, `minimax --acp` command) with built-in fallback models `MiniMax-M3` and `MiniMax-M2.7`, plus `minimaxCatalogModels()`/`minimaxDefaultModel()` catalog sync helpers mirroring the existing Gemini pattern. Register MiniMax in `syncCatalogProviderDefs()` and `applyAgentModelCatalog()` so its model options are refreshed alongside Claude, Codex, and Gemini.
- **test/catalog.test.ts**: Add a MiniMax provider entry to the catalog validation fixture and assert the two models, default model, and 1M context flag parse correctly.
- **test/e2e.ts**: Include `minimax` in the default e2e provider smoke list.

## Checks

- `bun x tsc --noEmit` — passes
- `bun run check` (tsc + unit test suite) — passes
- `bun test` — 3 pass, 0 fail

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787824612&installation_model_id=21920&pr_number=9050&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9050&signature=a387c0537d966a7c0c4b7729ae339075c91eff181acd5a093b9254b96b91e5f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the MiniMax provider to the agent-chat registry so users can select MiniMax models and keep them in sync with the remote catalog. Ships with default models MiniMax-M3 and MiniMax-M2.7.

- **New Features**
  - Catalog: accept `minimax` in provider types and registry.
  - Server: add MiniMax provider (ACP adapter, `minimax --acp`), with catalog sync helpers and default model wiring.
  - Tests: validate MiniMax models, default, and 1M context flag; include `minimax` in e2e smoke list.

<sup>Written for commit d46eb4521525240c0e39912e0f5effa360484775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a supported model provider.
  * Added MiniMax model selection, including `MiniMax-M3` and `MiniMax-M2.7`.
  * Added catalog support for MiniMax defaults and available models.
* **Tests**
  * Expanded catalog validation and end-to-end coverage to include MiniMax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->