### PR TITLE
Fix Dock terminal pointer focus

### DIFF
--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -138,12 +138,16 @@ private struct DockSplitContentView: View {
                     return store.panelIsSelectedInVisibleDockPane(panel.id)
                 },
                 onFocus: {
-                    store.bonsplitController.focusPane(paneId)
-                    store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
+                    store.focusPanelFromDockInteraction(
+                        panel.id,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
                 },
                 onRequestPanelFocus: {
-                    store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
-                    store.focusPanel(panel.id)
+                    store.focusPanelFromDockInteraction(
+                        panel.id,
+                        window: NSApp.keyWindow ?? NSApp.mainWindow
+                    )
                 },
                 onResumeAgentHibernation: {
                     _ = store.resumeAgentHibernation(panelId: panel.id, focus: true)

--- a/Sources/DockSplitStore+AttentionRouting.swift
+++ b/Sources/DockSplitStore+AttentionRouting.swift
@@ -13,7 +13,7 @@ extension DockSplitStore {
         requiresSplit: Bool = false,
         shouldFocus: Bool = false
     ) -> Bool {
-        guard let dock = liveStores.first(where: { $0.containsPanel(panelID) }),
+        guard let dock = liveStore(containingPanel: panelID),
               let panel = dock.panels[panelID],
               panel.panelType == .terminal else {
             return false

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -2,6 +2,10 @@ import AppKit
 import Bonsplit
 
 extension DockSplitStore {
+    static func liveStore(containingPanel panelId: UUID) -> DockSplitStore? {
+        liveStores.first(where: { $0.containsPanel(panelId) })
+    }
+
     var focusedPanelId: UUID? {
         guard let paneId = bonsplitController.focusedPaneId,
               let tabId = bonsplitController.selectedTab(inPane: paneId)?.id else { return nil }
@@ -46,6 +50,22 @@ extension DockSplitStore {
         applyDockSelection(tabId: tabId, inPane: paneId)
     }
 
+    /// Applies the complete user-interaction focus transaction for a Dock panel.
+    /// Model selection and window-scoped shortcut intent move together so AppKit
+    /// focus cannot point at one panel while Dock selection points at another.
+    func focusPanelFromDockInteraction(_ panelId: UUID, window: NSWindow?) {
+        noteKeyboardFocusIntent(window: window)
+        focusPanel(panelId)
+    }
+
+    /// Resolves both workspace and per-window Docks through their shared live
+    /// registry before applying pointer focus. The terminal portal can outlive a
+    /// SwiftUI host callback briefly, so pointer activation cannot depend on that
+    /// callback to update the authoritative Dock selection.
+    static func focusPanelFromDockPointer(_ panelId: UUID, window: NSWindow?) {
+        liveStore(containingPanel: panelId)?.focusPanelFromDockInteraction(panelId, window: window)
+    }
+
     func triggerFocusFlash(panelId: UUID) {
         panels[panelId]?.triggerFlash(reason: .navigation)
     }
@@ -65,7 +85,11 @@ extension DockSplitStore {
     }
 
     func noteKeyboardFocusIntent(window: NSWindow?) {
-        AppDelegate.shared?.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
+        guard let appDelegate = AppDelegate.shared else { return }
+        let ownerWindow = appDelegate.dockReferenceTabManager(for: self)
+            .flatMap { appDelegate.windowId(for: $0) }
+            .flatMap { appDelegate.mainWindow(for: $0) }
+        appDelegate.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: ownerWindow ?? window)
     }
 
     func browserPanel(owning responder: NSResponder?, in window: NSWindow?) -> BrowserPanel? {

--- a/Sources/GhosttyNSView+PointerFocusActivation.swift
+++ b/Sources/GhosttyNSView+PointerFocusActivation.swift
@@ -1,6 +1,21 @@
 import CmuxTerminalCore
 
 extension GhosttyNSView {
+    func activateContainerFocusFromPointerDown() {
+        guard let terminalSurface else { return }
+
+        switch terminalSurface.focusPlacement {
+        case .workspace:
+            AppDelegate.shared?.noteTerminalKeyboardFocusIntent(
+                workspaceId: terminalSurface.tabId,
+                panelId: terminalSurface.id,
+                in: window
+            )
+        case .rightSidebarDock:
+            DockSplitStore.focusPanelFromDockPointer(terminalSurface.id, window: window)
+        }
+    }
+
     func terminalPointerShouldForwardActivation() -> Bool {
         guard let terminalSurface else { return false }
         guard desiredFocus else { return false }
@@ -15,7 +30,7 @@ extension GhosttyNSView {
         case .rightSidebarDock:
             return policy.shouldForwardToTerminal(
                 currentPanelId: terminalSurface.id,
-                focusedPanelId: AppDelegate.shared?.windowDockContainingPanel(terminalSurface.id)?.focusedPanelId
+                focusedPanelId: DockSplitStore.liveStore(containingPanel: terminalSurface.id)?.focusedPanelId
             )
         }
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5943,15 +5943,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     func focusFromPointerDown() {
         terminalSurface?.didReceiveExplicitInput()
         if let terminalSurface {
-            if terminalSurface.focusPlacement == .rightSidebarDock {
-                AppDelegate.shared?.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
-            } else {
-                AppDelegate.shared?.noteTerminalKeyboardFocusIntent(
-                    workspaceId: terminalSurface.tabId,
-                    panelId: terminalSurface.id,
-                    in: window
-                )
-            }
+            activateContainerFocusFromPointerDown()
             terminalSurface.hostedView.clearReparentFocusSuppressionForPointerFocus()
         }
         requestPointerFocusRecovery()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -861,6 +861,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D86861000000000000000001 /* DockSplitStore+WorkingDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86861000000000000000002 /* DockSplitStore+WorkingDirectory.swift */; };
 		DCDC0000000000000000A001 /* DockSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000A002 /* DockSplitStore.swift */; };
 		DCDC1000000000000000B00D /* DockSurfaceKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00E /* DockSurfaceKind.swift */; };
+		A9042D0C0000000000000001 /* DockTerminalPointerFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9042D0C0000000000000002 /* DockTerminalPointerFocusTests.swift */; };
 		D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */; };
 		DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B010 /* DockTrustRequest.swift */; };
 		D86860000000000000000001 /* DockWorkingDirectoryInheritanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */; };
@@ -3219,6 +3220,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D86861000000000000000002 /* DockSplitStore+WorkingDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+WorkingDirectory.swift"; sourceTree = "<group>"; };
 		DCDC0000000000000000A002 /* DockSplitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitStore.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B00E /* DockSurfaceKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSurfaceKind.swift; sourceTree = "<group>"; };
+		A9042D0C0000000000000002 /* DockTerminalPointerFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTerminalPointerFocusTests.swift; sourceTree = "<group>"; };
 		D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTerminalReattachTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B010 /* DockTrustRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockTrustRequest.swift; sourceTree = "<group>"; };
 		D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockWorkingDirectoryInheritanceTests.swift; sourceTree = "<group>"; };
@@ -6665,6 +6667,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D81390010000000000000002 /* DockShortcutRoutingTests.swift */,
 				D86860000000000000000002 /* DockWorkingDirectoryInheritanceTests.swift */,
 				D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */,
+				A9042D0C0000000000000002 /* DockTerminalPointerFocusTests.swift */,
 				D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */,
 				D86840000000000000000002 /* DockSessionPersistenceTests.swift */,
 				D6212D0C00000000000000D2 /* WindowDockLifecycleTests.swift */,
@@ -9552,6 +9555,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D86840000000000000000001 /* DockSessionPersistenceTests.swift in Sources */,
 				D81390010000000000000001 /* DockShortcutRoutingTests.swift in Sources */,
 				D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */,
+				A9042D0C0000000000000001 /* DockTerminalPointerFocusTests.swift in Sources */,
 				D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */,
 				D86860000000000000000001 /* DockWorkingDirectoryInheritanceTests.swift in Sources */,
 				D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */,

--- a/cmuxTests/DockTerminalPointerFocusTests.swift
+++ b/cmuxTests/DockTerminalPointerFocusTests.swift
@@ -1,0 +1,203 @@
+import AppKit
+import Bonsplit
+import CmuxTerminal
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Dock terminal pointer focus", .serialized)
+struct DockTerminalPointerFocusTests {
+    @Test("Pointer-down activates the owning Dock pane without a portal callback")
+    func pointerDownActivatesOwningDockPaneWithoutPortalCallback() async throws {
+#if DEBUG
+        try await AppContextSerialGate.withExclusiveAppContext {
+            try exercisePointerDownActivation()
+        }
+#else
+        Issue.record("Ghostty pointer-focus coverage is only available in DEBUG")
+#endif
+    }
+
+#if DEBUG
+    private func exercisePointerDownActivation() throws {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        let fileExplorerState = FileExplorerState()
+        let windowId = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 480),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+
+        AppDelegate.shared = appDelegate
+        appDelegate.tabManager = manager
+        appDelegate.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: fileExplorerState
+        )
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+            manager.tabs.forEach { $0.teardownAllPanels() }
+            window.orderOut(nil)
+            window.close()
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        let dock = appDelegate.windowDock(forWindowId: windowId)
+        dock.setVisibleInUI(true)
+        defer { dock.setVisibleInUI(false) }
+
+        let firstPanel = TerminalPanel(
+            workspaceId: windowId,
+            focusPlacement: .rightSidebarDock
+        )
+        let secondPanel = TerminalPanel(
+            workspaceId: windowId,
+            focusPlacement: .rightSidebarDock
+        )
+        try seedSplitDock(dock, firstPanel: firstPanel, secondPanel: secondPanel)
+        dock.focusPanel(firstPanel.id)
+        #expect(dock.focusedPanelId == firstPanel.id)
+
+        let mainWorkspace = try #require(manager.selectedWorkspace)
+        let mainPanel = try #require(mainWorkspace.focusedTerminalPanel)
+        mainWorkspace.focusPanel(mainPanel.id)
+
+        let contentView = try #require(window.contentView)
+        let halfWidth = contentView.bounds.width / 2
+        mainPanel.hostedView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: halfWidth,
+            height: contentView.bounds.height
+        )
+        secondPanel.hostedView.frame = NSRect(
+            x: halfWidth,
+            y: 0,
+            width: halfWidth,
+            height: contentView.bounds.height
+        )
+        contentView.addSubview(mainPanel.hostedView)
+        contentView.addSubview(secondPanel.hostedView)
+        mainPanel.hostedView.setVisibleInUI(true)
+        mainPanel.hostedView.setActive(true)
+        secondPanel.hostedView.setVisibleInUI(true)
+        secondPanel.hostedView.setActive(false)
+
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        mainPanel.hostedView.layoutSubtreeIfNeeded()
+        secondPanel.hostedView.layoutSubtreeIfNeeded()
+
+        let mainSurfaceView = try #require(waitForSurfaceView(in: mainPanel.hostedView))
+        let surfaceView = try #require(waitForSurfaceView(in: secondPanel.hostedView))
+        #expect(window.makeFirstResponder(mainSurfaceView))
+        appDelegate.noteMainPanelKeyboardFocusIntent(
+            workspaceId: mainWorkspace.id,
+            panelId: mainPanel.id,
+            in: window
+        )
+
+        let pointInWindow = surfaceView.convert(NSPoint(x: 24, y: 24), to: nil)
+        surfaceView.mouseDown(with: try mouseDownEvent(at: pointInWindow, window: window))
+
+        #expect(dock.focusedPanelId == secondPanel.id)
+        #expect(window.firstResponder === surfaceView)
+        #expect(appDelegate.focusedDockStoreForShortcut(preferredWindow: window) === dock)
+        #expect(secondPanel.hostedView.debugRenderStats().isActive)
+    }
+#endif
+
+    private func seedSplitDock(
+        _ dock: DockSplitStore,
+        firstPanel: TerminalPanel,
+        secondPanel: TerminalPanel
+    ) throws {
+        let firstPane = try #require(dock.bonsplitController.allPaneIds.first)
+        let firstTab = try #require(dock.bonsplitController.createTab(
+            title: firstPanel.displayTitle,
+            icon: firstPanel.displayIcon,
+            kind: "terminal",
+            isDirty: false,
+            inPane: firstPane
+        ))
+        dock.panels[firstPanel.id] = firstPanel
+        dock.surfaceIdToPanelId[firstTab] = firstPanel.id
+
+        let secondTab = Bonsplit.Tab(
+            title: secondPanel.displayTitle,
+            icon: secondPanel.displayIcon,
+            kind: "terminal",
+            isDirty: false
+        )
+        dock.panels[secondPanel.id] = secondPanel
+        dock.surfaceIdToPanelId[secondTab.id] = secondPanel.id
+        let secondPane = dock.withProgrammaticDockSplit {
+            dock.bonsplitController.splitPane(
+                firstPane,
+                orientation: .horizontal,
+                withTab: secondTab,
+                insertFirst: false
+            )
+        }
+        _ = try #require(secondPane)
+    }
+
+    private func findSurfaceView(in hostedView: GhosttySurfaceScrollView) -> GhosttyNSView? {
+        var pending: [NSView] = [hostedView]
+        while let view = pending.popLast() {
+            if let surfaceView = view as? GhosttyNSView {
+                return surfaceView
+            }
+            pending.append(contentsOf: view.subviews)
+        }
+        return nil
+    }
+
+    private func waitForSurfaceView(
+        in hostedView: GhosttySurfaceScrollView,
+        timeout: TimeInterval = 2
+    ) -> GhosttyNSView? {
+        let deadline = ProcessInfo.processInfo.systemUptime + timeout
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            if let surfaceView = findSurfaceView(in: hostedView),
+               surfaceView.window != nil,
+               surfaceView.bounds.width > 1,
+               surfaceView.bounds.height > 1 {
+                return surfaceView
+            }
+            RunLoop.current.run(until: Date.now.addingTimeInterval(0.01))
+        }
+        return nil
+    }
+
+    private func mouseDownEvent(at point: NSPoint, window: NSWindow) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: point,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- make terminal pointer-down activate the owning Dock model before AppKit claims first responder
- route Dock pointer and pane-chrome focus through one store-owned focus transaction
- bind Dock shortcut focus intent to the Dock owner window

## Testing

- regression coverage drives the real Ghostty terminal mouse-down path and verifies Dock selection, first responder, shortcut routing, and active terminal state
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/normalize-pbxproj.py --check`
- `xcrun swiftc -parse` for changed Swift sources and tests

Closes #9042

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787825299&installation_model_id=21920&pr_number=9051&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9051&signature=0c6916d0453e8afdc3691f6f81f0e3824c158579b5ec24f6a9a4c66f12ef64c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pointer-down on a Docked terminal so its Dock pane is focused before AppKit takes first responder, ensuring shortcuts target the correct window. Adds tests that simulate a real Ghostty click to verify Dock selection, first responder, shortcut routing, and active terminal (addresses #9042).

- **Bug Fixes**
  - Route pointer focus via `GhosttyNSView.activateContainerFocusFromPointerDown` → `DockSplitStore.focusPanelFromDockPointer`.
  - Apply Dock selection and shortcut intent together, scoped to the Dock’s owner window.
  - Unify Dock panel focus through `focusPanelFromDockInteraction`; pointer-forwarding uses `liveStore(containingPanel:)`.

<sup>Written for commit 90d63678bbb6fe22e042d8261234e528feb9d9f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for dock terminal pointer focus behavior in `DEBUG` builds.
  * Verifies that clicking a terminal panel in a split dock transfers focus to the correct panel and updates related focus/first-responder expectations.
  * Includes setup to initialize windows, create split-dock terminals, wait for hosted surfaces to be ready, and simulate pointer activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->