### PR TITLE
Fix SDK publish Rust toolchain

### DIFF
--- a/.github/workflows/sdk-publish-npm.yml
+++ b/.github/workflows/sdk-publish-npm.yml
@@ -19,6 +19,9 @@ on:
 
 permissions: {}
 
+env:
+  RUST_TOOLCHAIN: "1.95.0"
+
 concurrency:
   group: sdk-publish-npm-${{ github.ref }}
   cancel-in-progress: false
@@ -100,13 +103,11 @@ jobs:
       - name: Install zig
         run: ./scripts/install-zig-ci.sh
 
-      - name: Rust version
+      - name: Install Rust toolchain
         run: |
-          rustc --version || true
-          if ! command -v cargo >/dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustc --version
 
       - name: Build cmux-tui server
         working-directory: cmux-tui

--- a/.github/workflows/sdk-publish-python.yml
+++ b/.github/workflows/sdk-publish-python.yml
@@ -14,6 +14,9 @@ on:
 
 permissions: {}
 
+env:
+  RUST_TOOLCHAIN: "1.95.0"
+
 concurrency:
   group: sdk-publish-python-${{ github.ref }}
   cancel-in-progress: false
@@ -95,13 +98,11 @@ jobs:
       - name: Install zig
         run: ./scripts/install-zig-ci.sh
 
-      - name: Rust version
+      - name: Install Rust toolchain
         run: |
-          rustc --version || true
-          if ! command -v cargo >/dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
+          rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+          rustup default "$RUST_TOOLCHAIN"
+          rustc --version
 
       - name: Build cmux-tui server
         working-directory: cmux-tui


### PR DESCRIPTION
The npm and PyPI SDK publish workflows retained the runner default Rust 1.92.0, causing `libsqlite3-sys` to fail on unstable `cfg_select!` before either package could publish.

Pin both workflows to Rust 1.95.0, matching the existing cmux-tui package build workflow.

Failed runs:
- https://github.com/manaflow-ai/cmux/actions/runs/30322238173
- https://github.com/manaflow-ai/cmux/actions/runs/30322265520

Verification:
- `actionlint .github/workflows/sdk-publish-python.yml .github/workflows/sdk-publish-npm.yml`
- `rustup run 1.95.0 cargo build -p cmux-tui --locked`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787829111&installation_model_id=21920&pr_number=9055&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9055&signature=28cf4f1e4b375b3984f05230ddc642276abdfebf60a28a0b16212bf18329104e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin npm and Python SDK publish workflows to Rust 1.95.0 to fix `libsqlite3-sys` build failures on 1.92.0 and unblock SDK publishing. Matches the existing `cmux-tui` build toolchain.

- **Bug Fixes**
  - Set `RUST_TOOLCHAIN=1.95.0` and install via `rustup` in both publish workflows.
  - Avoids unstable `cfg_select!` issues in `libsqlite3-sys` on older Rust.

<sup>Written for commit 9a0672d83d989267657d1e5e9e08d8e018678393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

