### PR TITLE
Route SDK npm releases through trusted publisher

### DIFF
--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -3,16 +3,33 @@ name: cmux-tui publish npm
 on:
   workflow_dispatch:
     inputs:
+      publish_target:
+        description: "Package contents to publish under the shared npm cmux name"
+        required: true
+        default: tui
+        type: choice
+        options:
+          - tui
+          - sdk
       version:
-        description: "TUI package version to publish, for example 0.1.0"
+        description: "Package version to publish, for example 0.1.0"
         required: true
         type: string
       artifact_run_id:
         description: "Successful cmux-tui release run containing verified packages"
-        required: true
+        required: false
+        type: string
+      sdk_verification_run_id:
+        description: "SDK npm workflow run whose TypeScript end-to-end job passed"
+        required: false
         type: string
       confirm_tui_cmux:
         description: "Set true only for the coordinated npm cmux TUI publish"
+        required: true
+        default: false
+        type: boolean
+      confirm_sdk_cmux:
+        description: "Set true only for the coordinated npm cmux SDK publish"
         required: true
         default: false
         type: boolean
@@ -25,6 +42,7 @@ concurrency:
 
 jobs:
   validate-version:
+    if: inputs.publish_target == 'tui'
     # This workflow's launcher publish deliberately omits --tag so the version
     # becomes npm `latest`. Only strict stable X.Y.Z may go through here; a
     # nightly-form version on latest would put a nightly in front of every
@@ -135,7 +153,109 @@ jobs:
             exit 1
           fi
 
+  validate-sdk-version:
+    if: inputs.publish_target == 'sdk'
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      release_sha: ${{ steps.release.outputs.release_sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Require protected main and verified SDK run
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DISPATCH_VERSION: ${{ inputs.version }}
+          SDK_VERIFICATION_RUN_ID: ${{ inputs.sdk_verification_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || {
+            echo "Refusing to publish the SDK from $GITHUB_REF; dispatch this workflow on main." >&2
+            exit 1
+          }
+          [[ "$DISPATCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+            echo "workflow_dispatch version must match X.Y.Z" >&2
+            exit 1
+          }
+          [[ "$SDK_VERIFICATION_RUN_ID" =~ ^[0-9]+$ ]] || {
+            echo "sdk_verification_run_id must be a GitHub Actions run ID" >&2
+            exit 1
+          }
+
+          git fetch --force origin main
+          current_main="$(git rev-parse origin/main)"
+          if [[ "$GITHUB_SHA" != "$current_main" ]]; then
+            echo "workflow commit $GITHUB_SHA is not current protected main $current_main" >&2
+            exit 1
+          fi
+
+          python3 - "$DISPATCH_VERSION" <<'PY'
+          import json
+          import pathlib
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          root = pathlib.Path.cwd()
+          versions = {
+              "typescript package.json": json.loads((root / "cmux-tui/bindings/typescript/package.json").read_text())["version"],
+              "python pyproject.toml": tomllib.loads((root / "cmux-tui/bindings/python/pyproject.toml").read_text())["project"]["version"],
+              "rust Cargo.toml": tomllib.loads((root / "cmux-tui/bindings/rust/Cargo.toml").read_text())["package"]["version"],
+          }
+          mismatches = {name: got for name, got in versions.items() if got != expected}
+          if mismatches:
+              for name, got in mismatches.items():
+                  print(f"{name}: expected {expected}, got {got}", file=sys.stderr)
+              raise SystemExit(1)
+          print(f"All package versions match {expected}")
+          PY
+
+          IFS=$'\t' read -r actual_path verified_sha event status <<<"$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SDK_VERIFICATION_RUN_ID" \
+              --jq '[.path, .head_sha, .event, .status] | @tsv'
+          )"
+          if [[ "$actual_path" != ".github/workflows/sdk-publish-npm.yml" ]]; then
+            echo "verification run $SDK_VERIFICATION_RUN_ID came from $actual_path" >&2
+            exit 1
+          fi
+          if [[ "$event" != "workflow_dispatch" || "$status" != "completed" ]]; then
+            echo "verification run must be a completed workflow_dispatch run; got $event/$status" >&2
+            exit 1
+          fi
+
+          IFS=$'\t' read -r job_count job_status job_conclusion <<<"$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SDK_VERIFICATION_RUN_ID/jobs" \
+              --jq '[.jobs[] | select(.name == "bindings-e2e-typescript")] as $jobs |
+                    [($jobs | length), ($jobs[0].status // ""), ($jobs[0].conclusion // "")] | @tsv'
+          )"
+          if [[ "$job_count" != "1" || "$job_status" != "completed" || "$job_conclusion" != "success" ]]; then
+            echo "verification run TypeScript end-to-end job is not a single completed success" >&2
+            exit 1
+          fi
+
+          git merge-base --is-ancestor "$verified_sha" "$GITHUB_SHA" || {
+            echo "verification commit $verified_sha is not an ancestor of $GITHUB_SHA" >&2
+            exit 1
+          }
+          if ! git diff --quiet "$verified_sha" "$GITHUB_SHA" -- \
+            cmux-tui \
+            .github/workflows/sdk-publish-npm.yml \
+            ':(exclude)cmux-tui/bindings/RELEASING.md'; then
+            echo "SDK sources or verification workflow changed after run $SDK_VERIFICATION_RUN_ID" >&2
+            exit 1
+          fi
+          echo "release_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
   publish:
+    if: inputs.publish_target == 'tui'
     needs: validate-version
     runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
     permissions:
@@ -216,3 +336,46 @@ jobs:
           # Deliberately do not pass --tag: this coordinated TUI publish takes
           # over the cmux latest dist-tag from the old 0.8.3 CLI when version > 0.8.3.
           npm publish --provenance dist/npm-packages/cmux
+
+  publish-sdk:
+    if: inputs.publish_target == 'sdk'
+    needs: validate-sdk-version
+    runs-on: ubuntu-latest # github-hosted-required: npm provenance needs a github-hosted runner
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: npm-tui
+      url: https://www.npmjs.com/package/cmux
+    steps:
+      - name: Require npm cmux SDK confirmation
+        if: inputs.confirm_sdk_cmux != true
+        run: |
+          echo "Refusing to publish npm package cmux for the SDK without confirm_sdk_cmux=true." >&2
+          exit 1
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate-sdk-version.outputs.release_sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22.14.0"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm with OIDC support
+        run: npm install -g npm@11.5.1
+
+      - name: Build and test SDK package
+        working-directory: cmux-tui/bindings/typescript
+        run: |
+          npm ci --no-audit --no-fund
+          npm test
+
+      - name: Publish SDK package
+        working-directory: cmux-tui/bindings/typescript
+        # Keep the TUI launcher on `latest`; SDK consumers opt in with
+        # `npm install cmux@sdk`.
+        run: npm publish --provenance --tag sdk

--- a/cmux-tui/bindings/RELEASING.md
+++ b/cmux-tui/bindings/RELEASING.md
@@ -23,12 +23,12 @@ from app release tags such as `vX.Y.Z`. Current SDK package versions are
   `.github/workflows/sdk-publish-crates.yml`, and environment `crates-io`. The
   workflow exchanges GitHub OIDC for a short-lived crates.io token via
   `rust-lang/crates-io-auth-action`.
-- npm: configure trusted publishing and required 2FA policy for package `cmux`,
-  workflow `.github/workflows/sdk-publish-npm.yml`, and environment `npm`.
-  Warning: the live npm package name `cmux` is currently a different cloud-VM CLI
-  package. Publishing the SDK to that name is a deliberate coordinated breaking
-  move; the npm workflow never publishes on tag push and requires manual
-  `workflow_dispatch` with `confirm_npm_cmux: true`.
+- npm: package `cmux` can have only one trusted publisher. Configure
+  `.github/workflows/tui-publish-npm.yml` with environment `npm-tui`; that
+  workflow publishes the TUI launcher on `latest` and the SDK on `sdk`. The SDK
+  lane requires a completed `sdk publish npm` verification run and manual
+  `workflow_dispatch` with `publish_target: sdk` and
+  `confirm_sdk_cmux: true`.
 - Maven Central: verify the `com.cmux` namespace in Central Portal, add complete
   Maven metadata, configure GPG signing, and decide the Central publishing
   workflow. Java publishing is intentionally a CI stub until those prerequisites
@@ -55,8 +55,9 @@ from app release tags such as `vX.Y.Z`. Current SDK package versions are
 
 5. Watch the SDK workflows. Python and Rust publish automatically after their
    conformance gates pass. Go validates only. Java reports the Maven Central
-   TODO. npm validates on tag push but does not publish until a maintainer runs
-   `sdk publish npm` manually with `confirm_npm_cmux: true`.
+   TODO. For npm, run `sdk publish npm` with `confirm_npm_cmux: true`, then
+   dispatch `cmux-tui publish npm` on `main` with `publish_target: sdk`,
+   `sdk_verification_run_id` set to that run, and `confirm_sdk_cmux: true`.
 
 ## Safety checks
 


### PR DESCRIPTION
npm permits one trusted publisher per package. The TUI launcher now owns the `cmux` package trust record through `tui-publish-npm.yml`, so the separate SDK workflow can verify successfully but cannot upload.

Add an SDK target to the authorized TUI publisher. It requires:
- protected `main`
- synchronized SDK manifest versions
- a completed successful TypeScript end-to-end job from `sdk-publish-npm.yml`
- no SDK or verifier changes since that run
- explicit SDK publication confirmation

The SDK stays on the `sdk` dist-tag, leaving the TUI launcher on `latest`.

Verification:
- `actionlint -shellcheck= .github/workflows/tui-publish-npm.yml`
- TypeScript: 63 tests passed
- npm pack: `cmux@0.4.0`, 34 files
- verification run: https://github.com/manaflow-ai/cmux/actions/runs/30353899996

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787830777&installation_model_id=21920&pr_number=9057&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9057&signature=60afeff8f27adef75c78f0cff8f3eaf49b9f198ec439109c4b219ddcda825952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes SDK npm releases through the TUI trusted publisher so `cmux` has a single trusted publisher. Adds an SDK lane to `.github/workflows/tui-publish-npm.yml` that publishes the TypeScript SDK on the `sdk` dist-tag while keeping the launcher on `latest`.

- **New Features**
  - Adds `publish_target` input (`tui` | `sdk`) and separate confirms: `confirm_tui_cmux`, `confirm_sdk_cmux`.
  - New `validate-sdk-version` gate: requires protected `main`, X.Y.Z version, synced TS/Python/Rust versions, a completed `sdk-publish-npm.yml` run with passing TypeScript E2E, and no SDK/verifier changes since that run.
  - New `publish-sdk` job uses OIDC in environment `npm-tui`, builds/tests TS bindings, and publishes `cmux` with `--tag sdk` and provenance.
  - Updates `RELEASING.md` with the new SDK publishing flow.

<sup>Written for commit 4913ba135100f4b09f4bac2df42d3455751f60f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated publishing for the TUI and SDK packages through a selectable release workflow.
  * Added SDK publishing to npm under the `sdk` distribution tag with provenance.
  * Added validation checks for SDK versions, verification runs, matching package versions, and protected release commits.

* **Documentation**
  * Updated release instructions for registry setup and the revised TUI and SDK publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->