### PR TITLE
Allow npm publish while main advances

### DIFF
--- a/.github/workflows/tui-publish-npm.yml
+++ b/.github/workflows/tui-publish-npm.yml
@@ -192,8 +192,8 @@ jobs:
 
           git fetch --force origin main
           current_main="$(git rev-parse origin/main)"
-          if [[ "$GITHUB_SHA" != "$current_main" ]]; then
-            echo "workflow commit $GITHUB_SHA is not current protected main $current_main" >&2
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "$current_main"; then
+            echo "workflow commit $GITHUB_SHA is not contained in protected main $current_main" >&2
             exit 1
           fi
 


### PR DESCRIPTION
The SDK npm publisher resolved `main` at dispatch, then rejected that valid commit if another PR merged before its validation step fetched `main`.

Require the dispatched commit to remain in protected `main` history instead of requiring equality with the moving branch tip. The existing SDK source-drift gate still rejects relevant changes after verification.

Reproduction: https://github.com/manaflow-ai/cmux/actions/runs/30355746738

Verification:
- `actionlint -shellcheck= .github/workflows/tui-publish-npm.yml`
- the rejected dispatch commit is an ancestor of current `main`
- no SDK source drift exists between verification and dispatch commits

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787831033&installation_model_id=21920&pr_number=9058&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9058&signature=258b989806bbffce22e7b2a6b7b4d896683bbee49ec14bfb74661216c0810c5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix npm publish race on `main`: the workflow now accepts the dispatch commit if it is contained in protected `main` (via `git merge-base --is-ancestor`) instead of requiring it to match the branch tip. This avoids false rejections when other PRs merge between dispatch and validation while the SDK source-drift gate still protects against relevant changes.

<sup>Written for commit 36eb3418a3c3df2671adf900892ae2b0962994b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

