### PR TITLE
Handle WebAuthn assertions without user handles

### DIFF
--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -653,6 +653,38 @@ func browserWebAuthnAdvertisedPlatformPasskeyAvailability(
     return deviceConfiguredForPasskeys
 }
 
+enum BrowserWebAuthnCredentialReply {
+    static func assertion(
+        credentialID: Data,
+        clientDataJSON: Data,
+        authenticatorData: Data,
+        signature: Data,
+        userHandle: Data?,
+        attachment: String,
+        clientExtensionResults: [String: Any]
+    ) -> [String: Any] {
+        var response: [String: Any] = [
+            "clientDataJSON": clientDataJSON.base64URLEncodedString(),
+            "authenticatorData": authenticatorData.base64URLEncodedString(),
+            "signature": signature.base64URLEncodedString(),
+        ]
+
+        if !userHandle!.isEmpty {
+            response["userHandle"] = userHandle!.base64URLEncodedString()
+        }
+
+        return [
+            "type": "public-key",
+            "id": credentialID.base64URLEncodedString(),
+            "rawId": credentialID.base64URLEncodedString(),
+            "authenticatorAttachment": attachment,
+            "responseKind": "assertion",
+            "response": response,
+            "clientExtensionResults": clientExtensionResults,
+        ]
+    }
+}
+
 @MainActor
 private struct BrowserWebAuthnClientDataContext {
     let callerOrigin: BrowserWebAuthnSecurityOrigin
@@ -1632,7 +1664,7 @@ private extension BrowserWebAuthnCoordinator {
         if let assertion = credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
             return [
                 "ok": true,
-                "credential": assertionReply(
+                "credential": BrowserWebAuthnCredentialReply.assertion(
                     credentialID: assertion.credentialID,
                     clientDataJSON: assertion.rawClientDataJSON,
                     authenticatorData: assertion.rawAuthenticatorData,
@@ -1647,7 +1679,7 @@ private extension BrowserWebAuthnCoordinator {
         if let assertion = credential as? ASAuthorizationSecurityKeyPublicKeyCredentialAssertion {
             return [
                 "ok": true,
-                "credential": assertionReply(
+                "credential": BrowserWebAuthnCredentialReply.assertion(
                     credentialID: assertion.credentialID,
                     clientDataJSON: assertion.rawClientDataJSON,
                     authenticatorData: assertion.rawAuthenticatorData,
@@ -1692,36 +1724,6 @@ private extension BrowserWebAuthnCoordinator {
         }
 
         return credential
-    }
-
-    func assertionReply(
-        credentialID: Data,
-        clientDataJSON: Data,
-        authenticatorData: Data,
-        signature: Data,
-        userHandle: Data,
-        attachment: String,
-        clientExtensionResults: [String: Any]
-    ) -> [String: Any] {
-        var response: [String: Any] = [
-            "clientDataJSON": clientDataJSON.base64URLEncodedString(),
-            "authenticatorData": authenticatorData.base64URLEncodedString(),
-            "signature": signature.base64URLEncodedString(),
-        ]
-
-        if !userHandle.isEmpty {
-            response["userHandle"] = userHandle.base64URLEncodedString()
-        }
-
-        return [
-            "type": "public-key",
-            "id": credentialID.base64URLEncodedString(),
-            "rawId": credentialID.base64URLEncodedString(),
-            "authenticatorAttachment": attachment,
-            "responseKind": "assertion",
-            "response": response,
-            "clientExtensionResults": clientExtensionResults,
-        ]
     }
 
     func securityKeyTransportValues(

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -653,38 +653,6 @@ func browserWebAuthnAdvertisedPlatformPasskeyAvailability(
     return deviceConfiguredForPasskeys
 }
 
-enum BrowserWebAuthnCredentialReply {
-    static func assertion(
-        credentialID: Data,
-        clientDataJSON: Data,
-        authenticatorData: Data,
-        signature: Data,
-        userHandle: Data?,
-        attachment: String,
-        clientExtensionResults: [String: Any]
-    ) -> [String: Any] {
-        var response: [String: Any] = [
-            "clientDataJSON": clientDataJSON.base64URLEncodedString(),
-            "authenticatorData": authenticatorData.base64URLEncodedString(),
-            "signature": signature.base64URLEncodedString(),
-        ]
-
-        if let userHandle, !userHandle.isEmpty {
-            response["userHandle"] = userHandle.base64URLEncodedString()
-        }
-
-        return [
-            "type": "public-key",
-            "id": credentialID.base64URLEncodedString(),
-            "rawId": credentialID.base64URLEncodedString(),
-            "authenticatorAttachment": attachment,
-            "responseKind": "assertion",
-            "response": response,
-            "clientExtensionResults": clientExtensionResults,
-        ]
-    }
-}
-
 @MainActor
 private struct BrowserWebAuthnClientDataContext {
     let callerOrigin: BrowserWebAuthnSecurityOrigin
@@ -1211,6 +1179,39 @@ extension BrowserWebAuthnCoordinator: ASAuthorizationControllerDelegate, ASAutho
 }
 
 @MainActor
+extension BrowserWebAuthnCoordinator {
+    func assertionReply(
+        credentialID: Data,
+        clientDataJSON: Data,
+        authenticatorData: Data,
+        signature: Data,
+        userHandle: Data?,
+        attachment: String,
+        clientExtensionResults: [String: Any]
+    ) -> [String: Any] {
+        var response: [String: Any] = [
+            "clientDataJSON": clientDataJSON.base64URLEncodedString(),
+            "authenticatorData": authenticatorData.base64URLEncodedString(),
+            "signature": signature.base64URLEncodedString(),
+        ]
+
+        if let userHandle, !userHandle.isEmpty {
+            response["userHandle"] = userHandle.base64URLEncodedString()
+        }
+
+        return [
+            "type": "public-key",
+            "id": credentialID.base64URLEncodedString(),
+            "rawId": credentialID.base64URLEncodedString(),
+            "authenticatorAttachment": attachment,
+            "responseKind": "assertion",
+            "response": response,
+            "clientExtensionResults": clientExtensionResults,
+        ]
+    }
+}
+
+@MainActor
 private extension BrowserWebAuthnCoordinator {
     enum BrowserWebAuthnAuthorizationErrorCode {
         // Keep these raw values in sync with AuthenticationServices/ASAuthorizationError.h
@@ -1664,7 +1665,7 @@ private extension BrowserWebAuthnCoordinator {
         if let assertion = credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
             return [
                 "ok": true,
-                "credential": BrowserWebAuthnCredentialReply.assertion(
+                "credential": assertionReply(
                     credentialID: assertion.credentialID,
                     clientDataJSON: assertion.rawClientDataJSON,
                     authenticatorData: assertion.rawAuthenticatorData,
@@ -1679,7 +1680,7 @@ private extension BrowserWebAuthnCoordinator {
         if let assertion = credential as? ASAuthorizationSecurityKeyPublicKeyCredentialAssertion {
             return [
                 "ok": true,
-                "credential": BrowserWebAuthnCredentialReply.assertion(
+                "credential": assertionReply(
                     credentialID: assertion.credentialID,
                     clientDataJSON: assertion.rawClientDataJSON,
                     authenticatorData: assertion.rawAuthenticatorData,

--- a/Sources/Panels/BrowserWebAuthnSupport.swift
+++ b/Sources/Panels/BrowserWebAuthnSupport.swift
@@ -669,8 +669,8 @@ enum BrowserWebAuthnCredentialReply {
             "signature": signature.base64URLEncodedString(),
         ]
 
-        if !userHandle!.isEmpty {
-            response["userHandle"] = userHandle!.base64URLEncodedString()
+        if let userHandle, !userHandle.isEmpty {
+            response["userHandle"] = userHandle.base64URLEncodedString()
         }
 
         return [

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -192,6 +192,24 @@ struct BrowserWebContentProcessTests {
     }
 
     @Test
+    func webAuthnAssertionReplyOmitsAbsentUserHandle() throws {
+        let credential = BrowserWebAuthnCredentialReply.assertion(
+            credentialID: Data([1, 2, 3]),
+            clientDataJSON: Data([4, 5]),
+            authenticatorData: Data([6, 7]),
+            signature: Data([8, 9]),
+            userHandle: nil,
+            attachment: "cross-platform",
+            clientExtensionResults: [:]
+        )
+        let response = try #require(credential["response"] as? [String: Any])
+
+        #expect(credential["id"] as? String == "AQID")
+        #expect(response["signature"] as? String == "CAk")
+        #expect(response["userHandle"] == nil)
+    }
+
+    @Test
     func webAuthnNativeBridgeScopesParentDomainRelyingPartyIDs() throws {
         let googleOrigin = try #require(
             BrowserWebAuthnSecurityOrigin(url: URL(string: "https://accounts.google.com")!)

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -191,15 +191,15 @@ struct BrowserWebContentProcessTests {
         #expect(probe.receivedKinds == ["getCredential"])
     }
 
-    @Test
-    func webAuthnAssertionReplyOmitsAbsentUserHandle() throws {
+    @Test(arguments: [nil, Data()] as [Data?])
+    func webAuthnAssertionReplyOmitsAbsentUserHandle(userHandle: Data?) throws {
         let coordinator = BrowserWebAuthnCoordinator()
         let credential = coordinator.assertionReply(
             credentialID: Data([1, 2, 3]),
             clientDataJSON: Data([4, 5]),
             authenticatorData: Data([6, 7]),
             signature: Data([8, 9]),
-            userHandle: nil,
+            userHandle: userHandle,
             attachment: "cross-platform",
             clientExtensionResults: [:]
         )

--- a/cmuxTests/BrowserWebContentProcessTests.swift
+++ b/cmuxTests/BrowserWebContentProcessTests.swift
@@ -193,7 +193,8 @@ struct BrowserWebContentProcessTests {
 
     @Test
     func webAuthnAssertionReplyOmitsAbsentUserHandle() throws {
-        let credential = BrowserWebAuthnCredentialReply.assertion(
+        let coordinator = BrowserWebAuthnCoordinator()
+        let credential = coordinator.assertionReply(
             credentialID: Data([1, 2, 3]),
             clientDataJSON: Data([4, 5]),
             authenticatorData: Data([6, 7]),


### PR DESCRIPTION
## Summary

- preserve nullable user handles returned by AuthenticationServices assertions
- omit `response.userHandle` when the authenticator does not provide one
- cover assertion serialization without a user handle

## Root cause

`ASAuthorizationPublicKeyCredentialAssertion.userID` is imported into Swift as
an implicitly unwrapped optional. Hardware security keys can legitimately return
no user handle for non-discoverable credentials, including assertions selected
from an `allowCredentials` list.

cmux passed that value into a non-optional `Data` parameter, which forced an
unwrap and trapped on the main thread after AuthenticationServices completed a
YubiKey assertion.

This behavior is permitted by the WebAuthn specification:
https://www.w3.org/TR/webauthn-3/#dom-authenticatorassertionresponse-userhandle

## Impact

YubiKey and other hardware-key authentication can complete without crashing
when the assertion has no user handle. Assertions that include a user handle
retain their existing serialized response.

## Validation

- red test commit `74c7abd7` preserves the pre-fix nil trap
- fix commit `0cf6468d` passes the nil fixture by omitting `userHandle`
- `swiftc -frontend -parse` passes for both changed Swift files
- `scripts/check-pbxproj.sh` passes
- `scripts/lint-pbxproj-test-wiring.sh` passes
- tagged app/unit builds are unavailable locally because this machine has
  Command Line Tools rather than full Xcode; upstream's main CI workflow is
  currently paused for pull requests

Related to #1278 and the WebAuthn implementation from #2727.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAuthn assertion replies by omitting the `userHandle` field when no (or an empty) user handle is available.
  * Preserved credential identifiers and signatures in WebAuthn assertion responses.
* **Tests**
  * Added a unit test to verify that WebAuthn assertion replies omit `userHandle` when it is absent, including checks for the resulting `id`, `signature`, and response payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->