### PR TITLE
cmux-tui: strip nested bracketed paste markers

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -30,6 +30,9 @@ pub use crate::browser::{
     BrowserAttachState, BrowserFrame, BrowserFrameStream, BrowserSource, BrowserStatus,
 };
 use crate::browser::{BrowserResizeWaiter, BrowserSurface, PendingBrowserResize};
+use crate::terminal_host_protocol::{
+    BRACKETED_PASTE_BEGIN, BRACKETED_PASTE_END, strip_bracketed_paste_markers,
+};
 #[cfg(unix)]
 use crate::terminal_host_protocol::{FLAG_COLORS_FOLLOW, Frame, MessageKind, PROTOCOL_VERSION};
 use cmux_tui_cdp::BrowserMode;
@@ -1958,7 +1961,9 @@ impl Surface {
 
     /// Write a protocol input payload, conditionally applying bracketed-paste
     /// markers from a terminal-mode snapshot taken before the PTY write.
-    pub fn write_paste(&self, bytes: &[u8]) -> std::io::Result<()> {
+    pub fn write_paste(&self, raw_bytes: &[u8]) -> std::io::Result<()> {
+        let bytes = strip_bracketed_paste_markers(raw_bytes);
+        let bytes = bytes.as_ref();
         let Some(pty) = self.as_pty() else {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,
@@ -1990,11 +1995,11 @@ impl Surface {
             unreachable!("hosted paste returned above")
         };
         if bracketed {
-            writer.write_all(b"\x1b[200~")?;
+            writer.write_all(BRACKETED_PASTE_BEGIN)?;
         }
         writer.write_all(bytes)?;
         if bracketed {
-            writer.write_all(b"\x1b[201~")?;
+            writer.write_all(BRACKETED_PASTE_END)?;
         }
         writer.flush()
     }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -425,6 +425,24 @@ impl FrameDecoder {
     }
 }
 
+/// Bracketed-paste begin marker emitted around paste payloads.
+pub const BRACKETED_PASTE_BEGIN: &[u8] = b"\x1b[200~";
+/// Bracketed-paste end marker emitted around paste payloads.
+pub const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
+
+/// Remove embedded bracketed-paste markers from a paste payload.
+///
+/// Paste sites wrap the payload in `\x1b[200~` / `\x1b[201~`. A payload that
+/// itself contains those markers would terminate the bracket early, letting
+/// the remainder reach the application as ordinary keyboard input. Stripping
+/// them keeps the whole payload inside one bracketed region.
+///
+/// Payloads without markers are returned borrowed, so the common path does not
+/// allocate.
+pub fn strip_bracketed_paste_markers(payload: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+    std::borrow::Cow::Borrowed(payload)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -567,5 +585,31 @@ mod tests {
             Err(ProtocolError::PayloadTooLarge { len, max })
                 if len == MAX_FRAME_PAYLOAD + 1 && max == MAX_FRAME_PAYLOAD
         ));
+    }
+
+    #[test]
+    fn paste_without_markers_is_borrowed_unchanged() {
+        let payload = b"plain text\nline two";
+        let out = strip_bracketed_paste_markers(payload);
+        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(out.as_ref(), payload);
+    }
+
+    #[test]
+    fn embedded_end_marker_is_stripped() {
+        let out = strip_bracketed_paste_markers(b"before\x1b[201~after");
+        assert_eq!(out.as_ref(), b"beforeafter");
+    }
+
+    #[test]
+    fn embedded_begin_and_end_markers_are_stripped() {
+        let out = strip_bracketed_paste_markers(b"a\x1b[200~b\x1b[201~c");
+        assert_eq!(out.as_ref(), b"abc");
+    }
+
+    #[test]
+    fn adjacent_markers_and_surrounding_content_are_preserved() {
+        let out = strip_bracketed_paste_markers(b"\x1b[201~\x1b[200~keep\x1b[2Dme\x1b[201~");
+        assert_eq!(out.as_ref(), b"keep\x1b[2Dme");
     }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -440,7 +440,32 @@ pub const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 /// Payloads without markers are returned borrowed, so the common path does not
 /// allocate.
 pub fn strip_bracketed_paste_markers(payload: &[u8]) -> std::borrow::Cow<'_, [u8]> {
-    std::borrow::Cow::Borrowed(payload)
+    fn marker_len_at(payload: &[u8], i: usize) -> Option<usize> {
+        let rest = &payload[i..];
+        if rest.starts_with(BRACKETED_PASTE_BEGIN) || rest.starts_with(BRACKETED_PASTE_END) {
+            Some(BRACKETED_PASTE_BEGIN.len())
+        } else {
+            None
+        }
+    }
+
+    let Some(first) = (0..payload.len()).find(|&i| marker_len_at(payload, i).is_some()) else {
+        return std::borrow::Cow::Borrowed(payload);
+    };
+
+    let mut out = Vec::with_capacity(payload.len() - BRACKETED_PASTE_BEGIN.len());
+    out.extend_from_slice(&payload[..first]);
+    let mut i = first;
+    while i < payload.len() {
+        match marker_len_at(payload, i) {
+            Some(len) => i += len,
+            None => {
+                out.push(payload[i]);
+                i += 1;
+            }
+        }
+    }
+    std::borrow::Cow::Owned(out)
 }
 
 #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -22,11 +22,12 @@ use crate::terminal_host::{
     HostHello, HostIncarnation, HostReady, TerminalId,
 };
 use crate::terminal_host_protocol::{
-    CLEAR_HISTORY_ACK_AMBIGUOUS, CLEAR_HISTORY_ACK_FALLBACK_UNREPRESENTABLE,
-    CLEAR_HISTORY_ACK_FALLBACK_WRITE_TIMEOUT, CLEAR_HISTORY_ACK_KNOWN_NOT_DELIVERED,
-    CLEAR_HISTORY_ACK_OK, CLEAR_HISTORY_ACK_PRESERVATION_FAILED, CLEAR_HISTORY_ACK_STREAM_TIMEOUT,
-    FLAG_COLORS_FOLLOW, FLAG_VIEWER_SIZE_ACKS, Frame, MAX_FRAME_PAYLOAD, MessageKind,
-    PROTOCOL_VERSION, RESIZE_ACK_CANONICAL_CHANGED, read_frame, write_frame,
+    BRACKETED_PASTE_BEGIN, BRACKETED_PASTE_END, CLEAR_HISTORY_ACK_AMBIGUOUS,
+    CLEAR_HISTORY_ACK_FALLBACK_UNREPRESENTABLE, CLEAR_HISTORY_ACK_FALLBACK_WRITE_TIMEOUT,
+    CLEAR_HISTORY_ACK_KNOWN_NOT_DELIVERED, CLEAR_HISTORY_ACK_OK,
+    CLEAR_HISTORY_ACK_PRESERVATION_FAILED, CLEAR_HISTORY_ACK_STREAM_TIMEOUT, FLAG_COLORS_FOLLOW,
+    FLAG_VIEWER_SIZE_ACKS, Frame, MAX_FRAME_PAYLOAD, MessageKind, PROTOCOL_VERSION,
+    RESIZE_ACK_CANONICAL_CHANGED, read_frame, strip_bracketed_paste_markers, write_frame,
 };
 
 const HOST_RECORD_VERSION: u32 = 2;
@@ -2609,14 +2610,15 @@ mod unix {
                         if !granted_rights.contains(CapabilityRights::INPUT) {
                             break;
                         }
+                        let payload = strip_bracketed_paste_markers(&frame.payload);
                         let bracketed = command_host.term.lock().unwrap().mode(2004, false);
                         let mut writer = command_host.writer.lock().unwrap();
                         if bracketed {
-                            let _ = writer.write_all(b"\x1b[200~");
+                            let _ = writer.write_all(BRACKETED_PASTE_BEGIN);
                         }
-                        let _ = writer.write_all(&frame.payload);
+                        let _ = writer.write_all(payload.as_ref());
                         if bracketed {
-                            let _ = writer.write_all(b"\x1b[201~");
+                            let _ = writer.write_all(BRACKETED_PASTE_END);
                         }
                         let _ = writer.flush();
                     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17,6 +17,9 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use base64::Engine;
+use cmux_tui_core::terminal_host_protocol::{
+    BRACKETED_PASTE_BEGIN, BRACKETED_PASTE_END, strip_bracketed_paste_markers,
+};
 use cmux_tui_core::{
     BrowserFrame, BrowserSource, BrowserStatus, ClearHistoryDelivery, ClearHistoryFailure,
     DEFAULT_VIEWPORT_PANE_WIDTH, Direction, LayoutUndoError, LayoutUndoResult,
@@ -11083,17 +11086,19 @@ impl App {
         let Some(bracketed) = surface.with_terminal(|t| t.mode(2004, false)) else {
             return;
         };
+        let text = strip_bracketed_paste_markers(text.as_bytes());
+        let text = text.as_ref();
         if bracketed {
             let mut bytes = Vec::with_capacity(text.len() + 12);
-            bytes.extend_from_slice(b"\x1b[200~");
-            bytes.extend_from_slice(text.as_bytes());
-            bytes.extend_from_slice(b"\x1b[201~");
+            bytes.extend_from_slice(BRACKETED_PASTE_BEGIN);
+            bytes.extend_from_slice(text);
+            bytes.extend_from_slice(BRACKETED_PASTE_END);
             let _ = self.write_pty_bytes(surface_id, surface, bytes.into(), PtyInputKind::Ordered);
         } else {
             let _ = self.write_pty_bytes(
                 surface_id,
                 surface,
-                PtyInputBytes::from_slice(text.as_bytes()),
+                PtyInputBytes::from_slice(text),
                 PtyInputKind::Ordered,
             );
         }
@@ -11105,17 +11110,19 @@ impl App {
         let Some(bracketed) = surface.with_terminal(|t| t.mode(2004, false)) else {
             return;
         };
+        let text = strip_bracketed_paste_markers(text.as_bytes());
+        let text = text.as_ref();
         if bracketed {
             let mut bytes = Vec::with_capacity(text.len() + 12);
-            bytes.extend_from_slice(b"\x1b[200~");
-            bytes.extend_from_slice(text.as_bytes());
-            bytes.extend_from_slice(b"\x1b[201~");
+            bytes.extend_from_slice(BRACKETED_PASTE_BEGIN);
+            bytes.extend_from_slice(text);
+            bytes.extend_from_slice(BRACKETED_PASTE_END);
             let _ = self.write_pty_bytes(surface_id, surface, bytes.into(), PtyInputKind::Ordered);
         } else {
             let _ = self.write_pty_bytes(
                 surface_id,
                 surface,
-                PtyInputBytes::from_slice(text.as_bytes()),
+                PtyInputBytes::from_slice(text),
                 PtyInputKind::Ordered,
             );
         }

--- a/cmux-tui/spec/commands.md
+++ b/cmux-tui/spec/commands.md
@@ -654,7 +654,7 @@ CLI mapping: verb `apply-layout`; flags `[--workspace <id>] [--name <name>] [--c
 
 Writes input to a PTY surface. `text`, when present, is UTF-8 encoded and written as bytes. `bytes`, when present, is standard base64 decoded and written as raw bytes. If both are present, v5 writes `text` first and `bytes` second. If neither is present, v5 returns success and writes nothing.
 
-Protocol v7 adds `paste`. The payload is the concatenation of encoded `text` followed by decoded `bytes`. With `paste:true` and a non-empty payload, the server checks the target terminal's current DEC private mode 2004 while holding the terminal/input lock. If enabled, it writes `ESC [ 200 ~`, the payload, then `ESC [ 201 ~`; if disabled, it writes the payload unchanged. `paste:false` is the exact v5/v6 path. The server does not inspect or remove caller-supplied bracketed-paste markers.
+Protocol v7 adds `paste`. The payload is the concatenation of encoded `text` followed by decoded `bytes`. With `paste:true` and a non-empty payload, the server removes embedded bracketed-paste begin/end markers from the combined payload, then checks the target terminal's current DEC private mode 2004 while holding the terminal/input lock. If enabled, it writes `ESC [ 200 ~`, the sanitized payload, then `ESC [ 201 ~`; if disabled, it writes the sanitized payload unchanged. `paste:false` is the exact v5/v6 path.
 
 Params:
 
@@ -663,7 +663,7 @@ Params:
 | `surface` | `Id` | required | Must identify a live PTY surface |
 | `text` | `string` | default null | Written before `bytes` when both are present |
 | `bytes` | `Base64` | default null | Decoded with standard base64 |
-| `paste` | `boolean` | default false | Protocol 7; conditionally wraps the combined non-empty payload when DEC mode 2004 is enabled |
+| `paste` | `boolean` | default false | Protocol 7; strips embedded bracketed-paste markers and conditionally wraps the combined non-empty payload when DEC mode 2004 is enabled |
 
 Result:
 


### PR DESCRIPTION
## Summary

- What changed?
  - Strip embedded bracketed-paste begin/end markers from cmux-tui paste payloads before wrapping them for PTY delivery.
  - Route the interactive TUI, control-server `send` paste path, and terminal-host paste frame through one shared sanitizer.
  - Update the command spec so `send` with `paste: true` documents the sanitized payload contract.
- Why?
  - A pasted payload containing `ESC [ 201 ~` can terminate the bracketed-paste region early, causing the remaining bytes to reach the application as ordinary input.
  - The sanitizer preserves all non-marker bytes and leaves marker-free payloads borrowed/unchanged.

## Testing

- `cargo fmt --check`
- Standalone Rust test harness for `terminal_host_protocol.rs`: 12 passed, including the new marker-stripping cases.
- `git diff --check main..HEAD`
- Privacy scan over `main..HEAD`: no absolute user paths, agent URLs, toolchain install paths, or secret-like tokens.

Workspace `cargo test` is currently blocked locally before reaching this change by `libsqlite3-sys` using the unstable `cfg_select` build-script feature with the installed Rust toolchain.

## Demo Video

No video. This is PTY paste hardening plus protocol docs; no visual UI flow changed.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved
