### PR TITLE
cmux-tui: document canonical browser tab key

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3616,4 +3616,45 @@ mod tests {
         assert_eq!(value["future"]["unknown"], json!(true));
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    /// `docs/keyboard.md` teaches users which action keys to configure, so it
+    /// must stay in sync with the canonical `ActionDefinition::config_key`
+    /// names and must never advertise a back-compat alias in their place.
+    #[test]
+    fn keyboard_docs_list_canonical_action_keys() {
+        const KEYBOARD_DOC: &str = include_str!("../../../docs/keyboard.md");
+
+        let block = KEYBOARD_DOC
+            .split_once("Supported action keys are:")
+            .expect("supported action keys section")
+            .1
+            .split_once("```text")
+            .expect("fenced action key block")
+            .1
+            .split_once("```")
+            .expect("closing fence")
+            .0;
+        let documented: Vec<&str> =
+            block.lines().map(str::trim).filter(|line| !line.is_empty()).collect();
+        assert_eq!(
+            documented.len(),
+            action_definitions().len(),
+            "docs/keyboard.md action key list should contain exactly the canonical action catalog"
+        );
+
+        for definition in action_definitions() {
+            assert!(
+                documented.contains(&definition.config_key),
+                "docs/keyboard.md does not list canonical action key `{}`",
+                definition.config_key
+            );
+        }
+
+        for alias in ["new_browser_tab", "rename-pane"] {
+            assert!(
+                !documented.contains(&alias),
+                "docs/keyboard.md lists back-compat alias `{alias}` in the supported action key block; list the canonical key instead"
+            );
+        }
+    }
 }

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -218,7 +218,7 @@ WebSocket clients pair through a six-digit browser/TUI comparison by default. We
 | `keys.super_shortcuts` | boolean | `true` | Enables default modeless Command/Super bindings when true |
 | `keys.send-prefix` | chord string or array or `"none"` | current prefix chord | Send the configured prefix to the active surface |
 | `keys.new-tab` | chord string or array or `"none"` | `["t","alt+t"]` | New PTY tab |
-| `keys.new_browser_tab` | chord string or array or `"none"` | `"B"` | Browser URL prompt |
+| `keys.new-browser-tab` | chord string or array or `"none"` | `"B"` | Browser URL prompt |
 | `keys.new-pane-smart` | chord string or array or `"none"` | `"alt+n"` | New pane using the default automatic layout |
 | `keys.next-tab` | chord string or array or `"none"` | `"tab"` | Next tab |
 | `keys.prev-tab` | chord string or array or `"none"` | `"backtab"` | Previous tab |
@@ -272,7 +272,7 @@ Kitty keyboard reports the same empty-text character sequence for a real termina
 
 `Ctrl-b x` closes the active tab because tab lifecycle is the more frequent cmux action. `Ctrl-b X` closes its containing pane. Both bindings accept independent overrides.
 
-Screen and tab positions are zero-based, so each `select-screen-N` or `select-tab-N` action selects index `N`. Generated workspace names also start at `0`. The snake_case spellings `select_screen_N` and `select_tab_N` are accepted as aliases. `Ctrl-b ]` and `Ctrl-b q` are intentionally unbound: cmux has no paste-buffer command and no pane-number quick-jump overlay yet. Zellij's modal `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are not defaults because they conflict with common shell and editor control keys.
+Screen and tab positions are zero-based, so each `select-screen-N` or `select-tab-N` action selects index `N`. Generated workspace names also start at `0`. The snake_case spellings `select_screen_N` and `select_tab_N` are accepted as aliases, as is `new_browser_tab` for `new-browser-tab`. `Ctrl-b ]` and `Ctrl-b q` are intentionally unbound: cmux has no paste-buffer command and no pane-number quick-jump overlay yet. Zellij's modal `ctrl+p`, `ctrl+t`, `ctrl+s`, `ctrl+n`, and `ctrl+o` modes are not defaults because they conflict with common shell and editor control keys.
 
 Chord strings can be single characters or a key name with optional `ctrl`, `control`, `alt`, `option`, `cmd`, `command`, `super`, or `shift` modifiers. Examples: `"c"`, `"%"`, `"ctrl+b"`, `"alt+enter"`, `"cmd+k"`, `"tab"`, `"backtab"`, `"shift+tab"`, `"pageup"`, `"pagedown"`, `"esc"`, `"space"`, `"left"`, `"right"`, `"up"`, `"down"`, `"home"`, and `"end"`.
 
@@ -350,7 +350,7 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "alt_shortcuts": false,
     "super_shortcuts": false,
     "new-tab": ["t", "alt+t"],
-    "new_browser_tab": "B",
+    "new-browser-tab": "B",
     "new-pane-smart": "alt+n",
     "next-tab": "tab",
     "prev-tab": "backtab",

--- a/cmux-tui/docs/keyboard.md
+++ b/cmux-tui/docs/keyboard.md
@@ -148,7 +148,7 @@ Supported action keys are:
 ```text
 send-prefix
 new-tab
-new_browser_tab
+new-browser-tab
 new-pane-smart
 next-tab
 prev-tab
@@ -214,7 +214,7 @@ show-shortcuts
 detach
 ```
 
-`rename-pane` is still accepted as an alias for `rename-tab`.
+`rename-pane` is still accepted as an alias for `rename-tab`, and `new_browser_tab` for `new-browser-tab`.
 
 ## Chord Format
 


### PR DESCRIPTION
## Summary

- What changed?
  - Document `keys.new-browser-tab` as the canonical cmux-tui browser-tab binding key.
  - Keep `new_browser_tab` documented only as a compatibility alias.
  - Add a regression test that keeps the keyboard docs action-key block aligned with the canonical action catalog.
- Why?
  - The runtime action catalog uses `new-browser-tab`; `new_browser_tab` is accepted only as a back-compat alias.
  - The docs previously taught the alias as the primary key, so future drift could recur without a source/docs guard.

## Testing

- `cargo fmt --check`
- Source-level parity check: 66 documented action keys matched 66 canonical action keys; no alias keys appeared in the supported-action-key block.
- `git diff --check main..HEAD`
- Privacy scan over `main..HEAD`: no absolute user paths, agent URLs, toolchain install paths, or secret-like tokens.

Workspace `cargo test` is currently blocked locally before reaching this change by `libsqlite3-sys` using the unstable `cfg_select` build-script feature with the installed Rust toolchain.

## Demo Video

No video. This is a docs/test-only change; no UI behavior changed.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved
