### PR TITLE
Keep resumed agent notification hooks armed during restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1004,6 +1004,7 @@ jobs:
           python3 tests/test_stress_cli_socket_api.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omo_openagent_plugin_migration.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_autodiscovery.py
+          python3 tests/test_codex_wrapper_resume_hooks.py
           python3 tests/test_claude_wrapper_hooks.py
           python3 tests/test_claude_wrapper_mutual_shim_loop.py
           python3 tests/test_claude_wrapper_user_binary_resolution.py

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30506,7 +30506,7 @@ export default CMUXSessionRestore;
         let action = Self.subcommandActions[subcommand] ?? .noop
 #if DEBUG
         agentHookDebugLog(
-            "agentHook.start agent=\(def.name) subcommand=\(subcommand) session=\(agentHookDebugShort(sessionId)) inputSession=\(agentHookDebugShort(input.sessionId)) rawBytes=\(rawInput.utf8.count) hasCwd=\(hookCwd == nil ? 0 : 1) envWorkspace=\(env["CMUX_WORKSPACE_ID"] == nil ? 0 : 1) envSurface=\(env["CMUX_SURFACE_ID"] == nil ? 0 : 1) directWorkspace=\(directWorkspaceArg == nil ? 0 : 1) directSurface=\(directSurfaceArg == nil ? 0 : 1) invalidDirect=\(hasUnusableDirectBinding ? 1 : 0) processBinding=\(processBindingDebugState()) socketName=\(agentHookDebugSocketName(client.socketPath))",
+            "agentHook.start agent=\(def.name) subcommand=\(subcommand) session=\(agentHookDebugShort(sessionId)) inputSession=\(agentHookDebugShort(input.sessionId)) resumed=\(env["CMUX_AGENT_RESUME_LAUNCH"] == "1" ? 1 : 0) rawBytes=\(rawInput.utf8.count) hasCwd=\(hookCwd == nil ? 0 : 1) envWorkspace=\(env["CMUX_WORKSPACE_ID"] == nil ? 0 : 1) envSurface=\(env["CMUX_SURFACE_ID"] == nil ? 0 : 1) directWorkspace=\(directWorkspaceArg == nil ? 0 : 1) directSurface=\(directSurfaceArg == nil ? 0 : 1) invalidDirect=\(hasUnusableDirectBinding ? 1 : 0) processBinding=\(processBindingDebugState()) socketName=\(agentHookDebugSocketName(client.socketPath))",
             socketPath: client.socketPath,
             env: env
         )
@@ -31472,7 +31472,7 @@ export default CMUXSessionRestore;
                 let notifyCommand = "notify_target_async \(workspaceId) \(surfaceId) \(payload)"
 #if DEBUG
                 agentHookDebugLog(
-                    "agentHook.stop.notify agent=\(def.name) session=\(agentHookDebugShort(sessionId)) fallback=\(shouldPublishGrokStopFallbackNotification ? 1 : 0) workspace=\(agentHookDebugShort(workspaceId)) surface=\(agentHookDebugShort(surfaceId)) subtitleLen=\(subtitle.count) bodyLen=\(body.count)",
+                    "agentHook.stop.notify agent=\(def.name) session=\(agentHookDebugShort(sessionId)) resumed=\(env["CMUX_AGENT_RESUME_LAUNCH"] == "1" ? 1 : 0) fallback=\(shouldPublishGrokStopFallbackNotification ? 1 : 0) workspace=\(agentHookDebugShort(workspaceId)) surface=\(agentHookDebugShort(surfaceId)) subtitleLen=\(subtitle.count) bodyLen=\(body.count)",
                     socketPath: client.socketPath,
                     env: env
                 )
@@ -31481,7 +31481,7 @@ export default CMUXSessionRestore;
                     let response = try sendV1Command(notifyCommand, client: client)
 #if DEBUG
                     agentHookDebugLog(
-                        "agentHook.stop.notify.sent agent=\(def.name) session=\(agentHookDebugShort(sessionId)) response=\(response)",
+                        "agentHook.stop.notify.sent agent=\(def.name) session=\(agentHookDebugShort(sessionId)) resumed=\(env["CMUX_AGENT_RESUME_LAUNCH"] == "1" ? 1 : 0) response=\(response)",
                         socketPath: client.socketPath,
                         env: env
                     )
@@ -31490,7 +31490,7 @@ export default CMUXSessionRestore;
                 } catch {
 #if DEBUG
                     agentHookDebugLog(
-                        "agentHook.stop.notify.error agent=\(def.name) session=\(agentHookDebugShort(sessionId)) error=\(String(describing: error))",
+                        "agentHook.stop.notify.error agent=\(def.name) session=\(agentHookDebugShort(sessionId)) resumed=\(env["CMUX_AGENT_RESUME_LAUNCH"] == "1" ? 1 : 0) error=\(String(describing: error))",
                         socketPath: client.socketPath,
                         env: env
                     )
@@ -31499,7 +31499,7 @@ export default CMUXSessionRestore;
             } else if shouldPublishStopAlert {
 #if DEBUG
                 agentHookDebugLog(
-                    "agentHook.stop.notify.skipDuplicate agent=\(def.name) session=\(agentHookDebugShort(sessionId)) fallback=\(shouldPublishGrokStopFallbackNotification ? 1 : 0) fingerprint=\(agentHookDebugShort(notificationFingerprint))",
+                    "agentHook.stop.notify.skipDuplicate agent=\(def.name) session=\(agentHookDebugShort(sessionId)) resumed=\(env["CMUX_AGENT_RESUME_LAUNCH"] == "1" ? 1 : 0) fallback=\(shouldPublishGrokStopFallbackNotification ? 1 : 0) fingerprint=\(agentHookDebugShort(notificationFingerprint))",
                     socketPath: client.socketPath,
                     env: env
                 )

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestoreLaunch.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestoreLaunch.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Describes one cmux-owned Claude or Codex session restore launch.
+///
+/// The value validates restore ownership once, then provides the provider-specific
+/// wrapper route and a shell-portable authorization transport for app-generated
+/// startup input. Invalid providers and non-UUID session identifiers cannot create
+/// a restore launch.
+public struct AgentRestoreLaunch: Sendable {
+    private enum Provider: String, Sendable {
+        case claude
+        case codex
+    }
+
+    private let provider: Provider
+    private let sessionID: String
+
+    /// Creates an authorized restore launch for a supported provider and UUID session.
+    ///
+    /// - Parameters:
+    ///   - kind: The persisted agent kind. Only `claude` and `codex` are supported.
+    ///   - sessionID: The exact session identifier that the wrapper must resume.
+    public init?(kind: String?, sessionID: String?) {
+        guard let normalizedKind = kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              let provider = Provider(rawValue: normalizedKind),
+              let sessionID = sessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+              UUID(uuidString: sessionID) != nil else {
+            return nil
+        }
+        self.provider = provider
+        self.sessionID = sessionID
+    }
+
+    /// The basename expected for a captured executable owned by this provider.
+    public var executableName: String {
+        provider.rawValue
+    }
+
+    /// The managed per-surface wrapper token used to restore hook injection.
+    public var wrapperShellExecutableToken: String {
+        switch provider {
+        case .claude: AgentResumeArgv.claudeWrapperShellExecutableToken
+        case .codex: AgentResumeArgv.codexWrapperShellExecutableToken
+        }
+    }
+
+    /// The environment key through which the wrapper preserves a captured executable.
+    public var customExecutablePathEnvironmentKey: String {
+        switch provider {
+        case .claude: "CMUX_CUSTOM_CLAUDE_PATH"
+        case .codex: "CMUX_CUSTOM_CODEX_PATH"
+        }
+    }
+
+    /// Wraps a provider-specific wrapper command so every supported login shell can dispatch it.
+    ///
+    /// - Parameter posixCommand: The command containing ``wrapperShellExecutableToken``.
+    /// - Returns: A `/bin/sh -c` command that can be typed into POSIX and non-POSIX shells.
+    public func portableWrapperShellCommand(posixCommand: String) -> String {
+        switch provider {
+        case .claude: AgentResumeArgv.portableClaudeResumeShellCommand(posixCommand: posixCommand)
+        case .codex: AgentResumeArgv.portableCodexResumeShellCommand(posixCommand: posixCommand)
+        }
+    }
+
+    /// Adds the one-shot restore authorization before an already routed command.
+    ///
+    /// `/usr/bin/env` carries the assignment because startup input is parsed by the
+    /// user's login shell, and csh/tcsh do not accept POSIX `NAME=value command`
+    /// syntax. `leadingShell` keeps app-owned working-directory guards outside the
+    /// portable wrapper command.
+    ///
+    /// - Parameters:
+    ///   - leadingShell: Shell syntax that must remain before the command executable.
+    ///   - routedCommand: The command beginning at its executable after wrapper routing.
+    /// - Returns: Startup input carrying provider- and session-bound authorization.
+    public func authorizing(leadingShell: String, routedCommand: String) -> String {
+        let assignment = "CMUX_AGENT_RESTORE_LAUNCH=\(provider.rawValue):\(sessionID)"
+        return leadingShell + "/usr/bin/env '\(assignment)' " + routedCommand
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestoreLaunch.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentRestoreLaunch.swift
@@ -6,6 +6,11 @@ import Foundation
 /// wrapper route and a shell-portable authorization transport for app-generated
 /// startup input. Invalid providers and non-UUID session identifiers cannot create
 /// a restore launch.
+///
+/// ```swift
+/// let launch = AgentRestoreLaunch(kind: "codex", sessionID: restoredSessionID)
+/// let startupInput = launch?.authorizing(leadingShell: "", routedCommand: resumeCommand)
+/// ```
 public struct AgentRestoreLaunch: Sendable {
     private enum Provider: String, Sendable {
         case claude

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentRestoreLaunchTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import CMUXAgentLaunch
+
+@Suite struct AgentRestoreLaunchTests {
+    private let sessionID = "a22293b7-bcef-4707-8439-2f538c8517a4"
+
+    @Test(arguments: ["claude", "codex"])
+    func supportedProviderOwnsWrapperConfiguration(kind: String) throws {
+        let launch = try #require(AgentRestoreLaunch(kind: " \(kind.uppercased()) ", sessionID: sessionID))
+
+        #expect(launch.executableName == kind)
+        #expect(launch.wrapperShellExecutableToken.contains("CMUX_\(kind.uppercased())_WRAPPER_SHIM"))
+        #expect(launch.customExecutablePathEnvironmentKey == "CMUX_CUSTOM_\(kind.uppercased())_PATH")
+        #expect(launch.portableWrapperShellCommand(posixCommand: "wrapper --resume").hasPrefix("/bin/sh -c "))
+    }
+
+    @Test func invalidOwnershipCannotCreateRestoreLaunch() {
+        #expect(AgentRestoreLaunch(kind: "gemini", sessionID: sessionID) == nil)
+        #expect(AgentRestoreLaunch(kind: "codex", sessionID: "not-a-session-id") == nil)
+        #expect(AgentRestoreLaunch(kind: nil, sessionID: sessionID) == nil)
+        #expect(AgentRestoreLaunch(kind: "claude", sessionID: nil) == nil)
+    }
+
+    @Test func authorizationUsesShellPortableEnvironmentTransport() throws {
+        let launch = try #require(AgentRestoreLaunch(kind: "codex", sessionID: sessionID))
+
+        #expect(
+            launch.authorizing(
+                leadingShell: "cd -- '/repo' && ",
+                routedCommand: "/bin/sh -c 'wrapper resume'"
+            ) == "cd -- '/repo' && /usr/bin/env 'CMUX_AGENT_RESTORE_LAUNCH=codex:\(sessionID)' /bin/sh -c 'wrapper resume'"
+        )
+    }
+}

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -156,6 +156,7 @@ cmux_claude_wrapper_exec_resolved_claude() {
         # A non-shim target is the boundary where a real Claude process starts.
         # Clear the shim-bounce guard so real Claude children that invoke
         # `claude` later begin a fresh wrapper resolution.
+        unset CMUX_AGENT_RESTORE_LAUNCH
         unset cmux_claude_wrapper_reexec_guard
         unset cmux_claude_wrapper_reexec_targets
         exec "$target" "$@"
@@ -178,6 +179,11 @@ cmux_claude_wrapper_exec_resolved_claude() {
     fi
     cmux_claude_wrapper_reexec_targets="$cmux_claude_wrapper_reexec_target_history"
     export cmux_claude_wrapper_reexec_targets
+    if [[ "${cmux_claude_app_restore_owned:-0}" == "1" ]]; then
+        # A supported shim will invoke this wrapper again. Re-issue the exact
+        # authorization for that pass; the next wrapper consumes it immediately.
+        export CMUX_AGENT_RESTORE_LAUNCH="$cmux_claude_app_restore_launch"
+    fi
     exec "$target" "$@"
 }
 
@@ -583,9 +589,9 @@ if [[ -n "$CMUX_SURFACE_ID" ]]; then
     IN_CMUX=1
 fi
 
-# CMUX_AGENT_RESTORE_LAUNCH is a one-shot ownership token attached only to
-# app-generated restore input. Consume it before every eventual exec so it can
-# authorize this wrapper's startup decision without leaking to Claude or hooks.
+# CMUX_AGENT_RESTORE_LAUNCH is a provider/session-bound one-shot token attached
+# only to app-generated restore input. Consume it before every eventual exec so
+# it can authorize this launch without leaking to Claude or hooks.
 cmux_claude_app_restore_launch="${CMUX_AGENT_RESTORE_LAUNCH:-}"
 unset CMUX_AGENT_RESTORE_LAUNCH
 
@@ -626,8 +632,8 @@ fi
 # and preserves native behavior when its inherited cmux environment is stale.
 cmux_claude_resume_sid="$(extract_claude_resume_session_id "$@")"
 cmux_claude_app_restore_owned=0
-if [[ "$cmux_claude_app_restore_launch" == "1" \
-      && "$cmux_claude_resume_sid" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+if [[ "$cmux_claude_resume_sid" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ \
+      && "$cmux_claude_app_restore_launch" == "claude:$cmux_claude_resume_sid" ]]; then
     cmux_claude_app_restore_owned=1
 fi
 if [[ "$cmux_claude_app_restore_owned" != "1" ]] \

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -583,6 +583,12 @@ if [[ -n "$CMUX_SURFACE_ID" ]]; then
     IN_CMUX=1
 fi
 
+# CMUX_AGENT_RESTORE_LAUNCH is a one-shot ownership token attached only to
+# app-generated restore input. Consume it before every eventual exec so it can
+# authorize this wrapper's startup decision without leaking to Claude or hooks.
+cmux_claude_app_restore_launch="${CMUX_AGENT_RESTORE_LAUNCH:-}"
+unset CMUX_AGENT_RESTORE_LAUNCH
+
 exec_real_claude_passthrough() {
     if [[ "$IN_CMUX" == "1" ]]; then
         clear_inherited_claude_session_identity_env
@@ -614,14 +620,21 @@ if [[ "$IN_CMUX" == "0" ]]; then
     exec_real_claude_passthrough "$@"
 fi
 
-# An explicit resume id is the stable signal that this launch must retain its
-# hooks even when app restore has not made the socket responsive yet. Ordinary
-# launches keep the stale inherited-environment fallback so cmux does not
-# disable Claude's native notifications when no live app owns the surface.
+# App-generated restore input plus an explicit resume id proves cmux owns this
+# launch, so a transient socket miss cannot permanently strip its hooks. An
+# unmarked resume from a detached shell/tmux keeps the bounded ownership probe
+# and preserves native behavior when its inherited cmux environment is stale.
 cmux_claude_resume_sid="$(extract_claude_resume_session_id "$@")"
-if [[ -z "$cmux_claude_resume_sid" ]] && ! cmux_socket_available; then
+cmux_claude_app_restore_owned=0
+if [[ "$cmux_claude_app_restore_launch" == "1" \
+      && "$cmux_claude_resume_sid" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    cmux_claude_app_restore_owned=1
+fi
+if [[ "$cmux_claude_app_restore_owned" != "1" ]] \
+      && ! cmux_socket_available; then
     clear_inherited_claude_session_identity_env
     clear_inherited_claude_auth_selection_env
+    reconcile_claude_config_dir_for_resume "$cmux_claude_resume_sid"
     REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
     exec_real_claude_passthrough "$@"
 fi

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -209,6 +209,23 @@ find_real_claude() {
     return 1
 }
 
+# Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
+cmux_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir cmux_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    cmux_bin="$self_dir/cmux"
+    [[ -x "$cmux_bin" ]] || cmux_bin="$(command -v cmux || true)"
+    [[ -n "$cmux_bin" ]] || return 1
+
+    # Keep stale/hung socket checks bounded so claude startup does not block
+    # behind the CLI default timeout (15s).
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
 resolve_hook_cmux_bin() {
     local self_dir bundled_cli
     bundled_cli="${CMUX_BUNDLED_CLI_PATH:-}"
@@ -591,10 +608,19 @@ if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" "$@"
 fi
 
-# Hook ownership is a launch invariant, not a point-in-time socket-health
-# decision. A restore-time ping can fail transiently; hooks injected now will
-# independently reconnect when their lifecycle event fires later.
 if [[ "$IN_CMUX" == "0" ]]; then
+    clear_inherited_claude_auth_selection_env
+    REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
+    exec_real_claude_passthrough "$@"
+fi
+
+# An explicit resume id is the stable signal that this launch must retain its
+# hooks even when app restore has not made the socket responsive yet. Ordinary
+# launches keep the stale inherited-environment fallback so cmux does not
+# disable Claude's native notifications when no live app owns the surface.
+cmux_claude_resume_sid="$(extract_claude_resume_session_id "$@")"
+if [[ -z "$cmux_claude_resume_sid" ]] && ! cmux_socket_available; then
+    clear_inherited_claude_session_identity_env
     clear_inherited_claude_auth_selection_env
     REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
     exec_real_claude_passthrough "$@"
@@ -846,7 +872,6 @@ fi
 # For an explicit `--resume <id>`, point CLAUDE_CONFIG_DIR at the config root that
 # actually holds the transcript so an inherited/foreign config dir cannot turn the
 # resume into "No conversation found". https://github.com/manaflow-ai/cmux/issues/6194
-cmux_claude_resume_sid="$(extract_claude_resume_session_id "$@")"
 reconcile_claude_config_dir_for_resume "$cmux_claude_resume_sid"
 if [[ -n "$cmux_claude_resume_sid" ]]; then
     export CMUX_AGENT_RESUME_LAUNCH=1

--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -209,23 +209,6 @@ find_real_claude() {
     return 1
 }
 
-# Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
-cmux_socket_available() {
-    local socket="${CMUX_SOCKET_PATH:-}"
-    [[ -n "$socket" && -S "$socket" ]] || return 1
-
-    local self_dir cmux_bin
-    self_dir="$(cd "$(dirname "$0")" && pwd)"
-    cmux_bin="$self_dir/cmux"
-    [[ -x "$cmux_bin" ]] || cmux_bin="$(command -v cmux || true)"
-    [[ -n "$cmux_bin" ]] || return 1
-
-    # Keep stale/hung socket checks bounded so claude startup does not block
-    # behind the CLI default timeout (15s).
-    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
-        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
-}
-
 resolve_hook_cmux_bin() {
     local self_dir bundled_cli
     bundled_cli="${CMUX_BUNDLED_CLI_PATH:-}"
@@ -608,16 +591,11 @@ if [[ "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]]; then
     cmux_claude_wrapper_exec_resolved_claude "$REAL_CLAUDE" "$@"
 fi
 
-if [[ "$IN_CMUX" == "0" ]] || ! cmux_socket_available; then
-    # In cmux-launched shells, preserve old behavior and always clear nested
-    # Claude session markers, even when we must pass through due to stale socket.
-    if [[ "$IN_CMUX" == "1" ]]; then
-        clear_inherited_claude_session_identity_env
-    fi
+# Hook ownership is a launch invariant, not a point-in-time socket-health
+# decision. A restore-time ping can fail transiently; hooks injected now will
+# independently reconnect when their lifecycle event fires later.
+if [[ "$IN_CMUX" == "0" ]]; then
     clear_inherited_claude_auth_selection_env
-    if [[ "$IN_CMUX" == "1" ]]; then
-        reconcile_claude_config_dir_for_resume "$(extract_claude_resume_session_id "$@")"
-    fi
     REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
     exec_real_claude_passthrough "$@"
 fi
@@ -868,7 +846,13 @@ fi
 # For an explicit `--resume <id>`, point CLAUDE_CONFIG_DIR at the config root that
 # actually holds the transcript so an inherited/foreign config dir cannot turn the
 # resume into "No conversation found". https://github.com/manaflow-ai/cmux/issues/6194
-reconcile_claude_config_dir_for_resume "$(extract_claude_resume_session_id "$@")"
+cmux_claude_resume_sid="$(extract_claude_resume_session_id "$@")"
+reconcile_claude_config_dir_for_resume "$cmux_claude_resume_sid"
+if [[ -n "$cmux_claude_resume_sid" ]]; then
+    export CMUX_AGENT_RESUME_LAUNCH=1
+else
+    unset CMUX_AGENT_RESUME_LAUNCH
+fi
 
 # Export the wrapper's PID. Because we exec claude below, this PID becomes
 # the actual claude process PID, which hooks use for stale-session detection.

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -237,9 +237,9 @@ if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
     IN_CMUX=1
 fi
 
-# CMUX_AGENT_RESTORE_LAUNCH is a one-shot ownership token attached only to
-# app-generated restore input. Consume it before every eventual exec so it can
-# authorize this wrapper's startup decision without leaking to Codex or hooks.
+# CMUX_AGENT_RESTORE_LAUNCH is a provider/session-bound one-shot token attached
+# only to app-generated restore input. Consume it before every eventual exec so
+# it can authorize this launch without leaking to Codex or hooks.
 cmux_codex_app_restore_launch="${CMUX_AGENT_RESTORE_LAUNCH:-}"
 unset CMUX_AGENT_RESTORE_LAUNCH
 
@@ -275,7 +275,8 @@ fi
 # unmarked resume from a detached shell/tmux keeps the bounded ownership probe
 # and preserves native behavior when its inherited cmux environment is stale.
 cmux_codex_resume_sid="$(cmux_codex_resume_session_id "$@")"
-if [[ "$cmux_codex_app_restore_launch" != "1" || -z "$cmux_codex_resume_sid" ]] \
+if [[ -z "$cmux_codex_resume_sid" \
+      || "$cmux_codex_app_restore_launch" != "codex:$cmux_codex_resume_sid" ]] \
       && ! cmux_socket_available; then
     exec_real_codex_passthrough "$@"
 fi

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -68,19 +68,6 @@ find_real_codex() {
     return 1
 }
 
-# Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
-cmux_socket_available() {
-    local socket="${CMUX_SOCKET_PATH:-}"
-    [[ -n "$socket" && -S "$socket" ]] || return 1
-
-    local cmux_bin
-    cmux_bin="$(resolve_hook_cmux_bin)"
-    [[ -n "$cmux_bin" ]] || return 1
-
-    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
-        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
-}
-
 resolve_hook_cmux_bin() {
     local self_dir bundled_cli
     bundled_cli="${CMUX_BUNDLED_CLI_PATH:-}"
@@ -252,11 +239,15 @@ exec_real_codex_passthrough() {
     exec "$REAL_CODEX" "$@"
 }
 
-# Opt-out, outside cmux, or stale/dead socket: pass straight through.
+# Hook ownership is a launch invariant, not a point-in-time socket-health
+# decision. During app restore the socket can briefly miss a ping while this
+# wrapper is starting; dropping injection then would remove every later Stop
+# notification for the lifetime of the resumed session. Each hook remains
+# best-effort and independently reconnects when its event fires.
 if [[ "${CMUX_CODEX_HOOKS_DISABLED:-}" == "1" ]]; then
     exec_real_codex_passthrough "$@"
 fi
-if [[ "$IN_CMUX" == "0" ]] || ! cmux_socket_available; then
+if [[ "$IN_CMUX" == "0" ]]; then
     exec_real_codex_passthrough "$@"
 fi
 
@@ -301,9 +292,11 @@ export CMUX_AGENT_LAUNCH_CWD="$PWD"
 # and pid from CMUX_CODEX_PID, re-binding the resumed session to its live pid and
 # flipping it back to idle/editable. Fire-and-forget (backgrounded + disowned) so
 # it never blocks the launch; best-effort so a failure can never break `codex`.
+unset CMUX_AGENT_RESUME_LAUNCH
 cmux_codex_resume_sid="$(cmux_codex_resume_session_id "$@")"
 if [[ -n "$cmux_codex_resume_sid" \
       && -n "$CMUX_CODEX_HOOK_CMUX_BIN" && -x "$CMUX_CODEX_HOOK_CMUX_BIN" ]]; then
+    export CMUX_AGENT_RESUME_LAUNCH=1
     cmux_codex_resume_payload="{\"session_id\":\"$cmux_codex_resume_sid\",\"cwd\":\"$PWD\"}"
     if [[ -n "${CMUX_SOCKET_PATH:-}" ]]; then
         ( printf '%s' "$cmux_codex_resume_payload" \

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -237,6 +237,12 @@ if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
     IN_CMUX=1
 fi
 
+# CMUX_AGENT_RESTORE_LAUNCH is a one-shot ownership token attached only to
+# app-generated restore input. Consume it before every eventual exec so it can
+# authorize this wrapper's startup decision without leaking to Codex or hooks.
+cmux_codex_app_restore_launch="${CMUX_AGENT_RESTORE_LAUNCH:-}"
+unset CMUX_AGENT_RESTORE_LAUNCH
+
 # Resolve real codex up front; if it cannot be found we error like a missing
 # binary would (same as the claude wrapper) rather than silently succeeding.
 REAL_CODEX="$(find_real_codex)" || { echo "Error: codex not found in PATH" >&2; exit 127; }
@@ -264,12 +270,13 @@ if ! should_inject_codex_hooks "$@"; then
     exec_real_codex_passthrough "$@"
 fi
 
-# An explicit resume id is the stable signal that this launch must retain its
-# hooks even when app restore has not made the socket responsive yet. Ordinary
-# launches keep the stale inherited-environment fallback so cmux does not
-# suppress the agent's native notifications when no live app owns the surface.
+# App-generated restore input plus an explicit resume id proves cmux owns this
+# launch, so a transient socket miss cannot permanently strip its hooks. An
+# unmarked resume from a detached shell/tmux keeps the bounded ownership probe
+# and preserves native behavior when its inherited cmux environment is stale.
 cmux_codex_resume_sid="$(cmux_codex_resume_session_id "$@")"
-if [[ -z "$cmux_codex_resume_sid" ]] && ! cmux_socket_available; then
+if [[ "$cmux_codex_app_restore_launch" != "1" || -z "$cmux_codex_resume_sid" ]] \
+      && ! cmux_socket_available; then
     exec_real_codex_passthrough "$@"
 fi
 

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -68,6 +68,19 @@ find_real_codex() {
     return 1
 }
 
+# Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
+cmux_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local cmux_bin
+    cmux_bin="$(resolve_hook_cmux_bin)"
+    [[ -n "$cmux_bin" ]] || return 1
+
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
 resolve_hook_cmux_bin() {
     local self_dir bundled_cli
     bundled_cli="${CMUX_BUNDLED_CLI_PATH:-}"
@@ -239,11 +252,6 @@ exec_real_codex_passthrough() {
     exec "$REAL_CODEX" "$@"
 }
 
-# Hook ownership is a launch invariant, not a point-in-time socket-health
-# decision. During app restore the socket can briefly miss a ping while this
-# wrapper is starting; dropping injection then would remove every later Stop
-# notification for the lifetime of the resumed session. Each hook remains
-# best-effort and independently reconnects when its event fires.
 if [[ "${CMUX_CODEX_HOOKS_DISABLED:-}" == "1" ]]; then
     exec_real_codex_passthrough "$@"
 fi
@@ -253,6 +261,15 @@ fi
 
 # Not a session entrypoint (review/login/doctor/--help/...): pass through.
 if ! should_inject_codex_hooks "$@"; then
+    exec_real_codex_passthrough "$@"
+fi
+
+# An explicit resume id is the stable signal that this launch must retain its
+# hooks even when app restore has not made the socket responsive yet. Ordinary
+# launches keep the stale inherited-environment fallback so cmux does not
+# suppress the agent's native notifications when no live app owns the surface.
+cmux_codex_resume_sid="$(cmux_codex_resume_session_id "$@")"
+if [[ -z "$cmux_codex_resume_sid" ]] && ! cmux_socket_available; then
     exec_real_codex_passthrough "$@"
 fi
 
@@ -293,7 +310,6 @@ export CMUX_AGENT_LAUNCH_CWD="$PWD"
 # flipping it back to idle/editable. Fire-and-forget (backgrounded + disowned) so
 # it never blocks the launch; best-effort so a failure can never break `codex`.
 unset CMUX_AGENT_RESUME_LAUNCH
-cmux_codex_resume_sid="$(cmux_codex_resume_session_id "$@")"
 if [[ -n "$cmux_codex_resume_sid" \
       && -n "$CMUX_CODEX_HOOK_CMUX_BIN" && -x "$CMUX_CODEX_HOOK_CMUX_BIN" ]]; then
     export CMUX_AGENT_RESUME_LAUNCH=1

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -415,5 +415,8 @@ extension DockSplitStore {
             workspaceID: workspaceId.uuidString,
             workingDirectory: workingDirectory
         )
+#if DEBUG
+        cmuxDebugLog("session.restore.dock.resumeBinding workspace=\(workspaceId.uuidString.prefix(8)) surface=\(panelId.uuidString.prefix(8)) source=\(session.source) session=\(session.id.prefix(8))")
+#endif
     }
 }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -778,7 +778,11 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         requireLauncherScript: Bool = false
     ) -> String? {
         let restoreCommand = resumeCommand.map {
-            "/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c \(shellSingleQuoted($0))"
+            SurfaceResumeCommandCanonicalizer.insertingAppOwnedAgentRestoreLaunch(
+                in: $0,
+                kind: kind.rawValue,
+                sessionId: sessionId
+            )
         }
         return startupInput(
             command: restoreCommand,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -777,12 +777,9 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         allowOversizedInlineInput: Bool = false,
         requireLauncherScript: Bool = false
     ) -> String? {
-        let restoreCommand = resumeCommand.map {
-            SurfaceResumeCommandCanonicalizer.insertingAppOwnedAgentRestoreLaunch(
-                in: $0,
-                kind: kind.rawValue,
-                sessionId: sessionId
-            )
+        let restoreCommand = resumeCommand.map { command in
+            AgentRestoreLaunch(kind: kind.rawValue, sessionID: sessionId)?
+                .applying(toStoredCommand: command) ?? command
         }
         return startupInput(
             command: restoreCommand,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -777,8 +777,11 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         allowOversizedInlineInput: Bool = false,
         requireLauncherScript: Bool = false
     ) -> String? {
-        startupInput(
-            command: resumeCommand,
+        let restoreCommand = resumeCommand.map {
+            "/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c \(shellSingleQuoted($0))"
+        }
+        return startupInput(
+            command: restoreCommand,
             fileManager: fileManager,
             temporaryDirectory: temporaryDirectory,
             allowLauncherScript: allowLauncherScript,

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -80,9 +80,6 @@ extension SurfaceResumeBindingSnapshot {
         )
         let repaired: String
         if repairPortableAgentExecutable {
-            // Suppression insertion runs before executable repair: repair can wrap a
-            // stale-executable command in `/bin/sh -c '…'`, whose single-word body no
-            // longer parses as a codex resume argv.
             repaired = SurfaceResumeCommandCanonicalizer.replacingPortableAgentExecutable(
                 in: suppressed,
                 kind: kind
@@ -90,37 +87,48 @@ extension SurfaceResumeBindingSnapshot {
         } else {
             repaired = suppressed
         }
-        return SurfaceResumeCommandCanonicalizer.insertingAppOwnedAgentRestoreLaunch(
-            in: repaired,
-            kind: kind,
-            sessionId: checkpointId
+        guard let restoreLaunch = AgentRestoreLaunch(kind: kind, sessionID: checkpointId) else { return repaired }
+        return restoreLaunch.applying(toStoredCommand: repaired)
+    }
+}
+
+extension AgentRestoreLaunch {
+    func applying(toStoredCommand command: String) -> String {
+        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
+        guard let executableIndex = SurfaceResumeCommandCanonicalizer.commandExecutableWordIndex(
+            in: words,
+            command: command
+        ) else { return command }
+        let wrapperToken = wrapperShellExecutableToken
+        let executable = words[executableIndex].value
+        guard command.contains(wrapperToken) || (executable as NSString).lastPathComponent == executableName else {
+            return command
+        }
+        let routed = command.contains(wrapperToken) ? command : SurfaceResumeCommandCanonicalizer.replacingExecutableWithWrapperShellCommand(
+            in: command,
+            words: words,
+            commandStartIndex: SurfaceResumeCommandCanonicalizer.commandStartWordIndex(in: words),
+            executableIndex: executableIndex,
+            wrapperToken: wrapperToken,
+            customExecutableEnvironment: executable == executableName
+                ? nil
+                : (customExecutablePathEnvironmentKey, executable),
+            wrapInPortableShell: { portableWrapperShellCommand(posixCommand: $0) }
+        )
+        let routedWords = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(routed)
+        guard let routedExecutableIndex = SurfaceResumeCommandCanonicalizer.commandExecutableWordIndex(
+            in: routedWords,
+            command: routed
+        ) else { return command }
+        let executableStart = routedWords[routedExecutableIndex].range.lowerBound
+        return authorizing(
+            leadingShell: String(routed[..<executableStart]),
+            routedCommand: String(routed[executableStart...])
         )
     }
 }
 
 extension SurfaceResumeCommandCanonicalizer {
-    static func insertingAppOwnedAgentRestoreLaunch(
-        in command: String,
-        kind: String?,
-        sessionId: String?
-    ) -> String {
-        guard let provider = kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-              provider == "codex" || provider == "claude",
-              let sessionId = sessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
-              UUID(uuidString: sessionId) != nil else {
-            return command
-        }
-        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
-        guard let executableIndex = commandExecutableWordIndex(in: words, command: command) else {
-            return command
-        }
-        let executableStart = words[executableIndex].range.lowerBound
-        let token = TerminalStartupShellQuoting.singleQuoted("\(provider):\(sessionId)")
-        return String(command[..<executableStart])
-            + "CMUX_AGENT_RESTORE_LAUNCH=\(token) "
-            + String(command[executableStart...])
-    }
-
     static func replacingPortableAgentExecutable(in command: String, kind: String?) -> String {
         let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
         guard let executableIndex = commandExecutableWordIndex(in: words, command: command) else { return command }
@@ -135,9 +143,7 @@ extension SurfaceResumeCommandCanonicalizer {
               isPATHManagedAgentExecutablePath(executable, executableName: executableName) else {
             return command
         }
-        guard !isExecutableFile(atPath: executable) else {
-            return command
-        }
+        guard !isExecutableFile(atPath: executable) else { return command }
 
         if executableName == "claude" {
             return replacingStaleWrapperRoutedExecutable(
@@ -150,10 +156,6 @@ extension SurfaceResumeCommandCanonicalizer {
                 wrapInPortableShell: { AgentResumeArgv.portableClaudeResumeShellCommand(posixCommand: $0) }
             )
         } else if executableName == "codex" {
-            // Mirror claude: route a stale codex executable (a PATH-managed path
-            // whose file is gone) through the codex wrapper token instead of a
-            // bare `codex`, so the restored codex surface keeps cmux hooks.
-            // https://github.com/manaflow-ai/cmux/issues/5639
             return replacingStaleWrapperRoutedExecutable(
                 in: command,
                 words: words,
@@ -180,18 +182,13 @@ extension SurfaceResumeCommandCanonicalizer {
         }
         return portableAgentExecutableName(forExecutableBasename: executableBasename)
     }
-
     private static func portableAgentExecutableName(for kind: String?) -> String? {
         switch kind?.trimmingCharacters(in: .whitespacesAndNewlines) {
-        case "claude":
-            return "claude"
-        case "codex":
-            return "codex"
-        default:
-            return nil
+        case "claude": return "claude"
+        case "codex": return "codex"
+        default: return nil
         }
     }
-
     private static func portableAgentExecutableName(forExecutableBasename basename: String) -> String? {
         portableAgentExecutableName(for: basename)
     }
@@ -247,7 +244,6 @@ extension SurfaceResumeCommandCanonicalizer {
             standardizedPath == root || standardizedPath.hasPrefix(root + "/")
         }
     }
-
     private static func isExecutableFile(atPath path: String) -> Bool {
         path.withCString { access($0, X_OK) == 0 }
     }
@@ -272,7 +268,7 @@ extension SurfaceResumeCommandCanonicalizer {
             command: command,
             commandStartIndex: commandStartIndex
         ) else {
-            return replacingStaleExecutableWithWrapperShellCommand(
+            return replacingExecutableWithWrapperShellCommand(
                 in: command,
                 words: words,
                 commandStartIndex: commandStartIndex,
@@ -287,7 +283,7 @@ extension SurfaceResumeCommandCanonicalizer {
             commandStartIndex: commandStartIndex,
             executableIndex: executableIndex
         ) else {
-            return replacingStaleExecutableWithWrapperShellCommand(
+            return replacingExecutableWithWrapperShellCommand(
                 in: command,
                 words: words,
                 commandStartIndex: commandStartIndex,
@@ -302,17 +298,21 @@ extension SurfaceResumeCommandCanonicalizer {
         return String(command[..<commandStart]) + renderedCommand
     }
 
-    private static func replacingStaleExecutableWithWrapperShellCommand(
+    fileprivate static func replacingExecutableWithWrapperShellCommand(
         in command: String,
         words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange],
         commandStartIndex: Int,
         executableIndex: Int,
         wrapperToken: String,
+        customExecutableEnvironment: (key: String, value: String)? = nil,
         wrapInPortableShell: (String) -> String
     ) -> String {
         let renderedParts = words[commandStartIndex...].indices.map { index in
             if index == executableIndex {
-                return wrapperToken
+                let customPath = customExecutableEnvironment.map {
+                    "\($0.key)=\(shellQuoted($0.value)) "
+                } ?? ""
+                return customPath + wrapperToken
             }
             return renderedPortableShellWord(words[index], in: command)
         }
@@ -443,7 +443,7 @@ extension SurfaceResumeCommandCanonicalizer {
         return index < words.count ? index : nil
     }
 
-    private static func commandStartWordIndex(
+    fileprivate static func commandStartWordIndex(
         in words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange]
     ) -> Int {
         if let guardEndIndex = leadingWorkingDirectoryGuardEndIndex(in: words) {

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -78,20 +78,49 @@ extension SurfaceResumeBindingSnapshot {
             in: startupCommand,
             kind: kind
         )
-        guard repairPortableAgentExecutable else {
-            return suppressed
+        let repaired: String
+        if repairPortableAgentExecutable {
+            // Suppression insertion runs before executable repair: repair can wrap a
+            // stale-executable command in `/bin/sh -c '…'`, whose single-word body no
+            // longer parses as a codex resume argv.
+            repaired = SurfaceResumeCommandCanonicalizer.replacingPortableAgentExecutable(
+                in: suppressed,
+                kind: kind
+            )
+        } else {
+            repaired = suppressed
         }
-        // Suppression insertion runs before executable repair: repair can wrap a
-        // stale-executable command in `/bin/sh -c '…'`, whose single-word body no
-        // longer parses as a codex resume argv.
-        return SurfaceResumeCommandCanonicalizer.replacingPortableAgentExecutable(
-            in: suppressed,
-            kind: kind
+        return SurfaceResumeCommandCanonicalizer.insertingAppOwnedAgentRestoreLaunch(
+            in: repaired,
+            kind: kind,
+            sessionId: checkpointId
         )
     }
 }
 
 extension SurfaceResumeCommandCanonicalizer {
+    static func insertingAppOwnedAgentRestoreLaunch(
+        in command: String,
+        kind: String?,
+        sessionId: String?
+    ) -> String {
+        guard let provider = kind?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              provider == "codex" || provider == "claude",
+              let sessionId = sessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              UUID(uuidString: sessionId) != nil else {
+            return command
+        }
+        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
+        guard let executableIndex = commandExecutableWordIndex(in: words, command: command) else {
+            return command
+        }
+        let executableStart = words[executableIndex].range.lowerBound
+        let token = TerminalStartupShellQuoting.singleQuoted("\(provider):\(sessionId)")
+        return String(command[..<executableStart])
+            + "CMUX_AGENT_RESTORE_LAUNCH=\(token) "
+            + String(command[executableStart...])
+    }
+
     static func replacingPortableAgentExecutable(in command: String, kind: String?) -> String {
         let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
         guard let executableIndex = commandExecutableWordIndex(in: words, command: command) else { return command }

--- a/Sources/Workspace+ForkAgentConversationAvailability.swift
+++ b/Sources/Workspace+ForkAgentConversationAvailability.swift
@@ -90,8 +90,17 @@ extension Workspace {
     }
 
     func resolveForkAgentConversationContextMenuAvailability(
+        forPanelId panelId: UUID
+    ) async {
+        await resolveForkAgentConversationContextMenuAvailability(
+            forPanelId: panelId,
+            liveAgentIndex: .shared
+        )
+    }
+
+    func resolveForkAgentConversationContextMenuAvailability(
         forPanelId panelId: UUID,
-        liveAgentIndex: SharedLiveAgentIndex = .shared
+        liveAgentIndex: SharedLiveAgentIndex
     ) async {
         let selection = forkAgentConversationContextMenuOpenSelection(
             forPanelId: panelId,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1488,7 +1488,7 @@ extension Workspace {
                     "kind=\(restorableAgent.kind.rawValue) session=\(sessionPreview) " +
                     "hasLaunch=\(restorableAgent.launchCommand == nil ? 0 : 1) " +
                     "launchArgc=\(launchArgc) hasResume=\(restoredAgentResumeLaunch == nil ? 0 : 1) " +
-                    "autoResume=\(autoResumeAgentSessions ? 1 : 0) " +
+                    "autoResume=\(autoResumeAgentSessions ? 1 : 0) typedStartup=\(restoredStartupInput == nil ? 0 : 1) " +
                     "replayScrollback=\(shouldReplayScrollback ? 1 : 0)"
                 )
             }

--- a/cmuxTests/ForkParentFallbackResidualTests.swift
+++ b/cmuxTests/ForkParentFallbackResidualTests.swift
@@ -157,7 +157,10 @@ struct ForkParentFallbackResidualTests {
                 .snapshot(workspaceId: fixture.workspaceId, panelId: fixture.panelId)
         )
         #expect(snapshot.workingDirectory == fixture.cwd.path)
-        #expect(snapshot.resumeStartupInput()?.contains("CMUX_AGENT_RESTORE_LAUNCH=1") == true)
+        #expect(
+            snapshot.resumeStartupInput()?
+                .contains("CMUX_AGENT_RESTORE_LAUNCH='codex:\(sessionId)'") == true
+        )
         #expect(snapshot.resumeCommand?.contains("cd -- '\(fixture.cwd.path)'") == true)
         #expect(snapshot.forkStartupInput()?.contains("cd -- '\(fixture.cwd.path)'") == true)
 

--- a/cmuxTests/ForkParentFallbackResidualTests.swift
+++ b/cmuxTests/ForkParentFallbackResidualTests.swift
@@ -159,7 +159,7 @@ struct ForkParentFallbackResidualTests {
         #expect(snapshot.workingDirectory == fixture.cwd.path)
         #expect(
             snapshot.resumeStartupInput()?
-                .contains("CMUX_AGENT_RESTORE_LAUNCH='codex:\(sessionId)'") == true
+                .contains("/usr/bin/env 'CMUX_AGENT_RESTORE_LAUNCH=codex:\(sessionId)'") == true
         )
         #expect(snapshot.resumeCommand?.contains("cd -- '\(fixture.cwd.path)'") == true)
         #expect(snapshot.forkStartupInput()?.contains("cd -- '\(fixture.cwd.path)'") == true)

--- a/cmuxTests/ForkParentFallbackResidualTests.swift
+++ b/cmuxTests/ForkParentFallbackResidualTests.swift
@@ -157,7 +157,8 @@ struct ForkParentFallbackResidualTests {
                 .snapshot(workspaceId: fixture.workspaceId, panelId: fixture.panelId)
         )
         #expect(snapshot.workingDirectory == fixture.cwd.path)
-        #expect(snapshot.resumeStartupInput()?.contains("cd -- '\(fixture.cwd.path)'") == true)
+        #expect(snapshot.resumeStartupInput()?.contains("CMUX_AGENT_RESTORE_LAUNCH=1") == true)
+        #expect(snapshot.resumeCommand?.contains("cd -- '\(fixture.cwd.path)'") == true)
         #expect(snapshot.forkStartupInput()?.contains("cd -- '\(fixture.cwd.path)'") == true)
 
         let cwdless = SessionRestorableAgentSnapshot(

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -9,6 +9,54 @@ import Testing
 #endif
 
 @Suite struct SessionPersistenceResumeBindingTests {
+    @Test(arguments: ["codex", "claude"])
+    func agentHookRestoreBindingCarriesProviderAndSessionBoundAuthorization(kind: String) throws {
+        let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
+        let resumeArgument = kind == "codex" ? "resume" : "--resume"
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: kind,
+            command: "'/opt/company/bin/\(kind)' '\(resumeArgument)' '\(sessionId)'",
+            checkpointId: sessionId,
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.inlineStartupInput)
+        #expect(
+            startupInput.contains("CMUX_AGENT_RESTORE_LAUNCH='\(kind):\(sessionId)'"),
+            "\(startupInput)"
+        )
+    }
+
+    @Test func restoreBindingAuthorizationRejectsUnownedOrUnboundCommands() throws {
+        let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
+        let nonHook = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume '\(sessionId)'",
+            checkpointId: sessionId,
+            source: "cli",
+            autoResume: true
+        )
+        let unsupported = SurfaceResumeBindingSnapshot(
+            kind: "gemini",
+            command: "gemini --resume '\(sessionId)'",
+            checkpointId: sessionId,
+            source: "agent-hook",
+            autoResume: true
+        )
+        let invalidSession = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "claude --resume not-a-session-id",
+            checkpointId: "not-a-session-id",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        #expect(try #require(nonHook.inlineStartupInput).contains("CMUX_AGENT_RESTORE_LAUNCH") == false)
+        #expect(try #require(unsupported.inlineStartupInput).contains("CMUX_AGENT_RESTORE_LAUNCH") == false)
+        #expect(try #require(invalidSession.inlineStartupInput).contains("CMUX_AGENT_RESTORE_LAUNCH") == false)
+    }
+
     @Test func agentHookSurfaceResumeStartupInputPreservesCustomAbsoluteAgentExecutable() throws {
         let binding = SurfaceResumeBindingSnapshot(
             kind: "codex",

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -23,9 +23,11 @@ import Testing
 
         let startupInput = try #require(binding.inlineStartupInput)
         #expect(
-            startupInput.contains("CMUX_AGENT_RESTORE_LAUNCH='\(kind):\(sessionId)'"),
+            startupInput.contains("/usr/bin/env 'CMUX_AGENT_RESTORE_LAUNCH=\(kind):\(sessionId)'"),
             "\(startupInput)"
         )
+        #expect(startupInput.contains("CMUX_\(kind.uppercased())_WRAPPER_SHIM"), "\(startupInput)")
+        #expect(startupInput.contains("CMUX_CUSTOM_\(kind.uppercased())_PATH="), "\(startupInput)")
     }
 
     @Test func restoreBindingAuthorizationRejectsUnownedOrUnboundCommands() throws {
@@ -57,18 +59,21 @@ import Testing
         #expect(try #require(invalidSession.inlineStartupInput).contains("CMUX_AGENT_RESTORE_LAUNCH") == false)
     }
 
-    @Test func agentHookSurfaceResumeStartupInputPreservesCustomAbsoluteAgentExecutable() throws {
+    @Test func agentHookSurfaceResumeRoutesCustomExecutableThroughWrapper() throws {
+        let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
         let binding = SurfaceResumeBindingSnapshot(
             kind: "codex",
-            command: "'/opt/company/bin/codex' 'resume' 'session-custom-cli'",
-            checkpointId: "session-custom-cli",
+            command: "'/opt/company/bin/codex' 'resume' '\(sessionId)'",
+            checkpointId: sessionId,
             source: "agent-hook",
             autoResume: true
         )
 
         let startupInput = try #require(binding.startupInput)
 
-        #expect(startupInput.contains("'/opt/company/bin/codex'"), "\(startupInput)")
+        #expect(startupInput.contains("CMUX_CODEX_WRAPPER_SHIM"), "\(startupInput)")
+        #expect(startupInput.contains("CMUX_CUSTOM_CODEX_PATH="), "\(startupInput)")
+        #expect(startupInput.contains("/opt/company/bin/codex"), "\(startupInput)")
     }
 
     @Test func decodingAgentHookBindingRewritesPersistedPATHManagedAgentExecutable() throws {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1914,7 +1914,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         XCTAssertEqual(
             snapshot.resumeCommand,
             "cd -- '/tmp/cmux project' 2>/dev/null || [ ! -d '/tmp/cmux project' ] && /bin/sh -c "
-                + shellQuotedForTest("'env' 'CLAUDE_CONFIG_DIR=/tmp/claude config' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' \"$([ -x \"${CMUX_CLAUDE_WRAPPER_SHIM:-}\" ] && printf '%s' \"$CMUX_CLAUDE_WRAPPER_SHIM\" || printf claude)\" '--resume' 'claude-session-123' '--model' 'sonnet' '--permission-mode' 'auto'")
+                + shellQuotedForTest("'env' 'CLAUDE_CONFIG_DIR=/tmp/claude config' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' \"$([ -x \"${CMUX_CLAUDE_WRAPPER_SHIM:-}\" ] && printf '%s' \"$CMUX_CLAUDE_WRAPPER_SHIM\" || printf claude)\" '--resume' 'a22293b7-bcef-4707-8439-2f538c8517a4' '--model' 'sonnet' '--permission-mode' 'auto'")
         )
         // The captured real-binary path must not survive: it would bypass the wrapper.
         XCTAssertFalse(snapshot.resumeCommand?.contains("/opt/Claude Code/bin/claude") ?? true)
@@ -2118,8 +2118,11 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         // (csh/tcsh cannot parse that prefix with or without this fix, a pre-existing
         // limitation shared by every agent kind) so the assertion isolates the claude
         // executable token itself.
-        let snapshot = Self.makeClaudeRestorableSnapshot(workingDirectory: nil)
-        let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
+        let snapshot = Self.makeClaudeRestorableSnapshot(
+            workingDirectory: nil,
+            sessionId: "a22293b7-bcef-4707-8439-2f538c8517a4"
+        )
+        let resumeCommand = try XCTUnwrap(snapshot.resumeStartupInput(allowLauncherScript: false))
 
         let recorded = try runClaudeResumeCommand(
             resumeCommand,
@@ -2297,10 +2300,13 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
-    private static func makeClaudeRestorableSnapshot(workingDirectory: String?) -> SessionRestorableAgentSnapshot {
+    private static func makeClaudeRestorableSnapshot(
+        workingDirectory: String?,
+        sessionId: String = "claude-session-123"
+    ) -> SessionRestorableAgentSnapshot {
         SessionRestorableAgentSnapshot(
             kind: .claude,
-            sessionId: "claude-session-123",
+            sessionId: sessionId,
             workingDirectory: workingDirectory,
             launchCommand: AgentLaunchCommandSnapshot(
                 launcher: "claude",
@@ -2566,7 +2572,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         let startupInput = try XCTUnwrap(snapshot.resumeStartupInput())
         XCTAssertTrue(
             startupInput.contains(
-                "CMUX_AGENT_RESTORE_LAUNCH='claude:\(sessionId)' /bin/sh -c"
+                "/usr/bin/env 'CMUX_AGENT_RESTORE_LAUNCH=claude:\(sessionId)' /bin/sh -c"
             ),
             startupInput
         )
@@ -2648,7 +2654,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
         XCTAssertTrue(
             scriptContents.contains(
-                "CMUX_AGENT_RESTORE_LAUNCH='codex:019dad34-d218-7943-b81a-eddac5c87951'"
+                "/usr/bin/env 'CMUX_AGENT_RESTORE_LAUNCH=codex:019dad34-d218-7943-b81a-eddac5c87951'"
             )
         )
         let command = try inlineResumeCommandResolvingLauncherScript(from: input)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2410,22 +2410,36 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         try assertZshCommandChangesDirectory(cdCommand, expectedPath: cwdURL.path)
     }
 
-    /// Resolves a resume startup input to the line holding the resume command:
-    /// inline inputs are returned directly; `/bin/zsh '<script>'` launcher-script
-    /// inputs (used when the inline form exceeds the startup-input byte budget)
-    /// are read and the script line carrying the resume command is returned.
+    /// Resolves inline or launcher-script startup input and unwraps cmux's
+    /// one-shot app-restore environment marker to the underlying resume command.
     private func inlineResumeCommandResolvingLauncherScript(from startupInput: String) throws -> String {
         let trimmed = startupInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.hasPrefix("/bin/zsh '") else { return trimmed }
-        let quotedPath = String(trimmed.dropFirst("/bin/zsh ".count))
-        let scriptPath = try XCTUnwrap(
-            singleQuotedValueForTest(quotedPath),
-            "unparseable launcher-script startup input: \(trimmed)"
-        )
-        let script = try String(contentsOfFile: scriptPath, encoding: .utf8)
+        let markedCommand: String
+        if trimmed.hasPrefix("/bin/zsh '") {
+            let quotedPath = String(trimmed.dropFirst("/bin/zsh ".count))
+            let scriptPath = try XCTUnwrap(
+                singleQuotedValueForTest(quotedPath),
+                "unparseable launcher-script startup input: \(trimmed)"
+            )
+            let script = try String(contentsOfFile: scriptPath, encoding: .utf8)
+            markedCommand = try XCTUnwrap(
+                script.split(separator: "\n").map(String.init).last(where: {
+                    $0.hasPrefix("/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c ")
+                }),
+                "no marked resume command line in launcher script: \(script)"
+            )
+        } else {
+            markedCommand = trimmed
+        }
+
+        let markerPrefix = "/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c "
+        guard markedCommand.hasPrefix(markerPrefix) else {
+            XCTFail("resume startup input omitted app restore marker: \(markedCommand)")
+            return markedCommand
+        }
         return try XCTUnwrap(
-            script.split(separator: "\n").map(String.init).last(where: { $0.contains(" && ") }),
-            "no resume command line in launcher script: \(script)"
+            singleQuotedValueForTest(String(markedCommand.dropFirst(markerPrefix.count))),
+            "unparseable marked resume command: \(markedCommand)"
         )
     }
 
@@ -2543,7 +2557,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         XCTAssertEqual(stdout, expectedPath, file: file, line: line)
     }
 
-    func testRestorableAgentStartupInputUsesInlineCommandWhenShort() {
+    func testRestorableAgentStartupInputUsesInlineCommandWhenShort() throws {
         let snapshot = SessionRestorableAgentSnapshot(
             kind: .claude,
             sessionId: "claude-session-123",
@@ -2563,7 +2577,14 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(snapshot.resumeStartupInput(), snapshot.resumeCommand.map { $0 + "\n" })
+        let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
+        XCTAssertEqual(
+            snapshot.resumeStartupInput(),
+            "/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c "
+                + shellQuotedForTest(resumeCommand)
+                + "\n"
+        )
+        XCTAssertFalse(resumeCommand.contains("CMUX_AGENT_RESTORE_LAUNCH"))
     }
 
     func testRestorableAgentStartupInputUsesLauncherScriptWhenCommandExceedsTerminalInputBudget() throws {
@@ -2604,9 +2625,11 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         let prefix = "/bin/zsh '"
         let scriptPath = String(trimmedInput.dropFirst(prefix.count).dropLast())
         let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
-        XCTAssertTrue(scriptContents.contains(longPath))
-        XCTAssertTrue(scriptContents.contains("'resume'"))
-        XCTAssertTrue(scriptContents.contains("'019dad34-d218-7943-b81a-eddac5c87951'"))
+        XCTAssertTrue(scriptContents.contains("CMUX_AGENT_RESTORE_LAUNCH=1"))
+        let command = try inlineResumeCommandResolvingLauncherScript(from: input)
+        XCTAssertTrue(command.contains(longPath))
+        XCTAssertTrue(command.contains("'resume'"))
+        XCTAssertTrue(command.contains("'019dad34-d218-7943-b81a-eddac5c87951'"))
 
         let attributes = try FileManager.default.attributesOfItem(atPath: scriptPath)
         let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).intValue & 0o777

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1892,7 +1892,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         // the bare `claude` wrapper. https://github.com/manaflow-ai/cmux/issues/5427
         let snapshot = SessionRestorableAgentSnapshot(
             kind: .claude,
-            sessionId: "claude-session-123",
+            sessionId: "a22293b7-bcef-4707-8439-2f538c8517a4",
             workingDirectory: "/tmp/cmux project",
             launchCommand: AgentLaunchCommandSnapshot(
                 launcher: "claude",
@@ -2410,11 +2410,9 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         try assertZshCommandChangesDirectory(cdCommand, expectedPath: cwdURL.path)
     }
 
-    /// Resolves inline or launcher-script startup input and unwraps cmux's
-    /// one-shot app-restore environment marker to the underlying resume command.
+    /// Resolves resume startup input to the inline command or launcher-script command line.
     private func inlineResumeCommandResolvingLauncherScript(from startupInput: String) throws -> String {
         let trimmed = startupInput.trimmingCharacters(in: .whitespacesAndNewlines)
-        let markedCommand: String
         if trimmed.hasPrefix("/bin/zsh '") {
             let quotedPath = String(trimmed.dropFirst("/bin/zsh ".count))
             let scriptPath = try XCTUnwrap(
@@ -2422,25 +2420,12 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
                 "unparseable launcher-script startup input: \(trimmed)"
             )
             let script = try String(contentsOfFile: scriptPath, encoding: .utf8)
-            markedCommand = try XCTUnwrap(
-                script.split(separator: "\n").map(String.init).last(where: {
-                    $0.hasPrefix("/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c ")
-                }),
-                "no marked resume command line in launcher script: \(script)"
+            return try XCTUnwrap(
+                script.split(separator: "\n").map(String.init).last,
+                "no resume command line in launcher script: \(script)"
             )
-        } else {
-            markedCommand = trimmed
         }
-
-        let markerPrefix = "/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c "
-        guard markedCommand.hasPrefix(markerPrefix) else {
-            XCTFail("resume startup input omitted app restore marker: \(markedCommand)")
-            return markedCommand
-        }
-        return try XCTUnwrap(
-            singleQuotedValueForTest(String(markedCommand.dropFirst(markerPrefix.count))),
-            "unparseable marked resume command: \(markedCommand)"
-        )
+        return trimmed
     }
 
     private func singleQuotedValueForTest(_ value: String) -> String? {
@@ -2558,9 +2543,10 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
     }
 
     func testRestorableAgentStartupInputUsesInlineCommandWhenShort() throws {
+        let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
         let snapshot = SessionRestorableAgentSnapshot(
             kind: .claude,
-            sessionId: "claude-session-123",
+            sessionId: sessionId,
             workingDirectory: "/tmp/cmux project",
             launchCommand: AgentLaunchCommandSnapshot(
                 launcher: "claude",
@@ -2577,14 +2563,49 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
             )
         )
 
-        let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
-        XCTAssertEqual(
-            snapshot.resumeStartupInput(),
-            "/usr/bin/env CMUX_AGENT_RESTORE_LAUNCH=1 /bin/sh -c "
-                + shellQuotedForTest(resumeCommand)
-                + "\n"
+        let startupInput = try XCTUnwrap(snapshot.resumeStartupInput())
+        XCTAssertTrue(
+            startupInput.contains(
+                "CMUX_AGENT_RESTORE_LAUNCH='claude:\(sessionId)' /bin/sh -c"
+            ),
+            startupInput
         )
-        XCTAssertFalse(resumeCommand.contains("CMUX_AGENT_RESTORE_LAUNCH"))
+        XCTAssertFalse(try XCTUnwrap(snapshot.resumeCommand).contains("CMUX_AGENT_RESTORE_LAUNCH"))
+        XCTAssertFalse(try XCTUnwrap(snapshot.forkStartupInput()).contains("CMUX_AGENT_RESTORE_LAUNCH"))
+    }
+
+    func testRestorableAgentRestoreMarkerRequiresSupportedProviderAndUUIDSession() throws {
+        let unsupported = SessionRestorableAgentSnapshot(
+            kind: .gemini,
+            sessionId: "5839bed1-0a60-4c05-b6d1-2410d7a3741e",
+            workingDirectory: "/tmp/gemini repo",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "gemini",
+                executablePath: "/Users/example/.bun/bin/gemini",
+                arguments: ["/Users/example/.bun/bin/gemini"],
+                workingDirectory: "/tmp/gemini repo",
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+        let invalidSession = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "not-a-session-id",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "claude",
+                arguments: ["claude"],
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: nil,
+                source: "process"
+            )
+        )
+
+        XCTAssertFalse(try XCTUnwrap(unsupported.resumeStartupInput()).contains("CMUX_AGENT_RESTORE_LAUNCH"))
+        XCTAssertFalse(try XCTUnwrap(invalidSession.resumeStartupInput()).contains("CMUX_AGENT_RESTORE_LAUNCH"))
     }
 
     func testRestorableAgentStartupInputUsesLauncherScriptWhenCommandExceedsTerminalInputBudget() throws {
@@ -2625,7 +2646,11 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         let prefix = "/bin/zsh '"
         let scriptPath = String(trimmedInput.dropFirst(prefix.count).dropLast())
         let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
-        XCTAssertTrue(scriptContents.contains("CMUX_AGENT_RESTORE_LAUNCH=1"))
+        XCTAssertTrue(
+            scriptContents.contains(
+                "CMUX_AGENT_RESTORE_LAUNCH='codex:019dad34-d218-7943-b81a-eddac5c87951'"
+            )
+        )
         let command = try inlineResumeCommandResolvingLauncherScript(from: input)
         XCTAssertTrue(command.contains(longPath))
         XCTAssertTrue(command.contains("'resume'"))

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -185,6 +185,7 @@ exit 0
             env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
         else:
             env.pop("CMUX_CLAUDE_HOOKS_DISABLED", None)
+        env.pop("CMUX_AGENT_RESTORE_LAUNCH", None)
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
@@ -234,6 +235,8 @@ def run_wrapper_terminal_env_probe(
     argv: list[str],
     *,
     hooks_disabled: bool = False,
+    socket_state: str = "live",
+    restore_launch: bool = False,
 ) -> tuple[int, dict[str, str], list[str], str, set[str]]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-env-probe-") as td:
         tmp = Path(td)
@@ -267,6 +270,8 @@ def run_wrapper_terminal_env_probe(
         }
         if hooks_disabled:
             fingerprint_env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
+        if restore_launch:
+            fingerprint_env["CMUX_AGENT_RESTORE_LAUNCH"] = "1"
         probe_key_lines = "\n".join(f"  {key}" for key in fingerprint_env)
 
         make_executable(
@@ -299,21 +304,25 @@ if [[ "${1:-}" == "--socket" ]]; then
   shift 2
 fi
 if [[ "${1:-}" == "ping" ]]; then
-  exit 0
+  [[ "${FAKE_CMUX_PING_OK:-0}" == "1" ]]
+  exit
 fi
 exit 0
 """,
         )
 
-        test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        test_socket: socket.socket | None = None
         try:
-            test_socket.bind(socket_path)
+            if socket_state in {"live", "stale"}:
+                test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                test_socket.bind(socket_path)
 
             env = os.environ.copy()
             env["PATH"] = f"{wrapper_dir}:{real_dir}:{env.get('PATH', '/usr/bin:/bin')}"
             env.update(fingerprint_env)
             env["FAKE_REAL_ENV_LOG"] = str(env_log)
             env["FAKE_REAL_ARGS_LOG"] = str(args_log)
+            env["FAKE_CMUX_PING_OK"] = "1" if socket_state == "live" else "0"
 
             proc = subprocess.run(
                 [str(wrapper), *argv],
@@ -324,7 +333,8 @@ exit 0
                 check=False,
             )
         finally:
-            test_socket.close()
+            if test_socket is not None:
+                test_socket.close()
 
         observed_env = dict(line.split("=", 1) for line in read_lines(env_log))
         return proc.returncode, observed_env, read_lines(args_log), proc.stderr.strip(), set(fingerprint_env)
@@ -1104,9 +1114,8 @@ def test_live_socket_resume_self_heals_bare_legacy_subrouter_config_dir(failures
 
 
 def test_stale_socket_resume_self_heals_mismatched_claude_config_dir(failures: list[str]) -> None:
-    # App restore can launch terminal startup commands before the cmux socket is
-    # accepting requests. Hook injection must survive that window, and explicit
-    # `--resume` still has to select the config root that owns the transcript.
+    # A manual resume from a detached shell can inherit stale cmux environment.
+    # It must keep native behavior while still selecting the transcript owner.
     session_id = "5b5d0816-ef91-4a8d-8933-68a114787c40"
     expected: dict[str, str] = {}
 
@@ -1133,8 +1142,8 @@ def test_stale_socket_resume_self_heals_mismatched_claude_config_dir(failures: l
     )
     expect(code == 0, f"stale socket resume self-heal: wrapper exited {code}: {stderr}", failures)
     expect(
-        "--settings" in real_argv and real_argv[-2:] == ["--resume", session_id],
-        f"stale socket resume self-heal: expected instrumented resume argv, got {real_argv}",
+        real_argv == ["--resume", session_id],
+        f"stale socket resume self-heal: expected passthrough resume argv, got {real_argv}",
         failures,
     )
     expect(
@@ -1174,9 +1183,8 @@ def test_stale_socket_resume_self_heals_after_value_option(failures: list[str]) 
     )
     expect(code == 0, f"stale socket option resume self-heal: wrapper exited {code}: {stderr}", failures)
     expect(
-        "--settings" in real_argv
-        and real_argv[-4:] == ["--permission-prompt-tool", "/tmp/cmux-permission-tool", "--resume", session_id],
-        f"stale socket option resume self-heal: expected instrumented argv, got {real_argv}",
+        real_argv == ["--permission-prompt-tool", "/tmp/cmux-permission-tool", "--resume", session_id],
+        f"stale socket option resume self-heal: expected passthrough argv, got {real_argv}",
         failures,
     )
     expect(
@@ -1877,6 +1885,39 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"stale socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
+def test_app_owned_stale_socket_resume_injects_hooks_and_consumes_marker(failures: list[str]) -> None:
+    session_id = "5b5d0816-ef91-4a8d-8933-68a114787c40"
+    code, observed_env, real_argv, stderr, _ = run_wrapper_terminal_env_probe(
+        ["--resume", session_id],
+        socket_state="stale",
+        restore_launch=True,
+    )
+    expect(code == 0, f"app restore/stale: wrapper exited {code}: {stderr}", failures)
+    expect(
+        "--settings" in real_argv and real_argv[-2:] == ["--resume", session_id],
+        f"app restore/stale: expected instrumented resume argv, got {real_argv}",
+        failures,
+    )
+    expect(
+        observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
+        f"app restore/stale: one-shot restore marker leaked to Claude: {observed_env}",
+        failures,
+    )
+
+
+def test_restore_marker_without_valid_resume_id_still_requires_live_socket(failures: list[str]) -> None:
+    code, observed_env, real_argv, stderr, _ = run_wrapper_terminal_env_probe(
+        ["--resume", "not-a-session-id"],
+        socket_state="stale",
+        restore_launch=True,
+    )
+    expect(code == 0, f"invalid app restore/stale: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["--resume", "not-a-session-id"],
+           f"invalid app restore/stale: expected passthrough, got {real_argv}", failures)
+    expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
+           f"invalid app restore/stale: marker leaked to Claude: {observed_env}", failures)
+
+
 def main() -> int:
     if ensure_node_on_path() is None:
         print("SKIP: node runtime not found; wrapper fakes exec node")
@@ -1924,6 +1965,8 @@ def main() -> int:
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_app_owned_stale_socket_resume_injects_hooks_and_consumes_marker(failures)
+    test_restore_marker_without_valid_resume_id_still_requires_live_socket(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -490,7 +490,12 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
             failures,
         )
     expect(real_argv[-1] == "hello", f"live socket: expected original arg to pass through, got {real_argv}", failures)
-    expect(cmux_log == [], f"live socket: launch should not probe transient socket health: {cmux_log}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"live socket: expected cmux ping, got {cmux_log}", failures)
+    expect(
+        any("timeout=0.75" in line for line in cmux_log),
+        f"live socket: expected bounded ping timeout, got {cmux_log}",
+        failures,
+    )
     expect(claudecode == "__UNSET__", f"live socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
     require_flag, _, remaining_flags = node_options.partition(" ")
     expect(
@@ -1763,7 +1768,7 @@ def test_live_socket_tmpdir_failure_skips_node_options_injection(failures: list[
     expect(code == 0, f"tmpdir failure: wrapper exited {code}: {stderr}", failures)
     expect("--settings" in real_argv, f"tmpdir failure: missing --settings in args: {real_argv}", failures)
     expect("--session-id" in real_argv, f"tmpdir failure: missing --session-id in args: {real_argv}", failures)
-    expect(cmux_log == [], f"tmpdir failure: launch should not probe transient socket health: {cmux_log}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"tmpdir failure: expected cmux ping, got {cmux_log}", failures)
     expect(claudecode == "__UNSET__", f"tmpdir failure: expected CLAUDECODE unset, got {claudecode!r}", failures)
     expect(node_options == "__UNSET__", f"tmpdir failure: expected NODE_OPTIONS injection to be skipped, got {node_options!r}", failures)
     expect(runtime_node_options == "__UNSET__", f"tmpdir failure: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
@@ -1819,20 +1824,19 @@ def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> 
     expect(child_node_options == "__UNSET__", f"stale mktemp literal: expected child NODE_OPTIONS restored, got {child_node_options!r}", failures)
 
 
-def test_missing_socket_still_injects_hooks(failures: list[str]) -> None:
+def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="missing",
         argv=["hello"],
     )
     expect(code == 0, f"missing socket: wrapper exited {code}: {stderr}", failures)
-    expect("--settings" in real_argv, f"missing socket: expected hook settings, got {real_argv}", failures)
-    expect("notifications_disabled" in " ".join(real_argv), f"missing socket: expected native notification suppression, got {real_argv}", failures)
+    expect(real_argv == ["hello"], f"missing socket: expected passthrough args, got {real_argv}", failures)
     expect(cmux_log == [], f"missing socket: expected no cmux calls, got {cmux_log}", failures)
     expect(claudecode == "__UNSET__", f"missing socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
-    expect(node_options.startswith("--require="), f"missing socket: expected NODE_OPTIONS guard injection, got {node_options!r}", failures)
+    expect(node_options == "__UNSET__", f"missing socket: expected NODE_OPTIONS passthrough, got {node_options!r}", failures)
     expect(runtime_node_options == "__UNSET__", f"missing socket: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
     expect(child_node_options == "__UNSET__", f"missing socket: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
-    expect(hook_cmux_bin != "__UNSET__", f"missing socket: expected pinned hook cmux, got {hook_cmux_bin!r}", failures)
+    expect(hook_cmux_bin == "__UNSET__", f"missing socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
 def test_disabled_integration_skips_hook_injection(failures: list[str]) -> None:
@@ -1853,20 +1857,24 @@ def test_disabled_integration_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"disabled integration: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
-def test_stale_socket_still_injects_hooks(failures: list[str]) -> None:
+def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="stale",
         argv=["hello"],
     )
     expect(code == 0, f"stale socket: wrapper exited {code}: {stderr}", failures)
-    expect("--settings" in real_argv, f"stale socket: expected hook settings, got {real_argv}", failures)
-    expect("notifications_disabled" in " ".join(real_argv), f"stale socket: expected native notification suppression, got {real_argv}", failures)
-    expect(cmux_log == [], f"stale socket: transient socket health must not decide session instrumentation: {cmux_log}", failures)
+    expect(real_argv == ["hello"], f"stale socket: expected passthrough args, got {real_argv}", failures)
+    expect(any(" ping" in line for line in cmux_log), f"stale socket: expected cmux ping probe, got {cmux_log}", failures)
+    expect(
+        any("timeout=0.75" in line for line in cmux_log),
+        f"stale socket: expected bounded ping timeout, got {cmux_log}",
+        failures,
+    )
     expect(claudecode == "__UNSET__", f"stale socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
-    expect(node_options.startswith("--require="), f"stale socket: expected NODE_OPTIONS guard injection, got {node_options!r}", failures)
+    expect(node_options == "__UNSET__", f"stale socket: expected NODE_OPTIONS passthrough, got {node_options!r}", failures)
     expect(runtime_node_options == "__UNSET__", f"stale socket: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
     expect(child_node_options == "__UNSET__", f"stale socket: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
-    expect(hook_cmux_bin != "__UNSET__", f"stale socket: expected pinned hook cmux, got {hook_cmux_bin!r}", failures)
+    expect(hook_cmux_bin == "__UNSET__", f"stale socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
 def main() -> int:
@@ -1913,9 +1921,9 @@ def main() -> int:
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
     test_live_socket_preserves_explicit_bypass_availability_flag(failures)
     test_live_socket_stale_mktemp_literal_does_not_warn(failures)
-    test_missing_socket_still_injects_hooks(failures)
+    test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
-    test_stale_socket_still_injects_hooks(failures)
+    test_stale_socket_skips_hook_injection(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -236,7 +236,7 @@ def run_wrapper_terminal_env_probe(
     *,
     hooks_disabled: bool = False,
     socket_state: str = "live",
-    restore_launch: bool = False,
+    restore_token: str | None = None,
 ) -> tuple[int, dict[str, str], list[str], str, set[str]]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-env-probe-") as td:
         tmp = Path(td)
@@ -270,8 +270,8 @@ def run_wrapper_terminal_env_probe(
         }
         if hooks_disabled:
             fingerprint_env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
-        if restore_launch:
-            fingerprint_env["CMUX_AGENT_RESTORE_LAUNCH"] = "1"
+        if restore_token is not None:
+            fingerprint_env["CMUX_AGENT_RESTORE_LAUNCH"] = restore_token
         probe_key_lines = "\n".join(f"  {key}" for key in fingerprint_env)
 
         make_executable(
@@ -1890,7 +1890,7 @@ def test_app_owned_stale_socket_resume_injects_hooks_and_consumes_marker(failure
     code, observed_env, real_argv, stderr, _ = run_wrapper_terminal_env_probe(
         ["--resume", session_id],
         socket_state="stale",
-        restore_launch=True,
+        restore_token=f"claude:{session_id}",
     )
     expect(code == 0, f"app restore/stale: wrapper exited {code}: {stderr}", failures)
     expect(
@@ -1909,13 +1909,32 @@ def test_restore_marker_without_valid_resume_id_still_requires_live_socket(failu
     code, observed_env, real_argv, stderr, _ = run_wrapper_terminal_env_probe(
         ["--resume", "not-a-session-id"],
         socket_state="stale",
-        restore_launch=True,
+        restore_token="claude:not-a-session-id",
     )
     expect(code == 0, f"invalid app restore/stale: wrapper exited {code}: {stderr}", failures)
     expect(real_argv == ["--resume", "not-a-session-id"],
            f"invalid app restore/stale: expected passthrough, got {real_argv}", failures)
     expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
            f"invalid app restore/stale: marker leaked to Claude: {observed_env}", failures)
+
+
+def test_mismatched_restore_tokens_still_require_live_socket(failures: list[str]) -> None:
+    session_id = "5b5d0816-ef91-4a8d-8933-68a114787c40"
+    for token in (
+        f"codex:{session_id}",
+        "claude:aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
+        "1",
+    ):
+        code, observed_env, real_argv, stderr, _ = run_wrapper_terminal_env_probe(
+            ["--resume", session_id],
+            socket_state="stale",
+            restore_token=token,
+        )
+        expect(code == 0, f"mismatched marker {token}: wrapper exited {code}: {stderr}", failures)
+        expect(real_argv == ["--resume", session_id],
+               f"mismatched marker {token}: expected passthrough, got {real_argv}", failures)
+        expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
+               f"mismatched marker {token}: marker leaked to Claude: {observed_env}", failures)
 
 
 def main() -> int:
@@ -1967,6 +1986,7 @@ def main() -> int:
     test_stale_socket_skips_hook_injection(failures)
     test_app_owned_stale_socket_resume_injects_hooks_and_consumes_marker(failures)
     test_restore_marker_without_valid_resume_id_still_requires_live_socket(failures)
+    test_mismatched_restore_tokens_still_require_live_socket(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -1825,19 +1825,20 @@ def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> 
     expect(child_node_options == "__UNSET__", f"stale mktemp literal: expected child NODE_OPTIONS restored, got {child_node_options!r}", failures)
 
 
-def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
+def test_missing_socket_still_injects_hooks(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="missing",
         argv=["hello"],
     )
     expect(code == 0, f"missing socket: wrapper exited {code}: {stderr}", failures)
-    expect(real_argv == ["hello"], f"missing socket: expected passthrough args, got {real_argv}", failures)
+    expect("--settings" in real_argv, f"missing socket: expected hook settings, got {real_argv}", failures)
+    expect("notifications_disabled" in " ".join(real_argv), f"missing socket: expected native notification suppression, got {real_argv}", failures)
     expect(cmux_log == [], f"missing socket: expected no cmux calls, got {cmux_log}", failures)
     expect(claudecode == "__UNSET__", f"missing socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
-    expect(node_options == "__UNSET__", f"missing socket: expected NODE_OPTIONS passthrough, got {node_options!r}", failures)
+    expect(node_options.startswith("--require="), f"missing socket: expected NODE_OPTIONS guard injection, got {node_options!r}", failures)
     expect(runtime_node_options == "__UNSET__", f"missing socket: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
     expect(child_node_options == "__UNSET__", f"missing socket: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
-    expect(hook_cmux_bin == "__UNSET__", f"missing socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
+    expect(hook_cmux_bin != "__UNSET__", f"missing socket: expected pinned hook cmux, got {hook_cmux_bin!r}", failures)
 
 
 def test_disabled_integration_skips_hook_injection(failures: list[str]) -> None:
@@ -1858,24 +1859,20 @@ def test_disabled_integration_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"disabled integration: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
-def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
+def test_stale_socket_still_injects_hooks(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="stale",
         argv=["hello"],
     )
     expect(code == 0, f"stale socket: wrapper exited {code}: {stderr}", failures)
-    expect(real_argv == ["hello"], f"stale socket: expected passthrough args, got {real_argv}", failures)
-    expect(any(" ping" in line for line in cmux_log), f"stale socket: expected cmux ping probe, got {cmux_log}", failures)
-    expect(
-        any("timeout=0.75" in line for line in cmux_log),
-        f"stale socket: expected bounded ping timeout, got {cmux_log}",
-        failures,
-    )
+    expect("--settings" in real_argv, f"stale socket: expected hook settings, got {real_argv}", failures)
+    expect("notifications_disabled" in " ".join(real_argv), f"stale socket: expected native notification suppression, got {real_argv}", failures)
+    expect(cmux_log == [], f"stale socket: transient socket health must not decide session instrumentation: {cmux_log}", failures)
     expect(claudecode == "__UNSET__", f"stale socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
-    expect(node_options == "__UNSET__", f"stale socket: expected NODE_OPTIONS passthrough, got {node_options!r}", failures)
+    expect(node_options.startswith("--require="), f"stale socket: expected NODE_OPTIONS guard injection, got {node_options!r}", failures)
     expect(runtime_node_options == "__UNSET__", f"stale socket: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
     expect(child_node_options == "__UNSET__", f"stale socket: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
-    expect(hook_cmux_bin == "__UNSET__", f"stale socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
+    expect(hook_cmux_bin != "__UNSET__", f"stale socket: expected pinned hook cmux, got {hook_cmux_bin!r}", failures)
 
 
 def main() -> int:
@@ -1922,9 +1919,9 @@ def main() -> int:
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
     test_live_socket_preserves_explicit_bypass_availability_flag(failures)
     test_live_socket_stale_mktemp_literal_does_not_warn(failures)
-    test_missing_socket_skips_hook_injection(failures)
+    test_missing_socket_still_injects_hooks(failures)
     test_disabled_integration_skips_hook_injection(failures)
-    test_stale_socket_skips_hook_injection(failures)
+    test_stale_socket_still_injects_hooks(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -490,12 +490,7 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
             failures,
         )
     expect(real_argv[-1] == "hello", f"live socket: expected original arg to pass through, got {real_argv}", failures)
-    expect(any(" ping" in line for line in cmux_log), f"live socket: expected cmux ping, got {cmux_log}", failures)
-    expect(
-        any("timeout=0.75" in line for line in cmux_log),
-        f"live socket: expected bounded ping timeout, got {cmux_log}",
-        failures,
-    )
+    expect(cmux_log == [], f"live socket: launch should not probe transient socket health: {cmux_log}", failures)
     expect(claudecode == "__UNSET__", f"live socket: expected CLAUDECODE unset, got {claudecode!r}", failures)
     require_flag, _, remaining_flags = node_options.partition(" ")
     expect(
@@ -1105,9 +1100,8 @@ def test_live_socket_resume_self_heals_bare_legacy_subrouter_config_dir(failures
 
 def test_stale_socket_resume_self_heals_mismatched_claude_config_dir(failures: list[str]) -> None:
     # App restore can launch terminal startup commands before the cmux socket is
-    # accepting pings. Hook injection should be skipped in that window, but
-    # explicit `--resume` still has to select the config root that owns the
-    # transcript or Claude reports "No conversation found".
+    # accepting requests. Hook injection must survive that window, and explicit
+    # `--resume` still has to select the config root that owns the transcript.
     session_id = "5b5d0816-ef91-4a8d-8933-68a114787c40"
     expected: dict[str, str] = {}
 
@@ -1134,8 +1128,8 @@ def test_stale_socket_resume_self_heals_mismatched_claude_config_dir(failures: l
     )
     expect(code == 0, f"stale socket resume self-heal: wrapper exited {code}: {stderr}", failures)
     expect(
-        real_argv == ["--resume", session_id],
-        f"stale socket resume self-heal: expected passthrough resume argv, got {real_argv}",
+        "--settings" in real_argv and real_argv[-2:] == ["--resume", session_id],
+        f"stale socket resume self-heal: expected instrumented resume argv, got {real_argv}",
         failures,
     )
     expect(
@@ -1147,9 +1141,8 @@ def test_stale_socket_resume_self_heals_mismatched_claude_config_dir(failures: l
 
 
 def test_stale_socket_resume_self_heals_after_value_option(failures: list[str]) -> None:
-    # The stale-socket path runs before hook injection. Its resume parser still
-    # has to skip value-taking options that appear before `--resume`, including
-    # newer Claude options that are not in cmux's preserved-argument allowlists.
+    # Resume parsing still has to skip value-taking options before `--resume`,
+    # including newer Claude options outside cmux's preserved-argument lists.
     session_id = "017427ef-1828-43d9-ae1d-8ec6d4b2bdb7"
     expected: dict[str, str] = {}
 
@@ -1176,8 +1169,9 @@ def test_stale_socket_resume_self_heals_after_value_option(failures: list[str]) 
     )
     expect(code == 0, f"stale socket option resume self-heal: wrapper exited {code}: {stderr}", failures)
     expect(
-        real_argv == ["--permission-prompt-tool", "/tmp/cmux-permission-tool", "--resume", session_id],
-        f"stale socket option resume self-heal: expected passthrough argv, got {real_argv}",
+        "--settings" in real_argv
+        and real_argv[-4:] == ["--permission-prompt-tool", "/tmp/cmux-permission-tool", "--resume", session_id],
+        f"stale socket option resume self-heal: expected instrumented argv, got {real_argv}",
         failures,
     )
     expect(
@@ -1769,7 +1763,7 @@ def test_live_socket_tmpdir_failure_skips_node_options_injection(failures: list[
     expect(code == 0, f"tmpdir failure: wrapper exited {code}: {stderr}", failures)
     expect("--settings" in real_argv, f"tmpdir failure: missing --settings in args: {real_argv}", failures)
     expect("--session-id" in real_argv, f"tmpdir failure: missing --session-id in args: {real_argv}", failures)
-    expect(any(" ping" in line for line in cmux_log), f"tmpdir failure: expected cmux ping, got {cmux_log}", failures)
+    expect(cmux_log == [], f"tmpdir failure: launch should not probe transient socket health: {cmux_log}", failures)
     expect(claudecode == "__UNSET__", f"tmpdir failure: expected CLAUDECODE unset, got {claudecode!r}", failures)
     expect(node_options == "__UNSET__", f"tmpdir failure: expected NODE_OPTIONS injection to be skipped, got {node_options!r}", failures)
     expect(runtime_node_options == "__UNSET__", f"tmpdir failure: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)

--- a/tests/test_claude_wrapper_mutual_shim_loop.py
+++ b/tests/test_claude_wrapper_mutual_shim_loop.py
@@ -373,6 +373,87 @@ printf 'real claude reached %s\\n' "$*"
             failures.append(f"guard fired for finite shim chain: {combined_output!r}")
 
 
+def test_app_owned_resume_keeps_authorization_across_finite_shim_reentry(failures: list[str]) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-restore-shim-chain-") as td:
+        root = Path(td)
+        cmux_shim_dir = root / "tmp" / "cmux-cli-shims" / "surface-restore"
+        foreign_shim_dir = root / "foreign-shim"
+        real_dir = root / "real-bin"
+        for directory in (cmux_shim_dir, foreign_shim_dir, real_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        cmux_shim = cmux_shim_dir / "claude"
+        shutil.copy2(WRAPPER, cmux_shim)
+        cmux_shim.chmod(0o755)
+        write_executable(
+            foreign_shim_dir / "claude",
+            f"""#!/usr/bin/env bash
+export PATH="{cmux_shim_dir}:{real_dir}:/usr/bin:/bin"
+exec claude "$@"
+""",
+        )
+        write_executable(
+            cmux_shim_dir / "cmux",
+            """#!/usr/bin/env bash
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+[[ "${1:-}" == "ping" ]] && exit 1
+exit 0
+""",
+        )
+        environment_log = root / "real-env.log"
+        arguments_log = root / "real-args.log"
+        write_executable(
+            real_dir / "claude",
+            """#!/usr/bin/env bash
+printf 'restore=%s\n' "${CMUX_AGENT_RESTORE_LAUNCH-__UNSET__}" > "$FAKE_REAL_ENV_LOG"
+printf 'surface=%s\n' "${CMUX_SURFACE_ID-__UNSET__}" >> "$FAKE_REAL_ENV_LOG"
+printf '%s\n' "$@" > "$FAKE_REAL_ARGS_LOG"
+""",
+        )
+
+        session_id = "5b5d0816-ef91-4a8d-8933-68a114787c40"
+        socket_path = root / "stale.sock"
+        stale_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        stale_socket.bind(str(socket_path))
+        env = {
+            "HOME": str(root / "home"),
+            "PATH": f"{cmux_shim_dir}:{foreign_shim_dir}:{real_dir}:/usr/bin:/bin",
+            "CMUX_CLAUDE_WRAPPER_SHIM": str(cmux_shim),
+            "CMUX_CLAUDE_WRAPPER_SHIM_ROOT": str(cmux_shim_dir),
+            "CMUX_AGENT_RESTORE_LAUNCH": f"claude:{session_id}",
+            "CMUX_SOCKET_PATH": str(socket_path),
+            "CMUX_SURFACE_ID": "surface:restore-test",
+            "FAKE_REAL_ENV_LOG": str(environment_log),
+            "FAKE_REAL_ARGS_LOG": str(arguments_log),
+        }
+        try:
+            result = subprocess.run(
+                [str(cmux_shim), "--resume", session_id],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        finally:
+            stale_socket.close()
+
+        combined_output = result.stdout + result.stderr
+        if result.returncode != 0:
+            failures.append(f"app-owned finite shim resume failed with {result.returncode}: {combined_output!r}")
+            return
+        observed_env = dict(line.split("=", 1) for line in environment_log.read_text().splitlines())
+        observed_args = arguments_log.read_text().splitlines()
+        if observed_env.get("restore") != "__UNSET__":
+            failures.append(f"restore marker leaked through finite shim chain: {observed_env!r}")
+        if observed_env.get("surface") != "surface:restore-test":
+            failures.append(f"finite shim chain lost cmux surface authorization: {observed_env!r}")
+        if "--settings" not in observed_args or observed_args[-2:] != ["--resume", session_id]:
+            failures.append(f"finite shim chain lost hook settings or resume argv: {observed_args!r}")
+
+
 def test_passthrough_real_node_claude_does_not_receive_guard_env(failures: list[str]) -> None:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-passthrough-guard-env-") as td:
         root = Path(td)
@@ -876,6 +957,7 @@ def main() -> int:
     test_wrapper_stops_indirect_shell_foreign_shim_loop(failures)
     test_wrapper_guard_allows_child_claude_process(failures)
     test_wrapper_allows_finite_layered_foreign_shims(failures)
+    test_app_owned_resume_keeps_authorization_across_finite_shim_reentry(failures)
     test_passthrough_real_node_claude_does_not_receive_guard_env(failures)
     test_custom_shim_path_with_colon_is_tracked_as_one_target(failures)
     test_real_shell_claude_launcher_allows_child_claude_process(failures)

--- a/tests/test_codex_wrapper_resume_hooks.py
+++ b/tests/test_codex_wrapper_resume_hooks.py
@@ -187,6 +187,21 @@ def test_explicit_disable_still_bypasses_hooks(failures: list[str]) -> None:
     expect(cmux_log == [], f"disabled: expected no cmux calls, got {cmux_log}", failures)
 
 
+def test_stale_socket_fresh_launch_preserves_native_behavior(failures: list[str]) -> None:
+    code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
+        socket_state="stale",
+        argv=["hello"],
+    )
+    expect(code == 0, f"fresh/stale: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["hello"], f"fresh/stale: expected passthrough, got {real_argv}", failures)
+    expect(any("ping" in line for line in cmux_log),
+           f"fresh/stale: expected bounded ownership probe, got {cmux_log}", failures)
+    expect(observed_env.get("CMUX_CODEX_HOOK_CMUX_BIN") == "__UNSET__",
+           f"fresh/stale: cmux hooks should remain disabled: {observed_env}", failures)
+    expect(observed_env.get("CMUX_AGENT_RESUME_LAUNCH") == "__UNSET__",
+           f"fresh/stale: resume marker leaked into ordinary launch: {observed_env}", failures)
+
+
 def test_non_session_command_still_bypasses_hooks(failures: list[str]) -> None:
     code, real_argv, cmux_log, _, stderr = run_wrapper(
         socket_state="stale",
@@ -201,6 +216,7 @@ def main() -> int:
     failures: list[str] = []
     test_resume_hook_injection_survives_transient_startup_outages(failures)
     test_explicit_disable_still_bypasses_hooks(failures)
+    test_stale_socket_fresh_launch_preserves_native_behavior(failures)
     test_non_session_command_still_bypasses_hooks(failures)
     if failures:
         print("FAIL: Codex resume wrapper reliability checks failed")

--- a/tests/test_codex_wrapper_resume_hooks.py
+++ b/tests/test_codex_wrapper_resume_hooks.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Regression checks for reliable Codex hook injection during cmux resume."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-codex-wrapper"
+SESSION_ID = "0198f073-0a5b-7000-8000-000000000059"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def run_wrapper(
+    *,
+    socket_state: str,
+    argv: list[str],
+    hooks_disabled: bool = False,
+) -> tuple[int, list[str], list[str], dict[str, str], str]:
+    with tempfile.TemporaryDirectory(prefix="cmux-codex-wrapper-test-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "wrapper-bin"
+        real_dir = tmp / "real-bin"
+        bundled_dir = tmp / "bundled cli"
+        wrapper_dir.mkdir()
+        real_dir.mkdir()
+        bundled_dir.mkdir()
+
+        wrapper = wrapper_dir / "cmux-codex-wrapper"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        real_args_log = tmp / "real-args.log"
+        real_env_log = tmp / "real-env.log"
+        cmux_log = tmp / "cmux.log"
+        socket_path = tmp / "cmux.sock"
+
+        make_executable(
+            real_dir / "codex",
+            """#!/usr/bin/env bash
+set -euo pipefail
+: > "$FAKE_REAL_ARGS_LOG"
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
+done
+{
+  printf 'CMUX_CODEX_PID=%s\\n' "${CMUX_CODEX_PID-__UNSET__}"
+  printf 'CMUX_CODEX_HOOK_CMUX_BIN=%s\\n' "${CMUX_CODEX_HOOK_CMUX_BIN-__UNSET__}"
+  printf 'CMUX_AGENT_LAUNCH_KIND=%s\\n' "${CMUX_AGENT_LAUNCH_KIND-__UNSET__}"
+} > "$FAKE_REAL_ENV_LOG"
+""",
+        )
+
+        bundled_cli = bundled_dir / "cmux"
+        make_executable(
+            bundled_cli,
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_CMUX_LOG"
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  exit 1
+fi
+if [[ "${1:-}" == "hooks" && "${2:-}" == "codex" && "${3:-}" == "inject-args" ]]; then
+  printf '%s\\0' \
+    '--enable' \
+    'hooks' \
+    '--dangerously-bypass-hook-trust' \
+    '-c' \
+    'hooks.SessionStart=[{hooks=[{type="command",command="fake-session-start",timeout=10000}]}]' \
+    '-c' \
+    'hooks.Stop=[{hooks=[{type="command",command="fake-stop",timeout=10000}]}]'
+  exit 0
+fi
+if [[ "${1:-}" == "hooks" && "${2:-}" == "codex" && "${3:-}" == "session-start" ]]; then
+  cat >/dev/null
+  exit 0
+fi
+exit 1
+""",
+        )
+
+        test_socket: socket.socket | None = None
+        if socket_state == "stale":
+            test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket.bind(str(socket_path))
+
+        env = os.environ.copy()
+        env["PATH"] = f"{wrapper_dir}:{real_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+        env["HOME"] = str(tmp / "home")
+        env["CMUX_SURFACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        env["CMUX_WORKSPACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        env["CMUX_SOCKET_PATH"] = str(socket_path)
+        env["CMUX_BUNDLED_CLI_PATH"] = str(bundled_cli)
+        env["FAKE_REAL_ARGS_LOG"] = str(real_args_log)
+        env["FAKE_REAL_ENV_LOG"] = str(real_env_log)
+        env["FAKE_CMUX_LOG"] = str(cmux_log)
+        if hooks_disabled:
+            env["CMUX_CODEX_HOOKS_DISABLED"] = "1"
+        else:
+            env.pop("CMUX_CODEX_HOOKS_DISABLED", None)
+
+        try:
+            proc = subprocess.run(
+                [str(wrapper), *argv],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            if test_socket is not None:
+                test_socket.close()
+
+        observed_env = dict(line.split("=", 1) for line in read_lines(real_env_log))
+        return proc.returncode, read_lines(real_args_log), read_lines(cmux_log), observed_env, proc.stderr.strip()
+
+
+def expect(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def assert_resume_is_instrumented(socket_state: str, failures: list[str]) -> None:
+    code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
+        socket_state=socket_state,
+        argv=["resume", SESSION_ID],
+    )
+    label = f"resume/{socket_state}"
+    expect(code == 0, f"{label}: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv[:3] == ["--enable", "hooks", "--dangerously-bypass-hook-trust"],
+           f"{label}: missing injected hook prefix: {real_argv}", failures)
+    expect(any(arg.startswith("hooks.SessionStart=") for arg in real_argv),
+           f"{label}: missing SessionStart hook: {real_argv}", failures)
+    expect(any(arg.startswith("hooks.Stop=") for arg in real_argv),
+           f"{label}: missing Stop hook: {real_argv}", failures)
+    expect(real_argv[-2:] == ["resume", SESSION_ID],
+           f"{label}: resume argv was not preserved: {real_argv}", failures)
+    expect(any("hooks codex inject-args" in line for line in cmux_log),
+           f"{label}: wrapper never requested local hook args: {cmux_log}", failures)
+    expect(not any("ping" in line for line in cmux_log),
+           f"{label}: transient socket health must not decide session instrumentation: {cmux_log}", failures)
+    expect(observed_env.get("CMUX_CODEX_PID") not in {None, "", "__UNSET__"},
+           f"{label}: missing Codex process identity: {observed_env}", failures)
+    expect(observed_env.get("CMUX_AGENT_LAUNCH_KIND") == "codex",
+           f"{label}: missing launch kind: {observed_env}", failures)
+
+
+def test_resume_hook_injection_survives_transient_startup_outages(failures: list[str]) -> None:
+    # Repeat both startup failure shapes to guard against a statistical regression
+    # where any single launch silently loses its hooks for the full agent lifetime.
+    for _ in range(12):
+        assert_resume_is_instrumented("missing", failures)
+        assert_resume_is_instrumented("stale", failures)
+
+
+def test_explicit_disable_still_bypasses_hooks(failures: list[str]) -> None:
+    code, real_argv, cmux_log, _, stderr = run_wrapper(
+        socket_state="stale",
+        argv=["resume", SESSION_ID],
+        hooks_disabled=True,
+    )
+    expect(code == 0, f"disabled: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["resume", SESSION_ID], f"disabled: expected passthrough, got {real_argv}", failures)
+    expect(cmux_log == [], f"disabled: expected no cmux calls, got {cmux_log}", failures)
+
+
+def test_non_session_command_still_bypasses_hooks(failures: list[str]) -> None:
+    code, real_argv, cmux_log, _, stderr = run_wrapper(
+        socket_state="stale",
+        argv=["--help"],
+    )
+    expect(code == 0, f"help: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["--help"], f"help: expected passthrough, got {real_argv}", failures)
+    expect(cmux_log == [], f"help: expected no cmux calls, got {cmux_log}", failures)
+
+
+def main() -> int:
+    failures: list[str] = []
+    test_resume_hook_injection_survives_transient_startup_outages(failures)
+    test_explicit_disable_still_bypasses_hooks(failures)
+    test_non_session_command_still_bypasses_hooks(failures)
+    if failures:
+        print("FAIL: Codex resume wrapper reliability checks failed")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("PASS: every cmux-owned Codex resume launch retains SessionStart and Stop hooks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_codex_wrapper_resume_hooks.py
+++ b/tests/test_codex_wrapper_resume_hooks.py
@@ -32,7 +32,7 @@ def run_wrapper(
     socket_state: str,
     argv: list[str],
     hooks_disabled: bool = False,
-    restore_launch: bool = False,
+    restore_token: str | None = None,
 ) -> tuple[int, list[str], list[str], dict[str, str], str]:
     with tempfile.TemporaryDirectory(prefix="cmux-codex-wrapper-test-") as td:
         tmp = Path(td)
@@ -120,8 +120,8 @@ exit 1
             env["CMUX_CODEX_HOOKS_DISABLED"] = "1"
         else:
             env.pop("CMUX_CODEX_HOOKS_DISABLED", None)
-        if restore_launch:
-            env["CMUX_AGENT_RESTORE_LAUNCH"] = "1"
+        if restore_token is not None:
+            env["CMUX_AGENT_RESTORE_LAUNCH"] = restore_token
         else:
             env.pop("CMUX_AGENT_RESTORE_LAUNCH", None)
 
@@ -151,7 +151,7 @@ def assert_resume_is_instrumented(socket_state: str, failures: list[str]) -> Non
     code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
         socket_state=socket_state,
         argv=["resume", SESSION_ID],
-        restore_launch=True,
+        restore_token=f"codex:{SESSION_ID}",
     )
     label = f"resume/{socket_state}"
     expect(code == 0, f"{label}: wrapper exited {code}: {stderr}", failures)
@@ -229,7 +229,7 @@ def test_restore_marker_without_explicit_id_still_requires_live_socket(failures:
     code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
         socket_state="stale",
         argv=["resume", "--last"],
-        restore_launch=True,
+        restore_token=f"codex:{SESSION_ID}",
     )
     expect(code == 0, f"marker without id: wrapper exited {code}: {stderr}", failures)
     expect(real_argv == ["resume", "--last"],
@@ -238,6 +238,26 @@ def test_restore_marker_without_explicit_id_still_requires_live_socket(failures:
            f"marker without id: expected bounded ownership probe, got {cmux_log}", failures)
     expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
            f"marker without id: app restore marker leaked to Codex: {observed_env}", failures)
+
+
+def test_mismatched_restore_tokens_still_require_live_socket(failures: list[str]) -> None:
+    for token in (
+        f"claude:{SESSION_ID}",
+        "codex:aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
+        "1",
+    ):
+        code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
+            socket_state="stale",
+            argv=["resume", SESSION_ID],
+            restore_token=token,
+        )
+        expect(code == 0, f"mismatched marker {token}: wrapper exited {code}: {stderr}", failures)
+        expect(real_argv == ["resume", SESSION_ID],
+               f"mismatched marker {token}: expected passthrough, got {real_argv}", failures)
+        expect(any("ping" in line for line in cmux_log),
+               f"mismatched marker {token}: expected ownership probe, got {cmux_log}", failures)
+        expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
+               f"mismatched marker {token}: marker leaked to Codex: {observed_env}", failures)
 
 
 def test_non_session_command_still_bypasses_hooks(failures: list[str]) -> None:
@@ -257,6 +277,7 @@ def main() -> int:
     test_stale_socket_fresh_launch_preserves_native_behavior(failures)
     test_unmarked_stale_socket_resume_preserves_native_behavior(failures)
     test_restore_marker_without_explicit_id_still_requires_live_socket(failures)
+    test_mismatched_restore_tokens_still_require_live_socket(failures)
     test_non_session_command_still_bypasses_hooks(failures)
     if failures:
         print("FAIL: Codex resume wrapper reliability checks failed")

--- a/tests/test_codex_wrapper_resume_hooks.py
+++ b/tests/test_codex_wrapper_resume_hooks.py
@@ -32,6 +32,7 @@ def run_wrapper(
     socket_state: str,
     argv: list[str],
     hooks_disabled: bool = False,
+    restore_launch: bool = False,
 ) -> tuple[int, list[str], list[str], dict[str, str], str]:
     with tempfile.TemporaryDirectory(prefix="cmux-codex-wrapper-test-") as td:
         tmp = Path(td)
@@ -64,6 +65,7 @@ done
   printf 'CMUX_CODEX_HOOK_CMUX_BIN=%s\\n' "${CMUX_CODEX_HOOK_CMUX_BIN-__UNSET__}"
   printf 'CMUX_AGENT_LAUNCH_KIND=%s\\n' "${CMUX_AGENT_LAUNCH_KIND-__UNSET__}"
   printf 'CMUX_AGENT_RESUME_LAUNCH=%s\\n' "${CMUX_AGENT_RESUME_LAUNCH-__UNSET__}"
+  printf 'CMUX_AGENT_RESTORE_LAUNCH=%s\\n' "${CMUX_AGENT_RESTORE_LAUNCH-__UNSET__}"
 } > "$FAKE_REAL_ENV_LOG"
 """,
         )
@@ -118,6 +120,10 @@ exit 1
             env["CMUX_CODEX_HOOKS_DISABLED"] = "1"
         else:
             env.pop("CMUX_CODEX_HOOKS_DISABLED", None)
+        if restore_launch:
+            env["CMUX_AGENT_RESTORE_LAUNCH"] = "1"
+        else:
+            env.pop("CMUX_AGENT_RESTORE_LAUNCH", None)
 
         try:
             proc = subprocess.run(
@@ -145,6 +151,7 @@ def assert_resume_is_instrumented(socket_state: str, failures: list[str]) -> Non
     code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
         socket_state=socket_state,
         argv=["resume", SESSION_ID],
+        restore_launch=True,
     )
     label = f"resume/{socket_state}"
     expect(code == 0, f"{label}: wrapper exited {code}: {stderr}", failures)
@@ -166,6 +173,8 @@ def assert_resume_is_instrumented(socket_state: str, failures: list[str]) -> Non
            f"{label}: missing launch kind: {observed_env}", failures)
     expect(observed_env.get("CMUX_AGENT_RESUME_LAUNCH") == "1",
            f"{label}: missing resume diagnostic marker: {observed_env}", failures)
+    expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
+           f"{label}: app restore marker leaked to Codex: {observed_env}", failures)
 
 
 def test_resume_hook_injection_survives_transient_startup_outages(failures: list[str]) -> None:
@@ -202,6 +211,35 @@ def test_stale_socket_fresh_launch_preserves_native_behavior(failures: list[str]
            f"fresh/stale: resume marker leaked into ordinary launch: {observed_env}", failures)
 
 
+def test_unmarked_stale_socket_resume_preserves_native_behavior(failures: list[str]) -> None:
+    code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
+        socket_state="stale",
+        argv=["resume", SESSION_ID],
+    )
+    expect(code == 0, f"manual resume/stale: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["resume", SESSION_ID],
+           f"manual resume/stale: expected passthrough, got {real_argv}", failures)
+    expect(any("ping" in line for line in cmux_log),
+           f"manual resume/stale: expected bounded ownership probe, got {cmux_log}", failures)
+    expect(observed_env.get("CMUX_CODEX_HOOK_CMUX_BIN") == "__UNSET__",
+           f"manual resume/stale: cmux hooks should remain disabled: {observed_env}", failures)
+
+
+def test_restore_marker_without_explicit_id_still_requires_live_socket(failures: list[str]) -> None:
+    code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
+        socket_state="stale",
+        argv=["resume", "--last"],
+        restore_launch=True,
+    )
+    expect(code == 0, f"marker without id: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["resume", "--last"],
+           f"marker without id: expected passthrough, got {real_argv}", failures)
+    expect(any("ping" in line for line in cmux_log),
+           f"marker without id: expected bounded ownership probe, got {cmux_log}", failures)
+    expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
+           f"marker without id: app restore marker leaked to Codex: {observed_env}", failures)
+
+
 def test_non_session_command_still_bypasses_hooks(failures: list[str]) -> None:
     code, real_argv, cmux_log, _, stderr = run_wrapper(
         socket_state="stale",
@@ -217,6 +255,8 @@ def main() -> int:
     test_resume_hook_injection_survives_transient_startup_outages(failures)
     test_explicit_disable_still_bypasses_hooks(failures)
     test_stale_socket_fresh_launch_preserves_native_behavior(failures)
+    test_unmarked_stale_socket_resume_preserves_native_behavior(failures)
+    test_restore_marker_without_explicit_id_still_requires_live_socket(failures)
     test_non_session_command_still_bypasses_hooks(failures)
     if failures:
         print("FAIL: Codex resume wrapper reliability checks failed")

--- a/tests/test_codex_wrapper_resume_hooks.py
+++ b/tests/test_codex_wrapper_resume_hooks.py
@@ -63,6 +63,7 @@ done
   printf 'CMUX_CODEX_PID=%s\\n' "${CMUX_CODEX_PID-__UNSET__}"
   printf 'CMUX_CODEX_HOOK_CMUX_BIN=%s\\n' "${CMUX_CODEX_HOOK_CMUX_BIN-__UNSET__}"
   printf 'CMUX_AGENT_LAUNCH_KIND=%s\\n' "${CMUX_AGENT_LAUNCH_KIND-__UNSET__}"
+  printf 'CMUX_AGENT_RESUME_LAUNCH=%s\\n' "${CMUX_AGENT_RESUME_LAUNCH-__UNSET__}"
 } > "$FAKE_REAL_ENV_LOG"
 """,
         )
@@ -163,6 +164,8 @@ def assert_resume_is_instrumented(socket_state: str, failures: list[str]) -> Non
            f"{label}: missing Codex process identity: {observed_env}", failures)
     expect(observed_env.get("CMUX_AGENT_LAUNCH_KIND") == "codex",
            f"{label}: missing launch kind: {observed_env}", failures)
+    expect(observed_env.get("CMUX_AGENT_RESUME_LAUNCH") == "1",
+           f"{label}: missing resume diagnostic marker: {observed_env}", failures)
 
 
 def test_resume_hook_injection_survives_transient_startup_outages(failures: list[str]) -> None:


### PR DESCRIPTION
## Summary

- Preserve Codex and Claude notification hooks for cmux-owned auto-resume launches even when the restore-time socket probe misses transiently.
- Authorize the bypass with a one-shot token bound to the exact provider and resumed session.
- Cover both restore sources: live agent snapshots and higher-precedence persisted `agent-hook` bindings.
- Route captured live executables through the per-surface wrapper while preserving the selected binary.
- Add privacy-safe DEBUG traces for restore binding, hook target resolution, and notification delivery decisions.

## Root cause and evidence

https://github.com/manaflow-ai/cmux/pull/8839 changed auto-resume to type the resume command into the normal interactive login shell. Both wrappers made one bounded 750 ms socket ping during that startup window and used the result to decide whether cmux hooks existed for the full agent process lifetime. A missing socket file, connection backlog, or slow ping caused permanent passthrough.

For Codex, resume does not emit SessionStart. A startup probe miss therefore removed both the wrapper-generated SessionStart and the injected Stop hook. No later event could bind the resumed session or create the unread notification. Claude used the same lifetime gate and had the same notification-loss class.

The regression stress harness launches 12 missing-socket and 12 stale-socket Codex restores. The test-only commit demonstrates that all restore launches lost SessionStart and Stop injection before the fix.

## Ownership fix

`AgentRestoreLaunch` in `Packages/macOS/CMUXAgentLaunch` is the single value owner for restore authorization. It can be constructed only for Codex or Claude with a UUID-shaped session ID. It supplies the provider wrapper route, custom executable environment key, portable shell wrapper, and exact `CMUX_AGENT_RESTORE_LAUNCH=<provider>:<session-id>` authorization.

The app composes that value with stored-command parsing in both restore paths:

- `SessionRestorableAgentSnapshot.resumeStartupInput()`
- persisted `SurfaceResumeBindingSnapshot` values whose source is `agent-hook`

Every authorized restore is routed through the managed per-surface wrapper. If persistence captured a live absolute provider binary, the wrapper receives that exact selection through `CMUX_CUSTOM_CODEX_PATH` or `CMUX_CUSTOM_CLAUDE_PATH` instead of silently selecting another binary from `PATH`.

Startup input transports the one-shot assignment through `/usr/bin/env` before the routed command. This spelling works when typed into bash, zsh, fish, csh, or tcsh. Persistent resume commands and fork commands remain unchanged. Unsupported providers, invalid session IDs, CLI bindings, and other non-hook commands remain unmarked.

Each wrapper consumes and unsets the token immediately. It bypasses socket health only when the token exactly matches the provider and explicit resume ID parsed from argv. Wrong-provider, wrong-session, legacy boolean, and missing-ID markers still require the live-socket ownership check.

Claude can legitimately resolve through a finite user-owned shim chain. The wrapper re-issues the same authorization only at a recognized wrapper-shim boundary, consumes it on the next wrapper pass, and unsets it before the real Claude process. This preserves hook settings and cmux surface context during a startup socket outage without leaking authorization into nested unrelated launches.

Once hooks remain installed, the existing target resolver validates current workspace and surface accessibility, prefers live TTY or PID binding over stale ambient surface state, and republishes the resolved resume binding at SessionStart and Stop.

## Diagnostics

DEBUG builds record bounded, privacy-safe decisions through the existing 500-entry debug ring and tagged log:

- restore discovery and typed startup presence
- restored workspace and surface binding publication
- hook event, resume intent, and target resolution source
- Stop notification send, success, failure, or dedupe decision

Session and target identifiers are truncated. Message content is represented only by byte or character counts.

## Tests

- Codex stress coverage for 12 missing-socket and 12 stale-socket app-owned restores.
- Codex and Claude coverage for exact provider/session authorization, wrong-provider tokens, wrong-session tokens, legacy boolean tokens, unmarked manual resumes, invalid IDs, and marker non-leakage.
- Claude coverage for stale-socket authorization across a supported finite shim re-entry.
- Swift package coverage for provider/session validation, wrapper selection, captured-binary preservation keys, portable wrapper dispatch, and `/usr/bin/env` authorization transport.
- App behavior coverage for snapshot and persisted `agent-hook` startup input, live custom executables, tcsh dispatch, unsupported providers, invalid IDs, CLI bindings, persistent resume commands, and fork commands.
- Full Claude wrapper, Claude mutual-shim, user-binary resolution, Codex stress, and shell dispatch suites.
- Bash syntax, Python compile, Swift parser, Package.resolved policy, test wiring, pbxproj normalization, and diff checks.
- Local Xcode tests were not run as required by https://github.com/manaflow-ai/cmux/issues/9059. The focused pure Swift package suite passed with the native arm64 Swift toolchain.

CI also exposed an existing actor-isolation warning in `Workspace+ForkAgentConversationAvailability.swift`. A separate repair removes the actor-isolated `.shared` default argument and resolves it inside a no-argument overload. No warning-budget file was changed.

## Scope

Fixes https://github.com/manaflow-ai/cmux/issues/9059.

https://github.com/manaflow-ai/cmux/issues/9040 is the deterministic Dock-pane ring rendering bug and is not changed here. https://github.com/manaflow-ai/cmux/issues/6184 and https://github.com/manaflow-ai/cmux/issues/1027 remain separate historical reports.
