### PR TITLE
Fix mobile terminal colors after host restart

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalOutputDelivery.swift
@@ -256,14 +256,15 @@ extension MobileShellComposite {
     ) -> Bool {
         let hasCurrentThemeRevision = hasCurrentTerminalThemeRevision(frame)
         recordTerminalTheme(frame)
+        let compatibleFrame = resolvingUnbackedRenderGridColorSemantics(in: frame)
         let deliveryFrame: MobileTerminalRenderGridFrame
         if hasCurrentThemeRevision {
-            deliveryFrame = frame
+            deliveryFrame = compatibleFrame
         } else {
             MobileDebugLog.anchormux(
                 "sync.render_grid_stale_theme surface=\(frame.surfaceID) revision=\(frame.terminalThemeRevision ?? 0)"
             )
-            deliveryFrame = frame.replacingThemeColors(
+            deliveryFrame = compatibleFrame.replacingThemeColors(
                 with: terminalTheme(for: frame.surfaceID),
                 config: terminalConfigTheme(for: frame.surfaceID),
                 revision: terminalThemeState.revisionsBySurfaceID[frame.surfaceID]

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalTheme.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalTheme.swift
@@ -47,6 +47,39 @@ extension MobileShellComposite {
         return revision >= currentRevision
     }
 
+    /// Makes semantic colors safe for producers that predate per-frame themes.
+    ///
+    /// Intermediate render-grid producers exported palette/default semantics and
+    /// their resolved RGB values, but did not export the palette those semantics
+    /// referenced. After a reconnect the phone therefore interpreted those cells
+    /// through its fallback palette. Preserve exact producer colors until a full
+    /// frame establishes an authoritative per-surface theme.
+    func resolvingUnbackedRenderGridColorSemantics(
+        in frame: MobileTerminalRenderGridFrame
+    ) -> MobileTerminalRenderGridFrame {
+        guard frame.terminalTheme == nil,
+              terminalThemeState.themesBySurfaceID[frame.surfaceID] == nil else {
+            return frame
+        }
+
+        var resolved = frame
+        resolved.styles = frame.styles.map { style in
+            var resolvedStyle = style
+            if resolvedStyle.foregroundSource != .rgb,
+               TerminalTheme.rgbComponents(resolvedStyle.foreground) != nil {
+                resolvedStyle.foregroundSource = .rgb
+                resolvedStyle.foregroundPaletteIndex = nil
+            }
+            if resolvedStyle.backgroundSource != .rgb,
+               TerminalTheme.rgbComponents(resolvedStyle.background) != nil {
+                resolvedStyle.backgroundSource = .rgb
+                resolvedStyle.backgroundPaletteIndex = nil
+            }
+            return resolvedStyle
+        }
+        return resolved
+    }
+
     /// Returns the most recent theme for one surface, falling back to the
     /// connected Mac's host-wide theme before its first full frame arrives.
     func terminalTheme(for surfaceID: String) -> TerminalTheme {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalThemeRenderGridTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TerminalThemeRenderGridTests.swift
@@ -117,6 +117,101 @@ import Testing
 }
 
 @MainActor
+@Test func legacySemanticFrameWithoutThemeUsesResolvedRGBColors() async throws {
+    let surfaceID = "terminal-legacy-semantic-theme"
+    let store = MobileShellComposite.preview()
+    var outputIterator = store.terminalOutputStream(surfaceID: surfaceID).makeAsyncIterator()
+    let frame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 1,
+        columns: 8,
+        rows: 1,
+        styles: [
+            .init(
+                id: 0,
+                foreground: "#d0d0d0",
+                background: "#101010",
+                foregroundSource: .defaultColor,
+                backgroundSource: .defaultColor
+            ),
+            .init(
+                id: 1,
+                foreground: "#ff8800",
+                background: "#101010",
+                foregroundSource: .palette,
+                foregroundPaletteIndex: 3,
+                backgroundSource: .defaultColor
+            ),
+        ],
+        rowSpans: [
+            .init(row: 0, column: 0, styleID: 1, text: "themed", cellWidth: 6),
+        ],
+        terminalForeground: "#d0d0d0",
+        terminalBackground: "#101010"
+    )
+
+    #expect(store.deliverTerminalRenderGrid(frame, surfaceID: surfaceID))
+    let chunk = try #require(await outputIterator.next())
+    let replay = try #require(String(data: chunk.data, encoding: .utf8))
+
+    #expect(replay.contains("38;2;255;136;0"))
+    #expect(replay.contains("48;2;16;16;16"))
+    #expect(!replay.contains("38;5;3"))
+    #expect(!replay.contains(";39;49m"))
+}
+
+@MainActor
+@Test func themeBackedDeltaKeepsSemanticPaletteColors() async throws {
+    let surfaceID = "terminal-backed-semantic-theme"
+    let store = MobileShellComposite.preview()
+    var outputIterator = store.terminalOutputStream(surfaceID: surfaceID).makeAsyncIterator()
+    let fullFrame = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 1,
+        columns: 6,
+        rows: 1,
+        rowSpans: [],
+        terminalTheme: .monokai,
+        terminalConfigTheme: .monokai,
+        terminalThemeRevision: 1
+    )
+
+    #expect(store.deliverTerminalRenderGrid(fullFrame, surfaceID: surfaceID))
+    let fullChunk = try #require(await outputIterator.next())
+    store.terminalOutputDidProcess(surfaceID: surfaceID, streamToken: fullChunk.streamToken)
+
+    let delta = try MobileTerminalRenderGridFrame(
+        surfaceID: surfaceID,
+        stateSeq: 2,
+        columns: 6,
+        rows: 1,
+        full: false,
+        clearedRows: [0],
+        styles: [
+            .init(
+                id: 0,
+                foreground: "#e6db74",
+                background: "#272822",
+                foregroundSource: .palette,
+                foregroundPaletteIndex: 3,
+                backgroundSource: .defaultColor
+            ),
+        ],
+        rowSpans: [
+            .init(row: 0, column: 0, styleID: 0, text: "color", cellWidth: 5),
+        ]
+    )
+
+    #expect(store.deliverTerminalRenderGrid(delta, surfaceID: surfaceID))
+    let deltaChunk = try #require(await outputIterator.next())
+    let replay = try #require(String(data: deltaChunk.data, encoding: .utf8))
+
+    #expect(replay.contains("38;5;3"))
+    #expect(replay.contains(";49m"))
+    #expect(!replay.contains("38;2;230;219;116"))
+}
+
+@MainActor
 @Test func staleTerminalContentStillAdvancesRevisionedThemeMetadata() throws {
     let surfaceID = "terminal-stale-content-fresh-theme"
     let store = MobileShellComposite.preview()


### PR DESCRIPTION
## Summary
- preserve producer-resolved RGB colors when a reconnecting mobile client receives semantic render-grid styles before an authoritative per-surface theme
- keep palette/default semantics once a theme-backed full frame has established the correct palette
- add red/green regression coverage for both compatibility and current-producer paths

## Test plan
- [x] `swift test --package-path Packages/iOS/CmuxMobileShell --filter TerminalTheme` (21 tests)
- [x] tagged macOS build and launch via `./scripts/reload.sh --tag fix-restart-theme --launch`
- [x] tagged iOS simulator build, install, launch, sign-in, and pairing via `ios/scripts/reload.sh --tag fix-restart-theme`
- [ ] Full mobile-shell suite: 784/787 passed; three unrelated existing replay/viewport timing tests also fail when rerun in isolation (`terminalViewportDetachKeepsGenerationTombstoneForStaleAcks`, `terminalReplayInFlightClearsWhenOutputStreamUnmountsBeforeResponse`, `staleReplayResponseAfterRemountDoesNotDeliverIntoCurrentStream`)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787865828&installation_model_id=21920&pr_number=9073&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9073&signature=1e5332483f0706b11afd17bb2bcff0a681c5ef9bc92e14b63f80f81ec15f69ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile terminal colors after host restart/reconnect by preserving producer-resolved RGB colors until a full theme is received. Prevents fallback palette repainting and keeps semantic palette colors once a theme-backed frame is established.

- **Bug Fixes**
  - When no per-surface theme exists, convert semantic color refs to the producer’s resolved RGB to render exact colors.
  - After a theme-backed full frame, keep palette/default semantics and apply the authoritative theme.
  - Added tests covering legacy semantic frames (RGB preserved) and theme-backed deltas (palette semantics kept).

<sup>Written for commit bb445e4d72a963ab037507dd3a46449d89a72439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal color handling for legacy render frames.
  * Preserved exact RGB colors when theme information is unavailable.
  * Maintained correct palette-based colors for theme-backed updates.
  * Prevented incorrect color escape sequences during terminal rendering.

* **Tests**
  * Added coverage for RGB and palette-based color output scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->