### PR TITLE
Instrument direct Codex fork sessions

### DIFF
--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -105,8 +105,8 @@ resolve_hook_cmux_bin() {
     printf '%s' "cmux"
 }
 
-# The interactive session, `exec`/`e`, and `resume` entrypoints all START a
-# Codex session, so all three must receive cmux's hook injection; everything
+# The interactive session, `exec`/`e`, `resume`, and `fork` entrypoints all START
+# a Codex session, so all four must receive cmux's hook injection; everything
 # else (review, login, mcp, doctor, --help, --version, ...) passes through
 # untouched. `resume` is critical: cmux auto-resumes a session as `codex resume
 # <id>` after a Mac relaunch, and without hooks the resumed process fires no
@@ -117,10 +117,10 @@ resolve_hook_cmux_bin() {
 # `--dangerously-bypass-hook-trust` / `-c hooks.X=...` flags before the `resume`
 # subcommand, so prepending them is safe. Mirrors should_inject_claude_hooks: a
 # leading non-option token that is a known Codex subcommand means "not a session"
-# unless it is exec or resume.
+# unless it is exec, resume, or fork.
 codex_subcommand_starts_session() {
     case "$1" in
-        exec|e|resume) return 0 ;;
+        exec|e|resume|fork) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -162,8 +162,9 @@ codex_passthrough_option_flag() {
 # Decide whether this invocation is a Codex SESSION entrypoint we should inject
 # hooks into. Bare `codex` (no args) and `codex [prompt]` are interactive
 # sessions; `codex exec ...` is a non-interactive session; `codex resume ...`
-# (picker, <id>, --last, --all <id>) resumes a session; any other leading
-# subcommand is not.
+# (picker, <id>, --last, --all <id>) resumes a session; `codex fork ...` starts
+# a child session whose hooks report the new id; any other leading subcommand
+# is not.
 should_inject_codex_hooks() {
     (( $# == 0 )) && return 0
 

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -117,7 +117,7 @@ resolve_hook_cmux_bin() {
 # `--dangerously-bypass-hook-trust` / `-c hooks.X=...` flags before the `resume`
 # subcommand, so prepending them is safe. Mirrors should_inject_claude_hooks: a
 # leading non-option token that is a known Codex subcommand means "not a session"
-# unless it is exec, resume, or fork.
+# unless it is exec, e, resume, or fork.
 codex_subcommand_starts_session() {
     case "$1" in
         exec|e|resume|fork) return 0 ;;

--- a/tests/test_codex_wrapper_resume_hooks.py
+++ b/tests/test_codex_wrapper_resume_hooks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression checks for reliable Codex hook injection during cmux resume."""
+"""Regression checks for reliable Codex session-entrypoint hook injection."""
 
 from __future__ import annotations
 
@@ -80,7 +80,8 @@ if [[ "${1:-}" == "--socket" ]]; then
   shift 2
 fi
 if [[ "${1:-}" == "ping" ]]; then
-  exit 1
+  [[ "${FAKE_SOCKET_STATE:-missing}" == "live" ]]
+  exit
 fi
 if [[ "${1:-}" == "hooks" && "${2:-}" == "codex" && "${3:-}" == "inject-args" ]]; then
   printf '%s\\0' \
@@ -102,7 +103,7 @@ exit 1
         )
 
         test_socket: socket.socket | None = None
-        if socket_state == "stale":
+        if socket_state in {"live", "stale"}:
             test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             test_socket.bind(str(socket_path))
 
@@ -116,6 +117,7 @@ exit 1
         env["FAKE_REAL_ARGS_LOG"] = str(real_args_log)
         env["FAKE_REAL_ENV_LOG"] = str(real_env_log)
         env["FAKE_CMUX_LOG"] = str(cmux_log)
+        env["FAKE_SOCKET_STATE"] = socket_state
         if hooks_disabled:
             env["CMUX_CODEX_HOOKS_DISABLED"] = "1"
         else:
@@ -183,6 +185,34 @@ def test_resume_hook_injection_survives_transient_startup_outages(failures: list
     for _ in range(12):
         assert_resume_is_instrumented("missing", failures)
         assert_resume_is_instrumented("stale", failures)
+
+
+def test_direct_fork_is_instrumented(failures: list[str]) -> None:
+    code, real_argv, cmux_log, observed_env, stderr = run_wrapper(
+        socket_state="live",
+        argv=["fork", SESSION_ID],
+    )
+    expect(code == 0, f"fork/live: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv[:3] == ["--enable", "hooks", "--dangerously-bypass-hook-trust"],
+           f"fork/live: missing injected hook prefix: {real_argv}", failures)
+    expect(any(arg.startswith("hooks.SessionStart=") for arg in real_argv),
+           f"fork/live: missing SessionStart hook: {real_argv}", failures)
+    expect(any(arg.startswith("hooks.Stop=") for arg in real_argv),
+           f"fork/live: missing Stop hook: {real_argv}", failures)
+    expect(real_argv[-2:] == ["fork", SESSION_ID],
+           f"fork/live: fork argv was not preserved: {real_argv}", failures)
+    expect(any("ping" in line for line in cmux_log),
+           f"fork/live: wrapper never verified cmux ownership: {cmux_log}", failures)
+    expect(any("hooks codex inject-args" in line for line in cmux_log),
+           f"fork/live: wrapper never requested local hook args: {cmux_log}", failures)
+    expect(observed_env.get("CMUX_CODEX_PID") not in {None, "", "__UNSET__"},
+           f"fork/live: missing Codex process identity: {observed_env}", failures)
+    expect(observed_env.get("CMUX_AGENT_LAUNCH_KIND") == "codex",
+           f"fork/live: missing launch kind: {observed_env}", failures)
+    expect(observed_env.get("CMUX_AGENT_RESUME_LAUNCH") == "__UNSET__",
+           f"fork/live: fork was mislabeled as a resume: {observed_env}", failures)
+    expect(observed_env.get("CMUX_AGENT_RESTORE_LAUNCH") == "__UNSET__",
+           f"fork/live: app restore marker leaked to Codex: {observed_env}", failures)
 
 
 def test_explicit_disable_still_bypasses_hooks(failures: list[str]) -> None:
@@ -273,6 +303,7 @@ def test_non_session_command_still_bypasses_hooks(failures: list[str]) -> None:
 def main() -> int:
     failures: list[str] = []
     test_resume_hook_injection_survives_transient_startup_outages(failures)
+    test_direct_fork_is_instrumented(failures)
     test_explicit_disable_still_bypasses_hooks(failures)
     test_stale_socket_fresh_launch_preserves_native_behavior(failures)
     test_unmarked_stale_socket_resume_preserves_native_behavior(failures)
@@ -280,11 +311,11 @@ def main() -> int:
     test_mismatched_restore_tokens_still_require_live_socket(failures)
     test_non_session_command_still_bypasses_hooks(failures)
     if failures:
-        print("FAIL: Codex resume wrapper reliability checks failed")
+        print("FAIL: Codex session-entrypoint wrapper reliability checks failed")
         for failure in failures:
             print(f"- {failure}")
         return 1
-    print("PASS: every cmux-owned Codex resume launch retains SessionStart and Stop hooks")
+    print("PASS: every cmux-owned Codex session entrypoint retains SessionStart and Stop hooks")
     return 0
 
 


### PR DESCRIPTION
## Summary
- classify `codex fork` as a session-producing wrapper entrypoint
- preserve the existing live-socket ownership check and native passthrough behavior
- add an executable red/green regression covering direct fork hook injection and launch identity

## Root cause
The per-surface PATH shim already routed typed `codex` commands through `cmux-codex-wrapper`, but the wrapper recognized `fork` only as a known non-session subcommand. It therefore passed the invocation to Codex before exporting launch identity or requesting SessionStart/Stop hooks. The fix updates the single session-entrypoint policy owner; downstream hook delivery and open-rollout discovery remain unchanged.

## Verification
- `python3 tests/test_codex_wrapper_resume_hooks.py`
- `bash -n Resources/bin/cmux-codex-wrapper`
- failing-test commit followed by fix commit
- Swift file/warning budgets unchanged: no Swift files changed (the requested legacy `scripts/swift_file_length_budget.py` is absent on current `main`)

Localization audit: no user-facing strings changed.

Closes #8988

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787870604&installation_model_id=21920&pr_number=9081&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9081&signature=1fd6a30d76d67fe5c5507fc5b78f3baaab3038bddf9871fffacb89688a1a1639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `codex fork` as a session entrypoint in `cmux-codex-wrapper` so hooks are injected and launch identity is exported, while keeping live-socket checks and passthrough. Also clarifies the `exec` alias `e` in wrapper comments. Closes #8988.

- **Bug Fixes**
  - Injects hook args and `CMUX_*` labels for `fork`; preserves argv and labels launch kind as `codex` (not resume/restore).
  - Adds a regression test for direct `fork` and refines socket ping in tests to model live/stale cases.

<sup>Written for commit 99e5384aab0483346f5b623e9fab34148b188ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for Codex `fork` sessions in cmux hook injection.
  * Ensured `fork` launches receive session-start and stop hooks, along with the appropriate environment markers.
  * Improved socket health checks during session hook setup for more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->