### PR TITLE
Fix TextBox selection replacement under refresh churn

### DIFF
--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1013,15 +1013,6 @@ func shouldHandleTextBoxPlainArrowLocally(
     }
 }
 
-func shouldSynchronizeExternalTextToTextBox(
-    inlineAttachmentCount: Int,
-    plainText: String,
-    externalText: String,
-    hasMarkedText: Bool
-) -> Bool {
-    inlineAttachmentCount == 0 && !hasMarkedText && plainText != externalText
-}
-
 func textBoxCommandShortcutKey(
     for event: NSEvent,
     translateKey: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:),
@@ -3044,14 +3035,9 @@ struct TextBoxInputView: NSViewRepresentable {
                 height: CGFloat.greatestFiniteMagnitude
             )
         }
-        if shouldSynchronizeExternalTextToTextBox(
-            inlineAttachmentCount: textView.inlineAttachments().count,
-            plainText: textView.plainText(),
-            externalText: text,
-            hasMarkedText: textView.hasMarkedText()
-        ) {
-            textView.string = text
-        }
+        // The mounted AppKit editor owns the live draft. Its binding publications can lag this
+        // update, so treating an older binding snapshot as input would clobber text, selection,
+        // marked text, and undo state. Restored drafts enter through the explicit install paths.
         updateTextView(textView, context: context)
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2174,6 +2174,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE7B210000000000000001 /* TextBoxMentionQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B210000000000000002 /* TextBoxMentionQuery.swift */; };
 		C0DE7B220000000000000001 /* TextBoxMentionSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B220000000000000002 /* TextBoxMentionSuggestion.swift */; };
 		C0DE7B290000000000000001 /* TextBoxProcessTerminationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B290000000000000002 /* TextBoxProcessTerminationStatus.swift */; };
+		9005A0010000000000000001 /* TextBoxSelectionReplacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9005A0010000000000000002 /* TextBoxSelectionReplacementTests.swift */; };
 		C0DE7B370000000000000001 /* TextBoxSubmitAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B370000000000000002 /* TextBoxSubmitAction.swift */; };
 		C0DE7B400000000000000001 /* TextBoxSubmitActionCycling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B400000000000000002 /* TextBoxSubmitActionCycling.swift */; };
 		C0DE7B390000000000000001 /* TextBoxSubmitActionImageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B390000000000000002 /* TextBoxSubmitActionImageSupport.swift */; };
@@ -4541,6 +4542,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE7B210000000000000002 /* TextBoxMentionQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionQuery.swift; sourceTree = "<group>"; };
 		C0DE7B220000000000000002 /* TextBoxMentionSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionSuggestion.swift; sourceTree = "<group>"; };
 		C0DE7B290000000000000002 /* TextBoxProcessTerminationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxProcessTerminationStatus.swift; sourceTree = "<group>"; };
+		9005A0010000000000000002 /* TextBoxSelectionReplacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSelectionReplacementTests.swift; sourceTree = "<group>"; };
 		C0DE7B370000000000000002 /* TextBoxSubmitAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TextBoxSubmitAction.swift; sourceTree = "<group>"; };
 		C0DE7B400000000000000002 /* TextBoxSubmitActionCycling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActionCycling.swift; sourceTree = "<group>"; };
 		C0DE7B390000000000000002 /* TextBoxSubmitActionImageSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActionImageSupport.swift; sourceTree = "<group>"; };
@@ -6768,6 +6770,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5330A0025330A0025330A002 /* TextBoxInlineAttachmentRenderingTests.swift */,
 				C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */,
 				C0DE86250000000000000002 /* TextBoxIMECompositionLayoutTests.swift */,
+				9005A0010000000000000002 /* TextBoxSelectionReplacementTests.swift */,
 				7898A0010000000000000002 /* TextBoxMentionGitIgnoreProbeTests.swift */,
 				C1713005C1713005C1713005 /* CommandPaletteShortcutCustomizationTests.swift */,
 				17FCD4CC61D54A2F8F2F463D /* AppDelegateBareSpaceShortcutRoutingTests.swift */,
@@ -10004,6 +10007,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5330A0015330A0015330A001 /* TextBoxInlineAttachmentRenderingTests.swift in Sources */,
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,
 				7898A0010000000000000001 /* TextBoxMentionGitIgnoreProbeTests.swift in Sources */,
+				9005A0010000000000000001 /* TextBoxSelectionReplacementTests.swift in Sources */,
 				C0DE7B410000000000000001 /* TextBoxSubmitActionMemoryTests.swift in Sources */,
 				C0DE7B3C0000000000000001 /* TextBoxSubmitActionSettingsFileTests.swift in Sources */,
 				C0DE7B360000000000000001 /* TextBoxSubmitActionTests.swift in Sources */,

--- a/cmuxTests/TextBoxMentionCompletionTests.swift
+++ b/cmuxTests/TextBoxMentionCompletionTests.swift
@@ -101,28 +101,6 @@ struct TextBoxMentionCompletionTests {
     }
 
     @Test
-    func testTextBoxExternalTextSyncDoesNotOverwriteActiveIMEMarkedText() {
-        #expect(!shouldSynchronizeExternalTextToTextBox(
-            inlineAttachmentCount: 0,
-            plainText: "に",
-            externalText: "",
-            hasMarkedText: true
-        ))
-        #expect(shouldSynchronizeExternalTextToTextBox(
-            inlineAttachmentCount: 0,
-            plainText: "に",
-            externalText: "",
-            hasMarkedText: false
-        ))
-        #expect(!shouldSynchronizeExternalTextToTextBox(
-            inlineAttachmentCount: 1,
-            plainText: "に",
-            externalText: "",
-            hasMarkedText: false
-        ))
-    }
-
-    @Test
     func testTextBoxPlaceholderHidesDuringActiveIMEMarkedText() {
         #expect(!TextBoxSubmitAvailability.shouldShowPlaceholder(
             text: "",

--- a/cmuxTests/TextBoxSelectionReplacementTests.swift
+++ b/cmuxTests/TextBoxSelectionReplacementTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+import SwiftUI
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("TextBox selection replacement", .serialized)
+struct TextBoxSelectionReplacementTests {
+    @Test("stale parent refresh does not resurrect text replaced in the editor")
+    func staleParentRefreshPreservesSelectionReplacement() throws {
+        let staleExternalText = "hello world"
+        var publishedText: String?
+        var createdTextView: TextBoxInputTextView?
+
+        let makeHarness = { refreshToken in
+            TextBoxSelectionReplacementHarness(
+                externalText: staleExternalText,
+                refreshToken: refreshToken,
+                onPublishedText: { publishedText = $0 },
+                onTextViewCreated: { textView in
+                    createdTextView = textView
+                    textView.string = staleExternalText
+                }
+            )
+        }
+        let hostingView = NSHostingView(rootView: makeHarness(0))
+        hostingView.frame = NSRect(x: 0, y: 0, width: 360, height: 60)
+        let window = NSWindow(
+            contentRect: hostingView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = hostingView
+        defer {
+            window.contentView = nil
+            window.close()
+        }
+
+        hostingView.layoutSubtreeIfNeeded()
+        let textView = try #require(createdTextView)
+        #expect(window.makeFirstResponder(textView))
+        textView.setSelectedRange(NSRange(location: 6, length: 5))
+
+        textView.insertText("x", replacementRange: textView.selectedRange())
+
+        #expect(textView.string == "hello x")
+        #expect(publishedText == "hello x")
+
+        hostingView.rootView = makeHarness(1)
+        hostingView.layoutSubtreeIfNeeded()
+
+        #expect(createdTextView === textView)
+        #expect(textView.string == "hello x")
+        #expect(textView.selectedRange() == NSRange(location: 7, length: 0))
+    }
+}
+
+@MainActor
+private struct TextBoxSelectionReplacementHarness: View {
+    let externalText: String
+    let refreshToken: Int
+    let onPublishedText: (String) -> Void
+    let onTextViewCreated: (TextBoxInputTextView) -> Void
+
+    var body: some View {
+        TextBoxInputView(
+            text: Binding(get: { externalText }, set: onPublishedText),
+            attachments: .constant([]),
+            textViewHeight: .constant(TextBoxLayout.minimumTextHeight),
+            hasPendingAttachmentUpload: .constant(false),
+            font: .systemFont(ofSize: 14),
+            backgroundColor: .textBackgroundColor,
+            foregroundColor: .labelColor,
+            terminalTitle: "refresh-\(refreshToken)",
+            completionRootDirectory: nil,
+            onSubmit: {},
+            onEscape: {},
+            onFocusTextBox: {},
+            onToggleFocus: {},
+            onForwardText: { _, _ in },
+            onForwardKey: { _ in },
+            onForwardControl: { _ in },
+            onPaste: { _, _ in false },
+            onInsertFileURLs: { _, _ in false },
+            onChooseFiles: {},
+            onContentChanged: {},
+            onTextViewCreated: onTextViewCreated,
+            onTextViewMovedToWindow: { _ in },
+            onTextViewDismantled: { _ in }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- make the mounted AppKit TextBox editor the sole owner of live draft storage
- stop stale SwiftUI binding snapshots from overwriting text, selection, marked text, or undo state during updateNSView
- add a hosted NSViewRepresentable regression that types over a selection and forces a stale parent refresh

## Architecture
TextBox bindings remain an outbound projection while the editor is mounted. Draft restoration and other legitimate inbound mutations already use explicit TextBoxInputTextView install/clear paths, so updateNSView now refreshes presentation and callbacks without replacing live text storage.

## Test plan
- ./scripts/lint-pbxproj-test-wiring.sh
- ./scripts/check-pbxproj.sh
- CI unit test: TextBoxSelectionReplacementTests
- tagged local build and TextBox dogfood after CI/review are green

Closes #9005

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787870699&installation_model_id=21920&pr_number=9084&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9084&signature=9fa5936690e4da2ec61ca1a2dbffb601c1ba5a8837c8f4601bb28dd20ac9159d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TextBox selection replacement being reverted during parent refreshes by making the mounted AppKit editor the source of truth. Stops stale SwiftUI bindings from overwriting text, selection, marked text, or undo state (closes #9005).

- **Bug Fixes**
  - Make the mounted AppKit editor own the live draft; remove external text sync from updateNSView.
  - Limit updateNSView to presentation and callbacks; draft restoration stays on explicit install/clear paths.
  - Add TextBoxSelectionReplacementTests to cover stale refresh; remove the old sync helper and its tests.

<sup>Written for commit 4da4dc27bb90409031a9b175a9a4f6b4c5f0a8ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

