### PR TITLE
Fix the sample sidebar extension failing to build

### DIFF
--- a/Examples/SampleSidebarExtensionApp/SampleSidebarExtension/Model/SidebarInsightModel.swift
+++ b/Examples/SampleSidebarExtensionApp/SampleSidebarExtension/Model/SidebarInsightModel.swift
@@ -110,6 +110,8 @@ struct SurfaceInsight: Identifiable {
             return "doc"
         case .rightSidebarTool:
             return "sidebar.right"
+        case .agentSession:
+            return "sparkles"
         case .project:
             return "folder"
         case .unknown:


### PR DESCRIPTION
The sample sidebar extension does not compile against its own SDK.

`CmuxSidebarSurfaceKind` gained an `agentSession` case, but `SidebarInsightModel.iconName` still switches over the older set, so the switch is no longer exhaustive:

```
SidebarInsightModel.swift:102:9: error: switch must be exhaustive
```

Reproduce on `main`:

```sh
cd Examples/SampleSidebarExtensionApp
xcodebuild -project SampleSidebarExtensionApp.xcodeproj \
  -scheme CMUXExtKitSampleSidebarApp -configuration Debug \
  -destination "platform=macOS" build
```

This matters more than a typical example being stale, because `Examples/SampleSidebarExtensionApp` is the project `docs/custom-sidebars.md` and the README point third-party authors at. It is the first thing anyone building a sidebar extension compiles, and it fails before they have written a line of their own.

The fix adds the missing case, using `sparkles` to match how agent surfaces are represented elsewhere in the sample. Happy to change the symbol if there is a preferred one.

Verified by building the sample with the patch applied: the build succeeds, the extension registers at `com.cmuxterm.app.cmux.sidebar`, and it loads in cmux.

One suggestion, no changes made for it here: CI does not appear to build `Examples/`, which is how this reached `main`. A compile-only job over the sample would catch the next SDK addition that outruns it, since the failure mode is always a non-exhaustive switch in the sample rather than anything in the SDK.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787871783&installation_model_id=21920&pr_number=9088&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9088&signature=4104b30181dbaa897b682537d67389cba0420da301c4e0d3b9da368804b9a12b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Sample Sidebar extension build by adding the missing `.agentSession` case to `SidebarInsightModel.iconName` (returns `sparkles`). The switch is now exhaustive so the sample compiles and the extension loads.

<sup>Written for commit bf73a67ae9022fc88c2cec88039726b4ba7f58be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

