### PR TITLE
Collapse spinner-frame titles before ingress dedup (~31% main-thread reduction under title churn)

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/TitleChurn/TerminalTitleChurnFilter.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/TitleChurn/TerminalTitleChurnFilter.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Collapses frame-by-frame spinner churn in terminal titles so an animated
+/// title — e.g. an agent cycling `⠋ Working…`, `⠙ Working…`, `⠹ Working…`
+/// through Braille glyphs on every animation frame — maps to one stable
+/// string before it reaches the title-update ingress.
+///
+/// The ingress already rejects duplicate updates synchronously, but spinner
+/// frames differ on every frame, so without this collapse the dedup never
+/// fires and every frame pays an `AsyncStream` yield plus a global-executor
+/// task enqueue on the main thread.
+///
+/// Scoped to Braille on purpose: unlike `|`, `/`, `-`, `*`, `▶`, `●`, …,
+/// Braille patterns never legitimately *lead* a human-readable terminal
+/// title, so stripping them cannot corrupt a real one. Stateless: callers
+/// rely on their existing last-value dedup to drop the now-identical frames.
+public enum TerminalTitleChurnFilter {
+    /// Returns the stable title to publish for `rawTitle`, or `nil` when the
+    /// frame is only a spinner glyph (no label survives the collapse) and
+    /// should be dropped rather than blanking a previously shown label.
+    public static func stableTitle(for rawTitle: String) -> String? {
+        let stable = collapseTerminalTitleSpinnerFrames(rawTitle)
+        if stable.isEmpty,
+           !rawTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return nil
+        }
+        return stable
+    }
+}
+
+/// Strips a leading run of Braille spinner glyphs and the whitespace that
+/// separates them from their label, returning the label untouched. A title
+/// with no leading spinner is returned exactly as given — plain OSC titles
+/// keep any intentional padding; only spinner frames are rewritten.
+private func collapseTerminalTitleSpinnerFrames(_ rawTitle: String) -> String {
+    var cursor = Substring(rawTitle)
+    // A spinner frame may carry leading whitespace before the glyph; peek past
+    // it to detect the spinner without disturbing non-spinner titles.
+    while let character = cursor.first, character.isWhitespace {
+        cursor = cursor.dropFirst()
+    }
+    guard let first = cursor.first, terminalTitleCharacterIsBrailleSpinnerGlyph(first) else {
+        return rawTitle
+    }
+    // Strip the spinner-glyph run and the whitespace separating it from the
+    // label; the label itself (including any trailing content) is kept.
+    while let character = cursor.first, terminalTitleCharacterIsBrailleSpinnerGlyph(character) {
+        cursor = cursor.dropFirst()
+    }
+    while let character = cursor.first, character.isWhitespace {
+        cursor = cursor.dropFirst()
+    }
+    return String(cursor)
+}
+
+/// A spinner frame is a single Braille Pattern code point (U+2800…U+28FF).
+/// Multi-scalar graphemes (emoji, combining sequences) are never spinner
+/// glyphs.
+private func terminalTitleCharacterIsBrailleSpinnerGlyph(_ character: Character) -> Bool {
+    guard character.unicodeScalars.count == 1,
+          let scalar = character.unicodeScalars.first else {
+        return false
+    }
+    return (0x2800...0x28FF).contains(scalar.value)
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalTitleChurnFilterTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalTitleChurnFilterTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import CmuxTerminalCore
+
+/// Regression coverage for spinner-frame terminal-title churn: an agent or
+/// CLI tool that animates its title with Braille glyphs on every frame must
+/// collapse to a single stable title so the per-frame updates dedup at the
+/// title-update ingress instead of paying a yield + task enqueue each frame.
+@Suite
+struct TerminalTitleChurnFilterTests {
+    /// The Braille spinner alphabet most CLI tools / agents cycle through.
+    private static let spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+    @Test func collapsesLeadingBrailleSpinnerToStableLabel() {
+        for frame in Self.spinnerFrames {
+            #expect(
+                TerminalTitleChurnFilter.stableTitle(for: "\(frame) Working…") == "Working…",
+                "frame \(frame) must collapse to the stable label"
+            )
+        }
+    }
+
+    @Test func collapsesLeadingSpaceBeforeSpinner() {
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "  ⠙  Building project") == "Building project")
+    }
+
+    @Test func collapsesMultipleLeadingBrailleGlyphs() {
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "⠋⠙⠹ Compiling") == "Compiling")
+    }
+
+    @Test func preservesPlainTitlesExactly() {
+        // A title with no leading spinner is returned verbatim — the churn fix
+        // must not silently trim ordinary OSC titles (intentional padding too).
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "npm install") == "npm install")
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "  zsh - ~/proj  ") == "  zsh - ~/proj  ")
+    }
+
+    @Test func preservesNonLeadingBrailleGlyphs() {
+        // Braille only counts as a spinner when it LEADS the title; a glyph
+        // mid-title is real content and must survive.
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "Build ⠋ step") == "Build ⠋ step")
+    }
+
+    @Test func pureSpinnerFrameIsDropped() {
+        // A frame that is only the spinner glyph carries no label; it must not
+        // be published (which would blank the title shown a moment ago).
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "⠋") == nil)
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "  ⠙  ") == nil)
+    }
+
+    @Test func emptyTitlePassesThrough() {
+        // A genuinely empty title is not a spinner frame and keeps its meaning.
+        #expect(TerminalTitleChurnFilter.stableTitle(for: "") == "")
+    }
+
+    @Test func spinnerFramesCollapseToEqualStrings() {
+        // The property the ingress dedup relies on: successive frames of the
+        // same label become string-equal after the collapse.
+        let collapsed = Set(Self.spinnerFrames.compactMap {
+            TerminalTitleChurnFilter.stableTitle(for: "\($0) Working…")
+        })
+        #expect(collapsed == ["Working…"])
+    }
+}

--- a/Sources/GhosttyTitleUpdateIngress.swift
+++ b/Sources/GhosttyTitleUpdateIngress.swift
@@ -1,4 +1,5 @@
 import CmuxFoundation
+import CmuxTerminalCore
 import Foundation
 
 /// Synchronous callback ingress: duplicate titles are rejected before an
@@ -58,13 +59,19 @@ final class GhosttyTitleUpdateIngress {
     }
 
     /// Returns false only when the update duplicates the callback-local
-    /// snapshot or the ingress has already terminated.
+    /// snapshot, is a label-less spinner frame, or the ingress has already
+    /// terminated.
     @discardableResult
     func submit(tabId: UUID, surfaceId: UUID, sourceSurface: AnyObject, title: String) -> Bool {
+        // Collapse spinner-frame churn before dedup: animated frames like
+        // "⠋ Working…" / "⠙ Working…" differ every frame, so without the
+        // collapse the duplicate guard below never fires and each frame pays
+        // a yield + global-executor enqueue on the main thread.
+        guard let stableTitle = TerminalTitleChurnFilter.stableTitle(for: title) else { return false }
         let update = GhosttyTitleUpdate(
             tabId: tabId,
             surfaceId: surfaceId,
-            title: title,
+            title: stableTitle,
             sourceSurfaceIdentifier: ObjectIdentifier(sourceSurface),
             attachmentGeneration: attachmentGeneration.loadRelaxed()
         )


### PR DESCRIPTION

Ports TerminalTitleChurnFilter from #6907 (credit @austinywang, co-authored-by on the commit) into GhosttyTitleUpdateIngress.submit. Spinner frames (`⠋ Working` -> `⠙ Working`) always differ, so the existing `update != lastSubmittedUpdate` guard never fires - every frame pays yield -> task enqueue -> workqueue syscall on the main thread. That's 31.2% of main-thread samples under heavy churn, and 3-5x worse click latency vs constant titles at matched rates.

What changed vs #6907:

1. Filter loses @MainActor - submit runs in ghostty's serialized per-view callback, same argument the ingress already makes for its own state (lines 13-15)
2. Per-surface LRU dropped - the ingress is per-view, so it collapses to a single lastStableTitle
3. FIFO drain gone - superseded by the AsyncStream + dispatcher that landed on main

What survives is the ~30 lines that matter: the braille U+2800-28FF leading-run collapse + its tests.

To be clear, this doesn't fix saturation-level unresponsiveness (https://github.com/manaflow-ai/cmux/issues/9092). Closes nothing, should help #6599.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787872817&installation_model_id=21920&pr_number=9094&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9094&signature=8ee9c836584e2fe1b88dfa6012ee87f4789a8cc9fd97289b783d63a6ed230aea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses leading Braille spinner glyphs in terminal titles before `GhosttyTitleUpdateIngress` dedup so animated frames become one stable string and spinner-only frames are dropped. Cuts ~31% main-thread time under heavy title churn and improves click latency.

- **Performance**
  - Added `TerminalTitleChurnFilter` with tests: strips leading Braille (U+2800–U+28FF) spinner glyphs and whitespace so frames collapse to the same label; pure spinner frames are ignored.
  - Applied in `GhosttyTitleUpdateIngress.submit` before existing dedup to avoid per-frame AsyncStream yields and global-executor enqueues.

<sup>Written for commit 4a78ba4c7a3f2b6104f9741021ae5ea9c54eac4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal titles now remain stable while spinner animations update, reducing visible title flicker.
  * Spinner-only title updates no longer replace an existing meaningful title with a blank value.

* **Bug Fixes**
  * Preserved intentional spacing and embedded Braille characters in unaffected titles.
  * Prevented duplicate stabilized title updates from being submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->