### PR TITLE
fix: restore closed remote tmux tabs by stable identity

### DIFF
--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -12,17 +12,17 @@ extension AppDelegate {
     @discardableResult
     func reopenMostRecentlyClosedItem(
         preferredTabManager: TabManager? = nil,
-        shouldActivate: Bool = true
+        shouldActivate: Bool = false
     ) -> Bool {
         var failedStoreRecordIds: Set<UUID> = []
-        let restoreStoreItem: (Date?) -> Bool = { cutoff in
-            ClosedItemHistoryStore.shared.restoreFirstRestorable(
+        let restoreStoreItem: (Date?) -> ClosedItemHistoryRestoreAttempt = { cutoff in
+            ClosedItemHistoryStore.shared.attemptFirstRestorable(
                 newerThan: cutoff,
                 excluding: failedStoreRecordIds,
                 onFailure: { failedStoreRecordIds.insert($0) },
-                using: { entry in
-                    self.restoreClosedItem(
-                        entry,
+                using: { record in
+                    self.attemptRestoreClosedItem(
+                        record,
                         preferredTabManager: preferredTabManager,
                         shouldActivate: shouldActivate
                     )
@@ -34,7 +34,7 @@ extension AppDelegate {
             guard let closedAt = manager.mostRecentLegacyClosedBrowserPanelClosedAt() else {
                 continue
             }
-            if restoreStoreItem(closedAt) {
+            if restoreStoreItem(closedAt).wasAccepted {
                 return true
             }
             if manager.reopenMostRecentlyClosedBrowserPanelFromLegacyStack() {
@@ -42,7 +42,7 @@ extension AppDelegate {
             }
         }
 
-        return restoreStoreItem(nil)
+        return restoreStoreItem(nil).wasAccepted
     }
 
     private func recentlyClosedLegacyBrowserManagers(preferredTabManager: TabManager?) -> [TabManager] {
@@ -55,23 +55,44 @@ extension AppDelegate {
         }
     }
 
-    @discardableResult
-    private func restoreClosedItem(
-        _ entry: ClosedItemHistoryEntry,
+    private func attemptRestoreClosedItem(
+        _ record: ClosedItemHistoryRecord,
         preferredTabManager: TabManager? = nil,
         shouldActivate: Bool
-    ) -> Bool {
-        switch entry {
+    ) -> ClosedItemHistoryRestoreAttempt {
+        switch record.entry {
         case .panel(let panelEntry):
             let manager =
                 tabManagerFor(tabId: panelEntry.workspaceId)
                 ?? preferredTabManager
                 ?? tabManager
             guard let manager, manager.restoreClosedPanel(panelEntry) else {
-                return false
+                return .failed
             }
             activateMainWindowIfNeeded(for: manager, shouldActivate: shouldActivate)
-            return true
+            return .restored
+        case .remoteTmuxMirror(let remoteEntry):
+            if let restored = remoteTmuxController.restoreClosedMirrorIfAlreadyLive(
+                remoteEntry,
+                shouldActivate: shouldActivate
+            ) {
+                return restored ? .restored : .failed
+            }
+            Task { @MainActor in
+                let succeeded = await remoteTmuxController.restoreClosedMirror(
+                    remoteEntry,
+                    preferredTabManager: preferredTabManager,
+                    shouldActivate: shouldActivate
+                )
+                ClosedItemHistoryStore.shared.completePendingRestore(
+                    id: record.id,
+                    succeeded: succeeded
+                )
+                if !succeeded {
+                    NSSound.beep()
+                }
+            }
+            return .pending
         case .workspace(let workspaceEntry):
             let manager =
                 workspaceEntry.windowId.flatMap { tabManagerFor(windowId: $0) }
@@ -84,10 +105,10 @@ extension AppDelegate {
                     excludingWorkspaceIds: liveWorkspaceIdSet(preferredTabManager: preferredTabManager)
                   )
             else {
-                return false
+                return .failed
             }
             activateMainWindowIfNeeded(for: manager, shouldActivate: shouldActivate)
-            return true
+            return .restored
         case .window(let windowEntry):
             var restoredPanelIdsByWorkspaceIndex: [[UUID: UUID]] = []
             var restoredTabManager: TabManager?
@@ -127,14 +148,14 @@ extension AppDelegate {
                     ClosedItemHistoryStore.shared.flushPendingSaves()
                 }
                 discardMainWindowWithoutClosedHistory(windowId: windowId)
-                return false
+                return .failed
             }
             restoredTabManager?.remapClosedPanelHistoryAfterSessionRestore(
                 originalWorkspaceIds: originalWorkspaceIdsByIndex,
                 restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex,
                 ambiguousOriginalWorkspaceIds: excludedWorkspaceIds
             )
-            return true
+            return .restored
         }
     }
 
@@ -142,22 +163,15 @@ extension AppDelegate {
     func reopenClosedHistoryItem(
         id: UUID,
         preferredTabManager: TabManager? = nil,
-        shouldActivate: Bool = true
+        shouldActivate: Bool = false
     ) -> Bool {
-        guard let removed = ClosedItemHistoryStore.shared.removeRecord(id: id) else {
-            return false
-        }
-
-        if restoreClosedItem(
-            removed.record.entry,
-            preferredTabManager: preferredTabManager,
-            shouldActivate: shouldActivate
-        ) {
-            return true
-        }
-
-        ClosedItemHistoryStore.shared.insert(removed.record, at: removed.index)
-        return false
+        ClosedItemHistoryStore.shared.attemptRestore(id: id) { record in
+            attemptRestoreClosedItem(
+                record,
+                preferredTabManager: preferredTabManager,
+                shouldActivate: shouldActivate
+            )
+        }.wasAccepted
     }
 
     private func activateMainWindowIfNeeded(for manager: TabManager, shouldActivate: Bool) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1020,6 +1020,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didBootstrapInitialMainWindow = false
     var isTerminatingApp = false
     private var closedWindowHistorySuppressedWindowIds: Set<UUID> = []
+    private var closedWindowHistoryRecordedWindowIds: Set<UUID> = []
 #if DEBUG
     var closeMainWindowContainingTabIdObserverForTesting: ((UUID, Bool) -> Void)?
 #endif
@@ -8889,6 +8890,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         controller.onClose = { [weak self, weak controller] in
             guard let self, let controller else { return }
             let manager = self.tabManagerFor(windowId: windowId)
+            if let context = self.mainWindowContexts.values.first(where: { $0.windowId == windowId }) {
+                self.recordClosedWindowHistoryIfNeeded(for: context)
+            }
             // An explicit close of the window's LAST remote workspace (a tab/session
             // close) kills its remote session(s) — synced with tmux — even though it
             // also closes the app window. A plain window/quit close leaves the marker
@@ -14428,7 +14432,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if matchConfiguredShortcut(event: event, action: .reopenClosedBrowserPanel) {
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
-            _ = reopenMostRecentlyClosedItem(preferredTabManager: routedManager)
+            _ = reopenMostRecentlyClosedItem(
+                preferredTabManager: routedManager,
+                shouldActivate: true
+            )
             return true
         }
 
@@ -16541,6 +16548,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 preserveManualRestoreBackupOnMissingPrimary: closingWindowIsCrashDiagnostic
             )
         }
+        closedWindowHistoryRecordedWindowIds.remove(removed.windowId)
     }
 
     private func closeWindowSnapshotPruningCrashDiagnostics(
@@ -16567,29 +16575,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func recordClosedWindowHistoryIfNeeded(for context: MainWindowContext) {
-        let shouldSuppressClosedWindowHistory = closedWindowHistorySuppressedWindowIds.remove(context.windowId) != nil
-        guard !shouldSuppressClosedWindowHistory,
-              !isTerminatingApp,
-              !isApplyingSessionRestore else {
+        if closedWindowHistorySuppressedWindowIds.remove(context.windowId) != nil {
+            closedWindowHistoryRecordedWindowIds.insert(context.windowId)
             return
         }
+        guard !isTerminatingApp,
+              !isApplyingSessionRestore,
+              closedWindowHistoryRecordedWindowIds.insert(context.windowId).inserted else {
+            return
+        }
+
+        // Capture remote mirrors while their controller registrations and live
+        // connection identities still exist. Session snapshots intentionally omit
+        // them, so the ordinary window snapshot alone cannot represent this close.
+        let remoteMirrorEntries: [ClosedRemoteTmuxMirrorHistoryEntry] = context.tabManager.tabs.enumerated().compactMap { index, workspace in
+            guard workspace.isRemoteTmuxMirror else { return nil }
+            return remoteTmuxController.closedMirrorHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: context.windowId,
+                workspaceIndex: index
+            )
+        }
+
         let restorableAgentIndex = SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
             ?? RestorableAgentSessionIndex.load()
-        guard let snapshot = closeWindowSnapshotPruningCrashDiagnostics(
+        if let snapshot = closeWindowSnapshotPruningCrashDiagnostics(
             for: context,
             includeScrollback: true,
             restorableAgentIndex: restorableAgentIndex
-        ).snapshot else {
-            return
+        ).snapshot,
+           !snapshot.tabManager.workspaces.isEmpty {
+            // Preserve the existing synchronous local-window history ordering.
+            ClosedItemHistoryStore.shared.push(.window(ClosedWindowHistoryEntry(
+                windowId: context.windowId,
+                snapshot: snapshot,
+                workspaceIds: snapshot.tabManager.workspaces.compactMap(\.workspaceId)
+            )))
         }
-        guard !snapshot.tabManager.workspaces.isEmpty else {
-            return
+
+        // Push after the local window record, in the manager's workspace order.
+        // Remote entries remain memory-only and retain their independent 20-record cap.
+        for entry in remoteMirrorEntries {
+            ClosedItemHistoryStore.shared.pushRemoteTmuxMirror(entry)
         }
-        ClosedItemHistoryStore.shared.push(.window(ClosedWindowHistoryEntry(
-            windowId: context.windowId,
-            snapshot: snapshot,
-            workspaceIds: snapshot.tabManager.workspaces.compactMap(\.workspaceId)
-        )))
     }
 
 #if DEBUG

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -62,10 +62,19 @@ struct ClosedWindowHistoryEntry: Codable {
     }
 }
 
+struct ClosedRemoteTmuxMirrorHistoryEntry: Codable {
+    let host: RemoteTmuxHost
+    let sessionName: String
+    let sessionId: Int?
+    let windowId: UUID?
+    let workspaceIndex: Int
+}
+
 enum ClosedItemHistoryEntry: Codable {
     case panel(ClosedPanelHistoryEntry)
     case workspace(ClosedWorkspaceHistoryEntry)
     case window(ClosedWindowHistoryEntry)
+    case remoteTmuxMirror(ClosedRemoteTmuxMirrorHistoryEntry)
 }
 
 struct ClosedItemHistoryRecord: Identifiable, Codable {
@@ -124,6 +133,21 @@ enum ClosedWindowRestoreValidation {
     }
 }
 
+enum ClosedItemHistoryRestoreAttempt {
+    case restored
+    case failed
+    case pending
+
+    var wasAccepted: Bool {
+        switch self {
+        case .restored, .pending:
+            return true
+        case .failed:
+            return false
+        }
+    }
+}
+
 @MainActor
 final class ClosedItemHistoryStore: ObservableObject {
     static let defaultWorkspaceCapacity = 100
@@ -141,6 +165,7 @@ final class ClosedItemHistoryStore: ObservableObject {
     private var needsPersistenceAfterPersistedRecordsLoad = false
     private var shouldDiscardPersistedRecordsOnLoad = false
     private var pendingPersistedRecordMutations: [PendingPersistedRecordMutation] = []
+    private var pendingRestoreRecordIds: Set<UUID> = []
 
     private enum PendingPersistedRecordMutation {
         case remapPanelWorkspaceIds(
@@ -195,6 +220,18 @@ final class ClosedItemHistoryStore: ObservableObject {
         persistRecords()
     }
 
+    func pushRemoteTmuxMirror(_ entry: ClosedRemoteTmuxMirrorHistoryEntry) {
+        records.removeAll { record in
+            guard case .remoteTmuxMirror(let existing) = record.entry else { return false }
+            return Self.remoteTmuxMirrorIdentityMatches(existing, entry)
+        }
+        records.append(ClosedItemHistoryRecord(entry: .remoteTmuxMirror(entry)))
+        trimRemoteTmuxMirrorRecordsIfNeeded()
+        trimToCapacityIfNeeded()
+        revision &+= 1
+        persistRecords()
+    }
+
     @discardableResult
     func restoreFirstRestorable(using restore: (ClosedItemHistoryEntry) -> Bool) -> Bool {
         restoreFirstRestorable(newerThan: nil, using: restore)
@@ -208,6 +245,25 @@ final class ClosedItemHistoryStore: ObservableObject {
         onFailure: ((UUID) -> Void)? = nil,
         using restore: (ClosedItemHistoryEntry) -> Bool
     ) -> Bool {
+        attemptFirstRestorable(
+            newerThan: cutoff,
+            excluding: excludedRecordIds,
+            matching: isCandidate,
+            onFailure: onFailure,
+            using: { record in
+                restore(record.entry) ? .restored : .failed
+            }
+        ).wasAccepted
+    }
+
+    @discardableResult
+    func attemptFirstRestorable(
+        newerThan cutoff: Date?,
+        excluding excludedRecordIds: Set<UUID> = [],
+        matching isCandidate: (ClosedItemHistoryEntry) -> Bool = { _ in true },
+        onFailure: ((UUID) -> Void)? = nil,
+        using restore: (ClosedItemHistoryRecord) -> ClosedItemHistoryRestoreAttempt
+    ) -> ClosedItemHistoryRestoreAttempt {
         let candidates = records.enumerated()
             .filter { _, record in
                 guard !excludedRecordIds.contains(record.id) else { return false }
@@ -221,24 +277,66 @@ final class ClosedItemHistoryStore: ObservableObject {
                 }
                 return lhs.offset > rhs.offset
             }
-            .map { _, record in (id: record.id, entry: record.entry) }
+            .map { _, record in record }
         for candidate in candidates {
-            guard restore(candidate.entry) else {
+            if pendingRestoreRecordIds.contains(candidate.id) {
+                return .pending
+            }
+            let attempt = restore(candidate)
+            switch attempt {
+            case .restored:
+                removeRestoredRecord(id: candidate.id)
+                return .restored
+            case .pending:
+                pendingRestoreRecordIds.insert(candidate.id)
+                return .pending
+            case .failed:
                 onFailure?(candidate.id)
-                continue
             }
-            if let index = records.firstIndex(where: { $0.id == candidate.id }) {
-                records.remove(at: index)
-                revision &+= 1
-                persistRecords()
-            }
-            return true
         }
-        return false
+        return .failed
+    }
+
+    @discardableResult
+    func attemptRestore(
+        id: UUID,
+        using restore: (ClosedItemHistoryRecord) -> ClosedItemHistoryRestoreAttempt
+    ) -> ClosedItemHistoryRestoreAttempt {
+        if pendingRestoreRecordIds.contains(id) {
+            return .pending
+        }
+        guard let record = records.first(where: { $0.id == id }) else {
+            return .failed
+        }
+        let attempt = restore(record)
+        switch attempt {
+        case .restored:
+            removeRestoredRecord(id: id)
+        case .pending:
+            pendingRestoreRecordIds.insert(id)
+        case .failed:
+            break
+        }
+        return attempt
+    }
+
+    func completePendingRestore(id: UUID, succeeded: Bool) {
+        guard pendingRestoreRecordIds.remove(id) != nil else { return }
+        if succeeded {
+            removeRestoredRecord(id: id)
+        }
+    }
+
+    private func removeRestoredRecord(id: UUID) {
+        guard let index = records.firstIndex(where: { $0.id == id }) else { return }
+        records.remove(at: index)
+        revision &+= 1
+        persistRecords()
     }
 
     func removeRecord(id: UUID) -> (record: ClosedItemHistoryRecord, index: Int)? {
-        guard let index = records.firstIndex(where: { $0.id == id }) else {
+        guard !pendingRestoreRecordIds.contains(id),
+              let index = records.firstIndex(where: { $0.id == id }) else {
             return nil
         }
         let record = records.remove(at: index)
@@ -335,6 +433,7 @@ final class ClosedItemHistoryStore: ObservableObject {
     }
 
     func removeAll() {
+        pendingRestoreRecordIds.removeAll(keepingCapacity: false)
         guard !records.isEmpty || !didFinishPersistedRecordsLoad else { return }
         if !didFinishPersistedRecordsLoad {
             shouldDiscardPersistedRecordsOnLoad = true
@@ -349,13 +448,37 @@ final class ClosedItemHistoryStore: ObservableObject {
         records = capacityPolicy.trimming(records)
         return records.count != previousCount
     }
+
+    private func trimRemoteTmuxMirrorRecordsIfNeeded() {
+        let remoteRecordIndices = records.indices.filter {
+            guard case .remoteTmuxMirror = records[$0].entry else { return false }
+            return true
+        }
+        let overflow = remoteRecordIndices.count - 20
+        guard overflow > 0 else { return }
+        for index in remoteRecordIndices.prefix(overflow).reversed() {
+            records.remove(at: index)
+        }
+    }
+
+    private static func remoteTmuxMirrorIdentityMatches(
+        _ lhs: ClosedRemoteTmuxMirrorHistoryEntry,
+        _ rhs: ClosedRemoteTmuxMirrorHistoryEntry
+    ) -> Bool {
+        guard lhs.host == rhs.host else { return false }
+        if let lhsSessionId = lhs.sessionId, let rhsSessionId = rhs.sessionId {
+            return lhsSessionId == rhsSessionId
+        }
+        return lhs.sessionName == rhs.sessionName
+    }
+
     private func persistRecords() {
         guard let fileURL else { return }
         guard didFinishPersistedRecordsLoad else {
             needsPersistenceAfterPersistedRecordsLoad = true
             return
         }
-        let recordsSnapshot = records
+        let recordsSnapshot = records.filter(Self.shouldPersist)
         let revisionSnapshot = revision
         if persistsRecordsSynchronously {
             Self.saveRecords(recordsSnapshot, fileURL: fileURL)
@@ -376,7 +499,7 @@ final class ClosedItemHistoryStore: ObservableObject {
             finishPersistedRecordsLoad(Self.loadRecords(fileURL: fileURL))
         }
         needsPersistenceAfterPersistedRecordsLoad = false
-        let recordsSnapshot = records
+        let recordsSnapshot = records.filter(Self.shouldPersist)
         let revisionSnapshot = revision
         if persistsRecordsSynchronously {
             Self.saveRecords(recordsSnapshot, fileURL: fileURL)
@@ -543,17 +666,31 @@ final class ClosedItemHistoryStore: ObservableObject {
     ) -> (records: [ClosedItemHistoryRecord], didUpdate: Bool) {
         var didUpdate = false
         let remappedRecords = records.map { record in
-            guard case .workspace(let workspaceEntry) = record.entry,
-                  workspaceEntry.windowId == oldWindowId else {
+            switch record.entry {
+            case .workspace(let workspaceEntry) where workspaceEntry.windowId == oldWindowId:
+                didUpdate = true
+                return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .workspace(ClosedWorkspaceHistoryEntry(
+                    workspaceId: workspaceEntry.workspaceId,
+                    windowId: newWindowId,
+                    workspaceIndex: workspaceEntry.workspaceIndex,
+                    snapshot: workspaceEntry.snapshot
+                )))
+            case .remoteTmuxMirror(let remoteEntry) where remoteEntry.windowId == oldWindowId:
+                didUpdate = true
+                return ClosedItemHistoryRecord(
+                    id: record.id,
+                    closedAt: record.closedAt,
+                    entry: .remoteTmuxMirror(ClosedRemoteTmuxMirrorHistoryEntry(
+                        host: remoteEntry.host,
+                        sessionName: remoteEntry.sessionName,
+                        sessionId: remoteEntry.sessionId,
+                        windowId: newWindowId,
+                        workspaceIndex: remoteEntry.workspaceIndex
+                    ))
+                )
+            default:
                 return record
             }
-            didUpdate = true
-            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .workspace(ClosedWorkspaceHistoryEntry(
-                workspaceId: workspaceEntry.workspaceId,
-                windowId: newWindowId,
-                workspaceIndex: workspaceEntry.workspaceIndex,
-                snapshot: workspaceEntry.snapshot
-            )))
         }
         return (remappedRecords, didUpdate)
     }
@@ -629,6 +766,11 @@ final class ClosedItemHistoryStore: ObservableObject {
         }
     }
 
+    private static func shouldPersist(_ record: ClosedItemHistoryRecord) -> Bool {
+        guard case .remoteTmuxMirror = record.entry else { return true }
+        return false
+    }
+
     nonisolated private static func defaultHistoryFileURL(
         bundleIdentifier: String? = Bundle.main.bundleIdentifier,
         appSupportDirectory: URL? = nil,
@@ -680,6 +822,13 @@ final class ClosedItemHistoryStore: ObservableObject {
                 id: record.id,
                 title: String(localized: "menu.history.recentlyClosed.kind.window", defaultValue: "Window"),
                 detail: windowWorkspaceCountLabel(entry.snapshot.tabManager.workspaces.count),
+                closedAt: record.closedAt
+            )
+        case .remoteTmuxMirror(let entry):
+            return ClosedItemHistoryMenuItem(
+                id: record.id,
+                title: entry.sessionName,
+                detail: String(localized: "menu.history.recentlyClosed.kind.workspace", defaultValue: "Workspace"),
                 closedAt: record.closedAt
             )
         }

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -39,14 +39,19 @@ final class RemoteTmuxControlConnection {
             switch connectionState {
             case .connected:
                 finishConnectionWaiters(connected: true)
+                finishInitialAttemptWaiters(connected: true)
             case .ended:
                 finishConnectionWaiters(connected: false)
-            case .connecting, .reconnecting:
+                finishInitialAttemptWaiters(connected: false)
+            case .reconnecting:
+                finishInitialAttemptWaiters(connected: false)
+            case .connecting:
                 break
             }
         }
     }
     private(set) var sessionId: Int?
+    var stableSessionId: Int? { sessionId ?? initialSessionId }
     var windowsByID: [Int: RemoteTmuxWindow] = [:]
     var windowOrder: [Int] = []
     var publishedWindowIdByPane: [Int: Int] = [:]
@@ -129,6 +134,7 @@ final class RemoteTmuxControlConnection {
     var windowReorderVerificationGeneration: UInt64?
     var windowReorderVerifications: [UInt64: (Bool) -> Void] = [:]
     private var connectionWaiters: [UUID: (Bool) -> Void] = [:]
+    private var initialAttemptWaiters: [UUID: (Bool) -> Void] = [:]
     /// `false` until the attach command's own `%begin`/`%end` block — always the
     /// FIRST block on each control stream, preceding every notification — has been
     /// consumed. That first block is matched explicitly (see the `.commandResult`
@@ -138,6 +144,7 @@ final class RemoteTmuxControlConnection {
     /// produces a fresh attach block).
     private var attachBlockDrained = false
     private let createIfMissing: Bool
+    private let initialSessionId: Int?
 
     /// Stateless pure decoders for control-mode message payloads (pane-state seed,
     /// window reorder, session-gone classification). Holds no state.
@@ -310,11 +317,13 @@ final class RemoteTmuxControlConnection {
         host: RemoteTmuxHost,
         sessionName: String,
         createIfMissing: Bool = false,
+        initialSessionId: Int? = nil,
         pendingPaneSeedByteLimit: Int = RemoteTmuxControlConnection.maximumPendingPaneSeedBytes
     ) {
         self.host = host
         self.sessionName = sessionName
         self.createIfMissing = createIfMissing
+        self.initialSessionId = initialSessionId
         self.pendingPaneSeedByteLimit = max(0, pendingPaneSeedByteLimit)
     }
 
@@ -322,20 +331,25 @@ final class RemoteTmuxControlConnection {
     func start() throws {
         guard !started else { return }
         try host.ensureControlSocketDirectory()
-        // The initial connect honors `createIfMissing`; reconnects never create.
-        try spawnProcess(createIfMissing: createIfMissing)
+        // Initial connects and reconnects target the immutable tmux session id
+        // whenever one is known. A mutable name is only the final fallback.
+        let attachTarget = createIfMissing
+            ? sessionName
+            : stableSessionId.map { "$\($0)" } ?? sessionName
+        try spawnProcess(createIfMissing: createIfMissing, attachTarget: attachTarget)
         started = true
     }
-
-    /// Suspends until the control stream really enters tmux control mode, or until
-    /// the connection reaches a permanent end. Launch success alone is not enough:
-    /// `ssh` can start and then fail authentication/session attach before tmux emits
-    /// `%enter`.
-    func waitUntilConnected() async -> Bool {
+    /// Suspends until the control stream really enters tmux control mode. Normal
+    /// callers may wait through reconnects until a permanent end; restore callers
+    /// can fail after the initial stream attempt so history remains retryable
+    /// instead of being held pending by the long-lived reconnect policy.
+    func waitUntilConnected(allowingReconnect: Bool = true) async -> Bool {
         switch connectionState {
         case .connected:
             return true
         case .ended:
+            return false
+        case .reconnecting where !allowingReconnect:
             return false
         case .connecting, .reconnecting:
             break
@@ -351,21 +365,37 @@ final class RemoteTmuxControlConnection {
                 case .ended:
                     continuation.resume(returning: false)
                     return
+                case .reconnecting where !allowingReconnect:
+                    continuation.resume(returning: false)
+                    return
                 case .connecting, .reconnecting:
                     break
                 }
 
-                connectionWaiters[token] = { connected in
+                let waiter: (Bool) -> Void = { connected in
                     continuation.resume(returning: connected)
+                }
+                if allowingReconnect {
+                    connectionWaiters[token] = waiter
+                } else {
+                    initialAttemptWaiters[token] = waiter
                 }
 
                 if Task.isCancelled {
-                    finishConnectionWaiter(token, connected: false)
+                    finishConnectionWaiter(
+                        token,
+                        allowingReconnect: allowingReconnect,
+                        connected: false
+                    )
                 }
             }
         } onCancel: {
             Task { @MainActor [weak self] in
-                self?.finishConnectionWaiter(token, connected: false)
+                self?.finishConnectionWaiter(
+                    token,
+                    allowingReconnect: allowingReconnect,
+                    connected: false
+                )
             }
         }
     }
@@ -378,7 +408,7 @@ final class RemoteTmuxControlConnection {
     /// - Parameter createIfMissing: `true` only for the initial connect. Reconnect
     ///   attempts pass `false` (`attach-session`), so a session killed during the
     ///   outage fails the re-attach (→ `.ended`) instead of being silently recreated.
-    private func spawnProcess(createIfMissing: Bool) throws {
+    private func spawnProcess(createIfMissing: Bool, attachTarget: String? = nil) throws {
         // A fresh control stream cannot retain the prior parser or command FIFO.
         #if DEBUG
         cmuxDebugLog("remote.stream.reset pendingCommands=\(pendingCommands.count) createIfMissing=\(createIfMissing)")
@@ -402,7 +432,7 @@ final class RemoteTmuxControlConnection {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: RemoteTmuxHost.defaultSSHExecutablePath())
         proc.arguments = host.controlModeArguments(
-            sessionName: sessionName,
+            sessionName: attachTarget ?? sessionName,
             createIfMissing: createIfMissing
         )
         let inPipe = Pipe(), outPipe = Pipe(), errPipe = Pipe()
@@ -501,8 +531,25 @@ final class RemoteTmuxControlConnection {
         }
     }
 
-    private func finishConnectionWaiter(_ token: UUID, connected: Bool) {
-        connectionWaiters.removeValue(forKey: token)?(connected)
+    private func finishInitialAttemptWaiters(connected: Bool) {
+        guard !initialAttemptWaiters.isEmpty else { return }
+        let waiters = Array(initialAttemptWaiters.values)
+        initialAttemptWaiters.removeAll()
+        for waiter in waiters {
+            waiter(connected)
+        }
+    }
+
+    private func finishConnectionWaiter(
+        _ token: UUID,
+        allowingReconnect: Bool,
+        connected: Bool
+    ) {
+        if allowingReconnect {
+            connectionWaiters.removeValue(forKey: token)?(connected)
+        } else {
+            initialAttemptWaiters.removeValue(forKey: token)?(connected)
+        }
     }
 
     /// Detaches: terminating ssh kills the control client but leaves the remote
@@ -766,7 +813,8 @@ final class RemoteTmuxControlConnection {
     private func attemptReconnectSpawn() {
         record("reconnect-attempt")
         do {
-            try spawnProcess(createIfMissing: false)
+            let attachTarget = stableSessionId.map { "$\($0)" } ?? sessionName
+            try spawnProcess(createIfMissing: false, attachTarget: attachTarget)
         } catch {
             scheduleReconnectAttempt()
         }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -89,31 +89,57 @@ final class RemoteTmuxController {
     // MARK: - Control connections (tmux -CC mirroring)
 
     /// Attaches a `tmux -CC` control connection to `sessionName` on `host`,
-    /// reusing an existing live connection for the same host+session.
+    /// reusing an existing live connection for the same stable session id first,
+    /// then by name when the identities are not known to differ.
     @discardableResult
     func attach(
         host: RemoteTmuxHost,
         sessionName: String,
-        createIfMissing: Bool = false
+        createIfMissing: Bool = false,
+        initialSessionId: Int? = nil
     ) throws -> RemoteTmuxControlConnection {
-        let key = Self.connectionKey(host: host, sessionName: sessionName)
-        if let existing = connectionsByHostSession[key] {
-            if !existing.exited { return existing }
-            // Replace a dead connection — fully tear down the old one first so
-            // its ssh process, stdin fd, stream continuation and ingest task
-            // don't leak.
-            removeCachedConnection(forKey: key)?.stop()
+        if let initialSessionId,
+           let stableMatch = connectionsByHostSession.values.first(where: {
+               $0.host.connectionHash == host.connectionHash
+                   && $0.stableSessionId == initialSessionId
+           }) {
+            if !stableMatch.exited { return stableMatch }
+            removeCachedConnection(stableMatch)?.stop()
         }
+
+        let nameKey = Self.connectionKey(host: host, sessionName: sessionName)
+        if let existing = connectionsByHostSession[nameKey] {
+            if existing.exited {
+                removeCachedConnection(forKey: nameKey)?.stop()
+            } else if initialSessionId == nil
+                        || existing.stableSessionId == nil
+                        || existing.stableSessionId == initialSessionId {
+                return existing
+            }
+        }
+
+        let cacheKey: String
+        if let initialSessionId,
+           let existing = connectionsByHostSession[nameKey],
+           !existing.exited,
+           let existingSessionId = existing.stableSessionId,
+           existingSessionId != initialSessionId {
+            cacheKey = Self.stableConnectionKey(host: host, sessionId: initialSessionId)
+        } else {
+            cacheKey = nameKey
+        }
+
         let connection = RemoteTmuxControlConnection(
             host: host,
             sessionName: sessionName,
-            createIfMissing: createIfMissing
+            createIfMissing: createIfMissing,
+            initialSessionId: initialSessionId
         )
         // Insert only after a successful launch, so a failed `start()` never
         // leaves a dead (never-started, `exited == false`) connection that a
         // later attach would wrongly reuse.
         try connection.start()
-        cacheConnection(connection, key: key)
+        cacheConnection(connection, key: cacheKey)
         return connection
     }
 
@@ -149,12 +175,10 @@ final class RemoteTmuxController {
 
     private func stopCachedConnectionIfCurrent(
         _ connection: RemoteTmuxControlConnection,
-        host: RemoteTmuxHost,
-        sessionName: String
+        host _: RemoteTmuxHost,
+        sessionName _: String
     ) {
-        let key = Self.connectionKey(host: host, sessionName: sessionName)
-        guard connectionsByHostSession[key] === connection else { return }
-        removeCachedConnection(forKey: key)?.stop()
+        removeCachedConnection(connection)?.stop()
     }
 
     func cacheConnection(_ connection: RemoteTmuxControlConnection, key: String? = nil) {
@@ -179,6 +203,16 @@ final class RemoteTmuxController {
             connection.removeObserver(token)
         }
         return connection
+    }
+
+    @discardableResult
+    private func removeCachedConnection(
+        _ connection: RemoteTmuxControlConnection
+    ) -> RemoteTmuxControlConnection? {
+        guard let key = connectionsByHostSession.first(where: { $0.value === connection })?.key else {
+            return nil
+        }
+        return removeCachedConnection(forKey: key)
     }
 
     private func handleCachedConnectionSessionNameChanged(
@@ -294,14 +328,57 @@ final class RemoteTmuxController {
         sessionId: Int? = nil,
         into tabManager: TabManager
     ) throws -> Bool {
-        let key = Self.connectionKey(host: host, sessionName: sessionName)
-        guard sessionMirrors[key] == nil else { return false }
+        guard liveMirror(host: host, sessionName: sessionName, sessionId: sessionId) == nil else {
+            return false
+        }
         // Attach (and start the ssh process) BEFORE creating the workspace, so a
         // failed connection doesn't leave an orphaned empty mirror workspace in
         // the sidebar.
-        let connection = try attach(host: host, sessionName: sessionName)
+        let connection = try attach(
+            host: host,
+            sessionName: sessionName,
+            initialSessionId: sessionId
+        )
+        guard sessionMirrors.values.contains(where: { $0.connection === connection }) == false else {
+            return false
+        }
+        return createMirror(
+            connection: connection,
+            seededSessionId: sessionId,
+            in: tabManager
+        ) != nil
+    }
+
+    private func createMirror(
+        connection: RemoteTmuxControlConnection,
+        seededSessionId: Int?,
+        in tabManager: TabManager
+    ) -> RemoteTmuxSessionMirror? {
+        let host = connection.host
+        let canonicalSessionName = connection.sessionName
+        let stableSessionId = connection.stableSessionId ?? seededSessionId
+        guard liveMirror(
+            host: host,
+            sessionName: canonicalSessionName,
+            sessionId: stableSessionId
+        ) == nil else {
+            return nil
+        }
+
+        let nameKey = Self.connectionKey(host: host, sessionName: canonicalSessionName)
+        let key: String
+        if let existing = sessionMirrors[nameKey],
+           let stableSessionId,
+           let existingSessionId = existing.connection.stableSessionId ?? existing.seededSessionId,
+           existingSessionId != stableSessionId {
+            key = Self.stableConnectionKey(host: host, sessionId: stableSessionId)
+        } else {
+            key = nameKey
+        }
+        guard sessionMirrors[key] == nil else { return nil }
+
         let workspace = tabManager.addWorkspace(
-            title: sessionName, titleSource: .auto,
+            title: canonicalSessionName, titleSource: .auto,
             select: false,
             autoWelcomeIfNeeded: false,
             workspaceDirectoryCustomizationMode: .disabled
@@ -315,10 +392,10 @@ final class RemoteTmuxController {
                 verification: verification
             )
         }
-        sessionMirrors[key] = RemoteTmuxSessionMirror(
+        let mirror = RemoteTmuxSessionMirror(
             host: host,
-            sessionName: sessionName,
-            seededSessionId: sessionId,
+            sessionName: canonicalSessionName,
+            seededSessionId: stableSessionId,
             connection: connection,
             tabManager: tabManager,
             workspace: workspace,
@@ -327,6 +404,204 @@ final class RemoteTmuxController {
                 workspaceID: workspace.id
             )
         )
+        sessionMirrors[key] = mirror
+        return mirror
+    }
+
+    func closedMirrorHistoryEntry(
+        workspaceId: UUID,
+        windowId: UUID?,
+        workspaceIndex: Int
+    ) -> ClosedRemoteTmuxMirrorHistoryEntry? {
+        guard let mirror = sessionMirror(workspaceId: workspaceId) else { return nil }
+        return ClosedRemoteTmuxMirrorHistoryEntry(
+            host: mirror.host,
+            sessionName: mirror.sessionName,
+            sessionId: mirror.connection.sessionId ?? mirror.seededSessionId,
+            windowId: windowId,
+            workspaceIndex: workspaceIndex
+        )
+    }
+
+    func restoreClosedMirrorIfAlreadyLive(
+        _ entry: ClosedRemoteTmuxMirrorHistoryEntry,
+        shouldActivate: Bool
+    ) -> Bool? {
+        guard let mirror = liveMirror(matching: entry) else { return nil }
+        return placeRestoredMirror(
+            mirror,
+            recordedWindowId: entry.windowId,
+            workspaceIndex: entry.workspaceIndex,
+            newlyCreated: false,
+            shouldActivate: shouldActivate
+        )
+    }
+
+    @discardableResult
+    func restoreClosedMirror(
+        _ entry: ClosedRemoteTmuxMirrorHistoryEntry,
+        preferredTabManager: TabManager? = nil,
+        shouldActivate: Bool
+    ) async -> Bool {
+        if let restored = restoreClosedMirrorIfAlreadyLive(entry, shouldActivate: shouldActivate) {
+            return restored
+        }
+
+        guard let appDelegate = AppDelegate.shared,
+              restoreTargetManager(
+                  for: entry,
+                  preferredTabManager: preferredTabManager,
+                  appDelegate: appDelegate
+              ) != nil else {
+            return false
+        }
+
+        do {
+            let cachedConnectionIds = Set(connectionsByHostSession.values.map { ObjectIdentifier($0) })
+            let connection = try attach(
+                host: entry.host,
+                sessionName: entry.sessionName,
+                initialSessionId: entry.sessionId
+            )
+            let launchedForRestore = !cachedConnectionIds.contains(ObjectIdentifier(connection))
+            if let mirror = sessionMirrors.values.first(where: { $0.connection === connection }) {
+                return placeRestoredMirror(
+                    mirror,
+                    recordedWindowId: entry.windowId,
+                    workspaceIndex: entry.workspaceIndex,
+                    newlyCreated: false,
+                    shouldActivate: shouldActivate
+                )
+            }
+            guard await connection.waitUntilConnected(allowingReconnect: false) else {
+                if launchedForRestore {
+                    removeCachedConnection(connection)?.stop()
+                }
+                return false
+            }
+            if let mirror = liveMirror(matching: entry) {
+                return placeRestoredMirror(
+                    mirror,
+                    recordedWindowId: entry.windowId,
+                    workspaceIndex: entry.workspaceIndex,
+                    newlyCreated: false,
+                    shouldActivate: shouldActivate
+                )
+            }
+            guard let targetManager = restoreTargetManager(
+                for: entry,
+                preferredTabManager: preferredTabManager,
+                appDelegate: appDelegate
+            ) else {
+                if launchedForRestore {
+                    removeCachedConnection(connection)?.stop()
+                }
+                return false
+            }
+            guard let restoredMirror = createMirror(
+                connection: connection,
+                seededSessionId: entry.sessionId,
+                in: targetManager
+            ) else {
+                if launchedForRestore {
+                    removeCachedConnection(connection)?.stop()
+                }
+                return false
+            }
+            return placeRestoredMirror(
+                restoredMirror,
+                recordedWindowId: entry.windowId,
+                workspaceIndex: entry.workspaceIndex,
+                newlyCreated: true,
+                shouldActivate: shouldActivate
+            )
+        } catch {
+            return false
+        }
+    }
+
+    private func restoreTargetManager(
+        for entry: ClosedRemoteTmuxMirrorHistoryEntry,
+        preferredTabManager: TabManager?,
+        appDelegate: AppDelegate
+    ) -> TabManager? {
+        if let windowId = entry.windowId,
+           appDelegate.mainWindow(for: windowId) != nil,
+           let recordedManager = appDelegate.tabManagerFor(windowId: windowId) {
+            return recordedManager
+        }
+        if let preferredTabManager,
+           let preferredWindowId = appDelegate.windowId(for: preferredTabManager),
+           appDelegate.mainWindow(for: preferredWindowId) != nil {
+            return preferredTabManager
+        }
+        guard let currentManager = appDelegate.tabManager,
+              let currentWindowId = appDelegate.windowId(for: currentManager),
+              appDelegate.mainWindow(for: currentWindowId) != nil else {
+            return nil
+        }
+        return currentManager
+    }
+
+    private func liveMirror(
+        matching entry: ClosedRemoteTmuxMirrorHistoryEntry
+    ) -> RemoteTmuxSessionMirror? {
+        liveMirror(
+            host: entry.host,
+            sessionName: entry.sessionName,
+            sessionId: entry.sessionId
+        )
+    }
+
+    private func liveMirror(
+        host: RemoteTmuxHost,
+        sessionName: String,
+        sessionId: Int?
+    ) -> RemoteTmuxSessionMirror? {
+        let endpointMirrors = sessionMirrors.values.filter {
+            $0.host.connectionHash == host.connectionHash
+        }
+        if let sessionId,
+           let stableMatch = endpointMirrors.first(where: {
+               ($0.connection.stableSessionId ?? $0.seededSessionId) == sessionId
+           }) {
+            return stableMatch
+        }
+        return endpointMirrors.first {
+            guard $0.sessionName == sessionName else { return false }
+            guard let sessionId,
+                  let candidateSessionId = $0.connection.stableSessionId ?? $0.seededSessionId else {
+                return true
+            }
+            return candidateSessionId == sessionId
+        }
+    }
+
+    private func placeRestoredMirror(
+        _ mirror: RemoteTmuxSessionMirror,
+        recordedWindowId: UUID?,
+        workspaceIndex: Int,
+        newlyCreated: Bool,
+        shouldActivate: Bool
+    ) -> Bool {
+        guard let workspace = mirror.mirroredWorkspace,
+              let manager = workspace.owningTabManager
+                ?? AppDelegate.shared?.tabManagerFor(tabId: workspace.id) else {
+            return false
+        }
+        let recordedManager = recordedWindowId.flatMap {
+            AppDelegate.shared?.tabManagerFor(windowId: $0)
+        }
+        let isInRecordedWindow = recordedManager.map { $0 === manager } ?? false
+        if newlyCreated || isInRecordedWindow {
+            _ = manager.reorderWorkspace(tabId: workspace.id, toIndex: workspaceIndex)
+        }
+        guard shouldActivate else { return true }
+        manager.selectWorkspace(workspace)
+        if let appDelegate = AppDelegate.shared,
+           let windowId = appDelegate.windowId(for: manager) {
+            _ = appDelegate.focusMainWindow(windowId: windowId)
+        }
         return true
     }
 
@@ -795,6 +1070,10 @@ final class RemoteTmuxController {
     /// + port + identity), so the same destination reached on a different port or
     /// with a different identity file never aliases onto another endpoint's
     /// connection.
+    private static func stableConnectionKey(host: RemoteTmuxHost, sessionId: Int) -> String {
+        "\(host.connectionHash)\u{1}\u{0}id:\(sessionId)"
+    }
+
     static func connectionKey(host: RemoteTmuxHost, sessionName: String) -> String {
         "\(host.connectionHash)\u{1}\(sessionName)"
     }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -887,8 +887,14 @@ final class RemoteTmuxController {
                 manager.closeWorkspace(workspace)
             case .explicitDetach:
                 // Detach is authoritative even for a pinned final mirror. Closing
-                // its owning window avoids stranding a blank `--new-window` shell.
+                // its owning window avoids stranding a blank `--new-window` shell,
+                // and the closed window must not linger as a recoverable route —
+                // recovering it would resurrect a dead remote path.
+                let owningWindowId = manager.windowId
                 _ = manager.closeWorkspaceNonInteractively(workspace, allowPinned: true)
+                if let owningWindowId, manager.tabs.isEmpty {
+                    AppDelegate.shared?.forgetRecoverableMainWindowRoute(windowId: owningWindowId)
+                }
             }
         }
     }

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -12,7 +12,7 @@ import Foundation
 /// `CMUX_REMOTE_TMUX_SSH_FOR_TESTING` so end-to-end tests can substitute a
 /// shim that strips the ssh framing and execs the remote command locally —
 /// the full mirror stack then runs hermetically (no sshd, no network).
-struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
+struct RemoteTmuxHost: Sendable, Equatable, Identifiable, Codable {
     /// The ssh executable used when the caller doesn't inject one (the
     /// connection and transport inits both take `sshExecutablePath`).
     ///

--- a/Sources/TabManager+NonInteractiveClose.swift
+++ b/Sources/TabManager+NonInteractiveClose.swift
@@ -21,8 +21,18 @@ extension TabManager {
         guard let appDelegate = AppDelegate.shared,
               let windowId = appDelegate.windowId(for: self),
               appDelegate.mainWindow(for: windowId) != nil else { return false }
+        let remoteHistoryEntry = recordHistory && workspace.isRemoteTmuxMirror
+            ? appDelegate.remoteTmuxController.closedMirrorHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: windowId,
+                workspaceIndex: 0
+            )
+            : nil
         if workspace.isRemoteTmuxMirror {
             appDelegate.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: workspace.id)
+            if let remoteHistoryEntry {
+                ClosedItemHistoryStore.shared.pushRemoteTmuxMirror(remoteHistoryEntry)
+            }
         }
         guard appDelegate.closeMainWindow(windowId: windowId, recordHistory: recordHistory) else {
             return false

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2093,6 +2093,18 @@ class TabManager: ObservableObject {
         guard tabs.count > 1 else { return }
         panelTitleUpdateCoalescer.flushNow()
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
+        let remoteHistoryEntry: ClosedRemoteTmuxMirrorHistoryEntry?
+        if recordHistory,
+           workspace.isRemoteTmuxMirror,
+           let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
+            remoteHistoryEntry = AppDelegate.shared?.remoteTmuxController.closedMirrorHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: AppDelegate.shared?.windowId(for: self),
+                workspaceIndex: index
+            )
+        } else {
+            remoteHistoryEntry = nil
+        }
         // Closing a mirrored remote tmux workspace DETACHES from the remote session,
         // leaving it alive on the server for resume. Killing the session is never a
         // side effect of closing a tab (PR #7264 review); it is only ever an explicit
@@ -2100,9 +2112,13 @@ class TabManager: ObservableObject {
         if workspace.isRemoteTmuxMirror {
             AppDelegate.shared?.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: workspace.id)
         }
-        if recordHistory,
-           workspace.isRestorableInSessionSnapshot,
-           let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
+        if workspace.isRemoteTmuxMirror {
+            if let remoteHistoryEntry {
+                ClosedItemHistoryStore.shared.pushRemoteTmuxMirror(remoteHistoryEntry)
+            }
+        } else if recordHistory,
+                  workspace.isRestorableInSessionSnapshot,
+                  let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
             // Prefer the warm cached agent index over a synchronous
             // RestorableAgentSessionIndex.load() (sysctl-per-record + disk) so closing a
             // workspace does not freeze the main thread; fall back to a fresh load only
@@ -4182,7 +4198,7 @@ class TabManager: ObservableObject {
                 return restoreClosedPanel(panelEntry)
             case .workspace(let workspaceEntry):
                 return restoreClosedWorkspace(workspaceEntry)
-            case .window:
+            case .window, .remoteTmuxMirror:
                 return false
             }
         }) {
@@ -4208,7 +4224,7 @@ class TabManager: ObservableObject {
             didRestore = restoreClosedPanel(panelEntry)
         case .workspace(let workspaceEntry):
             didRestore = restoreClosedWorkspace(workspaceEntry)
-        case .window:
+        case .window, .remoteTmuxMirror:
             didRestore = false
         }
 

--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -364,7 +364,6 @@ import Testing
             select: false,
             autoWelcomeIfNeeded: false
         )
-        let closedLocalWorkspaceId = localWorkspace.id
         let closedLocalPanelCount = localWorkspace.panels.count
         harness.manager.closeWorkspace(localWorkspace, recordHistory: true)
         #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
@@ -443,7 +442,6 @@ import Testing
         let restoredLocalWorkspace = try #require(
             harness.manager.tabs.first(where: { $0.customTitle == localTitle })
         )
-        #expect(restoredLocalWorkspace.id != closedLocalWorkspaceId)
         #expect(!restoredLocalWorkspace.isRemoteTmuxMirror)
         #expect(restoredLocalWorkspace.panels.count == closedLocalPanelCount)
         #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 0)

--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -53,6 +53,9 @@ import Testing
     /// the local ControlMaster exit as success, so this exercises the production
     /// close route without opening a network connection.
     @Test func socketCloseOfLiveLastMirrorDetachesWithoutKillingSession() async throws {
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("remote-tmux-close-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -63,9 +66,26 @@ import Testing
             at: sshURL,
             contents: """
             #!/bin/sh
+            is_control_client=0
+            is_control_master_exit=0
+            previous=
             for arg in "$@"; do
               printf 'ARG=%s\\n' "$arg" >> "${CMUX_PR7264_SSH_LOG:?}"
+              if [ "$previous" = "-O" ] && [ "$arg" = "exit" ]; then
+                is_control_master_exit=1
+              fi
+              case "$arg" in
+                *"-CC"*) is_control_client=1 ;;
+              esac
+              previous=$arg
             done
+            if [ "$is_control_master_exit" -eq 1 ]; then
+              exit 0
+            fi
+            if [ "$is_control_client" -eq 1 ]; then
+              printf '\\033P1000p%%begin 1 1 0\\n%%end 1 1 0\\n'
+              cat >/dev/null
+            fi
             exit 0
             """
         )
@@ -130,6 +150,19 @@ import Testing
         #expect(!log.contains("kill-session"), Comment(rawValue: log))
         #expect(controller.sessionMirror(host: host, sessionName: "dev") == nil)
         #expect(connection.exited)
+        let closedHistory = ClosedItemHistoryStore.shared.menuSnapshot()
+        #expect(closedHistory.totalItemCount == 1)
+        #expect(closedHistory.items.map(\.title) == ["dev"])
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(shouldActivate: false))
+        let reattachedMirror = try await waitForRemoteMirror(
+            host: host,
+            sessionName: "dev",
+            controller: controller
+        )
+        #expect(reattachedMirror.mirroredWorkspace != nil)
+        try await waitForHistoryItemCount(0)
+
     }
 
     /// Explicit detach of a mirror opened in its own window must close that
@@ -274,6 +307,146 @@ import Testing
         #expect(harness.manager.tabs.map(\.id) == [harness.workspace.id])
         #expect(controller.sessionMirror(host: host, sessionName: "dev") == nil)
         #expect(connection.exited)
+    }
+
+    @Test func recentlyClosedRemoteMirrorCoalescesWithLiveMirrorBeforeRestoringOlderLocalWorkspace() async throws {
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("remote-tmux-reopen-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let logURL = root.appendingPathComponent("ssh.log")
+        let sshURL = root.appendingPathComponent("ssh")
+        try writeExecutable(
+            at: sshURL,
+            contents: """
+            #!/bin/sh
+            is_control_client=0
+            is_control_master_exit=0
+            previous=
+            for arg in "$@"; do
+              printf 'ARG=%s\\n' "$arg" >> "${CMUX_PR7264_SSH_LOG:?}"
+              if [ "$previous" = "-O" ] && [ "$arg" = "exit" ]; then
+                is_control_master_exit=1
+              fi
+              case "$arg" in
+                *"-CC"*) is_control_client=1 ;;
+              esac
+              previous=$arg
+            done
+            if [ "$is_control_master_exit" -eq 1 ]; then
+              exit 0
+            fi
+            if [ "$is_control_client" -eq 1 ]; then
+              printf '\\033P1000p%%begin 1 1 0\\n%%end 1 1 0\\n'
+              cat >/dev/null
+            fi
+            exit 0
+            """
+        )
+        let previousSSH = environmentValue(for: sshOverrideKey)
+        let previousLog = environmentValue(for: sshLogKey)
+        setenv(sshOverrideKey, sshURL.path, 1)
+        setenv(sshLogKey, logURL.path, 1)
+        defer {
+            restoreEnvironment(sshOverrideKey, previousValue: previousSSH)
+            restoreEnvironment(sshLogKey, previousValue: previousLog)
+        }
+
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let localTitle = "Older Local Workspace"
+        let localWorkspace = harness.manager.addWorkspace(
+            title: localTitle,
+            select: false,
+            autoWelcomeIfNeeded: false
+        )
+        let closedLocalWorkspaceId = localWorkspace.id
+        let closedLocalPanelCount = localWorkspace.panels.count
+        harness.manager.closeWorkspace(localWorkspace, recordHistory: true)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
+
+        let host = RemoteTmuxHost(destination: "reopen-\(UUID().uuidString)@example.test")
+        let sessionName = "dev"
+        let controller = harness.controller
+        defer {
+            if controller.sessionMirror(host: host, sessionName: sessionName) != nil {
+                controller.detach(host: host, sessionName: sessionName)
+            }
+        }
+
+        #expect(try controller.mirrorSession(
+            host: host,
+            sessionName: sessionName,
+            into: harness.manager
+        ))
+        let closedMirrorWorkspace = try #require(
+            harness.manager.tabs.first(where: { $0.isRemoteTmuxMirror })
+        )
+
+        harness.manager.closeWorkspace(closedMirrorWorkspace, recordHistory: true)
+
+        let detachLog = try await waitForSSHArgument("exit", at: logURL)
+        #expect(!detachLog.contains("kill-session"), Comment(rawValue: detachLog))
+        #expect(controller.sessionMirror(host: host, sessionName: sessionName) == nil)
+        let historyAfterRemoteClose = ClosedItemHistoryStore.shared.menuSnapshot()
+        #expect(historyAfterRemoteClose.totalItemCount == 2)
+        #expect(Set(historyAfterRemoteClose.items.map(\.title)) == Set([sessionName, localTitle]))
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(
+            preferredTabManager: harness.manager,
+            shouldActivate: true
+        ))
+        let reattachedMirror = try await waitForRemoteMirror(
+            host: host,
+            sessionName: sessionName,
+            controller: controller
+        )
+        let reattachedWorkspace = try #require(reattachedMirror.mirroredWorkspace)
+        #expect(harness.manager.selectedTabId == reattachedWorkspace.id)
+        #expect(reattachedWorkspace.id != closedMirrorWorkspace.id)
+        #expect(harness.manager.tabs.filter(\.isRemoteTmuxMirror).count == 1)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
+
+        harness.manager.closeWorkspace(reattachedWorkspace, recordHistory: true)
+        #expect(controller.sessionMirror(host: host, sessionName: sessionName) == nil)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 2)
+
+        #expect(try controller.mirrorSession(
+            host: host,
+            sessionName: sessionName,
+            into: harness.manager
+        ))
+        let existingMirrorWorkspaceId = try #require(
+            controller.sessionMirror(host: host, sessionName: sessionName)?.mirroredWorkspaceId
+        )
+        #expect(harness.manager.tabs.filter(\.isRemoteTmuxMirror).count == 1)
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(
+            preferredTabManager: harness.manager,
+            shouldActivate: false
+        ))
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
+        #expect(harness.manager.tabs.filter(\.isRemoteTmuxMirror).count == 1)
+        #expect(
+            controller.sessionMirror(host: host, sessionName: sessionName)?.mirroredWorkspaceId
+                == existingMirrorWorkspaceId
+        )
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(
+            preferredTabManager: harness.manager,
+            shouldActivate: false
+        ))
+        let restoredLocalWorkspace = try #require(
+            harness.manager.tabs.first(where: { $0.customTitle == localTitle })
+        )
+        #expect(restoredLocalWorkspace.id != closedLocalWorkspaceId)
+        #expect(!restoredLocalWorkspace.isRemoteTmuxMirror)
+        #expect(restoredLocalWorkspace.panels.count == closedLocalPanelCount)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 0)
     }
 
     @Test func windowCreationFailureUsesLocalErrorMessage() {
@@ -459,6 +632,31 @@ import Testing
         let log = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
         Issue.record("Timed out waiting for fake SSH argument '\(argument)': \(log)")
         return log
+    }
+
+    private func waitForRemoteMirror(
+        host: RemoteTmuxHost,
+        sessionName: String,
+        controller: RemoteTmuxController
+    ) async throws -> RemoteTmuxSessionMirror {
+        for _ in 0..<200 {
+            if let mirror = controller.sessionMirror(host: host, sessionName: sessionName) {
+                return mirror
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("Timed out waiting for the remote tmux mirror to reattach")
+        return try #require(controller.sessionMirror(host: host, sessionName: sessionName))
+    }
+
+    private func waitForHistoryItemCount(_ count: Int) async throws {
+        for _ in 0..<200 {
+            if ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == count {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == count)
     }
 
     @MainActor


### PR DESCRIPTION
## Behavior

- records remotely mirrored tmux tabs in closed-item history without treating an intentional close as a permanent remote-session deletion
- reopens the matching remote mirror by stable host/session/window identity
- keeps non-interactive close and detach behavior explicit

## Scope

Focused remote-reopen change, rebased onto current upstream `main` (`2757d9de8`). Original pre-rebase tip is preserved in Arthur-CWW/cmux as `attic/pre-rebase-remote-tmux-reopen-20260728`.

## Verification

The prepared branch included `RemoteTmuxMirrorCloseDetachTests.swift`. Post-rebase focused QA is running separately; no unobserved pass claim is made here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787877006&installation_model_id=21920&pr_number=9108&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9108&signature=79cf8f7fa4c5aeccfee79176f736a6a4d24819f4a9bad6e58d7c1c741324ceba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore closed remote tmux tabs by stable host/session identity so an intentional close can be reopened without killing or duplicating the remote session. Reopen prefers session id, coalesces with any live mirror, restores window and tab index, and supports async pending restores.

- **Bug Fixes**
  - Treat closing a remote mirror as a detach; record it on both tab and window close; avoid duplicate history.
  - Reopen by stable identity (session id > name); don’t reuse mismatched control connections; wait only for the initial attach so history stays retryable.
  - Coalesce with an existing live mirror and keep its placement; respect the recorded window when available, else fall back; reopening doesn’t auto-activate unless invoked via the shortcut.
  - Keep remote mirror history in-memory only (20-item cap), de-duped by host/session; do not persist to disk.
  - Extend closed-history with attempt/accepted/pending semantics and protect pending records; add tests for detach-on-close and reopen ordering with a live mirror and an older local workspace.

<sup>Written for commit 45cefd98178c6d6e9d0e2ac772293d7e97d66696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added closed-history support for remote tmux mirror sessions.
  * Reopening closed items now supports asynchronous restoration with improved session reattachment.
  * Recently closed items no longer auto-activate by default.

* **Bug Fixes**
  * Prevented duplicate closed-window history entries.
  * Improved remote session reconnect behavior while preserving active tmux sessions.
  * Refined trimming and restoration handling for pending operations.

* **Tests**
  * Expanded coverage for remote mirror closing, detaching, reopening, and reattachment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->