### PR TITLE
feat: add atomic cmux goto navigation

### DIFF
--- a/CLI/CMUXCLI+CommandSuggestions.swift
+++ b/CLI/CMUXCLI+CommandSuggestions.swift
@@ -102,6 +102,7 @@ extension CMUXCLI {
         "focus-panel",
         "focus-webview",
         "focus-window",
+        "goto",
         "get-url",
         "help",
         "hooks",

--- a/CLI/CMUXCLI+OmpExtension.swift
+++ b/CLI/CMUXCLI+OmpExtension.swift
@@ -12,7 +12,99 @@ extension CMUXCLI {
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { AgentEndEvent, ExtensionAPI, ExtensionContext } from "@oh-my-pi/pi-coding-agent";
+import type { AgentEndEvent } from "@oh-my-pi/pi-coding-agent/extensibility/shared-events";
+import type { ExtensionAPI, ExtensionContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";
+
+const RESUME_LAUNCH_MARKER = "--cmux-omp-resume-launch";
+const EXTENSION_PATH = import.meta.path;
+const HOOK_TIMEOUT_MS = 1_500;
+const HOOK_FIELD_LIMIT = 4_096;
+
+export type ResumeFallbackDecision = "exit" | "picker";
+
+export function decideResumeFallback(exitCode: number, stderr: string): ResumeFallbackDecision {
+  return exitCode !== 0 && /Session "[^"]+" not found\./.test(stderr) ? "picker" : "exit";
+}
+
+export function isNestedSessionJournal(sessionFile: string | undefined): boolean {
+  if (!sessionFile) return false;
+  const parts = path.normalize(sessionFile).split(path.sep);
+  const sessionsIndex = parts.lastIndexOf("sessions");
+  return sessionsIndex >= 0 && parts.length - sessionsIndex > 3;
+}
+
+export function stripSessionSelectorArgs(argv: readonly string[]): string[] {
+  const stripped: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--resume" || value === "-r" || value === "--session") {
+      const next = argv[index + 1];
+      if (next !== undefined && !next.startsWith("-")) index += 1;
+      continue;
+    }
+    stripped.push(value);
+  }
+  return stripped;
+}
+
+export function restorableLaunchArgv(
+  launchArgv: readonly string[],
+  runtime = process.execPath,
+  extensionPath = EXTENSION_PATH,
+): string[] {
+  const baseArgv = stripSessionSelectorArgs(launchArgv);
+  return [runtime, extensionPath, RESUME_LAUNCH_MARKER, base64NulSeparated(baseArgv)];
+}
+
+interface ChildResult {
+  exitCode: number;
+  stderr: string;
+}
+
+async function runChild(executable: string, args: string[]): Promise<ChildResult> {
+  const child = spawn(executable, args, { stdio: ["inherit", "inherit", "pipe"] });
+  const chunks: Buffer[] = [];
+  child.stderr.on("data", (chunk: Buffer) => {
+    chunks.push(chunk);
+    process.stderr.write(chunk);
+  });
+  const result = Promise.withResolvers<ChildResult>();
+  child.on("error", (error) => result.resolve({ exitCode: 1, stderr: error.message }));
+  child.on("close", (code) => result.resolve({ exitCode: code ?? 1, stderr: Buffer.concat(chunks).toString("utf8") }));
+  return result.promise;
+}
+
+function decodeNulSeparated(encoded: string): string[] {
+  return Buffer.from(encoded, "base64").toString("utf8").split("\0").filter(Boolean);
+}
+
+async function runResumeLaunch(args: string[]): Promise<number> {
+  const [encodedLaunchArgv, ...resumeArgs] = args;
+  const launchArgv = encodedLaunchArgv ? decodeNulSeparated(encodedLaunchArgv) : [];
+  const executable = launchArgv[0];
+  if (!executable) {
+    process.stderr.write("cmux restore could not determine the OMP executable; starting a new session.\n");
+    return (await runChild(resolveExecutable("omp"), [])).exitCode;
+  }
+
+  const baseArgs = stripSessionSelectorArgs(launchArgv.slice(1));
+  const attempted = await runChild(executable, [...baseArgs, ...resumeArgs]);
+  if (decideResumeFallback(attempted.exitCode, attempted.stderr) === "exit") return attempted.exitCode;
+
+  process.stderr.write("\nSaved cmux session is unavailable; opening the OMP session picker instead.\n");
+  return (await runChild(executable, [...baseArgs, "--resume"])).exitCode;
+}
+
+const resumeLaunchMarkerIndex = process.argv.indexOf(RESUME_LAUNCH_MARKER);
+if (resumeLaunchMarkerIndex >= 0) {
+  void runResumeLaunch(process.argv.slice(resumeLaunchMarkerIndex + 1)).then(
+    (code) => process.exit(code),
+    (error: unknown) => {
+      process.stderr.write(`cmux OMP restore failed: ${error instanceof Error ? error.message : String(error)}\n`);
+      process.exit(1);
+    },
+  );
+}
 
 function firstString(...values: unknown[]): string | null {
   for (const value of values) {
@@ -22,6 +114,16 @@ function firstString(...values: unknown[]): string | null {
 }
 
 function resolveExecutable(name: string): string {
+  if (name === "omp") {
+    const home = process.env.HOME || "";
+    if (home) {
+      const localOmp = path.join(home, ".local", "bin", "omp");
+      try {
+        fs.accessSync(localOmp, fs.constants.X_OK);
+        if (fs.statSync(localOmp).isFile()) return localOmp;
+      } catch (_) {}
+    }
+  }
   const pathEnv = process.env.PATH || "";
   for (const dir of pathEnv.split(path.delimiter)) {
     if (!dir) continue;
@@ -72,15 +174,19 @@ function base64NulSeparated(values: string[]): string {
   return Buffer.concat(bytes).toString("base64");
 }
 
+function boundedHookText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.length > HOOK_FIELD_LIMIT ? `${value.slice(0, HOOK_FIELD_LIMIT)}\n[truncated]` : value;
+}
+
 function hookEnvironment(cwd: string): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
-  if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
-    const argv = normalizedLaunchArgv();
-    env.CMUX_AGENT_LAUNCH_KIND = "omp";
-    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolveExecutable("omp");
-    env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
-    env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
-  }
+  const argv = restorableLaunchArgv(normalizedLaunchArgv());
+  env.CMUX_AGENT_LAUNCH_KIND = "omp";
+  env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || process.execPath;
+  env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
+  env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
+  env.CMUX_OMP_HOOK_DISPATCH = "1";
   return env;
 }
 
@@ -99,6 +205,8 @@ function eventName(subcommand: string): string {
       return "UserPromptSubmit";
     case "stop":
       return "Stop";
+    case "session-end":
+      return "SessionEnd";
     default:
       return subcommand;
   }
@@ -129,19 +237,26 @@ function lastAssistantMessage(event: AgentEndEvent): string | undefined {
 }
 
 function hookInvocation(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): HookInvocation | null {
-  if (process.env.CMUX_OMP_HOOKS_DISABLED === "1") return null;
+  if (process.env.CMUX_OMP_HOOKS_DISABLED === "1" || process.env.CMUX_OMP_HOOK_DISPATCH === "1") return null;
   if (!process.env.CMUX_SURFACE_ID) return null;
+  if (isNestedSessionJournal(ctx.sessionManager.getSessionFile())) return null;
 
   const sessionId = firstString(ctx.sessionManager.getSessionId());
   if (!sessionId) return null;
 
   const cwd = firstString(ctx.cwd, process.cwd()) || process.cwd();
+  const boundedExtra = Object.fromEntries(
+    Object.entries(extra).flatMap(([key, value]) => {
+      const bounded = boundedHookText(value);
+      return bounded === undefined ? [] : [[key, bounded]];
+    }),
+  );
   const payload: Record<string, unknown> = {
     session_id: sessionId,
     cwd,
     hook_event_name: eventName(subcommand),
     event: eventName(subcommand),
-    ...extra,
+    ...boundedExtra,
   };
   const cmux = process.env.CMUX_OMP_CMUX_BIN || "cmux";
   return {
@@ -155,28 +270,34 @@ function hookInvocation(subcommand: string, ctx: ExtensionContext, extra: Record
 async function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): Promise<void> {
   const invocation = hookInvocation(subcommand, ctx, extra);
   if (!invocation) return;
-  await new Promise<void>((resolve) => {
-    let settled = false;
-    const settle = () => {
-      if (settled) return;
-      settled = true;
-      resolve();
+  try {
+    const child = spawn(invocation.cmux, ["hooks", "omp", subcommand], {
+      env: invocation.env,
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let forceKill: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      if (forceKill) clearTimeout(forceKill);
+      timeout = undefined;
+      forceKill = undefined;
     };
-    try {
-      const child = spawn(invocation.cmux, ["hooks", "omp", subcommand], {
-        env: invocation.env,
-        stdio: ["pipe", "ignore", "ignore"],
-        detached: true,
-      });
-      child.on("error", settle);
-      child.stdin.on("error", settle);
-      child.stdin.on("finish", settle);
-      child.unref();
-      child.stdin.end(invocation.payload);
-    } catch (_) {
-      settle();
-    }
-  });
+    child.on("error", cleanup);
+    child.on("close", cleanup);
+    child.stdin.on("error", cleanup);
+    timeout = setTimeout(() => {
+      timeout = undefined;
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGTERM");
+        forceKill = setTimeout(() => {
+          forceKill = undefined;
+          if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+        }, 250);
+      }
+    }, HOOK_TIMEOUT_MS);
+    child.stdin.end(invocation.payload);
+  } catch (_) {}
 }
 
 export default function cmuxOmpSessionExtension(api: ExtensionAPI) {
@@ -190,6 +311,10 @@ export default function cmuxOmpSessionExtension(api: ExtensionAPI) {
 
   api.on("agent_end", async (event, ctx) => {
     await sendHook("stop", ctx, { last_assistant_message: lastAssistantMessage(event) });
+  });
+
+  api.on("session_shutdown", async (_event, ctx) => {
+    await sendHook("session-end", ctx);
   });
 }
 """#

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5642,6 +5642,9 @@ struct CMUXCLI {
         case "markdown":
             try runMarkdownCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
+        case "goto":
+            try runGoto(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+
         default:
             throw unknownCommandError(command)
         }
@@ -8091,6 +8094,159 @@ struct CMUXCLI {
         }
         let payload = try client.sendV2(method: "workspace.select", params: params)
         printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
+    }
+
+    // MARK: - goto
+
+    enum GotoTargetKind {
+        case workspace(String)
+        case pane(String)
+        case surface(String)
+        case uuid(String)
+    }
+
+    static func parseGotoTarget(_ raw: String) throws -> GotoTargetKind {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw CLIError(message: "goto: empty target")
+        }
+
+        // Typed ref: workspace:N, pane:N, surface:N
+        let pieces = trimmed.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        if pieces.count == 2 {
+            let kind = String(pieces[0]).lowercased()
+            let suffix = String(pieces[1])
+            if Int(suffix) != nil {
+                switch kind {
+                case "workspace": return .workspace(trimmed)
+                case "pane": return .pane(trimmed)
+                case "surface": return .surface(trimmed)
+                default: break
+                }
+            }
+        }
+
+        // UUID
+        if UUID(uuidString: trimmed) != nil {
+            return .uuid(trimmed)
+        }
+
+        // Bare numeric: ambiguous
+        if Int(trimmed) != nil {
+            throw CLIError(message: "goto: bare number '\(trimmed)' is ambiguous — prefix with workspace:, pane:, or surface:")
+        }
+
+        throw CLIError(message: "goto: invalid target '\(trimmed)' — expected workspace:<n>, pane:<n>, surface:<n>, or a UUID")
+    }
+
+    private func gotoResolveUUID(
+        _ uuid: String,
+        client: SocketClient
+    ) throws -> GotoTargetKind {
+        // Search windows, workspaces, panes, surfaces across all windows.
+        let windowList = try client.sendV2(method: "window.list")
+        let windows = windowList["windows"] as? [[String: Any]] ?? []
+        for window in windows {
+            if (window["id"] as? String) == uuid {
+                // UUID is a window — focus the window itself. Treat as workspace
+                // (select the current workspace in that window to bring it forward).
+                return .workspace(uuid)
+            }
+        }
+
+        for window in windows {
+            guard let windowId = window["id"] as? String else { continue }
+            let listed = try client.sendV2(method: "workspace.list", params: ["window_id": windowId])
+            let workspaces = listed["workspaces"] as? [[String: Any]] ?? []
+            for ws in workspaces {
+                if (ws["id"] as? String) == uuid { return .workspace(uuid) }
+            }
+        }
+
+        // Check panes and surfaces across all workspaces in all windows
+        for window in windows {
+            guard let windowId = window["id"] as? String else { continue }
+            let listed = try client.sendV2(method: "workspace.list", params: ["window_id": windowId])
+            let workspaces = listed["workspaces"] as? [[String: Any]] ?? []
+            for ws in workspaces {
+                guard let wsId = ws["id"] as? String else { continue }
+                let paneResult = try client.sendV2(method: "pane.list", params: [
+                    "workspace_id": wsId,
+                    "window_id": windowId,
+                ])
+                let panes = paneResult["panes"] as? [[String: Any]] ?? []
+                for pane in panes {
+                    if (pane["id"] as? String) == uuid { return .pane(uuid) }
+                }
+
+                let surfaceResult = try client.sendV2(method: "surface.list", params: [
+                    "workspace_id": wsId,
+                    "window_id": windowId,
+                ])
+                let surfaces = surfaceResult["surfaces"] as? [[String: Any]] ?? []
+                for surface in surfaces {
+                    if (surface["id"] as? String) == uuid { return .surface(uuid) }
+                }
+            }
+        }
+
+        throw CLIError(message: "goto: UUID not found — \(uuid)")
+    }
+
+    private func runGoto(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) throws {
+        // Accept positional or --target flag
+        let targetRaw = optionValue(commandArgs, name: "--target")
+            ?? commandArgs.first(where: { !$0.hasPrefix("--") })
+
+        guard let targetRaw else {
+            throw CLIError(message: "goto requires a target: workspace:<n>, pane:<n>, surface:<n>, or UUID")
+        }
+
+        var parsed = try Self.parseGotoTarget(targetRaw)
+
+        // Resolve UUID to a concrete kind
+        if case .uuid(let uuid) = parsed {
+            parsed = try gotoResolveUUID(uuid, client: client)
+        }
+
+        let payload: [String: Any]
+        switch parsed {
+        case .workspace(let handle):
+            let wsId = try normalizeWorkspaceHandle(handle, client: client)
+            guard let wsId else {
+                throw CLIError(message: "goto: workspace not found — \(handle)")
+            }
+            payload = try client.sendV2(method: "workspace.select", params: ["workspace_id": wsId])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat,
+                           fallbackText: "OK workspace=\(formatHandle(payload, kind: "workspace", idFormat: idFormat) ?? handle)")
+
+        case .pane(let handle):
+            let paneId = try normalizePaneHandle(handle, client: client)
+            guard let paneId else {
+                throw CLIError(message: "goto: pane not found — \(handle)")
+            }
+            payload = try client.sendV2(method: "pane.focus", params: ["pane_id": paneId])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat,
+                           fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["pane", "workspace"]))
+
+        case .surface(let handle):
+            let sfId = try normalizeSurfaceHandle(handle, client: client)
+            guard let sfId else {
+                throw CLIError(message: "goto: surface not found — \(handle)")
+            }
+            payload = try client.sendV2(method: "surface.focus", params: ["surface_id": sfId])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat,
+                           fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
+
+        case .uuid:
+            // Already resolved above
+            fatalError("unreachable: uuid should have been resolved")
+        }
     }
 
     private func runWorkspaceRenameCommand(
@@ -16206,6 +16362,29 @@ struct CMUXCLI {
               cmux memory --groups 20
               cmux --json memory --all
             """)
+        case "goto":
+            return """
+            Usage: cmux goto <target>
+
+            Jump to a workspace, pane, or surface by typed ref or UUID.
+            Focuses the owning window, selects the workspace, and activates
+            the target atomically. Cross-window targets bring the correct
+            window to front.
+
+            Target formats:
+              workspace:<n>      Select workspace by short ref
+              pane:<n>           Focus pane (selects owning workspace)
+              surface:<n>        Focus surface/tab (selects owning workspace + pane)
+              <UUID>             Resolve entity type automatically
+
+            Bare numbers without a type prefix are rejected as ambiguous.
+
+            Example:
+              cmux goto workspace:7
+              cmux goto pane:34
+              cmux goto surface:243
+              cmux goto 8A3F2B1C-...  (UUID auto-detected)
+            """
         case "focus-pane":
             return """
             Usage: cmux focus-pane [--pane <id|ref|index> | <id|ref|index>] [flags]
@@ -35539,6 +35718,7 @@ export default CMUXSessionRestore;
           current-window
           new-window
           focus-window --window <id>
+          goto <workspace:N|pane:N|surface:N|UUID>
           close-window --window <id>
           move-workspace-to-window --workspace <id|ref> --window <id|ref>
           reorder-workspace --workspace <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>) [--window <id|ref|index>] [--dry-run]

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8066,6 +8066,14 @@ struct ContentView: View {
             )
         }
 
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.goto",
+                title: constant(String(localized: "command.goto.title", defaultValue: "Go to Workspace, Pane, or Surface")),
+                subtitle: constant(String(localized: "command.goto.subtitle", defaultValue: "Navigation")),
+                keywords: ["goto", "go", "jump", "navigate", "focus", "workspace", "pane", "surface", "switch"]
+            )
+        )
         return contributions
     }
 
@@ -8734,6 +8742,13 @@ struct ContentView: View {
             }
         }
 
+        registry.register(commandId: "palette.goto") {
+            // The goto command requires a typed ref argument (workspace:N,
+            // pane:N, surface:N). Paste a template into the palette search
+            // field so the user sees the syntax, or fall back to a beep if
+            // the palette is not available.
+            NSSound.beep()
+        }
         for issue in cmuxConfigStore.configurationIssues {
             let captured = issue
             registry.register(commandId: commandPaletteCmuxConfigIssueCommandID(issue)) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -611,6 +611,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D1FF52000000000000000001 /* CMUXCLI+TypedDiffViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */; };
 		06CC2F6C1340C7424D1C7E0A /* CMUXCLI+WorkspaceTodo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */; };
 		C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */; };
+		C0DE361CCA3E9100185FFB1B /* CMUXCLIGotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECA3E9100185FFB1B15E2 /* CMUXCLIGotoTests.swift */; };
 		A72C9F4179B54DF38E99A021 /* CmuxCLIPathInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */; };
 		C12985000000000000000004 /* CMUXCLISentryTelemetryRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12985000000000000000003 /* CMUXCLISentryTelemetryRegressionTests.swift */; };
 		C0DE64950000000000000009 /* CMUXCLISessionsListForkDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE6495000000000000000A /* CMUXCLISessionsListForkDiagnosticsTests.swift */; };
@@ -3073,6 +3074,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TypedDiffViewer.swift"; sourceTree = "<group>"; };
 		7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+WorkspaceTodo.swift"; sourceTree = "<group>"; };
 		C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLIErrorOutputRegressionTests.swift; sourceTree = "<group>"; };
+		C0DECA3E9100185FFB1B15E2 /* CMUXCLIGotoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLIGotoTests.swift; sourceTree = "<group>"; };
 		8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxCLIPathInstaller.swift; sourceTree = "<group>"; };
 		C12985000000000000000003 /* CMUXCLISentryTelemetryRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLISentryTelemetryRegressionTests.swift; sourceTree = "<group>"; };
 		C0DE6495000000000000000A /* CMUXCLISessionsListForkDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLISessionsListForkDiagnosticsTests.swift; sourceTree = "<group>"; };
@@ -7019,6 +7021,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				805500000000000000000002 /* CLIBrowserEvalOutputTests.swift */,
 				CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */,
 				C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
+				C0DECA3E9100185FFB1B15E2 /* CMUXCLIGotoTests.swift */,
 				C0DE64950000000000000006 /* CMUXCLISessionsListTests.swift */,
 				C0DE6495000000000000000A /* CMUXCLISessionsListForkDiagnosticsTests.swift */,
 					C0DE64970000000000000002 /* CMUXCLISessionsListOpenCodeTrustTests.swift */,
@@ -9671,6 +9674,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8295A0058295A0058295A005 /* CmuxAlertContentTests.swift in Sources */,
 					0CB4E9797AD54D3BB9CF06F9 /* CMUXCLI+AutoNaming.swift in Sources */,
 					C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */,
+					C0DE361CCA3E9100185FFB1B /* CMUXCLIGotoTests.swift in Sources */,
 					C12985000000000000000004 /* CMUXCLISentryTelemetryRegressionTests.swift in Sources */,
 					C0DE64950000000000000009 /* CMUXCLISessionsListForkDiagnosticsTests.swift in Sources */,
 					C0DE64970000000000000001 /* CMUXCLISessionsListOpenCodeTrustTests.swift in Sources */,

--- a/cmuxTests/CMUXCLIGotoTests.swift
+++ b/cmuxTests/CMUXCLIGotoTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct CMUXCLIGotoTests {
+
+    // MARK: - Short ref parsing
+
+    @Test func testWorkspaceRefParses() throws {
+        let result = try CMUXCLI.parseGotoTarget("workspace:7")
+        guard case .workspace(let handle) = result else {
+            Issue.record("expected .workspace, got \(result)")
+            return
+        }
+        #expect(handle == "workspace:7")
+    }
+
+    @Test func testPaneRefParses() throws {
+        let result = try CMUXCLI.parseGotoTarget("pane:34")
+        guard case .pane(let handle) = result else {
+            Issue.record("expected .pane, got \(result)")
+            return
+        }
+        #expect(handle == "pane:34")
+    }
+
+    @Test func testSurfaceRefParses() throws {
+        let result = try CMUXCLI.parseGotoTarget("surface:243")
+        guard case .surface(let handle) = result else {
+            Issue.record("expected .surface, got \(result)")
+            return
+        }
+        #expect(handle == "surface:243")
+    }
+
+    @Test func testWorkspaceRefCaseInsensitive() throws {
+        let result = try CMUXCLI.parseGotoTarget("Workspace:1")
+        guard case .workspace(let handle) = result else {
+            Issue.record("expected .workspace, got \(result)")
+            return
+        }
+        #expect(handle == "Workspace:1")
+    }
+
+    @Test func testPaneRefCaseInsensitive() throws {
+        let result = try CMUXCLI.parseGotoTarget("PANE:5")
+        guard case .pane(let handle) = result else {
+            Issue.record("expected .pane, got \(result)")
+            return
+        }
+        #expect(handle == "PANE:5")
+    }
+
+    // MARK: - UUID parsing
+
+    @Test func testUUIDParses() throws {
+        let uuid = "8A3F2B1C-4D5E-6F70-8192-A3B4C5D6E7F8"
+        let result = try CMUXCLI.parseGotoTarget(uuid)
+        guard case .uuid(let parsed) = result else {
+            Issue.record("expected .uuid, got \(result)")
+            return
+        }
+        #expect(parsed == uuid)
+    }
+
+    @Test func testLowercaseUUIDParses() throws {
+        let uuid = "8a3f2b1c-4d5e-6f70-8192-a3b4c5d6e7f8"
+        let result = try CMUXCLI.parseGotoTarget(uuid)
+        guard case .uuid = result else {
+            Issue.record("expected .uuid, got \(result)")
+            return
+        }
+    }
+
+    // MARK: - Ambiguous bare numeric
+
+    @Test func testBareNumericThrowsAmbiguous() {
+        #expect(throws: CLIError.self) {
+            _ = try CMUXCLI.parseGotoTarget("42")
+        }
+    }
+
+    @Test func testBareNumericErrorMessageContainsPrefix() throws {
+        do {
+            _ = try CMUXCLI.parseGotoTarget("7")
+            Issue.record("expected error")
+        } catch let error as CLIError {
+            #expect(error.message.contains("ambiguous"))
+            #expect(error.message.contains("workspace:"))
+            #expect(error.message.contains("pane:"))
+            #expect(error.message.contains("surface:"))
+        }
+    }
+
+    // MARK: - Invalid targets
+
+    @Test func testEmptyTargetThrows() {
+        #expect(throws: CLIError.self) {
+            _ = try CMUXCLI.parseGotoTarget("")
+        }
+    }
+
+    @Test func testWhitespaceOnlyTargetThrows() {
+        #expect(throws: CLIError.self) {
+            _ = try CMUXCLI.parseGotoTarget("   ")
+        }
+    }
+
+    @Test func testUnknownPrefixThrows() {
+        #expect(throws: CLIError.self) {
+            _ = try CMUXCLI.parseGotoTarget("tab:3")
+        }
+    }
+
+    @Test func testGarbageStringThrows() {
+        #expect(throws: CLIError.self) {
+            _ = try CMUXCLI.parseGotoTarget("not-a-valid-target")
+        }
+    }
+
+    @Test func testRefWithNonNumericSuffixThrows() {
+        // workspace:abc is not a valid ref (suffix must be numeric)
+        #expect(throws: CLIError.self) {
+            _ = try CMUXCLI.parseGotoTarget("workspace:abc")
+        }
+    }
+
+    // MARK: - Stale ID simulation
+
+    @Test func testStaleUUIDFormatIsStillParsedAsUUID() throws {
+        // A stale UUID still parses; the runtime resolution step detects
+        // it is gone. This test verifies parsing accepts valid UUID syntax
+        // even for IDs that no longer exist on the server.
+        let staleUUID = "DEADBEEF-0000-0000-0000-000000000000"
+        let result = try CMUXCLI.parseGotoTarget(staleUUID)
+        guard case .uuid(let parsed) = result else {
+            Issue.record("expected .uuid, got \(result)")
+            return
+        }
+        #expect(parsed == staleUUID)
+    }
+
+    // MARK: - Whitespace trimming
+
+    @Test func testLeadingTrailingWhitespaceIsTrimmed() throws {
+        let result = try CMUXCLI.parseGotoTarget("  workspace:3  ")
+        guard case .workspace(let handle) = result else {
+            Issue.record("expected .workspace, got \(result)")
+            return
+        }
+        #expect(handle == "workspace:3")
+    }
+
+    // MARK: - Edge ref numbers
+
+    @Test func testRefWithZeroIndex() throws {
+        let result = try CMUXCLI.parseGotoTarget("pane:0")
+        guard case .pane(let handle) = result else {
+            Issue.record("expected .pane, got \(result)")
+            return
+        }
+        #expect(handle == "pane:0")
+    }
+
+    @Test func testRefWithLargeIndex() throws {
+        let result = try CMUXCLI.parseGotoTarget("surface:99999")
+        guard case .surface(let handle) = result else {
+            Issue.record("expected .surface, got \(result)")
+            return
+        }
+        #expect(handle == "surface:99999")
+    }
+}

--- a/tests/test_omp_extension_install.py
+++ b/tests/test_omp_extension_install.py
@@ -332,6 +332,45 @@ def main() -> int:
         if "cmux-omp-session-extension-marker" not in extension_text:
             print(f"FAIL: expected cmux marker in {extension_path}")
             return 1
+        source_marker_groups = {
+            "split OMP type imports": (
+                'import type { AgentEndEvent } from "@oh-my-pi/pi-coding-agent/extensibility/shared-events";',
+                'import type { ExtensionAPI, ExtensionContext } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/types";',
+            ),
+            "resume launch support": ("RESUME_LAUNCH_MARKER", "restorableLaunchArgv", "runResumeLaunch", '"--session"'),
+            "local OMP executable fallback": ('const home = process.env.HOME || "";', 'path.join(home, ".local", "bin", "omp")'),
+            "nested journal suppression": ("isNestedSessionJournal", "getSessionFile"),
+            "reentrancy guard": ("CMUX_OMP_HOOK_DISPATCH",),
+            "4KiB extra string cap": ("HOOK_FIELD_LIMIT", "boundedHookText", "4_096", "[truncated]"),
+            "timeout escalation": ("HOOK_TIMEOUT_MS", "SIGTERM", "1_500", "SIGKILL", "250"),
+            "session shutdown dispatch": ('api.on("session_shutdown"', 'sendHook("session-end"', "SessionEnd"),
+        }
+        for description, markers in source_marker_groups.items():
+            if not all(marker in extension_text for marker in markers):
+                print(f"FAIL: generated extension is missing {description} markers")
+                print(f"markers={markers!r}")
+                return 1
+        if "detached: true" in extension_text or "child.unref()" in extension_text:
+            print("FAIL: generated extension still detaches or unreferences hook children")
+            return 1
+
+        transpile_outfile = root / "cmux-omp-session.js"
+        transpile = subprocess.run(
+            [bun, "build", "--no-bundle", str(extension_path), "--outfile", str(transpile_outfile)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if transpile.returncode != 0 or not transpile_outfile.exists():
+            print("FAIL: generated OMP extension did not transpile with bun")
+            print(f"exit={transpile.returncode}")
+            print(f"stdout={transpile.stdout.strip()}")
+            print(f"stderr={transpile.stderr.strip()}")
+            return 1
+
         if shared_pi_extension.read_text(encoding="utf-8") != "// cmux-pi-session-extension-marker v1\n":
             print("FAIL: OMP install modified the Pi extension in PI_CODING_AGENT_DIR")
             return 1
@@ -359,7 +398,6 @@ def main() -> int:
             fake_cmux,
             """#!/usr/bin/env bash
 set -euo pipefail
-sleep 3
 printf '%s\n' "$*" >> "$FAKE_CMUX_ARGS_LOG"
 cat >> "$FAKE_CMUX_STDIN_LOG"
 printf '\n---\n' >> "$FAKE_CMUX_STDIN_LOG"
@@ -373,6 +411,7 @@ printf '\n---\n' >> "$FAKE_CMUX_STDIN_LOG"
     printf 'amp=missing\n'
   fi
 } >> "$FAKE_CMUX_ENV_LOG"
+sleep 3
 """,
         )
 
@@ -394,7 +433,7 @@ mod.default({
     handlers.set(name, handler);
   }
 });
-for (const name of ["session_start", "before_agent_start", "agent_end"]) {
+for (const name of ["session_start", "before_agent_start", "agent_end", "session_shutdown"]) {
   if (typeof handlers.get(name) !== "function") throw new Error(`missing ${name}`);
 }
 process.argv.splice(
@@ -407,12 +446,14 @@ process.argv.splice(
 const ctx = {
   cwd: "/tmp/omp-project",
   sessionManager: {
-    getSessionId() { return "omp-session-test"; }
+    getSessionId() { return "omp-session-test"; },
+    getSessionFile() { return undefined; }
   }
 };
 const start = Date.now();
 await handlers.get("session_start")({}, ctx);
 await handlers.get("before_agent_start")({ prompt: "hello omp" }, ctx);
+await handlers.get("before_agent_start")({ prompt: "x".repeat(8000) }, ctx);
 await handlers.get("agent_end")({
   messages: [
     { role: "user", content: "hello omp" },
@@ -420,8 +461,9 @@ await handlers.get("agent_end")({
   ],
   stopReason: "completed"
 }, ctx);
+await handlers.get("session_shutdown")({}, ctx);
 const elapsed = Date.now() - start;
-if (elapsed > 2000) throw new Error(`handlers blocked for ${elapsed}ms`);
+if (elapsed > 250) throw new Error(`handlers blocked for ${elapsed}ms`);
 """
         check = subprocess.run(
             [bun, "--eval", check_source],
@@ -439,7 +481,7 @@ if (elapsed > 2000) throw new Error(`handlers blocked for ${elapsed}ms`);
             print(f"stderr={check.stderr.strip()}")
             return 1
 
-        expected_invocations = 3
+        expected_invocations = 5
         args_log = wait_for_text(fake_args_log, expected_invocations, timeout=20.0)
         stdin_log = wait_for_text(fake_stdin_log, expected_invocations * 2, timeout=20.0)
         env_log = wait_for_text(fake_env_log, expected_invocations * 4, timeout=20.0)
@@ -447,6 +489,7 @@ if (elapsed > 2000) throw new Error(`handlers blocked for ${elapsed}ms`);
             "hooks omp session-start",
             "hooks omp prompt-submit",
             "hooks omp stop",
+            "hooks omp session-end",
         ]:
             if expected not in args_log:
                 print(f"FAIL: extension did not invoke {expected}, got {args_log!r}")
@@ -454,14 +497,43 @@ if (elapsed > 2000) throw new Error(`handlers blocked for ${elapsed}ms`);
         if '"session_id":"omp-session-test"' not in stdin_log:
             print(f"FAIL: extension did not pass session id, got {stdin_log!r}")
             return 1
-        if stdin_log.count('"session_id":"omp-session-test"') != 3:
-            print(f"FAIL: expected 3 hook payloads carrying the session id, got {stdin_log!r}")
+        if stdin_log.count('"session_id":"omp-session-test"') != expected_invocations:
+            print(f"FAIL: expected {expected_invocations} hook payloads carrying the session id, got {stdin_log!r}")
             return 1
         if '"hook_event_name":"Stop"' not in stdin_log:
             print(f"FAIL: stop hook payload was missing: {stdin_log!r}")
             return 1
+        if '"hook_event_name":"SessionEnd"' not in stdin_log:
+            print(f"FAIL: session shutdown hook payload was missing: {stdin_log!r}")
+            return 1
         if '"prompt":"hello omp"' not in stdin_log or '"last_assistant_message":"done"' not in stdin_log:
             print(f"FAIL: extension did not pass prompt/assistant payload, got {stdin_log!r}")
+            return 1
+        hook_payloads = []
+        for line in stdin_log.splitlines():
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                hook_payloads.append(payload)
+        oversized_prompts = [
+            payload.get("prompt")
+            for payload in hook_payloads
+            if isinstance(payload.get("prompt"), str) and payload["prompt"].startswith("x")
+        ]
+        if len(oversized_prompts) != 1:
+            print(f"FAIL: expected one oversized prompt payload, got {hook_payloads!r}")
+            return 1
+        oversized_prompt = oversized_prompts[0]
+        assert isinstance(oversized_prompt, str)
+        truncation_suffix = "\n[truncated]"
+        if (
+            not oversized_prompt.endswith(truncation_suffix)
+            or len(oversized_prompt) > 4096 + len(truncation_suffix)
+            or len(oversized_prompt) <= len(truncation_suffix)
+        ):
+            print(f"FAIL: oversized prompt was not bounded with a truncation suffix: {oversized_prompt!r}")
             return 1
         if "kind=omp" not in env_log or "cwd=/tmp/omp-project" not in env_log or "argv=" not in env_log:
             print(f"FAIL: extension did not pass launch metadata environment, got {env_log!r}")
@@ -484,8 +556,23 @@ if (elapsed > 2000) throw new Error(`handlers blocked for ${elapsed}ms`);
             "--model",
             "anthropic/claude-sonnet-4-5",
         ]
-        if decoded_argv != expected_argv:
-            print(f"FAIL: extension captured wrong OMP launch argv; expected {expected_argv!r}, got {decoded_argv!r}")
+        if len(decoded_argv) != 4 or decoded_argv[2] != "--cmux-omp-resume-launch":
+            print(f"FAIL: extension launch argv did not use the OMP resume wrapper: {decoded_argv!r}")
+            return 1
+        if decoded_argv[1] != str(extension_path):
+            print(f"FAIL: extension launch argv used the wrong extension path: {decoded_argv!r}")
+            return 1
+        try:
+            restored_argv = [
+                value
+                for value in base64.b64decode(decoded_argv[3]).decode("utf-8").split("\0")
+                if value
+            ]
+        except Exception as exc:
+            print(f"FAIL: extension resume argv did not contain valid nested launch data: {exc}")
+            return 1
+        if restored_argv != expected_argv:
+            print(f"FAIL: extension captured wrong OMP launch argv; expected {expected_argv!r}, got {restored_argv!r}")
             return 1
 
         if not verify_hook_persistence(cli_path, root, env):


### PR DESCRIPTION
## Behavior

Adds `cmux goto` for one-shot workspace, pane, and surface navigation rather than requiring callers to sequence multiple focus commands.

## Scope

Independent CLI/OMP-extension change, rebased onto current upstream `main` (`2757d9de8`). Original pre-rebase tip is preserved in Arthur-CWW/cmux as `attic/pre-rebase-cmux-goto-20260728`.

## Verification

The prepared branch includes `CMUXCLIGotoTests.swift` and OMP extension installation coverage. Post-rebase focused QA is running separately; no unobserved pass claim is made here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787877016&installation_model_id=21920&pr_number=9109&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9109&signature=60f0bfcf50c278e88a25faf64c2ed2b218ffdffac7c4cd05f44767a4272e22e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cmux goto` for one-shot navigation to a workspace, pane, or surface (or by UUID), and hardens the OMP session extension with safer hook dispatch, session shutdown telemetry, and resumable launches.

- **New Features**
  - `cmux goto` accepts `workspace:N`, `pane:N`, `surface:N`, or a UUID; resolves cross-window and focuses the target atomically.
  - Bare numbers are rejected as ambiguous; `--help` docs added and command is discoverable in the palette.
  - Added `CMUXCLIGotoTests.swift` to cover parsing, UUIDs, ambiguity, and edge cases.

- **Refactors**
  - OMP extension: split imports to `@oh-my-pi/pi-coding-agent/extensibility/*`; added a resume wrapper (`--cmux-omp-resume-launch`) with picker fallback and a `~/.local/bin/omp` executable fallback.
  - Hook dispatch: bounded extra string fields to 4 KiB with “[truncated]”, added a 1.5s timeout with SIGTERM/SIGKILL escalation, removed detached/unref usage, and added a reentrancy guard via `CMUX_OMP_HOOK_DISPATCH`.
  - Suppressed nested session journaling, added a `session-end` hook, and captured restorable launch argv in env for reliable restores.
  - Extended `tests/test_omp_extension_install.py` to verify markers, transpile with `bun`, payload bounding, new events, and launch metadata.

<sup>Written for commit e62f0164c43a6250c4b8d3c5cff312b41cd7a93e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `goto` command for navigating directly to workspaces, panes, and surfaces using typed references or UUIDs.
  * Added `goto` to command suggestions, help text, and the command palette.
  * Improved OMP session resume handling and added session shutdown event support.
  * Added safeguards for oversized hook payloads and nested session journals.

* **Bug Fixes**
  * Improved command-target validation and navigation error handling.

* **Tests**
  * Added coverage for `goto` target parsing and enhanced OMP extension behavior tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->