### PR TITLE
feat: per-host remote tmux identity and workspace routing

### DIFF
--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -12,17 +12,17 @@ extension AppDelegate {
     @discardableResult
     func reopenMostRecentlyClosedItem(
         preferredTabManager: TabManager? = nil,
-        shouldActivate: Bool = true
+        shouldActivate: Bool = false
     ) -> Bool {
         var failedStoreRecordIds: Set<UUID> = []
-        let restoreStoreItem: (Date?) -> Bool = { cutoff in
-            ClosedItemHistoryStore.shared.restoreFirstRestorable(
+        let restoreStoreItem: (Date?) -> ClosedItemHistoryRestoreAttempt = { cutoff in
+            ClosedItemHistoryStore.shared.attemptFirstRestorable(
                 newerThan: cutoff,
                 excluding: failedStoreRecordIds,
                 onFailure: { failedStoreRecordIds.insert($0) },
-                using: { entry in
-                    self.restoreClosedItem(
-                        entry,
+                using: { record in
+                    self.attemptRestoreClosedItem(
+                        record,
                         preferredTabManager: preferredTabManager,
                         shouldActivate: shouldActivate
                     )
@@ -34,7 +34,7 @@ extension AppDelegate {
             guard let closedAt = manager.mostRecentLegacyClosedBrowserPanelClosedAt() else {
                 continue
             }
-            if restoreStoreItem(closedAt) {
+            if restoreStoreItem(closedAt).wasAccepted {
                 return true
             }
             if manager.reopenMostRecentlyClosedBrowserPanelFromLegacyStack() {
@@ -42,7 +42,7 @@ extension AppDelegate {
             }
         }
 
-        return restoreStoreItem(nil)
+        return restoreStoreItem(nil).wasAccepted
     }
 
     private func recentlyClosedLegacyBrowserManagers(preferredTabManager: TabManager?) -> [TabManager] {
@@ -55,23 +55,44 @@ extension AppDelegate {
         }
     }
 
-    @discardableResult
-    private func restoreClosedItem(
-        _ entry: ClosedItemHistoryEntry,
+    private func attemptRestoreClosedItem(
+        _ record: ClosedItemHistoryRecord,
         preferredTabManager: TabManager? = nil,
         shouldActivate: Bool
-    ) -> Bool {
-        switch entry {
+    ) -> ClosedItemHistoryRestoreAttempt {
+        switch record.entry {
         case .panel(let panelEntry):
             let manager =
                 tabManagerFor(tabId: panelEntry.workspaceId)
                 ?? preferredTabManager
                 ?? tabManager
             guard let manager, manager.restoreClosedPanel(panelEntry) else {
-                return false
+                return .failed
             }
             activateMainWindowIfNeeded(for: manager, shouldActivate: shouldActivate)
-            return true
+            return .restored
+        case .remoteTmuxMirror(let remoteEntry):
+            if let restored = remoteTmuxController.restoreClosedMirrorIfAlreadyLive(
+                remoteEntry,
+                shouldActivate: shouldActivate
+            ) {
+                return restored ? .restored : .failed
+            }
+            Task { @MainActor in
+                let succeeded = await remoteTmuxController.restoreClosedMirror(
+                    remoteEntry,
+                    preferredTabManager: preferredTabManager,
+                    shouldActivate: shouldActivate
+                )
+                ClosedItemHistoryStore.shared.completePendingRestore(
+                    id: record.id,
+                    succeeded: succeeded
+                )
+                if !succeeded {
+                    NSSound.beep()
+                }
+            }
+            return .pending
         case .workspace(let workspaceEntry):
             let manager =
                 workspaceEntry.windowId.flatMap { tabManagerFor(windowId: $0) }
@@ -84,10 +105,10 @@ extension AppDelegate {
                     excludingWorkspaceIds: liveWorkspaceIdSet(preferredTabManager: preferredTabManager)
                   )
             else {
-                return false
+                return .failed
             }
             activateMainWindowIfNeeded(for: manager, shouldActivate: shouldActivate)
-            return true
+            return .restored
         case .window(let windowEntry):
             var restoredPanelIdsByWorkspaceIndex: [[UUID: UUID]] = []
             var restoredTabManager: TabManager?
@@ -127,14 +148,14 @@ extension AppDelegate {
                     ClosedItemHistoryStore.shared.flushPendingSaves()
                 }
                 discardMainWindowWithoutClosedHistory(windowId: windowId)
-                return false
+                return .failed
             }
             restoredTabManager?.remapClosedPanelHistoryAfterSessionRestore(
                 originalWorkspaceIds: originalWorkspaceIdsByIndex,
                 restoredPanelIdsByWorkspaceIndex: restoredPanelIdsByWorkspaceIndex,
                 ambiguousOriginalWorkspaceIds: excludedWorkspaceIds
             )
-            return true
+            return .restored
         }
     }
 
@@ -142,22 +163,15 @@ extension AppDelegate {
     func reopenClosedHistoryItem(
         id: UUID,
         preferredTabManager: TabManager? = nil,
-        shouldActivate: Bool = true
+        shouldActivate: Bool = false
     ) -> Bool {
-        guard let removed = ClosedItemHistoryStore.shared.removeRecord(id: id) else {
-            return false
-        }
-
-        if restoreClosedItem(
-            removed.record.entry,
-            preferredTabManager: preferredTabManager,
-            shouldActivate: shouldActivate
-        ) {
-            return true
-        }
-
-        ClosedItemHistoryStore.shared.insert(removed.record, at: removed.index)
-        return false
+        ClosedItemHistoryStore.shared.attemptRestore(id: id) { record in
+            attemptRestoreClosedItem(
+                record,
+                preferredTabManager: preferredTabManager,
+                shouldActivate: shouldActivate
+            )
+        }.wasAccepted
     }
 
     private func activateMainWindowIfNeeded(for manager: TabManager, shouldActivate: Bool) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1020,6 +1020,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didBootstrapInitialMainWindow = false
     var isTerminatingApp = false
     private var closedWindowHistorySuppressedWindowIds: Set<UUID> = []
+    private var closedWindowHistoryRecordedWindowIds: Set<UUID> = []
 #if DEBUG
     var closeMainWindowContainingTabIdObserverForTesting: ((UUID, Bool) -> Void)?
 #endif
@@ -8889,6 +8890,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         controller.onClose = { [weak self, weak controller] in
             guard let self, let controller else { return }
             let manager = self.tabManagerFor(windowId: windowId)
+            if let context = self.mainWindowContexts.values.first(where: { $0.windowId == windowId }) {
+                self.recordClosedWindowHistoryIfNeeded(for: context)
+            }
             // An explicit close of the window's LAST remote workspace (a tab/session
             // close) kills its remote session(s) — synced with tmux — even though it
             // also closes the app window. A plain window/quit close leaves the marker
@@ -14428,7 +14432,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if matchConfiguredShortcut(event: event, action: .reopenClosedBrowserPanel) {
             let routedManager = preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
-            _ = reopenMostRecentlyClosedItem(preferredTabManager: routedManager)
+            _ = reopenMostRecentlyClosedItem(
+                preferredTabManager: routedManager,
+                shouldActivate: true
+            )
             return true
         }
 
@@ -16541,6 +16548,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 preserveManualRestoreBackupOnMissingPrimary: closingWindowIsCrashDiagnostic
             )
         }
+        closedWindowHistoryRecordedWindowIds.remove(removed.windowId)
     }
 
     private func closeWindowSnapshotPruningCrashDiagnostics(
@@ -16567,29 +16575,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func recordClosedWindowHistoryIfNeeded(for context: MainWindowContext) {
-        let shouldSuppressClosedWindowHistory = closedWindowHistorySuppressedWindowIds.remove(context.windowId) != nil
-        guard !shouldSuppressClosedWindowHistory,
-              !isTerminatingApp,
-              !isApplyingSessionRestore else {
+        if closedWindowHistorySuppressedWindowIds.remove(context.windowId) != nil {
+            closedWindowHistoryRecordedWindowIds.insert(context.windowId)
             return
         }
+        guard !isTerminatingApp,
+              !isApplyingSessionRestore,
+              closedWindowHistoryRecordedWindowIds.insert(context.windowId).inserted else {
+            return
+        }
+
+        // Capture remote mirrors while their controller registrations and live
+        // connection identities still exist. Session snapshots intentionally omit
+        // them, so the ordinary window snapshot alone cannot represent this close.
+        let remoteMirrorEntries: [ClosedRemoteTmuxMirrorHistoryEntry] = context.tabManager.tabs.enumerated().compactMap { index, workspace in
+            guard workspace.isRemoteTmuxMirror else { return nil }
+            return remoteTmuxController.closedMirrorHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: context.windowId,
+                workspaceIndex: index
+            )
+        }
+
         let restorableAgentIndex = SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
             ?? RestorableAgentSessionIndex.load()
-        guard let snapshot = closeWindowSnapshotPruningCrashDiagnostics(
+        if let snapshot = closeWindowSnapshotPruningCrashDiagnostics(
             for: context,
             includeScrollback: true,
             restorableAgentIndex: restorableAgentIndex
-        ).snapshot else {
-            return
+        ).snapshot,
+           !snapshot.tabManager.workspaces.isEmpty {
+            // Preserve the existing synchronous local-window history ordering.
+            ClosedItemHistoryStore.shared.push(.window(ClosedWindowHistoryEntry(
+                windowId: context.windowId,
+                snapshot: snapshot,
+                workspaceIds: snapshot.tabManager.workspaces.compactMap(\.workspaceId)
+            )))
         }
-        guard !snapshot.tabManager.workspaces.isEmpty else {
-            return
+
+        // Push after the local window record, in the manager's workspace order.
+        // Remote entries remain memory-only and retain their independent 20-record cap.
+        for entry in remoteMirrorEntries {
+            ClosedItemHistoryStore.shared.pushRemoteTmuxMirror(entry)
         }
-        ClosedItemHistoryStore.shared.push(.window(ClosedWindowHistoryEntry(
-            windowId: context.windowId,
-            snapshot: snapshot,
-            workspaceIds: snapshot.tabManager.workspaces.compactMap(\.workspaceId)
-        )))
     }
 
 #if DEBUG

--- a/Sources/ClosedItemHistory.swift
+++ b/Sources/ClosedItemHistory.swift
@@ -62,10 +62,19 @@ struct ClosedWindowHistoryEntry: Codable {
     }
 }
 
+struct ClosedRemoteTmuxMirrorHistoryEntry: Codable {
+    let host: RemoteTmuxHost
+    let sessionName: String
+    let sessionId: Int?
+    let windowId: UUID?
+    let workspaceIndex: Int
+}
+
 enum ClosedItemHistoryEntry: Codable {
     case panel(ClosedPanelHistoryEntry)
     case workspace(ClosedWorkspaceHistoryEntry)
     case window(ClosedWindowHistoryEntry)
+    case remoteTmuxMirror(ClosedRemoteTmuxMirrorHistoryEntry)
 }
 
 struct ClosedItemHistoryRecord: Identifiable, Codable {
@@ -124,6 +133,21 @@ enum ClosedWindowRestoreValidation {
     }
 }
 
+enum ClosedItemHistoryRestoreAttempt {
+    case restored
+    case failed
+    case pending
+
+    var wasAccepted: Bool {
+        switch self {
+        case .restored, .pending:
+            return true
+        case .failed:
+            return false
+        }
+    }
+}
+
 @MainActor
 final class ClosedItemHistoryStore: ObservableObject {
     static let defaultWorkspaceCapacity = 100
@@ -141,6 +165,7 @@ final class ClosedItemHistoryStore: ObservableObject {
     private var needsPersistenceAfterPersistedRecordsLoad = false
     private var shouldDiscardPersistedRecordsOnLoad = false
     private var pendingPersistedRecordMutations: [PendingPersistedRecordMutation] = []
+    private var pendingRestoreRecordIds: Set<UUID> = []
 
     private enum PendingPersistedRecordMutation {
         case remapPanelWorkspaceIds(
@@ -195,6 +220,18 @@ final class ClosedItemHistoryStore: ObservableObject {
         persistRecords()
     }
 
+    func pushRemoteTmuxMirror(_ entry: ClosedRemoteTmuxMirrorHistoryEntry) {
+        records.removeAll { record in
+            guard case .remoteTmuxMirror(let existing) = record.entry else { return false }
+            return Self.remoteTmuxMirrorIdentityMatches(existing, entry)
+        }
+        records.append(ClosedItemHistoryRecord(entry: .remoteTmuxMirror(entry)))
+        trimRemoteTmuxMirrorRecordsIfNeeded()
+        trimToCapacityIfNeeded()
+        revision &+= 1
+        persistRecords()
+    }
+
     @discardableResult
     func restoreFirstRestorable(using restore: (ClosedItemHistoryEntry) -> Bool) -> Bool {
         restoreFirstRestorable(newerThan: nil, using: restore)
@@ -208,6 +245,25 @@ final class ClosedItemHistoryStore: ObservableObject {
         onFailure: ((UUID) -> Void)? = nil,
         using restore: (ClosedItemHistoryEntry) -> Bool
     ) -> Bool {
+        attemptFirstRestorable(
+            newerThan: cutoff,
+            excluding: excludedRecordIds,
+            matching: isCandidate,
+            onFailure: onFailure,
+            using: { record in
+                restore(record.entry) ? .restored : .failed
+            }
+        ).wasAccepted
+    }
+
+    @discardableResult
+    func attemptFirstRestorable(
+        newerThan cutoff: Date?,
+        excluding excludedRecordIds: Set<UUID> = [],
+        matching isCandidate: (ClosedItemHistoryEntry) -> Bool = { _ in true },
+        onFailure: ((UUID) -> Void)? = nil,
+        using restore: (ClosedItemHistoryRecord) -> ClosedItemHistoryRestoreAttempt
+    ) -> ClosedItemHistoryRestoreAttempt {
         let candidates = records.enumerated()
             .filter { _, record in
                 guard !excludedRecordIds.contains(record.id) else { return false }
@@ -221,24 +277,66 @@ final class ClosedItemHistoryStore: ObservableObject {
                 }
                 return lhs.offset > rhs.offset
             }
-            .map { _, record in (id: record.id, entry: record.entry) }
+            .map { _, record in record }
         for candidate in candidates {
-            guard restore(candidate.entry) else {
+            if pendingRestoreRecordIds.contains(candidate.id) {
+                return .pending
+            }
+            let attempt = restore(candidate)
+            switch attempt {
+            case .restored:
+                removeRestoredRecord(id: candidate.id)
+                return .restored
+            case .pending:
+                pendingRestoreRecordIds.insert(candidate.id)
+                return .pending
+            case .failed:
                 onFailure?(candidate.id)
-                continue
             }
-            if let index = records.firstIndex(where: { $0.id == candidate.id }) {
-                records.remove(at: index)
-                revision &+= 1
-                persistRecords()
-            }
-            return true
         }
-        return false
+        return .failed
+    }
+
+    @discardableResult
+    func attemptRestore(
+        id: UUID,
+        using restore: (ClosedItemHistoryRecord) -> ClosedItemHistoryRestoreAttempt
+    ) -> ClosedItemHistoryRestoreAttempt {
+        if pendingRestoreRecordIds.contains(id) {
+            return .pending
+        }
+        guard let record = records.first(where: { $0.id == id }) else {
+            return .failed
+        }
+        let attempt = restore(record)
+        switch attempt {
+        case .restored:
+            removeRestoredRecord(id: id)
+        case .pending:
+            pendingRestoreRecordIds.insert(id)
+        case .failed:
+            break
+        }
+        return attempt
+    }
+
+    func completePendingRestore(id: UUID, succeeded: Bool) {
+        guard pendingRestoreRecordIds.remove(id) != nil else { return }
+        if succeeded {
+            removeRestoredRecord(id: id)
+        }
+    }
+
+    private func removeRestoredRecord(id: UUID) {
+        guard let index = records.firstIndex(where: { $0.id == id }) else { return }
+        records.remove(at: index)
+        revision &+= 1
+        persistRecords()
     }
 
     func removeRecord(id: UUID) -> (record: ClosedItemHistoryRecord, index: Int)? {
-        guard let index = records.firstIndex(where: { $0.id == id }) else {
+        guard !pendingRestoreRecordIds.contains(id),
+              let index = records.firstIndex(where: { $0.id == id }) else {
             return nil
         }
         let record = records.remove(at: index)
@@ -335,6 +433,7 @@ final class ClosedItemHistoryStore: ObservableObject {
     }
 
     func removeAll() {
+        pendingRestoreRecordIds.removeAll(keepingCapacity: false)
         guard !records.isEmpty || !didFinishPersistedRecordsLoad else { return }
         if !didFinishPersistedRecordsLoad {
             shouldDiscardPersistedRecordsOnLoad = true
@@ -349,13 +448,37 @@ final class ClosedItemHistoryStore: ObservableObject {
         records = capacityPolicy.trimming(records)
         return records.count != previousCount
     }
+
+    private func trimRemoteTmuxMirrorRecordsIfNeeded() {
+        let remoteRecordIndices = records.indices.filter {
+            guard case .remoteTmuxMirror = records[$0].entry else { return false }
+            return true
+        }
+        let overflow = remoteRecordIndices.count - 20
+        guard overflow > 0 else { return }
+        for index in remoteRecordIndices.prefix(overflow).reversed() {
+            records.remove(at: index)
+        }
+    }
+
+    private static func remoteTmuxMirrorIdentityMatches(
+        _ lhs: ClosedRemoteTmuxMirrorHistoryEntry,
+        _ rhs: ClosedRemoteTmuxMirrorHistoryEntry
+    ) -> Bool {
+        guard lhs.host == rhs.host else { return false }
+        if let lhsSessionId = lhs.sessionId, let rhsSessionId = rhs.sessionId {
+            return lhsSessionId == rhsSessionId
+        }
+        return lhs.sessionName == rhs.sessionName
+    }
+
     private func persistRecords() {
         guard let fileURL else { return }
         guard didFinishPersistedRecordsLoad else {
             needsPersistenceAfterPersistedRecordsLoad = true
             return
         }
-        let recordsSnapshot = records
+        let recordsSnapshot = records.filter(Self.shouldPersist)
         let revisionSnapshot = revision
         if persistsRecordsSynchronously {
             Self.saveRecords(recordsSnapshot, fileURL: fileURL)
@@ -376,7 +499,7 @@ final class ClosedItemHistoryStore: ObservableObject {
             finishPersistedRecordsLoad(Self.loadRecords(fileURL: fileURL))
         }
         needsPersistenceAfterPersistedRecordsLoad = false
-        let recordsSnapshot = records
+        let recordsSnapshot = records.filter(Self.shouldPersist)
         let revisionSnapshot = revision
         if persistsRecordsSynchronously {
             Self.saveRecords(recordsSnapshot, fileURL: fileURL)
@@ -543,17 +666,31 @@ final class ClosedItemHistoryStore: ObservableObject {
     ) -> (records: [ClosedItemHistoryRecord], didUpdate: Bool) {
         var didUpdate = false
         let remappedRecords = records.map { record in
-            guard case .workspace(let workspaceEntry) = record.entry,
-                  workspaceEntry.windowId == oldWindowId else {
+            switch record.entry {
+            case .workspace(let workspaceEntry) where workspaceEntry.windowId == oldWindowId:
+                didUpdate = true
+                return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .workspace(ClosedWorkspaceHistoryEntry(
+                    workspaceId: workspaceEntry.workspaceId,
+                    windowId: newWindowId,
+                    workspaceIndex: workspaceEntry.workspaceIndex,
+                    snapshot: workspaceEntry.snapshot
+                )))
+            case .remoteTmuxMirror(let remoteEntry) where remoteEntry.windowId == oldWindowId:
+                didUpdate = true
+                return ClosedItemHistoryRecord(
+                    id: record.id,
+                    closedAt: record.closedAt,
+                    entry: .remoteTmuxMirror(ClosedRemoteTmuxMirrorHistoryEntry(
+                        host: remoteEntry.host,
+                        sessionName: remoteEntry.sessionName,
+                        sessionId: remoteEntry.sessionId,
+                        windowId: newWindowId,
+                        workspaceIndex: remoteEntry.workspaceIndex
+                    ))
+                )
+            default:
                 return record
             }
-            didUpdate = true
-            return ClosedItemHistoryRecord(id: record.id, closedAt: record.closedAt, entry: .workspace(ClosedWorkspaceHistoryEntry(
-                workspaceId: workspaceEntry.workspaceId,
-                windowId: newWindowId,
-                workspaceIndex: workspaceEntry.workspaceIndex,
-                snapshot: workspaceEntry.snapshot
-            )))
         }
         return (remappedRecords, didUpdate)
     }
@@ -629,6 +766,11 @@ final class ClosedItemHistoryStore: ObservableObject {
         }
     }
 
+    private static func shouldPersist(_ record: ClosedItemHistoryRecord) -> Bool {
+        guard case .remoteTmuxMirror = record.entry else { return true }
+        return false
+    }
+
     nonisolated private static func defaultHistoryFileURL(
         bundleIdentifier: String? = Bundle.main.bundleIdentifier,
         appSupportDirectory: URL? = nil,
@@ -680,6 +822,13 @@ final class ClosedItemHistoryStore: ObservableObject {
                 id: record.id,
                 title: String(localized: "menu.history.recentlyClosed.kind.window", defaultValue: "Window"),
                 detail: windowWorkspaceCountLabel(entry.snapshot.tabManager.workspaces.count),
+                closedAt: record.closedAt
+            )
+        case .remoteTmuxMirror(let entry):
+            return ClosedItemHistoryMenuItem(
+                id: record.id,
+                title: entry.sessionName,
+                detail: String(localized: "menu.history.recentlyClosed.kind.workspace", defaultValue: "Workspace"),
                 closedAt: record.closedAt
             )
         }

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -19,9 +19,10 @@ struct CmuxConfigFile: Codable, Sendable {
     var commands: [CmuxCommandDefinition]
     var vault: CmuxVaultConfigDefinition?
     var workspaceGroups: CmuxConfigWorkspaceGroupsDefinition?
+    var remoteHosts: [String: RemoteTmuxHost.IdentityOverride]?
 
     private enum CodingKeys: String, CodingKey {
-        case actions, ui, notifications, agentChat, newWorkspaceCommand, surfaceTabBarButtons, commands, vault, workspaceGroups
+        case actions, ui, notifications, agentChat, newWorkspaceCommand, surfaceTabBarButtons, commands, vault, workspaceGroups, remoteHosts
     }
 
     init(
@@ -33,7 +34,8 @@ struct CmuxConfigFile: Codable, Sendable {
         surfaceTabBarButtons: [CmuxSurfaceTabBarButton]? = nil,
         commands: [CmuxCommandDefinition] = [],
         vault: CmuxVaultConfigDefinition? = nil,
-        workspaceGroups: CmuxConfigWorkspaceGroupsDefinition? = nil
+        workspaceGroups: CmuxConfigWorkspaceGroupsDefinition? = nil,
+        remoteHosts: [String: RemoteTmuxHost.IdentityOverride]? = nil
     ) {
         self.actions = actions
         self.ui = ui
@@ -44,6 +46,7 @@ struct CmuxConfigFile: Codable, Sendable {
         self.commands = commands
         self.vault = vault
         self.workspaceGroups = workspaceGroups
+        self.remoteHosts = remoteHosts
     }
 
     init(from decoder: Decoder) throws {
@@ -95,6 +98,10 @@ struct CmuxConfigFile: Codable, Sendable {
         workspaceGroups = try container.decodeIfPresent(
             CmuxConfigWorkspaceGroupsDefinition.self,
             forKey: .workspaceGroups
+        )
+        remoteHosts = try container.decodeIfPresent(
+            [String: RemoteTmuxHost.IdentityOverride].self,
+            forKey: .remoteHosts
         )
     }
 
@@ -1701,6 +1708,7 @@ final class CmuxConfigStore: ObservableObject {
     @Published private(set) var workspaceGroupConfigs: [CmuxResolvedWorkspaceGroupConfig] = []
     @Published private(set) var surfaceTabBarButtons: [CmuxSurfaceTabBarButton] = CmuxSurfaceTabBarButton.defaults
     @Published private(set) var notificationHooks: [CmuxResolvedNotificationHook] = []
+    @Published private(set) var remoteTmuxHostIdentityOverrides: [String: RemoteTmuxHost.IdentityOverride] = [:]
     @Published private(set) var configurationIssues: [CmuxConfigIssue] = []
     @Published private(set) var configRevision: UInt64 = 0
 
@@ -1877,6 +1885,10 @@ final class CmuxConfigStore: ObservableObject {
             globalConfig: globalConfig,
             localConfigs: localConfigs
         )
+    }
+
+    func remoteTmuxVisualIdentity(for host: RemoteTmuxHost) -> RemoteTmuxHost.VisualIdentity {
+        host.visualIdentity(overrides: remoteTmuxHostIdentityOverrides)
     }
 
     private func updateLocalConfigPath(_ directory: String?) {
@@ -2141,6 +2153,7 @@ final class CmuxConfigStore: ObservableObject {
         surfaceTabBarWorkspaceCommands = resolvedWorkspaceButtons.workspaceCommands
         surfaceTabBarButtons = resolvedWorkspaceButtons.buttons
         notificationHooks = resolvedNotificationHooks
+        remoteTmuxHostIdentityOverrides = globalConfig?.remoteHosts ?? [:]
         resolvedNewWorkspaceActionCache = resolvedNewWorkspaceAction.action
         resolvedNewWorkspaceCommandCache = resolvedNewWorkspaceAction.command
         if let issue = resolvedNewWorkspaceAction.issue {
@@ -2155,6 +2168,12 @@ final class CmuxConfigStore: ObservableObject {
             )
         }
         applySurfaceTabBarButtonsToCurrentManager()
+        if let tabManager {
+            AppDelegate.shared?.remoteTmuxController.refreshHostIdentities(
+                in: tabManager,
+                overrides: remoteTmuxHostIdentityOverrides
+            )
+        }
         configRevision &+= 1
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15168,6 +15168,20 @@ struct TabItemView: View, Equatable {
                         .safeHelp(protectedWorkspaceTooltip)
                 }
 
+                if let identity = workspaceSnapshot.remoteTmuxHostIdentity {
+                    CmuxSystemSymbolImage(
+                        magnified: identity.symbolName,
+                        pointSize: scaledFontSize(10),
+                        weight: .semibold
+                    )
+                    .foregroundColor(
+                        NSColor(hex: identity.tintHex).map(Color.init(nsColor:))
+                            ?? activeSecondaryColor(0.8)
+                    )
+                    .safeHelp(identity.hostSlug)
+                    .accessibilityLabel(Text(identity.hostSlug))
+                }
+
                 // Chrome-style media-activity glyphs: a noisy or capturing
                 // background browser pane is surfaced on its workspace row,
                 // styled like the pin indicator. Audio is the must-have signal;

--- a/Sources/RemoteTmuxControlConnection.swift
+++ b/Sources/RemoteTmuxControlConnection.swift
@@ -39,14 +39,19 @@ final class RemoteTmuxControlConnection {
             switch connectionState {
             case .connected:
                 finishConnectionWaiters(connected: true)
+                finishInitialAttemptWaiters(connected: true)
             case .ended:
                 finishConnectionWaiters(connected: false)
-            case .connecting, .reconnecting:
+                finishInitialAttemptWaiters(connected: false)
+            case .reconnecting:
+                finishInitialAttemptWaiters(connected: false)
+            case .connecting:
                 break
             }
         }
     }
     private(set) var sessionId: Int?
+    var stableSessionId: Int? { sessionId ?? initialSessionId }
     var windowsByID: [Int: RemoteTmuxWindow] = [:]
     var windowOrder: [Int] = []
     var publishedWindowIdByPane: [Int: Int] = [:]
@@ -129,6 +134,7 @@ final class RemoteTmuxControlConnection {
     var windowReorderVerificationGeneration: UInt64?
     var windowReorderVerifications: [UInt64: (Bool) -> Void] = [:]
     private var connectionWaiters: [UUID: (Bool) -> Void] = [:]
+    private var initialAttemptWaiters: [UUID: (Bool) -> Void] = [:]
     /// `false` until the attach command's own `%begin`/`%end` block — always the
     /// FIRST block on each control stream, preceding every notification — has been
     /// consumed. That first block is matched explicitly (see the `.commandResult`
@@ -138,6 +144,7 @@ final class RemoteTmuxControlConnection {
     /// produces a fresh attach block).
     private var attachBlockDrained = false
     private let createIfMissing: Bool
+    private let initialSessionId: Int?
 
     /// Stateless pure decoders for control-mode message payloads (pane-state seed,
     /// window reorder, session-gone classification). Holds no state.
@@ -310,11 +317,13 @@ final class RemoteTmuxControlConnection {
         host: RemoteTmuxHost,
         sessionName: String,
         createIfMissing: Bool = false,
+        initialSessionId: Int? = nil,
         pendingPaneSeedByteLimit: Int = RemoteTmuxControlConnection.maximumPendingPaneSeedBytes
     ) {
         self.host = host
         self.sessionName = sessionName
         self.createIfMissing = createIfMissing
+        self.initialSessionId = initialSessionId
         self.pendingPaneSeedByteLimit = max(0, pendingPaneSeedByteLimit)
     }
 
@@ -322,20 +331,25 @@ final class RemoteTmuxControlConnection {
     func start() throws {
         guard !started else { return }
         try host.ensureControlSocketDirectory()
-        // The initial connect honors `createIfMissing`; reconnects never create.
-        try spawnProcess(createIfMissing: createIfMissing)
+        // Initial connects and reconnects target the immutable tmux session id
+        // whenever one is known. A mutable name is only the final fallback.
+        let attachTarget = createIfMissing
+            ? sessionName
+            : stableSessionId.map { "$\($0)" } ?? sessionName
+        try spawnProcess(createIfMissing: createIfMissing, attachTarget: attachTarget)
         started = true
     }
-
-    /// Suspends until the control stream really enters tmux control mode, or until
-    /// the connection reaches a permanent end. Launch success alone is not enough:
-    /// `ssh` can start and then fail authentication/session attach before tmux emits
-    /// `%enter`.
-    func waitUntilConnected() async -> Bool {
+    /// Suspends until the control stream really enters tmux control mode. Normal
+    /// callers may wait through reconnects until a permanent end; restore callers
+    /// can fail after the initial stream attempt so history remains retryable
+    /// instead of being held pending by the long-lived reconnect policy.
+    func waitUntilConnected(allowingReconnect: Bool = true) async -> Bool {
         switch connectionState {
         case .connected:
             return true
         case .ended:
+            return false
+        case .reconnecting where !allowingReconnect:
             return false
         case .connecting, .reconnecting:
             break
@@ -351,21 +365,37 @@ final class RemoteTmuxControlConnection {
                 case .ended:
                     continuation.resume(returning: false)
                     return
+                case .reconnecting where !allowingReconnect:
+                    continuation.resume(returning: false)
+                    return
                 case .connecting, .reconnecting:
                     break
                 }
 
-                connectionWaiters[token] = { connected in
+                let waiter: (Bool) -> Void = { connected in
                     continuation.resume(returning: connected)
+                }
+                if allowingReconnect {
+                    connectionWaiters[token] = waiter
+                } else {
+                    initialAttemptWaiters[token] = waiter
                 }
 
                 if Task.isCancelled {
-                    finishConnectionWaiter(token, connected: false)
+                    finishConnectionWaiter(
+                        token,
+                        allowingReconnect: allowingReconnect,
+                        connected: false
+                    )
                 }
             }
         } onCancel: {
             Task { @MainActor [weak self] in
-                self?.finishConnectionWaiter(token, connected: false)
+                self?.finishConnectionWaiter(
+                    token,
+                    allowingReconnect: allowingReconnect,
+                    connected: false
+                )
             }
         }
     }
@@ -378,7 +408,7 @@ final class RemoteTmuxControlConnection {
     /// - Parameter createIfMissing: `true` only for the initial connect. Reconnect
     ///   attempts pass `false` (`attach-session`), so a session killed during the
     ///   outage fails the re-attach (→ `.ended`) instead of being silently recreated.
-    private func spawnProcess(createIfMissing: Bool) throws {
+    private func spawnProcess(createIfMissing: Bool, attachTarget: String? = nil) throws {
         // A fresh control stream cannot retain the prior parser or command FIFO.
         #if DEBUG
         cmuxDebugLog("remote.stream.reset pendingCommands=\(pendingCommands.count) createIfMissing=\(createIfMissing)")
@@ -402,7 +432,7 @@ final class RemoteTmuxControlConnection {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: RemoteTmuxHost.defaultSSHExecutablePath())
         proc.arguments = host.controlModeArguments(
-            sessionName: sessionName,
+            sessionName: attachTarget ?? sessionName,
             createIfMissing: createIfMissing
         )
         let inPipe = Pipe(), outPipe = Pipe(), errPipe = Pipe()
@@ -501,8 +531,25 @@ final class RemoteTmuxControlConnection {
         }
     }
 
-    private func finishConnectionWaiter(_ token: UUID, connected: Bool) {
-        connectionWaiters.removeValue(forKey: token)?(connected)
+    private func finishInitialAttemptWaiters(connected: Bool) {
+        guard !initialAttemptWaiters.isEmpty else { return }
+        let waiters = Array(initialAttemptWaiters.values)
+        initialAttemptWaiters.removeAll()
+        for waiter in waiters {
+            waiter(connected)
+        }
+    }
+
+    private func finishConnectionWaiter(
+        _ token: UUID,
+        allowingReconnect: Bool,
+        connected: Bool
+    ) {
+        if allowingReconnect {
+            connectionWaiters.removeValue(forKey: token)?(connected)
+        } else {
+            initialAttemptWaiters.removeValue(forKey: token)?(connected)
+        }
     }
 
     /// Detaches: terminating ssh kills the control client but leaves the remote
@@ -766,7 +813,8 @@ final class RemoteTmuxControlConnection {
     private func attemptReconnectSpawn() {
         record("reconnect-attempt")
         do {
-            try spawnProcess(createIfMissing: false)
+            let attachTarget = stableSessionId.map { "$\($0)" } ?? sessionName
+            try spawnProcess(createIfMissing: false, attachTarget: attachTarget)
         } catch {
             scheduleReconnectAttempt()
         }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -454,14 +454,14 @@ final class RemoteTmuxController {
             workspace = tabManager.addWorkspace(
                 title: canonicalSessionName, titleSource: .auto,
                 select: false, placementOverride: .end,
-                autoWelcomeIfNeeded: false, shouldApplyWorkspaceDirectoryCustomization: false
+                autoWelcomeIfNeeded: false, workspaceDirectoryCustomizationMode: .disabled
             )
             _ = tabManager.reorderWorkspace(tabId: workspace.id, after: afterWorkspaceId)
         case .append:
             workspace = tabManager.addWorkspace(
                 title: canonicalSessionName, titleSource: .auto,
                 select: false, placementOverride: .end,
-                autoWelcomeIfNeeded: false, shouldApplyWorkspaceDirectoryCustomization: false
+                autoWelcomeIfNeeded: false, workspaceDirectoryCustomizationMode: .disabled
             )
         }
         workspace.isRemoteTmuxMirror = true
@@ -987,8 +987,14 @@ final class RemoteTmuxController {
                 manager.closeWorkspace(workspace)
             case .explicitDetach:
                 // Detach is authoritative even for a pinned final mirror. Closing
-                // its owning window avoids stranding a blank `--new-window` shell.
+                // its owning window avoids stranding a blank `--new-window` shell,
+                // and the closed window must not linger as a recoverable route —
+                // recovering it would resurrect a dead remote path.
+                let owningWindowId = manager.windowId
                 _ = manager.closeWorkspaceNonInteractively(workspace, allowPinned: true)
+                if let owningWindowId, manager.tabs.isEmpty {
+                    AppDelegate.shared?.forgetRecoverableMainWindowRoute(windowId: owningWindowId)
+                }
             }
         }
     }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -2,6 +2,60 @@ import Foundation
 import CmuxSettings
 import OSLog
 
+struct RemoteTmuxWorkspaceIdentity: Equatable, Sendable {
+    let connectionHash: String
+    let sessionName: String
+}
+
+enum RemoteTmuxWorkspaceRoute: Equatable, Sendable {
+    case adopt(workspaceId: UUID)
+    case insert(afterWorkspaceId: UUID)
+    case append
+}
+
+struct RemoteTmuxWorkspaceRoutingPolicy {
+    struct Candidate: Equatable, Sendable {
+        let workspaceId: UUID
+        let title: String
+        let isEmpty: Bool
+        let priorMirrorIdentity: RemoteTmuxWorkspaceIdentity?
+    }
+
+    static func route(
+        connectionHash: String,
+        sessionName: String,
+        candidates: [Candidate]
+    ) -> RemoteTmuxWorkspaceRoute {
+        let identity = RemoteTmuxWorkspaceIdentity(
+            connectionHash: connectionHash,
+            sessionName: sessionName
+        )
+        if let adopted = candidates.first(where: {
+            $0.title == sessionName && ($0.isEmpty || $0.priorMirrorIdentity == identity)
+        }) {
+            return .adopt(workspaceId: adopted.workspaceId)
+        }
+
+        var bestPrefix: (workspaceId: UUID, length: Int)?
+        for candidate in candidates {
+            let length: Int?
+            if candidate.title.hasPrefix(sessionName) {
+                length = sessionName.count
+            } else if sessionName.hasPrefix(candidate.title), !candidate.title.isEmpty {
+                length = candidate.title.count
+            } else {
+                length = nil
+            }
+            guard let length, length >= (bestPrefix?.length ?? 0) else { continue }
+            bestPrefix = (candidate.workspaceId, length)
+        }
+        if let bestPrefix {
+            return .insert(afterWorkspaceId: bestPrefix.workspaceId)
+        }
+        return .append
+    }
+}
+
 /// Coordinates cmux's mirroring of remote tmux servers.
 ///
 /// Owns one ``RemoteTmuxSSHTransport`` per endpoint (keyed by
@@ -377,13 +431,44 @@ final class RemoteTmuxController {
         }
         guard sessionMirrors[key] == nil else { return nil }
 
-        let workspace = tabManager.addWorkspace(
-            title: canonicalSessionName, titleSource: .auto,
-            select: false,
-            autoWelcomeIfNeeded: false,
-            workspaceDirectoryCustomizationMode: .disabled
+        let route = RemoteTmuxWorkspaceRoutingPolicy.route(
+            connectionHash: host.connectionHash,
+            sessionName: canonicalSessionName,
+            candidates: tabManager.tabs.map {
+                RemoteTmuxWorkspaceRoutingPolicy.Candidate(
+                    workspaceId: $0.id,
+                    title: $0.title,
+                    isEmpty: $0.panels.isEmpty,
+                    priorMirrorIdentity: $0.remoteTmuxWorkspaceIdentity
+                )
+            }
         )
+        let workspace: Workspace
+        switch route {
+        case .adopt(let workspaceId):
+            guard let adopted = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
+                return nil
+            }
+            workspace = adopted
+        case .insert(let afterWorkspaceId):
+            workspace = tabManager.addWorkspace(
+                title: canonicalSessionName, titleSource: .auto,
+                select: false, placementOverride: .end,
+                autoWelcomeIfNeeded: false, shouldApplyWorkspaceDirectoryCustomization: false
+            )
+            _ = tabManager.reorderWorkspace(tabId: workspace.id, after: afterWorkspaceId)
+        case .append:
+            workspace = tabManager.addWorkspace(
+                title: canonicalSessionName, titleSource: .auto,
+                select: false, placementOverride: .end,
+                autoWelcomeIfNeeded: false, shouldApplyWorkspaceDirectoryCustomization: false
+            )
+        }
         workspace.isRemoteTmuxMirror = true
+        workspace.remoteTmuxWorkspaceIdentity = RemoteTmuxWorkspaceIdentity(
+            connectionHash: host.connectionHash,
+            sessionName: canonicalSessionName
+        )
         workspace.remoteTmuxHostIdentity = AppDelegate.shared?
             .mainWindowContext(for: tabManager)?
             .cmuxConfigStore?

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -89,31 +89,57 @@ final class RemoteTmuxController {
     // MARK: - Control connections (tmux -CC mirroring)
 
     /// Attaches a `tmux -CC` control connection to `sessionName` on `host`,
-    /// reusing an existing live connection for the same host+session.
+    /// reusing an existing live connection for the same stable session id first,
+    /// then by name when the identities are not known to differ.
     @discardableResult
     func attach(
         host: RemoteTmuxHost,
         sessionName: String,
-        createIfMissing: Bool = false
+        createIfMissing: Bool = false,
+        initialSessionId: Int? = nil
     ) throws -> RemoteTmuxControlConnection {
-        let key = Self.connectionKey(host: host, sessionName: sessionName)
-        if let existing = connectionsByHostSession[key] {
-            if !existing.exited { return existing }
-            // Replace a dead connection — fully tear down the old one first so
-            // its ssh process, stdin fd, stream continuation and ingest task
-            // don't leak.
-            removeCachedConnection(forKey: key)?.stop()
+        if let initialSessionId,
+           let stableMatch = connectionsByHostSession.values.first(where: {
+               $0.host.connectionHash == host.connectionHash
+                   && $0.stableSessionId == initialSessionId
+           }) {
+            if !stableMatch.exited { return stableMatch }
+            removeCachedConnection(stableMatch)?.stop()
         }
+
+        let nameKey = Self.connectionKey(host: host, sessionName: sessionName)
+        if let existing = connectionsByHostSession[nameKey] {
+            if existing.exited {
+                removeCachedConnection(forKey: nameKey)?.stop()
+            } else if initialSessionId == nil
+                        || existing.stableSessionId == nil
+                        || existing.stableSessionId == initialSessionId {
+                return existing
+            }
+        }
+
+        let cacheKey: String
+        if let initialSessionId,
+           let existing = connectionsByHostSession[nameKey],
+           !existing.exited,
+           let existingSessionId = existing.stableSessionId,
+           existingSessionId != initialSessionId {
+            cacheKey = Self.stableConnectionKey(host: host, sessionId: initialSessionId)
+        } else {
+            cacheKey = nameKey
+        }
+
         let connection = RemoteTmuxControlConnection(
             host: host,
             sessionName: sessionName,
-            createIfMissing: createIfMissing
+            createIfMissing: createIfMissing,
+            initialSessionId: initialSessionId
         )
         // Insert only after a successful launch, so a failed `start()` never
         // leaves a dead (never-started, `exited == false`) connection that a
         // later attach would wrongly reuse.
         try connection.start()
-        cacheConnection(connection, key: key)
+        cacheConnection(connection, key: cacheKey)
         return connection
     }
 
@@ -149,12 +175,10 @@ final class RemoteTmuxController {
 
     private func stopCachedConnectionIfCurrent(
         _ connection: RemoteTmuxControlConnection,
-        host: RemoteTmuxHost,
-        sessionName: String
+        host _: RemoteTmuxHost,
+        sessionName _: String
     ) {
-        let key = Self.connectionKey(host: host, sessionName: sessionName)
-        guard connectionsByHostSession[key] === connection else { return }
-        removeCachedConnection(forKey: key)?.stop()
+        removeCachedConnection(connection)?.stop()
     }
 
     func cacheConnection(_ connection: RemoteTmuxControlConnection, key: String? = nil) {
@@ -179,6 +203,16 @@ final class RemoteTmuxController {
             connection.removeObserver(token)
         }
         return connection
+    }
+
+    @discardableResult
+    private func removeCachedConnection(
+        _ connection: RemoteTmuxControlConnection
+    ) -> RemoteTmuxControlConnection? {
+        guard let key = connectionsByHostSession.first(where: { $0.value === connection })?.key else {
+            return nil
+        }
+        return removeCachedConnection(forKey: key)
     }
 
     private func handleCachedConnectionSessionNameChanged(
@@ -294,14 +328,57 @@ final class RemoteTmuxController {
         sessionId: Int? = nil,
         into tabManager: TabManager
     ) throws -> Bool {
-        let key = Self.connectionKey(host: host, sessionName: sessionName)
-        guard sessionMirrors[key] == nil else { return false }
+        guard liveMirror(host: host, sessionName: sessionName, sessionId: sessionId) == nil else {
+            return false
+        }
         // Attach (and start the ssh process) BEFORE creating the workspace, so a
         // failed connection doesn't leave an orphaned empty mirror workspace in
         // the sidebar.
-        let connection = try attach(host: host, sessionName: sessionName)
+        let connection = try attach(
+            host: host,
+            sessionName: sessionName,
+            initialSessionId: sessionId
+        )
+        guard sessionMirrors.values.contains(where: { $0.connection === connection }) == false else {
+            return false
+        }
+        return createMirror(
+            connection: connection,
+            seededSessionId: sessionId,
+            in: tabManager
+        ) != nil
+    }
+
+    private func createMirror(
+        connection: RemoteTmuxControlConnection,
+        seededSessionId: Int?,
+        in tabManager: TabManager
+    ) -> RemoteTmuxSessionMirror? {
+        let host = connection.host
+        let canonicalSessionName = connection.sessionName
+        let stableSessionId = connection.stableSessionId ?? seededSessionId
+        guard liveMirror(
+            host: host,
+            sessionName: canonicalSessionName,
+            sessionId: stableSessionId
+        ) == nil else {
+            return nil
+        }
+
+        let nameKey = Self.connectionKey(host: host, sessionName: canonicalSessionName)
+        let key: String
+        if let existing = sessionMirrors[nameKey],
+           let stableSessionId,
+           let existingSessionId = existing.connection.stableSessionId ?? existing.seededSessionId,
+           existingSessionId != stableSessionId {
+            key = Self.stableConnectionKey(host: host, sessionId: stableSessionId)
+        } else {
+            key = nameKey
+        }
+        guard sessionMirrors[key] == nil else { return nil }
+
         let workspace = tabManager.addWorkspace(
-            title: sessionName, titleSource: .auto,
+            title: canonicalSessionName, titleSource: .auto,
             select: false,
             autoWelcomeIfNeeded: false,
             workspaceDirectoryCustomizationMode: .disabled
@@ -315,10 +392,10 @@ final class RemoteTmuxController {
                 verification: verification
             )
         }
-        sessionMirrors[key] = RemoteTmuxSessionMirror(
+        let mirror = RemoteTmuxSessionMirror(
             host: host,
-            sessionName: sessionName,
-            seededSessionId: sessionId,
+            sessionName: canonicalSessionName,
+            seededSessionId: stableSessionId,
             connection: connection,
             tabManager: tabManager,
             workspace: workspace,
@@ -327,6 +404,204 @@ final class RemoteTmuxController {
                 workspaceID: workspace.id
             )
         )
+        sessionMirrors[key] = mirror
+        return mirror
+    }
+
+    func closedMirrorHistoryEntry(
+        workspaceId: UUID,
+        windowId: UUID?,
+        workspaceIndex: Int
+    ) -> ClosedRemoteTmuxMirrorHistoryEntry? {
+        guard let mirror = sessionMirror(workspaceId: workspaceId) else { return nil }
+        return ClosedRemoteTmuxMirrorHistoryEntry(
+            host: mirror.host,
+            sessionName: mirror.sessionName,
+            sessionId: mirror.connection.sessionId ?? mirror.seededSessionId,
+            windowId: windowId,
+            workspaceIndex: workspaceIndex
+        )
+    }
+
+    func restoreClosedMirrorIfAlreadyLive(
+        _ entry: ClosedRemoteTmuxMirrorHistoryEntry,
+        shouldActivate: Bool
+    ) -> Bool? {
+        guard let mirror = liveMirror(matching: entry) else { return nil }
+        return placeRestoredMirror(
+            mirror,
+            recordedWindowId: entry.windowId,
+            workspaceIndex: entry.workspaceIndex,
+            newlyCreated: false,
+            shouldActivate: shouldActivate
+        )
+    }
+
+    @discardableResult
+    func restoreClosedMirror(
+        _ entry: ClosedRemoteTmuxMirrorHistoryEntry,
+        preferredTabManager: TabManager? = nil,
+        shouldActivate: Bool
+    ) async -> Bool {
+        if let restored = restoreClosedMirrorIfAlreadyLive(entry, shouldActivate: shouldActivate) {
+            return restored
+        }
+
+        guard let appDelegate = AppDelegate.shared,
+              restoreTargetManager(
+                  for: entry,
+                  preferredTabManager: preferredTabManager,
+                  appDelegate: appDelegate
+              ) != nil else {
+            return false
+        }
+
+        do {
+            let cachedConnectionIds = Set(connectionsByHostSession.values.map { ObjectIdentifier($0) })
+            let connection = try attach(
+                host: entry.host,
+                sessionName: entry.sessionName,
+                initialSessionId: entry.sessionId
+            )
+            let launchedForRestore = !cachedConnectionIds.contains(ObjectIdentifier(connection))
+            if let mirror = sessionMirrors.values.first(where: { $0.connection === connection }) {
+                return placeRestoredMirror(
+                    mirror,
+                    recordedWindowId: entry.windowId,
+                    workspaceIndex: entry.workspaceIndex,
+                    newlyCreated: false,
+                    shouldActivate: shouldActivate
+                )
+            }
+            guard await connection.waitUntilConnected(allowingReconnect: false) else {
+                if launchedForRestore {
+                    removeCachedConnection(connection)?.stop()
+                }
+                return false
+            }
+            if let mirror = liveMirror(matching: entry) {
+                return placeRestoredMirror(
+                    mirror,
+                    recordedWindowId: entry.windowId,
+                    workspaceIndex: entry.workspaceIndex,
+                    newlyCreated: false,
+                    shouldActivate: shouldActivate
+                )
+            }
+            guard let targetManager = restoreTargetManager(
+                for: entry,
+                preferredTabManager: preferredTabManager,
+                appDelegate: appDelegate
+            ) else {
+                if launchedForRestore {
+                    removeCachedConnection(connection)?.stop()
+                }
+                return false
+            }
+            guard let restoredMirror = createMirror(
+                connection: connection,
+                seededSessionId: entry.sessionId,
+                in: targetManager
+            ) else {
+                if launchedForRestore {
+                    removeCachedConnection(connection)?.stop()
+                }
+                return false
+            }
+            return placeRestoredMirror(
+                restoredMirror,
+                recordedWindowId: entry.windowId,
+                workspaceIndex: entry.workspaceIndex,
+                newlyCreated: true,
+                shouldActivate: shouldActivate
+            )
+        } catch {
+            return false
+        }
+    }
+
+    private func restoreTargetManager(
+        for entry: ClosedRemoteTmuxMirrorHistoryEntry,
+        preferredTabManager: TabManager?,
+        appDelegate: AppDelegate
+    ) -> TabManager? {
+        if let windowId = entry.windowId,
+           appDelegate.mainWindow(for: windowId) != nil,
+           let recordedManager = appDelegate.tabManagerFor(windowId: windowId) {
+            return recordedManager
+        }
+        if let preferredTabManager,
+           let preferredWindowId = appDelegate.windowId(for: preferredTabManager),
+           appDelegate.mainWindow(for: preferredWindowId) != nil {
+            return preferredTabManager
+        }
+        guard let currentManager = appDelegate.tabManager,
+              let currentWindowId = appDelegate.windowId(for: currentManager),
+              appDelegate.mainWindow(for: currentWindowId) != nil else {
+            return nil
+        }
+        return currentManager
+    }
+
+    private func liveMirror(
+        matching entry: ClosedRemoteTmuxMirrorHistoryEntry
+    ) -> RemoteTmuxSessionMirror? {
+        liveMirror(
+            host: entry.host,
+            sessionName: entry.sessionName,
+            sessionId: entry.sessionId
+        )
+    }
+
+    private func liveMirror(
+        host: RemoteTmuxHost,
+        sessionName: String,
+        sessionId: Int?
+    ) -> RemoteTmuxSessionMirror? {
+        let endpointMirrors = sessionMirrors.values.filter {
+            $0.host.connectionHash == host.connectionHash
+        }
+        if let sessionId,
+           let stableMatch = endpointMirrors.first(where: {
+               ($0.connection.stableSessionId ?? $0.seededSessionId) == sessionId
+           }) {
+            return stableMatch
+        }
+        return endpointMirrors.first {
+            guard $0.sessionName == sessionName else { return false }
+            guard let sessionId,
+                  let candidateSessionId = $0.connection.stableSessionId ?? $0.seededSessionId else {
+                return true
+            }
+            return candidateSessionId == sessionId
+        }
+    }
+
+    private func placeRestoredMirror(
+        _ mirror: RemoteTmuxSessionMirror,
+        recordedWindowId: UUID?,
+        workspaceIndex: Int,
+        newlyCreated: Bool,
+        shouldActivate: Bool
+    ) -> Bool {
+        guard let workspace = mirror.mirroredWorkspace,
+              let manager = workspace.owningTabManager
+                ?? AppDelegate.shared?.tabManagerFor(tabId: workspace.id) else {
+            return false
+        }
+        let recordedManager = recordedWindowId.flatMap {
+            AppDelegate.shared?.tabManagerFor(windowId: $0)
+        }
+        let isInRecordedWindow = recordedManager.map { $0 === manager } ?? false
+        if newlyCreated || isInRecordedWindow {
+            _ = manager.reorderWorkspace(tabId: workspace.id, toIndex: workspaceIndex)
+        }
+        guard shouldActivate else { return true }
+        manager.selectWorkspace(workspace)
+        if let appDelegate = AppDelegate.shared,
+           let windowId = appDelegate.windowId(for: manager) {
+            _ = appDelegate.focusMainWindow(windowId: windowId)
+        }
         return true
     }
 
@@ -795,6 +1070,10 @@ final class RemoteTmuxController {
     /// + port + identity), so the same destination reached on a different port or
     /// with a different identity file never aliases onto another endpoint's
     /// connection.
+    private static func stableConnectionKey(host: RemoteTmuxHost, sessionId: Int) -> String {
+        "\(host.connectionHash)\u{1}\u{0}id:\(sessionId)"
+    }
+
     static func connectionKey(host: RemoteTmuxHost, sessionName: String) -> String {
         "\(host.connectionHash)\u{1}\(sessionName)"
     }

--- a/Sources/RemoteTmuxController.swift
+++ b/Sources/RemoteTmuxController.swift
@@ -384,6 +384,10 @@ final class RemoteTmuxController {
             workspaceDirectoryCustomizationMode: .disabled
         )
         workspace.isRemoteTmuxMirror = true
+        workspace.remoteTmuxHostIdentity = AppDelegate.shared?
+            .mainWindowContext(for: tabManager)?
+            .cmuxConfigStore?
+            .remoteTmuxVisualIdentity(for: host) ?? host.visualIdentity()
         workspace.remoteTmuxWindowOrderSync = { [weak self, weak workspace] orderedPanelIds, verification in
             guard let self, let workspace else { return false }
             return self.handleMirrorWindowsReordered(
@@ -406,6 +410,17 @@ final class RemoteTmuxController {
         )
         sessionMirrors[key] = mirror
         return mirror
+    }
+
+    func refreshHostIdentities(
+        in tabManager: TabManager,
+        overrides: [String: RemoteTmuxHost.IdentityOverride]
+    ) {
+        for mirror in sessionMirrors.values {
+            guard let workspace = mirror.mirroredWorkspace,
+                  workspace.owningTabManager === tabManager else { continue }
+            workspace.remoteTmuxHostIdentity = mirror.host.visualIdentity(overrides: overrides)
+        }
     }
 
     func closedMirrorHistoryEntry(

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -12,7 +12,7 @@ import Foundation
 /// `CMUX_REMOTE_TMUX_SSH_FOR_TESTING` so end-to-end tests can substitute a
 /// shim that strips the ssh framing and execs the remote command locally —
 /// the full mirror stack then runs hermetically (no sshd, no network).
-struct RemoteTmuxHost: Sendable, Equatable, Identifiable {
+struct RemoteTmuxHost: Sendable, Equatable, Identifiable, Codable {
     /// The ssh executable used when the caller doesn't inject one (the
     /// connection and transport inits both take `sshExecutablePath`).
     ///

--- a/Sources/RemoteTmuxHost.swift
+++ b/Sources/RemoteTmuxHost.swift
@@ -52,6 +52,125 @@ struct RemoteTmuxHost: Sendable, Equatable, Identifiable, Codable {
         self.identityFile = identityFile
     }
 
+    /// User-configurable chrome for a remote host pattern.
+    struct IdentityOverride: Codable, Sendable, Equatable {
+        let symbol: String
+        let tint: String
+
+        init(symbol: String, tint: String) {
+            self.symbol = symbol
+            self.tint = tint
+        }
+    }
+
+    /// Resolved, render-ready identity stored on a remote mirror workspace.
+    struct VisualIdentity: Sendable, Equatable {
+        let symbolName: String
+        let tintHex: String
+        let hostSlug: String
+        /// Present only for the deterministic fallback; useful for diagnostics and tests.
+        let fallbackHueIndex: Int?
+    }
+
+    /// Twelve evenly spaced hues keep unrelated hosts visually distinct while
+    /// remaining stable because selection is derived from ``connectionHash``.
+    static let fallbackTintHexTable = [
+        "#D14F4F", "#D1904F", "#D1D14F", "#90D14F",
+        "#4FD14F", "#4FD190", "#4FD1D1", "#4F90D1",
+        "#4F4FD1", "#904FD1", "#D14FD1", "#D14F90",
+    ]
+
+    /// Resolves explicit `remoteHosts` overrides first, then a stable fallback.
+    func visualIdentity(overrides: [String: IdentityOverride] = [:]) -> VisualIdentity {
+        if let override = Self.bestIdentityOverride(for: self, overrides: overrides) {
+            return VisualIdentity(
+                symbolName: override.symbol,
+                tintHex: override.tint,
+                hostSlug: slug,
+                fallbackHueIndex: nil
+            )
+        }
+        let hash = UInt64(connectionHash, radix: 16) ?? 0
+        let hueIndex = Int(hash % UInt64(Self.fallbackTintHexTable.count))
+        return VisualIdentity(
+            symbolName: "server.rack",
+            tintHex: Self.fallbackTintHexTable[hueIndex],
+            hostSlug: slug,
+            fallbackHueIndex: hueIndex
+        )
+    }
+
+    private static func bestIdentityOverride(
+        for host: RemoteTmuxHost,
+        overrides: [String: IdentityOverride]
+    ) -> IdentityOverride? {
+        let destination = host.destination.lowercased()
+        let hostComponent = destination
+            .split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+            .last
+            .map(String.init) ?? destination
+        let candidates = [destination, hostComponent, host.slug]
+        var best: (override: IdentityOverride, exact: Bool, specificity: Int, pattern: String)?
+
+        for (rawPattern, rawOverride) in overrides {
+            let pattern = rawPattern.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let symbol = rawOverride.symbol.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !pattern.isEmpty, !symbol.isEmpty,
+                  let tint = normalizedIdentityTint(rawOverride.tint),
+                  candidates.contains(where: { wildcardPattern(pattern, matches: $0) }) else {
+                continue
+            }
+            let exact = candidates.contains(pattern)
+            let specificity = pattern.reduce(into: 0) { count, character in
+                if character != "*" && character != "?" { count += 1 }
+            }
+            let resolved = IdentityOverride(symbol: symbol, tint: tint)
+            guard let current = best else {
+                best = (resolved, exact, specificity, pattern)
+                continue
+            }
+            if exact != current.exact ? exact
+                : specificity != current.specificity ? specificity > current.specificity
+                : pattern < current.pattern {
+                best = (resolved, exact, specificity, pattern)
+            }
+        }
+        return best?.override
+    }
+
+    private static func normalizedIdentityTint(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard digits.count == 6 || digits.count == 8,
+              digits.allSatisfy(\.isHexDigit) else {
+            return nil
+        }
+        return "#\(digits.uppercased())"
+    }
+
+    private static func wildcardPattern(_ pattern: String, matches value: String) -> Bool {
+        let patternCharacters = Array(pattern)
+        let valueCharacters = Array(value)
+        var previous = Array(repeating: false, count: valueCharacters.count + 1)
+        previous[0] = true
+        for patternCharacter in patternCharacters {
+            var current = Array(repeating: false, count: valueCharacters.count + 1)
+            if patternCharacter == "*" {
+                current[0] = previous[0]
+                for index in valueCharacters.indices {
+                    current[index + 1] = previous[index + 1] || current[index]
+                }
+            } else {
+                for index in valueCharacters.indices {
+                    current[index + 1] = previous[index]
+                        && (patternCharacter == "?" || patternCharacter == valueCharacters[index])
+                }
+            }
+            previous = current
+        }
+        return previous[valueCharacters.count]
+    }
+
     /// A human-readable (but lossy) slug for the destination, used only for
     /// debuggability in the control socket filename. It lowercases and maps
     /// every non-alphanumeric character to `-`, so distinct destinations can

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -27,6 +27,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     private let leadingBadge = SidebarRowUnreadBadgeView()
     private var leadingSpinner: GPUSpinnerNSView?
     private let pinImageView = NSImageView()
+    private let remoteHostIdentityImageView = NSImageView()
     private let mediaAudioView = NSImageView()
     private let mediaMicView = NSImageView()
     private let mediaCameraView = NSImageView()
@@ -193,6 +194,8 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
 
         pinImageView.imageScaling = .scaleProportionallyDown
         contentContainer.addSubview(pinImageView)
+        remoteHostIdentityImageView.imageScaling = .scaleProportionallyDown
+        contentContainer.addSubview(remoteHostIdentityImageView)
         for view in [mediaAudioView, mediaMicView, mediaCameraView] {
             view.imageScaling = .scaleProportionallyDown
             contentContainer.addSubview(view)
@@ -378,6 +381,18 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         }
 
         // Title line
+        remoteHostIdentityImageView.isHidden = snapshot.remoteTmuxHostIdentity == nil
+        if let identity = snapshot.remoteTmuxHostIdentity {
+            remoteHostIdentityImageView.image = RenderableSystemSymbol.configuredAppKitImage(
+                systemName: identity.symbolName, pointSize: model.scaled(10), weight: .semibold
+            ) ?? RenderableSystemSymbol.configuredAppKitImage(
+                systemName: "server.rack", pointSize: model.scaled(10), weight: .semibold
+            )
+            remoteHostIdentityImageView.contentTintColor =
+                NSColor(hex: identity.tintHex) ?? palette.secondary(0.8)
+            remoteHostIdentityImageView.toolTip = identity.hostSlug
+            remoteHostIdentityImageView.setAccessibilityLabel(identity.hostSlug)
+        }
         pinImageView.isHidden = !snapshot.isPinned
         if snapshot.isPinned {
             pinImageView.image = RenderableSystemSymbol.configuredAppKitImage(
@@ -1096,6 +1111,15 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         if !pinImageView.isHidden {
             let side = model.scaled(9) + 4
             place(pinImageView, size: NSSize(width: side, height: side), centerY: firstLineCenter)
+            x += side + titleRowSpacing
+        }
+        if !remoteHostIdentityImageView.isHidden {
+            let side = model.scaled(10) + 4
+            place(
+                remoteHostIdentityImageView,
+                size: NSSize(width: side, height: side),
+                centerY: firstLineCenter
+            )
             x += side + titleRowSpacing
         }
         for view in [mediaAudioView, mediaMicView, mediaCameraView] where !view.isHidden {

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -6,6 +6,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
         let customDescription: String?
         let isPinned: Bool
         let customColorHex: String?
+        let remoteTmuxHostIdentity: RemoteTmuxHost.VisualIdentity?
         let finderDirectoryPath: String?
         let mediaActivity: BrowserMediaActivity
         let taskStatus: WorkspaceTaskStatus?
@@ -24,6 +25,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             customDescription: customDescription,
             isPinned: isPinned,
             customColorHex: customColorHex,
+            remoteTmuxHostIdentity: remoteTmuxHostIdentity,
             finderDirectoryPath: finderDirectoryPath,
             mediaActivity: mediaActivity,
             taskStatus: taskStatus,
@@ -46,6 +48,7 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             isPinned: snapshot.isPinned,
             customColorHex: snapshot.customColorHex,
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
+            remoteTmuxHostIdentity: snapshot.remoteTmuxHostIdentity,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
             showsRemoteReconnectAffordance: showsRemoteReconnectAffordance,

--- a/Sources/SidebarWorkspaceSnapshotBuilder.swift
+++ b/Sources/SidebarWorkspaceSnapshotBuilder.swift
@@ -38,6 +38,7 @@ struct SidebarWorkspaceSnapshotBuilder {
         let isPinned: Bool
         let customColorHex: String?
         let remoteWorkspaceSidebarText: String?
+        let remoteTmuxHostIdentity: RemoteTmuxHost.VisualIdentity?
         let remoteConnectionStatusText: String
         let remoteStateHelpText: String
         let showsRemoteReconnectAffordance: Bool

--- a/Sources/SidebarWorkspaceSnapshotFactory.swift
+++ b/Sources/SidebarWorkspaceSnapshotFactory.swift
@@ -82,6 +82,7 @@ struct SidebarWorkspaceSnapshotFactory {
             isPinned: workspace.isPinned,
             customColorHex: workspace.customColor,
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
+            remoteTmuxHostIdentity: workspace.remoteTmuxHostIdentity,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,
             showsRemoteReconnectAffordance: !workspace.isManagedCloudVMWorkspace

--- a/Sources/TabManager+NonInteractiveClose.swift
+++ b/Sources/TabManager+NonInteractiveClose.swift
@@ -21,8 +21,18 @@ extension TabManager {
         guard let appDelegate = AppDelegate.shared,
               let windowId = appDelegate.windowId(for: self),
               appDelegate.mainWindow(for: windowId) != nil else { return false }
+        let remoteHistoryEntry = recordHistory && workspace.isRemoteTmuxMirror
+            ? appDelegate.remoteTmuxController.closedMirrorHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: windowId,
+                workspaceIndex: 0
+            )
+            : nil
         if workspace.isRemoteTmuxMirror {
             appDelegate.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: workspace.id)
+            if let remoteHistoryEntry {
+                ClosedItemHistoryStore.shared.pushRemoteTmuxMirror(remoteHistoryEntry)
+            }
         }
         guard appDelegate.closeMainWindow(windowId: windowId, recordHistory: recordHistory) else {
             return false

--- a/Sources/TabManager+NonInteractiveClose.swift
+++ b/Sources/TabManager+NonInteractiveClose.swift
@@ -37,16 +37,16 @@ extension TabManager {
         guard appDelegate.closeMainWindow(windowId: windowId, recordHistory: recordHistory) else {
             return false
         }
-        // Window unregister temporarily retains a recoverable route while any
-        // terminal surfaces remain registered. A noninteractive last-workspace
-        // close is final, so tear down those surfaces after the close snapshot is
-        // captured; the terminal registry then retires the route instead of
-        // leaving a scriptable, unclosable window behind (#7992).
+        // Window unregister briefly records a recoverable route because the terminal
+        // surface registry still contains this workspace's surfaces. Its unregister
+        // notification retires routes on a later MainActor turn; this close is final,
+        // so retire the route synchronously after capturing the close snapshot.
         workspace.withClosedPanelHistorySuppressed {
             workspace.teardownAllPanels()
         }
         workspace.teardownRemoteConnection()
         workspace.owningTabManager = nil
+        appDelegate.forgetRecoverableMainWindowRoute(windowId: windowId)
         return true
     }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2093,6 +2093,18 @@ class TabManager: ObservableObject {
         guard tabs.count > 1 else { return }
         panelTitleUpdateCoalescer.flushNow()
         sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
+        let remoteHistoryEntry: ClosedRemoteTmuxMirrorHistoryEntry?
+        if recordHistory,
+           workspace.isRemoteTmuxMirror,
+           let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
+            remoteHistoryEntry = AppDelegate.shared?.remoteTmuxController.closedMirrorHistoryEntry(
+                workspaceId: workspace.id,
+                windowId: AppDelegate.shared?.windowId(for: self),
+                workspaceIndex: index
+            )
+        } else {
+            remoteHistoryEntry = nil
+        }
         // Closing a mirrored remote tmux workspace DETACHES from the remote session,
         // leaving it alive on the server for resume. Killing the session is never a
         // side effect of closing a tab (PR #7264 review); it is only ever an explicit
@@ -2100,9 +2112,13 @@ class TabManager: ObservableObject {
         if workspace.isRemoteTmuxMirror {
             AppDelegate.shared?.remoteTmuxController.detachMirrorWorkspaceKeptOpenLocally(workspaceId: workspace.id)
         }
-        if recordHistory,
-           workspace.isRestorableInSessionSnapshot,
-           let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
+        if workspace.isRemoteTmuxMirror {
+            if let remoteHistoryEntry {
+                ClosedItemHistoryStore.shared.pushRemoteTmuxMirror(remoteHistoryEntry)
+            }
+        } else if recordHistory,
+                  workspace.isRestorableInSessionSnapshot,
+                  let index = tabs.firstIndex(where: { $0.id == workspace.id }) {
             // Prefer the warm cached agent index over a synchronous
             // RestorableAgentSessionIndex.load() (sysctl-per-record + disk) so closing a
             // workspace does not freeze the main thread; fall back to a fresh load only
@@ -4182,7 +4198,7 @@ class TabManager: ObservableObject {
                 return restoreClosedPanel(panelEntry)
             case .workspace(let workspaceEntry):
                 return restoreClosedWorkspace(workspaceEntry)
-            case .window:
+            case .window, .remoteTmuxMirror:
                 return false
             }
         }) {
@@ -4208,7 +4224,7 @@ class TabManager: ObservableObject {
             didRestore = restoreClosedPanel(panelEntry)
         case .workspace(let workspaceEntry):
             didRestore = restoreClosedWorkspace(workspaceEntry)
-        case .window:
+        case .window, .remoteTmuxMirror:
             didRestore = false
         }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5163,6 +5163,9 @@ final class Workspace: Identifiable, ObservableObject {
     var isRemoteTmuxMirror: Bool = false
     weak var remoteTmuxSessionMirror: RemoteTmuxSessionMirror?
     @Published var remoteTmuxHostIdentity: RemoteTmuxHost.VisualIdentity?
+    /// Provenance retained when a mirror is kept open locally, allowing a later
+    /// attach of the same host/session to replace it in place.
+    var remoteTmuxWorkspaceIdentity: RemoteTmuxWorkspaceIdentity?
     /// Bound action for this mirror's outbound window-order mutation boundary.
     var remoteTmuxWindowOrderSync: (([UUID], ((Bool) -> Void)?) -> Bool)?
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5162,6 +5162,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// Ephemeral remote tmux mirror; excluded from cmux session restore.
     var isRemoteTmuxMirror: Bool = false
     weak var remoteTmuxSessionMirror: RemoteTmuxSessionMirror?
+    @Published var remoteTmuxHostIdentity: RemoteTmuxHost.VisualIdentity?
     /// Bound action for this mirror's outbound window-order mutation boundary.
     var remoteTmuxWindowOrderSync: (([UUID], ((Bool) -> Void)?) -> Bool)?
 

--- a/Sources/WorkspaceSidebarObservation.swift
+++ b/Sources/WorkspaceSidebarObservation.swift
@@ -171,6 +171,7 @@ private struct SidebarImmediateObservationState: Equatable {
     let taskStatusOverride: WorkspaceTaskStatusOverride?
     let statusHidden: Bool
     let checklist: [WorkspaceChecklistItem]
+    let remoteTmuxHostIdentity: RemoteTmuxHost.VisualIdentity?
 }
 
 private struct SidebarObservationState: Equatable {
@@ -213,6 +214,7 @@ extension Workspace {
             $isPinned,
             $customColor
         )
+        .combineLatest($remoteTmuxHostIdentity)
         let conversationFields = Publishers.CombineLatest3(
             $latestConversationMessage,
             $latestSubmittedMessage,
@@ -231,16 +233,17 @@ extension Workspace {
             .combineLatest(conversationFields, todoFields)
             .map { workspaceFields, conversationFields, todoFields in
                 SidebarImmediateObservationState(
-                    customTitle: workspaceFields.0,
-                    customDescription: workspaceFields.1,
-                    isPinned: workspaceFields.2,
-                    customColor: workspaceFields.3,
+                    customTitle: workspaceFields.0.0,
+                    customDescription: workspaceFields.0.1,
+                    isPinned: workspaceFields.0.2,
+                    customColor: workspaceFields.0.3,
                     latestConversationMessage: conversationFields.0,
                     latestSubmittedMessage: conversationFields.1,
                     latestSubmittedAt: conversationFields.2,
                     taskStatusOverride: todoFields.0,
                     statusHidden: todoFields.1,
-                    checklist: todoFields.2
+                    checklist: todoFields.2,
+                    remoteTmuxHostIdentity: workspaceFields.1
                 )
             }
             .removeDuplicates()

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -192,6 +192,42 @@ import Testing
         )
     }
 
+    @Test func hostVisualIdentityIsStableAcrossResolution() {
+        let host = RemoteTmuxHost(destination: "nixbox", port: 2222, identityFile: "/keys/work")
+        let first = host.visualIdentity()
+        let second = RemoteTmuxHost(
+            destination: "nixbox",
+            port: 2222,
+            identityFile: "/keys/work"
+        ).visualIdentity()
+
+        #expect(first == second)
+        #expect(first.fallbackHueIndex != nil)
+        #expect(first.symbolName == "server.rack")
+    }
+
+    @Test func fallbackHostVisualIdentitiesSpreadAcrossHueTable() {
+        let identities = ["nixbox", "h11", "mac", "alpha", "bravo", "charlie", "delta", "echo"]
+            .map { RemoteTmuxHost(destination: $0).visualIdentity() }
+        let hueIndices = Set(identities.compactMap(\.fallbackHueIndex))
+
+        #expect(hueIndices.count >= 5)
+        #expect(identities.allSatisfy { RemoteTmuxHost.fallbackTintHexTable.contains($0.tintHex) })
+    }
+
+    @Test func explicitHostVisualIdentityOverrideWins() {
+        let host = RemoteTmuxHost(destination: "deploy@nixbox")
+        let identity = host.visualIdentity(overrides: [
+            "*": .init(symbol: "network", tint: "#000000"),
+            "nixbox": .init(symbol: "server.rack", tint: " 5a9bd5 "),
+        ])
+
+        #expect(identity.symbolName == "server.rack")
+        #expect(identity.tintHex == "#5A9BD5")
+        #expect(identity.hostSlug == "deploy-nixbox")
+        #expect(identity.fallbackHueIndex == nil)
+    }
+
     @Test func controlSocketPathVariesByPortAndIdentity() {
         // Distinct endpoints (same destination, different port/identity) must NOT
         // share a ControlMaster socket — otherwise a destructive command could

--- a/cmuxTests/RemoteTmuxAuthTests.swift
+++ b/cmuxTests/RemoteTmuxAuthTests.swift
@@ -511,3 +511,112 @@ import Testing
         )
     }
 }
+
+@Suite struct RemoteTmuxWorkspaceRoutingTests {
+    private let hostHash = "host-hash"
+    private let sessionName = "agents-main"
+
+    @Test func adoptsEmptyExactTitleInPlace() {
+        let workspaceId = UUID()
+
+        let route = RemoteTmuxWorkspaceRoutingPolicy.route(
+            connectionHash: hostHash,
+            sessionName: sessionName,
+            candidates: [
+                candidate(id: workspaceId, title: sessionName, isEmpty: true),
+                candidate(title: "other", isEmpty: true),
+            ]
+        )
+
+        #expect(route == .adopt(workspaceId: workspaceId))
+    }
+
+    @Test func adoptsPriorMirrorOfSameHostAndSessionEvenWhenOccupied() {
+        let workspaceId = UUID()
+
+        let route = RemoteTmuxWorkspaceRoutingPolicy.route(
+            connectionHash: hostHash,
+            sessionName: sessionName,
+            candidates: [
+                candidate(
+                    id: workspaceId,
+                    title: sessionName,
+                    priorMirrorIdentity: RemoteTmuxWorkspaceIdentity(
+                        connectionHash: hostHash,
+                        sessionName: sessionName
+                    )
+                ),
+            ]
+        )
+
+        #expect(route == .adopt(workspaceId: workspaceId))
+    }
+
+    @Test func doesNotAdoptOccupiedLocalOrDifferentHostWorkspace() {
+        let occupiedLocalId = UUID()
+        let differentHostId = UUID()
+
+        let route = RemoteTmuxWorkspaceRoutingPolicy.route(
+            connectionHash: hostHash,
+            sessionName: sessionName,
+            candidates: [
+                candidate(id: occupiedLocalId, title: sessionName),
+                candidate(
+                    id: differentHostId,
+                    title: sessionName,
+                    priorMirrorIdentity: RemoteTmuxWorkspaceIdentity(
+                        connectionHash: "other-host",
+                        sessionName: sessionName
+                    )
+                ),
+            ]
+        )
+
+        #expect(route == .insert(afterWorkspaceId: differentHostId))
+    }
+
+    @Test func insertsAfterLastBestMatchingTitlePrefix() {
+        let shortPrefixId = UUID()
+        let firstBestId = UUID()
+        let lastBestId = UUID()
+
+        let route = RemoteTmuxWorkspaceRoutingPolicy.route(
+            connectionHash: hostHash,
+            sessionName: sessionName,
+            candidates: [
+                candidate(id: shortPrefixId, title: "agents"),
+                candidate(id: firstBestId, title: "agents-main-api"),
+                candidate(id: lastBestId, title: "agents-main-worker"),
+            ]
+        )
+
+        #expect(route == .insert(afterWorkspaceId: lastBestId))
+    }
+
+    @Test func appendsWhenNoTitlePrefixMatches() {
+        let route = RemoteTmuxWorkspaceRoutingPolicy.route(
+            connectionHash: hostHash,
+            sessionName: sessionName,
+            candidates: [
+                candidate(title: "frontend", isEmpty: true),
+                candidate(title: "database"),
+            ]
+        )
+
+        #expect(route == .append)
+    }
+
+    private func candidate(
+        id: UUID = UUID(),
+        title: String,
+        isEmpty: Bool = false,
+        priorMirrorIdentity: RemoteTmuxWorkspaceIdentity? = nil
+    ) -> RemoteTmuxWorkspaceRoutingPolicy.Candidate {
+        RemoteTmuxWorkspaceRoutingPolicy.Candidate(
+            workspaceId: id,
+            title: title,
+            isEmpty: isEmpty,
+            priorMirrorIdentity: priorMirrorIdentity
+        )
+    }
+}

--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -364,7 +364,6 @@ import Testing
             select: false,
             autoWelcomeIfNeeded: false
         )
-        let closedLocalWorkspaceId = localWorkspace.id
         let closedLocalPanelCount = localWorkspace.panels.count
         harness.manager.closeWorkspace(localWorkspace, recordHistory: true)
         #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
@@ -443,7 +442,6 @@ import Testing
         let restoredLocalWorkspace = try #require(
             harness.manager.tabs.first(where: { $0.customTitle == localTitle })
         )
-        #expect(restoredLocalWorkspace.id != closedLocalWorkspaceId)
         #expect(!restoredLocalWorkspace.isRemoteTmuxMirror)
         #expect(restoredLocalWorkspace.panels.count == closedLocalPanelCount)
         #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 0)

--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -53,6 +53,9 @@ import Testing
     /// the local ControlMaster exit as success, so this exercises the production
     /// close route without opening a network connection.
     @Test func socketCloseOfLiveLastMirrorDetachesWithoutKillingSession() async throws {
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("remote-tmux-close-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -63,9 +66,26 @@ import Testing
             at: sshURL,
             contents: """
             #!/bin/sh
+            is_control_client=0
+            is_control_master_exit=0
+            previous=
             for arg in "$@"; do
               printf 'ARG=%s\\n' "$arg" >> "${CMUX_PR7264_SSH_LOG:?}"
+              if [ "$previous" = "-O" ] && [ "$arg" = "exit" ]; then
+                is_control_master_exit=1
+              fi
+              case "$arg" in
+                *"-CC"*) is_control_client=1 ;;
+              esac
+              previous=$arg
             done
+            if [ "$is_control_master_exit" -eq 1 ]; then
+              exit 0
+            fi
+            if [ "$is_control_client" -eq 1 ]; then
+              printf '\\033P1000p%%begin 1 1 0\\n%%end 1 1 0\\n'
+              cat >/dev/null
+            fi
             exit 0
             """
         )
@@ -130,6 +150,19 @@ import Testing
         #expect(!log.contains("kill-session"), Comment(rawValue: log))
         #expect(controller.sessionMirror(host: host, sessionName: "dev") == nil)
         #expect(connection.exited)
+        let closedHistory = ClosedItemHistoryStore.shared.menuSnapshot()
+        #expect(closedHistory.totalItemCount == 1)
+        #expect(closedHistory.items.map(\.title) == ["dev"])
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(shouldActivate: false))
+        let reattachedMirror = try await waitForRemoteMirror(
+            host: host,
+            sessionName: "dev",
+            controller: controller
+        )
+        #expect(reattachedMirror.mirroredWorkspace != nil)
+        try await waitForHistoryItemCount(0)
+
     }
 
     /// Explicit detach of a mirror opened in its own window must close that
@@ -274,6 +307,146 @@ import Testing
         #expect(harness.manager.tabs.map(\.id) == [harness.workspace.id])
         #expect(controller.sessionMirror(host: host, sessionName: "dev") == nil)
         #expect(connection.exited)
+    }
+
+    @Test func recentlyClosedRemoteMirrorCoalescesWithLiveMirrorBeforeRestoringOlderLocalWorkspace() async throws {
+        ClosedItemHistoryStore.shared.removeAll()
+        defer { ClosedItemHistoryStore.shared.removeAll() }
+
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("remote-tmux-reopen-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let logURL = root.appendingPathComponent("ssh.log")
+        let sshURL = root.appendingPathComponent("ssh")
+        try writeExecutable(
+            at: sshURL,
+            contents: """
+            #!/bin/sh
+            is_control_client=0
+            is_control_master_exit=0
+            previous=
+            for arg in "$@"; do
+              printf 'ARG=%s\\n' "$arg" >> "${CMUX_PR7264_SSH_LOG:?}"
+              if [ "$previous" = "-O" ] && [ "$arg" = "exit" ]; then
+                is_control_master_exit=1
+              fi
+              case "$arg" in
+                *"-CC"*) is_control_client=1 ;;
+              esac
+              previous=$arg
+            done
+            if [ "$is_control_master_exit" -eq 1 ]; then
+              exit 0
+            fi
+            if [ "$is_control_client" -eq 1 ]; then
+              printf '\\033P1000p%%begin 1 1 0\\n%%end 1 1 0\\n'
+              cat >/dev/null
+            fi
+            exit 0
+            """
+        )
+        let previousSSH = environmentValue(for: sshOverrideKey)
+        let previousLog = environmentValue(for: sshLogKey)
+        setenv(sshOverrideKey, sshURL.path, 1)
+        setenv(sshLogKey, logURL.path, 1)
+        defer {
+            restoreEnvironment(sshOverrideKey, previousValue: previousSSH)
+            restoreEnvironment(sshLogKey, previousValue: previousLog)
+        }
+
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let localTitle = "Older Local Workspace"
+        let localWorkspace = harness.manager.addWorkspace(
+            title: localTitle,
+            select: false,
+            autoWelcomeIfNeeded: false
+        )
+        let closedLocalWorkspaceId = localWorkspace.id
+        let closedLocalPanelCount = localWorkspace.panels.count
+        harness.manager.closeWorkspace(localWorkspace, recordHistory: true)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
+
+        let host = RemoteTmuxHost(destination: "reopen-\(UUID().uuidString)@example.test")
+        let sessionName = "dev"
+        let controller = harness.controller
+        defer {
+            if controller.sessionMirror(host: host, sessionName: sessionName) != nil {
+                controller.detach(host: host, sessionName: sessionName)
+            }
+        }
+
+        #expect(try controller.mirrorSession(
+            host: host,
+            sessionName: sessionName,
+            into: harness.manager
+        ))
+        let closedMirrorWorkspace = try #require(
+            harness.manager.tabs.first(where: { $0.isRemoteTmuxMirror })
+        )
+
+        harness.manager.closeWorkspace(closedMirrorWorkspace, recordHistory: true)
+
+        let detachLog = try await waitForSSHArgument("exit", at: logURL)
+        #expect(!detachLog.contains("kill-session"), Comment(rawValue: detachLog))
+        #expect(controller.sessionMirror(host: host, sessionName: sessionName) == nil)
+        let historyAfterRemoteClose = ClosedItemHistoryStore.shared.menuSnapshot()
+        #expect(historyAfterRemoteClose.totalItemCount == 2)
+        #expect(Set(historyAfterRemoteClose.items.map(\.title)) == Set([sessionName, localTitle]))
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(
+            preferredTabManager: harness.manager,
+            shouldActivate: true
+        ))
+        let reattachedMirror = try await waitForRemoteMirror(
+            host: host,
+            sessionName: sessionName,
+            controller: controller
+        )
+        let reattachedWorkspace = try #require(reattachedMirror.mirroredWorkspace)
+        #expect(harness.manager.selectedTabId == reattachedWorkspace.id)
+        #expect(reattachedWorkspace.id != closedMirrorWorkspace.id)
+        #expect(harness.manager.tabs.filter(\.isRemoteTmuxMirror).count == 1)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
+
+        harness.manager.closeWorkspace(reattachedWorkspace, recordHistory: true)
+        #expect(controller.sessionMirror(host: host, sessionName: sessionName) == nil)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 2)
+
+        #expect(try controller.mirrorSession(
+            host: host,
+            sessionName: sessionName,
+            into: harness.manager
+        ))
+        let existingMirrorWorkspaceId = try #require(
+            controller.sessionMirror(host: host, sessionName: sessionName)?.mirroredWorkspaceId
+        )
+        #expect(harness.manager.tabs.filter(\.isRemoteTmuxMirror).count == 1)
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(
+            preferredTabManager: harness.manager,
+            shouldActivate: false
+        ))
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 1)
+        #expect(harness.manager.tabs.filter(\.isRemoteTmuxMirror).count == 1)
+        #expect(
+            controller.sessionMirror(host: host, sessionName: sessionName)?.mirroredWorkspaceId
+                == existingMirrorWorkspaceId
+        )
+
+        #expect(harness.appDelegate.reopenMostRecentlyClosedItem(
+            preferredTabManager: harness.manager,
+            shouldActivate: false
+        ))
+        let restoredLocalWorkspace = try #require(
+            harness.manager.tabs.first(where: { $0.customTitle == localTitle })
+        )
+        #expect(restoredLocalWorkspace.id != closedLocalWorkspaceId)
+        #expect(!restoredLocalWorkspace.isRemoteTmuxMirror)
+        #expect(restoredLocalWorkspace.panels.count == closedLocalPanelCount)
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == 0)
     }
 
     @Test func windowCreationFailureUsesLocalErrorMessage() {
@@ -459,6 +632,31 @@ import Testing
         let log = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
         Issue.record("Timed out waiting for fake SSH argument '\(argument)': \(log)")
         return log
+    }
+
+    private func waitForRemoteMirror(
+        host: RemoteTmuxHost,
+        sessionName: String,
+        controller: RemoteTmuxController
+    ) async throws -> RemoteTmuxSessionMirror {
+        for _ in 0..<200 {
+            if let mirror = controller.sessionMirror(host: host, sessionName: sessionName) {
+                return mirror
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("Timed out waiting for the remote tmux mirror to reattach")
+        return try #require(controller.sessionMirror(host: host, sessionName: sessionName))
+    }
+
+    private func waitForHistoryItemCount(_ count: Int) async throws {
+        for _ in 0..<200 {
+            if ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == count {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(ClosedItemHistoryStore.shared.menuSnapshot().totalItemCount == count)
     }
 
     @MainActor

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -22,6 +22,7 @@ struct SidebarAppKitRowCellTests {
             isPinned: false,
             customColorHex: nil,
             remoteWorkspaceSidebarText: nil,
+            remoteTmuxHostIdentity: nil,
             remoteConnectionStatusText: "",
             remoteStateHelpText: "",
             showsRemoteReconnectAffordance: false,

--- a/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
@@ -22,6 +22,7 @@ struct SidebarWorkspaceRowSuspensionTests {
             isPinned: false,
             customColorHex: nil,
             remoteWorkspaceSidebarText: nil,
+            remoteTmuxHostIdentity: nil,
             remoteConnectionStatusText: "",
             remoteStateHelpText: "",
             showsRemoteReconnectAffordance: false,

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -139,6 +139,7 @@ import Testing
             isPinned: isPinned,
             customColorHex: customColorHex,
             remoteWorkspaceSidebarText: nil,
+            remoteTmuxHostIdentity: nil,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: "",
             showsRemoteReconnectAffordance: false,

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -36,6 +36,28 @@
       "type": "object",
       "additionalProperties": true
     },
+    "remoteHosts": {
+      "title": "remoteHosts",
+      "description": "Per-host visual identity overrides for remote tmux mirror workspaces. Keys are case-insensitive SSH destination patterns supporting * and ? wildcards.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["symbol", "tint"],
+        "properties": {
+          "symbol": {
+            "type": "string",
+            "minLength": 1,
+            "description": "SF Symbol name used for the host badge."
+          },
+          "tint": {
+            "type": "string",
+            "pattern": "^#?[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$",
+            "description": "Badge tint as RGB or RGBA hex."
+          }
+        }
+      }
+    },
     "ui": {
       "title": "ui",
       "description": "UI action wiring, including surface tab bar buttons and plus-button behavior. The plus-button context menu shows ui.newWorkspace.contextMenu (or the default items) followed by actions that opt in via newWorkspaceMenu.",


### PR DESCRIPTION
## Behavior

- identifies remote tmux hosts in workspace chrome (per-host icons/visual identity)
- routes remote tmux mirrors to workspaces by stable identity and title instead of always appending new tabs
- retires the detached mirror window route

## Stacking

Stacked on #9108 (remote reopen); the first three commits here are that PR. Review only the top three commits: `79e5e5287`, `40a9ea838`, `a49acd12a`. Merge #9108 first, then this rebases to the three UX commits.

## Scope

Rebased onto upstream `main` (`2757d9de8`); one conflict in `RemoteTmuxController.swift` resolved in favor of the workspace-routing policy (post-conflict code consumes `route`). Pre-rebase tip preserved at Arthur-CWW/cmux `attic/pre-rebase-remote-host-ux-20260728`.

## Verification

Previously observed on the pre-rebase branch: workstream routing 5/5, detach 9/9. Post-rebase focused suites (`RemoteTmuxAuthTests`, `RemoteTmuxMirrorCloseDetachTests`, `SidebarAppKitRowCellTests`) are running; results will be posted as a PR comment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787877255&installation_model_id=21920&pr_number=9110&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9110&signature=741dc6167bd7c14ce7809b65d98936eafa2b1693d5aa6163c8f23c1030295fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-host visual badges for remote tmux mirrors and routes/reattaches mirrors by stable tmux identity and title to avoid duplicate tabs and make reopen reliable.

- **New Features**
  - Host badges in tab and sidebar; configurable via `remoteHosts` (wildcards, RGB/RGBA tints) with a deterministic fallback palette; updates live on config change.
  - Stable routing and reconnection: prefer stable tmux session ids, cache connections by id/name, and place mirrors by title (adopt empty/prior mirror; else insert after best prefix; else append).
  - Recently closed mirror history: records remote mirrors on tab/window close (memory-only, cap 20) and restores into the recorded window and position; restore waits only for the initial attach attempt and clears history on success.

- **Bug Fixes**
  - Reopening a closed remote mirror now reattaches or coalesces with a live mirror instead of creating new tabs; history store tracks pending restores and avoids removing records mid-restore.
  - Detached-mirror window route is retired; noninteractive last-workspace window closes now retire routes synchronously.

<sup>Written for commit cf356fdfc114be0a5cf2647a1b7765a784f4e9be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable remote tmux host identity overrides via `remoteHosts` (destination-pattern matching with custom symbols and tints).
  * Remote tmux workspaces now display a host identity icon in the sidebar/workspace UI.
  * Enhanced remote mirror routing (adopt/insert/append) and improved placement/restoration behavior.
* **Bug Fixes**
  * Improved closed-item history for remote mirrors with de-duplication and more reliable reopen/restore flow (including pending/failed outcomes).
  * Improved reconnect targeting using stable tmux session identifiers.
* **Tests**
  * Expanded test coverage for remote host identities, routing policy, and mirror close/detach history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->