### PR TITLE
Bound overlapping agent hibernation evaluations

### DIFF
--- a/Sources/App/AgentHibernationController+EvaluationScheduling.swift
+++ b/Sources/App/AgentHibernationController+EvaluationScheduling.swift
@@ -6,11 +6,6 @@ extension AgentHibernationController {
         case running(id: UUID, task: Task<Void, Never>)
     }
 
-    var evaluationTask: Task<Void, Never>? {
-        guard case let .running(_, task) = evaluationPhase else { return nil }
-        return task
-    }
-
     func scheduleEvaluation(now: Date) {
         startEvaluationIfIdle { [weak self] in
             guard let self,
@@ -41,7 +36,9 @@ extension AgentHibernationController {
     }
 
     func cancelEvaluation() {
-        evaluationTask?.cancel()
+        if case let .running(_, task) = evaluationPhase {
+            task.cancel()
+        }
         evaluationPhase = .idle
     }
 

--- a/Sources/App/AgentHibernationController+EvaluationScheduling.swift
+++ b/Sources/App/AgentHibernationController+EvaluationScheduling.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+extension AgentHibernationController {
+    enum EvaluationPhase {
+        case idle
+        case running(id: UUID, task: Task<Void, Never>)
+    }
+
+    var evaluationTask: Task<Void, Never>? {
+        guard case let .running(_, task) = evaluationPhase else { return nil }
+        return task
+    }
+
+    func scheduleEvaluation(now: Date) {
+        startEvaluationIfIdle { [weak self] in
+            guard let self,
+                  AgentHibernationTrackingGate.isEnabled(),
+                  let index = await SharedLiveAgentIndex.shared.indexRefreshingNow(),
+                  !Task.isCancelled,
+                  AgentHibernationTrackingGate.isEnabled() else {
+                return
+            }
+            let settings = AgentHibernationSettings.values()
+            guard settings.enabled else { return }
+            self.evaluate(index: index, settings: settings, now: now)
+        }
+    }
+
+    @discardableResult
+    func startEvaluationIfIdle(
+        _ operation: @escaping @MainActor @Sendable () async -> Void
+    ) -> Bool {
+        guard case .idle = evaluationPhase else { return false }
+        let requestID = UUID()
+        let task = Task { @MainActor [weak self] in
+            await operation()
+            self?.finishEvaluation(id: requestID)
+        }
+        evaluationPhase = .running(id: requestID, task: task)
+        return true
+    }
+
+    func cancelEvaluation() {
+        evaluationTask?.cancel()
+        evaluationPhase = .idle
+    }
+
+    private func finishEvaluation(id: UUID) {
+        guard case let .running(activeID, _) = evaluationPhase,
+              activeID == id else {
+            return
+        }
+        evaluationPhase = .idle
+    }
+}

--- a/Sources/App/AgentHibernationController+EvaluationScheduling.swift
+++ b/Sources/App/AgentHibernationController+EvaluationScheduling.swift
@@ -12,6 +12,7 @@ extension AgentHibernationController {
                   AgentHibernationTrackingGate.isEnabled(),
                   let index = await SharedLiveAgentIndex.shared.indexRefreshingNow(),
                   !Task.isCancelled,
+                  // Re-check after suspension: stop() may disable tracking while the index refreshes.
                   AgentHibernationTrackingGate.isEnabled() else {
                 return
             }

--- a/Sources/App/AgentHibernationController.swift
+++ b/Sources/App/AgentHibernationController.swift
@@ -28,9 +28,9 @@ final class AgentHibernationController {
 
     static let unableToProtectRetrySeconds: TimeInterval = 120
 
-    private let timerQueue = DispatchQueue(label: "com.cmux.agent-hibernation", qos: .utility)
     private var timer: DispatchSourceTimer?
     private var settingsObserver: NSObjectProtocol?
+    var evaluationPhase: EvaluationPhase = .idle
     var activityByPanel: [AgentHibernationPanelKey: TimeInterval] = [:]
     var terminalInputByPanel: [AgentHibernationPanelKey: TimeInterval] = [:]
     var lifecycleChangeByPanel: [AgentHibernationPanelKey: TimeInterval] = [:]
@@ -142,17 +142,12 @@ final class AgentHibernationController {
             return
         }
         guard timer == nil else { return }
-        let timer = DispatchSource.makeTimerSource(queue: timerQueue)
+        let timer = DispatchSource.makeTimerSource(queue: .main)
         timer.schedule(deadline: .now() + 5, repeating: 30)
         timer.setEventHandler {
             let now = Date()
-            Task.detached(priority: .utility) {
-                let index = await RestorableAgentSessionIndex.loadIncludingProcessDetectedSnapshots()
-                await MainActor.run {
-                    let settings = AgentHibernationSettings.values()
-                    guard settings.enabled else { return }
-                    AgentHibernationController.shared.evaluate(index: index, settings: settings, now: now)
-                }
+            Task { @MainActor in
+                AgentHibernationController.shared.scheduleEvaluation(now: now)
             }
         }
         timer.resume()
@@ -439,6 +434,7 @@ final class AgentHibernationController {
     }
 
     private func clearTrackingState() {
+        cancelEvaluation()
         cancelPostTeardownRestoreTasks()
         teardownValidationGeneration = teardownValidationGeneration &+ 1
         activityByPanel.removeAll(keepingCapacity: false)

--- a/Sources/SharedLiveAgentIndex.swift
+++ b/Sources/SharedLiveAgentIndex.swift
@@ -438,6 +438,17 @@ final class SharedLiveAgentIndex {
         return index
     }
 
+    /// Returns a freshly loaded index, coalescing with any refresh already in flight.
+    func indexRefreshingNow() async -> RestorableAgentSessionIndex? {
+        ensureWatchingHookStoreDirectory()
+        if refreshTask == nil, forkAvailabilityRefreshTask == nil {
+            startReload()
+        }
+        let inFlight = forkAvailabilityRefreshTask ?? refreshTask
+        await inFlight?.value
+        return index
+    }
+
     func scheduleRefreshIfStale(
         validating panelKey: RestorableAgentSessionIndex.PanelKey? = nil,
         isRemoteContext: Bool = false

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		8997C00E8997C00E8997C00E /* AgentHibernationController+CommittedTerminationCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D00E8997D00E8997D00E /* AgentHibernationController+CommittedTerminationCleanup.swift */; };
 		8997C00F8997C00F8997C00F /* AgentHibernationController+CommittedTerminationObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D00F8997D00F8997D00F /* AgentHibernationController+CommittedTerminationObservation.swift */; };
 		F65760100000000000000001 /* AgentHibernationController+Confirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65760100000000000000002 /* AgentHibernationController+Confirmation.swift */; };
+		8740B0018740B0018740B001 /* AgentHibernationController+EvaluationScheduling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8740A0018740A0018740A001 /* AgentHibernationController+EvaluationScheduling.swift */; };
 		F65760110000000000000001 /* AgentHibernationController+InFlightTeardown.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65760110000000000000002 /* AgentHibernationController+InFlightTeardown.swift */; };
 		8997C0018997C0018997C001 /* AgentHibernationController+MemoryPressure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D0018997D0018997D001 /* AgentHibernationController+MemoryPressure.swift */; };
 		8997C0068997C0068997C006 /* AgentHibernationController+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D0068997D0068997D006 /* AgentHibernationController+PanelLifecycle.swift */; };
@@ -2616,6 +2617,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		8997D00E8997D00E8997D00E /* AgentHibernationController+CommittedTerminationCleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+CommittedTerminationCleanup.swift"; sourceTree = "<group>"; };
 		8997D00F8997D00F8997D00F /* AgentHibernationController+CommittedTerminationObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+CommittedTerminationObservation.swift"; sourceTree = "<group>"; };
 		F65760100000000000000002 /* AgentHibernationController+Confirmation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+Confirmation.swift"; sourceTree = "<group>"; };
+		8740A0018740A0018740A001 /* AgentHibernationController+EvaluationScheduling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+EvaluationScheduling.swift"; sourceTree = "<group>"; };
 		F65760110000000000000002 /* AgentHibernationController+InFlightTeardown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+InFlightTeardown.swift"; sourceTree = "<group>"; };
 		8997D0018997D0018997D001 /* AgentHibernationController+MemoryPressure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+MemoryPressure.swift"; sourceTree = "<group>"; };
 		8997D0068997D0068997D006 /* AgentHibernationController+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+PanelLifecycle.swift"; sourceTree = "<group>"; };
@@ -5466,6 +5468,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F65760030000000000000002 /* AgentHibernationController+Records.swift */,
 				F65760140000000000000002 /* AgentHibernationController+TailFingerprintSample.swift */,
 				F65760060000000000000002 /* AgentHibernationController+Teardown.swift */,
+				8740A0018740A0018740A001 /* AgentHibernationController+EvaluationScheduling.swift */,
 				F65760150000000000000002 /* AgentHibernationController+UnableToProtectMarker.swift */,
 				8997D0018997D0018997D001 /* AgentHibernationController+MemoryPressure.swift */,
 				8997D0028997D0028997D002 /* AgentHibernationMemoryPressureResponder.swift */,
@@ -8100,6 +8103,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8997C00E8997C00E8997C00E /* AgentHibernationController+CommittedTerminationCleanup.swift in Sources */,
 				8997C00F8997C00F8997C00F /* AgentHibernationController+CommittedTerminationObservation.swift in Sources */,
 				F65760100000000000000001 /* AgentHibernationController+Confirmation.swift in Sources */,
+				8740B0018740B0018740B001 /* AgentHibernationController+EvaluationScheduling.swift in Sources */,
 				F65760110000000000000001 /* AgentHibernationController+InFlightTeardown.swift in Sources */,
 				8997C0018997C0018997C001 /* AgentHibernationController+MemoryPressure.swift in Sources */,
 				8997C0068997C0068997C006 /* AgentHibernationController+PanelLifecycle.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		8997E0018997E0018997E001 /* AgentHibernationController+TeardownValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997F0018997F0018997F001 /* AgentHibernationController+TeardownValidation.swift */; };
 		F65760150000000000000001 /* AgentHibernationController+UnableToProtectMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65760150000000000000002 /* AgentHibernationController+UnableToProtectMarker.swift */; };
 		D36A00010000000000000001 /* AgentHibernationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00010000000000000002 /* AgentHibernationController.swift */; };
+		8740E0018740E0018740E001 /* AgentHibernationEvaluationSchedulingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8740D0018740D0018740D001 /* AgentHibernationEvaluationSchedulingTests.swift */; };
 		D36A00030000000000000001 /* AgentHibernationLifecycleState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */; };
 		D36A00030000000000000003 /* AgentHibernationLifecycleState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */; };
 		8997C0028997C0028997C002 /* AgentHibernationMemoryPressureResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8997D0028997D0028997D002 /* AgentHibernationMemoryPressureResponder.swift */; };
@@ -2632,6 +2633,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		8997F0018997F0018997F001 /* AgentHibernationController+TeardownValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+TeardownValidation.swift"; sourceTree = "<group>"; };
 		F65760150000000000000002 /* AgentHibernationController+UnableToProtectMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "App/AgentHibernationController+UnableToProtectMarker.swift"; sourceTree = "<group>"; };
 		D36A00010000000000000002 /* AgentHibernationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AgentHibernationController.swift; sourceTree = "<group>"; };
+		8740D0018740D0018740D001 /* AgentHibernationEvaluationSchedulingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernationEvaluationSchedulingTests.swift; sourceTree = "<group>"; };
 		D36A00030000000000000002 /* AgentHibernationLifecycleState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernation/AgentHibernationLifecycleState.swift; sourceTree = "<group>"; };
 		8997D0028997D0028997D002 /* AgentHibernationMemoryPressureResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AgentHibernationMemoryPressureResponder.swift; sourceTree = "<group>"; };
 		9090F0039090F0039090F003 /* AgentHibernationPanelCloseCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHibernationPanelCloseCleanupTests.swift; sourceTree = "<group>"; };
@@ -7013,6 +7015,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C51A760000000000000000D2 /* SimulatorPanelThemeTests.swift */,
 				A9E050000000000000000001 /* AgentSessionWebRendererTests.swift */,
 				A9E040000000000000000001 /* CodexAppServerSessionTests.swift */,
+				8740D0018740D0018740D001 /* AgentHibernationEvaluationSchedulingTests.swift */,
 				F65760010000000000000002 /* AgentHibernationPlannerSwiftTests.swift */,
 				9090F0039090F0039090F003 /* AgentHibernationPanelCloseCleanupTests.swift */,
 				8997D0048997D0048997D004 /* AgentHibernationProcessTerminationTests.swift */,
@@ -9847,6 +9850,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A51D000000000000000002 /* AgentChatSessionRegistryObservationTests.swift in Sources */,
 				A9E020000000000000000005 /* AgentExecutableResolverTests.swift in Sources */,
 				9090E0039090E0039090E003 /* AgentHibernationPanelCloseCleanupTests.swift in Sources */,
+				8740E0018740E0018740E001 /* AgentHibernationEvaluationSchedulingTests.swift in Sources */,
 				F65760010000000000000001 /* AgentHibernationPlannerSwiftTests.swift in Sources */,
 				D72260010000000000000001 /* AgentHibernationPortalVisibilityTests.swift in Sources */,
 				8997C0138997C0138997C013 /* AgentHibernationProcessSignalBoundaryTests.swift in Sources */,

--- a/cmuxTests/AgentHibernationEvaluationSchedulingTests.swift
+++ b/cmuxTests/AgentHibernationEvaluationSchedulingTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 
 #if canImport(cmux_DEV)
@@ -18,35 +19,134 @@ struct AgentHibernationEvaluationSchedulingTests {
 
         let evaluationStarted = AsyncStream<Void>.makeStream()
         let releaseEvaluation = AsyncStream<Void>.makeStream()
+        let activeEvaluationFinished = AsyncStream<Void>.makeStream()
         let counter = Counter()
 
         #expect(controller.startEvaluationIfIdle {
-            counter.value += 1
+            counter.begin()
+            defer { counter.end() }
             evaluationStarted.continuation.yield()
             await Self.waitForSignal(releaseEvaluation.stream)
+            activeEvaluationFinished.continuation.yield()
         })
         await Self.waitForSignal(evaluationStarted.stream)
 
         #expect(!controller.startEvaluationIfIdle {
-            counter.value += 1
+            counter.begin()
         })
         #expect(!controller.startEvaluationIfIdle {
-            counter.value += 1
+            counter.begin()
         })
 
-        let activeEvaluation = try #require(controller.evaluationTask)
         releaseEvaluation.continuation.yield()
-        await activeEvaluation.value
+        await Self.waitForSignal(activeEvaluationFinished.stream)
 
         let finalEvaluationFinished = AsyncStream<Void>.makeStream()
         #expect(controller.startEvaluationIfIdle {
-            counter.value += 1
+            counter.begin()
+            defer { counter.end() }
             finalEvaluationFinished.continuation.yield()
         })
         await Self.waitForSignal(finalEvaluationFinished.stream)
         await Task.yield()
 
         #expect(counter.value == 2)
+        #expect(counter.maximumActiveCount == 1)
+    }
+
+    @MainActor
+    @Test
+    func lateCompletionFromCancelledEvaluationDoesNotFinishReplacement() async {
+        let controller = AgentHibernationController.shared
+        controller.cancelEvaluation()
+        defer { controller.cancelEvaluation() }
+
+        let oldGate = Gate()
+        let oldStarted = AsyncStream<Void>.makeStream()
+        let oldFinished = AsyncStream<Void>.makeStream()
+        #expect(controller.startEvaluationIfIdle {
+            oldStarted.continuation.yield()
+            await oldGate.wait()
+            oldFinished.continuation.yield()
+        })
+        await Self.waitForSignal(oldStarted.stream)
+
+        controller.cancelEvaluation()
+
+        let replacementGate = Gate()
+        let replacementStarted = AsyncStream<Void>.makeStream()
+        let replacementFinished = AsyncStream<Void>.makeStream()
+        #expect(controller.startEvaluationIfIdle {
+            replacementStarted.continuation.yield()
+            await replacementGate.wait()
+            replacementFinished.continuation.yield()
+        })
+        await Self.waitForSignal(replacementStarted.stream)
+
+        oldGate.open()
+        await Self.waitForSignal(oldFinished.stream)
+        #expect(!controller.startEvaluationIfIdle {})
+
+        replacementGate.open()
+        await Self.waitForSignal(replacementFinished.stream)
+        #expect(controller.startEvaluationIfIdle {})
+    }
+
+    @MainActor
+    @Test
+    func immediateRefreshBypassesFreshCacheAndCoalescesCallers() async {
+        let hookStoreDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-hibernation-refresh-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: hookStoreDirectory) }
+
+        let loadCount = OSAllocatedUnfairLock(initialState: 0)
+        let sharedIndex = SharedLiveAgentIndex(
+            indexLoader: {
+                loadCount.withLock { $0 += 1 }
+                return (
+                    index: RestorableAgentSessionIndex.empty,
+                    liveAgentProcessFingerprint: [],
+                    processScopeFingerprint: [],
+                    forkValidatedPanels: []
+                )
+            },
+            hookStoreDirectoryProvider: { hookStoreDirectory.path }
+        )
+
+        _ = await sharedIndex.indexRefreshingNow()
+        #expect(loadCount.withLock { $0 } == 1)
+        _ = sharedIndex.currentIndexSchedulingRefresh()
+        await Task.yield()
+        #expect(loadCount.withLock { $0 } == 1)
+        _ = await sharedIndex.indexRefreshingNow()
+        #expect(loadCount.withLock { $0 } == 2)
+
+        let coalescedLoadCount = OSAllocatedUnfairLock(initialState: 0)
+        let loaderStarted = AsyncStream<Void>.makeStream()
+        let releaseLoader = DispatchSemaphore(value: 0)
+        let coalescingIndex = SharedLiveAgentIndex(
+            indexLoader: {
+                coalescedLoadCount.withLock { $0 += 1 }
+                loaderStarted.continuation.yield()
+                releaseLoader.wait()
+                return (
+                    index: RestorableAgentSessionIndex.empty,
+                    liveAgentProcessFingerprint: [],
+                    processScopeFingerprint: [],
+                    forkValidatedPanels: []
+                )
+            },
+            hookStoreDirectoryProvider: { hookStoreDirectory.path }
+        )
+
+        let first = Task { @MainActor in await coalescingIndex.indexRefreshingNow() }
+        await Self.waitForSignal(loaderStarted.stream)
+        let second = Task { @MainActor in await coalescingIndex.indexRefreshingNow() }
+        await Task.yield()
+        releaseLoader.signal()
+        _ = await first.value
+        _ = await second.value
+        #expect(coalescedLoadCount.withLock { $0 } == 1)
     }
 
     private static func waitForSignal(_ stream: AsyncStream<Void>) async {
@@ -58,5 +158,33 @@ struct AgentHibernationEvaluationSchedulingTests {
     @MainActor
     private final class Counter {
         var value = 0
+        var activeCount = 0
+        var maximumActiveCount = 0
+
+        func begin() {
+            value += 1
+            activeCount += 1
+            maximumActiveCount = max(maximumActiveCount, activeCount)
+        }
+
+        func end() {
+            activeCount -= 1
+        }
+    }
+
+    @MainActor
+    private final class Gate {
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func open() {
+            continuation?.resume()
+            continuation = nil
+        }
     }
 }

--- a/cmuxTests/AgentHibernationEvaluationSchedulingTests.swift
+++ b/cmuxTests/AgentHibernationEvaluationSchedulingTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct AgentHibernationEvaluationSchedulingTests {
+    @MainActor
+    @Test
+    func activeEvaluationRejectsLaterTimerRequests() async throws {
+        let controller = AgentHibernationController.shared
+        controller.cancelEvaluation()
+        defer { controller.cancelEvaluation() }
+
+        let evaluationStarted = AsyncStream<Void>.makeStream()
+        let releaseEvaluation = AsyncStream<Void>.makeStream()
+        let counter = Counter()
+
+        #expect(controller.startEvaluationIfIdle {
+            counter.value += 1
+            evaluationStarted.continuation.yield()
+            await Self.waitForSignal(releaseEvaluation.stream)
+        })
+        await Self.waitForSignal(evaluationStarted.stream)
+
+        #expect(!controller.startEvaluationIfIdle {
+            counter.value += 1
+        })
+        #expect(!controller.startEvaluationIfIdle {
+            counter.value += 1
+        })
+
+        let activeEvaluation = try #require(controller.evaluationTask)
+        releaseEvaluation.continuation.yield()
+        await activeEvaluation.value
+
+        let finalEvaluationFinished = AsyncStream<Void>.makeStream()
+        #expect(controller.startEvaluationIfIdle {
+            counter.value += 1
+            finalEvaluationFinished.continuation.yield()
+        })
+        await Self.waitForSignal(finalEvaluationFinished.stream)
+        await Task.yield()
+
+        #expect(counter.value == 2)
+    }
+
+    private static func waitForSignal(_ stream: AsyncStream<Void>) async {
+        for await _ in stream {
+            return
+        }
+    }
+
+    @MainActor
+    private final class Counter {
+        var value = 0
+    }
+}


### PR DESCRIPTION
## Summary

- make the shared live-agent index the only owner of expensive session-registry refreshes
- serialize periodic agent-hibernation evaluations with an explicit idle/running phase
- coalesce timer delivery on the main actor and cancel evaluation work with controller lifecycle changes

## Reproduction

From https://github.com/manaflow-ai/cmux/issues/8740:

> 1. Open cmux with ~20 terminal surfaces across multiple workspaces
> 2. Run multiple persistent terminal sessions inside cmux (e.g., zmx persistent sessions, pi coding agents, SSH connections, shell processes)
> 3. Make sure agentHibernation is enabled in cmux.json with reasonable limits
> 4. Wait 1–2 days

## Verification

- behavioral regression test holds one evaluation open, rejects later timer requests, and confirms a subsequent evaluation can run after returning to idle
- tagged dev-build dogfood will cover 20+ terminal surfaces, over-cap hibernation, enable/disable lifecycle, and main-thread CPU sampling

The original history-dependent 1–2 day failure has no stack trace and cannot be honestly reproduced within this PR session. Verification therefore targets the concrete unbounded-overlap mechanism plus live over-cap behavior; this residual uncertainty will remain explicit.

Closes #8740

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787878279&installation_model_id=21920&pr_number=9113&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9113&signature=29189095de3b5bea9d0c6cc3e9299a807186b443c6b60a0a6660ed0aee234c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound agent hibernation evaluations to run one at a time and moved the periodic timer to the main actor to stop overlapping work and CPU spikes, addressing #8740. Cancels in-flight work on lifecycle changes, re-checks the tracking gate after async index refresh, and ignores late completions; the shared live-agent index now owns and coalesces refreshes.

- **Bug Fixes**
  - Serialize evaluations with idle/running phases and id-tracked tasks via `startEvaluationIfIdle`/`finishEvaluation`.
  - Gate timer and manual requests while active; main-actor timer calls `scheduleEvaluation(now:)`; `SharedLiveAgentIndex.indexRefreshingNow()` returns a fresh index and coalesces callers; re-check the hibernation gate after suspension.
  - Clearing tracking cancels active work; tests cover gating, cancellation safety, and refresh coalescing.

<sup>Written for commit 7962a19079b658f9e342f325f1aca4b15437080f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added immediate “live agent index” refresh capability that coalesces concurrent refresh requests.
* **Bug Fixes**
  * Improved evaluation scheduling to ensure evaluations run strictly one at a time.
  * Prevented canceled evaluations from interfering with subsequently started evaluations.
  * Cancel in-progress evaluation when hibernation tracking is reset.
* **Reliability**
  * Evaluations now rely on the freshest available agent index when scheduling occurs.
* **Tests**
  * Added automated coverage for sequential evaluation behavior, cancellation safety, and refresh coalescing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->