### PR TITLE
Bump iroh-ffi to 1.0.2-cmux.6: dead-path failover + make-before-break relay rotation

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Package.resolved
+++ b/Packages/Shared/CmuxIrohTransport/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "442d4b8f7e05687956e3bb34a7825d438a861385fb98ae661b5e97cebfaa3672",
+  "originHash" : "fa21205e0ef32c6aea8b93edd9f9861c27284eb100dc11a0fec6915b2044f0f1",
   "pins" : [
     {
       "identity" : "iroh-ffi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "e10013af9ab5d541b3b9d632fda502b8232d3796",
-        "version" : "1.0.2-cmux.4"
+        "revision" : "017f1517c4afcdd8ffa2a2a83bcda7c329d222d8",
+        "version" : "1.0.2-cmux.6"
       }
     }
   ],

--- a/Packages/Shared/CmuxIrohTransport/Package.swift
+++ b/Packages/Shared/CmuxIrohTransport/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(path: "../CMUXMobileCore"),
         .package(
             url: "https://github.com/manaflow-ai/iroh-ffi.git",
-            exact: "1.0.2-cmux.4"
+            exact: "1.0.2-cmux.6"
         ),
     ],
     targets: [


### PR DESCRIPTION
Delivers the WiFi reconnect-loop root fix to cmux, per the never-disconnect program.

**What this pulls in:**
- https://github.com/manaflow-ai/iroh/pull/8 — a dead selected direct path demotes to relay in ~1-3 RTT (measured 1.55-1.58s failover vs 15.1s stall) with address quarantine + doubling backoff; the connection never closes. This removes the ~2s WiFi connect/die metronome from the 2026-07-23 field rings (50 deaths/21 min). Mechanism note: hq `out/iroh-fork-program/B1-mechanism-note.md`.
- https://github.com/manaflow-ai/iroh/pull/9 — relay credential rotation is make-before-break (no disconnect on token refresh).

**Verification:** CmuxIrohTransport 473/473, CMUXMobileCore 305/305 against the new artifact; the path fix's canary lineage (v1.0.2-cmux.5-canary.1) was previously built and run on the `ncon` dogfood pair. One non-reproducing first-run test flake, clean on two consecutive reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787885443&installation_model_id=21920&pr_number=9116&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9116&signature=ddf81f2e16b482ea9749ee14c5e96d94aa8fdd37846ce393662d27b604fa359e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `iroh-ffi` to 1.0.2-cmux.6 to add fast dead-path failover and make-before-break relay rotation. Fixes Wi‑Fi reconnect loop stalls and keeps connections alive.

- **Dependencies**
  - Bump `iroh-ffi` from 1.0.2-cmux.4 to 1.0.2-cmux.6.
  - Dead direct path fails over to relay in ~1–3 RTT, avoiding the 15s stall; connection stays open.
  - Relay credential rotation is make-before-break (no disconnect on refresh).
  - Verified: `CmuxIrohTransport` 473/473, `CMUXMobileCore` 305/305; clean on rerun.

<sup>Written for commit 7a68bdf2e2386cac42b982f0d43f6adc3e7032a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying transport dependency to a newer revision.
  * Includes the latest upstream fixes and improvements for builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->