### PR TITLE
Fix stale GhosttyKit in iOS reloads

### DIFF
--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -287,6 +287,17 @@ if [[ -n "$SIMULATOR_ID" ]]; then
   DESTINATION="platform=iOS Simulator,id=$SIMULATOR_ID"
 fi
 MOBILE_DEV_LAUNCH="$IOS_DIR/../scripts/mobile-dev-launch.sh"
+GHOSTTYKIT_ENSURE="$IOS_DIR/../scripts/ensure-ghosttykit.sh"
+
+# Keep the linked xcframework synchronized with the checked-out Ghostty
+# submodule before Xcode builds either target. Without this, a local cloud
+# fallback can reuse a stale GhosttyKit symlink and compile against an older C
+# header even though the Swift sources target the current submodule API.
+if [[ ! -x "$GHOSTTYKIT_ENSURE" ]]; then
+  echo "error: $GHOSTTYKIT_ENSURE not found or not executable" >&2
+  exit 1
+fi
+"$GHOSTTYKIT_ENSURE"
 
 # Auto-setup launch: relaunch the just-installed app signed in (dogfood creds
 # injected) and, unless --no-attach, auto-paired to the tagged Mac app. Delegates


### PR DESCRIPTION
## Summary
- provision GhosttyKit from the checked-out submodule before local iOS reloads
- fail clearly when the provisioning helper is unavailable

## Verification
- `bash -n ios/scripts/reload.sh`
- ran `ios/scripts/reload.sh --tag gkit --device-only --device-id DOES-NOT-EXIST --no-launch`; it provisioned the exact `2258bea9` GhosttyKit before stopping at the intentionally invalid device
- built, installed, launched, signed in, and auto-paired `irship` on Aziz’s iPhone after reprovisioning the current GhosttyKit

No source-shape regression test was added because repository test policy forbids grep-style implementation tests; the executable reload path above covers the failure mechanism.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787890709&installation_model_id=21920&pr_number=9121&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9121&signature=707f702ae6a8d112d2e81b949a2ecfe89cd87cdcb9aa66efd3f086ffd0b29686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale `GhosttyKit` in iOS reloads by provisioning from the checked-out submodule before Xcode builds, avoiding header/API mismatches. The reload script runs `scripts/ensure-ghosttykit.sh` and fails fast with a clear error if the helper is missing or not executable.

<sup>Written for commit 2f738bbcc39a593e8400c84b76849b7de3c230b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the iOS reload process by ensuring GhosttyKit is synchronized before continuing.
  * Added validation to stop the process with a clear error when the required synchronization helper is unavailable or cannot run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->