### PR TITLE
Render realistic onboarding iPhone frame

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneFooter.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneFooter.swift
@@ -30,7 +30,7 @@ struct OnboardingSceneFooter: View {
         }
         .frame(maxWidth: 520)
         .padding(.horizontal, 24)
-        .padding(.top, 10)
+        .padding(.top, 16)
         .padding(.bottom, 12)
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .contain)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingScreenshot.swift
@@ -54,9 +54,9 @@ struct OnboardingScreenshot: View {
 
     private var frameHeight: CGFloat {
         if dynamicTypeSize.isAccessibilitySize {
-            return 360
+            return 420
         }
-        return horizontalSizeClass == .regular ? 520 : 440
+        return horizontalSizeClass == .regular ? 660 : 560
     }
 
     private var language: OnboardingScreenshotLanguage {
@@ -154,7 +154,14 @@ private struct OnboardingIPhoneScreenshotFrame<Screen: View>: View {
                 cornerRadius: OnboardingIPhoneScreenshotFrameMetrics.outerCornerRadius,
                 style: .continuous
             )
+            .fill(titaniumRim)
+
+            RoundedRectangle(
+                cornerRadius: OnboardingIPhoneScreenshotFrameMetrics.glassCornerRadius,
+                style: .continuous
+            )
             .fill(Color.black)
+            .padding(OnboardingIPhoneScreenshotFrameMetrics.rimWidth)
 
             ZStack {
                 Color(.systemBackground)
@@ -165,33 +172,73 @@ private struct OnboardingIPhoneScreenshotFrame<Screen: View>: View {
                     )
             }
             .clipShape(screenShape)
-            .padding(8)
+            .padding(OnboardingIPhoneScreenshotFrameMetrics.screenInset)
 
             screenShape
-                .stroke(Color.white.opacity(0.10), lineWidth: 1)
-                .padding(8)
+                .stroke(
+                    Color.white.opacity(0.16),
+                    lineWidth: 1
+                )
+                .padding(OnboardingIPhoneScreenshotFrameMetrics.screenInset)
 
             RoundedRectangle(
                 cornerRadius: OnboardingIPhoneScreenshotFrameMetrics.outerCornerRadius,
                 style: .continuous
             )
-            .stroke(Color.white.opacity(0.16), lineWidth: 1)
+            .stroke(outerHighlight, lineWidth: 1)
+
+            RoundedRectangle(
+                cornerRadius: OnboardingIPhoneScreenshotFrameMetrics.outerCornerRadius,
+                style: .continuous
+            )
+            .stroke(Color.black.opacity(0.42), lineWidth: 1)
+            .padding(1)
+        }
+        .overlay(alignment: .top) {
+            OnboardingDynamicIsland()
+                .padding(.top, OnboardingIPhoneScreenshotFrameMetrics.dynamicIslandTopInset)
         }
         .overlay(alignment: .leading) {
-            sideButton(height: 46)
-                .offset(x: -3, y: -82)
+            OnboardingIPhoneSideButton(height: 48, edge: .leading)
+                .offset(x: -4, y: -104)
         }
         .overlay(alignment: .leading) {
-            sideButton(height: 62)
-                .offset(x: -3, y: -12)
+            OnboardingIPhoneSideButton(height: 66, edge: .leading)
+                .offset(x: -4, y: -24)
         }
         .overlay(alignment: .trailing) {
-            sideButton(height: 86)
-                .offset(x: 3, y: 34)
+            OnboardingIPhoneSideButton(height: 96, edge: .trailing)
+                .offset(x: 4, y: 48)
         }
         .aspectRatio(
             OnboardingIPhoneScreenshotFrameMetrics.outerAspectRatio,
             contentMode: .fit
+        )
+    }
+
+    private var titaniumRim: LinearGradient {
+        LinearGradient(
+            stops: [
+                .init(color: Color(white: 0.70), location: 0.00),
+                .init(color: Color(white: 0.16), location: 0.06),
+                .init(color: Color(white: 0.04), location: 0.48),
+                .init(color: Color(white: 0.30), location: 0.94),
+                .init(color: Color(white: 0.68), location: 1.00),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    private var outerHighlight: LinearGradient {
+        LinearGradient(
+            colors: [
+                Color.white.opacity(0.54),
+                Color.white.opacity(0.06),
+                Color.black.opacity(0.26),
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
         )
     }
 
@@ -201,19 +248,82 @@ private struct OnboardingIPhoneScreenshotFrame<Screen: View>: View {
             style: .continuous
         )
     }
-
-    private func sideButton(height: CGFloat) -> some View {
-        Capsule()
-            .fill(Color.black)
-            .frame(width: 4, height: height)
-    }
 }
 
 private enum OnboardingIPhoneScreenshotFrameMetrics {
-    static let outerAspectRatio: CGFloat = 0.49
+    static let outerAspectRatio: CGFloat = 78.0 / 163.4
     static let screenAspectRatio: CGFloat = 1206 / 2622
-    static let outerCornerRadius: CGFloat = 48
-    static let screenCornerRadius: CGFloat = 40
+    static let outerCornerRadius: CGFloat = 62
+    static let glassCornerRadius: CGFloat = 58
+    static let screenCornerRadius: CGFloat = 51
+    static let rimWidth: CGFloat = 4
+    static let screenInset: CGFloat = 9
+    static let dynamicIslandTopInset: CGFloat = 15
+}
+
+private struct OnboardingDynamicIsland: View {
+    var body: some View {
+        Capsule()
+            .fill(Color.black)
+            .frame(width: 76, height: 22)
+            .overlay(alignment: .trailing) {
+                Circle()
+                    .fill(cameraLensGradient)
+                    .frame(width: 8, height: 8)
+                    .padding(.trailing, 12)
+            }
+            .overlay {
+                Capsule()
+                    .stroke(Color.white.opacity(0.05), lineWidth: 1)
+            }
+    }
+
+    private var cameraLensGradient: RadialGradient {
+        RadialGradient(
+            colors: [
+                Color(red: 0.05, green: 0.12, blue: 0.20),
+                Color(red: 0.00, green: 0.03, blue: 0.07),
+                Color.black,
+            ],
+            center: .center,
+            startRadius: 1,
+            endRadius: 5
+        )
+    }
+}
+
+private struct OnboardingIPhoneSideButton: View {
+    enum Edge {
+        case leading
+        case trailing
+    }
+
+    let height: CGFloat
+    let edge: Edge
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 2, style: .continuous)
+            .fill(buttonGradient)
+            .frame(width: 4, height: height)
+            .overlay(alignment: edge == .leading ? .leading : .trailing) {
+                Rectangle()
+                    .fill(Color.white.opacity(0.24))
+                    .frame(width: 1)
+                    .padding(.vertical, 3)
+            }
+    }
+
+    private var buttonGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                Color(white: 0.38),
+                Color(white: 0.05),
+                Color(white: 0.22),
+            ],
+            startPoint: edge == .leading ? .leading : .trailing,
+            endPoint: edge == .leading ? .trailing : .leading
+        )
+    }
 }
 
 enum OnboardingScreenshotLanguage: String, CaseIterable, Equatable, Sendable {


### PR DESCRIPTION
## Summary
- Replace the flat onboarding screenshot wrapper with a realistic drawn iPhone frame.
- Keep the existing real screenshot assets and their light/dark, localized variants.
- Add rim, glass, side-button, screen-inset, and Dynamic Island details in SwiftUI instead of adding external bezel images.

## Testing
- xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -testPlan cmux -destination 'platform=iOS Simulator,id=E7E6B436-597C-45C9-8ED3-4ACB7F175EB5' -derivedDataPath ~/Library/Developer/Xcode/DerivedData/cmux-ios-bezel -only-testing:CmuxMobileShellUITests/OnboardingSceneChromeTests
- xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -testPlan cmux -destination 'platform=iOS Simulator,id=E7E6B436-597C-45C9-8ED3-4ACB7F175EB5' -derivedDataPath ~/Library/Developer/Xcode/DerivedData/cmux-ios-bezel -only-testing:cmuxUITests/cmuxUITests/testOnboardingScenesNotificationFeedResumeAndScannerFallback
- git diff --check origin/main...HEAD
- ios/scripts/reload.sh --tag bezel --simulator-id E7E6B436-597C-45C9-8ED3-4ACB7F175EB5 --no-setup, build succeeded, direct simulator launch succeeded after reboot/reinstall

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787890882&installation_model_id=21920&pr_number=9122&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9122&signature=d0f79e6a09fbff504cb8cc5820c7ecf81feb5950e2be4e4f95557a5c3f8549ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the flat onboarding screenshot wrapper with a realistic, drawn iPhone frame in SwiftUI. Adds a titanium rim and glass layer with refined sizing for a more polished look while keeping all localized light/dark screenshots.

- **New Features**
  - Titanium-inspired rim gradient and separate glass layer with tuned strokes and insets.
  - Redesigned Dynamic Island with a camera‑lens detail and subtle outline.
  - Gradient side buttons with edge highlights and corrected positions.
  - Updated metrics and sizing (aspect ratio, larger corner radii, increased frame heights for accessibility/size classes); added `OnboardingDynamicIsland`, `OnboardingIPhoneSideButton`, `OnboardingIPhoneScreenshotFrameMetrics` in `OnboardingScreenshot.swift`.

<sup>Written for commit f675d84aefb396e898968cfca2b7a8e06d6f7509. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iPhone onboarding screenshot framing for accessibility Dynamic Type sizes, including consistent frame sizing and sizing behavior across layout classes.
* **Style**
  * Refreshed iPhone onboarding screenshot frame visuals with updated titanium-style rim gradients, border/stroke handling, and highlight layering.
  * Improved decorative details, including new gradient side button styling and a refreshed Dynamic Island with a camera-lens effect and subtle overlay.
  * Increased onboarding scene footer top padding from 10 to 16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->