### PR TITLE
Remove top search bar on iOS Workspaces and Notifications tabs

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobilePrimaryTabScaffold.swift
@@ -43,17 +43,21 @@ struct MobilePrimaryTabScaffold<
                 primaryTabs
 
                 Tab(value: MobilePrimaryTab.search, role: .search) {
+                    // Scoped to the search tab's content: a TabView-level
+                    // searchable is inherited by every tab's navigation bar,
+                    // which rendered a second, top search field on the
+                    // workspaces and notifications tabs.
                     searchDestination
+                        .searchable(
+                            text: activeSearchText,
+                            isPresented: searchPresentation,
+                            prompt: activeSearchPrompt
+                        )
+                        .onSubmit(of: .search) {
+                            selection = searchCoordinator.commitSubmit()
+                        }
                 }
                 .accessibilityIdentifier("MobilePrimaryTabSearch")
-            }
-            .searchable(
-                text: activeSearchText,
-                isPresented: searchPresentation,
-                prompt: activeSearchPrompt
-            )
-            .onSubmit(of: .search) {
-                selection = searchCoordinator.commitSubmit()
             }
             .tabViewSearchActivation(.searchTabSelection)
             .accessibilityIdentifier("MobilePrimaryTabs")


### PR DESCRIPTION
The `.searchable` modifier sat on the primary `TabView` in `MobilePrimaryTabScaffold`, so on iOS 26 every tab's `NavigationStack` inherited it and rendered a second search field pinned to the top of the Workspaces and Notifications tabs, duplicating the bottom tab-bar search. This moves `.searchable` and its `.onSubmit(of: .search)` onto the search tab's destination, making the bottom search pill the only search entrypoint. `Tab(role: .search)` and `.tabViewSearchActivation(.searchTabSelection)` are unchanged, so pill activation, scope switching (workspaces vs notifications prompt), and submit-to-tab behavior all keep working.

Verified on an iOS 26.5 iPhone 17 Pro Max simulator: Workspaces and Notifications tabs no longer show a top search field; tapping the search pill from either tab presents the bottom search field with the matching scope prompt and keyboard. No automated test added: the field placement is system-rendered chrome with no practical behavior-level assertion, and the search coordinator logic is unchanged and already covered by MobilePrimarySearchCoordinatorTests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787894578&installation_model_id=21920&pr_number=9129&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9129&signature=4abfdac95510a33a516e67999911fdb71200b0a1bc4ae64f6a3bd309998deb22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate top search field on iOS by scoping `.searchable` to the Search tab content. The bottom search pill is now the only entry point, with activation and submit behavior unchanged.

- **Bug Fixes**
  - Moved `.searchable` and `.onSubmit(of: .search)` from the `TabView` to the Search tab destination to prevent inherited nav bar fields on Workspaces and Notifications.
  - Kept `Tab(role: .search)` and `.tabViewSearchActivation(.searchTabSelection)` so pill activation, scope prompts, and submit-to-tab still work.
  - Verified on iOS 26.5: no top search field on Workspaces or Notifications; tapping the pill shows the bottom search with the correct scope.

<sup>Written for commit dcca52e00d9bd3aec53bee6000e469e475c55ecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the iOS search experience by ensuring the search field appears only on the Search tab.
  * Prevented duplicate search fields from appearing in other tabs’ navigation bars.
  * Search submissions continue to update results as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->