### PR TITLE
iOS: anchor the keyboard-rise render slide to the cursor row

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1197,6 +1197,22 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         return abs(height - snapshot.layoutViewportRect.height) <= 1
     }
 
+    /// The cursor's bottom edge in render-local points (the coordinate space
+    /// of `lastRenderRect.size`), or nil when not measurable. Reads the same
+    /// non-blocking `ghostty_surface_ime_point` the cursor overlay uses, so
+    /// the provisional shrink pin can keep the cursor row visible without
+    /// riding the screen bottom.
+    private func cursorBottomInRenderPoints() -> CGFloat? {
+        guard let surface else { return nil }
+        var x: Double = 0
+        var y: Double = 0
+        var width: Double = 0
+        var height: Double = 0
+        ghostty_surface_ime_point(surface, &x, &y, &width, &height)
+        guard y > 0 else { return nil }
+        return CGFloat(y)
+    }
+
     private func layoutRenderedTerminalForCurrentViewport() {
         layoutRenderedTerminalForCurrentViewport(using: viewportSnapshot())
     }
@@ -1207,7 +1223,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         guard !lastRenderRect.isEmpty else { return }
         let renderRect = snapshot.renderRect(
             forRenderSize: lastRenderRect.size,
-            clampsStaleLiveViewport: shouldClampStaleLiveViewport(using: snapshot)
+            clampsStaleLiveViewport: shouldClampStaleLiveViewport(using: snapshot),
+            cursorBottomInRender: cursorBottomInRenderPoints()
         )
         guard renderRect != lastRenderRect else { return }
         lastRenderRect = renderRect
@@ -3680,7 +3697,8 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         let renderRect = snapshot.renderRect(
             forRenderSize: measuredRenderRect.size,
-            clampsStaleLiveViewport: shouldClampStaleLiveViewport(using: snapshot)
+            clampsStaleLiveViewport: shouldClampStaleLiveViewport(using: snapshot),
+            cursorBottomInRender: cursorBottomInRenderPoints()
         )
         lastRenderRect = renderRect
         #if DEBUG

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportSnapshot.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalViewportSnapshot.swift
@@ -25,7 +25,11 @@ struct TerminalViewportSnapshot {
         )
     }
 
-    func renderRect(forRenderSize renderSize: CGSize, clampsStaleLiveViewport: Bool) -> CGRect {
+    func renderRect(
+        forRenderSize renderSize: CGSize,
+        clampsStaleLiveViewport: Bool,
+        cursorBottomInRender: CGFloat? = nil
+    ) -> CGRect {
         let viewport = renderViewportRect(
             forRenderSize: renderSize,
             clampsStaleLiveViewport: clampsStaleLiveViewport
@@ -33,15 +37,17 @@ struct TerminalViewportSnapshot {
         // Bottom-pin against the live viewport, but never clip content that
         // will be visible at settle: while the viewport grows (keyboard
         // dismissal) a target-sized render keeps its top row in place and the
-        // keyboard reveals the lower rows, instead of the top rows being
-        // pushed off screen and sliding back (see
-        // `TerminalLetterboxGeometry.renderPinnedBottomEdge`).
+        // keyboard reveals the lower rows, and while it shrinks (keyboard
+        // rise) the old render slides only enough to keep the cursor row
+        // visible instead of shoving every content row up by the keyboard
+        // height (see `TerminalLetterboxGeometry.renderPinnedBottomEdge`).
         let bottomEdge = TerminalLetterboxGeometry.renderPinnedBottomEdge(
             liveViewportMaxY: viewport.maxY,
             targetViewportMaxY: layoutViewportRect.maxY,
             viewportMinY: viewport.minY,
             renderHeight: renderSize.height,
-            holdsProvisionalPin: viewportNegotiationUnsettled
+            holdsProvisionalPin: viewportNegotiationUnsettled,
+            cursorBottomInRender: cursorBottomInRender
         )
         return CGRect(
             x: viewport.minX,

--- a/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Sources/CmuxMobileTerminalKit/TerminalLetterboxGeometry.swift
@@ -246,22 +246,50 @@ public struct TerminalLetterboxGeometry {
     /// A settled letterboxed box (a genuinely smaller device pins the shared
     /// grid) keeps the legacy ride so it stays glued to the dock.
     ///
+    /// While the viewport SHRINKS under a provisional pin (keyboard rising,
+    /// old render still applied), the render slides up only as much as
+    /// needed to keep the cursor row visible above the keyboard, instead of
+    /// riding the screen bottom. The rows the keyboard covers are usually
+    /// the BLANK rows below the prompt, so pinning the screen bottom to the
+    /// keyboard edge shoved every content row up by the keyboard height and
+    /// the settle resize dropped them back — the "all rows momentarily
+    /// pushed up" glitch. `cursorBottomInRender` is the cursor's bottom
+    /// edge in render-local points; when it is unknown the legacy
+    /// screen-bottom ride is kept (never hides the prompt).
+    ///
     /// - Parameters:
     ///   - liveViewportMaxY: The live viewport bottom edge in points.
     ///   - targetViewportMaxY: The target (layout) viewport bottom edge.
     ///   - viewportMinY: The viewport top edge in points.
     ///   - renderHeight: The render rect height in points.
     ///   - holdsProvisionalPin: True while the grid negotiation is unsettled.
+    ///   - cursorBottomInRender: The cursor bottom in render-local points,
+    ///     when known.
     /// - Returns: The bottom edge to pin the render rect to.
     public static func renderPinnedBottomEdge(
         liveViewportMaxY: CGFloat,
         targetViewportMaxY: CGFloat,
         viewportMinY: CGFloat,
         renderHeight: CGFloat,
-        holdsProvisionalPin: Bool = false
+        holdsProvisionalPin: Bool = false,
+        cursorBottomInRender: CGFloat? = nil
     ) -> CGFloat {
         if holdsProvisionalPin, liveViewportMaxY < targetViewportMaxY {
             return min(targetViewportMaxY, viewportMinY + renderHeight)
+        }
+        // `>=` so the anchor keeps holding after the keyboard lands (live ==
+        // target) while the deferred resize is still waiting on the grid
+        // negotiation — releasing at equality would shove the rows up for
+        // the final stretch of the transition.
+        if holdsProvisionalPin,
+           liveViewportMaxY >= targetViewportMaxY,
+           let cursorBottom = cursorBottomInRender,
+           cursorBottom > 0 {
+            // Blank space below the cursor absorbs the keyboard intrusion
+            // before any content moves; once the cursor row itself would be
+            // covered, the render rides the live edge exactly like before.
+            let blankBelowCursor = max(0, renderHeight - cursorBottom)
+            return min(viewportMinY + renderHeight, liveViewportMaxY + blankBelowCursor)
         }
         return max(liveViewportMaxY, min(targetViewportMaxY, viewportMinY + renderHeight))
     }

--- a/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
+++ b/Packages/iOS/CmuxMobileTerminalKit/Tests/CmuxMobileTerminalKitTests/TerminalLetterboxGeometryTests.swift
@@ -393,4 +393,50 @@ struct TerminalLetterboxGeometryTests {
             viewportMinY: 0, renderHeight: 397, holdsProvisionalPin: true
         ) == 714)
     }
+
+    @Test("render pin: provisional shrink anchors the cursor, not the screen bottom")
+    func renderPinProvisionalShrinkCursorAnchor() {
+        // Keyboard rising over a prompt in the upper half (cursor bottom
+        // 400 of a 714pt render): the blank rows below the prompt absorb
+        // the keyboard, so the content must not move at all. The legacy
+        // screen-bottom ride gave 500 - 714 = -214 (all rows pushed up).
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 500, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714,
+            holdsProvisionalPin: true, cursorBottomInRender: 400
+        ) == 714)
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 403, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714,
+            holdsProvisionalPin: true, cursorBottomInRender: 400
+        ) == 714)
+        // Once the keyboard would cover the cursor row itself, the render
+        // slides exactly enough to keep it visible: cursor at 600, live at
+        // 500 -> bottom edge 500 + (714-600) = 614, cursor lands on the
+        // live bottom edge.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 500, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714,
+            holdsProvisionalPin: true, cursorBottomInRender: 600
+        ) == 614)
+        // Full-screen content (cursor on the last row) keeps the legacy
+        // ride so the prompt never hides under the keyboard.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 500, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714,
+            holdsProvisionalPin: true, cursorBottomInRender: 714
+        ) == 500)
+        // Unknown cursor falls back to the legacy ride.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 500, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714,
+            holdsProvisionalPin: true, cursorBottomInRender: nil
+        ) == 500)
+        // Settled shrink (no provisional pin) is unchanged by the cursor.
+        #expect(TerminalLetterboxGeometry.renderPinnedBottomEdge(
+            liveViewportMaxY: 500, targetViewportMaxY: 403,
+            viewportMinY: 0, renderHeight: 714,
+            holdsProvisionalPin: false, cursorBottomInRender: 400
+        ) == 500)
+    }
 }


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/8907 (merged as the hotfix): the "momentary push of all terminal rows" was still reproducible on main when the keyboard OPENS.

Repro on main, captured in the app debug log with a scripted simulator dance: the deferred old render is bottom-pinned to the live viewport during the rise, so with a prompt in the upper half of the screen (blank rows below it) the content slid to `renderRect=440x714@-287` for ~0.3s and the settle resize dropped it back. The rows the keyboard covers are blank, so no motion is needed at all.

Fix: while the grid negotiation is unsettled and the viewport is not growing, `TerminalLetterboxGeometry.renderPinnedBottomEdge` anchors the slide to the cursor row instead of the screen bottom — the blank space below the cursor absorbs the keyboard intrusion first (zero motion for short content), sliding starts only once the cursor row itself would be covered, and a full-screen prompt keeps the exact legacy ride so it never hides under the keyboard. Unknown cursor falls back to the legacy ride. The anchor also holds at `live == target` while the deferred resize waits on the grid echo. The cursor bottom comes from the same non-blocking `ghostty_surface_ime_point` read the cursor overlay already performs on the main thread.

Verification, before vs after on the identical scripted dance (raise + dismiss over a live Mac attach, window recorded at 20fps):
- main: `geom.deferShrink` then `renderRect@-45 → @-287 → settle @0`; recording shows all rows jumping up and back.
- this branch: `renderRect=440x714@0` on every geometry pass through the rise, `440x397@0` held through the dismissal; frame analysis puts the text top at the same pixel in all 384 frames.
- `CmuxMobileTerminalKit` host tests: 111 pass, including new cases for cursor-anchored shrink (no-motion, exact-slide, full-screen fallback, unknown-cursor fallback, settled-shrink unchanged).

A red/green two-commit split was not practical: the failing assertion requires the new `cursorBottomInRender` parameter to exist, so a test-only first commit cannot compile without shipping a stub of the fix.

No user-facing strings changed; no localization impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787899515&installation_model_id=21920&pr_number=9133&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9133&signature=55be52cab6c026c6991d92d23a611545927a2eec4e90bf223993ed2f3202be52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors the terminal render during iOS keyboard rise to the cursor row to stop the brief upward slide of all rows when the keyboard opens. Keeps the prompt visible with zero motion for short content; full-screen prompts keep the legacy ride.

- **Bug Fixes**
  - Pin the provisional slide to the cursor row while the viewport shrinks; fall back to screen-bottom ride if the cursor is unknown and keep the pin when live == target until the grid settles.
  - Read cursor bottom via non-blocking `ghostty_surface_ime_point` and pass `cursorBottomInRender` through `GhosttySurfaceView` → `TerminalViewportSnapshot` → `TerminalLetterboxGeometry`.
  - Added tests in `CmuxMobileTerminalKit` for no-motion, exact-slide, full-screen fallback, and unknown-cursor cases; all host tests pass.

<sup>Written for commit d5a860b93795343bb462fc208c546ddee9648722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal viewport behavior during keyboard-driven resizing.
  * Keeps the cursor row visible and prevents content from shifting prematurely while the viewport shrinks or expands.
  * Preserves previous positioning behavior when cursor location cannot be determined.

* **Tests**
  * Added coverage for cursor-anchored positioning across multiple viewport and cursor scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->