### PR TITLE
Bump iroh-ffi to 1.0.2-cmux.7: idle-path stall evidence fix

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Package.resolved
+++ b/Packages/Shared/CmuxIrohTransport/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "fa21205e0ef32c6aea8b93edd9f9861c27284eb100dc11a0fec6915b2044f0f1",
+  "originHash" : "4361e52c199c941ace4ca058d9af60cdcfc46890336e9eca1529459a9d50fa95",
   "pins" : [
     {
       "identity" : "iroh-ffi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "017f1517c4afcdd8ffa2a2a83bcda7c329d222d8",
-        "version" : "1.0.2-cmux.6"
+        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
+        "version" : "1.0.2-cmux.7"
       }
     }
   ],

--- a/Packages/Shared/CmuxIrohTransport/Package.swift
+++ b/Packages/Shared/CmuxIrohTransport/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(path: "../CMUXMobileCore"),
         .package(
             url: "https://github.com/manaflow-ai/iroh-ffi.git",
-            exact: "1.0.2-cmux.6"
+            exact: "1.0.2-cmux.7"
         ),
     ],
     targets: [

--- a/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c695ab593ec950f04678a577b27492e3cf98610315012f307cf70644317c6ba6",
+  "originHash" : "a44cf039348606fc14d5a8b392911aa9d2903db44b1aee29f12ff0a736caf38d",
   "pins" : [
     {
       "identity" : "aexml",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "017f1517c4afcdd8ffa2a2a83bcda7c329d222d8",
-        "version" : "1.0.2-cmux.6"
+        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
+        "version" : "1.0.2-cmux.7"
       }
     },
     {

--- a/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "017f1517c4afcdd8ffa2a2a83bcda7c329d222d8",
-        "version" : "1.0.2-cmux.6"
+        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
+        "version" : "1.0.2-cmux.7"
       }
     },
     {

--- a/ios/cmuxPackage/Package.resolved
+++ b/ios/cmuxPackage/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/manaflow-ai/iroh-ffi.git",
       "state" : {
-        "revision" : "017f1517c4afcdd8ffa2a2a83bcda7c329d222d8",
-        "version" : "1.0.2-cmux.6"
+        "revision" : "20f0e67cc3cb5179e816ef45b7a7ec5c8c58b0e0",
+        "version" : "1.0.2-cmux.7"
       }
     },
     {


### PR DESCRIPTION
Pulls the path-health detector correction into cmux. Structured review of the detector merge (manaflow-ai/iroh 6ff08b16cf) found a verified defect: the selected-path stall detector counted raw `udp_tx.datagrams` deltas as stall evidence, which include the per-path 5s keepalive PING and its PTO probe retransmissions. On an IDLE selected direct path, a transient 2-10s radio gap (WiFi roam, channel switch) reached the 3-datagram threshold inside the 1s stall floor, so one lost keepalive plus two probes demoted AND quarantined (5s doubling to 300s) a healthy path carrying zero application data — exactly the transients the 15s path-idle timeout was sized to tolerate. Repeated transients ratcheted quarantine and could pin users to relay semi-permanently.

Fix (https://github.com/manaflow-ai/iroh/pull/10, merge `4152d81047a6`): stall evidence now comes only from application-bearing frame transmissions (STREAM/DATAGRAM/RESET_STREAM/STOP_SENDING via per-path `PathStats.frame_tx`). noq's PTO probes retransmit pending app data whenever any exists and only fall back to bare PINGs when idle, so genuinely dead paths under load still fail over fast. Fork red/green: new `test_selected_direct_path_idle_transient_loss_does_not_demote` fails on the old detector (idle path demoted ~5.3s into an 8s gap) and passes with the fix; existing `test_dead_selected_direct_path_demotes_to_relay` stays green with ~1.8s relay failover (deadline 6s).

Delivery chain: fork PR merged → iroh-ffi release https://github.com/manaflow-ai/iroh-ffi/releases/tag/v1.0.2-cmux.7 (xcframework attested, checksum verified, release branch merged via https://github.com/manaflow-ai/iroh-ffi/pull/9) → this pin bump.

Verification here: `swift package resolve` against the published artifact, CmuxIrohTransport 494/494, CMUXMobileCore 306/306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787899876&installation_model_id=21920&pr_number=9134&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9134&signature=f9cc733e19aa31519bdc72da0f93afb8bf8765f8519aef920b2bf52d0776f087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `iroh-ffi` to 1.0.2-cmux.7 to fix idle-path stall detection so keepalive PINGs don’t trigger demotion. Reduces false quarantines during brief radio gaps and avoids unnecessary relay fallback.

- **Bug Fixes**
  - Stall evidence now counts only application frames, not keepalive PINGs or PTO probes.
  - Idle gaps no longer demote or quarantine healthy direct paths; dead paths under load still fail over quickly.

- **Dependencies**
  - Pinned `iroh-ffi` to `1.0.2-cmux.7` in `Packages/Shared/CmuxIrohTransport/Package.swift` and regenerated SwiftPM lockfiles across all workspaces (`cmux.xcodeproj`, `ios/cmux.xcworkspace`, `ios/cmuxPackage`).

<sup>Written for commit b849909ec4a176c6862269516940bc4511ff0566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled networking dependency to the latest compatible patch release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->