### PR TITLE
Keep iOS New Task button clear of the bottom search pill

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListLayoutPreviewView.swift
@@ -332,7 +332,12 @@ public struct WorkspaceListLayoutPreviewView: View {
             } else {
                 let workspaceListStack = NavigationStack {
                     MobilePrimaryWorkspaceSearchHost(
-                        searchCoordinator: primarySearchCoordinator
+                        searchCoordinator: primarySearchCoordinator,
+                        // The live shell puts New Task in the bottom toolbar
+                        // next to the system search pill; the tab-scaffold
+                        // preview must render both so their shared bottom-bar
+                        // layout can be exercised without Mac pairing.
+                        taskComposerAction: showsTabScaffold ? {} : nil
                     ) { searchText in
                         workspaceListFixture(searchText: searchText)
                     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListSearchHost.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListSearchHost.swift
@@ -34,28 +34,17 @@ struct WorkspaceListSearchHost<Content: View>: View {
     @ViewBuilder
     private var iOSContent: some View {
         if #available(iOS 26.0, *) {
+            // A `.bottomBar` toolbar item cannot host New Task here: the
+            // TabView's search-role tab renders its pill in the same
+            // bottom-trailing slot and the two stack on top of each other.
+            // Mount the shared button in the bottom safe-area bar instead,
+            // above the tab-bar chrome the system owns.
             content(searchText)
-                .toolbar {
+                .safeAreaBar(edge: .bottom, alignment: .trailing, spacing: 0) {
                     if let taskComposerAction {
-                        ToolbarSpacer(.flexible, placement: .bottomBar)
-                        ToolbarItem(placement: .bottomBar) {
-                            Button(action: taskComposerAction) {
-                                Image(systemName: "sparkles")
-                            }
-                            .accessibilityLabel(
-                                L10n.string(
-                                    "mobile.taskComposer.button.accessibilityLabel",
-                                    defaultValue: "New Task"
-                                )
-                            )
-                            .accessibilityHint(
-                                L10n.string(
-                                    "mobile.taskComposer.button.accessibilityHint",
-                                    defaultValue: "Opens the task composer."
-                                )
-                            )
-                            .accessibilityIdentifier("MobileTaskComposerButton")
-                        }
+                        TaskComposerButton(action: taskComposerAction)
+                            .padding(.trailing, 20)
+                            .padding(.bottom, 6)
                     }
                 }
         } else {
@@ -65,6 +54,13 @@ struct WorkspaceListSearchHost<Content: View>: View {
                     placement: .navigationBarDrawer(displayMode: .always)
                 )
                 .searchFocused($searchIsFocused)
+                .overlay(alignment: .bottomTrailing) {
+                    if let taskComposerAction {
+                        TaskComposerButton(action: taskComposerAction)
+                            .padding(.trailing, 20)
+                            .padding(.bottom, 6)
+                    }
+                }
         }
     }
     #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -465,11 +465,6 @@ struct WorkspaceShellView: View {
                     rootToolbarContent
                 }
             }
-            #if os(iOS)
-            .overlay(alignment: .bottomTrailing) {
-                taskComposerButtonOverlay
-            }
-            #endif
             .navigationDestination(for: MobileWorkspacePreview.ID.self) { workspaceID in
                 workspaceDestination(
                     for: workspaceID,
@@ -562,11 +557,6 @@ struct WorkspaceShellView: View {
             .toolbar {
                 rootToolbarContent
             }
-            #if os(iOS)
-            .overlay(alignment: .bottomTrailing) {
-                taskComposerButtonOverlay
-            }
-            #endif
             .navigationSplitViewColumnWidth(min: 320, ideal: 380, max: 440)
         } detail: {
             workspaceDestination(
@@ -804,22 +794,6 @@ struct WorkspaceShellView: View {
         }
     }
 
-    private var showsTaskComposerButtonOverlay: Bool {
-        guard displaySettings.taskComposerEnabled else { return false }
-        if #available(iOS 26.0, *) {
-            return false
-        }
-        return true
-    }
-
-    @ViewBuilder
-    private var taskComposerButtonOverlay: some View {
-        if showsTaskComposerButtonOverlay {
-            TaskComposerButton(action: openTaskComposer)
-                .padding(.trailing, 20)
-                .padding(.bottom, 6)
-        }
-    }
     #endif
 
     /// Apply (and clear) a pending deep-link navigation intent. On the compact

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -493,6 +493,49 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(restoredMinimizedSearchMatches.firstMatch.waitForExistence(timeout: 3))
     }
 
+    /// Regression: on iOS 26 the workspace list's New Task control rendered in
+    /// the same bottom-trailing slot as the system search tab pill, so the two
+    /// stacked and New Task was occluded. The shared list host must lay the
+    /// button out clear of the search pill and keep both tappable.
+    @MainActor
+    func testWorkspaceListNewTaskButtonClearsSearchPill() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("The detached workspace search pill requires iOS 26.")
+        }
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW": "1",
+            "CMUX_UITEST_WORKSPACE_LIST_PREVIEW_TABS": "1",
+        ])
+        defer { app.terminate() }
+
+        let composer = app.buttons["MobileTaskComposerButton"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 8))
+        guard let composerFrame = waitForUsableFrame(of: composer, timeout: 3) else {
+            XCTFail("New Task button had no usable frame")
+            return
+        }
+        let searchPill = app.tabBars.buttons
+            .matching(NSPredicate(format: "label == %@", "Search"))
+            .firstMatch
+        XCTAssertTrue(searchPill.waitForExistence(timeout: 3))
+        guard let searchPillFrame = waitForUsableFrame(of: searchPill, timeout: 3) else {
+            XCTFail("Search pill had no usable frame")
+            return
+        }
+        XCTAssertFalse(
+            composerFrame.intersects(searchPillFrame),
+            "New Task \(composerFrame) must not overlap the search pill \(searchPillFrame)"
+        )
+        XCTAssertTrue(
+            waitForHittable(composer, timeout: 3),
+            "New Task must be tappable next to the search pill"
+        )
+        XCTAssertTrue(
+            waitForHittable(searchPill, timeout: 3),
+            "The search pill must stay tappable next to New Task"
+        )
+    }
+
     @MainActor
     func testWorkspaceSearchClearUpdatesResults() throws {
         guard #available(iOS 26.0, *) else {


### PR DESCRIPTION
On iOS 26 the workspace list mounted New Task as a `.bottomBar` toolbar item (https://github.com/manaflow-ai/cmux/pull/8645), but the TabView search-role tab renders its pill in the same bottom-trailing slot, so the two controls stacked on top of each other: New Task sat underneath the search pill, occluded and untappable.

The fix mounts the shared `TaskComposerButton` in the bottom safe-area bar (`safeAreaBar`) on iOS 26, which the system lays out above the tab-bar chrome, so the button now sits as its own glass circle stacked above the search pill. The pre-iOS-26 overlay mounting moves from both shell layouts (compact stack and split sidebar) into the same `WorkspaceListSearchHost`, giving the button one shared layout path instead of three mounting sites.

First commit adds the failing regression test only (workspace-list preview now renders the New Task button next to the pill, and a UI test asserts the frames do not intersect and both stay tappable); second commit adds the fix.

## Verification

- Isolated iOS 26.5 simulators (cmux-bscomp-promax-20260728, cmux-bscomp-se-20260728): New Task renders above the search pill on iPhone 17 Pro Max and iPhone SE, no overlap, long-list content scrolls under the glass band.
- Isolated iOS 18.4 simulator (cmux-bscomp-ios18-20260728): pre-26 layout unchanged (top search drawer, bottom-trailing floating button above the opaque tab bar).
- Search tab destination mounts no composer, so the search-active/keyboard state has no colliding control by construction.
- Localization audit: no new user-facing strings; the button reuses TaskComposerButton's existing localized label and hint keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787901589&installation_model_id=21920&pr_number=9136&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9136&signature=36c197e97bb34edce3941c2d47d1d018190a206e93eed78b2b417e3d1337d47c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS 26 overlap where the New Task button sat under the bottom search pill. The button now sits above the tab bar and stays tappable.

- **Bug Fixes**
  - iOS 26: mount `TaskComposerButton` in the bottom `safeAreaBar` (trailing) instead of a `.bottomBar` toolbar item.
  - Unified pre‑iOS‑26 overlay into `WorkspaceListSearchHost`; removed shell overlays for a single layout path.
  - Updated preview to render both the search pill and New Task for layout coverage.
  - Added a UI test ensuring the two controls do not intersect and both are tappable.
  - iOS < 26 behavior unchanged.

<sup>Written for commit 3623212ffc512ec9448bdecb470b9093be6a6ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placement of the New Task button in the workspace list across supported iOS versions.
  * Prevented the button from overlapping the system Search control when tabs are enabled.
  * Removed redundant task composer overlays from workspace shell layouts.

* **Tests**
  * Added UI coverage verifying the New Task button and Search control remain separate and usable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->