### PR TITLE
Fix Swift 6 queued-recovery task capture

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -742,8 +742,9 @@ actor MobileCoreRPCSession {
     private func startQueuedDemandRecovery(requestID: String) {
         guard !queuedWriteIDs.isEmpty else { return }
         Task { [weak self, taskTimeout, cancelledWriteCompletionGraceNanoseconds] in
+            guard let self else { return }
             let waitTask = Task<Void, any Error> {
-                await self?.awaitCancelledWriteResolution()
+                await self.awaitCancelledWriteResolution()
             }
             do {
                 try await taskTimeout.value(
@@ -752,7 +753,7 @@ actor MobileCoreRPCSession {
                 )
             } catch {
                 waitTask.cancel()
-                await self?.recycleCancelledActiveWriteForQueuedDemand(
+                await self.recycleCancelledActiveWriteForQueuedDemand(
                     requestID: requestID
                 )
             }


### PR DESCRIPTION
The speculative merge for https://github.com/manaflow-ai/cmux/pull/8789 exposed a Swift 6 strict-concurrency compile failure in MobileCoreRPCSession on every app-test shard: https://github.com/manaflow-ai/cmux/actions/runs/30431246561.

The outer recovery task now promotes weak self to an immutable strong actor reference before constructing the nested sending task. This removes the shared mutable weak capture while retaining bounded ownership for the recovery interval.

Verification:
- MobileCoreRPCStalledWriteRecoveryTests, 12 passed
- cmux policy check, clean
- Exact Xcode 26.3 app-host compile is dispatched after opening this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787903213&installation_model_id=21920&pr_number=9138&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9138&signature=521a366e6ae7bdcb02928e3681e3aa6ac2039f47c4b30995747aff24143ffaff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Swift 6 strict-concurrency compile error in `MobileCoreRPCSession` by promoting the queued-recovery task’s weak self capture to a strong actor reference before starting nested tasks. This keeps the recovery path actor-isolated and removes a shared mutable weak capture.

- **Bug Fixes**
  - In `startQueuedDemandRecovery`, use `guard let self` in the outer `Task` and remove optional chaining inside nested tasks.
  - Restores Swift 6 builds and prevents racy weak captures during queued write recovery.
  - `MobileCoreRPCStalledWriteRecoveryTests`: 12 passing.

<sup>Written for commit 2d24ae4ed0a2f50b10edfc81ec45d81aa4d54aeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queued-demand recovery during cancelled writes.
  * Recovery steps now complete reliably when the active session remains available, preventing skipped operations caused by session deallocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->