### PR TITLE
Render panel header icons through the resolved-icon path (#8352)

### DIFF
--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -369,7 +369,6 @@ private struct FileExternalOpenHeaderMenuButton: View {
             PanelHeaderIconGlyph(systemName: "square.and.arrow.up")
         }
         .buttonStyle(.plain)
-        .foregroundColor(.secondary)
         .disabled(isDisabled)
         .help(helpText)
         .accessibilityLabel(helpText)

--- a/Sources/Panels/MarkdownTypographyControl.swift
+++ b/Sources/Panels/MarkdownTypographyControl.swift
@@ -45,7 +45,6 @@ struct MarkdownTypographyControl: View {
             PanelHeaderIconGlyph(systemName: "textformat.size")
         }
         .buttonStyle(.plain)
-        .foregroundColor(.secondary)
         .help(buttonLabel)
         .accessibilityLabel(buttonLabel)
         .popover(isPresented: $isPresented, arrowEdge: .bottom) {

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -357,9 +357,12 @@ struct PanelFilePathHeader<TrailingContent: View>: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            CmuxSystemSymbolImage(systemName: iconSystemName, pointSize: 16)
-                .foregroundStyle(.secondary)
-                .frame(width: 16)
+            CmuxResolvedIconImage(request: CmuxResolvedIconRequest(
+                source: .systemSymbol(name: iconSystemName, accessibilityDescription: nil),
+                size: NSSize(width: 16, height: 16),
+                tintColor: PanelHeaderIconGlyph.tint(headerForeground: foregroundColor)
+            ))
+            .frame(width: 16, height: 16)
             Text(filePath)
                 .cmuxFont(size: 11, design: .monospaced)
                 .foregroundStyle(Color(nsColor: foregroundColor).opacity(0.68))
@@ -372,6 +375,7 @@ struct PanelFilePathHeader<TrailingContent: View>: View {
         .padding(.horizontal, 12)
         .frame(height: 30)
         .background(Color.clear)
+        .environment(\.panelHeaderIconTint, PanelHeaderIconGlyph.tint(headerForeground: foregroundColor))
     }
 }
 
@@ -386,19 +390,70 @@ struct PanelHeaderIconButton: View {
             PanelHeaderIconGlyph(systemName: systemName)
         }
         .buttonStyle(.plain)
-        .foregroundColor(.secondary)
         .disabled(isDisabled)
         .help(label)
         .accessibilityLabel(label)
     }
 }
 
+/// Panel-header glyph rendered through the appearance-resolved AppKit icon
+/// path (`CmuxResolvedIconImage`) instead of a template `NSImage` in a SwiftUI
+/// `Image`. Template-image tinting intermittently rasterizes fully transparent
+/// on macOS 15 while the control stays clickable (#8352, #7725, #4476); the
+/// resolved renderer draws into an explicit bitmap context, verifies the
+/// output has visible pixels, and re-renders on appearance changes.
 struct PanelHeaderIconGlyph: View {
     let systemName: String
+    @Environment(\.panelHeaderIconTint) private var headerTint
+    @Environment(\.isEnabled) private var isEnabled
 
     var body: some View {
-        CmuxSystemSymbolImage(systemName: systemName, pointSize: 13)
-            .frame(width: 20, height: 20, alignment: .center)
-            .contentShape(Rectangle())
+        CmuxResolvedIconImage(
+            request: Self.request(systemName: systemName, tint: headerTint, isEnabled: isEnabled)
+        )
+        .frame(width: 13, height: 13)
+        .frame(width: 20, height: 20, alignment: .center)
+        .contentShape(Rectangle())
+    }
+
+    /// Builds the resolved-icon request for one header glyph.
+    ///
+    /// The tint is an explicit color (never left to template tinting): the
+    /// header's theme foreground when the glyph sits inside a
+    /// ``PanelFilePathHeader``, or the appearance-resolved secondary label
+    /// color otherwise. Disabled glyphs keep the color but drop alpha.
+    @MainActor
+    static func request(systemName: String, tint: NSColor?, isEnabled: Bool) -> CmuxResolvedIconRequest {
+        let baseTint = tint ?? .secondaryLabelColor
+        let resolvedTint = isEnabled
+            ? baseTint
+            : baseTint.withAlphaComponent(baseTint.alphaComponent * 0.45)
+        return CmuxResolvedIconRequest(
+            source: .systemSymbol(name: systemName, accessibilityDescription: nil),
+            size: NSSize(width: 13, height: 13),
+            tintColor: resolvedTint
+        )
+    }
+
+    /// Secondary-emphasis icon tint derived from a panel header's theme
+    /// foreground color, matching the previous `.secondary` template tint.
+    static func tint(headerForeground: NSColor) -> NSColor {
+        headerForeground.withAlphaComponent(headerForeground.alphaComponent * 0.55)
+    }
+}
+
+/// Explicit tint for ``PanelHeaderIconGlyph`` set by the enclosing
+/// ``PanelFilePathHeader`` so glyphs follow the panel's theme foreground even
+/// when the panel overrides the SwiftUI color scheme (the NSView-backed icon
+/// resolves the window appearance, not the SwiftUI override). `nil` falls back
+/// to the appearance-resolved secondary label color.
+private struct PanelHeaderIconTintKey: EnvironmentKey {
+    static let defaultValue: NSColor? = nil
+}
+
+extension EnvironmentValues {
+    var panelHeaderIconTint: NSColor? {
+        get { self[PanelHeaderIconTintKey.self] }
+        set { self[PanelHeaderIconTintKey.self] = newValue }
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1354,6 +1354,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C51A73000000000000000201 /* PaneDropTargetView+FileDropTextDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = C51A73000000000000000202 /* PaneDropTargetView+FileDropTextDestination.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
+		C58410020000000000000001 /* PanelHeaderIconGlyphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58410020000000000000002 /* PanelHeaderIconGlyphTests.swift */; };
 		BB49DF25341706C2A892C27C /* PanelOwnedNativeViewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */; };
 		C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */; };
 		B79500200000000000000001 /* PanelPortScanPublication.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500200000000000000002 /* PanelPortScanPublication.swift */; };
@@ -3769,6 +3770,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C51A73000000000000000202 /* PaneDropTargetView+FileDropTextDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaneDropTargetView+FileDropTextDestination.swift"; sourceTree = "<group>"; };
 		A5001410 /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/Panel.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
+		C58410020000000000000002 /* PanelHeaderIconGlyphTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelHeaderIconGlyphTests.swift; sourceTree = "<group>"; };
 		CE314D9700F6F1C8D4A2FE11 /* PanelOwnedNativeViewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelOwnedNativeViewSession.swift; sourceTree = "<group>"; };
 		C44550000000000000000002 /* PanelOwnedNativeViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelOwnedNativeViewSessionTests.swift; sourceTree = "<group>"; };
 		B79500200000000000000002 /* PanelPortScanPublication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelPortScanPublication.swift; sourceTree = "<group>"; };
@@ -6818,6 +6820,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D36A00020000000000000002 /* AgentHibernationTests.swift */,
 				D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */,
 				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
+				C58410020000000000000002 /* PanelHeaderIconGlyphTests.swift */,
 				DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */,
 				859100000000000000000002 /* TerminalLinkOpenCoordinatorTests.swift */,
 				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
@@ -9910,6 +9913,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				9637C6D3170F4BE1A7EF6243 /* OmnibarSubmitDecisionTests.swift in Sources */,
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
+				C58410020000000000000001 /* PanelHeaderIconGlyphTests.swift in Sources */,
 					C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
 					6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
 					D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */,

--- a/cmuxTests/PanelHeaderIconGlyphTests.swift
+++ b/cmuxTests/PanelHeaderIconGlyphTests.swift
@@ -1,0 +1,98 @@
+import AppKit
+import CmuxAppKitSupportUI
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Panel header icon glyphs")
+struct PanelHeaderIconGlyphTests {
+    /// Every SF Symbol shown in a panel file-path header (markdown viewer and
+    /// file preview), plus the default leading icons.
+    private static let headerSymbols: [String] = [
+        "textformat.size",
+        "arrow.clockwise",
+        "arrow.counterclockwise",
+        "square.and.arrow.down",
+        "square.and.arrow.up",
+        "doc.plaintext",
+        "eye",
+        "doc.on.doc",
+        "chevron.left.forwardslash.chevron.right",
+        "doc.richtext",
+        "doc.viewfinder",
+    ]
+
+    @Test @MainActor func requestUsesExplicitTintAndSymbolSource() throws {
+        let tint = NSColor(srgbRed: 0.9, green: 0.8, blue: 0.7, alpha: 1)
+        let request = PanelHeaderIconGlyph.request(
+            systemName: "textformat.size",
+            tint: tint,
+            isEnabled: true
+        )
+        guard case .systemSymbol(let name, _) = request.source else {
+            Issue.record("expected a system symbol source")
+            return
+        }
+        #expect(name == "textformat.size")
+        #expect(request.size == NSSize(width: 13, height: 13))
+        #expect(request.tintColor == tint)
+    }
+
+    @Test @MainActor func requestFallsBackToSecondaryLabelTint() {
+        let request = PanelHeaderIconGlyph.request(
+            systemName: "arrow.clockwise",
+            tint: nil,
+            isEnabled: true
+        )
+        #expect(request.tintColor == NSColor.secondaryLabelColor)
+    }
+
+    @Test @MainActor func disabledRequestReducesTintAlpha() throws {
+        let tint = NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.8)
+        let request = PanelHeaderIconGlyph.request(
+            systemName: "square.and.arrow.down",
+            tint: tint,
+            isEnabled: false
+        )
+        let resolvedTint = try #require(request.tintColor)
+        #expect(abs(resolvedTint.alphaComponent - 0.8 * 0.45) < 0.001)
+    }
+
+    @Test @MainActor func headerForegroundTintKeepsColorAtSecondaryEmphasis() {
+        let foreground = NSColor(srgbRed: 0.2, green: 0.4, blue: 0.6, alpha: 1)
+        let tint = PanelHeaderIconGlyph.tint(headerForeground: foreground)
+        #expect(abs(tint.alphaComponent - 0.55) < 0.001)
+        #expect(abs(tint.redComponent - 0.2) < 0.001)
+        #expect(abs(tint.greenComponent - 0.4) < 0.001)
+        #expect(abs(tint.blueComponent - 0.6) < 0.001)
+    }
+
+    /// Renders every header symbol through the appearance-resolved renderer in
+    /// both light and dark appearances. The renderer fails with `.blankOutput`
+    /// when the drawn bitmap has no visible pixels, so a returned image proves
+    /// the glyph is actually visible — the regression behind #8352.
+    @Test(arguments: headerSymbols)
+    @MainActor func headerSymbolRendersVisiblyInBothAppearances(symbolName: String) throws {
+        for appearanceName in [NSAppearance.Name.aqua, .darkAqua] {
+            let appearance = try #require(NSAppearance(named: appearanceName))
+            let request = PanelHeaderIconGlyph.request(
+                systemName: symbolName,
+                tint: nil,
+                isEnabled: true
+            )
+            let rendered = CmuxResolvedIconRenderer().render(for: request, appearance: appearance)
+            switch rendered {
+            case .success(let image):
+                #expect(image.size.width > 0)
+                #expect(image.size.height > 0)
+            case .failure(let failure):
+                Issue.record("\(symbolName) failed to render under \(appearanceName.rawValue): \(failure)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- What changed? Markdown viewer and file preview header controls (typography/font size, refresh, preview/text toggle, copy as Markdown/HTML, revert, save, open-externally) and the header's leading file icon now render through `CmuxResolvedIconImage` / `CmuxResolvedIconRenderer` — the explicit-bitmap-context path introduced in #7729 that verifies the drawn output contains visible pixels and re-renders on appearance changes. Previously `PanelHeaderIconGlyph` drew a shared, cached template `NSImage` via SwiftUI `Image(nsImage:).renderingMode(.template)`.
- Why? Another surface of #8352 / #7725 / #4476: on macOS 15, template-image tinting intermittently rasterizes fully transparent while the buttons stay laid out and clickable (reported in the markdown preview header on macOS 15.6). The glyph tint is now always an explicit `NSColor`: the panel's theme foreground threaded down via a `panelHeaderIconTint` environment key from `PanelFilePathHeader` (the NSView-backed icon resolves the window appearance, not the panel's SwiftUI `colorScheme` override), falling back to `secondaryLabelColor`. Disabled buttons keep the color at reduced alpha.

## Testing

- How did you test this change? Added `cmuxTests/PanelHeaderIconGlyphTests.swift` (Swift Testing): request construction (symbol source, size, explicit tint, disabled-alpha, fallback tint), theme-tint derivation, and a parameterized test rendering every header symbol through `CmuxResolvedIconRenderer` under both `aqua` and `darkAqua`, asserting the renderer's visible-pixel verification succeeds. No red/green regression-commit pair: the underlying failure is an OS-level appearance-race during template rasterization that cannot be reproduced deterministically in CI; the renderer-level visibility test is the meaningful behavioral guard.
- Localization audit: icon rendering only; no user-facing strings added or changed (all `String(localized:)` labels, help text, and accessibility labels untouched), so no `Localizable.xcstrings` or web message catalog changes.

## Demo Video

Not available — see the Xcode toolchain limitation above; the fix targets an intermittent macOS 15 rasterization race that cannot be captured on demand.

- Video URL or attachment: —

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (none needed)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

Fixes the markdown-preview-header surface of #8352 (related: #7725, #4476).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787909196&installation_model_id=21920&pr_number=9144&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9144&signature=e46fc92e9c5dfb8511350a4f0aa30d8169b1f75dfd1200cbe9ff560a080eb4f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render all panel header icons through the resolved-icon path to prevent invisible glyphs on macOS 15. Fixes #8352 for markdown and file preview headers, including the leading file icon.

- **Bug Fixes**
  - Route `PanelHeaderIconGlyph` and the header’s leading icon through `CmuxResolvedIconImage`/`CmuxResolvedIconRenderer` with visible-pixel verification and appearance re-rendering.
  - Apply explicit tints from the panel theme via a `panelHeaderIconTint` environment value, falling back to `secondaryLabelColor`; disabled buttons reduce alpha.
  - Add `PanelHeaderIconGlyphTests` to validate request construction and ensure all header symbols render visibly in `aqua` and `darkAqua`.

<sup>Written for commit c6c6b83da4af37a4f34cd49869cc15f63bd195fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated panel header icons to follow the active theme and surrounding interface styling more consistently.
  - Improved icon tinting across light and dark appearances.
  - Disabled icons now appear with appropriately reduced emphasis.
  - Refined “Open With” and font picker controls to use contextual styling while preserving existing accessibility labels, help text, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->