### PR TITLE
Defer agent session resume until first panel focus

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/TerminalCatalogSection.swift
@@ -49,6 +49,15 @@ public struct TerminalCatalogSection: SettingCatalogSection {
         userDefaultsKey: "terminal.autoResumeAgentSessions"
     )
 
+    /// Whether a restored agent's resume command waits for the panel's first
+    /// focus instead of firing immediately for every restorable panel at
+    /// startup. Only takes effect while `autoResumeAgentSessions` is enabled.
+    public let deferAgentResumeUntilFirstFocus = DefaultsKey<Bool>(
+        id: "terminal.deferAgentResumeUntilFirstFocus",
+        defaultValue: false,
+        userDefaultsKey: "terminal.deferAgentResumeUntilFirstFocus"
+    )
+
     /// Whether failed active agent sessions automatically resume with bounded retries.
     public let autoRetryAgentSessions = DefaultsKey<Bool>(
         id: "terminal.autoRetryAgentSessions",

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -112,7 +112,7 @@ extension Array where Element == CuratedSettingEntry {
             ),
             .init(section: .terminal, id: "copy-on-select", title: "Copy on Selection", synonyms: "terminal.copyOnSelect copy on selection select clipboard mouse double click triple click iterm"),
             .init(section: .terminal, id: "agent-auto-resume", title: "Resume Agent Sessions on Reopen", synonyms: "terminal.autoResumeAgentSessions auto resume restore reopen relaunch quit sessions agents claude code codex opencode rovo dev rovodev toggle"),
-            .init(section: .terminal, id: "agent-defer-resume-until-focus", title: "Resume Agents on First Focus", synonyms: "terminal.deferAgentResumeUntilFirstFocus defer lazy resume focus startup thundering herd many sessions agents claude code codex opencode toggle"),
+            .init(section: .terminal, id: "agent-defer-resume-until-focus", title: String(localized: "settings.terminal.agentDeferResumeUntilFirstFocus", defaultValue: "Resume Agents on First Focus"), synonyms: "terminal.deferAgentResumeUntilFirstFocus defer lazy resume focus startup thundering herd many sessions agents claude code codex opencode toggle"),
             .init(
                 section: .terminal,
                 id: "agent-auto-retry",

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -112,6 +112,7 @@ extension Array where Element == CuratedSettingEntry {
             ),
             .init(section: .terminal, id: "copy-on-select", title: "Copy on Selection", synonyms: "terminal.copyOnSelect copy on selection select clipboard mouse double click triple click iterm"),
             .init(section: .terminal, id: "agent-auto-resume", title: "Resume Agent Sessions on Reopen", synonyms: "terminal.autoResumeAgentSessions auto resume restore reopen relaunch quit sessions agents claude code codex opencode rovo dev rovodev toggle"),
+            .init(section: .terminal, id: "agent-defer-resume-until-focus", title: "Resume Agents on First Focus", synonyms: "terminal.deferAgentResumeUntilFirstFocus defer lazy resume focus startup thundering herd many sessions agents claude code codex opencode toggle"),
             .init(
                 section: .terminal,
                 id: "agent-auto-retry",

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AgentRecoverySettingsModel.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AgentRecoverySettingsModel.swift
@@ -6,6 +6,7 @@ import Observation
 @Observable
 final class AgentRecoverySettingsModel {
     let autoResume: DefaultsValueModel<Bool>
+    let deferResumeUntilFirstFocus: DefaultsValueModel<Bool>
     let autoRetry: DefaultsValueModel<Bool>
 
     @ObservationIgnored private let hostActions: any SettingsHostActions
@@ -19,6 +20,10 @@ final class AgentRecoverySettingsModel {
             store: defaultsStore,
             key: catalog.terminal.autoResumeAgentSessions
         )
+        deferResumeUntilFirstFocus = DefaultsValueModel(
+            store: defaultsStore,
+            key: catalog.terminal.deferAgentResumeUntilFirstFocus
+        )
         autoRetry = DefaultsValueModel(
             store: defaultsStore,
             key: catalog.terminal.autoRetryAgentSessions
@@ -28,11 +33,16 @@ final class AgentRecoverySettingsModel {
 
     func startObserving() {
         autoResume.startObserving()
+        deferResumeUntilFirstFocus.startObserving()
         autoRetry.startObserving()
     }
 
     func setAutoResume(_ enabled: Bool) {
         autoResume.set(enabled)
+    }
+
+    func setDeferResumeUntilFirstFocus(_ enabled: Bool) {
+        deferResumeUntilFirstFocus.set(enabled)
     }
 
     func setAutoRetry(_ enabled: Bool) {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AgentRecoverySettingsRows.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AgentRecoverySettingsRows.swift
@@ -44,6 +44,32 @@ struct AgentRecoverySettingsRows: View {
         }
         SettingsCardDivider()
         SettingsCardRow(
+            configurationReview: .json("terminal.deferAgentResumeUntilFirstFocus"),
+            String(
+                localized: "settings.terminal.agentDeferResumeUntilFirstFocus",
+                defaultValue: "Resume Agents on First Focus"
+            ),
+            subtitle: model.deferResumeUntilFirstFocus.current
+                ? String(
+                    localized: "settings.terminal.agentDeferResumeUntilFirstFocus.subtitleOn",
+                    defaultValue: "Restored agent terminals wait until you focus or view their tab before running their resume command, so opening many sessions at once doesn't launch them all immediately."
+                )
+                : String(
+                    localized: "settings.terminal.agentDeferResumeUntilFirstFocus.subtitleOff",
+                    defaultValue: "Restored agent terminals run their resume command immediately, even for tabs you haven't looked at yet."
+                )
+        ) {
+            Toggle("", isOn: Binding(
+                get: { model.deferResumeUntilFirstFocus.current },
+                set: { model.setDeferResumeUntilFirstFocus($0) }
+            ))
+            .labelsHidden()
+            .controlSize(.small)
+            .disabled(!model.autoResume.current)
+            .accessibilityIdentifier("SettingsTerminalAgentDeferResumeToggle")
+        }
+        SettingsCardDivider()
+        SettingsCardRow(
             configurationReview: .json("terminal.autoRetryAgentSessions"),
             String(
                 localized: "settings.terminal.agentAutoRetry",

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -126,6 +126,7 @@ struct SettingsRowAnchorResolutionTests {
         "terminal.rendererRealization.idleSeconds",
         "terminal.rendererRealization.maxWarmRenderers",
         "terminal.autoResumeAgentSessions",
+        "terminal.deferAgentResumeUntilFirstFocus",
         "terminal.autoRetryAgentSessions",
         "terminal.copyOnSelect",
         "terminal.resumeCommands",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -194276,6 +194276,57 @@
         }
       }
     },
+    "settings.terminal.agentDeferResumeUntilFirstFocus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Agents on First Focus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "初めてフォーカスした時にエージェントを再開"
+          }
+        }
+      }
+    },
+    "settings.terminal.agentDeferResumeUntilFirstFocus.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restored agent terminals run their resume command immediately, even for tabs you haven't looked at yet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復元されたエージェント端末は、まだ表示していないタブでもすぐに再開コマンドを実行します。"
+          }
+        }
+      }
+    },
+    "settings.terminal.agentDeferResumeUntilFirstFocus.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restored agent terminals wait until you focus or view their tab before running their resume command, so opening many sessions at once doesn't launch them all immediately."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "復元されたエージェント端末は、タブをフォーカスまたは表示するまで再開コマンドを実行しません。これにより、多数のセッションを一度に開いてもすべてがすぐには起動しません。"
+          }
+        }
+      }
+    },
     "settings.terminal.agentHibernation": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -255,6 +255,58 @@ enum AgentSessionAutoResumeSettings {
     }
 }
 
+/// Whether a restored agent's resume command is deferred until the user
+/// actually focuses or views the restored panel, instead of firing
+/// immediately for every restorable panel at startup. Only takes effect
+/// when ``AgentSessionAutoResumeSettings`` is also enabled; a restored panel
+/// that would otherwise auto-resume instead enters the same synthetic
+/// "agent hibernation" state used for a panel that was already hibernated
+/// when quit, and the existing focus/visibility-triggered resume picks it
+/// up on first look. Prevents a startup thundering herd where dozens of
+/// restored panels all fire their resume commands concurrently.
+enum AgentSessionDeferredResumeSettings {
+    static let deferUntilFirstFocusKey = "terminal.deferAgentResumeUntilFirstFocus"
+    static let defaultDeferUntilFirstFocus = false
+    static let didChangeNotification = Notification.Name("cmux.agentSessionDeferredResumeSettingsDidChange")
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: deferUntilFirstFocusKey) != nil else {
+            return defaultDeferUntilFirstFocus
+        }
+        return defaults.bool(forKey: deferUntilFirstFocusKey)
+    }
+
+    static func setEnabled(
+        _ enabled: Bool,
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        let wasEnabled = isEnabled(defaults: defaults)
+        defaults.set(enabled, forKey: deferUntilFirstFocusKey)
+        if wasEnabled != enabled {
+            notifyDidChange(notificationCenter: notificationCenter)
+        }
+    }
+
+    @discardableResult
+    static func reset(
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) -> Bool {
+        let wasEnabled = isEnabled(defaults: defaults)
+        defaults.removeObject(forKey: deferUntilFirstFocusKey)
+        let didChange = wasEnabled != isEnabled(defaults: defaults)
+        if didChange {
+            notifyDidChange(notificationCenter: notificationCenter)
+        }
+        return didChange
+    }
+
+    static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
+        notificationCenter.post(name: didChangeNotification, object: nil)
+    }
+}
+
 enum AgentHibernationSettings {
     struct Values: Equatable, Sendable {
         var enabled: Bool

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -230,6 +230,11 @@ enum TerminalSettingsFileMapping {
             invalidPath: "terminal.autoResumeAgentSessions"
         ),
         .init(
+            jsonKey: "deferAgentResumeUntilFirstFocus",
+            defaultsKey: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey,
+            invalidPath: "terminal.deferAgentResumeUntilFirstFocus"
+        ),
+        .init(
             jsonKey: "autoRetryAgentSessions",
             defaultsKey: AgentSessionAutoRetrySettings.autoRetryAgentSessionsKey,
             invalidPath: "terminal.autoRetryAgentSessions"
@@ -423,6 +428,7 @@ extension CmuxSettingsFileStore {
         "terminal.scrollSpeed",
         "terminal.copyOnSelect",
         "terminal.autoResumeAgentSessions",
+        "terminal.deferAgentResumeUntilFirstFocus",
         "terminal.autoRetryAgentSessions",
         "terminal.showTextBoxOnNewTerminals",
         "terminal.focusTextBoxOnNewTerminals",

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -457,6 +457,26 @@ enum CommandPaletteSettingsToggleCommands {
                     )
                 }
             ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "deferAgentResumeUntilFirstFocus",
+                settingsKey: "terminal.deferAgentResumeUntilFirstFocus",
+                title: {
+                    String(
+                        localized: "settings.terminal.agentDeferResumeUntilFirstFocus",
+                        defaultValue: "Resume Agents on First Focus"
+                    )
+                },
+                sectionTitle: terminal,
+                keywords: ["terminal.deferAgentResumeUntilFirstFocus", "terminal", "agent", "defer", "resume", "focus", "lazy", "startup"],
+                isOn: { defaults in AgentSessionDeferredResumeSettings.isEnabled(defaults: defaults) },
+                setOn: { newValue, defaults, notificationCenter in
+                    AgentSessionDeferredResumeSettings.setEnabled(
+                        newValue,
+                        defaults: defaults,
+                        notificationCenter: notificationCenter
+                    )
+                }
+            ),
             agentSessionAutoRetryDescriptor(sectionTitle: terminal),
             CommandPaletteSettingToggleDescriptor(
                 commandId: commandIdPrefix + "agentHibernation",

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -137,8 +137,22 @@ extension DockSplitStore {
         let shouldAutoResumeAgent = AgentSessionAutoResumeSettings.isEnabled(
             defaults: agentSessionAutoResumeDefaults
         ) && agentWasRunning
+        // "Resume Agents on First Focus" candidate: the agent itself is
+        // resumable, so any startup resume — the agent's own command AND an
+        // agent-hook binding for the same session — can be deferred into the
+        // synthetic hibernation state below. `restorableAgent` is already
+        // validated against the binding (`restorableAgentForSessionRestore`),
+        // and the hibernation wake rebuilds the command from the captured
+        // launch argv, so suppressing the binding here replays the same
+        // session later. Non-agent-hook bindings (tmux attach, persistent
+        // SSH) are never deferred.
+        let deferAgentResumeCandidate = AgentSessionDeferredResumeSettings.isEnabled(
+            defaults: agentSessionAutoResumeDefaults
+        ) && shouldAutoResumeAgent && hibernation == nil && restorableAgent?.resumeCommand != nil
         let resumeBindingForStartup = hibernation != nil ||
-            (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true)
+            (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true) ||
+            (deferAgentResumeCandidate && resumeBinding?.isAgentHookBinding == true
+                && resumeBinding?.launchFlavor == .local)
             ? nil
             : resumeBinding
         let approvedResumeBinding = policy.approvedSurfaceResumeBinding(
@@ -194,11 +208,11 @@ extension DockSplitStore {
         // startup doesn't fire dozens of concurrent resume commands. The
         // existing focus/visibility-triggered resume (`resumeAgentHibernation`)
         // then fires it lazily the first time the user actually looks at the
-        // panel.
-        let deferAgentResumeUntilFocus = AgentSessionDeferredResumeSettings.isEnabled(
-            defaults: agentSessionAutoResumeDefaults
-        ) && shouldAutoResumeAgent && hibernation == nil && bindingLaunch == nil
-            && !agentSessionAlreadyActive && restorableAgent?.resumeCommand != nil
+        // panel. `bindingLaunch` is nil for deferred agent-hook bindings
+        // (suppressed above) but still set for tmux/SSH bindings, which keep
+        // their immediate startup launch.
+        let deferAgentResumeUntilFocus = deferAgentResumeCandidate && bindingLaunch == nil
+            && !agentSessionAlreadyActive
         let agentLaunch = shouldAutoResumeAgent && hibernation == nil && bindingLaunch == nil
             && !agentSessionAlreadyActive && !deferAgentResumeUntilFocus
             ? restorableAgent?.resumeStartupInput(requireLauncherScript: true).map {

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -188,8 +188,19 @@ extension DockSplitStore {
             snapshotPanelId: snapshot.id,
             shouldAutoResume: shouldAutoResumeAgent && hibernation == nil && bindingLaunch == nil
         )
+        // When enabled, a panel that would otherwise auto-resume its agent
+        // immediately instead defers to the same synthetic hibernation state
+        // used for a snapshot that was already hibernated at quit time, so
+        // startup doesn't fire dozens of concurrent resume commands. The
+        // existing focus/visibility-triggered resume (`resumeAgentHibernation`)
+        // then fires it lazily the first time the user actually looks at the
+        // panel.
+        let deferAgentResumeUntilFocus = AgentSessionDeferredResumeSettings.isEnabled(
+            defaults: agentSessionAutoResumeDefaults
+        ) && shouldAutoResumeAgent && hibernation == nil && bindingLaunch == nil
+            && !agentSessionAlreadyActive && restorableAgent?.resumeCommand != nil
         let agentLaunch = shouldAutoResumeAgent && hibernation == nil && bindingLaunch == nil
-            && !agentSessionAlreadyActive
+            && !agentSessionAlreadyActive && !deferAgentResumeUntilFocus
             ? restorableAgent?.resumeStartupInput(requireLauncherScript: true).map {
                 WorkspaceSurfaceResumeStartupLaunch.input($0)
                     .restoringWorkingDirectory(resumeSessionWorkingDirectory)
@@ -264,6 +275,12 @@ extension DockSplitStore {
                 agent: restorableAgent,
                 lastActivityAt: Date(timeIntervalSince1970: hibernation.lastActivityAt),
                 hibernatedAt: Date(timeIntervalSince1970: hibernation.hibernatedAt)
+            )
+        } else if deferAgentResumeUntilFocus, let restorableAgent {
+            terminal.enterAgentHibernation(
+                agent: restorableAgent,
+                lastActivityAt: Date(),
+                hibernatedAt: Date()
             )
         }
         if willRunAgentCommand || willRunAgentInput,

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -96,6 +96,7 @@ extension CmuxSettingsFileStore {
                     "sessionContentAlignment": SessionContentAlignment.center.rawValue,
                     "copyOnSelect": TerminalCopyOnSelectSettings.defaultCopyOnSelect,
                     "autoResumeAgentSessions": AgentSessionAutoResumeSettings.defaultAutoResumeAgentSessions,
+                    "deferAgentResumeUntilFirstFocus": AgentSessionDeferredResumeSettings.defaultDeferUntilFirstFocus,
                     "autoRetryAgentSessions": AgentSessionAutoRetrySettings.defaultAutoRetryAgentSessions,
                     "showTextBoxOnNewTerminals": TerminalTextBoxInputSettings.defaultShowOnNewTerminals,
                     "focusTextBoxOnNewTerminals": TerminalTextBoxInputSettings.defaultFocusOnNewTerminals,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -1529,6 +1529,7 @@ final class CmuxSettingsFileStore {
         let changes = sideEffects.changes
         let apply = {
             var agentSessionAutoResumeDidChange = false
+            var agentSessionDeferredResumeDidChange = false
             var agentSessionAutoRetryDidChange = false
             var agentHibernationDidChange = false
             var rendererRealizationDidChange = false
@@ -1549,6 +1550,9 @@ final class CmuxSettingsFileStore {
 
                 if change.defaultsKey == AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey {
                     agentSessionAutoResumeDidChange = true
+                }
+                if change.defaultsKey == AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey {
+                    agentSessionDeferredResumeDidChange = true
                 }
                 if change.defaultsKey == AgentSessionAutoRetrySettings.autoRetryAgentSessionsKey {
                     agentSessionAutoRetryDidChange = true
@@ -1577,6 +1581,9 @@ final class CmuxSettingsFileStore {
 
             if agentSessionAutoResumeDidChange {
                 AgentSessionAutoResumeSettings.notifyDidChange(notificationCenter: notificationCenter)
+            }
+            if agentSessionDeferredResumeDidChange {
+                AgentSessionDeferredResumeSettings.notifyDidChange(notificationCenter: notificationCenter)
             }
             if agentSessionAutoRetryDidChange {
                 AgentSessionAutoRetrySettings(

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -385,6 +385,7 @@ enum SettingsSearchIndex {
         setting(.terminal, "copy-on-select", String(localized: "settings.terminal.copyOnSelect", defaultValue: "Copy on Selection"), "terminal.copyOnSelect clipboard selection mouse double click triple click"),
         setting(.terminal, "tab-bar-font-size", String(localized: "settings.terminal.tabBarFontSize", defaultValue: "Tab Bar Font Size"), "font size text scale terminal browser pane tab title surface-tab-bar-font-size"),
         setting(.terminal, "agent-auto-resume", String(localized: "settings.terminal.agentAutoResume", defaultValue: "Resume Agent Sessions on Reopen"), "terminal.autoResumeAgentSessions auto resume restore reopen relaunch quit sessions agents claude code codex opencode rovo dev rovodev toggle"),
+        setting(.terminal, "agent-defer-resume-until-focus", String(localized: "settings.terminal.agentDeferResumeUntilFirstFocus", defaultValue: "Resume Agents on First Focus"), "terminal.deferAgentResumeUntilFirstFocus defer lazy resume focus startup thundering herd many sessions agents claude code codex opencode toggle"),
         setting(
             .terminal,
             "agent-auto-retry",
@@ -570,6 +571,7 @@ enum SettingsSearchIndex {
         "terminal.sessionContentMaxWidth": settingID(for: .terminal, idSuffix: "session-content-width"),
         "terminal.sessionContentAlignment": settingID(for: .terminal, idSuffix: "session-content-alignment"),
         "terminal.autoResumeAgentSessions": settingID(for: .terminal, idSuffix: "agent-auto-resume"),
+        "terminal.deferAgentResumeUntilFirstFocus": settingID(for: .terminal, idSuffix: "agent-defer-resume-until-focus"),
         "terminal.autoRetryAgentSessions": settingID(for: .terminal, idSuffix: "agent-auto-retry"),
         "terminal.agentHibernation.enabled": settingID(for: .terminal, idSuffix: "agent-hibernation"),
         "terminal.agentHibernation.idleSeconds": settingID(for: .terminal, idSuffix: "agent-hibernation"),

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1390,9 +1390,18 @@ extension Workspace {
                     sessionId: restorableAgent.sessionId
                 )
             }()
+            // When enabled, defer this panel's resume the same way the dock
+            // split restore path does: skip firing it now and instead enter
+            // the existing synthetic-hibernation state below so the
+            // focus/visibility-triggered resume fires it lazily (avoids a
+            // startup thundering herd of concurrent agent resumes).
+            let deferAgentResumeUntilFocus = AgentSessionDeferredResumeSettings.isEnabled(
+                defaults: agentSessionAutoResumeDefaults
+            ) && shouldAutoResumeAgent && restoredHibernation == nil && restoredBindingLaunch == nil
+                && !agentSessionAlreadyActive && restorableAgent?.resumeCommand != nil
             let restoredAgentResumeLaunch: SurfaceResumeStartupLaunch? =
                 if shouldAutoResumeAgent && restoredHibernation == nil && restoredBindingLaunch == nil
-                    && !agentSessionAlreadyActive {
+                    && !agentSessionAlreadyActive && !deferAgentResumeUntilFocus {
                     if restoresRemoteWorkspaceTerminalSnapshot {
                         restorableAgent?.resumeStartupInput(allowLauncherScript: false, allowOversizedInlineInput: true)
                             .map(SurfaceResumeStartupLaunch.input)
@@ -1636,6 +1645,12 @@ extension Workspace {
                         agent: restorableAgent,
                         lastActivityAt: Date(timeIntervalSince1970: restoredHibernation.lastActivityAt),
                         hibernatedAt: Date(timeIntervalSince1970: restoredHibernation.hibernatedAt)
+                    )
+                } else if deferAgentResumeUntilFocus {
+                    terminalPanel.enterAgentHibernation(
+                        agent: restorableAgent,
+                        lastActivityAt: Date(),
+                        hibernatedAt: Date()
                     )
                 }
             } else {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1295,9 +1295,25 @@ extension Workspace {
                 locatedResumeBinding,
                 restorableAgent: restorableAgent
             )
+            // "Resume Agents on First Focus" candidate: the agent itself is
+            // resumable, so any startup resume — the agent's own command AND
+            // a local agent-hook binding for the same session — can be
+            // deferred into the synthetic hibernation state below.
+            // `restorableAgent` is already validated against the binding
+            // (`restorableAgentForSessionRestore`), and the hibernation wake
+            // rebuilds the command from the captured launch argv, so
+            // suppressing the binding here replays the same session later.
+            // Non-agent-hook bindings (tmux attach) and remote/persistent-SSH
+            // bindings are never deferred.
+            let deferAgentResumeCandidate = AgentSessionDeferredResumeSettings.isEnabled(
+                defaults: agentSessionAutoResumeDefaults
+            ) && shouldAutoResumeAgent && restoredHibernation == nil
+                && restorableAgent?.resumeCommand != nil
             let resumeBindingForStartup =
                 restoredHibernation != nil ||
-                (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true)
+                (resumeBinding?.isProcessDetected == true && resumeBinding?.autoResume != true) ||
+                (deferAgentResumeCandidate && resumeBinding?.isAgentHookBinding == true
+                    && resumeBinding?.launchFlavor == .local)
                     ? nil
                     : resumeBinding
             let effectiveResumeBindingForStartup = sessionRestorePolicy.approvedSurfaceResumeBinding(
@@ -1398,10 +1414,11 @@ extension Workspace {
             // the existing synthetic-hibernation state below so the
             // focus/visibility-triggered resume fires it lazily (avoids a
             // startup thundering herd of concurrent agent resumes).
-            let deferAgentResumeUntilFocus = AgentSessionDeferredResumeSettings.isEnabled(
-                defaults: agentSessionAutoResumeDefaults
-            ) && shouldAutoResumeAgent && restoredHibernation == nil && restoredBindingLaunch == nil
-                && !agentSessionAlreadyActive && restorableAgent?.resumeCommand != nil
+            // `restoredBindingLaunch` is nil for deferred local agent-hook
+            // bindings (suppressed above) but still set for tmux/SSH
+            // bindings, which keep their immediate startup launch.
+            let deferAgentResumeUntilFocus = deferAgentResumeCandidate
+                && restoredBindingLaunch == nil && !agentSessionAlreadyActive
             let restoredAgentResumeLaunch: SurfaceResumeStartupLaunch? =
                 if shouldAutoResumeAgent && restoredHibernation == nil && restoredBindingLaunch == nil
                     && !agentSessionAlreadyActive && !deferAgentResumeUntilFocus {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -175,6 +175,9 @@ extension Workspace {
         let previousSuppressClosedPanelHistory = suppressClosedPanelHistory
         suppressClosedPanelHistory = true
         defer { suppressClosedPanelHistory = previousSuppressClosedPanelHistory }
+        let previousSuppressesHibernationResume = suppressesHibernationResumeDuringRestore
+        suppressesHibernationResumeDuringRestore = true
+        defer { suppressesHibernationResumeDuringRestore = previousSuppressesHibernationResume }
         sessionRestoreIdentityExclusions.beginRestore(excluding: excludingStableIdentities)
         defer { sessionRestoreIdentityExclusions.endRestore() }
 
@@ -3472,6 +3475,14 @@ final class Workspace: Identifiable, ObservableObject {
     private var closeHistoryEligibleTabIds: Set<TabID> = []
     private var closeHistoryEligiblePanelIds: Set<UUID> = []
     private var suppressClosedPanelHistory = false
+    /// True while `restoreSessionSnapshot` runs. Tab creation during restore
+    /// emits transient bonsplit selection, focus, and portal-visibility
+    /// events; without this guard those events immediately resume agents the
+    /// restore just put into (deferred) hibernation. Actual visibility-driven
+    /// resume stays with the post-restore render passes and the view layer
+    /// (`onAutoResumeAgentHibernation`), which only fire for panels the user
+    /// really sees.
+    private var suppressesHibernationResumeDuringRestore = false
     /// Stable identities not re-adopted by the in-flight snapshot restore.
     let sessionRestoreIdentityExclusions = SessionRestoreIdentityExclusions()
     private var tabStripCloseButtonByTabId: [TabID: Bool] = [:]
@@ -4790,7 +4801,8 @@ final class Workspace: Identifiable, ObservableObject {
 
     @discardableResult
     func resumeAgentHibernation(panelId: UUID, focus: Bool) -> Bool {
-        guard let terminalPanel = panels[panelId] as? TerminalPanel,
+        guard !suppressesHibernationResumeDuringRestore,
+              let terminalPanel = panels[panelId] as? TerminalPanel,
               terminalPanel.isAgentHibernated else {
             return false
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		A9F20000000000000000000B /* AgentSessionBridgeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F10000000000000000000B /* AgentSessionBridgeError.swift */; };
 		A9F20000000000000000000C /* AgentSessionBridgeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F10000000000000000000C /* AgentSessionBridgeRequest.swift */; };
 		A9F200000000000000000003 /* AgentSessionDebugMenuButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000003 /* AgentSessionDebugMenuButtons.swift */; };
+		D3610B030000000000000001 /* AgentSessionDeferredResumeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B030000000000000002 /* AgentSessionDeferredResumeSettingsTests.swift */; };
 		A9F20000000000000000001B /* AgentSessionInputWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F10000000000000000001B /* AgentSessionInputWriter.swift */; };
 		A9F200000000000000000004 /* AgentSessionLaunchPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000004 /* AgentSessionLaunchPlan.swift */; };
 		A9F20000000000000000000E /* AgentSessionOutputLineBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F10000000000000000000E /* AgentSessionOutputLineBuffer.swift */; };
@@ -2601,6 +2602,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A9F10000000000000000000B /* AgentSessionBridgeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionBridgeError.swift; sourceTree = "<group>"; };
 		A9F10000000000000000000C /* AgentSessionBridgeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionBridgeRequest.swift; sourceTree = "<group>"; };
 		A9F100000000000000000003 /* AgentSessionDebugMenuButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionDebugMenuButtons.swift; sourceTree = "<group>"; };
+		D3610B030000000000000002 /* AgentSessionDeferredResumeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionDeferredResumeSettingsTests.swift; sourceTree = "<group>"; };
 		A9F10000000000000000001B /* AgentSessionInputWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionInputWriter.swift; sourceTree = "<group>"; };
 		A9F100000000000000000004 /* AgentSessionLaunchPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionLaunchPlan.swift; sourceTree = "<group>"; };
 		A9F10000000000000000000E /* AgentSessionOutputLineBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionOutputLineBuffer.swift; sourceTree = "<group>"; };
@@ -6799,6 +6801,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				842300000000000000000006 /* RestorableAgentProcessGenerationTests.swift */,
 				842300000000000000000008 /* SurfaceResumeAgentBindingGenerationTests.swift */,
 				D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */,
+				D3610B030000000000000002 /* AgentSessionDeferredResumeSettingsTests.swift */,
 				E90140000000000000000008 /* AgentSessionRetryCoordinatorTests.swift */,
 				E90140000000000000000014 /* AgentSessionRetryInteractionTests.swift */,
 				E90140000000000000000018 /* AgentSessionRetryOrderingTests.swift */,
@@ -9585,6 +9588,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8837A0010000000000000001 /* AgentResumeReturnShellStartupTests.swift in Sources */,
 				D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */,
 				D3610B020000000000000001 /* AgentSessionAutoResumeSwiftTests.swift in Sources */,
+				D3610B030000000000000001 /* AgentSessionDeferredResumeSettingsTests.swift in Sources */,
 				E90140000000000000000007 /* AgentSessionRetryCoordinatorTests.swift in Sources */,
 				E90140000000000000000013 /* AgentSessionRetryInteractionTests.swift in Sources */,
 				E90140000000000000000017 /* AgentSessionRetryOrderingTests.swift in Sources */,

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -663,9 +663,13 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
 
     /// Restore-Pfad B (`Workspace.restoreSessionSnapshot`) coverage for
     /// "Resume Agents on First Focus": with the defer setting enabled, a
-    /// restorable agent that would otherwise auto-resume immediately instead
-    /// enters the existing synthetic agent-hibernation state, and the
-    /// existing focus-triggered resume still wakes it on demand.
+    /// restorable agent on a background (non-selected) tab enters the
+    /// existing synthetic agent-hibernation state instead of firing its
+    /// resume command at restore, and the existing focus-triggered resume
+    /// still wakes it on demand. The agent must sit on a background tab
+    /// here because restoring the selected tab re-selects it, and tab
+    /// selection intentionally resumes a hibernated agent immediately
+    /// (the panel the user is looking at is supposed to start right away).
     @MainActor
     func testDeferredResumeEnabledEntersHibernationInsteadOfAutoResuming() throws {
         try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
@@ -675,28 +679,34 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
                 defaults.set(true, forKey: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey)
 
                 let source = Workspace()
-                let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+                let sourceFocusedPanelId = try XCTUnwrap(source.focusedPanelId)
+                let backgroundPanel = try XCTUnwrap(source.newTerminalSurfaceInFocusedPane(focus: false))
+                XCTAssertEqual(source.focusedPanelId, sourceFocusedPanelId)
                 let sourceIndex = try makeRestorableAgentIndex(
                     workspaceId: source.id,
-                    panelId: sourcePanelId,
+                    panelId: backgroundPanel.id,
                     sessionId: "codex-defer-resume-session"
                 )
-                source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+                source.updatePanelShellActivityState(panelId: backgroundPanel.id, state: .commandRunning)
                 let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: sourceIndex)
 
                 let restored = Workspace()
                 restored.restoreSessionSnapshot(snapshot)
-                let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
-                let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+                let restoredFocusedPanelId = try XCTUnwrap(restored.focusedPanelId)
+                let restoredAgentPanelId = try XCTUnwrap(
+                    restored.restoredAgentResumeStatesByPanelId.keys.first
+                )
+                XCTAssertNotEqual(restoredAgentPanelId, restoredFocusedPanelId)
+                let restoredAgentPanel = try XCTUnwrap(restored.terminalPanel(for: restoredAgentPanelId))
 
-                XCTAssertTrue(restoredPanel.isAgentHibernated)
-                let restoredInput = restoredPanel.surface.debugInitialInputMetadata()
+                XCTAssertTrue(restoredAgentPanel.isAgentHibernated)
+                let restoredInput = restoredAgentPanel.surface.debugInitialInputMetadata()
                 XCTAssertFalse(restoredInput.hasInitialInput)
                 XCTAssertEqual(restoredInput.byteCount, 0)
 
                 // The existing focus-triggered resume must still be able to wake it.
-                XCTAssertTrue(restored.resumeAgentHibernation(panelId: restoredPanelId, focus: false))
-                XCTAssertFalse(restoredPanel.isAgentHibernated)
+                XCTAssertTrue(restored.resumeAgentHibernation(panelId: restoredAgentPanelId, focus: false))
+                XCTAssertFalse(restoredAgentPanel.isAgentHibernated)
             }
         }
     }

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -745,6 +745,68 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
         }
     }
 
+    /// Real-world restores mostly resume through a local agent-hook resume
+    /// binding, not through the agent's own resume command. The defer setting
+    /// must suppress that binding launch too, or a restart still fires every
+    /// session's resume at once (#9145 dogfood: ~90 concurrent binding
+    /// launches despite the setting being on).
+    @MainActor
+    func testDeferredResumeEnabledSuppressesAgentHookBindingLaunch() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            try withRestoredDefaults(key: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey) {
+                let defaults = UserDefaults.standard
+                defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+                defaults.set(true, forKey: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey)
+
+                let source = Workspace()
+                let sourceFocusedPanelId = try XCTUnwrap(source.focusedPanelId)
+                let backgroundPanel = try XCTUnwrap(source.newTerminalSurfaceInFocusedPane(focus: false))
+                XCTAssertEqual(source.focusedPanelId, sourceFocusedPanelId)
+                let sessionId = "codex-defer-binding-session"
+                let sourceIndex = try makeRestorableAgentIndex(
+                    workspaceId: source.id,
+                    panelId: backgroundPanel.id,
+                    sessionId: sessionId
+                )
+                let bindingIndex = SurfaceResumeBindingIndex(bindingsByPanel: [
+                    SurfaceResumeBindingIndex.PanelKey(workspaceId: source.id, panelId: backgroundPanel.id): SurfaceResumeBindingSnapshot(
+                        name: "Codex",
+                        kind: "codex",
+                        command: "codex resume \(sessionId)",
+                        cwd: "/tmp/repo",
+                        checkpointId: sessionId,
+                        source: "agent-hook",
+                        autoResume: true,
+                        updatedAt: 1_777_777_777
+                    ),
+                ])
+                source.updatePanelShellActivityState(panelId: backgroundPanel.id, state: .commandRunning)
+                let snapshot = source.sessionSnapshot(
+                    includeScrollback: false,
+                    restorableAgentIndex: sourceIndex,
+                    surfaceResumeBindingIndex: bindingIndex
+                )
+
+                let restored = Workspace()
+                restored.restoreSessionSnapshot(snapshot)
+                let restoredFocusedPanelId = try XCTUnwrap(restored.focusedPanelId)
+                let restoredAgentPanelId = try XCTUnwrap(
+                    restored.restoredAgentResumeStatesByPanelId.keys.first
+                )
+                XCTAssertNotEqual(restoredAgentPanelId, restoredFocusedPanelId)
+                let restoredAgentPanel = try XCTUnwrap(restored.terminalPanel(for: restoredAgentPanelId))
+
+                XCTAssertTrue(restoredAgentPanel.isAgentHibernated)
+                let restoredInput = restoredAgentPanel.surface.debugInitialInputMetadata()
+                XCTAssertFalse(restoredInput.hasInitialInput)
+                XCTAssertEqual(restoredInput.byteCount, 0)
+
+                XCTAssertTrue(restored.resumeAgentHibernation(panelId: restoredAgentPanelId, focus: false))
+                XCTAssertFalse(restoredAgentPanel.isAgentHibernated)
+            }
+        }
+    }
+
     private func withRestoredDefaults<T>(
         key: String,
         defaults: UserDefaults = .standard,

--- a/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSettingsTests.swift
@@ -661,6 +661,80 @@ final class AgentSessionAutoResumeSettingsTests: XCTestCase {
         )
     }
 
+    /// Restore-Pfad B (`Workspace.restoreSessionSnapshot`) coverage for
+    /// "Resume Agents on First Focus": with the defer setting enabled, a
+    /// restorable agent that would otherwise auto-resume immediately instead
+    /// enters the existing synthetic agent-hibernation state, and the
+    /// existing focus-triggered resume still wakes it on demand.
+    @MainActor
+    func testDeferredResumeEnabledEntersHibernationInsteadOfAutoResuming() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            try withRestoredDefaults(key: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey) {
+                let defaults = UserDefaults.standard
+                defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+                defaults.set(true, forKey: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey)
+
+                let source = Workspace()
+                let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+                let sourceIndex = try makeRestorableAgentIndex(
+                    workspaceId: source.id,
+                    panelId: sourcePanelId,
+                    sessionId: "codex-defer-resume-session"
+                )
+                source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+                let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: sourceIndex)
+
+                let restored = Workspace()
+                restored.restoreSessionSnapshot(snapshot)
+                let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+                let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+
+                XCTAssertTrue(restoredPanel.isAgentHibernated)
+                let restoredInput = restoredPanel.surface.debugInitialInputMetadata()
+                XCTAssertFalse(restoredInput.hasInitialInput)
+                XCTAssertEqual(restoredInput.byteCount, 0)
+
+                // The existing focus-triggered resume must still be able to wake it.
+                XCTAssertTrue(restored.resumeAgentHibernation(panelId: restoredPanelId, focus: false))
+                XCTAssertFalse(restoredPanel.isAgentHibernated)
+            }
+        }
+    }
+
+    /// Default-off companion to the above: without the defer setting, restore
+    /// behavior on this path must stay bit-identical to today (immediate
+    /// auto-resume, no synthetic hibernation).
+    @MainActor
+    func testDeferredResumeDisabledMatchesPriorAutoResumeBehavior() throws {
+        try withRestoredDefaults(key: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey) {
+            try withRestoredDefaults(key: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey) {
+                let defaults = UserDefaults.standard
+                defaults.removeObject(forKey: AgentSessionAutoResumeSettings.autoResumeAgentSessionsKey)
+                defaults.removeObject(forKey: AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey)
+
+                let source = Workspace()
+                let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+                let sourceIndex = try makeRestorableAgentIndex(
+                    workspaceId: source.id,
+                    panelId: sourcePanelId,
+                    sessionId: "codex-defer-off-session"
+                )
+                source.updatePanelShellActivityState(panelId: sourcePanelId, state: .commandRunning)
+                let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: sourceIndex)
+
+                let restored = Workspace()
+                restored.restoreSessionSnapshot(snapshot)
+                let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+                let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+
+                XCTAssertFalse(restoredPanel.isAgentHibernated)
+                let restoredInput = restoredPanel.surface.debugInitialInputMetadata()
+                XCTAssertTrue(restoredInput.hasInitialInput)
+                XCTAssertGreaterThan(restoredInput.byteCount, 0)
+            }
+        }
+    }
+
     private func withRestoredDefaults<T>(
         key: String,
         defaults: UserDefaults = .standard,

--- a/cmuxTests/AgentSessionDeferredResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionDeferredResumeSettingsTests.swift
@@ -151,7 +151,77 @@ struct AgentSessionDeferredResumeSettingsTests {
         #expect(!panel.surface.debugInitialInputMetadata().hasInitialInput)
     }
 
-    private static func makeDockAgentSnapshot(sessionId: String) throws -> SessionSplitContainerSnapshot {
+    /// Real-world restores mostly carry a local agent-hook resume binding for
+    /// the session (`codex resume …` / `claude --resume …` replayed into the
+    /// terminal). Deferring only the agent's own resume command while letting
+    /// the binding fire at startup would defeat the setting for exactly those
+    /// panels — the original ~90-concurrent-resume storm came from binding
+    /// launches (#9145 dogfood).
+    @Test("Dock restore defers an agent-hook binding resume into hibernation when enabled")
+    func deferEnabledSuppressesAgentHookBindingLaunch() throws {
+        let suiteName = "cmux-agent-session-deferred-resume-binding-on-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        AgentSessionDeferredResumeSettings.setEnabled(true, defaults: defaults)
+
+        let snapshot = try Self.makeDockAgentSnapshot(
+            sessionId: "dock-defer-binding-on-session-\(UUID().uuidString)",
+            includeAgentHookBinding: true
+        )
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { store.closeAllPanels() }
+
+        let restoredIds = store.restoreSessionSnapshot(snapshot)
+        let panelId = try #require(restoredIds.values.first)
+        let panel = try #require(store.panels[panelId] as? TerminalPanel)
+
+        #expect(panel.isAgentHibernated)
+        let input = panel.surface.debugInitialInputMetadata()
+        #expect(!input.hasInitialInput)
+        #expect(input.byteCount == 0)
+
+        // The existing focus-triggered resume must still be able to wake it.
+        #expect(store.resumeAgentHibernation(panelId: panelId, focus: false))
+        #expect(!panel.isAgentHibernated)
+    }
+
+    /// Default-off companion: without the defer setting, an auto-resume
+    /// agent-hook binding keeps firing its startup launch immediately.
+    @Test("Dock restore fires an agent-hook binding immediately while the setting is off")
+    func deferDisabledKeepsAgentHookBindingLaunch() throws {
+        let suiteName = "cmux-agent-session-deferred-resume-binding-off-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let snapshot = try Self.makeDockAgentSnapshot(
+            sessionId: "dock-defer-binding-off-session-\(UUID().uuidString)",
+            includeAgentHookBinding: true
+        )
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { store.closeAllPanels() }
+
+        let restoredIds = store.restoreSessionSnapshot(snapshot)
+        let panelId = try #require(restoredIds.values.first)
+        let panel = try #require(store.panels[panelId] as? TerminalPanel)
+
+        #expect(!panel.isAgentHibernated)
+        let input = panel.surface.debugInitialInputMetadata()
+        #expect(input.hasInitialInput)
+        #expect(input.byteCount > 0)
+    }
+
+    private static func makeDockAgentSnapshot(
+        sessionId: String,
+        includeAgentHookBinding: Bool = false
+    ) throws -> SessionSplitContainerSnapshot {
         let panelId = UUID()
         let agent = SessionRestorableAgentSnapshot(
             kind: .codex,
@@ -159,6 +229,18 @@ struct AgentSessionDeferredResumeSettingsTests {
             workingDirectory: "/tmp/dock-defer-project",
             launchCommand: nil
         )
+        let resumeBinding = includeAgentHookBinding
+            ? SurfaceResumeBindingSnapshot(
+                name: "Codex",
+                kind: "codex",
+                command: "codex resume \(sessionId)",
+                cwd: "/tmp/dock-defer-project",
+                checkpointId: sessionId,
+                source: "agent-hook",
+                autoResume: true,
+                updatedAt: 1_777_777_777
+            )
+            : nil
         let panel = SessionPanelSnapshot(
             id: panelId,
             type: .terminal,
@@ -172,6 +254,7 @@ struct AgentSessionDeferredResumeSettingsTests {
             terminal: SessionTerminalPanelSnapshot(
                 workingDirectory: "/tmp/dock-defer-project",
                 agent: agent,
+                resumeBinding: resumeBinding,
                 wasAgentRunning: true
             ),
             browser: nil,

--- a/cmuxTests/AgentSessionDeferredResumeSettingsTests.swift
+++ b/cmuxTests/AgentSessionDeferredResumeSettingsTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Coverage for "Resume Agents on First Focus" (`terminal.deferAgentResumeUntilFirstFocus`):
+/// with auto-resume enabled, a restorable agent panel normally fires its resume
+/// command immediately on restore. With this setting also enabled, cmux instead
+/// defers that resume into the existing synthetic "agent hibernation" state, so
+/// dozens of restored panels don't all launch resume commands at once on
+/// startup; the existing focus/visibility-triggered resume fires it lazily.
+@MainActor
+@Suite("Agent session deferred resume settings", .serialized)
+struct AgentSessionDeferredResumeSettingsTests {
+    @Test("Defaults key and notification on flip")
+    func defaultsKeyAndNotificationOnFlip() throws {
+        let suiteName = "cmux-agent-session-deferred-resume-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(
+            AgentSessionDeferredResumeSettings.deferUntilFirstFocusKey
+                == "terminal.deferAgentResumeUntilFirstFocus"
+        )
+        #expect(!AgentSessionDeferredResumeSettings.isEnabled(defaults: defaults))
+
+        let notificationCenter = NotificationCenter()
+        var notificationCount = 0
+        let observer = notificationCenter.addObserver(
+            forName: AgentSessionDeferredResumeSettings.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationCount += 1
+        }
+        defer { notificationCenter.removeObserver(observer) }
+
+        AgentSessionDeferredResumeSettings.setEnabled(
+            true,
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+        #expect(AgentSessionDeferredResumeSettings.isEnabled(defaults: defaults))
+        #expect(notificationCount == 1)
+
+        AgentSessionDeferredResumeSettings.setEnabled(
+            true,
+            defaults: defaults,
+            notificationCenter: notificationCenter
+        )
+        #expect(notificationCount == 1)
+
+        AgentSessionDeferredResumeSettings.reset(defaults: defaults, notificationCenter: notificationCenter)
+        #expect(!AgentSessionDeferredResumeSettings.isEnabled(defaults: defaults))
+        #expect(notificationCount == 2)
+    }
+
+    /// Default-off path (dock restore): behavior must stay bit-identical to
+    /// today's immediate auto-resume when the new setting isn't enabled.
+    @Test("Dock restore auto-resumes immediately while the setting is off")
+    func deferDisabledMatchesPriorBehaviorOnDockRestore() throws {
+        let suiteName = "cmux-agent-session-deferred-resume-dock-off-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let snapshot = try Self.makeDockAgentSnapshot(sessionId: "dock-defer-off-session-\(UUID().uuidString)")
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { store.closeAllPanels() }
+
+        let restoredIds = store.restoreSessionSnapshot(snapshot)
+        let panelId = try #require(restoredIds.values.first)
+        let panel = try #require(store.panels[panelId] as? TerminalPanel)
+
+        #expect(!panel.isAgentHibernated)
+        let input = panel.surface.debugInitialInputMetadata()
+        #expect(input.hasInitialInput)
+        #expect(input.byteCount > 0)
+    }
+
+    /// With the setting enabled, the dock restore path must skip the immediate
+    /// resume and instead enter the same synthetic hibernation state a
+    /// snapshot that was already hibernated at quit time would use.
+    @Test("Dock restore defers resume into synthetic hibernation when enabled")
+    func deferEnabledEntersHibernationOnDockRestore() throws {
+        let suiteName = "cmux-agent-session-deferred-resume-dock-on-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        AgentSessionDeferredResumeSettings.setEnabled(true, defaults: defaults)
+
+        let snapshot = try Self.makeDockAgentSnapshot(sessionId: "dock-defer-on-session-\(UUID().uuidString)")
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer { store.closeAllPanels() }
+
+        let restoredIds = store.restoreSessionSnapshot(snapshot)
+        let panelId = try #require(restoredIds.values.first)
+        let panel = try #require(store.panels[panelId] as? TerminalPanel)
+
+        #expect(panel.isAgentHibernated)
+        let input = panel.surface.debugInitialInputMetadata()
+        #expect(!input.hasInitialInput)
+        #expect(input.byteCount == 0)
+
+        // The existing focus-triggered resume must still be able to wake it.
+        #expect(store.resumeAgentHibernation(panelId: panelId, focus: false))
+        #expect(!panel.isAgentHibernated)
+    }
+
+    /// An agent whose process is already live (so cmux would connect to it as
+    /// already-active rather than resuming) must not be forced into hibernation
+    /// just because the defer setting is on.
+    @Test("Dock restore leaves an already-active agent session alone even when deferring")
+    func deferEnabledDoesNotHibernateAlreadyActiveAgent() throws {
+        let suiteName = "cmux-agent-session-deferred-resume-dock-active-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        AgentSessionDeferredResumeSettings.setEnabled(true, defaults: defaults)
+
+        let sessionId = "dock-defer-active-session-\(UUID().uuidString)"
+        // Pre-claim the resume launch slot the same way a live process would
+        // be treated as already active by `sessionAgentAlreadyActive`.
+        #expect(AgentResumeLaunchGuard.shared.claimResumeLaunch(kind: RestorableAgentKind.codex.rawValue, sessionId: sessionId))
+
+        let snapshot = try Self.makeDockAgentSnapshot(sessionId: sessionId)
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            agentSessionAutoResumeDefaults: defaults
+        )
+        defer {
+            store.closeAllPanels()
+            AgentResumeLaunchGuard.shared.releaseResumeLaunch(kind: RestorableAgentKind.codex.rawValue, sessionId: sessionId)
+        }
+
+        let restoredIds = store.restoreSessionSnapshot(snapshot)
+        let panelId = try #require(restoredIds.values.first)
+        let panel = try #require(store.panels[panelId] as? TerminalPanel)
+
+        #expect(!panel.isAgentHibernated)
+        #expect(!panel.surface.debugInitialInputMetadata().hasInitialInput)
+    }
+
+    private static func makeDockAgentSnapshot(sessionId: String) throws -> SessionSplitContainerSnapshot {
+        let panelId = UUID()
+        let agent = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: sessionId,
+            workingDirectory: "/tmp/dock-defer-project",
+            launchCommand: nil
+        )
+        let panel = SessionPanelSnapshot(
+            id: panelId,
+            type: .terminal,
+            title: "Agent",
+            customTitle: nil,
+            directory: "/tmp/dock-defer-project",
+            isPinned: false,
+            isManuallyUnread: false,
+            listeningPorts: [],
+            ttyName: "ttys002",
+            terminal: SessionTerminalPanelSnapshot(
+                workingDirectory: "/tmp/dock-defer-project",
+                agent: agent,
+                wasAgentRunning: true
+            ),
+            browser: nil,
+            markdown: nil,
+            filePreview: nil,
+            rightSidebarTool: nil
+        )
+        return SessionSplitContainerSnapshot(
+            focusedPanelId: panelId,
+            layout: .pane(SessionPaneLayoutSnapshot(panelIds: [panelId], selectedPanelId: panelId)),
+            panels: [panel]
+        )
+    }
+}

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -590,6 +590,11 @@
           "default": true,
           "description": "Automatically run agent resume commands for restored terminal sessions when cmux reopens after quit. Set false to restore panes while keeping Claude Code, Codex, OpenCode, and other saved agent sessions idle until you resume them manually."
         },
+        "deferAgentResumeUntilFirstFocus": {
+          "type": "boolean",
+          "default": false,
+          "description": "Only takes effect when autoResumeAgentSessions is true. Set true to wait until you actually focus or view a restored agent terminal's tab before running its resume command, instead of running every restorable terminal's resume command immediately on restore."
+        },
         "autoRetryAgentSessions": {
           "type": "boolean",
           "default": false,

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -593,6 +593,7 @@
         "deferAgentResumeUntilFirstFocus": {
           "type": "boolean",
           "default": false,
+          "descriptionKey": "schemaDescriptions.terminal.deferAgentResumeUntilFirstFocus",
           "description": "Only takes effect when autoResumeAgentSessions is true. Set true to wait until you actually focus or view a restored agent terminal's tab before running its resume command, instead of running every restorable terminal's resume command immediately on restore."
         },
         "autoRetryAgentSessions": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1774,6 +1774,7 @@
         "terminal": {
           "autoRetryAgentSessions": "Automatically resume a managed agent session when its active command exits with a nonzero, non-signal error status. Retries are bounded and use exponential backoff; normal completion and explicit user termination are never retried.",
           "copyOnSelect": "When true, copy selected terminal text to the system clipboard when the selection is committed. When false, cmux does not emit a Ghostty copy-on-select override; Ghostty config and defaults control selection-clipboard behavior.",
+          "deferAgentResumeUntilFirstFocus": "Only takes effect when autoResumeAgentSessions is true. Set true to wait until you actually focus or view a restored agent terminal's tab before running its resume command, instead of running every restorable terminal's resume command immediately on restore.",
           "scrollSpeed": "Multiplier applied to terminal scroll wheel and trackpad deltas. Higher values scroll faster; lower values scroll slower.",
           "sessionContentMaxWidth": "Optional maximum width, in points, for terminal and built-in agent chat content. Set false to use the full pane width.",
           "sessionContentAlignment": "Horizontal placement for terminal and built-in agent chat content when sessionContentMaxWidth is enabled.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1697,6 +1697,7 @@
         "terminal": {
           "autoRetryAgentSessions": "アクティブな管理対象エージェントのコマンドが、シグナル以外の 0 でないエラーステータスで終了した場合に、セッションを自動的に再開します。再試行は回数制限付きの指数バックオフで行い、正常終了やユーザーによる明示的な終了は再試行しません。",
           "copyOnSelect": "true の場合、選択が確定したときにターミナルで選択したテキストをシステムクリップボードへコピーします。false の場合、cmux は Ghostty の copy-on-select 上書きを出力せず、選択クリップボードの動作は Ghostty の設定と既定値に従います。",
+          "deferAgentResumeUntilFirstFocus": "autoResumeAgentSessions が true の場合にのみ有効です。true にすると、復元されたすべてのエージェントターミナルの resume コマンドを復元直後に一斉に実行するのではなく、そのタブを実際にフォーカスまたは表示するまで待ってから実行します。",
           "scrollSpeed": "ターミナルのスクロールホイールとトラックパッドの移動量に適用される倍率です。値を大きくするとスクロールが速くなり、小さくすると遅くなります。",
           "sessionContentMaxWidth": "ターミナルと組み込みエージェントチャットのコンテンツ幅の上限をポイント単位で指定します。ペインの全幅を使うには false を設定します。",
           "sessionContentAlignment": "sessionContentMaxWidth が有効な場合の、ターミナルと組み込みエージェントチャットの水平方向の配置です。",


### PR DESCRIPTION
## Problem

With auto-resume enabled, quitting and relaunching cmux (or a machine reboot) fires the resume command for **every** restorable agent panel at startup. With ~90 restored Claude sessions this launches ~90 concurrent `claude --resume` processes (load average 115, 24 GB compressed memory) and grinds the machine to a halt.

## Solution

New opt-in setting `terminal.deferAgentResumeUntilFirstFocus` (default **off**, so default behavior is unchanged). When enabled together with *Resume Agent Sessions on Reopen*:

- Both session-restore paths (dock split restore and workspace restore) skip the immediate resume launch for panels that would auto-resume — **both** the agent's own resume command **and** local agent-hook resume bindings for the same session (real-world profiles resume almost entirely through binding launches; deferring only the agent path left the startup storm intact in dogfood).
- Those panels instead enter the **existing** synthetic agent-hibernation state. The hibernation wake rebuilds the command from the captured launch argv, so hook settings and flags are preserved.
- The existing focus/visibility-triggered `resumeAgentHibernation` machinery launches the agent the first time the user actually views the panel. Visible panels of the active workspace resume right away.
- During `restoreSessionSnapshot`, transient bonsplit selection/focus/portal-visibility events are gated (`suppressesHibernationResumeDuringRestore`) — without this, restore-time churn immediately woke every freshly hibernated panel.
- Agents whose process is still alive keep connecting immediately; tmux-attach and remote/persistent-SSH bindings are never deferred; scrollback replay is unaffected.

## Wiring

Settings key catalog, Agent Recovery settings row (disabled while auto-resume is off), settings navigation + curated search entry, command palette toggle, cmux.json JSON-path support, settings file store + template, `web/data/cmux.schema.json` (with `descriptionKey`), en/ja localization (app strings + web message catalogs).

## Verification

- `xcodebuild -scheme cmux -configuration Debug build`: **BUILD SUCCEEDED**
- Focused tests (cmux-unit): `AgentSessionDeferredResumeSettingsTests` 6/6, defer tests in `AgentSessionAutoResumeSettingsTests` 3/3, hibernation suites (`AgentHibernationTests`, `AgentHibernationPortalVisibilityTests`, `AgentHibernationRestoreMonitorTests`) all green. Remaining local failures are byte-identical to an origin/main baseline run (pre-existing Xcode 26.2 environment issues, incl. an unrelated `CmuxMobileRPC` `sending`-closure compile error in test builds).
- `CmuxSettings` 265/265 and `CmuxSettingsUI` 138/138 package tests green; `./scripts/lint-pbxproj-test-wiring.sh` ok (626 files).
- Regression-style commit pairs: test-first commits `e92f16a` / `39cdbea` fail without their fixes `0741052` / `431d4fd`.
- **Real-profile dogfood** (~90-session profile): before — load 115, 71 concurrent `claude` launches, 122 MCP child processes; after — load 2.6, 3 launches (visible panels only), zero new `cmux-surface-resume` launcher scripts written at startup. Background tabs wake individually on first focus.

## Localization audit

Settings row title + on/off subtitles (`settings.terminal.agentDeferResumeUntilFirstFocus*`) in `Resources/Localizable.xcstrings` (en + ja); curated search entry uses the same key; schema description via `schemaDescriptions.terminal.deferAgentResumeUntilFirstFocus` in `web/messages/en.json` + `ja.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)