### PR TITLE
Repair Subrouter web CI on current main

### DIFF
--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -31,6 +31,11 @@ const requiredRelayProductionEnv = {
   CMUX_RELAY_TOKEN_RATE_LIMIT_ID: "relay-token-rule",
 };
 
+const requiredSubrouterDeploymentEnv = {
+  SUBROUTER_ENFORCE_STACK_PERMISSIONS: "0",
+  SUBROUTER_ALLOWED_TEAM_IDS: "test-team",
+};
+
 describe("client config env validation", () => {
   test("allows local builds with VERCEL set but no deployment environment", () => {
     const result = importEnv({
@@ -52,6 +57,7 @@ describe("client config env validation", () => {
       ...baseEnv,
       VERCEL: "1",
       VERCEL_ENV: "production",
+      ...requiredSubrouterDeploymentEnv,
       ...requiredIrohProductionEnv,
       ...relayEnv,
     });
@@ -67,6 +73,7 @@ describe("client config env validation", () => {
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
+      ...requiredSubrouterDeploymentEnv,
       ...requiredIrohProductionEnv,
       ...requiredRelayProductionEnv,
     });
@@ -92,6 +99,7 @@ describe("client config env validation", () => {
       VERCEL: "1",
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+      ...requiredSubrouterDeploymentEnv,
       ...requiredIrohProductionEnv,
       ...requiredRelayProductionEnv,
     });
@@ -106,6 +114,7 @@ describe("client config env validation", () => {
       VERCEL: "1",
       VERCEL_ENV: "development",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+      ...requiredSubrouterDeploymentEnv,
       ...requiredIrohProductionEnv,
       ...requiredRelayProductionEnv,
     });
@@ -125,6 +134,7 @@ describe("client config env validation", () => {
       CMUX_IROH_GRANT_SIGNING_KID: requiredIrohProductionEnv.CMUX_IROH_GRANT_SIGNING_KID,
       CMUX_IROH_GRANT_VERIFICATION_KEYS_JSON:
         requiredIrohProductionEnv.CMUX_IROH_GRANT_VERIFICATION_KEYS_JSON,
+      ...requiredSubrouterDeploymentEnv,
       ...requiredRelayProductionEnv,
     });
 
@@ -140,6 +150,7 @@ describe("client config env validation", () => {
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
+      ...requiredSubrouterDeploymentEnv,
     });
 
     expect(result.exitCode).toBe(0);
@@ -154,6 +165,7 @@ describe("client config env validation", () => {
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
       CMUX_IROH_RATE_LIMIT_ID: "iroh-rule",
+      ...requiredSubrouterDeploymentEnv,
     });
 
     expect(result.exitCode).not.toBe(0);
@@ -169,6 +181,7 @@ describe("client config env validation", () => {
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
+      ...requiredSubrouterDeploymentEnv,
     });
 
     expect(result.exitCode).not.toBe(0);
@@ -231,6 +244,7 @@ describe("client config env validation", () => {
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
       CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
+      ...requiredSubrouterDeploymentEnv,
       ...requiredRelayProductionEnv,
       CMUX_IROH_DEV_ALLOW_INSECURE_LOOPBACK_MINTER: "1",
       CMUX_IROH_MINT_URL: "http://localhost:49152/api/relay-token",

--- a/web/tests/subrouter-accounts-route.test.ts
+++ b/web/tests/subrouter-accounts-route.test.ts
@@ -85,12 +85,7 @@ describe("subrouter accounts route", () => {
     const operation = withSubrouterAuthorizationDeadline(
       async () => await new Promise<never>(() => {}),
     );
-    const result = await Promise.race([
-      operation.catch((error: unknown) => error),
-      new Promise<"still-pending">((resolve) =>
-        setTimeout(() => resolve("still-pending"), 100)
-      ),
-    ]);
+    const result = await operation.catch((error: unknown) => error);
 
     expect(result).toBeInstanceOf(SubrouterAuthorizationTimeoutError);
   });
@@ -998,9 +993,8 @@ describe("subrouter accounts route", () => {
       { length: 12 },
       () => teamsRoute.GET(request("/api/subrouter/teams")),
     );
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    releasePermissions();
     const responses = await Promise.all(routes);
+    releasePermissions();
 
     expect(responses.every((response) => response.status === 503)).toBe(true);
     expect(maxActive).toBeLessThanOrEqual(8);


### PR DESCRIPTION
## Summary

- Supply mandatory Subrouter deployment variables in production environment fixtures.
- Remove two redundant wall-clock sleeps from authorization timeout tests.

## Testing

- `bun test tests/client-config-env.test.ts tests/subrouter-accounts-route.test.ts`
- `bun test --isolate` (922 passed, 127 skipped)
- `bun run typecheck`
- `python3 scripts/check-test-determinism.py --strict`
- `biome check` on both changed files

## Demo Video

Not applicable. This is a test-only CI repair.

## Review Trigger

The current-main gate for https://github.com/manaflow-ai/cmux/pull/8709 exposed failures introduced by https://github.com/manaflow-ai/cmux/pull/9099.

## Checklist

- [x] No runtime source changed.
- [x] Focused failures reproduced before the repair.
- [x] Full web validation passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787910337&installation_model_id=21920&pr_number=9147&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9147&signature=4ce448dcfe9ee23f51672830552b5ee00ac9d4fb090b0c64c8094e7b374e2c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Subrouter web CI on main by adding required Subrouter deployment env to test fixtures and removing redundant sleeps in auth timeout tests. Test-only changes; no runtime code.

- **Bug Fixes**
  - Added `SUBROUTER_ENFORCE_STACK_PERMISSIONS=0` and `SUBROUTER_ALLOWED_TEAM_IDS=test-team` to production env fixtures in `client-config-env.test.ts`.
  - Removed unnecessary sleeps in `subrouter-accounts-route.test.ts`; await the timeout error directly and release permissions after responses to reduce flakes and speed up tests.

<sup>Written for commit a2526eee7f7e5fa0f5dc771a02d82c637a61cdc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated environment configuration coverage for subrouter deployment scenarios.
  * Improved authorization timeout tests to verify abort handling directly.
  * Refined concurrent request timeout testing for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->