### PR TITLE
Fix Debug-build crash on macOS 26.5: non-finite event coordinates trap in sidebar divider diagnostics

### DIFF
--- a/Sources/Sidebar/SidebarDividerTrackingView.swift
+++ b/Sources/Sidebar/SidebarDividerTrackingView.swift
@@ -48,10 +48,15 @@ final class SidebarDividerTrackingView: NSView {
         diagnosticsInstalled = true
         NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown]) { event in
             if let contentView = event.window?.contentView {
-                let point = contentView.convert(event.locationInWindow, from: nil)
+                let location = event.locationInWindow
+                let point = contentView.convert(location, from: nil)
                 let hit = contentView.hitTest(point)
+                // macOS 26 can deliver events whose window location is
+                // non-finite; `Int(_:)` traps on NaN/infinity and takes the
+                // whole app down from this log line.
+                let x = location.x.isFinite ? String(Int(location.x)) : "non-finite"
                 cmuxDebugLog(
-                    "sidebar.divider.downRouting x=\(Int(event.locationInWindow.x)) " +
+                    "sidebar.divider.downRouting x=\(x) " +
                     "hit=\(hit.map { String(describing: type(of: $0)) } ?? "nil")"
                 )
             }

--- a/Sources/Sidebar/SidebarDividerTrackingView.swift
+++ b/Sources/Sidebar/SidebarDividerTrackingView.swift
@@ -53,8 +53,9 @@ final class SidebarDividerTrackingView: NSView {
                 let hit = contentView.hitTest(point)
                 // macOS 26 can deliver events whose window location is
                 // non-finite; `Int(_:)` traps on NaN/infinity and takes the
-                // whole app down from this log line.
-                let x = location.x.isFinite ? String(Int(location.x)) : "non-finite"
+                // whole app down from this log line. `%.0f` formats any
+                // Double without trapping ("nan"/"inf" for the odd ones).
+                let x = String(format: "%.0f", location.x)
                 cmuxDebugLog(
                     "sidebar.divider.downRouting x=\(x) " +
                     "hit=\(hit.map { String(describing: type(of: $0)) } ?? "nil")"


### PR DESCRIPTION
Debug builds crash on macOS 26.5 when AppKit delivers a left-mouse-down event with a non-finite window location. The DEBUG-only divider-routing diagnostics in `SidebarDividerTrackingView.installDiagnosticsIfNeeded()` format the coordinate with `Int(event.locationInWindow.x)`, and `Int(_:)` traps on NaN:

```
Swift runtime failure: Double value cannot be converted to Int because it is either infinite or NaN
implicit closure #1 in closure #1 in static SidebarDividerTrackingView.installDiagnosticsIfNeeded()
  (SidebarDividerTrackingView.swift:53)
```

Hit this twice within minutes while dogfooding a tagged Debug build on macOS 26.5.2 (Mac14,6). Release builds are unaffected since the monitor is `#if DEBUG`, and CI on macOS 15 never sees these events — the "test on the reporter's macOS" class of issue from the contributor notes.

The fix renders non-finite coordinates as `non-finite` instead of trapping. No behavior change beyond the log text.

No regression test: the trap lives in a DEBUG-only `NSEvent` local-monitor closure with no seam to inject a synthetic NaN-location event, so a test would only re-assert source shape. Verified instead by running the same Debug build with the guard through the interactions that previously crashed it — no crashes since.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug diagnostics for sidebar divider mouse interactions.
  * Prevented potential logging failures when cursor coordinates contain invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->