### PR TITLE
Add a dev target to the presence deploy workflow

### DIFF
--- a/.github/workflows/presence.yml
+++ b/.github/workflows/presence.yml
@@ -4,6 +4,13 @@
 # the Durable Object migrations declared in wrangler.toml atomically with the code
 # upload, so the service's schema can never lag a deploy.
 #
+# The `target` input picks the worker: `prod` (default) deploys `cmux-presence`
+# on presence.cmux.dev; `dev` deploys the shared integration baseline
+# `cmux-presence-dev` from wrangler.dev.toml. Both use the repository's
+# Cloudflare secrets, so nobody needs a personal Cloudflare account membership
+# to keep the shared dev worker current. Per-developer isolated workers stay on
+# `scripts/deploy-dev.sh` (they need per-instance Stack secrets at creation).
+#
 # Required repository secrets (deploy job):
 #   CLOUDFLARE_API_TOKEN   API token with Workers Scripts:Edit on the account
 #   CLOUDFLARE_ACCOUNT_ID  the Cloudflare account id
@@ -16,6 +23,14 @@ name: presence
 
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: "Worker to deploy"
+        type: choice
+        options:
+          - prod
+          - dev
+        default: prod
 
 permissions:
   contents: read
@@ -100,7 +115,12 @@ jobs:
           fi
 
       - name: Deploy (applies DO migrations atomically)
-        run: bunx wrangler deploy
+        run: |
+          if [ "${{ inputs.target }}" = "dev" ]; then
+            bunx wrangler deploy --config wrangler.dev.toml
+          else
+            bunx wrangler deploy
+          fi
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/presence.yml
+++ b/.github/workflows/presence.yml
@@ -115,12 +115,17 @@ jobs:
           fi
 
       - name: Deploy (applies DO migrations atomically)
+        # The target reaches the shell via env, never template interpolation
+        # (an API dispatch is not limited to the UI's choice list), and any
+        # value other than the two known targets fails closed instead of
+        # silently deploying production.
         run: |
-          if [ "${{ inputs.target }}" = "dev" ]; then
-            bunx wrangler deploy --config wrangler.dev.toml
-          else
-            bunx wrangler deploy
-          fi
+          case "$DEPLOY_TARGET" in
+            dev) bunx wrangler deploy --config wrangler.dev.toml ;;
+            prod) bunx wrangler deploy ;;
+            *) echo "::error::Unsupported deployment target '$DEPLOY_TARGET'"; exit 1 ;;
+          esac
         env:
+          DEPLOY_TARGET: ${{ inputs.target }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/workers/presence/README.md
+++ b/workers/presence/README.md
@@ -77,10 +77,13 @@ lifecycle proof, including real Stack sign-in and the alarm-driven timeout, is
 
 ## Deploy
 
-Deploys run automatically from `.github/workflows/presence.yml` on push to
-main (path-filtered). `wrangler deploy` applies the `[[migrations]]` block in
-`wrangler.toml` atomically with the upload, so Durable Object storage classes
-can never lag the deployed code.
+Deploys run from `.github/workflows/presence.yml` via manual dispatch on
+main: `gh workflow run presence.yml` deploys production, and
+`gh workflow run presence.yml -f target=dev` deploys the shared
+`cmux-presence-dev` baseline, both with the repository's Cloudflare secrets
+(no personal Cloudflare account membership needed). `wrangler deploy` applies
+the `[[migrations]]` block atomically with the upload, so Durable Object
+storage classes can never lag the deployed code.
 
 Required GitHub repository secrets:
 
@@ -106,8 +109,10 @@ Stack project's Worker secrets:
 https://cmux-presence-dev.debussy.workers.dev
 ```
 
-Redeploy it manually with `bunx wrangler deploy --config wrangler.dev.toml`
-(its `STACK_*` Worker secrets are already provisioned and survive deploys).
+Redeploy it with `gh workflow run presence.yml -f target=dev` (or locally with
+`bunx wrangler deploy --config wrangler.dev.toml` if your Cloudflare login has
+the account); its `STACK_*` Worker secrets are already provisioned and survive
+deploys.
 
 > [!IMPORTANT]
 > Use `--config wrangler.dev.toml`, NOT `--name cmux-presence-dev`. The default


### PR DESCRIPTION
## Problem

The shared `cmux-presence-dev` worker (the integration baseline every Debug/tagged build points at) can only be redeployed with a personal Cloudflare login that is a member of the org account. Most of the team is not (aziz@manaflow.ai's login sees only a personal account), and local wrangler OAuth tokens expire. Prod already deploys through `presence.yml` with the org's repo-secret token, so dev deploys were the odd one out; after https://github.com/manaflow-ai/cmux/pull/9012 merged, prod got the nudge code via the workflow but the dev worker was stuck stale.

## Mechanism

`presence.yml` gains a `target` dispatch input: `prod` (default, unchanged behavior, `wrangler.toml` → presence.cmux.dev) or `dev` (`wrangler.dev.toml` → `cmux-presence-dev`). Both run the same test job first and use the same `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` repo secrets, so keeping the shared dev baseline current is now `gh workflow run presence.yml -f target=dev` with no personal Cloudflare access. Per-developer isolated workers stay on `scripts/deploy-dev.sh` since they need per-instance Stack secrets at creation. Also fixes the README, which claimed deploys run on push to main; the workflow is manual dispatch only (and had to be re-enabled for the 9012 prod deploy).

Principled or hacky: principled — it routes the dev deploy through the exact path prod already uses instead of spreading personal credentials.

## Verification

Workflow-file-only change; no runtime build. After merge I will run `gh workflow run presence.yml -f target=dev`, confirm the run deploys `cmux-presence-dev`, and probe `https://cmux-presence-dev.debussy.workers.dev/v1/presence/nudge` for 401 (route exists) versus the current stale 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787945548&installation_model_id=21920&pr_number=9161&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9161&signature=3d47dec7acdbb96edba8a1fa99b2475e3b95fd47a25e8cc2481780cf5acf3e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dev deployment target to `presence.yml` so anyone can deploy the shared `cmux-presence-dev` worker with repo Cloudflare secrets. Also hardens target handling (env var, fail-closed on unknown values) and fixes the README to note manual dispatch.

- **New Features**
  - Adds `target` input to `presence.yml`: `prod` (default) or `dev`. `dev` runs `bunx wrangler deploy --config wrangler.dev.toml` to deploy `cmux-presence-dev` with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets.
  - Run: `gh workflow run presence.yml -f target=dev`.

- **Bug Fixes**
  - Passes the target via env (`DEPLOY_TARGET`) and errors on any value other than `prod`/`dev` to prevent template injection and accidental prod deploys.

<sup>Written for commit fa911fa143c5659a0629a371caa5759a4c089cb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual deployment target selection for production vs development.
  * Limited selectable targets to `prod` (default) and `dev`, with unsupported values rejected.

* **Documentation**
  * Updated deployment guidance to reflect manual GitHub Actions workflow dispatch for production and development.
  * Revised redeployment instructions for development/staging to use the workflow target (`target=dev`) or the local Wrangler dev config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->