### PR TITLE
Batch iOS TestFlight uploads on a schedule instead of per merge

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,24 +1,16 @@
 name: iOS TestFlight (CMUX INTERNAL)
 
 on:
-  # Automatically upload only when main changes the iOS app or a direct archive
-  # input. Manual dispatch remains available for intentional rebuilds.
-  push:
-    branches:
-      - main
-    paths:
-      - "ios/**"
-      - "Packages/iOS/**"
-      - "Packages/Shared/**"
-      - "Sources/Mobile/**"
-      - "vendor/stack-auth-swift-sdk-prerelease/**"
-      - "ghostty"
-      - "ghostty.h"
-      - "scripts/ensure-ghosttykit.sh"
-      - "scripts/ghosttykit-checksums.txt"
-      - "scripts/install-zig-ci.sh"
-      - "scripts/validate-xcframework-archive.py"
-      - ".github/workflows/ios-testflight.yml"
+  # Scheduled batching instead of per-merge uploads: App Store Connect enforces a
+  # per-app upload quota that merge bursts exhausted. The decide job skips a
+  # scheduled run when main has not changed since the variant's last upload or
+  # when the changes touch no iOS-relevant paths. Manual dispatch remains
+  # available for intentional rebuilds.
+  schedule:
+    # Hourly cmux INTERNAL upload of current main.
+    - cron: "7 * * * *"
+    # Twice-daily (every 12 hours) cmux DEMO upload of current main.
+    - cron: "37 5,17 * * *"
   workflow_dispatch:
     inputs:
       build_number:
@@ -42,10 +34,10 @@ on:
           - demo
 
 concurrency:
-  # A shared group keeps only one pending run and silently replaces older pending
-  # SHAs during merge bursts. Key qualifying push runs by SHA so every iOS change
-  # survives. Manual runs use run_id because an operator may intentionally rebuild.
-  group: ios-testflight-${{ github.event_name == 'push' && github.sha || github.run_id }}
+  # Every run keys by run_id: scheduled runs must not cancel each other (the
+  # decide job already serializes uploads), and an operator may intentionally
+  # rebuild via dispatch.
+  group: ios-testflight-${{ github.run_id }}
   cancel-in-progress: false
 
 permissions:
@@ -61,6 +53,7 @@ jobs:
     outputs:
       should_build: ${{ steps.decide.outputs.should_build }}
       last_uploaded_sha: ${{ steps.decide.outputs.last_uploaded_sha }}
+      variant: ${{ steps.decide.outputs.variant }}
     steps:
       - name: Decide whether a TestFlight upload is needed
         id: decide
@@ -68,6 +61,20 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
+
+            // Resolve the upload variant once. Scheduled runs select the variant
+            // by which cron fired; dispatch runs use the variant input. Every
+            // downstream job reads needs.decide.outputs.variant instead of
+            // re-deriving it from event fields.
+            const demoCron = '37 5,17 * * *';
+            const isDemo =
+              (context.eventName === 'workflow_dispatch' &&
+                context.payload?.inputs?.variant === 'demo') ||
+              (context.eventName === 'schedule' && context.payload?.schedule === demoCron);
+            const variant = isDemo ? 'demo' : 'internal';
+            const canonicalArtifactName = isDemo
+              ? 'ios-testflight-build-metadata-demo'
+              : 'ios-testflight-build-metadata';
 
             // Per-SHA workflow concurrency preserves every push, but it also lets
             // several runs reach App Store Connect at once. Build numbers must be
@@ -91,7 +98,7 @@ jobs:
                     (run) =>
                       Number(run.id) < currentRunId &&
                       run.status !== 'completed' &&
-                      ['push', 'workflow_dispatch'].includes(run.event)
+                      ['push', 'schedule', 'workflow_dispatch'].includes(run.event)
                   );
                   for (const run of earlierActiveRuns) {
                     const jobs = await github.rest.actions.listJobsForWorkflowRun({
@@ -188,10 +195,7 @@ jobs:
                     const artifactNames = new Set(
                       (artifacts.data.artifacts || []).map((artifact) => artifact.name)
                     );
-                    if (
-                      artifactNames.has('ios-testflight-build-metadata-override') &&
-                      !artifactNames.has('ios-testflight-build-metadata')
-                    ) {
+                    if (!artifactNames.has(canonicalArtifactName)) {
                       continue;
                     }
                     lastUploadedSha = run.head_sha;
@@ -204,20 +208,71 @@ jobs:
               core.warning(`could not resolve last uploaded sha: ${e.message}`);
             }
 
-            // Push runs have already passed the workflow's iOS path filter.
-            // Manual runs are intentional rebuilds, so every event that reaches
-            // this workflow should build.
-            const shouldBuild =
-              context.eventName === 'push' || context.eventName === 'workflow_dispatch';
+            // Manual runs are intentional rebuilds and always build. Scheduled
+            // runs batch merges instead of shipping each one: skip when this
+            // variant already shipped the current head, or when the delta since
+            // the last upload touches no iOS-relevant paths, so idle hours never
+            // spend App Store Connect upload quota.
+            const iosRelevantPaths = [
+              'ios/',
+              'Packages/iOS/',
+              'Packages/Shared/',
+              'Sources/Mobile/',
+              'vendor/stack-auth-swift-sdk-prerelease/',
+              'ghostty',
+              'ghostty.h',
+              'scripts/ensure-ghosttykit.sh',
+              'scripts/ghosttykit-checksums.txt',
+              'scripts/install-zig-ci.sh',
+              'scripts/validate-xcframework-archive.py',
+              '.github/workflows/ios-testflight.yml',
+            ];
+            const touchesIOS = (filename) =>
+              iosRelevantPaths.some((p) =>
+                p.endsWith('/') ? filename.startsWith(p) : filename === p
+              );
+            let shouldBuild = true;
+            let reason = 'manual dispatch';
+            if (context.eventName === 'schedule') {
+              if (!lastUploadedSha) {
+                reason = 'no prior upload found for this variant';
+              } else if (lastUploadedSha === context.sha) {
+                shouldBuild = false;
+                reason = 'main unchanged since last upload';
+              } else {
+                // Fail open: when the compare is unavailable or truncated, build
+                // rather than silently skipping a real iOS change.
+                reason = 'new commits since last upload';
+                try {
+                  const compare = await github.rest.repos.compareCommits({
+                    owner,
+                    repo,
+                    base: lastUploadedSha,
+                    head: context.sha,
+                  });
+                  const files = compare.data.files || [];
+                  const truncated = files.length >= 300;
+                  if (!truncated && !files.some((file) => touchesIOS(file.filename))) {
+                    shouldBuild = false;
+                    reason = 'no iOS-relevant changes since last upload';
+                  }
+                } catch (e) {
+                  core.warning(`could not compare against last upload: ${e.message}`);
+                }
+              }
+            }
             core.setOutput('should_build', shouldBuild ? 'true' : 'false');
             core.setOutput('last_uploaded_sha', lastUploadedSha || '');
+            core.setOutput('variant', variant);
             core.summary
               .addHeading('iOS TestFlight upload decision')
               .addTable([
                 [{ data: 'event', header: true }, context.eventName],
+                [{ data: 'variant', header: true }, variant],
                 [{ data: 'head sha', header: true }, context.sha],
                 [{ data: 'last uploaded sha (notes base)', header: true }, String(lastUploadedSha)],
                 [{ data: 'should build', header: true }, String(shouldBuild)],
+                [{ data: 'reason', header: true }, reason],
               ])
               .write();
 
@@ -243,8 +298,8 @@ jobs:
       # provisioning profile step can use it). The manual demo variant ships the
       # same main head as a separate app so demos are isolated from the internal
       # firehose (and its per-app upload limit).
-      IOS_BETA_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
-      IOS_BETA_DISPLAY_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
+      IOS_BETA_BUNDLE_ID: ${{ needs.decide.outputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+      IOS_BETA_DISPLAY_NAME: ${{ needs.decide.outputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -401,7 +456,7 @@ jobs:
           echo "Installed $PROFILE_TYPE provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
 
       - name: Use DEMO-badged app icon
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo'
+        if: needs.decide.outputs.variant == 'demo'
         run: |
           set -euo pipefail
           # Swap the AppIcon PNGs in the CI checkout instead of overriding
@@ -439,11 +494,11 @@ jobs:
           INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
           # Display name for automatic internal builds (auto-synced to internal group).
           # The demo variant ships as "cmux DEMO" / dev.cmux.app.demo instead.
-          IOS_BETA_DISPLAY_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
+          IOS_BETA_DISPLAY_NAME: ${{ needs.decide.outputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
           # Internal builds use separate bundle ID (dev.cmux.app.internal) so internal
           # and external can coexist on same device.
-          IOS_BETA_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
-          INPUT_VARIANT: ${{ github.event.inputs.variant }}
+          IOS_BETA_BUNDLE_ID: ${{ needs.decide.outputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+          INPUT_VARIANT: ${{ needs.decide.outputs.variant }}
         run: |
           set -euo pipefail
           if [ "${INPUT_VARIANT:-internal}" = "demo" ] && [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
@@ -498,8 +553,8 @@ jobs:
         env:
           BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number || github.event.inputs.build_number || 'unknown' }}
           INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
-          UPLOAD_BUNDLE_ID: ${{ github.event.inputs.marketing_version_override != '' && 'dev.cmux.app.beta' || github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
-          UPLOAD_DISPLAY_NAME: ${{ github.event.inputs.marketing_version_override != '' && 'cmux BETA' || github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
+          UPLOAD_BUNDLE_ID: ${{ github.event.inputs.marketing_version_override != '' && 'dev.cmux.app.beta' || needs.decide.outputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+          UPLOAD_DISPLAY_NAME: ${{ github.event.inputs.marketing_version_override != '' && 'cmux BETA' || needs.decide.outputs.variant == 'demo' && 'cmux DEMO' || 'cmux INTERNAL' }}
           UPLOAD_AUDIENCE: ${{ github.event.inputs.marketing_version_override != '' && 'external TestFlight testers' || 'internal TestFlight group' }}
           UPLOAD_REVIEW_NOTE: ${{ github.event.inputs.marketing_version_override != '' && 'Beta App Review may be required' || 'no beta review needed' }}
         run: |
@@ -537,7 +592,9 @@ jobs:
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ github.event.inputs.marketing_version_override != '' && 'ios-testflight-build-metadata-override' || 'ios-testflight-build-metadata' }}
+          # Variant-specific names keep the decide job's last-upload lookup (and
+          # therefore skip logic + notes ranges) independent per app.
+          name: ${{ github.event.inputs.marketing_version_override != '' && 'ios-testflight-build-metadata-override' || needs.decide.outputs.variant == 'demo' && 'ios-testflight-build-metadata-demo' || 'ios-testflight-build-metadata' }}
           path: ${{ runner.temp }}/ios-testflight-build.json
           retention-days: 30
 
@@ -567,8 +624,8 @@ jobs:
       # repo variables were wired in.
       # The demo variant assigns to the "cmux DEMO" internal group on the
       # dev.cmux.app.demo app record instead.
-      CMUX_TESTFLIGHT_INTERNAL_GROUP_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dd5c5cde-05a6-44e5-bd71-c2ec08a3ebfe' || vars.IOS_TESTFLIGHT_INTERNAL_GROUP_ID }}
-      ASSIGN_BUNDLE_ID: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
+      CMUX_TESTFLIGHT_INTERNAL_GROUP_ID: ${{ needs.decide.outputs.variant == 'demo' && 'dd5c5cde-05a6-44e5-bd71-c2ec08a3ebfe' || vars.IOS_TESTFLIGHT_INTERNAL_GROUP_ID }}
+      ASSIGN_BUNDLE_ID: ${{ needs.decide.outputs.variant == 'demo' && 'dev.cmux.app.demo' || 'dev.cmux.app.internal' }}
       BUILD_NUMBER: ${{ needs.upload.outputs.final_build_number }}
     steps:
       - name: Checkout


### PR DESCRIPTION
We hit the App Store Connect upload limit from per-merge internal uploads.

- **cmux INTERNAL**: uploads hourly (cron `7 * * * *`) instead of on every merge to main.
- **cmux DEMO**: new scheduled upload every 12 hours (cron `37 5,17 * * *`), same lane as the existing `variant=demo` dispatch.
- Scheduled runs skip (no quota spent) when main is unchanged since that variant's last upload, or when the delta touches no iOS-relevant paths (the old push-trigger path filter, now enforced via `compareCommits` with fail-open on truncation/errors).
- The variant is resolved once in the `decide` job from the firing cron or the dispatch input; all downstream jobs read `needs.decide.outputs.variant`.
- Demo runs now upload `ios-testflight-build-metadata-demo` so internal and demo keep independent last-upload lookups (skip logic + What to Test ranges).
- Manual `workflow_dispatch` behavior is unchanged: always builds, both variants, override lane untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787952697&installation_model_id=21920&pr_number=9165&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9165&signature=e82911d0ccb506c042fd42ff7fb36c0bb36ce858ff0fc07c6abb1b57607e2ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch iOS TestFlight uploads from per-merge to scheduled batches to prevent App Store Connect upload quota issues. INTERNAL runs hourly and DEMO runs every 12 hours, with smart skipping when no iOS changes or main hasn’t moved.

- **New Features**
  - Scheduled uploads: INTERNAL `7 * * * *`, DEMO `37 5,17 * * *`.
  - Scheduled runs skip when the variant already shipped the current head or the diff has no iOS-relevant paths (`compareCommits`, fail-open).
  - Variant resolved once in `decide` and passed as `needs.decide.outputs.variant`.
  - Variant-specific build metadata artifacts: `ios-testflight-build-metadata` and `ios-testflight-build-metadata-demo`.

- **Refactors**
  - Concurrency keyed by `github.run_id`; `decide` waits to keep build numbers monotonic.
  - Bundle IDs, display names, and icon selection read from `needs.decide.outputs.variant`. Manual `workflow_dispatch` remains unchanged and always builds.

<sup>Written for commit 8911c22d9f6e991dee193f265b125c99d242a949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS TestFlight uploads now run on scheduled hourly or twice-daily cadences for the appropriate app variant.
  * Added variant-specific handling for builds, app settings, TestFlight groups, and uploaded artifacts.
* **Improvements**
  * Scheduled uploads can skip unnecessary builds when there are no relevant iOS changes or the app is unchanged since the last upload.
  * Manual uploads continue to support intentional build execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->