### PR TITLE
Hide iOS cursor while reviewing scrollback

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/GhosttySurfaceView+BottomScrollStressDebug.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/Debug/GhosttySurfaceView+BottomScrollStressDebug.swift
@@ -19,11 +19,6 @@ extension GhosttySurfaceView {
         enqueueScrollToBottom()
     }
 
-    @MainActor
-    func recordBottomScrollStressScrollbar(total: Int, offset: Int, len: Int) {
-        debugLastScrollbar = (total: total, offset: offset, len: len)
-    }
-
     var bottomScrollDebugScrollbarAtBottom: Bool {
         guard let snapshot = debugLastScrollbar else { return false }
         return snapshot.total > snapshot.len && snapshot.offset >= max(0, snapshot.total - snapshot.len - 1)

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttyRuntime.swift
@@ -303,18 +303,23 @@ public final class GhosttyRuntime {
             return true
         }
 
-        #if DEBUG
         if action.tag == GHOSTTY_ACTION_SCROLLBAR {
+            guard target.tag == GHOSTTY_TARGET_SURFACE,
+                  let surface = target.target.surface,
+                  let bridge = GhosttySurfaceBridge.fromOpaque(ghostty_surface_userdata(surface)) else { return false }
             let sb = action.action.scrollbar
+            #if DEBUG
             MobileDebugLog.anchormux("scroll.bar total=\(sb.total) offset=\(sb.offset) len=\(sb.len)")
-            if target.tag == GHOSTTY_TARGET_SURFACE, let surface = target.target.surface {
-                Task { @MainActor in
-                    GhosttySurfaceView.view(for: surface)?.recordBottomScrollStressScrollbar(total: Int(sb.total), offset: Int(sb.offset), len: Int(sb.len))
-                }
+            #endif
+            Task { @MainActor [bridge] in
+                bridge.surfaceView?.handleScrollbarUpdate(
+                    total: sb.total,
+                    offset: sb.offset,
+                    length: sb.len
+                )
             }
             return true
         }
-        #endif
 
         return false
     }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+Scrollback.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView+Scrollback.swift
@@ -1,0 +1,21 @@
+#if canImport(UIKit)
+extension GhosttySurfaceView {
+    /// Applies Ghostty's authoritative viewport position to UIKit overlays.
+    func handleScrollbarUpdate(total: UInt64, offset: UInt64, length: UInt64) {
+        #if DEBUG
+        debugLastScrollbar = (
+            total: Int(clamping: total),
+            offset: Int(clamping: offset),
+            len: Int(clamping: length)
+        )
+        #endif
+
+        let visibleLength = min(total, length)
+        let isAtBottom = offset >= total - visibleLength
+        guard viewportIsAtScrollbackBottom != isAtBottom else { return }
+
+        viewportIsAtScrollbackBottom = isAtBottom
+        updateCursorOverlay()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -114,6 +114,10 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     /// the last applied state from the byte stream and hide the overlay to
     /// match. Defaults to visible (a normal shell shows its cursor).
     private var hostCursorVisible: Bool = true
+    /// Whether Ghostty's viewport currently includes the live bottom row.
+    /// The cursor is a UIKit overlay, so it must be suppressed independently
+    /// while the terminal renderer is showing historical scrollback.
+    var viewportIsAtScrollbackBottom = true
     var needsDraw: Bool = false
     /// Countdown of extra draw requests after a geometry change, so the
     /// renderer (which presents a frame behind) produces a frame at the final
@@ -2874,6 +2878,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     func initializeSurface() {
+        viewportIsAtScrollbackBottom = true
         guard let app = runtime?.app else { return }
         surface = makeSurface(app: app)
         if let surface {
@@ -3174,6 +3179,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
         }
         guard let surface,
               hostCursorVisible,
+              viewportIsAtScrollbackBottom,
               verifiedReplayFrozenPresentationLayer == nil,
               window != nil,
               !isHidden,

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalInputScrollToBottomTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/TerminalInputScrollToBottomTests.swift
@@ -71,9 +71,9 @@ struct TerminalInputScrollToBottomTests {
         view.renderedTextForTesting() ?? ""
     }
 
-    /// Seeds numbered scrollback and scrolls up until the last line leaves the
-    /// viewport, returning the marker text of the last (bottom) line.
-    private func seedAndScrollUp(_ view: GhosttySurfaceView) async throws -> String {
+    /// Seeds numbered scrollback at the live bottom, returning the marker text
+    /// of the last line.
+    private func seed(_ view: GhosttySurfaceView) async throws -> String {
         let lastLineMarker = "seed-line 300"
         var text = ""
         for i in 1...300 {
@@ -82,11 +82,20 @@ struct TerminalInputScrollToBottomTests {
         _ = await view.processOutputAndWait(Data(text.utf8))
         #expect(await waitUntil { viewportText(view).contains(lastLineMarker) },
                 "seeded output should land with the viewport at the bottom")
+        return lastLineMarker
+    }
 
+    /// Scrolls up until the supplied bottom marker leaves the viewport.
+    private func scrollUp(_ view: GhosttySurfaceView, past lastLineMarker: String) async {
         view.applyLocalScrollbackScroll(lines: 120, col: 2, row: 2)
         #expect(await waitUntil { !viewportText(view).contains(lastLineMarker) },
                 "scrolling up should move the last line out of the viewport")
-        return lastLineMarker
+    }
+
+    private func seedAndScrollUp(_ view: GhosttySurfaceView) async throws -> String {
+        let marker = try await seed(view)
+        await scrollUp(view, past: marker)
+        return marker
     }
 
     @Test("typing while scrolled up snaps the viewport back to the bottom")
@@ -118,6 +127,30 @@ struct TerminalInputScrollToBottomTests {
                 || viewportText(harness.view).contains("passive-tail")
         }
         #expect(!jumped, "passive output must not auto-follow while the user reads scrollback")
+    }
+
+    @Test("cursor is hidden while reviewing scrollback")
+    func cursorIsHiddenWhileScrolledUp() async throws {
+        let harness = try makeHarness()
+        defer { harness.view.prepareForDismantle() }
+
+        let marker = try await seed(harness.view)
+        #expect(
+            await waitUntil {
+                harness.view.updateCursorOverlay()
+                return harness.view.cursorOverlayLayer != nil
+            },
+            "the live cursor overlay should be mounted at the bottom"
+        )
+        let cursor = try #require(harness.view.cursorOverlayLayer)
+        #expect(!cursor.isHidden, "the live terminal cursor should be visible at the bottom")
+
+        await scrollUp(harness.view, past: marker)
+
+        #expect(
+            await waitUntil { cursor.isHidden },
+            "the live terminal cursor must not be drawn over historical rows while scrolled up"
+        )
     }
 }
 #endif


### PR DESCRIPTION
Summary:
- consume Ghostty scrollbar updates in release builds
- hide the independent UIKit cursor overlay outside the live bottom viewport
- add a real-surface regression test for historical scrollback

Verification:
- focused cursor regression test passes on cmux-scrcur-0729
- typed-input bottom follow test passes
- passive-output scroll preservation test passes
- macOS and iOS Simulator tagged reloads succeeded with scrcur

The package convention lint still reports existing repository-wide violations outside these changed files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787953337&installation_model_id=21920&pr_number=9168&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9168&signature=3d93de98359394412ff1fab4b685cbdfbdd3d182b412beea21c9299a58a96a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the iOS cursor overlay while reviewing scrollback, and consume Ghostty scrollbar updates in release builds to keep the UIKit overlay in sync.

- **Bug Fixes**
  - Forward scrollbar updates from `GhosttyRuntime` to `GhosttySurfaceView` via `handleScrollbarUpdate`, and track when the viewport is at the live bottom.
  - Only draw the cursor when the viewport includes the bottom row; hide it during scrollback review. Added a feature test to cover both states.

<sup>Written for commit 88c171f695a42397674b37ca28c7dd3b6fff05dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scrollbar updates now consistently track the terminal’s scrollback position.
  * Cursor overlays are hidden while viewing historical scrollback and restored at the live bottom position.

* **Bug Fixes**
  * Improved cursor visibility behavior when scrolling through terminal history.
  * Added regression coverage for cursor hiding while scrolled up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->