### PR TITLE
Shrink Iroh pairing QR payload

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
@@ -1,14 +1,22 @@
 import Foundation
 
-/// The minimal pairing-QR grammar: expected Mac account/build metadata plus
-/// plain `host:port` routes in the URL query.
+/// The minimal pairing-QR grammars for Iroh identity and Tailscale routes.
 ///
-/// `cmux-ios://attach?v=2&ub=<stack-user-id>&pc=<compat>&av=<version>&ab=<build>&r=<host>:<port>[&r=<host>:<port>...]`
+/// Current Iroh codes carry only the stable EndpointID:
+/// `cmux-ios://attach?v=3&i=<endpoint-id>`.
 ///
-/// A pairing QR needs to tell the phone where to dial and which non-secret
-/// account/build context to check before dialing. The account value is the
-/// opaque Stack user id, never the email itself. Everything else the earlier
-/// grammars carried has a better channel or no reason to exist:
+/// The EndpointID is the only value the phone needs before dialing. The
+/// signed-in trust broker verifies same-account ownership while minting the
+/// pair grant, and the authenticated `mobile.host.status` response supplies
+/// the Mac's device id, display name, and build metadata after connection.
+/// Omitting those duplicate fields avoids JSON and base64 overhead, lowering
+/// the QR version while its displayed size stays unchanged.
+///
+/// Tailscale compatibility codes keep the v2 grammar so already-released
+/// clients can still scan them:
+/// `cmux-ios://attach?v=2&ub=<stack-user-id>&pc=<compat>&av=<version>&ab=<build>&r=<host>:<port>[&r=<host>:<port>...]`.
+///
+/// Both grammars share these properties:
 /// - **No auth token.** The owner's Stack access token is the host's sole
 ///   authorization gate; a token in the QR authorized nothing and made the
 ///   code look like a leaked credential.
@@ -17,7 +25,7 @@ import Foundation
 /// - **No display name, no device id.** Both arrive post-handshake from
 ///   `mobile.host.status`; the decoder leaves `macDeviceID` empty and the
 ///   shell adopts the host-reported identity once connected.
-/// - **No loopback, ever.** Routes are Tailscale `host:port` only: the
+/// - **No loopback, ever.** v2 routes are Tailscale `host:port` only: the
 ///   encoder drops a DEBUG Mac's dev loopback route instead of encoding it,
 ///   the Mac refuses to mint a QR without a Tailscale route (it shows the
 ///   set-up-Tailscale guidance instead), and the decoder rejects loopback
@@ -28,20 +36,28 @@ import Foundation
 ///   into an `NWConnection` `.waiting` black hole for the full request
 ///   timeout before the Tailscale route was ever tried.
 ///
-/// The payload is deliberately *not* wrapped in base64 JSON: anyone can read
+/// The payloads are deliberately *not* wrapped in base64 JSON: anyone can read
 /// the URL off the QR and see for themselves that it carries only an address.
 /// Plain text is also smaller, which lowers the QR version (fewer, larger
 /// modules) and makes the code scan faster from a Mac screen.
 ///
-/// Compatibility: this grammar only ever appears in the Mac's pairing QR.
-/// Workspace-scoped tickets, dev loopback tickets, and every RPC consumer
+/// Compatibility: these grammars only ever appear in the Mac's pairing QR.
+/// v2 remains decodable; an older iPhone presented with a v3 Iroh code gets
+/// the existing update-app error and can use the Tailscale compatibility code
+/// when one is available. Workspace-scoped tickets, dev loopback tickets, and
+/// every RPC consumer
 /// keep the compact v1 JSON payload (``CmxAttachTicketCompactCoder``), and the
 /// decoder keeps accepting both that and the legacy full-key grammar.
 public struct CmxPairingQRCode: Sendable {
-    /// The grammar version carried in the URL's `v` query item. Distinct from
-    /// ``CmxAttachTicket/currentVersion`` (the ticket *structure* version):
-    /// `v=1` URLs carry a base64 JSON `payload`, `v=2` URLs carry bare routes.
-    public static let version = 2
+    /// The newest grammar version this build can decode.
+    ///
+    /// Distinct from ``CmxAttachTicket/currentVersion`` (the ticket structure
+    /// version): v1 URLs carry base64 JSON, v2 carries Tailscale routes, and
+    /// v3 carries one bare Iroh EndpointID.
+    public static let version = 3
+
+    private static let tailscaleVersion = 2
+    private static let irohVersion = 3
 
     /// Defensive cap on routes accepted from a scanned code. The Mac's route
     /// resolver emits at most a couple (MagicDNS name + Tailscale IP); a QR
@@ -53,41 +69,53 @@ public struct CmxPairingQRCode: Sendable {
     /// site; every instance speaks the same grammar version.
     public init() {}
 
-    /// Encode `ticket` as a v2 pairing URL, or `nil` when the ticket does not
+    /// Encode `ticket` as a minimal pairing URL, or `nil` when it does not
     /// qualify (see ``canEncode(_:routeDisclosureMode:)``); callers fall back
     /// to the compact v1 payload so every ticket still has an attach URL.
     ///
-    /// Only the ticket's Tailscale routes are encoded: a DEBUG Mac's dev
-    /// loopback route is dropped, never written into a scannable code.
+    /// Iroh mode writes one EndpointID and nothing else. Compatibility mode
+    /// writes only the ticket's Tailscale routes; a DEBUG Mac's dev loopback
+    /// route is dropped, never written into a scannable code.
     public func encode(
         _ ticket: CmxAttachTicket,
         routeDisclosureMode: CmxPairingRouteDisclosureMode
     ) -> String? {
-        guard routeDisclosureMode == .legacyPrivateNetworkCompatibility,
-              let routes = encodableRoutes(of: ticket) else {
-            return nil
-        }
-        var items: [String] = ["v=\(Self.version)"]
-        if let userID = normalizedNonEmpty(ticket.macUserID) {
-            items.append("ub=\(percentEncodeQueryValue(userID))")
-        }
-        if let compatibilityVersion = ticket.macPairingCompatibilityVersion {
-            items.append("pc=\(compatibilityVersion)")
-        }
-        if let version = normalizedNonEmpty(ticket.macAppVersion) {
-            items.append("av=\(percentEncodeQueryValue(version))")
-        }
-        if let build = normalizedNonEmpty(ticket.macAppBuild) {
-            items.append("ab=\(percentEncodeQueryValue(build))")
-        }
-        let routeItems = routes.map { route -> String in
-            guard case let .hostPort(host, port) = route.endpoint else {
-                // Unreachable: `encodableRoutes` admits host/port endpoints only.
-                return ""
+        let items: [String]
+        switch routeDisclosureMode {
+        case .irohIdentityOnly:
+            guard let identity = encodableIrohIdentity(of: ticket) else {
+                return nil
             }
-            return "r=\(hostPortString(host: host, port: port))"
+            items = [
+                "v=\(Self.irohVersion)",
+                "i=\(identity.endpointID)"
+            ]
+        case .legacyPrivateNetworkCompatibility:
+            guard let routes = encodableTailscaleRoutes(of: ticket) else {
+                return nil
+            }
+            var compatibilityItems: [String] = ["v=\(Self.tailscaleVersion)"]
+            if let userID = normalizedNonEmpty(ticket.macUserID) {
+                compatibilityItems.append("ub=\(percentEncodeQueryValue(userID))")
+            }
+            if let compatibilityVersion = ticket.macPairingCompatibilityVersion {
+                compatibilityItems.append("pc=\(compatibilityVersion)")
+            }
+            if let version = normalizedNonEmpty(ticket.macAppVersion) {
+                compatibilityItems.append("av=\(percentEncodeQueryValue(version))")
+            }
+            if let build = normalizedNonEmpty(ticket.macAppBuild) {
+                compatibilityItems.append("ab=\(percentEncodeQueryValue(build))")
+            }
+            compatibilityItems.append(contentsOf: routes.map { route -> String in
+                guard case let .hostPort(host, port) = route.endpoint else {
+                    // Unreachable: the selector admits host/port endpoints only.
+                    return ""
+                }
+                return "r=\(hostPortString(host: host, port: port))"
+            })
+            items = compatibilityItems
         }
-        items.append(contentsOf: routeItems)
         // The scheme is channel-specific (see ``CmxPairingURLScheme``): a dev
         // Mac's QR opens the dev iOS build, a release Mac's QR opens the
         // release build, and the system camera can no longer hand a beta/prod
@@ -95,15 +123,17 @@ public struct CmxPairingQRCode: Sendable {
         return "\(CmxPairingURLScheme.current)://attach?" + items.joined(separator: "&")
     }
 
-    /// Whether `ticket` is expressible in the minimal grammar under the
-    /// explicitly selected disclosure mode; see ``encodableRoutes(of:)`` for
-    /// the rules.
+    /// Whether `ticket` is expressible in the selected minimal grammar.
     public func canEncode(
         _ ticket: CmxAttachTicket,
         routeDisclosureMode: CmxPairingRouteDisclosureMode
     ) -> Bool {
-        routeDisclosureMode == .legacyPrivateNetworkCompatibility
-            && encodableRoutes(of: ticket) != nil
+        switch routeDisclosureMode {
+        case .irohIdentityOnly:
+            encodableIrohIdentity(of: ticket) != nil
+        case .legacyPrivateNetworkCompatibility:
+            encodableTailscaleRoutes(of: ticket) != nil
+        }
     }
 
     /// The route subsequence a v2 pairing URL would carry for `ticket`, or
@@ -119,7 +149,7 @@ public struct CmxPairingQRCode: Sendable {
     /// Tailscale route at all, or a non-Tailscale fallback route such as an
     /// iroh peer that the bare `host:port` grammar cannot express) keeps the
     /// compact v1 payload so the mapping stays lossless.
-    private func encodableRoutes(of ticket: CmxAttachTicket) -> [CmxAttachRoute]? {
+    private func encodableTailscaleRoutes(of ticket: CmxAttachTicket) -> [CmxAttachRoute]? {
         guard ticket.version == CmxAttachTicket.currentVersion,
               ticket.workspaceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               ticket.terminalID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false else {
@@ -144,10 +174,37 @@ public struct CmxPairingQRCode: Sendable {
         return routes
     }
 
-    /// Whether `components` (an already-parsed `cmux-ios://attach` URL) speaks
-    /// this grammar. v1 URLs carry the base64 `payload` item instead.
+    /// The single canonical Iroh identity a v3 code can carry.
+    ///
+    /// Other route kinds and Iroh path hints are deliberately discarded under
+    /// identity-only disclosure. The decoder reconstructs the sole route with
+    /// canonical id `iroh` and priority zero; neither value affects selection
+    /// when the ticket has exactly one disclosed route.
+    private func encodableIrohIdentity(
+        of ticket: CmxAttachTicket
+    ) -> CmxIrohPeerIdentity? {
+        guard ticket.version == CmxAttachTicket.currentVersion,
+              ticket.workspaceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              ticket.terminalID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false else {
+            return nil
+        }
+        let irohRoutes = ticket.routes.filter { $0.kind == .iroh }
+        guard irohRoutes.count == 1,
+              let route = irohRoutes.first,
+              case let .peer(identity, _) = route.endpoint else {
+            return nil
+        }
+        return identity
+    }
+
+    /// Whether `components` speaks a supported plain pairing-code grammar.
+    ///
+    /// v1 URLs carry a base64 JSON `payload` item instead.
     public func isPairingCodeURL(_ components: URLComponents) -> Bool {
-        components.queryItems?.first(where: { $0.name == "v" })?.value == "\(Self.version)"
+        guard let version = Self.attachURLVersion(components) else {
+            return false
+        }
+        return version == Self.tailscaleVersion || version == Self.irohVersion
     }
 
     /// The integer grammar version declared by an attach URL's `v` query item,
@@ -161,9 +218,11 @@ public struct CmxPairingQRCode: Sendable {
         return Int(raw)
     }
 
-    /// Whether `rawValue` is a v2 pairing URL. String-level convenience for
-    /// callers that hold the encoded URL (the Mac's pairing window asserting
-    /// the code it is about to display speaks the minimal grammar).
+    /// Whether `rawValue` is a supported plain pairing URL.
+    ///
+    /// String-level convenience for callers that hold the encoded URL (the
+    /// Mac's pairing window asserting the code it is about to display speaks
+    /// the minimal grammar).
     public func isPairingCodeURLString(_ rawValue: String) -> Bool {
         guard let url = URL(string: rawValue),
               CmxPairingURLScheme.isPairingScheme(url.scheme),
@@ -174,19 +233,33 @@ public struct CmxPairingQRCode: Sendable {
         return isPairingCodeURL(components)
     }
 
-    /// Decode a v2 pairing URL into a validated ``CmxAttachTicket``.
+    /// Decode a supported plain pairing URL into a validated ticket.
     ///
     /// The ticket comes back unscoped with an empty `macDeviceID`; the shell
     /// recovers the Mac's identity post-handshake from `mobile.host.status`.
-    /// - Parameter components: The parsed `cmux-ios://attach?v=2&...` URL.
+    /// - Parameter components: A parsed v2 or v3 attach URL.
     /// - Throws: ``MobileSyncPairingPayloadError/invalidURL`` for malformed
     ///   input and ``MobileSyncPairingPayloadError/loopbackRouteRejected``
     ///   when any route names a loopback host (a scanned code must never
     ///   point the phone at itself).
     public func decode(_ components: URLComponents) throws -> CmxAttachTicket {
-        guard isPairingCodeURL(components) else {
+        guard let version = Self.attachURLVersion(components) else {
             throw MobileSyncPairingPayloadError.invalidURL
         }
+        switch version {
+        case Self.tailscaleVersion:
+            return try decodeTailscale(components)
+        case Self.irohVersion:
+            return try decodeIroh(components)
+        default:
+            throw MobileSyncPairingPayloadError.invalidURL
+        }
+    }
+}
+
+private extension CmxPairingQRCode {
+    /// Decode the v2 Tailscale compatibility grammar.
+    func decodeTailscale(_ components: URLComponents) throws -> CmxAttachTicket {
         let rawRoutes = (components.queryItems ?? [])
             .filter { $0.name == "r" }
             .compactMap(\.value)
@@ -222,8 +295,37 @@ public struct CmxPairingQRCode: Sendable {
         try ticket.validate()
         return ticket
     }
-}
-private extension CmxPairingQRCode {
+
+    /// Decode the v3 endpoint-only Iroh grammar.
+    func decodeIroh(_ components: URLComponents) throws -> CmxAttachTicket {
+        let items = components.queryItems ?? []
+        guard items.count == 2,
+              items.filter({ $0.name == "v" }).count == 1,
+              let endpointID = items.first(where: { $0.name == "i" })?.value,
+              items.filter({ $0.name == "i" }).count == 1,
+              let identity = try? CmxIrohPeerIdentity(endpointID: endpointID) else {
+            throw MobileSyncPairingPayloadError.invalidURL
+        }
+        let route = try CmxAttachRoute(
+            id: CmxAttachTransportKind.iroh.rawValue,
+            kind: .iroh,
+            endpoint: .peer(identity: identity, pathHints: []),
+            priority: 0
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "",
+            macDisplayName: nil,
+            macPairingCompatibilityVersion: 0,
+            routes: [route],
+            expiresAt: nil,
+            authToken: nil
+        )
+        try ticket.validate()
+        return ticket
+    }
+
     /// The route id the Mac's route resolver mints for the route at `index`
     /// (`tailscale` for the first, `tailscale_N` after).
     func synthesizedRouteID(index: Int) -> String {

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CompactAttachTicket.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CompactAttachTicket.swift
@@ -7,7 +7,8 @@ import Foundation
 /// grammar revision that still carry `e` (expiry) and `n` (display name)
 /// decode here with both intentionally dropped: a pairing QR never expires,
 /// and the Mac's name is read post-handshake from `mobile.host.status`.
-/// New Iroh pairing payloads disclose only EndpointID identity. The explicit
+/// Compact Iroh fallbacks disclose only EndpointID identity. The primary
+/// scannable Iroh code uses ``CmxPairingQRCode`` instead; the explicit
 /// compatibility mode temporarily retains released clients' legacy routes.
 struct CompactAttachTicket: Codable {
     let v: Int

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxAttachTicketIrohQRCodeTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxAttachTicketIrohQRCodeTests.swift
@@ -17,7 +17,7 @@ private func compactIrohQRHostPortRoute() throws -> CmxAttachRoute {
     )
 }
 
-@Test func identityOnlyQRModeKeepsOnlyIrohIdentityAndRejectsTicketsWithoutIt() throws {
+@Test func identityOnlyQRModeUsesPlainEndpointIDAndRejectsTicketsWithoutIt() throws {
     let privateAddress = "100.64.1.2:49152"
     let relayURL = "https://relay.attacker.example/"
     let websocketURL = "wss://private.example/connect?token=secret"
@@ -86,10 +86,61 @@ private func compactIrohQRHostPortRoute() throws -> CmxAttachRoute {
     }
     #expect(identity.endpointID == compactIrohQREndpointID)
     #expect(hints.isEmpty)
-    #expect(CmxPairingQRCode().encode(
+    let pairingURL = try #require(CmxPairingQRCode().encode(
         ticket,
         routeDisclosureMode: .irohIdentityOnly
-    ) == nil)
+    ))
+    #expect(
+        pairingURL
+            == "\(CmxPairingURLScheme.current)://attach?v=3&i=\(compactIrohQREndpointID)"
+    )
+    #expect(!pairingURL.contains("payload="))
+    #expect(!pairingURL.contains("mac-1"))
+    #expect(!pairingURL.contains(privateAddress))
+    #expect(!pairingURL.contains(relayURL))
+    #expect(!pairingURL.contains(websocketURL))
+
+    let parsedURL = try #require(URL(string: pairingURL))
+    let components = try #require(
+        URLComponents(url: parsedURL, resolvingAgainstBaseURL: false)
+    )
+    let pairingDecoded = try CmxPairingQRCode().decode(components)
+    #expect(pairingDecoded.routes == [
+        try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(endpointID: compactIrohQREndpointID),
+                pathHints: []
+            )
+        ),
+    ])
+    #expect(pairingDecoded.macDeviceID.isEmpty)
+    #expect(pairingDecoded.macDisplayName == nil)
+    #expect(pairingDecoded.macUserID == nil)
+    #expect(pairingDecoded.macAppVersion == nil)
+    #expect(pairingDecoded.macAppBuild == nil)
+    #expect(pairingDecoded.expiresAt == nil)
+    #expect(pairingDecoded.authToken == nil)
+
+    let compactBase64 = encoded.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+    let beforeURL =
+        "\(CmxPairingURLScheme.current)://attach?v=1&payload=\(compactBase64)"
+    let beforeImage = try #require(CmxPairingQRBitmap().makeImage(payload: beforeURL))
+    let afterImage = try #require(CmxPairingQRBitmap().makeImage(payload: pairingURL))
+    let quietZone = CmxPairingQRBitmap.quietZoneModules * 2
+    let beforeModules = beforeImage.width - quietZone
+    let afterModules = afterImage.width - quietZone
+    print(
+        "iroh-pairing-qr: \(beforeURL.utf8.count)B/\(beforeModules)x\(beforeModules) -> "
+            + "\(pairingURL.utf8.count)B/\(afterModules)x\(afterModules)"
+    )
+    #expect(pairingURL.utf8.count < beforeURL.utf8.count)
+    #expect(afterModules < beforeModules)
+    #expect(afterModules <= 41)
 
     let tailscaleOnly = try CmxAttachTicket(
         workspaceID: "",

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRBitmapTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRBitmapTests.swift
@@ -7,6 +7,8 @@ import Testing
     private let oneRoutePayload = "cmux-ios://attach?v=2&r=100.64.0.5:52341"
     private let twoRoutePayload =
         "cmux-ios://attach?v=2&r=lawrences-mac.tail1234.ts.net:52341&r=100.64.0.5:52341"
+    private let irohPayload =
+        "cmux-ios-dev://attach?v=3&i=\(String(repeating: "c", count: 64))"
 
     /// The full 4-module quiet zone is part of the bitmap itself, so it
     /// scales with the code and cannot be cropped away by view layout. Also
@@ -54,7 +56,7 @@ import Testing
     /// breaks that arithmetic means the margin assumption in the renderer is
     /// wrong.
     @Test func moduleCountMatchesAVersionAtOrBelowSix() throws {
-        for payload in [oneRoutePayload, twoRoutePayload] {
+        for payload in [oneRoutePayload, twoRoutePayload, irohPayload] {
             let image = try #require(CmxPairingQRBitmap().makeImage(payload: payload))
             let modules = image.width - CmxPairingQRBitmap.quietZoneModules * 2
             #expect((modules - 17) % 4 == 0, "\(modules) modules is not a QR version")

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRCodeTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRCodeTests.swift
@@ -280,6 +280,20 @@ import Testing
         }
     }
 
+    @Test(arguments: [
+        "cmux-ios://attach?v=3",
+        "cmux-ios://attach?v=3&i=",
+        "cmux-ios://attach?v=3&i=abc",
+        "cmux-ios://attach?v=3&i=\(String(repeating: "C", count: 64))",
+        "cmux-ios://attach?v=3&i=\(String(repeating: "c", count: 64))&i=\(String(repeating: "d", count: 64))",
+        "cmux-ios://attach?v=3&i=\(String(repeating: "c", count: 64))&ub=user",
+    ])
+    func decodeRejectsMalformedOrBloatedIrohCodes(url: String) throws {
+        #expect(throws: MobileSyncPairingPayloadError.invalidURL) {
+            try CmxPairingQRCode().decode(try components(url))
+        }
+    }
+
     @Test func decodeCapsHostileRouteCounts() throws {
         let routes = (0..<(CmxPairingQRCode.maximumRouteCount + 1))
             .map { "r=100.64.0.\($0 + 1):58465" }
@@ -291,6 +305,9 @@ import Testing
 
     @Test func versionedURLDetectionDistinguishesGrammars() throws {
         #expect(CmxPairingQRCode().isPairingCodeURLString("cmux-ios://attach?v=2&r=100.64.0.5:58465"))
+        #expect(CmxPairingQRCode().isPairingCodeURLString(
+            "cmux-ios://attach?v=3&i=\(String(repeating: "c", count: 64))"
+        ))
         #expect(!CmxPairingQRCode().isPairingCodeURLString("cmux-ios://attach?v=1&payload=abc"))
         #expect(!CmxPairingQRCode().isPairingCodeURLString("cmux-ios://pair?v=1&payload=abc"))
         #expect(!CmxPairingQRCode().isPairingCodeURLString("https://example.com?v=2"))

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/CmxAttachTicketInput.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/CmxAttachTicketInput.swift
@@ -42,8 +42,8 @@ public struct CmxAttachTicketInput {
            version > CmxPairingQRCode.version {
             throw MobileSyncPairingPayloadError.unrecognizedURLVersion(version)
         }
-        // The minimal v2 pairing-code grammar (bare Tailscale routes, loopback
-        // rejected). v1 URLs carry a base64 JSON `payload` item instead.
+        // The plain pairing grammars: v2 carries bare Tailscale routes and v3
+        // carries one Iroh EndpointID. v1 carries a base64 JSON payload.
         if CmxPairingQRCode().isPairingCodeURL(components) {
             return try CmxPairingQRCode().decode(components)
         }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/CmxAttachTicketInputTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/CmxAttachTicketInputTests.swift
@@ -262,8 +262,10 @@ import Testing
         // The current grammar version is not "newer", so it decodes normally
         // rather than tripping the unrecognized-version path.
         let decoded = try CmxAttachTicketInput.decode(
-            "cmux-ios://attach?v=\(CmxPairingQRCode.version)&r=100.64.0.5:58465"
+            "cmux-ios://attach?v=\(CmxPairingQRCode.version)&i="
+                + String(repeating: "c", count: 64)
         )
         #expect(decoded.routes.count == 1)
+        #expect(decoded.routes.first?.kind == .iroh)
     }
 }

--- a/Sources/Mobile/MobileAttachTicketStore.swift
+++ b/Sources/Mobile/MobileAttachTicketStore.swift
@@ -188,7 +188,8 @@ final class MobileAttachTicketStore {
         // QR must open the matching iOS channel just like the v2 path in
         // ``CmxPairingQRCode/encode(_:)``, so a dev Mac never hands a release
         // phone a code the system camera routes to a dev build (or vice versa).
-        guard let url = URL(string: "\(CmxPairingURLScheme.current)://attach?v=\(ticket.version)&payload=\(payload)") else {
+        let rawURL = "\(CmxPairingURLScheme.current)://attach?v=\(ticket.version)&payload=\(payload)"
+        guard let url = URL(string: rawURL) else {
             throw MobileAttachTicketStoreError.invalidAttachURL
         }
         return url
@@ -220,10 +221,21 @@ final class MobileAttachTicketStore {
             )
         case .physicalDevice:
             if Self.hasOnlyIdentityOnlyIrohRoutes(ticket.routes) {
-                return try compactAttachURL(
-                    for: ticket,
+                guard let pairingURL = CmxPairingQRCode().encode(
+                    ticket,
                     routeDisclosureMode: .irohIdentityOnly
-                )
+                ),
+                let url = URL(string: pairingURL),
+                let components = URLComponents(
+                    url: url,
+                    resolvingAgainstBaseURL: false
+                ),
+                let decoded = try? CmxPairingQRCode().decode(components),
+                decoded.routes.count == ticket.routes.count,
+                decoded.routes.first?.endpoint == ticket.routes.first?.endpoint else {
+                    throw MobileAttachTicketStoreError.invalidAttachURL
+                }
+                return url
             }
             guard ticket.routes.allSatisfy({
                 $0.kind == .tailscale && !CmxLoopbackHost().matches($0)

--- a/cmuxTests/MobileHostWorkspaceTicketAuthorizationTests.swift
+++ b/cmuxTests/MobileHostWorkspaceTicketAuthorizationTests.swift
@@ -109,9 +109,23 @@ struct MobileHostWorkspaceTicketAuthorizationTests {
 
             let payload = try store.payload(for: ticket, target: target)
             let attachURL = try #require(payload["attach_url"] as? String)
-            let decoded = try compactTicket(from: attachURL)
+            let decoded: CmxAttachTicket
+            switch target {
+            case .simulatorInjection:
+                #expect(attachURL.contains("?v=1&payload="))
+                decoded = try compactTicket(from: attachURL)
+            case .physicalDevice:
+                #expect(attachURL.contains("?v=3&i="))
+                #expect(!attachURL.contains("payload="))
+                let components = try #require(URLComponents(string: attachURL))
+                decoded = try CmxPairingQRCode().decode(components)
+            case .ticketOnly:
+                Issue.record("Ticket-only target does not produce an attach URL")
+                continue
+            }
             let authToken = try #require(ticket.authToken)
-            #expect(decoded.routes == selectedRoutes)
+            #expect(decoded.routes.count == selectedRoutes.count)
+            #expect(decoded.routes.first?.endpoint == selectedRoutes.first?.endpoint)
             #expect(decoded.authToken == nil)
             #expect(!attachURL.contains("relay.should-not-leak.example"))
             #expect(!attachURL.contains(authToken))


### PR DESCRIPTION
## Summary

- Encode Iroh pairing as an endpoint-only v3 URL while retaining v2 Tailscale compatibility.
- Remove redundant Mac metadata, JSON, base64, route IDs, and priorities from the Iroh QR.
- Reduce the representative payload from 188 bytes and 57x57 modules to 92 bytes and 41x41 modules at the same physical size.

## Verification

- Added the regression test first in 58538f0d30, where it failed before the fix.
- CMUXMobileCore: 307 tests passed.
- CmxAttachTicketInputTests: 14 tests passed.
- Tagged macOS cloud build: qrslim.
- Isolated iOS simulator build, sign-in, pairing, and workspace sync passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787955020&installation_model_id=21920&pr_number=9174&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9174&signature=0b4a129d992970d7395b7ca515d6fabbbde290bf9014c41b35640b1db7b6453f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink the Iroh pairing QR by switching to a v3 endpoint‑only attach URL. We keep a v2 Tailscale URL for compatibility and cut the payload from 188B/57×57 to 92B/41×41 at the same physical size.

- **New Features**
  - Added v3 grammar: `cmux-ios://attach?v=3&i=<endpoint-id>`; decoder now accepts v2 (Tailscale routes) and v3 (Iroh EndpointID), while v1 remains for compact tickets.
  - Iroh QR encodes only the EndpointID (no auth token, Mac metadata, JSON/base64, route IDs, or priorities).
  - Physical device flow emits v3 when the ticket exposes only Iroh identity; otherwise it falls back to v2 (routes) or compact v1 as needed. The URL scheme stays channel-specific.

- **Migration**
  - No app changes required. Released clients continue to scan v2 Tailscale codes; older clients shown v3 will prompt an update and can use the compatibility code when available.
  - Workspace-scoped tickets and other RPC consumers remain on the compact v1 JSON format.

<sup>Written for commit 9e8f6c82dfda4c939da94ee1f1a47d8363185eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compact v3 pairing QR codes containing only an Iroh endpoint identity.
  * Continued support for v2 pairing URLs using Tailscale routes.
  * QR-based pairing now supports smaller payloads while omitting authentication secrets and private path hints.
* **Bug Fixes**
  * Added validation for malformed, oversized, or incomplete pairing URLs.
  * Physical-device pairing URLs are verified before use to ensure they preserve the intended endpoint.
* **Tests**
  * Expanded coverage for v2/v3 URL decoding, compact QR sizing, and identity-only pairing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->