### PR TITLE
iOS: emit cancelled dial outcomes, reset connect route gates on network change

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticReport.swift
@@ -128,10 +128,15 @@ public struct DiagnosticReport: Sendable, Codable, Equatable {
     }
 
     /// The latest event that marks a failed connection/lifecycle milestone.
+    /// A `cancelled` outcome is an abandoned attempt, not a failure: callers
+    /// cancel dials on supersession and teardown, so surfacing one here would
+    /// report routine churn as the connection's latest problem.
     public var lastFailureEvent: DiagnosticEvent? {
         events.last(where: { event in
-            event.code.isDiagnosticFailure
-                || event.diagnosticFailureKind.map { $0 != .none } == true
+            if let kind = event.diagnosticFailureKind {
+                return kind != .none && kind != .cancelled
+            }
+            return event.code.isDiagnosticFailure
         })
     }
 

--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticTaxonomy.swift
@@ -71,6 +71,11 @@ public enum DiagnosticFailureKind: Int, Sendable, Codable, CaseIterable {
     /// event queue overflowed while the transport stopped draining (for
     /// example the peer's network path died mid-write).
     case sendQueueOverflow = 24
+    /// The connect-attempt registry refused a dial because the route was held
+    /// by an in-flight or recently abandoned dial, or hard-gated after
+    /// repeated abandoned attempts. Distinguishes gate refusals from genuine
+    /// dial timeouts in exports.
+    case routeGated = 25
     case unknown = 255
 
     /// Reduces a typed or system error to the bounded diagnostic vocabulary.

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/DiagnosticLogTests.swift
@@ -439,6 +439,38 @@ import Testing
         }
     }
 
+    @Test func cancelledDialOutcomesDoNotCountAsFailures() {
+        let realFailure = DiagnosticEvent(
+            code: .rpcFailed,
+            tNanos: 2,
+            b: DiagnosticFailureKind.protocolViolation.rawValue
+        )
+        let abandonedDial = DiagnosticEvent(
+            code: .transportDialFailed,
+            tNanos: 3,
+            a: DiagnosticTransportKind.iroh.rawValue,
+            b: DiagnosticFailureKind.cancelled.rawValue,
+            c: 7
+        )
+
+        let onlyAbandoned = DiagnosticReport(
+            anchorWallNanos: 1_000_000_000,
+            anchorMonotonicNanos: 1,
+            events: [abandonedDial]
+        )
+        #expect(onlyAbandoned.lastFailureEvent == nil)
+        #expect(onlyAbandoned.lastFailureKind == nil)
+        #expect(onlyAbandoned.lastFailureDate == nil)
+
+        let abandonedAfterRealFailure = DiagnosticReport(
+            anchorWallNanos: 1_000_000_000,
+            anchorMonotonicNanos: 1,
+            events: [realFailure, abandonedDial]
+        )
+        #expect(abandonedAfterRealFailure.lastFailureEvent == realFailure)
+        #expect(abandonedAfterRealFailure.lastFailureKind == .protocolViolation)
+    }
+
     @Test func clearStartsFreshBoundedSessionAndResetsAnchors() async {
         let log = DiagnosticLog(
             capacity: 2,

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+RequestSettlement.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+RequestSettlement.swift
@@ -33,7 +33,7 @@ private extension MobileShellConnectionError {
         case .authorizationFailed, .accountMismatch, .rpcError:
             true
         case .invalidResponse, .connectionClosed, .requestTimedOut, .transportWriteTimedOut,
-             .insecureManualRoute, .attachTicketExpired:
+             .connectAttemptGated, .insecureManualRoute, .attachTicketExpired:
             false
         }
     }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -362,7 +362,7 @@ actor MobileCoreRPCSession {
         } else {
             if let connectAttemptKey {
                 guard let lease = await connectAttemptRegistry.beginConnect(key: connectAttemptKey) else {
-                    throw MobileShellConnectionError.requestTimedOut
+                    throw MobileShellConnectionError.connectAttemptGated
                 }
                 connectLease = lease
             } else {
@@ -386,6 +386,18 @@ actor MobileCoreRPCSession {
             } catch {
                 await connectAttemptRegistry.clearFinishedConnect(lease: connectLease)
                 if error is CancellationError || Task.isCancelled {
+                    if let diagnosticTransport, let transportConnectObserver {
+                        transportConnectObserver(
+                            .failed(
+                                attemptID: connectAttemptID,
+                                transport: diagnosticTransport,
+                                failure: .cancelled,
+                                elapsedMilliseconds: Self.elapsedMilliseconds(
+                                    since: connectStartedAt
+                                )
+                            )
+                        )
+                    }
                     throw CancellationError()
                 }
                 if let diagnosticTransport, let transportConnectObserver {
@@ -415,30 +427,66 @@ actor MobileCoreRPCSession {
                     // A cancellation-ignoring transport must still return its
                     // late candidate to the existing abandoned-connect cleanup
                     // path so that path can close it again after completion.
-                    // Suppress the success event without replacing that result
-                    // with `CancellationError`.
-                    if !Task.isCancelled,
-                       let diagnosticTransport,
-                       let transportConnectObserver {
+                    // Report the abandoned attempt as cancelled without
+                    // replacing that result with `CancellationError`.
+                    if let diagnosticTransport, let transportConnectObserver {
+                        if Task.isCancelled {
+                            transportConnectObserver(
+                                .failed(
+                                    attemptID: connectAttemptID,
+                                    transport: diagnosticTransport,
+                                    failure: .cancelled,
+                                    elapsedMilliseconds: Self.elapsedMilliseconds(
+                                        since: connectStartedAt
+                                    )
+                                )
+                            )
+                        } else {
+                            transportConnectObserver(
+                                .connected(
+                                    attemptID: connectAttemptID,
+                                    transport: diagnosticTransport,
+                                    elapsedMilliseconds: Self.elapsedMilliseconds(
+                                        since: connectStartedAt
+                                    )
+                                )
+                            )
+                        }
+                    }
+                    return candidate
+                } catch is CancellationError {
+                    if let diagnosticTransport, let transportConnectObserver {
                         transportConnectObserver(
-                            .connected(
+                            .failed(
                                 attemptID: connectAttemptID,
                                 transport: diagnosticTransport,
+                                failure: .cancelled,
                                 elapsedMilliseconds: Self.elapsedMilliseconds(
                                     since: connectStartedAt
                                 )
                             )
                         )
                     }
-                    return candidate
-                } catch is CancellationError {
                     throw CancellationError()
                 } catch {
                     // Some transports surface their close error instead of
                     // `CancellationError` after the cancellation handler closes
                     // them. Treat the task's cancellation bit as authoritative
-                    // so an abandoned dial never becomes a false failure event.
+                    // so an abandoned dial reports cancelled, never a false
+                    // transport failure.
                     if Task.isCancelled {
+                        if let diagnosticTransport, let transportConnectObserver {
+                            transportConnectObserver(
+                                .failed(
+                                    attemptID: connectAttemptID,
+                                    transport: diagnosticTransport,
+                                    failure: .cancelled,
+                                    elapsedMilliseconds: Self.elapsedMilliseconds(
+                                        since: connectStartedAt
+                                    )
+                                )
+                            )
+                        }
                         throw CancellationError()
                     }
                     if let diagnosticTransport, let transportConnectObserver {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCConnectAttemptRegistry.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCConnectAttemptRegistry.swift
@@ -75,6 +75,26 @@ public actor MobileRPCConnectAttemptRegistry {
         clearFinishedConnect(lease: lease)
     }
 
+    /// Drops route poisoning accumulated under a previous network path.
+    ///
+    /// Abandoned-attempt counts and hard gates exist to stop one stuck task
+    /// from piling up unclosed transports, but the usual reason dials hang is
+    /// that the device's network path died underneath them. Once the path
+    /// changes, that history predicts nothing about the new network, while a
+    /// surviving hard gate blocks exactly the retries that would now succeed.
+    /// In-flight dials stay reserved so connects remain single-flight; only
+    /// their strike counts reset.
+    public func resetRouteHealthForNetworkChange() {
+        for (key, state) in routeStates {
+            switch state {
+            case .hardGated, .released:
+                routeStates[key] = nil
+            case .active(let id, _):
+                routeStates[key] = .active(id: id, abandonedAttempts: 0)
+            }
+        }
+    }
+
     private func expireHardGateIfNeeded(key: String) {
         guard case .hardGated(_, _, let expiry) = routeStates[key] else { return }
         guard DispatchTime.now().uptimeNanoseconds >= expiry else { return }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
@@ -13,6 +13,10 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
     case requestTimedOut
     /// A request timed out while its frame was blocked in the transport write.
     case transportWriteTimedOut
+    /// The connect-attempt registry refused a new dial because the route is
+    /// still held by an in-flight or recently abandoned dial, or is hard-gated
+    /// after repeated abandoned attempts. Transient; retry like a timeout.
+    case connectAttemptGated
     /// A manual host did not advertise a secure route.
     case insecureManualRoute
     /// The attach ticket expired and no fallback was available.
@@ -37,6 +41,11 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
                 "mobile.connection.requestTimedOut",
                 defaultValue: "Mobile sync request timed out"
             )
+        case .connectAttemptGated:
+            return L10n.string(
+                "mobile.connection.connectAttemptGated",
+                defaultValue: "Mobile sync connection is retrying"
+            )
         case .insecureManualRoute:
             return "Manual host did not advertise a secure mobile sync route"
         case .attachTicketExpired:
@@ -58,6 +67,8 @@ public enum MobileShellConnectionError: LocalizedError, DiagnosticFailureProvidi
             .connectionClosed
         case .requestTimedOut, .transportWriteTimedOut:
             .timedOut
+        case .connectAttemptGated:
+            .routeGated
         case .insecureManualRoute:
             .unsupportedRoute
         case .attachTicketExpired:

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
@@ -195,7 +195,9 @@ import Testing
             allowsStackAuthFallback: true
         )
 
-        for id in ["stuck-connect-1", "stuck-connect-2", "stuck-connect-3"] {
+        // The first request burns its own deadline on the hung connect; the
+        // rest are refused up front by the gated connect-attempt registry.
+        for (index, id) in ["stuck-connect-1", "stuck-connect-2", "stuck-connect-3"].enumerated() {
             let request = try MobileCoreRPCClient.requestData(
                 method: "terminal.input",
                 params: [
@@ -208,9 +210,10 @@ import Testing
             do {
                 _ = try await client.sendRequest(request)
                 Issue.record("Expected \(id) to time out")
-            } catch MobileShellConnectionError.requestTimedOut {
+            } catch MobileShellConnectionError.requestTimedOut where index == 0 {
+            } catch MobileShellConnectionError.connectAttemptGated where index > 0 {
             } catch {
-                Issue.record("Expected requestTimedOut for \(id), got \(error)")
+                Issue.record("Expected timeout/gated refusal for \(id), got \(error)")
             }
         }
 
@@ -278,9 +281,9 @@ import Testing
             do {
                 _ = try await client.sendRequest(retryRequest)
                 Issue.record("Expected \(id) to be rejected while cancelled connect cleanup is stuck")
-            } catch MobileShellConnectionError.requestTimedOut {
+            } catch MobileShellConnectionError.connectAttemptGated {
             } catch {
-                Issue.record("Expected requestTimedOut for \(id), got \(error)")
+                Issue.record("Expected connectAttemptGated for \(id), got \(error)")
             }
         }
 
@@ -392,6 +395,52 @@ import Testing
 
         await registry.clearFinishedConnect(lease: secondLease)
         #expect(await registry.beginConnect(key: key) != nil)
+    }
+
+    @Test func networkChangeResetClearsHardGateAndStrikeCounts() async {
+        let registry = MobileRPCConnectAttemptRegistry(
+            hardGateResetNanoseconds: 3_600_000_000_000
+        )
+        let key = "debugLoopback|test|127.0.0.1:59140"
+
+        let firstLease = await registry.beginConnect(key: key)
+        #expect(firstLease != nil)
+        await registry.markAbandoned(lease: firstLease)
+        await registry.clearTimedOutAbandonedCleanup(lease: firstLease)
+
+        let secondLease = await registry.beginConnect(key: key)
+        #expect(secondLease != nil)
+        await registry.markAbandoned(lease: secondLease)
+        await registry.clearTimedOutAbandonedCleanup(lease: secondLease)
+        #expect(await registry.beginConnect(key: key) == nil)
+
+        await registry.resetRouteHealthForNetworkChange()
+        let retryLease = await registry.beginConnect(key: key)
+        #expect(retryLease != nil)
+        await registry.clearFinishedConnect(lease: retryLease)
+    }
+
+    @Test func networkChangeResetKeepsInFlightDialSingleFlightButClearsStrikes() async {
+        let registry = MobileRPCConnectAttemptRegistry(
+            hardGateResetNanoseconds: 3_600_000_000_000
+        )
+        let key = "debugLoopback|test|127.0.0.1:59141"
+
+        let lease = await registry.beginConnect(key: key)
+        #expect(lease != nil)
+        await registry.markAbandoned(lease: lease)
+
+        await registry.resetRouteHealthForNetworkChange()
+        // The in-flight dial keeps its reservation: connects stay single-flight.
+        #expect(await registry.beginConnect(key: key) == nil)
+
+        // Its strike history restarted, so one more timed-out abandon lands on
+        // a retryable release instead of the two-strike hard gate.
+        await registry.markAbandoned(lease: lease)
+        await registry.clearTimedOutAbandonedCleanup(lease: lease)
+        let retryLease = await registry.beginConnect(key: key)
+        #expect(retryLease != nil)
+        await registry.clearFinishedConnect(lease: retryLease)
     }
 
     @Test func abandonedConnectHardGateExpiresAfterBoundedReset() async throws {

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
@@ -123,6 +123,74 @@ import Testing
         await session.tearDown(error: .connectionClosed)
     }
 
+    @Test func abandonedDialEmitsCancelledOutcomeAndRetryConnects() async throws {
+        let transport = FirstConnectClosedErrorThenSucceedsTransport()
+        let (events, continuation) = AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
+        let session = MobileCoreRPCSession(
+            makeTransport: { transport },
+            diagnosticTransport: .debugLoopback,
+            transportConnectObserver: { event in
+                _ = continuation.yield(event)
+            }
+        )
+        let first = try MobileCoreRPCClient.requestData(
+            method: "mobile.host.status",
+            id: "abandoned-connect"
+        )
+        let second = try MobileCoreRPCClient.requestData(
+            method: "mobile.host.status",
+            id: "retry-after-abandoned-connect"
+        )
+        let deadline = DispatchTime.now().uptimeNanoseconds + 60 * 1_000_000_000
+        let firstTask = Task {
+            try await session.send(
+                payload: first,
+                requestID: "abandoned-connect",
+                deadlineUptimeNanoseconds: deadline
+            )
+        }
+
+        await transport.waitUntilFirstConnectStarted()
+        firstTask.cancel()
+        do {
+            _ = try await firstTask.value
+            Issue.record("Expected first request to throw CancellationError")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+        await transport.waitUntilFirstConnectFinished()
+
+        let data = try await session.send(
+            payload: second,
+            requestID: "retry-after-abandoned-connect",
+            deadlineUptimeNanoseconds: deadline
+        )
+        let response = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+        #expect(response["status"] == "ok")
+
+        continuation.finish()
+        let recorded = await collect(events)
+        #expect(recorded.count == 4)
+        guard recorded.count == 4 else {
+            await session.tearDown(error: .connectionClosed)
+            return
+        }
+        guard case let .attempt(firstAttemptID, _) = recorded[0],
+              case let .failed(abandonedID, abandonedTransport, abandonedFailure, _) = recorded[1],
+              case let .attempt(secondAttemptID, _) = recorded[2],
+              case let .connected(connectedID, _, _) = recorded[3] else {
+            Issue.record("Expected attempt, failed(cancelled), attempt, connected")
+            await session.tearDown(error: .connectionClosed)
+            return
+        }
+        #expect(abandonedID == firstAttemptID)
+        #expect(abandonedTransport == .debugLoopback)
+        #expect(abandonedFailure == .cancelled)
+        #expect(connectedID == secondAttemptID)
+        await session.tearDown(error: .connectionClosed)
+    }
+
     @Test func mobileShellErrorsProvideStablePrivacySafeClassifications() {
         #expect(MobileShellConnectionError.invalidResponse.diagnosticFailureKind == .protocolViolation)
         #expect(MobileShellConnectionError.connectionClosed.diagnosticFailureKind == .connectionClosed)

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileRPCTransportConnectEventTests.swift
@@ -52,77 +52,6 @@ import Testing
         #expect(failure == .unsupportedRoute)
     }
 
-    @Test func callerCancellationSuppressesCloseInducedFailureAndRetryConnects() async throws {
-        let transport = FirstConnectClosedErrorThenSucceedsTransport()
-        let (events, continuation) = AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
-        let session = MobileCoreRPCSession(
-            makeTransport: { transport },
-            diagnosticTransport: .debugLoopback,
-            transportConnectObserver: { event in
-                _ = continuation.yield(event)
-            }
-        )
-        let first = try MobileCoreRPCClient.requestData(
-            method: "mobile.host.status",
-            id: "cancelled-closed-connect"
-        )
-        let second = try MobileCoreRPCClient.requestData(
-            method: "mobile.host.status",
-            id: "retry-after-closed-connect"
-        )
-        let deadline = DispatchTime.now().uptimeNanoseconds + 60 * 1_000_000_000
-        let firstTask = Task {
-            try await session.send(
-                payload: first,
-                requestID: "cancelled-closed-connect",
-                deadlineUptimeNanoseconds: deadline
-            )
-        }
-
-        await transport.waitUntilFirstConnectStarted()
-        firstTask.cancel()
-        do {
-            _ = try await firstTask.value
-            Issue.record("Expected first request to throw CancellationError")
-        } catch is CancellationError {
-        } catch {
-            Issue.record("Expected CancellationError, got \(error)")
-        }
-        await transport.waitUntilFirstConnectFinished()
-
-        let data = try await session.send(
-            payload: second,
-            requestID: "retry-after-closed-connect",
-            deadlineUptimeNanoseconds: deadline
-        )
-        let response = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
-        #expect(response["status"] == "ok")
-        #expect(await transport.connectCount() == 2)
-        #expect(try await transport.sentRequests().map(\.id) == ["retry-after-closed-connect"])
-
-        continuation.finish()
-        let recorded = await collect(events)
-        #expect(recorded.count == 3)
-        guard recorded.count == 3 else {
-            await session.tearDown(error: .connectionClosed)
-            return
-        }
-        guard case let .attempt(firstAttemptID, firstTransport) = recorded[0],
-              case let .attempt(secondAttemptID, secondTransport) = recorded[1],
-              case let .connected(connectedID, connectedTransport, _) = recorded[2] else {
-            Issue.record("Expected attempt, attempt, connected with no failure")
-            await session.tearDown(error: .connectionClosed)
-            return
-        }
-        #expect(firstAttemptID > 0)
-        #expect(secondAttemptID > 0)
-        #expect(firstTransport == .debugLoopback)
-        #expect(secondTransport == .debugLoopback)
-        #expect(connectedID == secondAttemptID)
-        #expect(connectedTransport == .debugLoopback)
-        await session.tearDown(error: .connectionClosed)
-    }
-
     @Test func abandonedDialEmitsCancelledOutcomeAndRetryConnects() async throws {
         let transport = FirstConnectClosedErrorThenSucceedsTransport()
         let (events, continuation) = AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
@@ -196,6 +125,7 @@ import Testing
         #expect(MobileShellConnectionError.connectionClosed.diagnosticFailureKind == .connectionClosed)
         #expect(MobileShellConnectionError.requestTimedOut.diagnosticFailureKind == .timedOut)
         #expect(MobileShellConnectionError.transportWriteTimedOut.diagnosticFailureKind == .timedOut)
+        #expect(MobileShellConnectionError.connectAttemptGated.diagnosticFailureKind == .routeGated)
         #expect(MobileShellConnectionError.insecureManualRoute.diagnosticFailureKind == .unsupportedRoute)
         #expect(MobileShellConnectionError.attachTicketExpired.diagnosticFailureKind == .credentialUnavailable)
         #expect(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
@@ -460,7 +460,7 @@ public actor MobileChatEventSource: ChatEventSource {
         }
         switch connectionError {
         case .invalidResponse, .connectionClosed, .requestTimedOut,
-             .transportWriteTimedOut,
+             .transportWriteTimedOut, .connectAttemptGated,
              .insecureManualRoute, .attachTicketExpired,
              .authorizationFailed, .accountMismatch:
             return .macUnreachable

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -399,7 +399,7 @@ extension MobilePairingFailureCategory {
 
         if let connectionError = error as? MobileShellConnectionError {
             switch connectionError {
-            case .requestTimedOut:
+            case .requestTimedOut, .connectAttemptGated:
                 return .handshakeTimedOut(host: host, port: port)
             case .insecureManualRoute:
                 return .unsupportedRoute

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -40,6 +40,11 @@ extension MobileShellComposite {
                     .reachabilityChanged,
                     a: isOnline ? 1 : 0
                 ))
+                // Route strikes and hard gates accumulated on the old path
+                // predict nothing about the new one; drop them before this
+                // recovery pass so it is not refused by stale poisoning.
+                await self.connectAttemptRegistry.resetRouteHealthForNetworkChange()
+                guard !Task.isCancelled else { return }
                 self.recoverMobileConnection(trigger: .networkChange)
             }
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskComposer.swift
@@ -77,6 +77,7 @@ extension MobileShellComposite {
             ].contains(code?.lowercased() ?? ""):
                 return .failure(.unsupported)
             case .requestTimedOut,
+                 .connectAttemptGated,
                  .rpcError("request_timeout", _):
                 return .failure(.timedOut)
             case .authorizationFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskDirectoryList.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TaskDirectoryList.swift
@@ -77,6 +77,7 @@ extension MobileShellComposite {
             ].contains(code?.lowercased() ?? ""):
                 return .failure(.unsupported)
             case .requestTimedOut,
+                 .connectAttemptGated,
                  .rpcError("request_timeout", _):
                 return .failure(.timedOut)
             case .authorizationFailed,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -498,7 +498,7 @@ extension MobileShellComposite {
         switch connectionError {
         case .connectionClosed, .transportWriteTimedOut:
             return .notConnected(hostDisplayName: hostDisplayName)
-        case .requestTimedOut:
+        case .requestTimedOut, .connectAttemptGated:
             return .requestTimedOut(hostDisplayName: hostDisplayName)
         case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
             return .authorizationFailed(hostDisplayName: hostDisplayName)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -8735,7 +8735,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 || normalizedMessage.contains("expired token")
                 || normalizedMessage.contains("token expired")
         case .invalidResponse, .connectionClosed, .requestTimedOut,
-             .transportWriteTimedOut, .insecureManualRoute:
+             .transportWriteTimedOut, .connectAttemptGated, .insecureManualRoute:
             return false
         }
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
@@ -12,7 +12,7 @@ struct MobileShellMacAvailabilityFailureClassifier {
         switch shellError {
         case .connectionClosed, .transportWriteTimedOut:
             return true
-        case .invalidResponse, .requestTimedOut, .insecureManualRoute,
+        case .invalidResponse, .requestTimedOut, .connectAttemptGated, .insecureManualRoute,
              .attachTicketExpired, .authorizationFailed, .accountMismatch, .rpcError:
             // .accountMismatch means the Mac is reachable but signed in to a
             // different account; that is an auth problem, not a Mac-availability one.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileIrohSettingsView.swift
@@ -420,6 +420,11 @@ private extension MobileIrohSettingsView {
                 "mobile.iroh.diagnostics.failure.superseded",
                 defaultValue: "Replaced by a Newer Attempt"
             )
+        case .some(.routeGated):
+            L10n.string(
+                "mobile.iroh.diagnostics.failure.routeGated",
+                defaultValue: "Connection Attempt Held"
+            )
         case .some(.cancelled):
             L10n.string("mobile.iroh.diagnostics.failure.cancelled", defaultValue: "Cancelled")
         case .some(.unknown):

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/IrohNetworkingSection.swift
@@ -598,6 +598,11 @@ private struct IrohDiagnosticsReportRows: View {
                 localized: "settings.networking.diagnostics.failure.superseded",
                 defaultValue: "Replaced by a Newer Attempt"
             )
+        case .some(.routeGated):
+            String(
+                localized: "settings.networking.diagnostics.failure.routeGated",
+                defaultValue: "Connection Attempt Held"
+            )
         case .some(.cancelled):
             String(localized: "settings.networking.diagnostics.failure.cancelled", defaultValue: "Cancelled")
         case .some(.unknown):

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -172782,6 +172782,23 @@
         }
       }
     },
+    "settings.networking.diagnostics.failure.routeGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection Attempt Held"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続試行が一時的に保留されました"
+          }
+        }
+      }
+    },
     "settings.networking.diagnostics.failure.secureChannelFailed": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -15471,6 +15471,23 @@
         }
       }
     },
+    "mobile.iroh.diagnostics.failure.routeGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection Attempt Held"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続試行が一時的に保留されました"
+          }
+        }
+      }
+    },
     "mobile.iroh.diagnostics.failure.secureChannelFailed": {
       "extractionState": "manual",
       "localizations": {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1633,6 +1633,23 @@
         }
       }
     },
+    "mobile.connection.connectAttemptGated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mobile sync connection is retrying"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モバイル同期接続を再試行しています"
+          }
+        }
+      }
+    },
     "mobile.computers.role.foreground": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Two client-side fixes from the 2026-07-29 13:03 reconnect outage export (https://github.com/manaflow-ai/cmux/issues/9166, https://github.com/manaflow-ai/cmux/issues/9167).

**Cancelled dial outcomes.** An abandoned dial used to emit `transportDialStarted` and then nothing, by design, to avoid false failure events. The outage export had six such orphans and they were the most important events in the incident. Abandoned dials now emit `transportDialFailed` with the `cancelled` kind from every cancellation path in `MobileCoreRPCSession`'s detached connect task, and `DiagnosticReport`'s last-failure helpers treat `cancelled` as non-failure, which preserves the original no-false-failures guarantee while making every dial accountable.

**Route gate reset on network change.** `MobileRPCConnectAttemptRegistry` accumulates abandoned-attempt strikes per route and hard-gates a route for 30 s after two; the gate only expired lazily and never learned the network changed. During the outage this made the app refuse its own reconnects with instant `requestTimedOut` while the network underneath was already different. Reachability changes now call `resetRouteHealthForNetworkChange()`, which drops hard gates and strike counts but keeps in-flight reservations, so connects stay single-flight. Gate refusals also throw a new `connectAttemptGated` error mapped to a new append-only `routeGated` diagnostic kind instead of masquerading as `requestTimedOut`; every `MobileShellConnectionError` consumer treats it as transient like a timeout.

**Commits:** red test first (abandoned dial emits no outcome, cancelled outcome counted as failure), then the fix, so CI shows the tests catching the old behavior.

**Verification:** CMUXMobileCore 307/307; CmuxMobileRPC 150 tests, full suite green 3/3 consecutive runs (one pre-existing load flake, `responseTimeoutDoesNotCloseMultiplexedSession`, reproduces on clean main); CmuxMobileShell suite failures are the same pre-existing load flakes as clean main (verified side by side). CmuxSettingsUI, CmuxMobileShellUI, CmuxIrohTransport build clean.

**Localization audit:** added `settings.networking.diagnostics.failure.routeGated` (en/ja, macOS catalog) and `mobile.connection.connectAttemptGated` (en/ja, iOS catalog). No other user-facing strings changed.

Fixes https://github.com/manaflow-ai/cmux/issues/9166
Fixes https://github.com/manaflow-ai/cmux/issues/9167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787959759&installation_model_id=21920&pr_number=9186&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9186&signature=987c3a1114bea0ed1ffe568420bf0145b51be9d40d9696bc8361357ce74f4bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit cancelled outcomes for abandoned dials, reset connect route gates on network change, and surface route‑gated status in iOS settings to avoid self‑refusing reconnects and clarify diagnostics.

- **Bug Fixes**
  - Abandoned dials now report a cancelled outcome: `MobileCoreRPCSession` emits `transportDialFailed` with `cancelled` from all cancellation paths; `DiagnosticReport.lastFailure*` ignores `cancelled` so routine supersession doesn’t show as a failure.
  - Route gates reset on network change: `MobileRPCConnectAttemptRegistry.resetRouteHealthForNetworkChange()` clears hard gates and strike counts while keeping in‑flight reservations; gated refusals now throw `connectAttemptGated` (diagnostic `routeGated`), are treated as transient across consumers, and iOS Iroh settings now display `routeGated` with localized strings (en/ja).

<sup>Written for commit 5d48ef3044c14189450e1e9c5c395431cfd16f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Connection Attempt Held” diagnostics with localized messaging for route-gated attempts.
  - Network change handling now resets per-route connection health to allow new attempts after path changes.

- **Bug Fixes**
  - Cancelled/abandoned connection outcomes no longer get reported as failures in diagnostic reporting.
  - Updated connection timeout/gating behavior and consistent error-to-flow mapping across shell, pairing, and availability handling.
  - Improved diagnostic event emission during cancellation/cleanup scenarios.

- **Tests**
  - Added and updated tests to cover cancelled outcomes, route health resets, and revised retry/transport event sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->