### PR TITLE
iOS: throttle presence-push recovery restarts during a persistent outage

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePresencePushRecoveryThrottle.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePresencePushRecoveryThrottle.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Decides whether one presence delivery may start another recovery pass.
+///
+/// Presence heartbeats about an online Mac arrive roughly every 15 seconds.
+/// While the phone is disconnected, each heartbeat used to restart connection
+/// recovery, so during a persistent outage the phone kept abandoning its own
+/// in-flight dials on the heartbeat cadence and each abandoned dial fed the
+/// connect-registry hard gate
+/// (https://github.com/manaflow-ai/cmux/issues/9177).
+///
+/// Changed evidence (new routes, a Mac coming online) always passes: that is
+/// the wake-up signal presence exists for. Unchanged heartbeats pass at most
+/// once per ``minimumUnchangedEvidenceInterval`` so an already-failing
+/// recovery loop gets its full dial budget between presence-triggered
+/// restarts.
+struct MobilePresencePushRecoveryThrottle {
+    /// Chosen above the ~15s presence heartbeat cadence and the dial budget a
+    /// recovery pass needs, below the point where a stalled recovery would be
+    /// user-visible next to the 30-60s automatic backoff ladder.
+    static let minimumUnchangedEvidenceInterval: TimeInterval = 45
+
+    private var lastRecoveryAt: Date?
+
+    /// Records and reports whether a presence-triggered recovery may start.
+    mutating func shouldRecover(evidenceChanged: Bool, now: Date) -> Bool {
+        if evidenceChanged {
+            lastRecoveryAt = now
+            return true
+        }
+        guard let lastRecoveryAt else {
+            self.lastRecoveryAt = now
+            return true
+        }
+        let elapsed = now.timeIntervalSince(lastRecoveryAt)
+        // A rewound wall clock (negative elapsed) must not freeze the
+        // throttle until the clock catches back up; treat it as expired.
+        guard elapsed >= 0, elapsed < Self.minimumUnchangedEvidenceInterval else {
+            self.lastRecoveryAt = now
+            return true
+        }
+        return false
+    }
+
+    /// Forgets throttle history at an account or session boundary.
+    mutating func reset() {
+        lastRecoveryAt = nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
@@ -146,8 +146,15 @@ extension MobileShellComposite {
                         }
                         // Presence is only a wake-up signal. The recovery pass
                         // still obtains first-pair candidates from the
-                        // authenticated personal broker.
-                        self.recoverMobileConnection(trigger: .presencePush)
+                        // authenticated personal broker. Unchanged heartbeats
+                        // are throttled so a failing recovery loop is not
+                        // restarted on the ~15s presence cadence.
+                        if self.presencePushRecoveryThrottle.shouldRecover(
+                            evidenceChanged: evidenceChanged,
+                            now: self.runtime?.now() ?? Date()
+                        ) {
+                            self.recoverMobileConnection(trigger: .presencePush)
+                        }
                     }
                 }
             }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -261,6 +261,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         scope: MobileShellScopeSnapshot,
         instances: [MobilePresenceReconnectEvidence]
     )?
+    var presencePushRecoveryThrottle = MobilePresencePushRecoveryThrottle()
     /// Whether the current attach ticket has a non-empty auth token and has not expired.
     public var hasActiveUnexpiredAttachTicket: Bool {
         guard let activeTicket,
@@ -1334,6 +1335,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // projections.
         resetStateSyncForAccountBoundary()
         lastPresenceReconnectEvidence = nil
+        presencePushRecoveryThrottle.reset()
         connectionRecoveryOwner.cancel()
         applyConnectionRecoveryOwnerState()
         invalidatePairingAttempt()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePresencePushRecoveryThrottleTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePresencePushRecoveryThrottleTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@Suite
+struct MobilePresencePushRecoveryThrottleTests {
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let interval = MobilePresencePushRecoveryThrottle.minimumUnchangedEvidenceInterval
+
+    @Test
+    func firstUnchangedHeartbeatRecoversThenHeartbeatCadenceIsThrottled() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        // ~15s presence heartbeats inside the interval must not restart
+        // recovery; this cadence starved in-flight dials during the outage.
+        let heartbeat15 = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(15)
+        )
+        let heartbeat30 = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(30)
+        )
+        let afterInterval = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(interval)
+        )
+
+        #expect(first)
+        #expect(!heartbeat15)
+        #expect(!heartbeat30)
+        #expect(afterInterval)
+    }
+
+    @Test
+    func changedEvidenceAlwaysRecoversAndReArmsTheThrottle() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let changed = throttle.shouldRecover(
+            evidenceChanged: true,
+            now: now.addingTimeInterval(5)
+        )
+        // The changed-evidence pass restarts the unchanged-heartbeat window.
+        let unchangedAfterChanged = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(6)
+        )
+        let afterReArmedInterval = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(5 + interval)
+        )
+
+        #expect(first)
+        #expect(changed)
+        #expect(!unchangedAfterChanged)
+        #expect(afterReArmedInterval)
+    }
+
+    @Test
+    func rewoundWallClockDoesNotFreezeTheThrottle() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let afterRewind = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(-3600)
+        )
+
+        #expect(first)
+        #expect(afterRewind)
+    }
+
+    @Test
+    func resetForgetsHistorySoTheNextHeartbeatRecoversImmediately() {
+        var throttle = MobilePresencePushRecoveryThrottle()
+
+        let first = throttle.shouldRecover(evidenceChanged: false, now: now)
+        let throttled = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(1)
+        )
+        throttle.reset()
+        let afterReset = throttle.shouldRecover(
+            evidenceChanged: false,
+            now: now.addingTimeInterval(2)
+        )
+
+        #expect(first)
+        #expect(!throttled)
+        #expect(afterReset)
+    }
+}


### PR DESCRIPTION
During the 2026-07-29 13:03 reconnect outage (https://github.com/manaflow-ai/cmux/issues/9177), presence heartbeats restarted recovery every ~15 s (`recoveryStarted trigger=presencePush` at 13:03:30, 13:03:45, 13:03:59, 13:04:15), abandoning in-flight dials before they could finish and feeding the connect-registry hard gate (https://github.com/manaflow-ai/cmux/issues/9166).

New `MobilePresencePushRecoveryThrottle` gates the `recoverMobileConnection(trigger: .presencePush)` call in `MobileShellComposite+PresenceRouteSync`:
- **Changed evidence** (new routes, a Mac coming online) passes immediately, so presence keeps its wake-up-signal value.
- **Unchanged heartbeats** pass at most once per 45 s, chosen above the heartbeat cadence and a recovery pass's dial budget, below the 30-60 s automatic-backoff ladder.
- State resets at the account boundary next to the existing evidence cache; time comes from the injected runtime clock; a rewound wall clock counts as expired instead of freezing the throttle.

Backoff clearing was already gated on changed evidence and is untouched. All other recovery triggers (foreground, networkChange, eventStreamEnded, liveness, backoff expiry, manual) are unaffected.

**Verification:** 4 new behavior tests on the throttle (heartbeat cadence throttled, changed evidence re-arms, clock rewind, boundary reset); CmuxMobileShell package builds clean. A red/green commit split was not practical because the throttle type is new API; the tests pin the outage cadence directly.

Fixes https://github.com/manaflow-ai/cmux/issues/9177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787960706&installation_model_id=21920&pr_number=9188&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9188&signature=3bd65253f6c9eb3d0c2a0f1c6e8128962c4f5024d39d0e79d5a7dddc7092b553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle presence-push recovery on iOS to stop restart loops during outages. In-flight dials now get time to complete, improving reconnect stability and fixing #9177.

- **Bug Fixes**
  - Gate `recoverMobileConnection(trigger: .presencePush)` with `MobilePresencePushRecoveryThrottle` in `CmuxMobileShell`.
  - Changed evidence passes immediately; unchanged heartbeats pass at most once every 45s.
  - Reset throttle at account boundaries; use runtime clock; treat clock rewinds as expired.
  - Add tests for cadence throttling, changed-evidence re-arm, clock rewind, and reset.
  - Other recovery triggers remain unchanged; backoff clearing stays gated on changed evidence.

<sup>Written for commit c8c9e52cb792e377bdd9543e0323bf1c185d9025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile connection recovery triggered by presence updates.
  * Prevented repeated recovery attempts during rapid, unchanged presence updates.
  * Recovery now resumes after the appropriate interval or when presence evidence changes.
  * Ensured recovery state resets when signing out or when system time moves backward.

* **Tests**
  * Added coverage for throttling intervals, evidence changes, resets, and clock adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->