### PR TITLE
iOS: classify quinn Display close causes so close attribution stops exporting unknown/unknown

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohConnectionCloseAttribution.swift
@@ -60,10 +60,37 @@ public struct CmxIrohConnectionCloseAttribution: Sendable, Equatable {
             || cause.contains("ConnectionLost(Reset)") {
             return .remote
         }
+        // Connection.closed()/close_reason() cross the uniffi boundary as
+        // quinn ConnectionError DISPLAY strings, which start with the variant
+        // text. Prefix-anchoring keeps a peer-chosen close reason from
+        // spoofing a different initiator.
+        if cause.hasPrefix("closed by peer")
+            || cause.hasPrefix("aborted by peer")
+            || cause.hasPrefix("reset by peer") {
+            return .remote
+        }
+        if cause == "timed out" {
+            return .timedOut
+        }
+        if cause == "closed" {
+            return .local
+        }
         return .unknown
     }
 
     private static func applicationErrorCode(in cause: String) -> Int64? {
+        // Display format of a peer application close is either
+        // "closed by peer: {code}" or "closed by peer: {reason} (code {code})";
+        // the formatter always appends the authentic code last, so a code-like
+        // fragment inside the peer-chosen reason cannot shadow it.
+        let displayPeerClose = "closed by peer: "
+        if cause.hasPrefix(displayPeerClose) {
+            let payload = cause.dropFirst(displayPeerClose.count)
+            if let range = payload.range(of: "(code ", options: .backwards) {
+                return firstInteger(in: payload[range.upperBound...])
+            }
+            return firstInteger(in: payload)
+        }
         guard cause.contains("ApplicationClosed(") else { return nil }
         for label in [
             "application error code",
@@ -103,11 +130,18 @@ public struct CmxIrohConnectionCloseAttribution: Sendable, Equatable {
     }
 
     private static func failureKind(in cause: String) -> DiagnosticFailureKind {
-        if cause.contains("ConnectionLost(TimedOut)") {
+        if cause.contains("ConnectionLost(TimedOut)") || cause == "timed out" {
             return .transportIdleTimedOut
         }
-        if cause.contains("ConnectionLost(LocallyClosed)") {
+        if cause.contains("ConnectionLost(LocallyClosed)") || cause == "closed" {
             return .cancelled
+        }
+        // Display-format peer closes are prefix-anchored so a peer-chosen
+        // reason cannot rewrite the kind via the keyword fallbacks below.
+        if cause.hasPrefix("closed by peer")
+            || cause.hasPrefix("aborted by peer")
+            || cause.hasPrefix("reset by peer") {
+            return .connectionClosed
         }
         if cause.contains("ConnectionLost(TransportError(")
             && (cause.contains("Code::crypto(")

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionCloseAttributionTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohConnectionCloseAttributionTests.swift
@@ -70,6 +70,99 @@ struct CmxIrohConnectionCloseAttributionTests {
         )
     }
 
+    // The uniffi boundary returns quinn ConnectionError DISPLAY strings from
+    // Connection.closed()/close_reason() ("timed out", "closed",
+    // "closed by peer: ..."), not the Debug fragments matched above. Every
+    // production close cause fell through to unknown/unknown until these
+    // formats were recognized (https://github.com/manaflow-ai/cmux/issues/9169).
+
+    @Test
+    func classifiesDisplayIdleTimeout() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("timed out")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .timedOut,
+                    applicationErrorCode: nil,
+                    failureKind: .transportIdleTimedOut
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayLocalClose() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("closed")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .local,
+                    applicationErrorCode: nil,
+                    failureKind: .cancelled
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerApplicationCloseWithBareCode() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("closed by peer: 42")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .remote,
+                    applicationErrorCode: 42,
+                    failureKind: .connectionClosed
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerApplicationCloseWithReasonAndCode() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "closed by peer: going away (code 42)"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .remote,
+                applicationErrorCode: 42,
+                failureKind: .connectionClosed
+            )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerReset() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify("reset by peer")
+                == CmxIrohConnectionCloseAttribution(
+                    initiator: .remote,
+                    applicationErrorCode: nil,
+                    failureKind: .connectionClosed
+                )
+        )
+    }
+
+    @Test
+    func classifiesDisplayPeerTransportAbortWithoutStealingApplicationCode() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "aborted by peer: CONNECTION_REFUSED: server busy"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .remote,
+                applicationErrorCode: nil,
+                failureKind: .connectionClosed
+            )
+        )
+    }
+
+    @Test
+    func displayPeerReasonCannotSpoofInitiatorOrTimeoutKind() {
+        #expect(
+            CmxIrohConnectionCloseAttribution.classify(
+                "closed by peer: timed out (code 7)"
+            ) == CmxIrohConnectionCloseAttribution(
+                initiator: .remote,
+                applicationErrorCode: 7,
+                failureKind: .connectionClosed
+            )
+        )
+    }
+
     @Test
     func authoritativeDriverCauseSupersedesTentativeLocalClose() async {
         let store = CmxIrohConnectionCloseAttributionStore()


### PR DESCRIPTION
Every `transportCloseAttribution` event in the 2026-07-29 outage export carried `initiator=unknown, failureKind=unknown` across 24 session closes (https://github.com/manaflow-ai/cmux/issues/9169), which made the incident's disconnects unattributable.

**Root cause.** The iroh-ffi boundary returns quinn `ConnectionError` **Display** strings from `Connection.closed()` / `close_reason()` (`timed out`, `closed`, `closed by peer: …`, `aborted by peer: …`, `reset by peer`; verified against quinn-proto 0.11.14 and the fork's `src/endpoint.rs`), but `CmxIrohConnectionCloseAttribution.classify` only matched **Debug**-format stream-error fragments like `ConnectionLost(TimedOut)`. Every real close cause fell through to unknown.

**Fix.** The classifier now recognizes the Display grammar alongside the Debug fragments:
- Prefix-anchored matching (`closed by peer`/`aborted by peer`/`reset by peer` → remote; exact `timed out` → timedOut; exact `closed` → local), so a peer-chosen close reason embedded in the string cannot spoof the initiator or rewrite the kind via the keyword fallbacks.
- Application error code parses both peer-close shapes (`closed by peer: {code}` and `closed by peer: {reason} (code {code})`); the formatter appends the authentic code last, so a code-like fragment inside the reason cannot shadow it (backwards search).
- Transport-level aborts (`aborted by peer: CONNECTION_REFUSED: …`) keep `applicationErrorCode=nil`, matching the existing crypto-code rule.

**Commits:** red tests first (7 Display-format causes misclassified as unknown, including two spoof cases), then the fix.

**Verification:** CmxIrohConnectionCloseAttributionTests 15/15; full CmuxIrohTransport suite 501/501.

Fixes https://github.com/manaflow-ai/cmux/issues/9169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787962384&installation_model_id=21920&pr_number=9192&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9192&signature=ea4587da14cbe1f9c5b8802d198d20e2fcbf09a600cbe9002b2f53ee0628fd3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misclassified connection close causes on iOS by recognizing quinn Display strings from `Connection.closed()`/`close_reason()`, so `transportCloseAttribution` exports correct initiator and failureKind. Fixes #9169.

- **Bug Fixes**
  - Classify Display strings: remote for prefixes `closed by peer`/`aborted by peer`/`reset by peer`, timed out for exact `timed out`, local for exact `closed`.
  - Parse application error codes from `closed by peer: {code}` and `closed by peer: {reason} (code {code})` using a backward search; transport aborts keep `applicationErrorCode=nil`.
  - Preserve existing Debug-format handling for stream errors; add tests covering Display formats and spoof attempts.

<sup>Written for commit 5953e8accdc82d7f7caa3ba175a149803c02a524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

