### PR TITLE
Fix CmuxMobileShellUI build break from PR 9146 merge

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -577,7 +577,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             // remap is authoritative and anchor math never sees reflow as append drift.
             let capturedViewportAnchor =
                 await surfaceView.captureVerifiedReplayViewportAnchor()
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else { return false }
             let replayViewportAnchor: VerifiedReplayCapturedViewportAnchor?
             if frame.anchor == .screen, frame.activeScreen == .primary {
                 if let capturedViewportAnchor {


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/9146 merged with a conflict resolution that left one bare `return` in the now-Bool-returning verified-replay cancellation guard (`applyVerifiedRenderGrid` anchor-capture path), breaking the iOS app build in `CmuxMobileShellUI`. One-line fix: `return false` on cancellation, matching the other guards. Verified locally: tagged iOS simulator build of the same tree succeeds with this change and fails without it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787965923&installation_model_id=21920&pr_number=9195&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9195&signature=3c6df9e04412f9cf6710044404af68cee5ac58a57122c62e56ab0e1a409eeeb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS build break in `CmuxMobileShellUI` by replacing a bare `return` with `return false` in the verified-replay cancellation guard within the anchor-capture path of `applyVerifiedRenderGrid`. iOS simulator build now succeeds.

<sup>Written for commit 654111799606a80c6c3514012a3872ff4bfe0073. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling during verified replay rendering so cancelled operations consistently report that they were not applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->