### PR TITLE
Fix 9071 review P1s: adopt legacy device id on in-place upgrade, total-order challenge mints

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DeviceRegistryService.swift
@@ -102,8 +102,12 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
     }
 
     /// Testable core of ``deviceID(defaults:)`` with an injectable identity store.
-    static func deviceID(store: any DeviceIdentityStoring, defaults: UserDefaults) -> String {
-        switch resolveDurableDeviceID(store: store, defaults: defaults) {
+    static func deviceID(
+        store: any DeviceIdentityStoring,
+        defaults: UserDefaults,
+        evidence: any SameDeviceEvidenceProbing = IrohEndpointIdentityEvidenceProbe()
+    ) -> String {
+        switch resolveDurableDeviceID(store: store, defaults: defaults, evidence: evidence) {
         case .durable(let id):
             return id
         case .unavailable:
@@ -131,8 +135,12 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
     }
 
     /// Testable core of ``durableDeviceID(defaults:)`` with an injectable store.
-    static func durableDeviceID(store: any DeviceIdentityStoring, defaults: UserDefaults) -> String? {
-        switch resolveDurableDeviceID(store: store, defaults: defaults) {
+    static func durableDeviceID(
+        store: any DeviceIdentityStoring,
+        defaults: UserDefaults,
+        evidence: any SameDeviceEvidenceProbing = IrohEndpointIdentityEvidenceProbe()
+    ) -> String? {
+        switch resolveDurableDeviceID(store: store, defaults: defaults, evidence: evidence) {
         case .durable(let id):
             return id
         case .unavailable:
@@ -156,7 +164,8 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
     /// `(user, device, tag)` slot stable.
     static func resolveDurableDeviceID(
         store: any DeviceIdentityStoring,
-        defaults: UserDefaults
+        defaults: UserDefaults,
+        evidence: any SameDeviceEvidenceProbing = IrohEndpointIdentityEvidenceProbe()
     ) -> DurableDeviceIDResolution {
         switch store.read() {
         case .found(let stored):
@@ -173,6 +182,41 @@ public actor DeviceRegistryService: DeviceRegistryRefreshing {
             }
             return .durable(trimmed)
         case .absent:
+            // No Keychain id yet. Two very different situations land here with a
+            // legacy UserDefaults mirror present: an in-place UPGRADE from a
+            // pre-Keychain build (the mirror IS the id of this phone's active
+            // iroh binding; minting a new one strands that binding behind
+            // `endpoint_already_bound` because the endpoint identity survives
+            // the upgrade), and a backup RESTORE onto different hardware (the
+            // mirror crossed devices; adopting it would make two phones share
+            // one `(user, device, tag)` slot). Disambiguate with ThisDeviceOnly
+            // evidence: the iroh endpoint-identity Keychain item cannot cross
+            // hardware, so its presence proves same-device continuation. See
+            // ``SameDeviceEvidenceProbing`` for the full matrix.
+            if let legacy = trimmedLegacyDeviceID(defaults) {
+                switch evidence.probe() {
+                case .present:
+                    // Continuing install: adopt the binding's existing id into
+                    // the authoritative store. createOrAdopt never overwrites a
+                    // concurrent winner, so racing launches still converge.
+                    guard let winner = store.createOrAdopt(legacy) else {
+                        return .unavailable
+                    }
+                    defaults.set(winner, forKey: deviceIDKey)
+                    return .durable(winner)
+                case .absent:
+                    // Fresh install or cross-device restore: mint (which also
+                    // clears the foreign mirror).
+                    return adoptOrGenerateDeviceID(store: store, defaults: defaults)
+                case .unavailable:
+                    // The evidence probe cannot read the Keychain right now
+                    // (locked before first unlock). Minting here would rotate an
+                    // upgrading device's identity — the exact P1. Fail closed
+                    // like the device-id store's own `.unavailable` path and let
+                    // the caller defer until after first unlock.
+                    return .unavailable
+                }
+            }
             return adoptOrGenerateDeviceID(store: store, defaults: defaults)
         case .unavailable:
             // Fail closed: the store exists but is unreadable right now (a

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SameDeviceEvidence.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/SameDeviceEvidence.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Security
+
+/// Evidence that this install is CONTINUING on the same physical device, used
+/// to decide whether a legacy `UserDefaults` device-id mirror may be adopted
+/// when the authoritative device-id Keychain item is absent.
+///
+/// The dilemma it resolves: on an in-place UPGRADE from a pre-Keychain build,
+/// the device-id Keychain item does not exist yet while `UserDefaults` holds
+/// the id of the phone's ACTIVE iroh binding — minting a fresh id there targets
+/// a new `(user, device, tag)` slot while the surviving endpoint identity still
+/// owns the old slot, so registration fails `endpoint_already_bound` and iroh
+/// is disabled for every upgrading install. But `UserDefaults` alone cannot be
+/// adopted blindly, because an encrypted device backup restores it onto
+/// DIFFERENT hardware, where adoption would make two phones share one slot.
+///
+/// The discriminator is the iroh endpoint-identity Keychain item: it is stored
+/// with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` and
+/// `kSecAttrSynchronizable = false` (`CmxIrohKeychainIdentityStore` in
+/// CmuxIrohTransport), so it can NEVER cross hardware via backup or iCloud
+/// sync. Upgrade/restore matrix:
+///
+/// - Upgrade in place: mirror present, endpoint identity present → ADOPT.
+/// - Restore to new hardware: mirror present (backups carry UserDefaults),
+///   endpoint identity absent (ThisDeviceOnly) → MINT.
+/// - Same-device erase + restore: endpoint identity absent → MINT (safe: the
+///   endpoint key was lost too, so the old binding is re-keyed on next
+///   registration either way).
+/// - Fresh install: mirror absent → MINT (evidence never consulted).
+/// - Keychain locked (`errSecInteractionNotAllowed`): cannot prove either way
+///   → NO evidence, mint is deferred by the caller's existing `.unavailable`
+///   path when the device-id store is also unreadable; when only this probe is
+///   locked, fail toward MINT-safe `false` is wrong (it would rotate an
+///   upgrading device), so the probe reports `.unavailable` and resolution
+///   defers, mirroring the device-id store's own fail-closed behavior.
+protocol SameDeviceEvidenceProbing: Sendable {
+    func probe() -> SameDeviceEvidence
+}
+
+enum SameDeviceEvidence: Equatable, Sendable {
+    /// A ThisDeviceOnly artifact from the prior install exists on this device.
+    case present
+    /// No such artifact exists (fresh install, or restore onto new hardware).
+    case absent
+    /// The Keychain cannot be read right now (locked before first unlock).
+    case unavailable
+}
+
+/// Probes for any item under the iroh endpoint-identity Keychain service.
+///
+/// CROSS-PACKAGE CONTRACT: the service name mirrors
+/// `CmxIrohKeychainIdentityStore.init(service:)` in CmuxIrohTransport
+/// ("com.cmuxterm.iroh.endpoint-identity.v1"). CmuxMobileShell does not depend
+/// on CmuxIrohTransport, so the constant is duplicated here deliberately; both
+/// sites carry a comment pointing at the other. The probe only asks "does any
+/// item exist" — it never reads key material (`kSecReturnData` is not set).
+struct IrohEndpointIdentityEvidenceProbe: SameDeviceEvidenceProbing {
+    private let service: String
+
+    init(service: String = "com.cmuxterm.iroh.endpoint-identity.v1") {
+        self.service = service
+    }
+
+    func probe() -> SameDeviceEvidence {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrSynchronizable as String: false,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        let status = SecItemCopyMatching(query as CFDictionary, nil)
+        switch status {
+        case errSecSuccess:
+            return .present
+        case errSecItemNotFound:
+            return .absent
+        default:
+            return .unavailable
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DeviceRegistryRouteSelectionTests.swift
@@ -296,11 +296,13 @@ import Testing
         defaults.set(legacy, forKey: "cmux.deviceRegistry.iosDeviceID")
         let store = InMemoryDeviceIdentityStore()
 
-        let resolved = DeviceRegistryService.deviceID(store: store, defaults: defaults)
+        let resolved = DeviceRegistryService.deviceID(
+            store: store, defaults: defaults, evidence: StaticEvidenceProbe(.absent),
+        )
         // UserDefaults can cross hardware in a restored backup, while the
-        // ThisDeviceOnly Keychain item cannot. An empty authoritative store must
-        // therefore mint for this physical phone instead of cloning the old
-        // phone's `(user, device, tag)` identity.
+        // ThisDeviceOnly Keychain item cannot. With no same-device evidence, an
+        // empty authoritative store must mint for this physical phone instead
+        // of cloning the old phone's `(user, device, tag)` identity.
         #expect(resolved != legacy)
         #expect(UUID(uuidString: resolved) != nil)
         #expect(store.read() == .found(resolved))
@@ -431,10 +433,11 @@ import Testing
     }
 
     @Test func durableDeviceIDRejectsRestoredLegacyWhenFreshMintCannotPersist() {
-        // A UserDefaults-only id is not durable evidence for this physical
-        // device because it may have arrived in a restored backup. If the empty
-        // authoritative store cannot persist a fresh id, defer registration and
-        // remove the unsafe mirror instead of cloning another phone's identity.
+        // A UserDefaults-only id with NO same-device evidence is not durable
+        // for this physical device: it may have arrived in a restored backup.
+        // If the empty authoritative store also cannot persist a fresh id,
+        // defer registration and remove the unsafe mirror instead of cloning
+        // another phone's identity.
         let suite = "test.deviceRegistry.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
         defer { defaults.removePersistentDomain(forName: suite) }
@@ -442,9 +445,90 @@ import Testing
         defaults.set(legacy, forKey: "cmux.deviceRegistry.iosDeviceID")
         let store = InMemoryDeviceIdentityStore(writeAlwaysFails: true)
 
-        let resolved = DeviceRegistryService.durableDeviceID(store: store, defaults: defaults)
+        let resolved = DeviceRegistryService.durableDeviceID(
+            store: store, defaults: defaults, evidence: StaticEvidenceProbe(.absent),
+        )
         #expect(resolved == nil)
         #expect(defaults.string(forKey: "cmux.deviceRegistry.iosDeviceID") == nil)
+    }
+
+    // MARK: - Upgrade vs restore disambiguation (9071 review finding 1)
+
+    @Test func durableDeviceIDAdoptsLegacyMirrorOnInPlaceUpgrade() {
+        // In-place upgrade from a pre-Keychain build: device-id Keychain item is
+        // absent, the legacy mirror holds the id of this phone's ACTIVE binding,
+        // and the ThisDeviceOnly iroh endpoint identity proves same-device
+        // continuation. The resolver must ADOPT the mirror — minting would
+        // target a new (user, device, tag) slot while the surviving endpoint
+        // identity still owns the old one (endpoint_already_bound, iroh dead).
+        let suite = "test.deviceRegistry.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let legacy = "legacy-device-id-\(UUID().uuidString.lowercased())"
+        defaults.set(legacy, forKey: "cmux.deviceRegistry.iosDeviceID")
+        let store = InMemoryDeviceIdentityStore()
+
+        let resolved = DeviceRegistryService.durableDeviceID(
+            store: store, defaults: defaults, evidence: StaticEvidenceProbe(.present),
+        )
+        #expect(resolved == legacy)
+        // Adopted into the authoritative store and still mirrored.
+        #expect(store.read() == .found(legacy))
+        #expect(defaults.string(forKey: "cmux.deviceRegistry.iosDeviceID") == legacy)
+    }
+
+    @Test func durableDeviceIDMintsFreshOnCrossDeviceRestore() {
+        // Backup restore onto different hardware: the mirror crossed devices
+        // inside the backup, but the ThisDeviceOnly endpoint identity did not.
+        // Adopting the mirror would make two phones share one slot; mint fresh.
+        let suite = "test.deviceRegistry.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let foreign = "restored-foreign-id-\(UUID().uuidString.lowercased())"
+        defaults.set(foreign, forKey: "cmux.deviceRegistry.iosDeviceID")
+        let store = InMemoryDeviceIdentityStore()
+
+        let resolved = DeviceRegistryService.durableDeviceID(
+            store: store, defaults: defaults, evidence: StaticEvidenceProbe(.absent),
+        )
+        #expect(resolved != nil)
+        #expect(resolved != foreign)
+        #expect(defaults.string(forKey: "cmux.deviceRegistry.iosDeviceID") == resolved)
+    }
+
+    @Test func durableDeviceIDDefersWhenEvidenceUnreadableWithLegacyMirror() {
+        // Locked Keychain during the evidence probe: cannot distinguish upgrade
+        // from restore. Minting would rotate an upgrading device's identity, so
+        // fail closed and let the caller retry after first unlock.
+        let suite = "test.deviceRegistry.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let legacy = "legacy-device-id-\(UUID().uuidString.lowercased())"
+        defaults.set(legacy, forKey: "cmux.deviceRegistry.iosDeviceID")
+        let store = InMemoryDeviceIdentityStore()
+
+        let resolved = DeviceRegistryService.durableDeviceID(
+            store: store, defaults: defaults, evidence: StaticEvidenceProbe(.unavailable),
+        )
+        #expect(resolved == nil)
+        // Nothing minted, mirror preserved for the post-unlock retry.
+        #expect(store.read() == .absent)
+        #expect(defaults.string(forKey: "cmux.deviceRegistry.iosDeviceID") == legacy)
+    }
+
+    @Test func durableDeviceIDMintsOnFreshInstallRegardlessOfEvidence() {
+        // No mirror at all: evidence is irrelevant; a fresh install mints even
+        // if a stale endpoint-identity item lingers from a previous install.
+        let suite = "test.deviceRegistry.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = InMemoryDeviceIdentityStore()
+
+        let resolved = DeviceRegistryService.durableDeviceID(
+            store: store, defaults: defaults, evidence: StaticEvidenceProbe(.present),
+        )
+        #expect(resolved != nil)
+        #expect(store.read() == .found(resolved!))
     }
 
     @Test func durableDeviceIDAdoptsConcurrentWinnerInsteadOfMintingSecondID() {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/InMemoryDeviceIdentityStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/InMemoryDeviceIdentityStore.swift
@@ -40,3 +40,10 @@ final class InMemoryDeviceIdentityStore: DeviceIdentityStoring, @unchecked Senda
         }
     }
 }
+
+/// Fixed-answer same-device-evidence probe for tests.
+struct StaticEvidenceProbe: SameDeviceEvidenceProbing {
+    private let answer: SameDeviceEvidence
+    init(_ answer: SameDeviceEvidence) { self.answer = answer }
+    func probe() -> SameDeviceEvidence { answer }
+}

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, eq, gt, inArray, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, inArray, isNull, lte, ne, or, sql } from "drizzle-orm";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -242,6 +242,31 @@ function makeLiveRepository(): IrohRepositoryShape {
         if ((outstanding?.total ?? 0) >= challengeQuota.outstanding) {
           throw new IrohQuotaExceededError({ code: "too_many_outstanding_challenges", retryAfterSeconds: 300 });
         }
+        // The register gate rejects a challenge whose createdAt is strictly
+        // below the slot's registeredAt high-water mark. Both are millisecond
+        // wall clocks, so two serialized mints can carry EQUAL timestamps; a
+        // delayed older challenge that ties the mark passes the `<` gate and
+        // can land after a newer one, reversing the order the gate enforces.
+        // Fix at the source: make challenge mint time a strict total order per
+        // slot. registeredAt is only ever stamped from a challenge's createdAt
+        // (insert, reincarnation, and heartbeat paths alike), so if each new
+        // challenge is strictly newer than every prior challenge for its slot,
+        // the strict `<` gate is exact. All mints for a user serialize under
+        // the per-user challenge advisory lock above, so this read cannot race
+        // another mint for the same slot.
+        const [priorChallenge] = await tx
+          .select({ createdAt: irohRegistrationChallenges.createdAt })
+          .from(irohRegistrationChallenges)
+          .where(and(
+            eq(irohRegistrationChallenges.userId, input.userId),
+            eq(irohRegistrationChallenges.deviceUuid, input.deviceUuid),
+            eq(irohRegistrationChallenges.tag, input.tag),
+          ))
+          .orderBy(desc(irohRegistrationChallenges.createdAt))
+          .limit(1);
+        const createdAt = priorChallenge && input.now <= priorChallenge.createdAt
+          ? new Date(priorChallenge.createdAt.getTime() + 1)
+          : input.now;
         const [challenge] = await tx
           .insert(irohRegistrationChallenges)
           .values({
@@ -253,7 +278,7 @@ function makeLiveRepository(): IrohRepositoryShape {
             identityGeneration: input.identityGeneration,
             payloadSha256: input.payloadSha256,
             nonceHash: input.nonceHash,
-            createdAt: input.now,
+            createdAt,
             expiresAt: input.expiresAt,
           })
           .returning();

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -1127,6 +1127,94 @@ describe("Iroh trust broker database behavior", () => {
     expect(row?.appInstanceId).toBe(newerApp);
   });
 
+  dbTest("rejects a stale challenge minted in the same millisecond as the applied one", async () => {
+    // 9071 review finding 2: the register gate is strict (`createdAt <
+    // registeredAt`), and challenge createdAt is a millisecond wall clock, so
+    // two serialized mints CAN tie. Without total ordering at mint time, the
+    // older-of-two-equal challenges completes after the newer and passes the
+    // gate, reversing the order the gate exists to enforce. Minting now bumps
+    // a tying createdAt strictly above the slot's latest challenge, so the
+    // delayed twin must be rejected as superseded.
+    const repo = requiredRepository();
+    const userId = "user-slot-equal-millis";
+    const deviceId = randomUUID();
+    const endpoint = "5c".repeat(32);
+    const tag = "stable";
+
+    const prepare = async (input: { appInstanceId: string; suffix: string; now: Date }) => {
+      const nonceHash = input.suffix.repeat(64);
+      const challenge = await Effect.runPromise(repo.issueChallenge({
+        userId,
+        deviceUuid: deviceId,
+        appInstanceId: input.appInstanceId,
+        tag,
+        endpointId: endpoint,
+        identityGeneration: 1,
+        payloadSha256: `${input.suffix}${"0".repeat(63)}`,
+        nonceHash,
+        now: input.now,
+        expiresAt: new Date(input.now.getTime() + 5 * 60 * 1_000),
+      }));
+      return { id: challenge.id, nonceHash, appInstanceId: input.appInstanceId };
+    };
+    const register = (
+      prepared: { id: string; nonceHash: string; appInstanceId: string },
+      now: Date,
+    ) => repo.consumeChallengeAndRegister({
+      userId,
+      challengeId: prepared.id,
+      nonceHash: prepared.nonceHash,
+      payload: {
+        route_contract_version: 1,
+        deviceId,
+        appInstanceId: prepared.appInstanceId,
+        tag,
+        platform: "ios",
+        endpointId: endpoint,
+        identityGeneration: 1,
+        pairingEnabled: true,
+        capabilities: [],
+        pathHints: [],
+      },
+      now,
+    });
+
+    // Establish the slot, then mint two challenges with the SAME wall-clock
+    // input. Serialized issuance must still order them.
+    const initial = await prepare({ appInstanceId: randomUUID(), suffix: "1", now: NOW });
+    expect((await Effect.runPromise(register(initial, new Date(NOW.getTime() + 500)))).created).toBe(true);
+
+    const tieInstant = new Date(NOW.getTime() + 1_000);
+    const olderApp = randomUUID();
+    const newerApp = randomUUID();
+    const older = await prepare({ appInstanceId: olderApp, suffix: "2", now: tieInstant });
+    const newer = await prepare({ appInstanceId: newerApp, suffix: "3", now: tieInstant });
+
+    // The NEWER twin lands first and refreshes the slot.
+    const newerResult = await Effect.runPromise(register(newer, new Date(NOW.getTime() + 2_000)));
+    expect(newerResult.created).toBe(false);
+    expect(newerResult.binding.appInstanceId).toBe(newerApp);
+
+    // The OLDER twin, delayed, must be rejected — not clobber the newer state.
+    const stale = await Effect.runPromiseExit(register(older, new Date(NOW.getTime() + 3_000)));
+    expect(stale._tag).toBe("Failure");
+    const causeError = stale._tag === "Failure"
+      ? Option.getOrUndefined(Cause.failureOption(stale.cause))
+      : undefined;
+    expect(causeError).toMatchObject({
+      _tag: "IrohConflictError",
+      code: "challenge_superseded",
+    });
+
+    const [row] = await requiredSql()<Array<{ appInstanceId: string }>>`
+      select app_instance_id as "appInstanceId"
+      from iroh_endpoint_bindings
+      where user_id = ${userId} and device_uuid = ${deviceId}
+        and tag = ${tag} and revoked_at is null
+    `;
+    expect(row?.appInstanceId).toBe(newerApp);
+  });
+
   dbTest("revokes a retired incarnation's pair grants instead of reassigning them", async () => {
     const repo = requiredRepository();
     const initiatorUser = "user-rekey-grant-initiator";


### PR DESCRIPTION
Fixes the two P1 findings from the structured review of https://github.com/manaflow-ai/cmux/pull/9071 (both verified against main by direct code reading).

**1. Upgrade-path device identity rotation (iOS, would disable iroh for every upgrading install).** `resolveDurableDeviceID`'s `.absent` branch deleted the legacy UserDefaults device-id mirror and minted a fresh id. On an in-place upgrade from a pre-Keychain build, the mirror is the id of the phone's active iroh binding and the endpoint identity survives, so registration would target a new `(user, device, tag)` slot while the endpoint still owned the old one → `endpoint_already_bound`. The mirror can't be adopted blindly (encrypted backups restore UserDefaults onto different hardware). **Fix:** disambiguate with ThisDeviceOnly evidence — the iroh endpoint-identity Keychain item (`AfterFirstUnlockThisDeviceOnly`, non-synchronizable, per `CmxIrohKeychainIdentityStore`) cannot cross hardware, so presence ⇒ same-device continuation ⇒ adopt the mirror; absence ⇒ mint as before; unreadable ⇒ fail closed and defer (mirrors the store's own `.unavailable` semantics). Full upgrade/restore matrix documented on the new `SameDeviceEvidenceProbing` and covered by tests.

**2. Challenge ordering tie (web).** The register gate rejects only strictly-older challenges and `createdAt` is a millisecond wall clock, so serialized mints can tie; a delayed older twin then passes the gate and can clobber newer state (heartbeat fields, reincarnation). **Fix:** `issueChallenge` assigns each challenge a `createdAt` strictly above the slot's latest prior challenge — mints for a user serialize under the existing advisory lock, so this makes mint time a per-slot total order and the strict gate exact. Regression test covers equal-millisecond completion reversal.

**Verification:** CmuxMobileShell DeviceRegistry suites 41/41 (2 pre-existing unrelated failures on main in terminalReplay/staleReplay tests); web typecheck clean; iroh-route-handler + trust-broker 41/41; new db regression test runs under the CMUX_DB_TEST=1 CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787966817&installation_model_id=21920&pr_number=9196&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9196&signature=366c0386ea2aa68912138eec4a6281b0eada08fd12beed976083d76ee952bd08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two P1s: prevents iOS device identity rotation on in‑place upgrades by adopting the legacy device ID when same‑device Keychain evidence is present, and makes challenge mints a strict per‑slot total order to avoid stale challenges clobbering newer state.

- **Bug Fixes**
  - iOS (`CmuxMobileShell`): add same‑device evidence probe using the ThisDeviceOnly iroh endpoint identity; adopt the legacy `UserDefaults` device ID when evidence is present, mint when absent, and defer when Keychain access is unavailable. This avoids `endpoint_already_bound` on upgrade and keeps the existing binding intact.
  - Web (`web/services/iroh/repository.ts`): in `issueChallenge`, set `createdAt` strictly above the latest prior challenge for the `(user, device, tag)` slot (under the existing per‑user advisory lock). This removes millisecond ties and makes the strict gate exact; adds a regression test that rejects a stale challenge minted in the same millisecond as the applied one.

<sup>Written for commit 7a87aa5c7df499a380010a386a5d4928ef9f91bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved device identity handling during upgrades and restores, distinguishing same-device continuation from cross-device restoration.
  - Prevented unsafe adoption of restored device information when secure storage is unavailable.
  - Ensured newer registration challenges consistently supersede older challenges, even when created within the same millisecond.
  - Preserved the most recent device registration when delayed or stale challenges are submitted.
- **Tests**
  - Added coverage for device restoration scenarios and simultaneous challenge creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->