### PR TITLE
Exempt quoted script-path strings from Ghostty Zig workflow guard

### DIFF
--- a/.github/test-determinism-allowlist.txt
+++ b/.github/test-determinism-allowlist.txt
@@ -2,5 +2,5 @@
 # Format: relpath<TAB>rule<TAB>short reason
 # A finding whose (path, rule) appears here is suppressed.
 # Remove a line once the underlying test is determinized.
-cmuxTests/WorkspaceForkConversationContextMenuTests.swift	assert-on-duration	grandfathered
-cmuxTests/WorkspaceForkConversationContextMenuTests.swift	sleep-then-assert	grandfathered
+Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCTransportDrainTests.swift	sleep-then-assert	landed via https://github.com/manaflow-ai/cmux/pull/8931; determinize then remove
+Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/OnboardingMacDiscoveryKeepAliveTests.swift	sleep-then-assert	landed via https://github.com/manaflow-ai/cmux/pull/9163; determinize then remove

--- a/tests/check_ghostty_zig_workflows.py
+++ b/tests/check_ghostty_zig_workflows.py
@@ -33,6 +33,11 @@ def workflow_failures(workflow_dir: Path) -> list[str]:
             stripped = line.strip()
             if stripped.startswith("#") or stripped.startswith(("- \"scripts/", "- 'scripts/")):
                 continue
+            # A line that is nothing but a quoted script path (optionally with a
+            # trailing comma) names the script without executing it, e.g. a JS
+            # path array used for change detection inside a github-script step.
+            if re.fullmatch(r"""(["'])scripts/[^"']+\1,?""", stripped):
+                continue
             if not any(name in line for name in CONSUMER_NAMES):
                 continue
             if current_job is None:


### PR DESCRIPTION
Two guard steps in `workflow-guard-tests` fail on every branch containing current main; this PR fixes both so the cheap CI layer gates real regressions again.

1. **Ghostty Zig sync guard**: since https://github.com/manaflow-ai/cmux/pull/9165, `tests/check_ghostty_zig_workflows.py` flags `ios-testflight.yml`'s `decide` job because it lists `scripts/install-zig-ci.sh` and `scripts/ghostty-zig-version.sh` as plain JS string entries in a change-detection path array inside a github-script step. The job never executes them. The checker now skips lines that consist solely of a quoted `scripts/...` path (optionally with a trailing comma), matching the existing exemption for YAML list items. Verified: passes against current workflows, still fails a synthetic workflow that really invokes the resolver without prior submodule init.

2. **Test determinism gate**: `scripts/check-test-determinism.py --strict` reports 5 `sleep-then-assert` findings that landed via https://github.com/manaflow-ai/cmux/pull/8931 (MobileCoreRPCTransportDrainTests) and https://github.com/manaflow-ai/cmux/pull/9163 (OnboardingMacDiscoveryKeepAliveTests). Grandfathered into `.github/test-determinism-allowlist.txt` with provenance notes; determinizing those tests remains follow-up work, and removing the entries re-arms the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation to ignore standalone quoted script-path declarations.
  * Prevented these declarations from being incorrectly treated as requiring submodule initialization.
* **Tests**
  * Updated the test determinism allowlist by removing two legacy suppressed entries and adding targeted suppressions for specific iOS Swift tests until they can be fully determinized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->