### PR TITLE
iOS: make workspace-list pull-to-refresh visible again

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListBarUnderlap.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListBarUnderlap.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 #if os(iOS)
+private struct WorkspaceListChromeTopInsetKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var workspaceListChromeTopInset: CGFloat {
+        get { self[WorkspaceListChromeTopInsetKey.self] }
+        set { self[WorkspaceListChromeTopInsetKey.self] = newValue }
+    }
+}
+
 /// Extends the workspace table under the vertical bars on iOS 26, where the
 /// scroll edge effect and `WorkspaceListScrollEdgeCoordinator`'s bar
 /// registration render the App Store-style soft blur over the underlap.
@@ -7,15 +18,29 @@ import SwiftUI
 /// SwiftUI fits a `UIViewRepresentable` inside the safe area, so without this
 /// the table's frame starts below the search drawer and ends above the tab
 /// bar: rows hard-clip at the chrome and no scroll edge effect can render.
-/// The real UIKit bars still contribute safe area, so the table's automatic
-/// content-inset adjustment keeps rows and indicators clear of the chrome,
-/// and the keyboard region stays respected. Earlier releases keep the fitted
-/// frame: the coordinator's registration is iOS 26-gated, and underlapping
-/// without it would scroll full-opacity rows beneath legacy bars.
+/// The pre-underlap top safe area is passed to the table as
+/// `workspaceListChromeTopInset` so rows and the refresh indicator stay below
+/// the chrome: ignoring the safe area also removes it from the table's
+/// automatic content-inset adjustment, which UIKit uses to position the
+/// `UIRefreshControl`, so without the explicit inset the pull spinner renders
+/// behind the header material. Earlier releases keep the fitted frame: the
+/// coordinator's registration is iOS 26-gated, and underlapping without it
+/// would scroll full-opacity rows beneath legacy bars.
 struct WorkspaceListBarUnderlap: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
-            content.ignoresSafeArea(.container, edges: .vertical)
+            // The GeometryReader must stay fitted (inside the safe area) with
+            // `ignoresSafeArea` applied to the content within it. Applying
+            // `ignoresSafeArea` to the GeometryReader itself expands it first,
+            // and its proxy then reports zero top safe area.
+            GeometryReader { proxy in
+                content
+                    .environment(
+                        \.workspaceListChromeTopInset,
+                        proxy.safeAreaInsets.top
+                    )
+                    .ignoresSafeArea(.container, edges: .vertical)
+            }
         } else {
             content
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTable.swift
@@ -56,6 +56,7 @@ struct WorkspaceListTable: UIViewRepresentable {
     let showAddDevice: (() -> Void)?
     let reconnect: (() -> Void)?
     let refresh: (@Sendable () async -> Void)?
+    var chromeTopInset: CGFloat = 0
 
     func makeCoordinator() -> WorkspaceListTableCoordinator {
         WorkspaceListTableCoordinator(configuration: self)
@@ -73,12 +74,19 @@ struct WorkspaceListTable: UIViewRepresentable {
         tableView.sectionFooterHeight = 0
         tableView.rowHeight = UITableView.automaticDimension
         tableView.accessibilityIdentifier = "MobileWorkspaceList"
+        var resolvedConfiguration = self
+        resolvedConfiguration.chromeTopInset =
+            context.environment.workspaceListChromeTopInset
+        context.coordinator.configuration = resolvedConfiguration
         context.coordinator.attach(to: tableView)
         return tableView
     }
 
     func updateUIView(_ uiView: WorkspaceListUITableView, context: Context) {
-        context.coordinator.update(configuration: self, in: uiView)
+        var resolvedConfiguration = self
+        resolvedConfiguration.chromeTopInset =
+            context.environment.workspaceListChromeTopInset
+        context.coordinator.update(configuration: resolvedConfiguration, in: uiView)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListTableCoordinator.swift
@@ -98,6 +98,7 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
         let previous = previousConfiguration
         configuration = next
         tableView.dragInteractionEnabled = next.enablesReorder
+        updateChromeTopInset(in: tableView)
         updateRefreshControl(in: tableView)
 
         guard let dataSource else {
@@ -387,6 +388,32 @@ final class WorkspaceListTableCoordinator: NSObject, UITableViewDelegate,
             previewProvider: nil
         ) { _ in
             UIMenu(children: actions)
+        }
+    }
+
+    private func updateChromeTopInset(in tableView: UITableView) {
+        let nextTopInset = configuration.chromeTopInset
+        let contentInsetChanged = tableView.contentInset.top != nextTopInset
+        let oldRestingOffset = -tableView.adjustedContentInset.top
+        let shouldRepinRestingOffset = contentInsetChanged
+            && !tableView.isTracking
+            && !tableView.isDragging
+            && !tableView.isDecelerating
+            && tableView.refreshControl?.isRefreshing != true
+            && abs(tableView.contentOffset.y - oldRestingOffset) <= 1
+
+        if contentInsetChanged {
+            var contentInset = tableView.contentInset
+            contentInset.top = nextTopInset
+            tableView.contentInset = contentInset
+        }
+        if tableView.verticalScrollIndicatorInsets.top != nextTopInset {
+            var indicatorInsets = tableView.verticalScrollIndicatorInsets
+            indicatorInsets.top = nextTopInset
+            tableView.verticalScrollIndicatorInsets = indicatorInsets
+        }
+        if shouldRepinRestingOffset {
+            tableView.contentOffset.y = -tableView.adjustedContentInset.top
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollUpdateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListScrollUpdateTests.swift
@@ -27,6 +27,58 @@ import UIKit
         )
     }
 
+    @Test func chromeTopInsetKeepsRowsAndScrollIndicatorBelowChrome() {
+        let topInset: CGFloat = 72
+        let initial = configuration(
+            workspaceIDs: ["workspace-1"],
+            chromeTopInset: topInset
+        )
+        let coordinator = WorkspaceListTableCoordinator(configuration: initial)
+        let tableView = makeTableView()
+
+        coordinator.attach(to: tableView)
+
+        #expect(tableView.contentInset.top == topInset)
+        #expect(tableView.verticalScrollIndicatorInsets.top == topInset)
+        #expect(tableView.contentOffset.y == -tableView.adjustedContentInset.top)
+    }
+
+    @Test func refreshConfigurationInstallsRefreshControl() {
+        let initial = configuration(
+            workspaceIDs: ["workspace-1"],
+            refresh: {}
+        )
+        let coordinator = WorkspaceListTableCoordinator(configuration: initial)
+        let tableView = makeTableView()
+
+        coordinator.attach(to: tableView)
+
+        #expect(tableView.refreshControl != nil)
+    }
+
+    @Test func chromeTopInsetChangePreservesNonTopContentOffset() {
+        let initial = configuration(
+            workspaceIDs: ["workspace-1"],
+            chromeTopInset: 20
+        )
+        let coordinator = WorkspaceListTableCoordinator(configuration: initial)
+        let tableView = makeTableView()
+        coordinator.attach(to: tableView)
+        tableView.contentOffset.y = 40
+
+        coordinator.update(
+            configuration: configuration(
+                workspaceIDs: ["workspace-1"],
+                chromeTopInset: 72
+            ),
+            in: tableView
+        )
+
+        #expect(tableView.contentInset.top == 72)
+        #expect(tableView.verticalScrollIndicatorInsets.top == 72)
+        #expect(tableView.contentOffset.y == 40)
+    }
+
     @Test func structuralUpdateAppliesThroughNativeDataSource() {
         let initial = configuration(workspaceIDs: ["workspace-1"])
         let coordinator = WorkspaceListTableCoordinator(configuration: initial)
@@ -234,7 +286,9 @@ import UIKit
         setUnread: ((MobileWorkspacePreview.ID, Bool) -> Void)? = nil,
         setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)? = nil,
         renameRequest: ((MobileWorkspacePreview.ID) -> Void)? = nil,
-        customizeRequest: ((MobileWorkspacePreview.ID) -> Void)? = nil
+        customizeRequest: ((MobileWorkspacePreview.ID) -> Void)? = nil,
+        chromeTopInset: CGFloat = 0,
+        refresh: (@Sendable () async -> Void)? = nil
     ) -> WorkspaceListTable {
         let workspaces = workspaceIDs.map { rawID in
             var workspace = MobileWorkspacePreview(
@@ -252,7 +306,9 @@ import UIKit
             setUnread: setUnread,
             setPinned: setPinned,
             renameRequest: renameRequest,
-            customizeRequest: customizeRequest
+            customizeRequest: customizeRequest,
+            chromeTopInset: chromeTopInset,
+            refresh: refresh
         )
     }
 
@@ -263,7 +319,9 @@ import UIKit
         setUnread: ((MobileWorkspacePreview.ID, Bool) -> Void)? = nil,
         setPinned: ((MobileWorkspacePreview.ID, Bool) -> Void)? = nil,
         renameRequest: ((MobileWorkspacePreview.ID) -> Void)? = nil,
-        customizeRequest: ((MobileWorkspacePreview.ID) -> Void)? = nil
+        customizeRequest: ((MobileWorkspacePreview.ID) -> Void)? = nil,
+        chromeTopInset: CGFloat = 0,
+        refresh: (@Sendable () async -> Void)? = nil
     ) -> WorkspaceListTable {
         return WorkspaceListTable(
             items: workspaces.map { .workspace($0.id, indented: false) },
@@ -309,7 +367,8 @@ import UIKit
             retryInitialConnection: nil,
             showAddDevice: nil,
             reconnect: nil,
-            refresh: nil
+            refresh: refresh,
+            chromeTopInset: chromeTopInset
         )
     }
 }


### PR DESCRIPTION
Pull-to-refresh on the iOS workspace list looked removed since the UITableView rewrite (https://github.com/manaflow-ai/cmux/pull/8186) landed together with the iOS 26 bar underlap. The gesture still fired, but the spinner rendered behind the top chrome: `WorkspaceListBarUnderlap` applies `ignoresSafeArea(.container, edges: .vertical)`, which zeroes the table's safe-area/content-inset adjustment, and UIKit anchors `UIRefreshControl` to exactly that inset. Measured at runtime pre-fix: `safeAreaInsets.top == 0`, `adjustedContentInset.top == 0`, refresh-control window frame `(0, 0, 440, 60)`, fully under the status bar and header material. Rows at rest also started behind the chrome for the same reason.

Fix: a fitted `GeometryReader` captures the pre-underlap top safe area (116pt on iPhone 17 Pro Max) and passes it to the table as `workspaceListChromeTopInset`; the coordinator applies it to `contentInset.top` and the scroll-indicator inset, and re-pins the resting offset only while idle at the top (never during drag, deceleration, or an active refresh). The nesting matters: `ignoresSafeArea` goes on the content inside the reader, because applying it to the reader itself expands it first and its proxy then reports zero top safe area. Underlap and the iOS 26 soft scroll-edge blur are unchanged; the table frame still extends under the bars.

Commit 1 adds the regression tests only (CI red), commit 2 adds the fix (CI green).

Verified on an iOS 26.5 simulator with the DEBUG list fixture (`CMUX_UITEST_WORKSPACE_LIST_PREVIEW=1`, tab scaffold): pre-fix the pull fired invisibly; post-fix the spinner renders below the header, rows rest below the chrome, the fixture's refresh generation increments, and a 40-row list still scrolls under the header/tab-bar blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787973815&installation_model_id=21920&pr_number=9202&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9202&signature=f26dcbb9a6faa4cee164f007eef8d17ab749eeeb4fe0faf4781dd378c017a1a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores visible pull-to-refresh on the iOS workspace list. The spinner and rows now sit below the header while keeping the iOS 26 underlap effect.

- **Bug Fixes**
  - Capture the pre-underlap top safe-area with a fitted `GeometryReader` in `WorkspaceListBarUnderlap`, pass it via `workspaceListChromeTopInset` to `WorkspaceListTable`.
  - In `WorkspaceListTableCoordinator`, set `contentInset.top` and `verticalScrollIndicatorInsets.top`, and re-pin the resting offset only when idle (not during drag/deceleration/refresh).
  - Added tests to verify inset application, refresh control installation, and preserving non-top content offset on inset changes.

<sup>Written for commit 960b578b9ca6057aeb59fd3736f8e8bc47ce4538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace list underlap behavior on iOS 26 and later.
  - Preserved correct top spacing for rows, pull-to-refresh controls, and scroll indicators.
  - Maintained scroll position when workspace list spacing updates.
  - Improved handling of pull-to-refresh controls during workspace list updates.

- **Tests**
  - Added coverage for safe-area spacing, refresh controls, inset updates, and scroll positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->