### PR TITLE
Fix SSH retry script compiler timeout

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHPTYAttachRetryScriptBuilder.swift
@@ -34,7 +34,7 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
         let noProgressStatus = SSHPTYAttachExitCode.bridgeClosedWithoutProgress.rawValue
         let sessionRunningStatus = SSHPTYAttachExitCode.bridgeClosedSessionRunning.rawValue
         let transientStatus = SSHPTYAttachExitCode.retryableTransient.rawValue
-        return [
+        var lines = [
             "cmux_ssh_attach_reconnect_limit=\"${CMUX_SSH_RECONNECT_LIMIT:-}\"",
             "case \"$cmux_ssh_attach_reconnect_limit\" in '') cmux_ssh_attach_reconnect_limit='∞'; cmux_ssh_attach_reconnect_unbounded=1 ;; *[!0-9]*) cmux_ssh_attach_reconnect_limit=20; cmux_ssh_attach_reconnect_unbounded=0 ;; *) cmux_ssh_attach_reconnect_unbounded=0 ;; esac",
             "cmux_ssh_attach_reconnect_delay=\"${CMUX_SSH_RECONNECT_DELAY_SECONDS:-2}\"",
@@ -43,14 +43,18 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
             "case \"$cmux_ssh_attach_reconnect_max_delay\" in ''|*[!0-9]*|0*) cmux_ssh_attach_reconnect_max_delay=30 ;; esac",
             "if [ \"$cmux_ssh_attach_reconnect_delay\" -gt \"$cmux_ssh_attach_reconnect_max_delay\" ]; then cmux_ssh_attach_reconnect_delay=\"$cmux_ssh_attach_reconnect_max_delay\"; fi",
             "cmux_ssh_attach_reconnect_initial_delay=\"$cmux_ssh_attach_reconnect_delay\"",
-        ] + noProgressPolicy.configurationLines + [
+        ]
+        lines.append(contentsOf: noProgressPolicy.configurationLines)
+        lines.append(contentsOf: [
             "cmux_ssh_attach_no_progress_retry=0",
             "cmux_ssh_attach_retry=0",
             "cmux_ssh_attach_auth_retry=0",
             "cmux_ssh_attach_auth_retry_limit=\(authPolicy.maximumConsecutiveTransientFailures)",
             "cmux_ssh_attach_reauth_required=\(initialReauthentication)",
             "cmux_ssh_attach_auth_launching=0",
-        ] + backoffBuilder.stateInitializationLines + [
+        ])
+        lines.append(contentsOf: backoffBuilder.stateInitializationLines)
+        lines.append(contentsOf: [
             "while :; do",
             "  if [ \"$cmux_ssh_attach_reauth_required\" -eq 1 ]; then",
             "    cmux_ssh_attach_auth_launching=1",
@@ -76,9 +80,12 @@ public struct SSHPTYAttachRetryScriptBuilder: Sendable {
             "  if [ \"$cmux_ssh_attach_reconnect_unbounded\" -eq 0 ] && [ \"$cmux_ssh_attach_retry\" -ge \"$cmux_ssh_attach_reconnect_limit\" ]; then exit \"$cmux_ssh_attach_status\"; fi",
             "  cmux_ssh_attach_retry=$((cmux_ssh_attach_retry + 1))",
             "  if [ -t 2 ]; then printf '\\n\\033[33m%s\\033[0m\\n' \"$(printf \(reattachingFormat) \"$cmux_ssh_attach_retry\" \"$cmux_ssh_attach_reconnect_limit\")\" >&2 || true; fi",
-        ] + backoffBuilder.waitLines + [
+        ])
+        lines.append(contentsOf: backoffBuilder.waitLines)
+        lines.append(contentsOf: [
             "  if [ \"$cmux_ssh_attach_reconnect_delay\" -lt \"$cmux_ssh_attach_reconnect_max_delay\" ]; then cmux_ssh_attach_reconnect_delay=$((cmux_ssh_attach_reconnect_delay * 2)); if [ \"$cmux_ssh_attach_reconnect_delay\" -gt \"$cmux_ssh_attach_reconnect_max_delay\" ]; then cmux_ssh_attach_reconnect_delay=\"$cmux_ssh_attach_reconnect_max_delay\"; fi; fi",
             "done",
-        ]
+        ])
+        return lines
     }
 }


### PR DESCRIPTION
## Summary

- replace the chained Swift array `+` expression with incremental `append(contentsOf:)` calls
- preserve every generated SSH retry script line and its ordering
- unblock the macOS build and test jobs exposed by #9209

## Root cause

PR #9083 introduced one large expression combining array literals and computed arrays through multiple overloaded `+` operations. Swift cannot type-check that expression in reasonable time, so every macOS compilation lane fails in `SSHPTYAttachRetryScriptBuilder.swift`. Automatic full CI was paused, and the workflow guard outage hid the macOS lanes, so the merge showed only bots and scanners instead of a compile failure.

## Verification

- the changed file is byte-identical to the compiler fix already exercised in commit `74ab86da6c8e`
- existing `SSHPTYAttachRetryScriptBuilderTests` cover generated content and ordering
- the CI integration ref combines this commit with #9209 so macOS jobs can execute
- no local Xcode build or XCUITest was run
- no Swift budget TSV changes

Depends on #9209 to restore the macOS CI fan-out on main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787987731&installation_model_id=21920&pr_number=9213&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9213&signature=bd22bd26bf4789946b03f2de7b40c6c3c97971bcbaf031d7d6a7868e8f358df0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Swift type-check timeout in the SSH retry script builder by switching from chained array concatenations to incremental appends. This preserves all script lines and ordering and unblocks macOS builds.

- **Bug Fixes**
  - Use `append(contentsOf:)` instead of chained `+` to avoid the compiler timeout in SSHPTYAttachRetryScriptBuilder.swift.
  - Depends on #9209 to restore macOS CI fan-out.

<sup>Written for commit 73364bed563076cdb20beb36118d0a573066e832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal script construction while preserving the generated retry behavior and output.
  * No user-visible functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->