### PR TITLE
Fix remote PTY lifecycle test fake

### DIFF
--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Combine
 import XCTest
+import os
 import CmuxControlSocket
 import CmuxCore
 import CmuxRemoteDaemon
@@ -24,8 +25,57 @@ private typealias RemoteProcessScript = (_ executable: String, _ arguments: [Str
 private final class ManualRemotePTYLifecycleCommitLease:
     ControlRemotePTYLifecycleCommitLease
 {
-    var isCurrent = true
+    private enum DeliveryState {
+        case available
+        case inFlight
+        case completed
+    }
+
+    private struct State {
+        var isCurrent = true
+        var delivery = DeliveryState.available
+    }
+
+    private nonisolated let state = OSAllocatedUnfairLock(initialState: State())
+
+    var isCurrent: Bool {
+        get {
+            state.withLock { $0.isCurrent }
+        }
+        set {
+            state.withLock {
+                $0.isCurrent = newValue
+                if !newValue {
+                    $0.delivery = .available
+                }
+            }
+        }
+    }
     var afterOperation: (@MainActor () -> Void)?
+
+    nonisolated func beginReadinessDelivery()
+        -> ControlRemotePTYReadinessDeliveryAdmission
+    {
+        state.withLock {
+            guard $0.isCurrent else { return .stale }
+            switch $0.delivery {
+            case .available:
+                $0.delivery = .inFlight
+                return .acquired
+            case .inFlight:
+                return .inFlight
+            case .completed:
+                return .alreadyCompleted
+            }
+        }
+    }
+
+    nonisolated func finishReadinessDelivery(succeeded: Bool) {
+        state.withLock {
+            guard $0.delivery == .inFlight else { return }
+            $0.delivery = succeeded ? .completed : .available
+        }
+    }
 
     func commitIfCurrent(
         _ operation: @MainActor @Sendable () -> Bool


### PR DESCRIPTION
## Summary

- update `ManualRemotePTYLifecycleCommitLease` for the readiness-delivery protocol requirements added by #9085
- model available, in-flight, completed, and stale delivery states in the app-host test fake
- restore compilation of the `cmuxTests` target and its four CI shards

## Root cause

PR #9085 extended `ControlRemotePTYLifecycleCommitLease` with `beginReadinessDelivery()` and `finishReadinessDelivery(succeeded:)`, but the fake in `WorkspaceRemoteConnectionTests.swift` was not updated. Full CI was hidden by the workflow guard outage, so the protocol-conformance error was not visible before merge.

## Lock justification

The protocol methods are synchronous and nonisolated, and CI compiles the fake as `Sendable`. `OSAllocatedUnfairLock` protects only the short compare-and-set delivery state, matching the package test fake and the synchronous lock carve-out in the architecture policy.

## Verification

- exact correction already authored and compiled in commit `6d73d4b5858b23226750f1dada44a97ca9a395bd`
- one test-only Swift file changes
- no runtime app behavior or Swift budget TSV changes
- final `main` CI will be dispatched after merge

Follow-up for the compile failure exposed by #9209.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787988674&installation_model_id=21920&pr_number=9214&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9214&signature=bf80143460f687b1b1394919856b77259d84deb6726f4665d85578cf9d0d6d4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the remote PTY lifecycle test fake to implement the readiness-delivery protocol, restoring `cmuxTests` compilation and CI shards. Ensures delivery state transitions are thread-safe and align with the new API.

- **Bug Fixes**
  - Added `beginReadinessDelivery()` and `finishReadinessDelivery(succeeded:)` to `ManualRemotePTYLifecycleCommitLease` per `ControlRemotePTYLifecycleCommitLease`.
  - Modeled delivery states (available, in-flight, completed) and reset on invalidation; protected with `OSAllocatedUnfairLock`.
  - Test-only change in `WorkspaceRemoteConnectionTests.swift`; no runtime impact.

<sup>Written for commit c6fc556b2f5cb0dbf7666c7e1be6998698480249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for remote workspace connection lifecycle behavior.
  * Added validation for readiness delivery sequencing, stale connection handling, and concurrent state transitions.
  * Strengthened test reliability around connection lease updates and post-operation callbacks.

* **User Impact**
  * No user-facing feature or interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->