### PR TITLE
Fix detached transfer test fixture

### DIFF
--- a/cmuxTests/AppDelegateEqualizeSplitsShortcutTests.swift
+++ b/cmuxTests/AppDelegateEqualizeSplitsShortcutTests.swift
@@ -7892,6 +7892,7 @@ final class AppDelegateEqualizeSplitsShortcutTests {
             shellActivityState: nil,
             restoredResumeSessionWorkingDirectory: nil,
             resumeBinding: nil,
+            managedAgentResumeBinding: nil,
             agentRuntime: nil,
             isRemoteTerminal: false,
             remoteRelayPort: nil,


### PR DESCRIPTION
## Summary

- pass the new `managedAgentResumeBinding` argument in the dormant detached-transfer test fixture
- restore compilation of `AppDelegateEqualizeSplitsShortcutTests.swift`

## Root cause

PR #9091 added `managedAgentResumeBinding` to `Workspace.DetachedSurfaceTransfer`, but one test-only initializer call was not updated. Full CI was hidden by the workflow guard outage, so the missing argument was not visible before merge.

## Verification

- exact one-line correction already authored in commit `dc948fba79a67bfb719d6d4a12a0809e086ce61b`
- one test-only Swift file changes
- no runtime behavior or Swift budget TSV changes
- final `main` CI will be dispatched after merge

Follow-up for the compile failures exposed by #9209.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787989495&installation_model_id=21920&pr_number=9216&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9216&signature=4f6f2ab4181ce1fccdd583332bec9636bfb13725d9bd00545812ed62537b2344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix detached transfer test fixture by passing the new `managedAgentResumeBinding` argument. Restores compilation for AppDelegateEqualizeSplitsShortcutTests.swift.

- **Bug Fixes**
  - Add `managedAgentResumeBinding: nil` to the test-only `DetachedSurfaceTransfer` initializer to match current API.
  - Test-only change; no runtime behavior or performance impact.

<sup>Written for commit 771b92beff8a486119f961ca633fc00cdcbb388a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal transfer handling to remain compatible with updated transfer requirements.
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->