### PR TITLE
fix: detect app-host tests from embedded bundle

### DIFF
--- a/Sources/App/MacSentryStartupPolicy.swift
+++ b/Sources/App/MacSentryStartupPolicy.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct MacSentryStartupPolicy: Sendable {
     let telemetryEnabled: Bool
     let isRunningUnderXCTest: Bool
@@ -36,6 +38,17 @@ struct MacSentryStartupPolicy: Sendable {
         if environment["XCInjectBundleInto"] != nil { return true }
         if environment["DYLD_INSERT_LIBRARIES"]?.contains("libXCTest") == true { return true }
         if environment.keys.contains(where: { $0.hasPrefix("CMUX_UI_TEST_") }) { return true }
+        if hasEmbeddedXCTestBundle() { return true }
         return false
+    }
+
+    private static func hasEmbeddedXCTestBundle() -> Bool {
+        guard
+            let plugInsPath = Bundle.main.builtInPlugInsPath,
+            let plugInNames = try? FileManager.default.contentsOfDirectory(atPath: plugInsPath)
+        else {
+            return false
+        }
+        return plugInNames.contains { $0.hasSuffix(".xctest") }
     }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -529,9 +529,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private let cmuxThemePreviewReloadScheduler = MainActorDeferredActionScheduler()
 
     private func isRunningUnderXCTest(_ env: [String: String]) -> Bool {
-        // On some macOS/Xcode setups, the app-under-test process doesn't get
-        // `XCTestConfigurationFilePath`. Use a broader set of signals so UI tests
-        // can reliably skip heavyweight startup work and bring up a window.
+        // App-host tests embed an .xctest bundle even when Xcode omits its test
+        // environment keys. Keep those keys as compatibility signals for UI tests
+        // and other launch paths.
         MacSentryStartupPolicy.isRunningUnderXCTest(environment: env)
     }
 

--- a/cmuxTests/SentryEventScrubberTests.swift
+++ b/cmuxTests/SentryEventScrubberTests.swift
@@ -244,6 +244,15 @@ import Testing
         )
     }
 
+    @Test func embeddedAppHostTestBundlePreventsSentryStartup() {
+        #expect(
+            MacSentryStartupPolicy(
+                environment: [:],
+                telemetryEnabled: true
+            ).shouldStart == false
+        )
+    }
+
     @Test func explicitTestTelemetryOptInOverridesUITestMarker() {
         #expect(
             MacSentryStartupPolicy(


### PR DESCRIPTION
## Summary

- detect app-host test launches from the embedded `.xctest` bundle
- keep existing Xcode environment keys as compatibility fallbacks
- add separate failing-test and fix commits for the regression

## Why

Restoring the workflow guard exposed intermittent `SIGSEGV` crashes on the `sentry-init` thread before XCTest could connect. Xcode 26.3 does not reliably pass its XCTest environment keys or TestAction environment variables to the app-host process. The app-host test artifact is deterministic: the built app contains `cmuxTests.xctest` under `Contents/PlugIns` before launch. Shipping app bundles do not contain an `.xctest` plug-in.

This unblocks the app-host shards and the nightly build. During the #9208 outage all macOS CI jobs were skipped, so PRs merged in that window were never built or tested and need to be re-checked.

## Tests

- behavior regression in `MacSentryStartupPolicyTests`
- `bash tests/test_ghostty_zig_version_sync.sh`
- full `ci.yml` workflow dispatch on the final PR head

Follow-up to #9208.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of app-host test runs, including tests embedded in `.xctest` bundles.
  - Prevented telemetry startup during embedded test execution, even when standard test environment indicators are unavailable.

- **Tests**
  - Added coverage verifying that embedded app-host tests do not start telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->