### PR TITLE
Remove TUI install path notes

### DIFF
--- a/web/app/[locale]/(landing)/docs/tui/page.tsx
+++ b/web/app/[locale]/(landing)/docs/tui/page.tsx
@@ -65,8 +65,6 @@ export default async function TuiDocsPage() {
         unixLabel={t("installTabs.unix")}
         windowsLabel={t("installTabs.windows")}
         tabListLabel={t("installTabs.label")}
-        unixNote={t("installTabs.unixNote")}
-        windowsNote={t("installTabs.windowsNote")}
         viewScriptLabel={t("installTabs.viewScript")}
         copyLabel={t("installTabs.copy")}
         copiedLabel={t("installTabs.copied")}

--- a/web/app/[locale]/(landing)/tui/install-tabs.tsx
+++ b/web/app/[locale]/(landing)/tui/install-tabs.tsx
@@ -41,8 +41,6 @@ export function TuiInstallTabs({
   unixLabel,
   windowsLabel,
   tabListLabel,
-  unixNote,
-  windowsNote,
   viewScriptLabel,
   copyLabel,
   copiedLabel,
@@ -50,8 +48,6 @@ export function TuiInstallTabs({
   unixLabel: string;
   windowsLabel: string;
   tabListLabel: string;
-  unixNote: string;
-  windowsNote: string;
   viewScriptLabel: string;
   copyLabel: string;
   copiedLabel: string;
@@ -175,9 +171,6 @@ export function TuiInstallTabs({
             )}
           </button>
         </div>
-        <p className="mt-2 text-xs leading-relaxed text-muted">
-          {platform === "unix" ? unixNote : windowsNote}
-        </p>
       </div>
     </div>
   );

--- a/web/app/[locale]/(landing)/tui/page.tsx
+++ b/web/app/[locale]/(landing)/tui/page.tsx
@@ -55,8 +55,6 @@ export default async function TuiPage() {
               unixLabel={t("installTabs.unix")}
               windowsLabel={t("installTabs.windows")}
               tabListLabel={t("installTabs.label")}
-              unixNote={t("installTabs.unixNote")}
-              windowsNote={t("installTabs.windowsNote")}
               viewScriptLabel={t("installTabs.viewScript")}
               copyLabel={t("installTabs.copy")}
               copiedLabel={t("installTabs.copied")}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -4889,8 +4889,6 @@
         "label": "Operating system",
         "unix": "macOS & Linux",
         "windows": "Windows",
-        "unixNote": "Installs to ~/.cmux/bin and updates your shell PATH.",
-        "windowsNote": "Installs the x64 build to %USERPROFILE%\\.cmux\\bin and updates your user PATH. Windows on Arm uses x64 emulation.",
         "viewScript": "View install script",
         "copy": "Copy install command",
         "copied": "Copied"
@@ -4912,8 +4910,6 @@
         "label": "Operating system",
         "unix": "macOS & Linux",
         "windows": "Windows",
-        "unixNote": "Installs to ~/.cmux/bin and updates your shell PATH.",
-        "windowsNote": "Installs the x64 build to %USERPROFILE%\\.cmux\\bin and updates your user PATH. Windows on Arm uses x64 emulation.",
         "viewScript": "View install script",
         "copy": "Copy install command",
         "copied": "Copied"

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -4799,8 +4799,6 @@
         "label": "オペレーティングシステム",
         "unix": "macOS & Linux",
         "windows": "Windows",
-        "unixNote": "~/.cmux/bin にインストールし、シェルの PATH を更新します。",
-        "windowsNote": "x64 ビルドを %USERPROFILE%\\.cmux\\bin にインストールし、ユーザー PATH を更新します。Windows on Arm では x64 エミュレーションを使います。",
         "viewScript": "インストールスクリプトを見る",
         "copy": "インストールコマンドをコピー",
         "copied": "コピーしました"
@@ -4822,8 +4820,6 @@
         "label": "オペレーティングシステム",
         "unix": "macOS & Linux",
         "windows": "Windows",
-        "unixNote": "~/.cmux/bin にインストールし、シェルの PATH を更新します。",
-        "windowsNote": "x64 ビルドを %USERPROFILE%\\.cmux\\bin にインストールし、ユーザー PATH を更新します。Windows on Arm では x64 エミュレーションを使います。",
         "viewScript": "インストールスクリプトを見る",
         "copy": "インストールコマンドをコピー",
         "copied": "コピーしました"


### PR DESCRIPTION
Removes the platform-specific install path notes below the compact installer on both the TUI landing page and documentation page. Removes the unused English and Japanese message keys.

Checks:
- `bun run typecheck`
- focused ESLint
- focused Bun tests
- `SKIP_ENV_VALIDATION=1 bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787995703&installation_model_id=21920&pr_number=9219&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9219&signature=726ae67df82c9dc9c11b8c44980d44cb722090b629dd0b549fbc9b79e425b0fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the platform-specific install path notes from the TUI installer on the landing and docs pages to simplify the UI. Also removed unused i18n keys for these notes.

- **Refactors**
  - `TuiInstallTabs`: removed `unixNote`/`windowsNote` props and the note paragraph.
  - Deleted `installTabs.unixNote`/`installTabs.windowsNote` from `en.json` and `ja.json`; updated pages to stop passing them.

<sup>Written for commit 4d484b38738be8422ba70c50e70d17d732b13fa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TUI installation tabs with clearer operating system labels for macOS/Linux and Windows.
  * Added localized controls to view installation scripts and copy commands, including copied-state feedback.

* **Bug Fixes**
  * Removed redundant platform-specific notes from the installation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->