### PR TITLE
Fix dark sidebar description contrast and add active rail

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -14942,7 +14942,7 @@ struct TabItemView: View, Equatable {
     private func showsLeadingRail(
         for workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
     ) -> Bool {
-        explicitRailColor(for: workspaceSnapshot) != nil
+        resolvedRailColor(for: workspaceSnapshot) != nil
     }
 
     private var activeBorderLineWidth: CGFloat {
@@ -15686,14 +15686,15 @@ struct TabItemView: View, Equatable {
     private func railColor(
         for workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
     ) -> Color {
-        explicitRailColor(for: workspaceSnapshot) ?? .clear
+        resolvedRailColor(for: workspaceSnapshot) ?? .clear
     }
 
-    private func explicitRailColor(
+    private func resolvedRailColor(
         for workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
     ) -> Color? {
-        guard let railColor = sidebarWorkspaceRowExplicitRailNSColor(
+        guard let railColor = sidebarWorkspaceRowRailNSColor(
             activeTabIndicatorStyle: activeTabIndicatorStyle,
+            isActive: isActive,
             customColorHex: workspaceSnapshot.customColorHex,
             colorScheme: colorScheme
         ) else {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -367,8 +367,9 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         } else {
             backgroundView.layer?.borderWidth = 0
         }
-        let railColor = sidebarWorkspaceRowExplicitRailNSColor(
+        let railColor = sidebarWorkspaceRowRailNSColor(
             activeTabIndicatorStyle: settings.activeTabIndicatorStyle,
+            isActive: model.isActive,
             customColorHex: snapshot.customColorHex,
             colorScheme: palette.colorScheme
         )

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -472,16 +472,17 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         descriptionView.isHidden = description == nil
         if let description {
             let display = description.sidebarBoundedDisplayString(maxDisplayedLines: 12, maxDisplayedCharacters: 4096)
+            let descriptionColor = palette.descriptionTextColor
             if let rendered = SidebarMarkdownRenderer(markdown: display).workspaceDescription {
                 descriptionView.attributedStringValue = SidebarRowPalette.attributed(
                     rendered,
                     font: .systemFont(ofSize: model.scaled(10.5)),
-                    color: model.isActive ? palette.secondary(0.84) : NSColor.secondaryLabelColor.withAlphaComponent(0.95)
+                    color: descriptionColor
                 )
             } else {
                 descriptionView.stringValue = display
                 descriptionView.font = .systemFont(ofSize: model.scaled(10.5))
-                descriptionView.textColor = model.isActive ? palette.secondary(0.84) : NSColor.secondaryLabelColor.withAlphaComponent(0.95)
+                descriptionView.textColor = descriptionColor
             }
         }
 

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -31,6 +31,28 @@ struct SidebarRowPalette {
         model.isActive ? selectedForeground(opacity) : .secondaryLabelColor
     }
 
+    /// `withAlphaComponent` resolves a semantic AppKit color in the *ambient*
+    /// appearance. A recycled dark sidebar row can otherwise cache black text
+    /// when its configuration runs under Aqua. Resolve the semantic color in
+    /// the model's intended scheme first, then apply the row-specific alpha.
+    func resolvedSemanticColor(_ color: NSColor, opacity: CGFloat) -> NSColor {
+        let appearanceName: NSAppearance.Name = colorScheme == .dark ? .darkAqua : .aqua
+        guard let appearance = NSAppearance(named: appearanceName) else {
+            return color.withAlphaComponent(opacity)
+        }
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB) ?? color
+        }
+        return resolved.withAlphaComponent(opacity)
+    }
+
+    var descriptionTextColor: NSColor {
+        model.isActive
+            ? selectedForeground(0.84)
+            : resolvedSemanticColor(.secondaryLabelColor, opacity: 0.95)
+    }
+
     static func attributed(_ source: AttributedString, font: NSFont, color: NSColor) -> NSAttributedString {
         let mutable = NSMutableAttributedString(attributedString: NSAttributedString(source))
         let fullRange = NSRange(location: 0, length: mutable.length)

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -272,20 +272,23 @@ struct SidebarWorkspaceRowBackgroundStyle: Equatable, Hashable {
     static let clear = Self(color: nil, opacity: 0)
 }
 
-func sidebarWorkspaceRowExplicitRailNSColor(
+func sidebarWorkspaceRowRailNSColor(
     activeTabIndicatorStyle: WorkspaceIndicatorStyle,
+    isActive: Bool,
     customColorHex: String?,
     colorScheme: ColorScheme
 ) -> NSColor? {
-    guard activeTabIndicatorStyle == .leftRail,
-          let customColorHex else {
+    guard activeTabIndicatorStyle == .leftRail else {
         return nil
     }
-    return WorkspaceTabColorSettings.displayNSColor(
-        hex: customColorHex,
-        colorScheme: colorScheme,
-        forceBright: true
-    )
+    if let customColorHex {
+        return WorkspaceTabColorSettings.displayNSColor(
+            hex: customColorHex,
+            colorScheme: colorScheme,
+            forceBright: true
+        )
+    }
+    return isActive ? cmuxAccentNSColor(for: colorScheme) : nil
 }
 
 func sidebarWorkspaceRowBackgroundStyle(

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -10,6 +10,7 @@ import Testing
 struct SidebarAppKitRowCellTests {
     private static func makeSnapshot(
         title: String = "Workspace",
+        customDescription: String? = nil,
         metadataEntries: [SidebarStatusEntry] = []
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
@@ -18,7 +19,7 @@ struct SidebarAppKitRowCellTests {
                 showsAgentActivity: false
             ),
             title: title,
-            customDescription: nil,
+            customDescription: customDescription,
             isPinned: false,
             customColorHex: nil,
             remoteWorkspaceSidebarText: nil,
@@ -56,15 +57,20 @@ struct SidebarAppKitRowCellTests {
         isActive: Bool = false,
         canClose: Bool = true,
         settings: SidebarTabItemSettingsSnapshot? = nil,
+        customDescription: String? = nil,
         metadataEntries: [SidebarStatusEntry] = [],
-        shortcutHintText: String? = nil
+        shortcutHintText: String? = nil,
+        colorSchemeIsDark: Bool = true
     ) -> SidebarWorkspaceRowModel {
         let resolvedSettings = settings
             ?? SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!)
         return SidebarWorkspaceRowModel(
             workspaceId: workspaceId,
             index: 0,
-            snapshot: makeSnapshot(metadataEntries: metadataEntries),
+            snapshot: makeSnapshot(
+                customDescription: customDescription,
+                metadataEntries: metadataEntries
+            ),
             settings: resolvedSettings,
             isActive: isActive,
             isMultiSelected: false,
@@ -81,7 +87,7 @@ struct SidebarAppKitRowCellTests {
             isFirstRow: true,
             shortcutHintText: shortcutHintText,
             showsShortcutHints: shortcutHintText != nil,
-            colorSchemeIsDark: true,
+            colorSchemeIsDark: colorSchemeIsDark,
             globalFontMagnificationPercent: 100,
             isChecklistExpanded: false,
             checklistAddFieldActivationToken: 0,
@@ -287,6 +293,54 @@ struct SidebarAppKitRowCellTests {
             y: textView.textContainerOrigin.y + glyphBounds.midY
         )
         return textView.convert(localPoint, to: textView.superview)
+    }
+
+    @Test
+    func reusedDarkWorkspaceDescriptionKeepsAnExplicitLightForeground() throws {
+        let description = "1. First detail\n2. Second detail"
+        let workspaceId = UUID()
+        let active = Self.makeModel(
+            workspaceId: workspaceId,
+            isActive: true,
+            customDescription: description,
+            colorSchemeIsDark: true
+        )
+        let inactive = Self.makeModel(
+            workspaceId: workspaceId,
+            isActive: false,
+            customDescription: description,
+            colorSchemeIsDark: true
+        )
+        let cell = Self.configuredCell(model: active)
+        let lightAppearance = try #require(NSAppearance(named: .aqua))
+
+        lightAppearance.performAsCurrentDrawingAppearance {
+            cell.configure(
+                model: inactive,
+                actions: Self.makeActions(model: inactive),
+                isPointerHovering: false,
+                contextMenuDidOpen: {},
+                contextMenuDidClose: {}
+            )
+        }
+
+        let descriptionView = try #require(
+            Self.descendants(of: cell)
+                .compactMap { $0 as? SidebarRowTextView }
+                .first { $0.attributedStringValue.string == description }
+        )
+        let foreground = try #require(
+            descriptionView.attributedStringValue.attribute(
+                .foregroundColor,
+                at: 0,
+                effectiveRange: nil
+            ) as? NSColor
+        )
+        let resolvedForeground = try #require(foreground.usingColorSpace(.sRGB))
+
+        #expect(resolvedForeground.redComponent > 0.8)
+        #expect(resolvedForeground.greenComponent > 0.8)
+        #expect(resolvedForeground.blueComponent > 0.8)
     }
 
     @Test(arguments: zip(["codex", "claude_code"], ["Running", "Needs input"]))

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -278,6 +278,51 @@ final class SidebarWidthPolicyTests: XCTestCase {
 }
 
 final class SidebarWorkspaceSelectionColorTests: XCTestCase {
+    func testActiveUncoloredLeftRailUsesAccentButInactiveAndSolidFillDoNot() {
+        let activeRail = sidebarWorkspaceRowRailNSColor(
+            activeTabIndicatorStyle: .leftRail,
+            isActive: true,
+            customColorHex: nil,
+            colorScheme: .dark
+        )
+        assertColor(activeRail, equals: cmuxAccentNSColor(for: .dark))
+
+        let inactiveRail = sidebarWorkspaceRowRailNSColor(
+            activeTabIndicatorStyle: .leftRail,
+            isActive: false,
+            customColorHex: nil,
+            colorScheme: .dark
+        )
+        XCTAssertNil(inactiveRail)
+
+        let solidFillRail = sidebarWorkspaceRowRailNSColor(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: true,
+            customColorHex: "#C0392B",
+            colorScheme: .dark
+        )
+        XCTAssertNil(solidFillRail)
+    }
+
+    func testLeftRailPreservesExplicitWorkspaceColor() throws {
+        let customColor = "#C0392B"
+        let rail = sidebarWorkspaceRowRailNSColor(
+            activeTabIndicatorStyle: .leftRail,
+            isActive: false,
+            customColorHex: customColor,
+            colorScheme: .light
+        )
+        let expected = try XCTUnwrap(
+            WorkspaceTabColorSettings.displayNSColor(
+                hex: customColor,
+                colorScheme: .light,
+                forceBright: true
+            )
+        )
+
+        assertColor(rail, equals: expected)
+    }
+
     func testSelectedColoredWorkspaceUsesStandardSelectionBackgroundInLightAndDark() {
         for colorScheme in [ColorScheme.light, .dark] {
             let coloredSelected = sidebarWorkspaceRowBackgroundStyle(

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -218,8 +218,9 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
 
         manager.setTabColor(tabId: workspace.id, color: "#C0392B")
 
-        let railColor = sidebarWorkspaceRowExplicitRailNSColor(
+        let railColor = sidebarWorkspaceRowRailNSColor(
             activeTabIndicatorStyle: .leftRail,
+            isActive: false,
             customColorHex: workspace.customColor,
             colorScheme: .light
         )


### PR DESCRIPTION
## Summary
- Resolve inactive AppKit sidebar-description colors in the model's intended appearance before applying alpha, preventing black text in dark rows after active/inactive reuse.
- Add a blue accent rail for an active, uncolored `leftRail` workspace while preserving custom workspace rails and leaving `solidFill` unchanged.
- Add regressions for the dark-description reuse path and rail-color policy.

## Verification
- `CMUX_SKIP_ZIG_BUILD=1 ... -only-testing:cmuxTests/SidebarAppKitRowCellTests/reusedDarkWorkspaceDescriptionKeepsAnExplicitLightForeground()`
- `CMUX_SKIP_ZIG_BUILD=1 ... -only-testing:cmuxTests/SidebarWorkspaceSelectionColorTests`
- `CMUX_SKIP_ZIG_BUILD=1 ... -only-testing:cmuxTests/SidebarSelectedWorkspaceColorTests/testLeftRailResolvesExplicitRailColorForCustomColoredWorkspaceRow`
- `python3 scripts/check-sidebar-lazy-layout.py`
- `python3 scripts/lint-feature-flags.py`
- `./scripts/lint-pbxproj-test-wiring.sh`
- Tagged local debug dogfood: dark graphite sidebar, 100% UI scale, active/inactive Markdown descriptions, and selection transition.

No user-facing strings were added or changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788002523&installation_model_id=21920&pr_number=9223&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9223&signature=d454a4cc0e0cc27cc73d779b53cff7bb2be32db61d6ae7652fac7d7d4ca5b1da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark-mode sidebar description contrast on reused AppKit cells and adds an accent left rail for active workspaces without a custom color. Custom workspace rails and solid-fill behavior are unchanged.

- **Bug Fixes**
  - Resolve semantic colors in the intended appearance before applying alpha to keep descriptions readable in dark rows after reuse.
  - Use a single descriptionTextColor for both markdown and plain text in the sidebar description.

- **New Features**
  - Show an accent left rail when the active indicator style is leftRail and the workspace has no custom color; inactive rows do not show a rail.
  - Rail visibility now checks a resolved rail color, not only explicit custom colors.

<sup>Written for commit 6f39beef723af29d54400d6381f4f911be40b243. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Active workspace rows with a left-rail indicator now use the accent color when no custom color is configured.
  - Custom rail colors continue to be displayed consistently.

- **Bug Fixes**
  - Improved rail visibility and coloring across active and inactive workspace states.
  - Workspace descriptions now maintain consistent contrast across light and dark appearances, including when rows are reused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->