### PR TITLE
Fix silently dead panes when restore suppresses agent auto-resume (#8446 follow-up)

### DIFF
--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -942,6 +942,30 @@ struct RestorableAgentSessionIndex: Sendable {
         entriesByPanel[PanelKey(workspaceId: workspaceId, panelId: panelId)] ?? entriesByPanelId[panelId]
     }
 
+    /// True when any panel's entry reports a live process for `(kind, sessionId)`,
+    /// regardless of which panel that process is bound to. The panel-scoped
+    /// `entry(workspaceId:panelId:)` cannot see a duplicate panel's live
+    /// process for the same session (#8446).
+    func hasLiveProcessForSession(kind: RestorableAgentKind, sessionId: String) -> Bool {
+        entriesByPanel.values.contains {
+            !$0.processIDs.isEmpty && $0.snapshot.kind == kind && $0.snapshot.sessionId == sessionId
+        } || entriesByPanelId.values.contains {
+            !$0.processIDs.isEmpty && $0.snapshot.kind == kind && $0.snapshot.sessionId == sessionId
+        }
+    }
+
+    /// True when the hook store still holds a restorable record for
+    /// `(kind, sessionId)`. A deliberate exit delivers SessionEnd and marks
+    /// the record non-restorable, so it does not count; a session whose
+    /// process died with a crashed cmux keeps its restorable record.
+    func hasRestorableEntryForSession(kind: RestorableAgentKind, sessionId: String) -> Bool {
+        entriesByPanel.values.contains {
+            $0.snapshot.kind == kind && $0.snapshot.sessionId == sessionId
+        } || entriesByPanelId.values.contains {
+            $0.snapshot.kind == kind && $0.snapshot.sessionId == sessionId
+        }
+    }
+
     func snapshot(workspaceId: UUID, panelId: UUID) -> SessionRestorableAgentSnapshot? {
         entry(workspaceId: workspaceId, panelId: panelId)?.snapshot
     }

--- a/Sources/Workspace+AgentLifecycle.swift
+++ b/Sources/Workspace+AgentLifecycle.swift
@@ -1,5 +1,15 @@
 import CmuxWorkspaces
 import Foundation
+import os
+
+/// Release-visible restore/wake decision log. The pre-existing `cmuxDebugLog`
+/// calls compile out of Release builds, which made field diagnosis of
+/// never-resuming panels impossible; keep these decision points visible via
+/// the unified log (`log show --predicate 'subsystem == "com.cmuxterm.app"'`).
+nonisolated let cmuxAgentRestoreLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "AgentRestore"
+)
 
 extension Workspace {
     func allowsAgentContinuation(forPanelId panelId: UUID) -> Bool {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1697,6 +1697,35 @@ extension Workspace {
                         lastActivityAt: Date(timeIntervalSince1970: restoredHibernation.lastActivityAt),
                         hibernatedAt: Date(timeIntervalSince1970: restoredHibernation.hibernatedAt)
                     )
+                } else if autoResumeAgentSessions,
+                          restoredHibernation == nil,
+                          !restoredAgentWillRunStartupCommand,
+                          !restoredAgentWillRunStartupInput,
+                          restoredBindingLaunch == nil,
+                          restorableAgent.resumeCommand != nil,
+                          (SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
+                              ?? RestorableAgentSessionIndex.load())
+                              .hasRestorableEntryForSession(
+                                  kind: restorableAgent.kind,
+                                  sessionId: restorableAgent.sessionId
+                              ) {
+                    // Auto-resume was suppressed for this panel — a live
+                    // process from a crashed previous launch or a duplicate
+                    // panel's dedup claim (`agentSessionAlreadyActive`), or the
+                    // agent-was-not-running-at-quit gate. Without this branch
+                    // the panel restores as a silent empty shell whose
+                    // suppression is never re-evaluated, so the session can
+                    // never come back on its own (#8446 follow-up). Park it in
+                    // agent hibernation instead: the visible-panel wake path
+                    // retries the resume, and `resumeAgentHibernation` refuses
+                    // to fire while a live process for the session remains.
+                    // Deliberate exits are excluded above: SessionEnd marks the
+                    // hook record non-restorable, so they have no restorable
+                    // entry and keep today's plain-shell restore.
+                    terminalPanel.enterAgentHibernation(
+                        agent: restorableAgent,
+                        lastActivityAt: Date()
+                    )
                 }
             } else {
                 seedSessionRestoredAgentState(
@@ -4846,8 +4875,39 @@ final class Workspace: Identifiable, ObservableObject {
               terminalPanel.isAgentHibernated else {
             return false
         }
+        // Waking types `claude --resume <id>` / `codex resume <id>` into the
+        // pane. If the session still has a live process anywhere — a
+        // crash-orphaned process from a previous launch, or a duplicate panel
+        // referencing the same session — firing another resume would contend
+        // for the same on-disk session data (#8446). Leave the panel
+        // hibernated; a later visible-wake retries once the process is gone.
+        let hibernatedAgent = terminalPanel.agentHibernationState?.agent
+        if let hibernatedAgent {
+            let liveIndex = SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
+                ?? RestorableAgentSessionIndex.load()
+            if liveIndex.hasLiveProcessForSession(
+                kind: hibernatedAgent.kind,
+                sessionId: hibernatedAgent.sessionId
+            ) {
+                return false
+            }
+            guard AgentResumeLaunchGuard.shared.claimResumeLaunch(
+                kind: hibernatedAgent.kind.rawValue,
+                sessionId: hibernatedAgent.sessionId
+            ) else {
+                return false
+            }
+        }
         let preparation = terminalPanel.prepareAgentHibernationResume()
-        guard preparation.didResume else { return false }
+        guard preparation.didResume else {
+            if let hibernatedAgent {
+                AgentResumeLaunchGuard.shared.releaseResumeLaunch(
+                    kind: hibernatedAgent.kind.rawValue,
+                    sessionId: hibernatedAgent.sessionId
+                )
+            }
+            return false
+        }
         if restoredAgentSnapshotsByPanelId[panelId] != nil {
             restoredAgentResumeStatesByPanelId[panelId] = preparation.queuedStartupInput
                 ? .awaitingAutoResumeCommand

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1722,6 +1722,9 @@ extension Workspace {
                     // Deliberate exits are excluded above: SessionEnd marks the
                     // hook record non-restorable, so they have no restorable
                     // entry and keep today's plain-shell restore.
+                    cmuxAgentRestoreLogger.info(
+                        "restore.park panel=\(String(terminalPanel.id.uuidString.prefix(5)), privacy: .public) kind=\(restorableAgent.kind.rawValue, privacy: .public) session=\(String(restorableAgent.sessionId.prefix(8)), privacy: .public)"
+                    )
                     terminalPanel.enterAgentHibernation(
                         agent: restorableAgent,
                         lastActivityAt: Date()
@@ -4889,12 +4892,18 @@ final class Workspace: Identifiable, ObservableObject {
                 kind: hibernatedAgent.kind,
                 sessionId: hibernatedAgent.sessionId
             ) {
+                cmuxAgentRestoreLogger.info(
+                    "wake.blocked.liveProcess panel=\(String(panelId.uuidString.prefix(5)), privacy: .public) session=\(String(hibernatedAgent.sessionId.prefix(8)), privacy: .public)"
+                )
                 return false
             }
             guard AgentResumeLaunchGuard.shared.claimResumeLaunch(
                 kind: hibernatedAgent.kind.rawValue,
                 sessionId: hibernatedAgent.sessionId
             ) else {
+                cmuxAgentRestoreLogger.info(
+                    "wake.blocked.claimHeld panel=\(String(panelId.uuidString.prefix(5)), privacy: .public) session=\(String(hibernatedAgent.sessionId.prefix(8)), privacy: .public)"
+                )
                 return false
             }
         }
@@ -4906,7 +4915,15 @@ final class Workspace: Identifiable, ObservableObject {
                     sessionId: hibernatedAgent.sessionId
                 )
             }
+            cmuxAgentRestoreLogger.error(
+                "wake.prepareFailed panel=\(String(panelId.uuidString.prefix(5)), privacy: .public)"
+            )
             return false
+        }
+        if let hibernatedAgent {
+            cmuxAgentRestoreLogger.info(
+                "wake.fired panel=\(String(panelId.uuidString.prefix(5)), privacy: .public) session=\(String(hibernatedAgent.sessionId.prefix(8)), privacy: .public) queuedInput=\(preparation.queuedStartupInput, privacy: .public)"
+            )
         }
         if restoredAgentSnapshotsByPanelId[panelId] != nil {
             restoredAgentResumeStatesByPanelId[panelId] = preparation.queuedStartupInput


### PR DESCRIPTION
## Problem

When session restore suppresses a panel's agent auto-resume — via the `agentSessionAlreadyActive` gate added in #8446 (a live process from a crashed previous launch, or a duplicate panel losing the dedup claim), or via the agent-was-not-running-at-quit gate — the panel restores as a plain empty shell seeded `.manualResumeAvailable`, which drives no UI, and the suppression is never re-evaluated. `cmuxDebugLog` only fires in DEBUG builds, so release users get zero signal.

The pathological case is a crash loop: force-killing a hung cmux leaves the agent processes (e.g. `claude`) alive as orphans. On relaunch every such panel trips `hasLiveProcess` → suppressed → permanently dead, even after the orphan later exits. Observed in the field over three weeks of daily crash-restarts: restore success varied between 0/14 and 12/13 panels per boot depending on which orphans happened to still be alive at restore time, and dead panels never revived on focus. Full forensic writeup available (hook-store pid records + event-log timing showing each SessionStart firing seconds after first panel view, and suppressed panels never firing at all).

## Fix

- **Park suppressed panels in agent hibernation** instead of a silent empty shell (`Workspace.swift` restore path). The existing visible-panel wake path then retries the resume automatically, and the hibernation chip gives the user a visible affordance. Deliberate exits keep today's plain-shell restore: SessionEnd marks the hook record non-restorable, and parking requires a restorable entry.
- **Gate `resumeAgentHibernation` with a session-wide live-process check** (`hasLiveProcessForSession`) plus the per-launch `AgentResumeLaunchGuard` claim, releasing the claim if preparation fails. A wake can never fire a duplicate resume onto a session that is still running anywhere — including a duplicate panel's process, which the panel-scoped `entry(workspaceId:panelId:)` lookup cannot see.
- New `RestorableAgentSessionIndex.hasLiveProcessForSession` / `hasRestorableEntryForSession` accessors.

## Behavior after the fix

| Scenario | Before | After |
|---|---|---|
| Crash-orphaned claude alive at relaunch | Panel silently dead forever | Hibernated; auto-resumes on view once orphan exits |
| Duplicate panel, session live elsewhere | Silently dead | Hibernated, never double-fires |
| Agent not running at quit (died in earlier crash) | Silently dead | Hibernated; auto-resumes on view |
| Deliberate exit before quit | Plain shell | Plain shell (unchanged) |
| Normal clean-quit restore | Auto-resumes | Auto-resumes (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788003613&installation_model_id=21920&pr_number=9224&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9224&signature=bb590e72a268875ff9ace9a0b566e44d8e972c541225a677e4217a73ce41e356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops restored panes from staying dead when agent auto‑resume is suppressed by parking those sessions in hibernation and retrying resume on view. Adds a session‑wide live‑process check and a launch guard to prevent duplicate resumes, and logs restore/wake decisions in Release builds (follow‑up to #8446).

- **Bug Fixes**
  - On restore, if auto‑resume is suppressed (orphaned process, duplicate panel, or agent not running at quit), enter hibernation with a visible affordance and auto‑resume on view when safe.
  - Gate wake with a session‑wide live‑process check and per‑launch `AgentResumeLaunchGuard`; release the claim if resume preparation fails. Add `hasLiveProcessForSession` and `hasRestorableEntryForSession`; deliberate exits keep plain‑shell restore.
  - Emit park/wake decisions to the unified log in Release (subsystem `com.cmuxterm.app`, category `AgentRestore`) for field diagnosis.

<sup>Written for commit 32cfb538dd3b0d01013f3432373a6d7187a4f9bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration behavior for terminal-based agent sessions when auto-resume can’t run, ensuring sessions don’t come back as unresponsive shells.
  * Restored sessions are now placed directly into hibernation when appropriate, so they can be woken later through the normal panel wake flow.
  * Stronger safeguards prevent resuming when another live process already exists for the same agent session, reducing conflicts and duplicates.
  * Added clearer restore/wake decision logging to help diagnose restoration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->