### PR TITLE
Replay sidebar clicks after reveal actions return

### DIFF
--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -7,10 +7,22 @@ import SwiftUI
 /// Main-actor owner of the default sidebar table lifecycle and its AppKit interactions.
 @MainActor
 final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+    private struct DeferredRowClick {
+        let rowId: SidebarWorkspaceRenderItemID
+        let modifiers: NSEvent.ModifierFlags
+    }
+
+    private enum RowClickDispatchOutcome {
+        case dispatched
+        case awaitingActions
+        case invalid
+    }
+
     private weak var containerView: SidebarWorkspaceTableContainerView?
     private let createdCellViews = NSHashTable<NSView>.weakObjects()
     private var rows: [SidebarWorkspaceTableRowConfiguration] = []
     private var actions: SidebarWorkspaceTableActions?
+    private var deferredRowClick: DeferredRowClick?
     private var hoveredRowId: SidebarWorkspaceRenderItemID?
     private var contextMenuRowId: SidebarWorkspaceRenderItemID?
     private var workspaceIds: [UUID] = []
@@ -149,7 +161,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         selectedScrollTargetWorkspaceId = nil
         hoveredRowId = nil
         contextMenuRowId = nil
-        selectionCoalescer.cancel()
+        cancelSelectionIntent()
         clearDropViewActions(in: container)
         setAppKitDropIndicator(nil, scope: .raw, includeRowTargets: false)
         container.tableView.workspaceController = nil
@@ -207,7 +219,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         contextMenuRowId = nil
         optimisticallyPaintedRowIds.removeAll(keepingCapacity: true)
         pumpHeightOverrides.removeAll(keepingCapacity: true)
-        selectionCoalescer.cancel()
+        cancelSelectionIntent()
         rowHeightCache.suspendPresentation(retaining: Set(rows.map(\.id)))
         if let containerView {
             clearDropViewActions(in: containerView)
@@ -436,6 +448,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         enforceHoverOnVisibleCells()
         updateDropTargets()
         replanReorderDragIfActive()
+        replayDeferredRowClickIfPossible()
     }
 
     /// Row clicks route through the table's action (NSTableView owns the
@@ -447,43 +460,79 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         cmuxDebugLog("sidebar.table.click row=\(row) rows=\(rows.count)")
 #endif
         guard rows.indices.contains(row) else { return }
-        if let actions = rows[row].appKitWorkspaceRowActions {
-            // Capture modifiers from the clicking EVENT at action time: a
-            // coalesced (trailing) apply must not re-read the keyboard
-            // ~100ms later, and the global NSEvent.modifierFlags reads
-            // hardware state, which misses event-carried flags (synthetic
-            // clicks, exotic input methods).
-            let modifiers = NSApp.currentEvent?.modifierFlags ?? NSEvent.modifierFlags
-            // Down-then-up highlight: the optimistic paint bridges the model
-            // round trip, applied here (action == completed click), never on
-            // the press.
+        // Capture modifiers from the clicking EVENT at action time: a
+        // deferred or coalesced apply must not re-read the keyboard later,
+        // and the global NSEvent.modifierFlags reads hardware state, which
+        // misses event-carried flags (synthetic clicks, exotic input methods).
+        let modifiers = NSApp.currentEvent?.modifierFlags ?? NSEvent.modifierFlags
+        let click = DeferredRowClick(rowId: rows[row].id, modifiers: modifiers)
+        switch dispatchRowClick(click) {
+        case .dispatched:
+            deferredRowClick = nil
+        case .awaitingActions:
+            // Presentation snapshots intentionally release their live action
+            // captures while hidden. The retained row can become visible
+            // before SwiftUI supplies its first authoritative reveal apply,
+            // so preserve the completed click by stable row identity.
             previewSelection(row: row, modifiers: modifiers, hitView: nil)
-            if modifiers.contains(.command) || modifiers.contains(.shift) {
-                // Multi-select mutations are order-dependent and extend the
-                // selection the user currently sees: flush (not drop) a
-                // plain click still in the coalescing window first.
-                selectionCoalescer.flushNow()
-                actions.commands.updateSelection(modifiers: modifiers)
-            } else {
-                selectionCoalescer.request {
-                    actions.commands.updateSelection(modifiers: modifiers)
-                }
-            }
-        } else if let headerActions = rows[row].appKitGroupHeaderActions {
-            // Group headers focus their anchor workspace: same fast path as
-            // workspace rows (burst coalescing; the completed click paints
-            // the optimistic anchor-active treatment).
-            let modifiers = NSApp.currentEvent?.modifierFlags ?? NSEvent.modifierFlags
-            previewSelection(row: row, modifiers: modifiers, hitView: nil)
-            if modifiers.contains(.command) || modifiers.contains(.shift) {
-                selectionCoalescer.flushNow()
-                headerActions.onFocusAnchor(modifiers)
-            } else {
-                selectionCoalescer.request {
-                    headerActions.onFocusAnchor(modifiers)
-                }
-            }
+            deferredRowClick = click
+        case .invalid:
+            deferredRowClick = nil
         }
+    }
+
+    private func dispatchRowClick(_ click: DeferredRowClick) -> RowClickDispatchOutcome {
+        guard let row = rows.firstIndex(where: { $0.id == click.rowId }) else {
+            return .invalid
+        }
+        let configuration = rows[row]
+        if let actions = configuration.appKitWorkspaceRowActions {
+            previewSelection(row: row, modifiers: click.modifiers, hitView: nil)
+            dispatchSelection(modifiers: click.modifiers) {
+                actions.commands.updateSelection(modifiers: click.modifiers)
+            }
+            return .dispatched
+        }
+        if let headerActions = configuration.appKitGroupHeaderActions {
+            previewSelection(row: row, modifiers: click.modifiers, hitView: nil)
+            dispatchSelection(modifiers: click.modifiers) {
+                headerActions.onFocusAnchor(click.modifiers)
+            }
+            return .dispatched
+        }
+        if configuration.appKitWorkspaceRowModel != nil
+            || configuration.appKitGroupHeaderModel != nil {
+            return .awaitingActions
+        }
+        return .invalid
+    }
+
+    private func dispatchSelection(
+        modifiers: NSEvent.ModifierFlags,
+        action: @escaping @MainActor () -> Void
+    ) {
+        if modifiers.contains(.command) || modifiers.contains(.shift) {
+            // Multi-select mutations are order-dependent and extend the
+            // selection the user currently sees: flush (not drop) a plain
+            // click still in the coalescing window first.
+            selectionCoalescer.flushNow()
+            action()
+        } else {
+            selectionCoalescer.request(action)
+        }
+    }
+
+    private func replayDeferredRowClickIfPossible() {
+        guard let click = deferredRowClick else { return }
+        deferredRowClick = nil
+        if case .awaitingActions = dispatchRowClick(click) {
+            deferredRowClick = click
+        }
+    }
+
+    private func cancelSelectionIntent() {
+        deferredRowClick = nil
+        selectionCoalescer.cancel()
     }
 
     @objc private func didDoubleClickTableRow() {
@@ -503,7 +552,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         // end-editing commits the untouched title — the field flashes and
         // vanishes. A double-click is a rename gesture: drop the queued
         // selection before starting the edit.
-        selectionCoalescer.cancel()
+        cancelSelectionIntent()
         cell.beginInlineRename()
     }
 
@@ -682,7 +731,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         // fast drag leaves the grabbed row painted selected and every other
         // visible row peeled. Drop the queued selection and restore visible
         // cells from their stored models before drop targets paint.
-        selectionCoalescer.cancel()
+        cancelSelectionIntent()
         previewBailoutTask?.cancel()
         previewBailoutTask = nil
         restoreVisibleCellPaint()

--- a/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowSuspensionTests.swift
@@ -114,6 +114,7 @@ struct SidebarWorkspaceRowSuspensionTests {
     static func makeActions(
         model: SidebarWorkspaceRowModel,
         workspace: Workspace? = nil,
+        tabManager: TabManager? = nil,
         onCommitRename: @escaping (String) -> Void = { _ in },
         onConsumeChecklistAddFieldActivation: @escaping () -> Void = {},
         onChecklistAddItem: @escaping (String) -> Void = { _ in },
@@ -124,7 +125,7 @@ struct SidebarWorkspaceRowSuspensionTests {
         let workspace = workspace ?? Workspace()
         let commands = SidebarWorkspaceRowCommands(
             tab: workspace,
-            tabManager: nil,
+            tabManager: tabManager,
             notificationStore: nil,
             index: model.index,
             contextMenuWorkspaceIds: [model.workspaceId],

--- a/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableSuspensionTests.swift
@@ -101,6 +101,87 @@ struct SidebarWorkspaceTableSuspensionTests {
     }
 
     @Test
+    func visibleRowClickWhileRevealApplyIsPendingReplaysWhenActionsReturn() async throws {
+        let tabManager = TabManager(autoWelcomeIfNeeded: false)
+        let initiallySelectedWorkspace = try #require(tabManager.selectedWorkspace)
+        let clickedWorkspace = tabManager.addWorkspace(
+            select: false,
+            autoWelcomeIfNeeded: false,
+            autoRefreshMetadata: false
+        )
+        let model = SidebarWorkspaceRowSuspensionTests.makeModel(
+            workspaceId: clickedWorkspace.id
+        )
+        let row = SidebarWorkspaceTableRowConfiguration(
+            workspaceRowModel: model,
+            actions: SidebarWorkspaceRowSuspensionTests.makeActions(
+                model: model,
+                workspace: clickedWorkspace,
+                tabManager: tabManager
+            ),
+            groupId: nil,
+            isPinned: false,
+            environment: SidebarWorkspaceTableEnvironmentSnapshot(
+                colorScheme: .light,
+                globalFontMagnificationPercent: 100,
+                lazyContractProbe: SidebarLazyContractProbe()
+            )
+        )
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        defer {
+            window.contentView = nil
+            window.close()
+        }
+
+        controller.apply(
+            rows: [row],
+            actions: makeTableActions(),
+            workspaceIds: [clickedWorkspace.id],
+            selectedWorkspaceId: initiallySelectedWorkspace.id,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+
+        controller.setPresentationActive(false, workspaceIds: [clickedWorkspace.id])
+        controller.setPresentationActive(true, workspaceIds: [clickedWorkspace.id])
+
+        let table = container.tableView
+        let clickPoint = NSPoint(x: table.bounds.midX, y: table.rect(ofRow: 0).midY)
+        #expect(!table.isHidden)
+        #expect(table.row(at: clickPoint) == 0)
+        #expect(table.hitTest(clickPoint) != nil)
+        let action = try #require(table.action)
+        let target = try #require(table.target)
+        table.setValue(0, forKey: "clickedRow")
+        defer { table.setValue(-1, forKey: "clickedRow") }
+        #expect(table.sendAction(action, to: target))
+
+        controller.apply(
+            rows: [row],
+            actions: makeTableActions(),
+            workspaceIds: [clickedWorkspace.id],
+            selectedWorkspaceId: initiallySelectedWorkspace.id,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        await flushStagedTableMutations()
+
+        #expect(
+            tabManager.selectedTabId == clickedWorkspace.id,
+            "A completed click on a visible reveal-time row must replay once live row actions return."
+        )
+    }
+
+    @Test
     func hidingRetiresNativeReorderSession() async {
         let controller = SidebarWorkspaceTableController()
         let container = controller.makeContainerView()


### PR DESCRIPTION
## Summary

- reproduce the dropped click on a visible, hit-testable AppKit sidebar row while its presentation snapshot has released live actions
- retain a completed click by stable render-item identity until the authoritative reveal apply restores actions
- route immediate and replayed clicks through the same selection/coalescing path, and retire pending intent on teardown or a consuming gesture
- add behavior-level coverage through the real `NSTableView` target/action path

## Proof

The DEBUG trace showed a valid row click with no following selection action; the live reveal apply arrived about 2 ms later:

```text
sidebar.table.issue9221Repro row=1 resolved=1 frame=(0.0, 0.0, 240.0, 612.0) hidden=0
sidebar.table.click row=1 rows=2
```

The test-only commit fails on the original implementation at the expected selection assertion. The fix commit makes the same test pass.

## Tests

- `SidebarWorkspaceTableSuspensionTests/visibleRowClickWhileRevealApplyIsPendingReplaysWhenActionsReturn()`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check`
- `./scripts/reload.sh --tag issue-9221 --launch`

Fixes #9221

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788005925&installation_model_id=21920&pr_number=9225&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9225&signature=6c76c156b11ce3f2dc596efea1f0c790e6229b24604eac02bead5f697c4396e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replays valid sidebar row clicks that occur during a reveal when live actions are temporarily unavailable, so selection is applied once actions return. Routes both immediate and delayed clicks through the same coalesced selection path to prevent dropped clicks. Fixes #9221.

- **Bug Fixes**
  - Defers a completed click by storing row ID and modifiers, and replays it after the reveal apply restores actions.
  - Adds a unified click dispatch with coalesced selection using the original event modifiers; cancels pending intent via `cancelSelectionIntent` on teardown, drag, or rename.
  - Adds a regression test that exercises the real `NSTableView` target/action path to verify replay behavior.

<sup>Written for commit 2e78c84f42c96526a8e64e1fd7bf624772b3bf4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace row selection while rows are loading or becoming visible.
  * Clicks are now replayed automatically once the row’s actions become available.
  * Prevented pending selection updates from interfering with renaming or drag-and-drop interactions.

* **Tests**
  * Added coverage for row-click replay during suspended and resumed sidebar states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->