### PR TITLE
extensions: add permission-scoped terminal command action

### DIFF
--- a/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Manifest/CMUXExtensionScope.swift
+++ b/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Manifest/CMUXExtensionScope.swift
@@ -23,4 +23,6 @@ public enum CmuxExtensionActionScope: String, Codable, CaseIterable, Equatable, 
     case navigateSurface
     case openURL
     case createWorkspaceWithPath
+    /// Run commands in existing terminal surfaces.
+    case runCommand
 }

--- a/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarAction.swift
+++ b/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarAction.swift
@@ -24,6 +24,8 @@ public enum CmuxSidebarAction: Codable, Equatable, Sendable {
     case splitBrowser(workspaceID: UUID, surfaceID: UUID, direction: CmuxSidebarSplitDirection, url: String?)
     case toggleSurfaceZoom(workspaceID: UUID, surfaceID: UUID)
     case openURL(String)
+    /// Run a command in the identified existing terminal surface.
+    case runCommand(workspaceID: UUID, surfaceID: UUID, command: String)
 
     public var requiredScopes: Set<CmuxExtensionActionScope> {
         switch self {
@@ -53,6 +55,8 @@ public enum CmuxSidebarAction: Codable, Equatable, Sendable {
             return [.zoomSurface]
         case .openURL:
             return [.openURL]
+        case .runCommand:
+            return [.runCommand]
         }
     }
 }

--- a/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarExtensionConnection.swift
+++ b/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarExtensionConnection.swift
@@ -201,14 +201,17 @@ final class CMUXSidebarExtensionConnection: @unchecked Sendable {
     }
 
     private func markInterrupted(ifCurrentGeneration generation: UInt64) {
-        let transition = withState { state -> (replies: [ActionReplyHandler], generation: UInt64)? in
+        let transition = withState { state -> (connection: NSXPCConnection?, replies: [ActionReplyHandler], generation: UInt64)? in
             guard state.generation == generation else { return nil }
             state.generation += 1
+            let connection = state.connection
+            state.connection = nil
             state.host = nil
             let replies = pendingReplies(from: &state, matching: generation)
-            return (replies, state.generation)
+            return (connection, replies, state.generation)
         }
         if let transition {
+            transition.connection?.invalidate()
             deliver(.rejected("cmux connection was interrupted"), to: transition.replies)
             report(.waitingForHost, ifCurrentGeneration: transition.generation)
         }

--- a/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarExtensionConnection.swift
+++ b/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarExtensionConnection.swift
@@ -201,29 +201,31 @@ final class CMUXSidebarExtensionConnection: @unchecked Sendable {
     }
 
     private func markInterrupted(ifCurrentGeneration generation: UInt64) {
-        let repliesToDrain = withState { state -> [ActionReplyHandler]? in
+        let transition = withState { state -> (replies: [ActionReplyHandler], generation: UInt64)? in
             guard state.generation == generation else { return nil }
+            state.generation += 1
             state.host = nil
             let replies = pendingReplies(from: &state, matching: generation)
-            return replies
+            return (replies, state.generation)
         }
-        if let repliesToDrain {
-            deliver(.rejected("cmux connection was interrupted"), to: repliesToDrain)
-            report(.waitingForHost, ifCurrentGeneration: generation)
+        if let transition {
+            deliver(.rejected("cmux connection was interrupted"), to: transition.replies)
+            report(.waitingForHost, ifCurrentGeneration: transition.generation)
         }
     }
 
     private func clearConnection(ifCurrentGeneration generation: UInt64) {
-        let repliesToDrain = withState { state -> [ActionReplyHandler]? in
+        let transition = withState { state -> (replies: [ActionReplyHandler], generation: UInt64)? in
             guard state.generation == generation else { return nil }
+            state.generation += 1
             state.connection = nil
             state.host = nil
             let replies = pendingReplies(from: &state, matching: generation)
-            return replies
+            return (replies, state.generation)
         }
-        if let repliesToDrain {
-            deliver(.rejected("cmux connection was closed"), to: repliesToDrain)
-            report(.waitingForHost, ifCurrentGeneration: generation)
+        if let transition {
+            deliver(.rejected("cmux connection was closed"), to: transition.replies)
+            report(.waitingForHost, ifCurrentGeneration: transition.generation)
         }
     }
 

--- a/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarRunCommandDispatcher.swift
+++ b/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarRunCommandDispatcher.swift
@@ -1,0 +1,95 @@
+/// A terminal's lifecycle state for sidebar command dispatch.
+@_spi(CmuxHostTransport)
+public enum CMUXSidebarRunCommandTerminalState: Equatable, Sendable {
+    /// The terminal has a live surface that can accept input.
+    case live
+    /// The terminal is hibernated and must not be woken by dispatch.
+    case hibernated
+    /// The terminal does not currently have a live surface.
+    case cold
+    /// The terminal surface's process has exited.
+    case dead
+}
+
+/// The resolved kind of target for a sidebar command.
+@_spi(CmuxHostTransport)
+public enum CMUXSidebarRunCommandTargetKind: Equatable, Sendable {
+    /// A terminal target with its current lifecycle state.
+    case terminal(CMUXSidebarRunCommandTerminalState)
+    /// No target exists at the requested workspace and surface identifiers.
+    case missing
+    /// The requested target exists but is not a terminal.
+    case nonterminal
+}
+
+/// A structured reason that a sidebar command was rejected.
+@_spi(CmuxHostTransport)
+public enum CMUXSidebarRunCommandRejection: Equatable, Sendable {
+    /// The command violates the accepted input contract.
+    case commandRejected
+    /// No target exists at the requested identifiers.
+    case terminalNotFound
+    /// The requested target is not a terminal.
+    case targetNotTerminal
+    /// The terminal is not live and dispatch must not wake it.
+    case terminalUnavailable
+    /// The terminal rejected either the text or Enter input event.
+    case terminalInputRejected
+}
+
+/// The result of attempting to dispatch a sidebar command.
+@_spi(CmuxHostTransport)
+public enum CMUXSidebarRunCommandDispatchResult: Equatable, Sendable {
+    /// The terminal accepted the command text followed by Enter.
+    case accepted
+    /// Dispatch was rejected for the associated structured reason.
+    case rejected(CMUXSidebarRunCommandRejection)
+}
+
+/// Validates and synchronously sends sidebar commands to an already-live terminal.
+@_spi(CmuxHostTransport)
+public struct CMUXSidebarRunCommandDispatcher: Sendable {
+    /// The maximum accepted command length measured in UTF-8 bytes.
+    public let maximumCommandUTF8Bytes = 8_192
+
+    /// Creates a command dispatcher with the fixed host input limit.
+    public init() {}
+
+    /// Validates the command and target before sending exact text followed by Enter.
+    ///
+    /// The callbacks are nonescaping and execute synchronously on the caller's executor.
+    public func dispatch(
+        command: String,
+        targetKind: CMUXSidebarRunCommandTargetKind,
+        sendText: (String) -> Bool,
+        sendEnter: () -> Bool
+    ) -> CMUXSidebarRunCommandDispatchResult {
+        guard !command.isEmpty,
+              command.utf8.count <= maximumCommandUTF8Bytes,
+              !command.unicodeScalars.contains(where: { scalar in
+                  let value = scalar.value
+                  return value <= 0x1F
+                      || (0x7F...0x9F).contains(value)
+                      || value == 0x2028
+                      || value == 0x2029
+              }) else {
+            return .rejected(.commandRejected)
+        }
+
+        switch targetKind {
+        case .missing:
+            return .rejected(.terminalNotFound)
+        case .nonterminal:
+            return .rejected(.targetNotTerminal)
+        case .terminal(.live):
+            break
+        case .terminal(.hibernated), .terminal(.cold), .terminal(.dead):
+            return .rejected(.terminalUnavailable)
+        }
+
+        guard sendText(command), sendEnter() else {
+            return .rejected(.terminalInputRejected)
+        }
+        return .accepted
+    }
+}

--- a/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CmuxSidebarHost.swift
+++ b/Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CmuxSidebarHost.swift
@@ -133,6 +133,17 @@ public struct CmuxSidebarHost {
         try await send(.toggleSurfaceZoom(workspaceID: workspaceID, surfaceID: surfaceID))
     }
 
+    /// Sends a single command to an existing terminal surface and presses Enter.
+    ///
+    /// This requires the `.runCommand` action scope.
+    public func runCommand(
+        _ command: String,
+        workspaceID: UUID,
+        surfaceID: UUID
+    ) async throws {
+        try await send(.runCommand(workspaceID: workspaceID, surfaceID: surfaceID, command: command))
+    }
+
     private func send(_ action: CmuxSidebarAction) async throws {
         let result = await perform(action)
         guard result.accepted else {

--- a/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CMUXSidebarExtensionConnectionTests.swift
+++ b/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CMUXSidebarExtensionConnectionTests.swift
@@ -70,7 +70,7 @@ struct CMUXSidebarExtensionConnectionTests {
     }
 }
 
-private enum DisconnectPath: CaseIterable, Sendable {
+enum DisconnectPath: CaseIterable, Sendable {
     case interruption
     case invalidation
 

--- a/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CMUXSidebarExtensionConnectionTests.swift
+++ b/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CMUXSidebarExtensionConnectionTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@_spi(CmuxHostTransport) @testable import CmuxExtensionKit
+
+@Suite
+struct CMUXSidebarExtensionConnectionTests {
+    @Test(arguments: DisconnectPath.allCases)
+    @MainActor
+    func queuedSnapshotIsFencedAfterDisconnectAndFreshConnectionDelivers(
+        disconnectPath: DisconnectPath
+    ) async throws {
+        var deliveredSequences: [UInt64] = []
+        var statuses: [CmuxSidebarConnectionStatus] = []
+        let connection = CMUXSidebarExtensionConnection(
+            manifest: CmuxExtensionManifest(
+                id: "dev.cmux.connection-generation-test",
+                displayName: "Connection Generation Test",
+                readScopes: []
+            ),
+            onSnapshot: { deliveredSequences.append($0.sequence) },
+            onStatus: { statuses.append($0) }
+        )
+
+        let staleTransport = try makeTransport(for: connection)
+        staleTransport.receiver.sidebarSnapshotDidChange(
+            try encodedSnapshot(sequence: 1)
+        )
+        disconnectPath.disconnect(staleTransport.connection)
+
+        await waitUntil { statuses.contains(.waitingForHost) }
+        #expect(deliveredSequences.isEmpty)
+        #expect(statuses == [.waitingForHost])
+
+        let freshTransport = try makeTransport(for: connection)
+        freshTransport.receiver.sidebarSnapshotDidChange(
+            try encodedSnapshot(sequence: 2)
+        )
+
+        await waitUntil { deliveredSequences == [2] }
+        #expect(deliveredSequences == [2])
+        #expect(statuses == [.waitingForHost, .connected])
+
+        connection.invalidate()
+        staleTransport.connection.invalidate()
+        freshTransport.connection.invalidate()
+    }
+
+    private func makeTransport(
+        for extensionConnection: CMUXSidebarExtensionConnection
+    ) throws -> TestTransport {
+        let listener = NSXPCListener.anonymous()
+        let connection = NSXPCConnection(listenerEndpoint: listener.endpoint)
+        #expect(extensionConnection.accept(connection))
+        let receiver = try #require(connection.exportedObject as? any CMUXSidebarExtensionXPC)
+        return TestTransport(listener: listener, connection: connection, receiver: receiver)
+    }
+
+    private func encodedSnapshot(sequence: UInt64) throws -> NSData {
+        try CmuxSidebarXPCCodec.encodeSnapshot(
+            CmuxSidebarSnapshot(sequence: sequence, selectedWorkspaceID: nil, workspaces: [])
+        )
+    }
+
+    @MainActor
+    private func waitUntil(_ condition: @MainActor () -> Bool) async {
+        for _ in 0..<100 {
+            if condition() { return }
+            await Task.yield()
+        }
+    }
+}
+
+private enum DisconnectPath: CaseIterable, Sendable {
+    case interruption
+    case invalidation
+
+    func disconnect(_ connection: NSXPCConnection) {
+        switch self {
+        case .interruption:
+            connection.interruptionHandler?()
+        case .invalidation:
+            connection.invalidationHandler?()
+        }
+    }
+}
+
+private struct TestTransport {
+    // Retaining the anonymous listener keeps its endpoint valid while the connection is exercised.
+    let listener: NSXPCListener
+    let connection: NSXPCConnection
+    let receiver: any CMUXSidebarExtensionXPC
+}

--- a/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CMUXSidebarRunCommandDispatcherTests.swift
+++ b/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CMUXSidebarRunCommandDispatcherTests.swift
@@ -1,0 +1,152 @@
+import Testing
+@_spi(CmuxHostTransport) @testable import CmuxExtensionKit
+
+@Suite
+struct CMUXSidebarRunCommandDispatcherTests {
+    private let dispatcher = CMUXSidebarRunCommandDispatcher()
+
+    @Test
+    func rejectsInvalidScalarsAndEmptyInputBeforeSending() {
+        let invalidCommands = [
+            "",
+            "echo first\necho second",
+            "printf\u{0}bad",
+            "printf\tbad",
+            "printf\u{7F}bad",
+            "printf\u{80}bad",
+            "printf\u{85}bad",
+            "printf\u{9B}bad",
+            "printf\u{9D}bad",
+            "printf\u{9F}bad",
+            "echo first\u{2028}echo second",
+            "echo first\u{2029}echo second",
+        ]
+
+        for command in invalidCommands {
+            var events: [String] = []
+            let result = dispatcher.dispatch(
+                command: command,
+                targetKind: .terminal(.live),
+                sendText: { text in events.append("text:\(text)"); return true },
+                sendEnter: { events.append("enter"); return true }
+            )
+
+            #expect(result == .rejected(.commandRejected))
+            #expect(events.isEmpty)
+        }
+    }
+
+    @Test
+    func rejectsCommandLargerThan8192UTF8Bytes() {
+        let command = String(repeating: "é", count: 4_097)
+        #expect(command.utf8.count > dispatcher.maximumCommandUTF8Bytes)
+
+        var events: [String] = []
+        let result = dispatcher.dispatch(
+            command: command,
+            targetKind: .terminal(.live),
+            sendText: { _ in events.append("text"); return true },
+            sendEnter: { events.append("enter"); return true }
+        )
+
+        #expect(result == .rejected(.commandRejected))
+        #expect(events.isEmpty)
+    }
+
+    @Test
+    func acceptsPrintableUnicodeAt8192UTF8ByteLimit() {
+        let command = String(repeating: "é", count: 4_096)
+        #expect(command.utf8.count == dispatcher.maximumCommandUTF8Bytes)
+
+        var events: [String] = []
+        let result = dispatcher.dispatch(
+            command: command,
+            targetKind: .terminal(.live),
+            sendText: { text in events.append(text); return true },
+            sendEnter: { events.append("enter"); return true }
+        )
+
+        #expect(result == .accepted)
+        #expect(events == [command, "enter"])
+    }
+
+    @Test
+    func rejectsMissingAndNonterminalTargets() {
+        let cases: [(CMUXSidebarRunCommandTargetKind, CMUXSidebarRunCommandRejection)] = [
+            (.missing, .terminalNotFound),
+            (.nonterminal, .targetNotTerminal),
+        ]
+
+        for (targetKind, expectedRejection) in cases {
+            var events: [String] = []
+            let result = dispatcher.dispatch(
+                command: "printf hello",
+                targetKind: targetKind,
+                sendText: { _ in events.append("text"); return true },
+                sendEnter: { events.append("enter"); return true }
+            )
+
+            #expect(result == .rejected(expectedRejection))
+            #expect(events.isEmpty)
+        }
+    }
+
+    @Test
+    func rejectsUnavailableTerminalsBeforeSendingInput() {
+        for state in [
+            CMUXSidebarRunCommandTerminalState.hibernated,
+            .cold,
+            .dead,
+        ] {
+            var events: [String] = []
+            let result = dispatcher.dispatch(
+                command: "printf hello",
+                targetKind: .terminal(state),
+                sendText: { _ in events.append("text"); return true },
+                sendEnter: { events.append("enter"); return true }
+            )
+
+            #expect(result == .rejected(.terminalUnavailable))
+            #expect(events.isEmpty)
+        }
+    }
+
+    @Test
+    func liveTargetSendsTextThenEnter() {
+        var events: [String] = []
+        let result = dispatcher.dispatch(
+            command: "printf λ你好",
+            targetKind: .terminal(.live),
+            sendText: { text in events.append("text:\(text)"); return true },
+            sendEnter: { events.append("enter"); return true }
+        )
+
+        #expect(result == .accepted)
+        #expect(events == ["text:printf λ你好", "enter"])
+    }
+
+    @Test
+    func rejectsTerminalInputFailuresInCallOrder() {
+        var events: [String] = []
+        let textRejected = dispatcher.dispatch(
+            command: "printf hello",
+            targetKind: .terminal(.live),
+            sendText: { _ in events.append("text"); return false },
+            sendEnter: { events.append("enter"); return true }
+        )
+
+        #expect(textRejected == .rejected(.terminalInputRejected))
+        #expect(events == ["text"])
+
+        events.removeAll()
+        let enterRejected = dispatcher.dispatch(
+            command: "printf hello",
+            targetKind: .terminal(.live),
+            sendText: { _ in events.append("text"); return true },
+            sendEnter: { events.append("enter"); return false }
+        )
+
+        #expect(enterRejected == .rejected(.terminalInputRejected))
+        #expect(events == ["text", "enter"])
+    }
+}

--- a/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CmuxExtensionKitTests.swift
+++ b/Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CmuxExtensionKitTests.swift
@@ -204,15 +204,15 @@ struct CMUXExtensionKitTests {
 
         let actionScopedSnapshot = snapshot.filtered(
             for: [CmuxExtensionScope.workspaceMetadata],
-            actionScopes: [CmuxExtensionActionScope.selectWorkspace]
+            actionScopes: [CmuxExtensionActionScope.selectWorkspace, .runCommand]
         )
-        #expect(actionScopedSnapshot.grantedActionScopes == [.selectWorkspace])
+        #expect(actionScopedSnapshot.grantedActionScopes == [.selectWorkspace, .runCommand])
 
         let manifest = CmuxExtensionManifest(
             id: "dev.example.sidebar",
             displayName: "Example Sidebar",
             readScopes: [.workspaceMetadata, .networkPorts],
-            actionScopes: [.selectWorkspace, .closeWorkspace]
+            actionScopes: [.selectWorkspace, .closeWorkspace, .runCommand]
         )
         let decodedManifest = try CmuxSidebarXPCCodec.decodeManifest(
             try CmuxSidebarXPCCodec.encodeManifest(manifest)
@@ -225,6 +225,18 @@ struct CMUXExtensionKitTests {
             try CmuxSidebarXPCCodec.encodeAction(action)
         )
         #expect(decodedAction == action)
+
+        let surfaceID = UUID(uuidString: "44444444-4444-4444-4444-444444444444")!
+        let commandAction = CmuxSidebarAction.runCommand(
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            command: "printf hello"
+        )
+        #expect(commandAction.requiredScopes == [.runCommand])
+        let decodedCommandAction = try CmuxSidebarXPCCodec.decodeAction(
+            try CmuxSidebarXPCCodec.encodeAction(commandAction)
+        )
+        #expect(decodedCommandAction == commandAction)
 
         let result = CmuxSidebarActionResult.rejected("Not found")
         let decodedResult = try CmuxSidebarXPCCodec.decodeActionResult(
@@ -245,6 +257,7 @@ struct CMUXExtensionKitTests {
         var actions = [CmuxSidebarAction]()
         var refreshCount = 0
         let workspaceID = UUID(uuidString: "77777777-7777-7777-7777-777777777777")!
+        let surfaceID = UUID(uuidString: "88888888-8888-8888-8888-888888888888")!
         let url = URL(string: "https://example.com/pr/1")!
         let host = CmuxSidebarHost(
             performAction: { action, reply in
@@ -265,6 +278,7 @@ struct CMUXExtensionKitTests {
         try await host.selectPreviousWorkspace()
         try await host.createTerminalSurface(in: workspaceID)
         try await host.createBrowserSurface(in: workspaceID, url: url)
+        try await host.runCommand("printf hello", workspaceID: workspaceID, surfaceID: surfaceID)
         try await host.openURL(url)
 
         #expect(refreshCount == 1)
@@ -277,6 +291,7 @@ struct CMUXExtensionKitTests {
             .selectPreviousWorkspace,
             .createTerminalSurface(workspaceID: workspaceID),
             .createBrowserSurface(workspaceID: workspaceID, url: "https://example.com/pr/1"),
+            .runCommand(workspaceID: workspaceID, surfaceID: surfaceID, command: "printf hello"),
             .openURL("https://example.com/pr/1"),
         ])
     }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -212339,6 +212339,131 @@
         }
       }
     },
+    "sidebar.extensions.action.commandRejected": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يجب ألا يكون الأمر فارغًا، وألا يتجاوز 8192 بايت بترميز UTF-8، وأن يكون في سطر واحد، وألا يحتوي على أحرف تحكم أو أحرف فاصلة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komanda mora biti neprazna, ne duža od 8192 UTF-8 bajta, u jednom redu i bez kontrolnih znakova ili znakova razdvajanja"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kommandoen må ikke være tom, må højst fylde 8192 UTF-8-bytes, skal være på én linje og må ikke indeholde kontrol- eller skilletegn"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Befehl darf nicht leer sein, höchstens 8192 UTF-8-Bytes umfassen, muss einzeilig sein und darf keine Steuer- oder Trennzeichen enthalten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command must be nonempty, no more than 8192 UTF-8 bytes, single-line, and contain no control or separator characters"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El comando no debe estar vacío, no debe superar los 8192 bytes UTF-8, debe ser de una sola línea y no debe contener caracteres de control ni separadores"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La commande doit être non vide, ne pas dépasser 8192 octets UTF-8, tenir sur une seule ligne et ne contenir aucun caractère de contrôle ou séparateur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il comando non deve essere vuoto, non deve superare 8192 byte UTF-8, deve essere su una sola riga e non deve contenere caratteri di controllo o separatori"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドは空にできず、UTF-8で8192バイト以内の単一行で、制御文字または区切り文字を含めることはできません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ពាក្យបញ្ជាត្រូវតែមិនទទេ មិនលើសពី 8192 បៃ UTF-8 មានតែមួយបន្ទាត់ និងមិនមានតួអក្សរបញ្ជា ឬតួអក្សរបំបែក"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령은 비어 있지 않아야 하고, 8192 UTF-8 바이트 이하의 한 줄이어야 하며, 제어 문자나 구분 문자를 포함할 수 없습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kommandoen kan ikke være tom, må være på maksimalt 8192 UTF-8-byte, på én linje og uten kontroll- eller skilletegn"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polecenie nie może być puste, nie może przekraczać 8192 bajtów UTF-8, musi mieścić się w jednym wierszu i nie może zawierać znaków sterujących ani separatorów"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O comando não pode estar vazio, deve ter no máximo 8192 bytes UTF-8, estar em uma única linha e não conter caracteres de controle ou separadores"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команда должна быть непустой, содержать не более 8192 байт в кодировке UTF-8, состоять из одной строки и не содержать управляющих символов или символов-разделителей"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คำสั่งต้องไม่ว่างเปล่า มีขนาดไม่เกิน 8192 ไบต์ UTF-8 เป็นบรรทัดเดียว และไม่มีอักขระควบคุมหรืออักขระคั่น"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komut boş olmamalı, 8192 UTF-8 baytı aşmamalı, tek satırdan oluşmalı ve denetim veya ayırıcı karakterleri içermemelidir"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команда має бути непорожньою, не перевищувати 8192 байтів UTF-8, складатися з одного рядка та не містити керуючих символів або символів-роздільників"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令不能为空，长度不得超过 8192 个 UTF-8 字节，必须为单行，且不能包含控制字符或分隔字符"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指令不得為空、不得超過 8192 個 UTF-8 位元組、必須為單行，且不得包含控制字元或分隔字元"
+          }
+        }
+      }
+    },
     "sidebar.extensions.action.remoteTmuxWindowRequested": {
       "extractionState": "manual",
       "localizations": {
@@ -212424,6 +212549,506 @@
         }
       }
     },
+    "sidebar.extensions.action.targetNotTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "السطح المستهدف ليس طرفية"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciljna površina nije terminal"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Målfladen er ikke en terminal"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zieloberfläche ist kein Terminal"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Target surface is not a terminal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La superficie de destino no es un terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La surface cible n’est pas un terminal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La superficie di destinazione non è un terminale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対象のサーフェスはターミナルではありません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្ទៃគោលដៅមិនមែនជា terminal ទេ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대상 서피스가 터미널이 아닙니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Målflaten er ikke en terminal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powierzchnia docelowa nie jest terminalem"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A superfície de destino não é um terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Целевая поверхность не является терминалом"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นผิวเป้าหมายไม่ใช่เทอร์มินัล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hedef yüzey bir terminal değil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цільова поверхня не є терміналом"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目标界面不是终端"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目標介面不是終端機"
+          }
+        }
+      }
+    },
+    "sidebar.extensions.action.terminalInputRejected": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يقبل سطح الطرفية الإدخال"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površina terminala nije prihvatila unos"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminalfladen accepterede ikke input"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminaloberfläche hat die Eingabe nicht akzeptiert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal surface did not accept input"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La superficie del terminal no aceptó la entrada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La surface de terminal n’a pas accepté la saisie"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La superficie del terminale non ha accettato l’input"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルサーフェスが入力を受け付けませんでした"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្ទៃ terminal មិនបានទទួលយកការបញ្ចូលទេ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 서피스가 입력을 받아들이지 않았습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminalflaten godtok ikke inndata"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powierzchnia terminala nie przyjęła danych wejściowych"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A superfície do terminal não aceitou a entrada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность терминала не приняла ввод"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นผิวเทอร์มินัลไม่ยอมรับการป้อนข้อมูล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal yüzeyi girişi kabul etmedi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхня термінала не прийняла введення"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端界面未接受输入"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終端機介面未接受輸入"
+          }
+        }
+      }
+    },
+    "sidebar.extensions.action.terminalNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لم يتم العثور على سطح الطرفية"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površina terminala nije pronađena"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminalfladen blev ikke fundet"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminaloberfläche nicht gefunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal surface not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontró la superficie del terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface de terminal introuvable"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superficie del terminale non trovata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルサーフェスが見つかりません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "រកមិនឃើញផ្ទៃ terminal ទេ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 서피스를 찾을 수 없습니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fant ikke terminalflaten"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie znaleziono powierzchni terminala"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Superfície do terminal não encontrada"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность терминала не найдена"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบพื้นผิวเทอร์มินัล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal yüzeyi bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхню термінала не знайдено"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到终端界面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "找不到終端機介面"
+          }
+        }
+      }
+    },
+    "sidebar.extensions.action.terminalUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سطح الطرفية غير نشط"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Površina terminala nije aktivna"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminalfladen er ikke aktiv"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminaloberfläche ist nicht aktiv"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal surface is not live"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La superficie del terminal no está activa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La surface de terminal n’est pas active"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La superficie del terminale non è attiva"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルサーフェスは稼働していません"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ផ្ទៃ terminal មិនកំពុងដំណើរការទេ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 서피스가 활성 상태가 아닙니다."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminalflaten er ikke aktiv"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powierzchnia terminala nie jest aktywna"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A superfície do terminal não está ativa"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность терминала неактивна"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นผิวเทอร์มินัลไม่ได้ทำงานอยู่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal yüzeyi etkin değil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхня термінала неактивна"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端界面未处于活动状态"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終端機介面目前未在運作中"
+          }
+        }
+      }
+    },
     "sidebar.extensions.action.urlRejected": {
       "extractionState": "manual",
       "localizations": {
@@ -212505,6 +213130,131 @@
           "stringUnit": {
             "state": "translated",
             "value": "URLを開く"
+          }
+        }
+      }
+    },
+    "sidebar.extensions.actionScope.runCommand": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل أوامر الطرفية"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokretanje komandi u terminalu"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kør terminalkommandoer"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminalbefehle ausführen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run terminal commands"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar comandos de terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter des commandes de terminal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esegui comandi nel terminale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルコマンドを実行"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ដំណើរការពាក្យបញ្ជា terminal"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 명령 실행"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kjør terminalkommandoer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uruchamianie poleceń terminala"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar comandos no terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполнение команд терминала"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เรียกใช้คำสั่งเทอร์มินัล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal komutlarını çalıştırma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виконувати команди термінала"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行终端命令"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行終端機指令"
           }
         }
       }
@@ -213833,6 +214583,131 @@
           "stringUnit": {
             "state": "translated",
             "value": "ワークスペースに関連するプルリクエストリンクを読み取ります"
+          }
+        }
+      }
+    },
+    "sidebar.extensions.permission.runCommand.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تشغيل الأوامر في أسطح الطرفية الموجودة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokretanje komandi u postojećim površinama terminala"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kør kommandoer i eksisterende terminalflader"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehle in vorhandenen Terminaloberflächen ausführen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run commands in existing terminal surfaces"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ejecutar comandos en superficies de terminal existentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exécuter des commandes dans les surfaces de terminal existantes"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esegui comandi in superfici di terminale esistenti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既存のターミナルサーフェスでコマンドを実行します"
+          }
+        },
+        "km": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ដំណើរការពាក្យបញ្ជានៅក្នុងផ្ទៃ terminal ដែលមានស្រាប់"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기존 터미널 서피스에서 명령 실행"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kjør kommandoer i eksisterende terminalflater"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uruchamianie poleceń w istniejących powierzchniach terminala"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executar comandos em superfícies de terminal existentes"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполнение команд в существующих поверхностях терминала"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เรียกใช้คำสั่งในพื้นผิวเทอร์มินัลที่มีอยู่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mevcut terminal yüzeylerinde komut çalıştırma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виконання команд у наявних поверхнях термінала"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在现有终端界面中运行命令"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在現有的終端機介面中執行指令"
           }
         }
       }

--- a/Sources/CMUXInstalledExtensionSidebarHostView.swift
+++ b/Sources/CMUXInstalledExtensionSidebarHostView.swift
@@ -905,6 +905,8 @@ struct CMUXInstalledExtensionSidebarHostView: View {
             return String(localized: "sidebar.extensions.permission.openURL.detail", defaultValue: "Open links from the extension")
         case .createWorkspaceWithPath:
             return String(localized: "sidebar.extensions.permission.createWorkspaceWithPath.detail", defaultValue: "Create workspaces for specific local folders")
+        case .runCommand:
+            return String(localized: "sidebar.extensions.permission.runCommand.detail", defaultValue: "Run commands in existing terminal surfaces")
         }
     }
 
@@ -1030,6 +1032,8 @@ private extension CmuxExtensionActionScope {
             return String(localized: "sidebar.extensions.actionScope.openURL", defaultValue: "Open URLs")
         case .createWorkspaceWithPath:
             return String(localized: "sidebar.extensions.actionScope.createWorkspaceWithPath", defaultValue: "Create workspaces with paths")
+        case .runCommand:
+            return String(localized: "sidebar.extensions.actionScope.runCommand", defaultValue: "Run terminal commands")
         }
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -28,6 +28,85 @@ import ObjectiveC
 import UniformTypeIdentifiers
 import WebKit
 
+/// Adapts app-owned terminal panels to the ExtensionKit run-command dispatcher.
+@MainActor
+struct CMUXSidebarRunCommandTerminalAdapter {
+    private let dispatcher = CMUXSidebarRunCommandDispatcher()
+
+    /// Creates an adapter that uses the production package dispatcher.
+    init() {}
+
+    /// Classifies a terminal panel without waking or mutating it.
+    func targetKind(for panel: TerminalPanel) -> CMUXSidebarRunCommandTargetKind {
+        guard !panel.isAgentHibernated else {
+            return .terminal(.hibernated)
+        }
+        guard panel.surface.hasLiveSurface, let surface = panel.surface.surface else {
+            return .terminal(.cold)
+        }
+        guard !ghostty_surface_process_exited(surface) else {
+            return .terminal(.dead)
+        }
+        return .terminal(.live)
+    }
+
+    /// Dispatches a command to an existing terminal panel and localizes its result.
+    func dispatch(command: String, to panel: Panel?) -> CmuxSidebarActionResult {
+        let terminalPanel = panel as? TerminalPanel
+        let resolvedTargetKind: CMUXSidebarRunCommandTargetKind
+        if let terminalPanel {
+            resolvedTargetKind = targetKind(for: terminalPanel)
+        } else if panel == nil {
+            resolvedTargetKind = .missing
+        } else {
+            resolvedTargetKind = .nonterminal
+        }
+
+        let dispatchResult = dispatcher.dispatch(
+            command: command,
+            targetKind: resolvedTargetKind,
+            sendText: { terminalPanel?.sendText($0) ?? false },
+            sendEnter: { terminalPanel?.sendNamedKey("enter") ?? false }
+        )
+        return result(for: dispatchResult)
+    }
+
+    /// Maps structured package rejections to app-localized action results.
+    func result(
+        for dispatchResult: CMUXSidebarRunCommandDispatchResult
+    ) -> CmuxSidebarActionResult {
+        switch dispatchResult {
+        case .accepted:
+            return .accepted
+        case .rejected(.commandRejected):
+            return .rejected(String(
+                localized: "sidebar.extensions.action.commandRejected",
+                defaultValue: "Command must be nonempty, no more than 8192 UTF-8 bytes, single-line, and contain no control or separator characters"
+            ))
+        case .rejected(.terminalNotFound):
+            return .rejected(String(
+                localized: "sidebar.extensions.action.terminalNotFound",
+                defaultValue: "Terminal surface not found"
+            ))
+        case .rejected(.targetNotTerminal):
+            return .rejected(String(
+                localized: "sidebar.extensions.action.targetNotTerminal",
+                defaultValue: "Target surface is not a terminal"
+            ))
+        case .rejected(.terminalUnavailable):
+            return .rejected(String(
+                localized: "sidebar.extensions.action.terminalUnavailable",
+                defaultValue: "Terminal surface is not live"
+            ))
+        case .rejected(.terminalInputRejected):
+            return .rejected(String(
+                localized: "sidebar.extensions.action.terminalInputRejected",
+                defaultValue: "Terminal surface did not accept input"
+            ))
+        }
+    }
+}
+
 var fileDropOverlayKey: UInt8 = 0
 private var commandPaletteWindowOverlayKey: UInt8 = 0
 let commandPaletteOverlayContainerIdentifier = NSUserInterfaceItemIdentifier("cmux.commandPalette.overlay.container")
@@ -10477,6 +10556,7 @@ struct VerticalTabsSidebar: View, Equatable {
     let onToggleSidebar: () -> Void
     let onNewTab: () -> Void
     let observedWindowReference: WeakWindowReference
+    private let runCommandTerminalAdapter = CMUXSidebarRunCommandTerminalAdapter()
     var observedWindow: NSWindow? { observedWindowReference.window }
     @EnvironmentObject var tabManager: TabManager
     // Observe the coalesced unread projection instead of the notification store
@@ -12373,6 +12453,13 @@ struct VerticalTabsSidebar: View, Equatable {
                 return .rejected(String(localized: "sidebar.extensions.action.surfaceNotFound", defaultValue: "Surface not found"))
             }
             return .accepted
+
+
+        case .runCommand(let workspaceId, let surfaceId, let command):
+            let panel = tabManager.tabs
+                .first(where: { $0.id == workspaceId })?
+                .panels[surfaceId]
+            return runCommandTerminalAdapter.dispatch(command: command, to: panel)
 
         case .openURL(let urlString):
             guard let url = cmuxSidebarExtensionRequiredHTTPURL(from: urlString),

--- a/cmuxTests/WorkspaceActionDispatcherTests.swift
+++ b/cmuxTests/WorkspaceActionDispatcherTests.swift
@@ -1,4 +1,6 @@
+import AppKit
 import XCTest
+@_spi(CmuxHostTransport) import CmuxExtensionKit
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -95,5 +97,319 @@ final class WorkspaceActionDispatcherTests: XCTestCase {
         XCTAssertTrue(state.pinned)
         XCTAssertTrue(workspace.isPinned)
         XCTAssertTrue(result.changedWorkspaceIds.isEmpty)
+    }
+}
+
+@MainActor
+final class CMUXSidebarRunCommandTerminalAdapterTests: XCTestCase {
+    private struct HostedTerminalPanel {
+        let panel: TerminalPanel
+        let window: NSWindow
+    }
+
+    private let adapter = CMUXSidebarRunCommandTerminalAdapter()
+
+    private func makeHostedTerminalPanel() throws -> HostedTerminalPanel {
+        _ = NSApplication.shared
+        let panel = TerminalPanel(workspaceId: UUID())
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = try XCTUnwrap(window.contentView)
+        panel.hostedView.frame = contentView.bounds
+        panel.hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(panel.hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        panel.hostedView.layoutSubtreeIfNeeded()
+        panel.hostedView.setVisibleInUI(true)
+        panel.hostedView.setActive(true)
+        return HostedTerminalPanel(panel: panel, window: window)
+    }
+
+    private func waitForLiveSurface(
+        _ panel: TerminalPanel,
+        timeout: TimeInterval = 3
+    ) async -> Bool {
+        if panel.surface.hasLiveSurface { return true }
+
+        let ready = expectation(description: "Ghostty terminal surface to become live")
+        let center = NotificationCenter.default
+        let token = center.addObserver(
+            forName: .terminalSurfaceDidBecomeReady,
+            object: panel.surface,
+            queue: .main
+        ) { _ in
+            ready.fulfill()
+        }
+        defer { center.removeObserver(token) }
+
+        if panel.surface.hasLiveSurface { return true }
+        let result = await XCTWaiter.fulfillment(of: [ready], timeout: timeout)
+        return result == .completed && panel.surface.hasLiveSurface
+    }
+
+    private func waitForVisibleText(
+        from panel: TerminalPanel,
+        description: String,
+        timeout: TimeInterval = 3,
+        condition: @escaping @MainActor (String) -> Bool
+    ) async -> String? {
+        if let text = panel.surface.visibleText(), condition(text) { return text }
+
+        let releaseTicks = GhosttyApp.retainTickNotifications()
+        let releaseFrames = GhosttyNSView.retainRenderedFrameNotifications()
+        defer {
+            releaseFrames()
+            releaseTicks()
+        }
+
+        let (events, continuation) = AsyncStream<Void>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        let center = NotificationCenter.default
+        let tokens = [
+            center.addObserver(forName: .ghosttyDidTick, object: nil, queue: .main) { _ in
+                continuation.yield()
+            },
+            center.addObserver(forName: .ghosttyDidRenderFrame, object: nil, queue: .main) { _ in
+                continuation.yield()
+            },
+            center.addObserver(
+                forName: .terminalSurfaceDidBecomeReady,
+                object: panel.surface,
+                queue: .main
+            ) { _ in
+                continuation.yield()
+            },
+        ]
+        defer {
+            for token in tokens { center.removeObserver(token) }
+            continuation.finish()
+        }
+
+        let observed = expectation(description: description)
+        var matchingText: String?
+        let observer = Task { @MainActor in
+            for await _ in events {
+                guard let text = panel.surface.visibleText(), condition(text) else { continue }
+                matchingText = text
+                observed.fulfill()
+                return
+            }
+        }
+        defer { observer.cancel() }
+
+        if let text = panel.surface.visibleText(), condition(text) {
+            matchingText = text
+            observed.fulfill()
+        } else {
+            GhosttyApp.shared.scheduleTick()
+        }
+
+        let result = await XCTWaiter.fulfillment(of: [observed], timeout: timeout)
+        guard result == .completed else {
+            XCTFail(
+                "Timed out after \(timeout)s waiting for \(description). " +
+                    "Last visible terminal text:\n\(panel.surface.visibleText() ?? "<unavailable>")"
+            )
+            return panel.surface.visibleText()
+        }
+        return matchingText ?? panel.surface.visibleText()
+    }
+
+    func testDeferredTerminalIsClassifiedColdWithoutWaking() {
+        let panel = TerminalPanel(workspaceId: UUID(), runtimeSpawnPolicy: .pacedSessionRestore)
+
+        XCTAssertEqual(adapter.targetKind(for: panel), .terminal(.cold))
+        XCTAssertFalse(panel.surface.hasLiveSurface)
+    }
+
+    func testMissingTargetMapsToLocalizedTerminalNotFoundRejection() {
+        let result = adapter.dispatch(command: "printf hello", to: nil)
+
+        XCTAssertFalse(result.accepted)
+        XCTAssertEqual(
+            result.message,
+            String(
+                localized: "sidebar.extensions.action.terminalNotFound",
+                defaultValue: "Terminal surface not found"
+            )
+        )
+    }
+
+    func testNonterminalPanelMapsToLocalizedTargetNotTerminalWithoutTerminalInput() {
+        let panel = BrowserPanel(workspaceId: UUID(), renderInitialNavigation: false)
+        defer { panel.close() }
+
+        let result = adapter.dispatch(command: "printf hello", to: panel)
+
+        XCTAssertFalse(result.accepted)
+        XCTAssertEqual(
+            result.message,
+            String(
+                localized: "sidebar.extensions.action.targetNotTerminal",
+                defaultValue: "Target surface is not a terminal"
+            )
+        )
+    }
+
+    func testInvalidCommandWinsBeforeMissingTarget() {
+        let result = adapter.dispatch(command: "echo first\necho second", to: nil)
+
+        XCTAssertFalse(result.accepted)
+        XCTAssertEqual(
+            result.message,
+            String(
+                localized: "sidebar.extensions.action.commandRejected",
+                defaultValue: "Command must be nonempty, no more than 8192 UTF-8 bytes, single-line, and contain no control or separator characters"
+            )
+        )
+    }
+
+    func testDeferredTerminalMapsToLocalizedUnavailableRejection() {
+        let panel = TerminalPanel(workspaceId: UUID(), runtimeSpawnPolicy: .pacedSessionRestore)
+        let result = adapter.dispatch(command: "printf hello", to: panel)
+
+        XCTAssertFalse(result.accepted)
+        XCTAssertEqual(
+            result.message,
+            String(
+                localized: "sidebar.extensions.action.terminalUnavailable",
+                defaultValue: "Terminal surface is not live"
+            )
+        )
+        XCTAssertFalse(panel.surface.hasLiveSurface)
+    }
+
+    func testLiveTerminalDispatchesExactCommandThenEnterAndAccepts() async throws {
+        let hosted = try makeHostedTerminalPanel()
+        defer {
+            hosted.panel.close()
+            hosted.window.orderOut(nil)
+        }
+        let liveSurfaceReady = await waitForLiveSurface(hosted.panel)
+        try XCTSkipUnless(
+            liveSurfaceReady,
+            "Ghostty surface failed to initialize on this host; Metal/embedded_window unavailable."
+        )
+        let initialText = await waitForVisibleText(
+            from: hosted.panel,
+            description: "initial shell prompt"
+        ) { text in
+            text.rangeOfCharacter(from: .whitespacesAndNewlines.inverted) != nil
+        }
+        try XCTUnwrap(
+            initialText,
+            "Terminal shell never produced visible output before command dispatch."
+        )
+
+        let command = #"printf 'X42\n'"#
+
+        let result = adapter.dispatch(command: command, to: hosted.panel)
+
+        let observedText = await waitForVisibleText(
+            from: hosted.panel,
+            description: "echoed command followed by a standalone X42 output line"
+        ) { text in
+            let normalizedText = text
+                .replacingOccurrences(of: "\r\n", with: "\n")
+                .replacingOccurrences(of: "\r", with: "\n")
+            let lines = normalizedText.components(separatedBy: "\n")
+            guard let commandLineIndex = lines.firstIndex(where: { $0.contains(command) }) else {
+                return false
+            }
+            return lines[(commandLineIndex + 1)...].contains {
+                $0.trimmingCharacters(in: .whitespaces) == "X42"
+            }
+        }
+        let transcript = try XCTUnwrap(
+            observedText,
+            "Terminal transcript never exposed an echoed command followed by a standalone X42 output line. " +
+                "Transcript:\n\(hosted.panel.surface.visibleText() ?? "<unavailable>")"
+        )
+        let normalizedTranscript = transcript
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let lines = normalizedTranscript.components(separatedBy: "\n")
+        let commandEchoIndices = lines.indices.filter { lines[$0].contains(command) }
+        let outputIndices = lines.indices.filter {
+            lines[$0].trimmingCharacters(in: .whitespaces) == "X42"
+        }
+
+        XCTAssertTrue(
+            result.accepted,
+            "Live terminal rejected the command: \(result.message ?? "<no reason>"). " +
+                "Transcript:\n\(normalizedTranscript)"
+        )
+        XCTAssertNil(
+            result.message,
+            "Accepted live terminal command unexpectedly returned a message. " +
+                "Transcript:\n\(normalizedTranscript)"
+        )
+        XCTAssertTrue(
+            commandEchoIndices.contains { commandIndex in
+                outputIndices.contains { commandIndex < $0 }
+            },
+            "Expected at least one echoed command line before the X42 output line. " +
+                "Transcript:\n\(normalizedTranscript)"
+        )
+        XCTAssertEqual(
+            outputIndices.count,
+            1,
+            "Expected exactly one standalone trimmed X42 output line; duplicate execution must fail. " +
+                "Transcript:\n\(normalizedTranscript)"
+        )
+    }
+
+    func testAllStructuredPackageRejectionsUseProductionLocalizedMapping() {
+        let cases: [(rejection: CMUXSidebarRunCommandRejection, expected: String)] = [
+            (
+                .commandRejected,
+                String(
+                    localized: "sidebar.extensions.action.commandRejected",
+                    defaultValue: "Command must be nonempty, no more than 8192 UTF-8 bytes, single-line, and contain no control or separator characters"
+                )
+            ),
+            (
+                .terminalNotFound,
+                String(
+                    localized: "sidebar.extensions.action.terminalNotFound",
+                    defaultValue: "Terminal surface not found"
+                )
+            ),
+            (
+                .targetNotTerminal,
+                String(
+                    localized: "sidebar.extensions.action.targetNotTerminal",
+                    defaultValue: "Target surface is not a terminal"
+                )
+            ),
+            (
+                .terminalUnavailable,
+                String(
+                    localized: "sidebar.extensions.action.terminalUnavailable",
+                    defaultValue: "Terminal surface is not live"
+                )
+            ),
+            (
+                .terminalInputRejected,
+                String(
+                    localized: "sidebar.extensions.action.terminalInputRejected",
+                    defaultValue: "Terminal surface did not accept input"
+                )
+            ),
+        ]
+
+        for testCase in cases {
+            let result = adapter.result(for: .rejected(testCase.rejection))
+
+            XCTAssertFalse(result.accepted, "\(testCase.rejection)")
+            XCTAssertEqual(result.message, testCase.expected, "\(testCase.rejection)")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add one generic ExtensionKit behavior: a permission-scoped `.runCommand` sidebar action that safely resumes and submits text to an exact terminal target.

The pure validation/acceptance engine is now extracted into the existing `CmuxExtensionKit` package behind its `CmuxHostTransport` SPI. `ContentView` is only the app-owned `TerminalPanel` adapter and localized-result mapping; there is no duplicate app engine.

Provenance: Majordomo/cmux UX investigation session 2026-07-29/30 identified that the existing ExtensionKit lacked a safe resume seam.

## Behavior and security

- Requires an explicit `.runCommand` extension grant.
- Addresses the exact terminal target supplied by the action; it does not fall back to another terminal.
- Accepts at most 8192 UTF-8 bytes and only a single line.
- Rejects the full C0, DEL, C1, U+2028, and U+2029 control/separator ranges.
- Requires the target to be live, nonhibernated, noncold, and nondead before dispatch.
- Sends validated text, then Enter, and short-circuits input failures.
- Keeps the dispatcher instance-owned, with no ambient enum, static namespace, singleton, wake, retry, or fallback behavior.

This is ExtensionKit/host plumbing only: there is no sidebar- or product-specific logic and no live migration.

## Scope

Exactly 10 files are changed:

- `Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Manifest/CMUXExtensionScope.swift`
- `Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarAction.swift`
- `Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CMUXSidebarRunCommandDispatcher.swift`
- `Packages/macOS/CmuxExtensionKit/Sources/CmuxExtensionKit/Sidebar/CmuxSidebarHost.swift`
- `Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CMUXSidebarRunCommandDispatcherTests.swift`
- `Packages/macOS/CmuxExtensionKit/Tests/CmuxExtensionKitTests/CmuxExtensionKitTests.swift`
- `Resources/Localizable.xcstrings`
- `Sources/CMUXInstalledExtensionSidebarHostView.swift`
- `Sources/ContentView.swift`
- `cmuxTests/WorkspaceActionDispatcherTests.swift`

The `ghostty`, `homebrew-cmux`, and `vendor/bonsplit` pointers are unchanged.

## Verification

Run from:

```sh
cd /Users/arthur/agents/vendor/manaflow-ai/cmux
```

Full internationalization policy audit passed: all 7 run-command keys have translated `stringUnit` values for all 20 supported locales, as required by `.github/review-bot-rules/full-internationalization.md`. The command-rejection source/default and translations now explicitly communicate both control and separator characters.

Package-boundary review passed with no findings: the pure engine exists only in `CmuxExtensionKit` SPI, while `ContentView` remains the thin app adapter.

Package tests:

```sh
swift test --package-path Packages/macOS/CmuxExtensionKit
```

Observed: **26/26 passed**.

Current app adapter and workspace suites:

```sh
./scripts/ensure-ghosttykit.sh
DD=/tmp/cmux-run-command-final
rm -rf "$DD"
CMUX_SKIP_ZIG_BUILD=1 xcodebuild \
  -project cmux.xcodeproj -scheme cmux-unit -configuration Debug \
  -destination 'platform=macOS' -derivedDataPath "$DD" build-for-testing
XCTESTRUN=$(printf '%s\n' "$DD"/Build/Products/*.xctestrun)
xcodebuild test-without-building -xctestrun "$XCTESTRUN" \
  -destination 'platform=macOS' \
  -only-testing:cmuxTests/CMUXSidebarRunCommandTerminalAdapterTests \
  -only-testing:cmuxTests/WorkspaceActionDispatcherTests
```

Observed: **11/11 passed** (7 terminal-adapter + 4 workspace-action tests).

The exact live terminal test was then run twice against the same build:

```sh
xcodebuild test-without-building -xctestrun "$XCTESTRUN" \
  -destination 'platform=macOS' \
  -only-testing:cmuxTests/CMUXSidebarRunCommandTerminalAdapterTests/testLiveTerminalDispatchesExactCommandThenEnterAndAccepts
# Repeat the same command once.
```

Observed: **1/1 passed twice**. Each run verified the echoed command, a later normalized standalone `X42`, an accepted result, and exactly one standalone trimmed `X42` output line.

Full unsigned Debug app build:

```sh
./scripts/ensure-ghosttykit.sh
APP_DD=/tmp/cmux-run-command-app-final
rm -rf "$APP_DD"
CMUX_SKIP_ZIG_BUILD=1 xcodebuild build \
  -project cmux.xcodeproj -scheme cmux -configuration Debug \
  -destination 'platform=macOS' -derivedDataPath "$APP_DD" \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
```

Observed: **BUILD SUCCEEDED**, including the changed package/app sources and string catalog.

`CMUX_SKIP_ZIG_BUILD=1` is the repository-supported path for these tests/builds and does not skip the ExtensionKit or terminal-adapter behavior under test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788017916&installation_model_id=21920&pr_number=9227&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9227&signature=a6797c3d508650b127254c46782fc91ef636bfec378fef56b256c1ec5e331e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a permission-scoped `.runCommand` sidebar action to run one validated command in a specific live terminal and press Enter, wired end-to-end through `CmuxExtensionKit`. Also invalidates interrupted sidebar extension connections and fences stale callbacks so only the current session delivers updates.

- **New Features**
  - Adds `.runCommand` scope, `CmuxSidebarAction.runCommand(...)`, and `CmuxSidebarHost.runCommand(...)`; updates manifest/codec and localized UI labels.
  - Introduces `CMUXSidebarRunCommandDispatcher` with structured target/state/result enums, a terminal adapter, and integration in `VerticalTabsSidebar`.
  - Validates input (single line, ≤8192 UTF‑8 bytes; rejects C0/C1/DEL/U+2028/U+2029) and maps rejections to localized messages; adds tests for validation, terminal availability, and connection fencing across interruption/invalidation paths.

- **Migration**
  - Extensions must add `.runCommand` to `actionScopes` in their manifest to use this action.

<sup>Written for commit 6c83d3096aac95a29bca7f398cb36d57714cb46f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a sidebar extension action for running commands in existing live terminal surfaces.
  - Added localized permission, status, and rejection messages for the new action.

- **Bug Fixes**
  - Improved validation and handling for unavailable, missing, non-terminal, or invalid command targets.
  - Prevented stale extension connection responses after interruptions or invalidation.

- **Tests**
  - Added coverage for command validation, terminal availability, localized errors, successful execution, and connection recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->