### PR TITLE
Fall back to legacy /tmp socket when the state directory is uncreatable

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Policy/SocketListenerPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Policy/SocketListenerPolicy.swift
@@ -197,9 +197,14 @@ public struct SocketListenerPolicy: Sendable {
     /// The fallback socket path after a bind failure at the stable default
     /// path, or nil when no fallback applies.
     ///
-    /// Only the shared stable default path falls back (to the user-scoped
-    /// stable path) and only for permission/lock/occupancy failures another
-    /// user's listener can cause. Tagged and explicit paths never fall back.
+    /// Only the shared stable default path falls back, and only for failures
+    /// with a usable alternative. Permission/lock/occupancy failures another
+    /// user's listener can cause fall back to the user-scoped stable path.
+    /// Failures creating the state directory itself (`create_directory`,
+    /// `create_lock_directory` — e.g. `~/.local/state` owned by root after a
+    /// past `sudo` install) fall back to the legacy `/tmp` per-user path,
+    /// because the user-scoped path shares the uncreatable directory and would
+    /// fail identically. Tagged and explicit paths never fall back.
     ///
     /// - Parameters:
     ///   - requestedPath: The path the bind attempted.
@@ -219,9 +224,11 @@ public struct SocketListenerPolicy: Sendable {
         }
 
         switch stage {
+        case "create_directory", "create_lock_directory":
+            return SocketControlSettings.legacyUserScopedStableSocketPath(currentUserID: currentUserID)
         case "unlink" where errnoCode == EACCES || errnoCode == EPERM:
             return SocketControlSettings.userScopedStableSocketPath(currentUserID: currentUserID)
-        case "create_lock_directory", "open_lock", "lock":
+        case "open_lock", "lock":
             return SocketControlSettings.userScopedStableSocketPath(currentUserID: currentUserID)
         case "existing_path", "stat_existing_path":
             return SocketControlSettings.userScopedStableSocketPath(currentUserID: currentUserID)

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketListenerPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketListenerPolicyTests.swift
@@ -208,7 +208,6 @@ import Testing
     }
 
     @Test(arguments: [
-        ("create_lock_directory", EACCES),
         ("open_lock", EACCES),
         ("open_lock", ELOOP),
         ("open_lock", EINVAL),
@@ -224,6 +223,29 @@ import Testing
                 errnoCode: errnoCode,
                 currentUserID: 501
             ) == SocketControlSettings.userScopedStableSocketPath(currentUserID: 501)
+        )
+    }
+
+    // The user-scoped fallback lives in the same state directory as the stable
+    // default socket, so when that directory itself cannot be created (e.g.
+    // ~/.local/state owned by root after a past `sudo` install) every sibling
+    // path fails identically and the listener must escape to /tmp.
+    @Test(arguments: [
+        ("create_directory", EACCES),
+        ("create_directory", EPERM),
+        ("create_directory", EIO),
+        ("create_lock_directory", EACCES),
+        ("create_lock_directory", EPERM),
+        ("create_lock_directory", EIO),
+    ] as [(String, Int32)])
+    func stableSocketStateDirectoryCreationFailuresFallBackToLegacyTmpSocket(stage: String, errnoCode: Int32) {
+        #expect(
+            policy.fallbackSocketPathAfterBindFailure(
+                requestedPath: SocketControlSettings.stableDefaultSocketPath,
+                stage: stage,
+                errnoCode: errnoCode,
+                currentUserID: 501
+            ) == SocketControlSettings.legacyUserScopedStableSocketPath(currentUserID: 501)
         )
     }
 

--- a/skills/cmux-workspace/SKILL.md
+++ b/skills/cmux-workspace/SKILL.md
@@ -98,7 +98,7 @@ CMUX_SOCKET_PATH=/tmp/cmux-debug-<short-tag>.sock cmux identify --json
 
 ## Socket access
 
-Use the socket path cmux provided before any default: `SOCK="${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"`. Socket access can be off, restricted to cmux-spawned processes, or open to all local processes. If a command cannot connect, inspect `cmux capabilities --json` and `cmux ping` before changing settings.
+Use the socket path cmux provided before any default: `SOCK="${CMUX_SOCKET_PATH:-$HOME/.local/state/cmux/cmux.sock}"`. Socket access can be off, restricted to cmux-spawned processes, or open to all local processes. If a command cannot connect, inspect `cmux capabilities --json` and `cmux ping` before changing settings.
 
 ## Rules
 

--- a/web/app/[locale]/(landing)/docs/api/page.tsx
+++ b/web/app/[locale]/(landing)/docs/api/page.tsx
@@ -58,7 +58,7 @@ export default function ApiPage() {
           <tr>
             <td>{t("release")}</td>
             <td>
-              <code>/tmp/cmux.sock</code>
+              <code>~/.local/state/cmux/cmux.sock</code>
             </td>
           </tr>
           <tr>
@@ -433,7 +433,7 @@ cmux identify --json`}
 
       <DocsHeading level={2} id="detecting-cmux">{t("detectingCmux")}</DocsHeading>
       <CodeBlock title="bash" lang="bash">{`# Prefer explicit socket path if set
-SOCK="\${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+SOCK="\${CMUX_SOCKET_PATH:-$HOME/.local/state/cmux/cmux.sock}"
 [ -S "$SOCK" ] && echo "Socket available"
 
 # Check for the CLI
@@ -452,7 +452,9 @@ command -v cmux &>/dev/null && echo "cmux available"
 import os
 import socket
 
-SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux.sock")
+SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH") or os.path.expanduser(
+    "~/.local/state/cmux/cmux.sock"
+)
 
 def rpc(method, params=None, req_id=1):
     payload = {"id": req_id, "method": method, "params": params or {}}
@@ -473,7 +475,7 @@ print(rpc(
 
       <DocsHeading level={3} id="shell-script">{t("shellScript")}</DocsHeading>
       <CodeBlock title="bash" lang="bash">{`#!/bin/bash
-SOCK="\${CMUX_SOCKET_PATH:-/tmp/cmux.sock}"
+SOCK="\${CMUX_SOCKET_PATH:-$HOME/.local/state/cmux/cmux.sock}"
 
 cmux_cmd() {
     printf "%s\\n" "$1" | nc -U "$SOCK"

--- a/web/app/[locale]/(landing)/docs/notifications/page.tsx
+++ b/web/app/[locale]/(landing)/docs/notifications/page.tsx
@@ -213,7 +213,7 @@ printf '\\e]99;i=1;e=1;d=1;p=body:All tests passed\\e\\\\'`}</CodeBlock>
       <DocsHeading level={3} id="create-hook-script">{t("createHookScript")}</DocsHeading>
       <CodeBlock title="~/.claude/hooks/cmux-notify.sh" lang="bash">{`#!/bin/bash
 # Skip if not in cmux
-[ -S /tmp/cmux.sock ] || exit 0
+[ -S "\${CMUX_SOCKET_PATH:-$HOME/.local/state/cmux/cmux.sock}" ] || exit 0
 
 EVENT=$(cat)
 EVENT_TYPE=$(echo "$EVENT" | jq -r '.hook_event_name // "unknown"')


### PR DESCRIPTION
## Problem

Since the control socket moved to `~/.local/state/cmux/cmux.sock` (#5146), a machine where `~/.local/state` is not writable by the user (real case: the directory is owned by root after a past `sudo gem install`) loses the control socket entirely:

1. `acquireSocketPathLock` / `bindListenerSocket` fail at the `create_lock_directory` / `create_directory` stage with `EACCES`.
2. `SocketListenerPolicy.fallbackSocketPathAfterBindFailure` has no case for `create_directory`, and routes `create_lock_directory` to the user-scoped path — which lives in the **same uncreatable directory** and fails identically.
3. The listener dies with only a telemetry breadcrumb. Every `cmux` CLI command then fails with `Socket not found at ~/.local/state/cmux/cmux.sock`, and agent hooks silently no-op.

## Fix

When the state directory itself cannot be created (`create_directory` / `create_lock_directory` stages), fall back to the legacy `/tmp` per-user path (`/tmp/cmux-<uid>.sock`) instead of a sibling of the uncreatable directory. The CLI already includes that path in its stable discovery candidates, so clients find the listener with no changes.

Commits follow the regression-test policy: commit 1 adds the failing policy tests only (CI red), commit 2 adds the fix (CI green).

## Docs

The API/notifications docs and the workspace skill still showed the pre-0.64.20 default `/tmp/cmux.sock`; they now show `~/.local/state/cmux/cmux.sock` behind `CMUX_SOCKET_PATH`. Localization audit: only untranslated code literals inside `CodeBlock`/`<code>` changed; no message-catalog strings added or modified.

## Validation

- `swiftc -parse` on the changed Swift files passes; the policy tests are pure-function Swift Testing cases in `CmuxControlSocketTests` (no pbxproj wiring involved).
- Local `swift test`/tagged build were blocked on this machine (Xcode 26.6 license re-agreement pending), so red→green proof is delegated to CI per the regression-commit policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788019697&installation_model_id=21920&pr_number=9228&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9228&signature=8bd3c34e5fabb3e2f84429ce931029ec3f93a3751141adc95d0c65a9c287ac64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fall back to the legacy per-user socket at `/tmp/cmux-<uid>.sock` when `~/.local/state` can’t be created, so the listener stays reachable. Docs now show the current default socket path `~/.local/state/cmux/cmux.sock` behind `CMUX_SOCKET_PATH`.

- **Bug Fixes**
  - Update `SocketListenerPolicy.fallbackSocketPathAfterBindFailure` to route `create_directory` and `create_lock_directory` failures to `SocketControlSettings.legacyUserScopedStableSocketPath(...)` (the `/tmp` path). Other permission/lock/occupancy failures still fall back to the user-scoped state path; tagged/explicit paths don’t fall back.
  - Add tests confirming `/tmp` fallback when the state directory is uncreatable. No client changes required; the CLI already discovers the legacy path.

<sup>Written for commit 6bcf66306d1c3dbae78581d760d4a73b5e4580b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket fallback behavior when the default state or lock directories cannot be created, using a reliable per-user legacy path instead.

* **Documentation**
  * Updated workspace, API, and notification examples to use the per-user default socket path under `~/.local/state/cmux/cmux.sock`.
  * Clarified socket fallback behavior and environment-variable overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->