### PR TITLE
Ship dSYMs with iOS TestFlight builds and persist them as run artifacts

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -486,6 +486,10 @@ jobs:
           # The script writes the CFBundleVersion that actually shipped here (the
           # monotonic guard may bump it), so the summary reports the real value.
           CMUX_BUILD_NUMBER_OUT_FILE: ${{ runner.temp }}/cmux-final-build-number.txt
+          # Pin the archive/export workspace: the default is a /tmp dir keyed by
+          # the build number, which this workflow cannot compute, and the
+          # post-upload dSYM artifact step must find the archive's dSYM bundle.
+          CMUX_IOS_UPLOAD_DIR: ${{ runner.temp }}/cmux-ios-upload
           # The previous beta's commit (the last successful run's head_sha): base
           # of the per-build "What to Test" commit range. Empty on the very first
           # run / a missing history, where the generator falls back gracefully.
@@ -597,6 +601,23 @@ jobs:
           # therefore skip logic + notes ranges) independent per app.
           name: ${{ github.event.inputs.marketing_version_override != '' && 'ios-testflight-build-metadata-override' || needs.decide.outputs.variant == 'demo' && 'ios-testflight-build-metadata-demo' || 'ios-testflight-build-metadata' }}
           path: ${{ runner.temp }}/ios-testflight-build.json
+          retention-days: 30
+
+      - name: Persist dSYM bundle as run artifact
+        # The runner is ephemeral, so the archive's dSYMs are the only durable
+        # copy of this build's symbols besides the Symbols/ files uploaded
+        # inside the IPA; without this artifact, a TestFlight crash whose
+        # symbols ASC cannot serve is permanently unsymbolicatable (build
+        # 20260730090940). Keyed by variant + CFBundleVersion so a crash
+        # report's build number finds the right bundle. The override path is
+        # excluded like the canonical metadata artifact: it archives on a fleet
+        # Mac via cloud-testflight.sh, not under CMUX_IOS_UPLOAD_DIR.
+        if: success() && github.event.inputs.marketing_version_override == ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-dsyms-${{ needs.decide.outputs.variant }}-${{ steps.upload.outputs.final_build_number }}
+          path: ${{ runner.temp }}/cmux-ios-upload/cmux.xcarchive/dSYMs
+          if-no-files-found: error
           retention-days: 30
 
       - name: Cleanup keychain

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -612,7 +612,11 @@ jobs:
         # report's build number finds the right bundle. The override path is
         # excluded like the canonical metadata artifact: it archives on a fleet
         # Mac via cloud-testflight.sh, not under CMUX_IOS_UPLOAD_DIR.
-        if: success() && github.event.inputs.marketing_version_override == ''
+        # Gated on the UPLOAD step's outcome, not whole-job success(): once the
+        # IPA reached TestFlight its symbols must be persisted even if a later
+        # step (summary/metadata artifact) failed, or a shipped build becomes
+        # unsymbolicatable again.
+        if: ${{ !cancelled() && steps.upload.outcome == 'success' && github.event.inputs.marketing_version_override == '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-dsyms-${{ needs.decide.outputs.variant }}-${{ steps.upload.outputs.final_build_number }}

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -224,7 +224,9 @@ verify_ipa_framework_minimum_os_versions() {
 # 20260730090940 shipped unsymbolicatable.
 verify_ipa_contains_app_symbols() {
   local ipa="$1"
-  zipinfo -1 "$ipa" 2>/dev/null | grep -q '^Symbols/.*\.symbols$'
+  # No `grep -q` here: under `set -o pipefail`, -q's early exit can kill
+  # zipinfo with SIGPIPE and fail a VALID IPA. Plain grep drains its input.
+  zipinfo -1 "$ipa" 2>/dev/null | grep '^Symbols/.*\.symbols$' >/dev/null
 }
 
 verify_app_store_ipa_has_no_external_purchase_links() {
@@ -909,7 +911,7 @@ fi
 # dSYMs (DEBUG_INFORMATION_FORMAT != dwarf-with-dsym, or a truncated fleet
 # download) would ship a build whose crashes can never be symbolicated by
 # anyone, so fail before the expensive export.
-if ! find "$ARCHIVE_PATH/dSYMs" -maxdepth 1 -name '*.dSYM' -print -quit 2>/dev/null | grep -q .; then
+if ! find "$ARCHIVE_PATH/dSYMs" -maxdepth 1 -type d -name '*.dSYM' -print -quit 2>/dev/null | grep -q .; then
   echo "error: archive has no dSYM bundles at $ARCHIVE_PATH/dSYMs; crashes for this build could never be symbolicated. Archive Release with DEBUG_INFORMATION_FORMAT=dwarf-with-dsym (or re-fetch the archive if it was downloaded)." >&2
   exit 1
 fi

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -214,6 +214,19 @@ verify_ipa_framework_minimum_os_versions() {
   return 0
 }
 
+# App Store Connect symbolicates TestFlight/App Store crashes from the
+# .symbols files that an app-store-connect export places in the IPA's
+# top-level Symbols/ directory (extracted from the archive's dSYMs when the
+# export options carry uploadSymbols=YES). Without them ASC reports "No dSYM
+# files available" and every crash arrives as raw `cmux + offset` frames.
+# Check the IPA that actually ships: a re-zip that packs only Payload/
+# silently drops Symbols/, which is exactly how every beta through build
+# 20260730090940 shipped unsymbolicatable.
+verify_ipa_contains_app_symbols() {
+  local ipa="$1"
+  zipinfo -1 "$ipa" 2>/dev/null | grep -q '^Symbols/.*\.symbols$'
+}
+
 verify_app_store_ipa_has_no_external_purchase_links() {
   local ipa="$1"
   local workdir app matches
@@ -889,6 +902,18 @@ if [[ "$ARCHIVE_MARKETING_VERSION" != "$EXPECTED_MARKETING_VERSION" ]]; then
   exit 1
 fi
 
+# The archive's dSYMs are the source of both symbol paths for this build: the
+# Symbols/ files the export embeds in the IPA for App Store Connect crash
+# symbolication, and the dSYM run artifact ios-testflight.yml persists for
+# local symbolication after ASC's copy is unavailable. An archive without
+# dSYMs (DEBUG_INFORMATION_FORMAT != dwarf-with-dsym, or a truncated fleet
+# download) would ship a build whose crashes can never be symbolicated by
+# anyone, so fail before the expensive export.
+if ! find "$ARCHIVE_PATH/dSYMs" -maxdepth 1 -name '*.dSYM' -print -quit 2>/dev/null | grep -q .; then
+  echo "error: archive has no dSYM bundles at $ARCHIVE_PATH/dSYMs; crashes for this build could never be symbolicated. Archive Release with DEBUG_INFORMATION_FORMAT=dwarf-with-dsym (or re-fetch the archive if it was downloaded)." >&2
+  exit 1
+fi
+
 # Now that the archive exists, its marketing version (CFBundleShortVersionString)
 # is the version testers will see. Re-run the notes preflight WITH that version so
 # a deterministic mismatch (changelog top is 1.0.3 but the archived build is 1.0.0)
@@ -1159,11 +1184,24 @@ PY
   fi
   codesign --verify --strict --verbose=2 "$RESIGN_APP"
 
-  # Re-zip with the exact IPA layout (Payload/ at archive root) and repoint
-  # $IPA_PATH so the existing upload step ships the re-signed IPA.
+  # Re-zip with the exact IPA layout and repoint $IPA_PATH so the existing
+  # upload step ships the re-signed IPA. Payload/ is not the only top-level
+  # member that matters: the export also produced Symbols/ (the .symbols files
+  # App Store Connect needs to symbolicate crash reports) and may produce
+  # SwiftSupport/. A Payload-only re-zip shipped every beta without symbols
+  # ("No dSYM files available" on ASC), so pack every Apple package directory
+  # the export put in the IPA. The include list stays explicit because this
+  # script also writes loose entitlements/profile plists into $RESIGN_DIR that
+  # must never ship.
   RESIGNED_IPA="$EXPORT_PATH/cmux-resigned.ipa"
   rm -f "$RESIGNED_IPA"
-  ( cd "$RESIGN_DIR" && zip -qrX "$RESIGNED_IPA" Payload )
+  IPA_MEMBERS=(Payload)
+  for ipa_member in Symbols SwiftSupport BCSymbolMaps; do
+    if [[ -d "$RESIGN_DIR/$ipa_member" ]]; then
+      IPA_MEMBERS+=("$ipa_member")
+    fi
+  done
+  ( cd "$RESIGN_DIR" && zip -qrX "$RESIGNED_IPA" "${IPA_MEMBERS[@]}" )
 
   # Post-zip gate: a wrong Payload root or stripped attributes corrupts the bundle
   # silently, and the whole point is that aps-environment survives. Re-verify the
@@ -1207,6 +1245,12 @@ if ! verify_ipa_framework_minimum_os_versions "$IPA_PATH"; then
   exit 1
 fi
 echo "signed IPA framework deployment metadata verified"
+
+if ! verify_ipa_contains_app_symbols "$IPA_PATH"; then
+  echo "error: final IPA carries no Symbols/*.symbols, so App Store Connect would report 'No dSYM files available' and every crash for this build would be unsymbolicatable; refusing to upload. The export must run with uploadSymbols=YES against an archive that has dSYMs, and any re-zip must preserve the Symbols/ directory." >&2
+  exit 1
+fi
+echo "signed IPA app symbols verified (Symbols/*.symbols present for ASC crash symbolication)"
 
 echo "IPA_PATH=$IPA_PATH"
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -226,7 +226,7 @@ verify_ipa_contains_app_symbols() {
   local ipa="$1"
   # No `grep -q` here: under `set -o pipefail`, -q's early exit can kill
   # zipinfo with SIGPIPE and fail a VALID IPA. Plain grep drains its input.
-  zipinfo -1 "$ipa" 2>/dev/null | grep '^Symbols/.*\.symbols$' >/dev/null
+  zipinfo -1 "$ipa" 2>/dev/null | grep '^Symbols/[^/]*\.symbols$' >/dev/null
 }
 
 verify_app_store_ipa_has_no_external_purchase_links() {


### PR DESCRIPTION
App Store Connect reports "No dSYM files available" for every cmux INTERNAL/DEMO TestFlight build, so crashes arrive as raw `cmux + offset` frames. The 2026-07-30 SIGSEGV on `dev.cmux.app.internal` build `20260730090940` is permanently unsymbolicatable: ASC has no symbols and the CI runner that held the dSYMs was ephemeral.

Root cause: `ios/scripts/upload-testflight.sh` already exports with `uploadSymbols=YES` and the archive does contain dSYMs, but the manual-signing path re-zips the re-signed IPA from `Payload/` alone, dropping the top-level `Symbols/` directory (the `.symbols` files ASC uses for crash symbolication) that Xcode put in the exported IPA.

Changes:
- Re-zip every Apple package directory the export produced (`Payload`, plus `Symbols`, `SwiftSupport`, `BCSymbolMaps` when present). The include list stays explicit because the script writes loose entitlement/profile plists into the re-sign dir that must never ship.
- Fail closed before the export when the archive has no dSYM bundles, and before the upload when the final IPA carries no `Symbols/*.symbols`, so the symbolication path cannot silently regress again. Both gates also cover the reused-archive lane (fleet archives are zipped whole, dSYMs included).
- Persist the archive's dSYM bundle as a run artifact `ios-dsyms-<variant>-<build-number>` with 30-day retention, for both internal and demo variants, so a crash's CFBundleVersion locates the exact bundle after ASC's copy is unavailable. The upload step pins `CMUX_IOS_UPLOAD_DIR` to `$RUNNER_TEMP` so the workflow can find the archive (the default is a /tmp path keyed by a build number the workflow cannot compute).
- The `marketing_version_override` escape hatch is excluded from the artifact step, matching the canonical metadata artifact: it archives on a fleet Mac via `cloud-testflight.sh`, not under `CMUX_IOS_UPLOAD_DIR`. Its shipped IPA still passes through the new Symbols gates.

Verified with `bash -n` and YAML parse; the lane itself only runs on `main` (schedule/dispatch), so the first scheduled internal upload after merge is the live proof: the run should show the two new "verified" log lines, produce the `ios-dsyms-internal-<build>` artifact, and the build's ASC page should stop saying "No dSYM files available".

Residual risk: if some Xcode version ever stops embedding `Symbols/` in app-store-connect exports, the new gate fails the hourly lane loudly instead of shipping symbol-less; that is intentional fail-closed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788039870&installation_model_id=21920&pr_number=9236&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9236&signature=3b9a1aa1575168e7be4a695aa08146138a4f75d8e1f33672fc16bb5cee2c0449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship dSYMs with every iOS TestFlight build and keep a 30‑day copy as run artifacts. This fixes “No dSYM files available” in App Store Connect so crashes are symbolicated.

- **Bug Fixes**
  - Re-zip the exported IPA with `Symbols/` (and `SwiftSupport/`, `BCSymbolMaps/` when present) alongside `Payload/`.
  - Fail before export if the archive has no `*.dSYM` directories.
  - Fail before upload if the final IPA lacks top‑level `Symbols/*.symbols` (pipefail‑safe check that avoids SIGPIPE).

- **New Features**
  - Persist the archive’s dSYM bundle as `ios-dsyms-<variant>-<build-number>` (30-day retention), gated on upload success.
  - Pin `CMUX_IOS_UPLOAD_DIR` to the runner temp so the workflow can locate the archive.
  - Skip the artifact when `marketing_version_override` is used (fleet Mac path).

<sup>Written for commit 4bf1daaa9cc949e94f9a16fc1368fa3360667aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS TestFlight uploads to preserve and validate crash-reporting symbols.
  * Added safeguards to stop uploads when required debugging symbols are missing.
  * Ensured generated dSYM bundles are reliably retained after successful uploads for troubleshooting and crash analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->