### PR TITLE
Add public company information page

### DIFF
--- a/web/app/[locale]/(legal)/company-information/page.tsx
+++ b/web/app/[locale]/(legal)/company-information/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import { JsonLd } from "../../components/json-ld";
+import { legalMetadata } from "../legal-metadata";
+
+const legalName = "Manaflow, Inc.";
+const contactEmail = "founders@manaflow.com";
+const streetAddress = "18428 Vantage Pointe Dr";
+const locality = "Rowland Heights";
+const region = "CA";
+const postalCode = "91748-5142";
+
+export const metadata: Metadata = legalMetadata(
+  "/company-information",
+  "Company information — cmux",
+  "Legal entity, address, contact, and domain information for cmux and Manaflow",
+);
+
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Manaflow",
+  legalName,
+  url: "https://manaflow.com",
+  email: contactEmail,
+  address: {
+    "@type": "PostalAddress",
+    streetAddress,
+    addressLocality: locality,
+    addressRegion: region,
+    postalCode,
+    addressCountry: "US",
+  },
+  contactPoint: {
+    "@type": "ContactPoint",
+    contactType: "general inquiries",
+    email: contactEmail,
+  },
+  sameAs: ["https://cmux.com", "https://manaflow.com"],
+};
+
+export default function CompanyInformationPage() {
+  return (
+    <>
+      <JsonLd data={organizationJsonLd} />
+      <h1>Company information</h1>
+      <p>
+        This page provides the official legal entity and domain information for
+        cmux.
+      </p>
+
+      <dl className="my-8 grid max-w-3xl gap-0 overflow-hidden rounded-lg border border-border">
+        <CompanyDetail term="Legal entity">{legalName}</CompanyDetail>
+        <CompanyDetail term="Business address">
+          <address className="not-italic">
+            {streetAddress}
+            <br />
+            {locality}, {region} {postalCode}
+            <br />
+            United States
+          </address>
+        </CompanyDetail>
+        <CompanyDetail term="Contact">
+          <a href={`mailto:${contactEmail}`}>{contactEmail}</a>
+        </CompanyDetail>
+        <CompanyDetail term="Company domain">
+          <a href="https://manaflow.com">manaflow.com</a>
+        </CompanyDetail>
+        <CompanyDetail term="Product domain">
+          <a href="https://cmux.com">cmux.com</a>
+        </CompanyDetail>
+      </dl>
+
+      <h2>Domain ownership and operation</h2>
+      <p>
+        {legalName} owns and operates <a href="https://manaflow.com">manaflow.com</a>{" "}
+        and <a href="https://cmux.com">cmux.com</a>. cmux is developed and
+        operated by {legalName}.
+      </p>
+      <p>Last updated: July 30, 2026</p>
+    </>
+  );
+}
+
+function CompanyDetail({
+  term,
+  children,
+}: {
+  readonly term: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className="grid gap-1 border-b border-border px-5 py-4 last:border-b-0 sm:grid-cols-[11rem_1fr] sm:gap-6">
+      <dt className="font-medium">{term}</dt>
+      <dd>{children}</dd>
+    </div>
+  );
+}

--- a/web/app/[locale]/components/site-footer.tsx
+++ b/web/app/[locale]/components/site-footer.tsx
@@ -56,6 +56,11 @@ export async function SiteFooter() {
     {
       heading: t("legal"),
       links: [
+        {
+          label: t("companyInformation"),
+          href: "/company-information",
+          unlocalized: true,
+        },
         { label: t("privacy"), href: "/privacy-policy" },
         { label: t("terms"), href: "/terms-of-service", unlocalized: true },
         { label: t("eula"), href: "/eula", unlocalized: true },

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -101,6 +101,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/agents/aider", lastModified: "2026-06-23", changeFrequency: "monthly" as const, priority: 0.6 },
     { path: "/agents/amp", lastModified: "2026-06-23", changeFrequency: "monthly" as const, priority: 0.6 },
     { path: "/agents/cursor-cli", lastModified: "2026-06-23", changeFrequency: "monthly" as const, priority: 0.6 },
+    { path: "/company-information", lastModified: "2026-07-30", changeFrequency: "yearly" as const, priority: 0.3 },
     { path: "/privacy-policy", lastModified: "2026-07-10", changeFrequency: "yearly" as const, priority: 0.3 },
     { path: "/terms-of-service", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
     { path: "/eula", lastModified: "2026-03-18", changeFrequency: "yearly" as const, priority: 0.3 },
@@ -108,7 +109,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   // Legal pages are English-only, so they only get one entry.
   // The SEO landing pages are localized, so they go through the per-locale loop.
-  const englishOnly = new Set(["/terms-of-service", "/eula"]);
+  const englishOnly = new Set([
+    "/company-information",
+    "/terms-of-service",
+    "/eula",
+  ]);
 
   const entries: MetadataRoute.Sitemap = [];
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -376,6 +376,7 @@
     "pricing": "Pricing",
     "docs": "Docs",
     "changelog": "Changelog",
+    "companyInformation": "Company information",
     "privacy": "Privacy",
     "terms": "Terms",
     "eula": "EULA",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -376,6 +376,7 @@
     "community": "コミュニティ",
     "docs": "ドキュメント",
     "changelog": "変更履歴",
+    "companyInformation": "会社情報",
     "privacy": "プライバシー",
     "terms": "利用規約",
     "eula": "EULA",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -146,6 +146,7 @@ export default function middleware(request: NextRequest) {
   // locale detection can't redirect back. The privacy policy has complete
   // localized content and follows the normal next-intl path.
   const englishOnlyPages = new Set([
+    "/company-information",
     "/terms-of-service",
     "/eula",
   ]);

--- a/web/tests/company-information.test.tsx
+++ b/web/tests/company-information.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import sitemap from "../app/sitemap";
+import CompanyInformationPage from "../app/[locale]/(legal)/company-information/page";
+
+test("publishes the legal entity, contact, address, and both domains", () => {
+  const html = renderToStaticMarkup(<CompanyInformationPage />);
+
+  expect(html).toContain("Manaflow, Inc.");
+  expect(html).toContain("18428 Vantage Pointe Dr");
+  expect(html).toContain("Rowland Heights");
+  expect(html).toContain("91748-5142");
+  expect(html).toContain("founders@manaflow.com");
+  expect(html).toContain("manaflow.com");
+  expect(html).toContain("cmux.com");
+  expect(html).toContain("application/ld+json");
+});
+
+test("lists only the canonical English company-information page", () => {
+  const urls = sitemap()
+    .map((entry) => entry.url)
+    .filter((url) => url.endsWith("/company-information"));
+
+  expect(urls).toEqual(["https://cmux.com/company-information"]);
+});


### PR DESCRIPTION
## Summary
- add a public company-information page with Manaflow legal identity, address, contact, and both domains
- link it from the localized Legal footer and keep the legal page canonical in English
- add Organization structured data, sitemap coverage, and focused tests

## Verification
- bun test tests/company-information.test.tsx
- bun run typecheck
- bunx eslint on changed TypeScript files
- bun run build (with non-production local build placeholders for required secrets)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788045488&installation_model_id=21920&pr_number=9240&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9240&signature=7bc124aa9c0acc1310eb17b047f30720e66ced50cf9901a9e02c81126f53b6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public company-information page with Manaflow’s legal entity, address, contact email, and both domains. Linked from the Legal footer, includes `Organization` JSON‑LD for SEO, and is listed as an English-only canonical page in the sitemap.

- **New Features**
  - New page at /company-information (English-only canonical).
  - Added footer link with localized label; updated `en.json` and `ja.json`.
  - Injects `Organization` structured data via `JsonLd`.
  - Sitemap adds a single entry for /company-information; middleware updated to treat it as English-only.
  - Tests verify displayed details, JSON‑LD presence, and a single canonical sitemap URL.

<sup>Written for commit 37d20eeec8ca2ba5591f655a366e72a0c66ed883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Company Information page with legal entity, address, contact, domain ownership, and update details.
  - Added localized footer links in English and Japanese.
  - Added the page to the sitemap and supported canonical English-only routing.

- **Tests**
  - Added coverage for company information content, structured data, and sitemap inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->