### PR TITLE
Register company-information as an agent-readable page

### DIFF
--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -82,6 +82,7 @@ const blockedPrefixes = [
   "/handler",
 ];
 const englishOnlyPages = [
+  "/company-information",
   "/privacy-policy",
   "/terms-of-service",
   "/eula",
@@ -232,6 +233,7 @@ export const agentReadablePages = [
   { path: "/agents/aider", title: "Terminal for Aider" },
   { path: "/agents/amp", title: "Terminal for Amp" },
   { path: "/agents/cursor-cli", title: "Terminal for Cursor CLI" },
+  { path: "/company-information", title: "Company Information" },
   { path: "/privacy-policy", title: "Privacy Policy" },
   { path: "/terms-of-service", title: "Terms of Service" },
   { path: "/eula", title: "EULA" },


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/9240 added `/company-information` to the sitemap but not to `web/app/lib/agent-page-paths.ts`, so `web-typecheck`'s sitemap-driven variant test (`agent page variants > supports Markdown and text variants for sitemap pages`) fails on main: `resolveAgentPageVariant` returns null for `/company-information.md`/`.txt`. This registers the page in `englishOnlyPages` and `agentReadablePages`, matching the other English-only legal pages. `bun test tests/agent-page-variants.test.ts`: 23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788049171&installation_model_id=21920&pr_number=9245&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9245&signature=0b9baec20c30612389ecc25dbf9c1d1ea23021193a185d33e860579bee0d5cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Register `/company-information` in `englishOnlyPages` and `agentReadablePages` so its Markdown and text variants resolve like other legal pages. Fixes the failing sitemap-driven agent page variant test on main.

<sup>Written for commit 6da3a9ac17c92e8d96610849d794c6b07243c001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Company Information page to the English-only routes.
  * Made the page available for agent-readable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->