### PR TITLE
Transport plane round 1: health-gated recovery, discovery freshness, host shed, broker nudge+reaper

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/DiagnosticEventCode.swift
@@ -191,6 +191,14 @@ public enum DiagnosticEventCode: UInt16, Sendable, Codable, CaseIterable {
     /// `b` is ``DiagnosticPathKind`` for the affected path, and `c` is the
     /// matching positive, process-local session correlation ID.
     case transportPathEvent = 55
+    /// The Mac host's bounded per-connection event queue shed events under
+    /// backpressure instead of closing the connection (macOS host ring). One
+    /// row per coalesced repair cycle: `a` is the number of events dropped
+    /// since the previous cycle on that connection, `b` is the number of
+    /// topics that received a repair signal once the queue drained. Rings
+    /// showing this code with no nearby ``sessionClosed`` mean backpressure
+    /// was absorbed without a connection death.
+    case hostEventQueueShed = 56
 }
 
 /// Scene phase carried by ``DiagnosticEventCode/appLifecycleChanged``.

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientContextProvider.swift
@@ -14,6 +14,19 @@ public protocol CmxIrohClientContextProvider: CmxIrohPrivateFallbackValidating, 
         for request: CmxByteTransportRequest,
         basedOn context: CmxIrohClientContext
     ) async throws -> CmxIrohClientContext
+
+    /// Records one terminal dial failure so the provider can invalidate any
+    /// reusable discovery state before the next attempt for the same peer.
+    ///
+    /// - Parameters:
+    ///   - request: The exact peer intent whose dial failed.
+    ///   - dialPlan: The plan the failed dial used.
+    ///   - failure: The bounded classification of the dial error.
+    func noteDialFailure(
+        for request: CmxByteTransportRequest,
+        dialPlan: CmxIrohDialPlan,
+        failure: DiagnosticFailureKind
+    ) async
 }
 
 public extension CmxIrohClientContextProvider {
@@ -31,4 +44,11 @@ public extension CmxIrohClientContextProvider {
     ) async throws {
         throw CmxIrohPrivateFallbackValidationError.unavailable
     }
+
+    /// Providers without reusable discovery state ignore dial outcomes.
+    func noteDialFailure(
+        for _: CmxByteTransportRequest,
+        dialPlan _: CmxIrohDialPlan,
+        failure _: DiagnosticFailureKind
+    ) async {}
 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -292,6 +292,16 @@ public actor CmxIrohClientRuntime {
         await sessionPool.selectedPathChanges()
     }
 
+    /// Whether the pool's selected session currently reports a usable path
+    /// (direct, private network, or relay), regardless of relay-policy
+    /// attribution. Unlike ``selectedTransportPath(relayPolicy:)``, a relay
+    /// outside the current verified policy still counts as usable: this is
+    /// a health signal (docs/transport-plane.md D3), not a settings label.
+    /// `false` also covers "no pooled session".
+    public func hasUsableSelectedPath() async -> Bool {
+        await sessionPool.selectedObservedPath() != .unavailable
+    }
+
     /// Binds the endpoint, registers it, and installs exact discovery and relay policy.
     ///
     /// - Throws: A bind, broker, signature, fleet, or local-binding validation error.

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientRuntime.swift
@@ -470,6 +470,22 @@ public actor CmxIrohClientRuntime {
         await sessionPool.invalidate(for: request)
     }
 
+    /// Invalidates reusable broker discovery state for one Mac device.
+    ///
+    /// Called when a presence route push proves the Mac's endpoint
+    /// re-registered: any snapshot captured before the push is corpse data,
+    /// so the next dial to that Mac fetches a fresh discovery snapshot
+    /// (single-flight, bounded by the broker backpressure gate) instead of
+    /// reusing it.
+    ///
+    /// - Parameter deviceID: The Mac's registry device id, or `nil` to
+    ///   invalidate discovery reuse for every peer.
+    public func invalidateDiscoverySnapshot(forMacDeviceID deviceID: String?) async {
+        await registryContextProvider?.invalidateVerifiedDiscovery(
+            forDeviceID: deviceID
+        )
+    }
+
     /// Stops network ownership while preserving account-scoped persistence.
     public func stop() async {
         guard lifecyclePhase == .starting || lifecyclePhase == .active else {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohClientSessionPool.swift
@@ -153,6 +153,18 @@ actor CmxIrohClientSessionPool {
                         return session
                     } catch {
                         await session.close()
+                        // Level-triggered discovery refresh: report the failed
+                        // dial (with the exact plan it used) so the provider
+                        // can invalidate stale discovery reuse before the next
+                        // attempt. Cancellation is caller intent, not route
+                        // evidence.
+                        if !(Task.isCancelled || error is CancellationError) {
+                            await contextProvider.noteDialFailure(
+                                for: request,
+                                dialPlan: context.dialPlan,
+                                failure: DiagnosticFailureKind.classify(error)
+                            )
+                        }
                         throw error
                     }
                 }

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRegistryContextProvider.swift
@@ -34,6 +34,17 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
     var pairGrantRetryDeadline: (code: String?, date: Date)?
     var lanAuthorities: [CmxIrohPeerIdentity: CmxIrohRegistryLANAuthority] = [:]
     private var verifiedDiscoverySnapshot: VerifiedDiscoverySnapshot?
+    /// Peers whose last dial produced staleness evidence (an empty dial plan
+    /// or an unreachable-class failure). Their next dial bypasses every
+    /// discovery reuse window and fetches a fresh broker snapshot.
+    private var staleDiscoveryPeers: Set<CmxIrohPeerIdentity> = []
+    /// Same staleness marker keyed by canonical Mac device id, for callers
+    /// (presence route pushes) that know the device but not its endpoint.
+    private var staleDiscoveryDeviceIDs: Set<String> = []
+    /// The one in-flight broker discovery fetch. Concurrent dials join it
+    /// instead of issuing their own request, so a reconnect burst costs one
+    /// broker call and the backpressure gate sees no storm.
+    private var sharedDiscoveryTask: Task<CmxIrohDiscoveryResponse, any Error>?
 
     /// Creates a public-route provider from the generation-less seam.
     public init(
@@ -115,12 +126,21 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             throw CmxIrohRegistryContextError.localBindingUnavailable
         }
         let clock = now()
+        // Staleness evidence (a failed dial on an empty/unreachable plan, or
+        // a presence route push) bypasses the verified-snapshot reuse window:
+        // reuse applies only to healthy-plan dials.
+        let requiresFreshDiscovery = discoveryIsMarkedStale(
+            identity: targetIdentity,
+            deviceID: request.expectedPeerDeviceID
+        )
+        var usedFreshDiscovery = false
         let discovery: CmxIrohDiscoveryResponse
-        if let verified = takeVerifiedDiscovery(at: clock) {
+        if !requiresFreshDiscovery, let verified = takeVerifiedDiscovery(at: clock) {
             discovery = verified
         } else {
             do {
-                discovery = try await broker.discover()
+                discovery = try await sharedDiscover()
+                usedFreshDiscovery = true
             } catch {
                 guard Self.isConnectivity(error),
                       let cached = try await cachedPolicy(
@@ -139,6 +159,63 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
                 )
             }
         }
+        if usedFreshDiscovery {
+            clearDiscoveryStaleness(
+                identity: targetIdentity,
+                deviceID: request.expectedPeerDeviceID
+            )
+        }
+        let resolved = try await resolveContext(
+            for: request,
+            targetIdentity: targetIdentity,
+            routeHints: routeHints,
+            discovery: discovery,
+            at: clock
+        )
+        // A reused snapshot that yields a plan with no relays and no direct
+        // addresses would send the session into a doomed dial. Rebuild once
+        // from a fresh snapshot instead; a plan already built from fresh
+        // discovery is authoritative, so no second fetch can help it.
+        guard !usedFreshDiscovery, Self.dialPlanIsEmpty(resolved.dialPlan) else {
+            return resolved
+        }
+        let freshClock = now()
+        let freshDiscovery: CmxIrohDiscoveryResponse
+        do {
+            freshDiscovery = try await sharedDiscover()
+        } catch {
+            // Broker cooldown or connectivity failure: keep the buildable
+            // context (its LAN fallback may still connect) instead of
+            // spinning against the gate.
+            return resolved
+        }
+        clearDiscoveryStaleness(
+            identity: targetIdentity,
+            deviceID: request.expectedPeerDeviceID
+        )
+        do {
+            return try await resolveContext(
+                for: request,
+                targetIdentity: targetIdentity,
+                routeHints: routeHints,
+                discovery: freshDiscovery,
+                at: freshClock
+            )
+        } catch {
+            // The fresh snapshot no longer authorizes this peer. Preserve
+            // the prior context so the existing LAN fallback path keeps its
+            // chance; the dial failure will re-mark the peer stale.
+            return resolved
+        }
+    }
+
+    private func resolveContext(
+        for request: CmxByteTransportRequest,
+        targetIdentity: CmxIrohPeerIdentity,
+        routeHints: [CmxIrohPathHint],
+        discovery: CmxIrohDiscoveryResponse,
+        at clock: Date
+    ) async throws -> CmxIrohClientContext {
         guard discovery.routeContractVersion == 1 else {
             throw CmxIrohRegistryContextError.incompatibleContract
         }
@@ -235,6 +312,8 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             grantCache.removeAll(keepingCapacity: false)
             lanAuthorities.removeAll(keepingCapacity: false)
             verifiedDiscoverySnapshot = nil
+            staleDiscoveryPeers.removeAll(keepingCapacity: false)
+            staleDiscoveryDeviceIDs.removeAll(keepingCapacity: false)
         }
         self.localBindingExpectation = localBindingExpectation
         self.managedRelayURLs = managedRelayURLs
@@ -258,6 +337,128 @@ public actor CmxIrohRegistryContextProvider: CmxIrohClientContextProvider {
             return nil
         }
         return snapshot.response
+    }
+
+    /// Fetches one broker discovery snapshot, coalescing concurrent callers
+    /// onto the same in-flight request. The broker seam already serializes and
+    /// floors requests through ``CmxIrohBrokerBackpressureGate``; sharing the
+    /// task means a burst of dials consumes one quota unit instead of queuing
+    /// one request per dial. A gate cooldown propagates unchanged so callers
+    /// wait out the directive instead of spinning.
+    private func sharedDiscover() async throws -> CmxIrohDiscoveryResponse {
+        if let sharedDiscoveryTask {
+            return try await sharedDiscoveryTask.value
+        }
+        let broker = broker
+        let task = Task { try await broker.discover() }
+        sharedDiscoveryTask = task
+        defer { sharedDiscoveryTask = nil }
+        return try await task.value
+    }
+
+    /// Records dial-failure evidence from the session pool. An empty plan or
+    /// an unreachable-class failure marks the peer's discovery state stale, so
+    /// the next dial bypasses every reuse window and rebuilds its plan from a
+    /// fresh broker snapshot instead of redialing a corpse route.
+    public func noteDialFailure(
+        for request: CmxByteTransportRequest,
+        dialPlan: CmxIrohDialPlan,
+        failure: DiagnosticFailureKind
+    ) async {
+        guard request.route.kind == .iroh,
+              case let .peer(targetIdentity, _) = request.route.endpoint else {
+            return
+        }
+        let planWasEmpty = Self.dialPlanIsEmpty(dialPlan)
+        guard planWasEmpty || Self.indicatesUnreachablePeer(failure) else {
+            return
+        }
+        markDiscoveryStale(
+            identity: targetIdentity,
+            deviceID: request.expectedPeerDeviceID
+        )
+    }
+
+    /// Invalidates reusable discovery state for one Mac (or, with `nil`, for
+    /// every peer). Used when a presence route push proves the Mac's endpoint
+    /// re-registered: the next dial must refetch instead of reusing a snapshot
+    /// captured before the relaunch.
+    public func invalidateVerifiedDiscovery(forDeviceID deviceID: String? = nil) {
+        verifiedDiscoverySnapshot = nil
+        guard let deviceID else {
+            staleDiscoveryPeers.removeAll(keepingCapacity: false)
+            staleDiscoveryDeviceIDs.removeAll(keepingCapacity: false)
+            return
+        }
+        staleDiscoveryDeviceIDs.insert(Self.canonicalDeviceID(deviceID))
+    }
+
+    private func markDiscoveryStale(
+        identity: CmxIrohPeerIdentity,
+        deviceID: String?
+    ) {
+        // The snapshot predates the staleness evidence; nothing may reuse it.
+        verifiedDiscoverySnapshot = nil
+        staleDiscoveryPeers.insert(identity)
+        if let deviceID {
+            staleDiscoveryDeviceIDs.insert(Self.canonicalDeviceID(deviceID))
+        }
+    }
+
+    private func clearDiscoveryStaleness(
+        identity: CmxIrohPeerIdentity,
+        deviceID: String?
+    ) {
+        staleDiscoveryPeers.remove(identity)
+        if let deviceID {
+            staleDiscoveryDeviceIDs.remove(Self.canonicalDeviceID(deviceID))
+        }
+    }
+
+    private func discoveryIsMarkedStale(
+        identity: CmxIrohPeerIdentity,
+        deviceID: String?
+    ) -> Bool {
+        if staleDiscoveryPeers.contains(identity) { return true }
+        guard let deviceID else { return false }
+        return staleDiscoveryDeviceIDs.contains(Self.canonicalDeviceID(deviceID))
+    }
+
+    private static func canonicalDeviceID(_ deviceID: String) -> String {
+        CmxIrohDeviceID(deviceID)?.value
+            ?? deviceID
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private static func dialPlanIsEmpty(_ dialPlan: CmxIrohDialPlan) -> Bool {
+        dialPlan.publicPaths.isEmpty && dialPlan.privateFallbackPaths.isEmpty
+    }
+
+    /// Failure classes that mean the dialed endpoint state, not our request,
+    /// was bad: the peer could not be reached on the plan we used. Auth,
+    /// admission, cancellation, and local-policy failures stay out; refetching
+    /// discovery cannot repair those and would only burn broker quota.
+    private static func indicatesUnreachablePeer(
+        _ failure: DiagnosticFailureKind
+    ) -> Bool {
+        switch failure {
+        case .timedOut,
+             .hostUnreachable,
+             .connectionRefused,
+             .connectionClosed,
+             .noRoute,
+             .transportIdleTimedOut:
+            return true
+        case .none, .offline, .permissionDenied, .dnsFailed,
+             .secureChannelFailed, .unsupportedRoute, .credentialUnavailable,
+             .policyUnavailable, .endpointUnavailable, .identityMismatch,
+             .admissionDenied, .authorizationFailed, .accountMismatch,
+             .protocolViolation, .superseded, .cancelled,
+             .admissionLeaseExpired, .admissionRevalidationFailed,
+             .sendQueueOverflow, .unknown:
+            return false
+        }
     }
 
     private func context(

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRuntimeContextRouter.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohRuntimeContextRouter.swift
@@ -40,4 +40,16 @@ actor CmxIrohRuntimeContextRouter: CmxIrohClientContextProvider {
         }
         try await provider.validatePrivateFallback(authorization)
     }
+
+    func noteDialFailure(
+        for request: CmxByteTransportRequest,
+        dialPlan: CmxIrohDialPlan,
+        failure: DiagnosticFailureKind
+    ) async {
+        await provider?.noteDialFailure(
+            for: request,
+            dialPlan: dialPlan,
+            failure: failure
+        )
+    }
 }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeAuthorizationTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientRuntimeAuthorizationTests.swift
@@ -4,8 +4,13 @@ import Testing
 @testable import CmuxIrohTransport
 
 extension CmxIrohClientRuntimeTests {
+    /// The startup snapshot here advertises NO usable target paths, so the
+    /// first dial performs one empty-plan rescue fetch (docs/transport-plane.md,
+    /// D5: reuse windows apply only to healthy-plan dials). When the broker
+    /// rate-limits that duplicate lookup, the dial still proceeds on the
+    /// startup snapshot: exactly two lookups, no spin, no failure.
     @Test
-    func firstDialReusesStartupDiscoveryWhenBrokerRateLimitsDuplicateLookup() async throws {
+    func firstDialOnHintlessStartupDiscoverySurvivesRateLimitedRescueFetch() async throws {
         let fixture = try RegistryFixture()
         let discovery = try fixture.discovery(targetHints: [])
         let identity = try CmxIrohIdentityMaterial(
@@ -57,9 +62,79 @@ extension CmxIrohClientRuntimeTests {
         try await runtime.start()
         let provider = try #require(await runtime.registryContextProvider)
 
-        _ = try await provider.context(for: fixture.request(hints: []))
+        let context = try await provider.context(for: fixture.request(hints: []))
 
+        #expect(await broker.observedDiscoveryCount() == 2)
+        #expect(context.dialPlan.publicPaths.isEmpty)
+        await runtime.stop()
+    }
+
+    /// A presence route push invalidates one Mac's reusable discovery through
+    /// the runtime seam: the next dial must refetch instead of consuming the
+    /// startup snapshot (docs/transport-plane.md, D5).
+    @Test
+    func presenceInvalidationThroughRuntimeForcesFreshDiscoveryOnNextDial() async throws {
+        let fixture = try RegistryFixture()
+        let relayHint = try CmxIrohPathHint(
+            kind: .relayURL,
+            value: fixture.relayURL,
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: fixture.now,
+            expiresAt: fixture.now.addingTimeInterval(60)
+        )
+        let discovery = try fixture.discovery(targetHints: [relayHint])
+        let identity = try CmxIrohIdentityMaterial(
+            secretKey: CmxIrohSecretKey(bytes: fixture.privateKey.rawRepresentation),
+            generation: fixture.initiator.identityGeneration
+        )
+        let configuration = CmxIrohClientRuntimeConfiguration(
+            accountID: "account-a",
+            deviceID: fixture.initiator.deviceID,
+            appInstanceID: discovery.bindings[0].appInstanceID,
+            tag: fixture.initiator.tag,
+            displayName: nil,
+            identity: identity,
+            capabilities: discovery.bindings[0].capabilities,
+            managedRelayURLs: [fixture.relayURL]
+        )
+        let relay = CmxIrohRelayTokenResponse(
+            token: "testrelaytoken",
+            expiresAt: "2027-01-15T10:00:00Z",
+            refreshAfter: "2027-01-15T09:00:00Z",
+            relayFleet: [fixture.relayURL]
+        )
+        let broker = TestIrohClientBroker(
+            binding: discovery.bindings[0],
+            discovery: discovery,
+            relay: relay,
+            pairGrant: try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 3_600
+            )
+        )
+        let runtime = try CmxIrohClientRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [TestIrohEndpoint(identity: fixture.initiator.endpointID)]
+            ),
+            broker: broker,
+            configuration: configuration,
+            pendingRevocations: CmxIrohPendingRevocationOutbox(
+                secureStore: TestSecureCredentialStore()
+            ),
+            now: { fixture.now }
+        )
+        try await runtime.start()
+        let provider = try #require(await runtime.registryContextProvider)
         #expect(await broker.observedDiscoveryCount() == 1)
+
+        await runtime.invalidateDiscoverySnapshot(
+            forMacDeviceID: fixture.acceptor.deviceID
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+        #expect(await broker.observedDiscoveryCount() == 2)
+        #expect(context.dialPlan.publicPaths == [relayHint])
         await runtime.stop()
     }
 

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohClientSessionPoolTests.swift
@@ -945,6 +945,65 @@ struct CmxIrohClientSessionPoolTests {
         #expect(await endpoint.observedDialedAddresses().count == 1)
         await foreground.close()
     }
+
+    @Test
+    func failedDialReportsPlanAndClassifiedFailureToContextProvider() async throws {
+        let fixture = try PoolFixture()
+        let provider = TestIrohClientContextProvider(context: fixture.context)
+        let endpoint = TestDialingIrohEndpoint(
+            localIdentity: fixture.localIdentity,
+            dialResults: [.failure(.noEndpoint)]
+        )
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            contextProvider: provider
+        )
+
+        await #expect(throws: TestIrohTransportError.noEndpoint) {
+            _ = try await pool.session(for: fixture.request)
+        }
+
+        let failures = await provider.observedDialFailures()
+        #expect(failures.count == 1)
+        #expect(failures.first?.request == fixture.request)
+        #expect(failures.first?.dialPlan == fixture.context.dialPlan)
+        #expect(failures.first?.failure == .unknown)
+        await pool.deactivate()
+    }
+
+    @Test
+    func cancelledDialDoesNotReportAFailureOutcome() async throws {
+        let fixture = try PoolFixture()
+        let provider = TestIrohClientContextProvider(context: fixture.context)
+        let endpoint = TestCancellableDialEndpoint(
+            localIdentity: fixture.localIdentity
+        )
+        let pool = try await fixture.pool(
+            endpoint: endpoint,
+            generation: 1,
+            contextProvider: provider
+        )
+        let connect = Task { try await pool.session(for: fixture.request) }
+        var reachedDial = false
+        for _ in 0 ..< 2_000 {
+            if await endpoint.observedDialCount() >= 1 {
+                reachedDial = true
+                break
+            }
+            await Task.yield()
+        }
+        #expect(reachedDial)
+
+        // Retiring the pending connection cancels the dial task; the parked
+        // endpoint dial settles with a CancellationError.
+        await pool.invalidate(for: fixture.request)
+        _ = try? await connect.value
+
+        #expect(await provider.observedDialFailures().isEmpty)
+        await pool.deactivate()
+        await endpoint.close()
+    }
 }
 
 private func waitForControlWaiter(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRegistryContextProviderStalenessTests.swift
@@ -1,0 +1,481 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxIrohTransport
+
+/// Level-triggered discovery-freshness behavior (docs/transport-plane.md, D5):
+/// a failed dial on an empty or unreachable plan, an empty plan before
+/// dialing, and a presence route push must all force the next dial plan to be
+/// rebuilt from a fresh broker snapshot, while healthy dials keep reusing the
+/// verified-snapshot window and broker cooldowns are never spun against.
+@Suite
+struct CmxIrohRegistryContextProviderStalenessTests {
+    @Test
+    func dialFailureOnEmptyPlanForcesOneFreshDiscoveryAndRebuiltPlan() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        // The reusable verified snapshot advertises NO usable target paths:
+        // the corpse state a relaunched Mac leaves behind.
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: []),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [])
+        )
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try testIrohDialPlan(publicPaths: []),
+            failure: .unknown
+        )
+        // The broker has since seen the Mac re-register with a live relay path.
+        await broker.setDiscovery(try fixture.discovery(targetHints: [relay]))
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
+    func unreachableDialFailureBypassesVerifiedSnapshotReuse() async throws {
+        let fixture = try RegistryFixture()
+        let staleRelay = try managedRelayHint(fixture)
+        let freshDirect = try publicDirectHint(fixture, value: "8.8.8.8:4433")
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [freshDirect]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [staleRelay])
+        )
+        // A non-empty plan whose dial timed out: the peer endpoint is stale.
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try nonEmptyPlan(fixture, hints: [staleRelay]),
+            failure: .timedOut
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths == [freshDirect])
+    }
+
+    @Test
+    func authorizationFailuresDoNotInvalidateDiscoveryReuse() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [relay]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [relay])
+        )
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try nonEmptyPlan(fixture, hints: [relay]),
+            failure: .admissionDenied
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        // The verified snapshot was reused: no broker fetch happened.
+        #expect(await broker.discoveryRequestCount() == 0)
+        #expect(context.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
+    func normalDialsReuseVerifiedSnapshotOnceWithinWindow() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [relay]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [relay])
+        )
+
+        let first = try await provider.context(for: fixture.request(hints: []))
+        #expect(await broker.discoveryRequestCount() == 0)
+        #expect(first.dialPlan.publicPaths == [relay])
+
+        // The snapshot is one-shot: a healthy second dial fetches normally.
+        let second = try await provider.context(for: fixture.request(hints: []))
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(second.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
+    func emptyPlanFromReusedSnapshotRefetchesBeforeDialing() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [relay]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [])
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        // The reused snapshot produced a no-relays/no-direct-addrs plan, so
+        // the provider refetched once instead of returning a doomed dial.
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
+    func emptyPlanFromFreshDiscoveryDoesNotRefetchAgain() async throws {
+        let fixture = try RegistryFixture()
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: []),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: nil
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+
+        // Fresh discovery is authoritative: an empty plan stays empty with
+        // exactly one fetch, never a same-dial retry storm.
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths.isEmpty)
+        #expect(context.dialPlan.privateFallbackPaths.isEmpty)
+    }
+
+    @Test
+    func concurrentStaleDialsShareOneFreshDiscoveryFetch() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [relay]),
+            pairGrantResponses: [
+                try fixture.pairGrantResponse(
+                    issuedAt: fixture.nowSeconds,
+                    expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+                ),
+                try fixture.pairGrantResponse(
+                    issuedAt: fixture.nowSeconds,
+                    expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+                ),
+            ]
+        )
+        await broker.holdDiscoverCalls()
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: nil
+        )
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try testIrohDialPlan(publicPaths: []),
+            failure: .timedOut
+        )
+
+        let request = try fixture.request(hints: [])
+        let firstDial = Task { try await provider.context(for: request) }
+        let secondDial = Task { try await provider.context(for: request) }
+        let reachedBroker = await waitForHeldDiscoverCalls(broker, atLeast: 1)
+        #expect(reachedBroker)
+        // Both dials are in flight; only one broker request may exist.
+        for _ in 0 ..< 100 {
+            await Task.yield()
+            #expect(await broker.heldDiscoverCallCount() == 1)
+        }
+        await broker.releaseHeldDiscoverCalls()
+
+        let first = try await firstDial.value
+        let second = try await secondDial.value
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(first.dialPlan.publicPaths == [relay])
+        #expect(second.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
+    func presenceInvalidationBypassesReuseWindowForThatDevice() async throws {
+        let fixture = try RegistryFixture()
+        let staleRelay = try managedRelayHint(fixture)
+        let freshDirect = try publicDirectHint(fixture, value: "8.8.4.4:4433")
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [freshDirect]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [staleRelay])
+        )
+
+        // A presence route push announced this Mac re-registered. The device
+        // id arrives in registry (uppercase-tolerant) form.
+        await provider.invalidateVerifiedDiscovery(
+            forDeviceID: fixture.acceptor.deviceID.uppercased()
+        )
+
+        let context = try await provider.context(for: fixture.request(hints: []))
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths == [freshDirect])
+    }
+
+    @Test
+    func brokerCooldownIsRespectedWithoutFetchStormAndStalenessSurvives() async throws {
+        let fixture = try RegistryFixture()
+        let relay = try managedRelayHint(fixture)
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: [relay]),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: nil
+        )
+        await provider.noteDialFailure(
+            for: try fixture.request(hints: []),
+            dialPlan: try testIrohDialPlan(publicPaths: []),
+            failure: .timedOut
+        )
+        await broker.setDiscoverError(
+            CmxIrohTrustBrokerClientError.rateLimited(code: "slow_down", retryAfterSeconds: 30)
+        )
+
+        // The gate's directive propagates: the dial fails with the bounded
+        // retry-after (the reconnect backoff owner waits it out) instead of
+        // the provider retrying discovery inside one attempt.
+        await #expect(throws: CmxIrohTrustBrokerClientError.rateLimited(
+            code: "slow_down",
+            retryAfterSeconds: 30
+        )) {
+            _ = try await provider.context(for: fixture.request(hints: []))
+        }
+        #expect(await broker.discoveryRequestCount() == 1)
+
+        // After the floor lifts, the retained staleness still forces exactly
+        // one fresh fetch and the plan rebuilds.
+        await broker.setDiscoverError(nil)
+        let context = try await provider.context(for: fixture.request(hints: []))
+        #expect(await broker.discoveryRequestCount() == 2)
+        #expect(context.dialPlan.publicPaths == [relay])
+    }
+
+    @Test
+    func cooldownDuringEmptyPlanRefetchKeepsResolvedContextInsteadOfSpinning() async throws {
+        let fixture = try RegistryFixture()
+        let broker = ConfigurableRegistryBroker(
+            discovery: try fixture.discovery(targetHints: []),
+            pairGrantResponses: [try fixture.pairGrantResponse(
+                issuedAt: fixture.nowSeconds,
+                expiresAt: fixture.nowSeconds + 7 * 24 * 60 * 60
+            )]
+        )
+        let provider = try await makeProvider(
+            fixture: fixture,
+            broker: broker,
+            verifiedDiscovery: try fixture.discovery(targetHints: [])
+        )
+        await broker.setDiscoverError(
+            CmxIrohBrokerCooldownError(retryAfterSeconds: 42)
+        )
+
+        // The reused snapshot yields an empty plan; the rescue refetch hits a
+        // broker cooldown. Waiting means returning the buildable context (its
+        // LAN fallback still applies), not failing or retrying the broker.
+        let context = try await provider.context(for: fixture.request(hints: []))
+        #expect(await broker.discoveryRequestCount() == 1)
+        #expect(context.dialPlan.publicPaths.isEmpty)
+    }
+
+    // MARK: - Support
+
+    private func makeProvider(
+        fixture: RegistryFixture,
+        broker: ConfigurableRegistryBroker,
+        verifiedDiscovery: CmxIrohDiscoveryResponse?
+    ) async throws -> CmxIrohRegistryContextProvider {
+        CmxIrohRegistryContextProvider(
+            supervisor: try await fixture.activeSupervisor(),
+            broker: broker,
+            localBindingExpectation: try fixture.localExpectation(),
+            managedRelayURLs: [fixture.relayURL],
+            networkPathSnapshot: {
+                CmxIrohNetworkPathSnapshot(
+                    generation: 1,
+                    activeNetworkProfiles: []
+                )
+            },
+            verifiedDiscovery: verifiedDiscovery,
+            now: { fixture.now }
+        )
+    }
+
+    private func managedRelayHint(
+        _ fixture: RegistryFixture
+    ) throws -> CmxIrohPathHint {
+        // Broker bindings only carry hints with a bounded observation window.
+        try CmxIrohPathHint(
+            kind: .relayURL,
+            value: fixture.relayURL,
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: fixture.now,
+            expiresAt: fixture.now.addingTimeInterval(60)
+        )
+    }
+
+    private func publicDirectHint(
+        _ fixture: RegistryFixture,
+        value: String
+    ) throws -> CmxIrohPathHint {
+        try CmxIrohPathHint(
+            kind: .directAddress,
+            value: value,
+            source: .native,
+            privacyScope: .publicInternet,
+            observedAt: fixture.now,
+            expiresAt: fixture.now.addingTimeInterval(60)
+        )
+    }
+
+    /// A dial plan carrying `hints` as usable public paths at the fixture's
+    /// frozen clock (the shared `testIrohDialPlan` helper evaluates usability
+    /// at the real wall clock, which sits before the fixture epoch).
+    private func nonEmptyPlan(
+        _ fixture: RegistryFixture,
+        hints: [CmxIrohPathHint]
+    ) throws -> CmxIrohDialPlan {
+        let plan = CmxAttachEndpoint.peer(
+            identity: fixture.acceptor.endpointID,
+            pathHints: hints
+        ).irohDialPlan(
+            at: fixture.now,
+            managedRelayURLs: [fixture.relayURL],
+            activeNetworkProfiles: []
+        )
+        guard let plan, !plan.publicPaths.isEmpty else {
+            throw TestRegistryError.noGrantResponse
+        }
+        return plan
+    }
+
+    private func waitForHeldDiscoverCalls(
+        _ broker: ConfigurableRegistryBroker,
+        atLeast count: Int
+    ) async -> Bool {
+        for _ in 0 ..< 2_000 {
+            if await broker.heldDiscoverCallCount() >= count { return true }
+            await Task.yield()
+        }
+        return await broker.heldDiscoverCallCount() >= count
+    }
+}
+
+/// A registry broker whose discovery response, failure mode, and completion
+/// timing are all adjustable mid-test, so staleness tests can model a Mac
+/// re-registering, a broker cooldown, and concurrent held requests.
+actor ConfigurableRegistryBroker: CmxIrohRegistryServing {
+    private var discoveryResponse: CmxIrohDiscoveryResponse
+    private var pairGrantResponses: [CmxIrohPairGrantResponse]
+    private var discoverError: (any Error)?
+    private var completedDiscoverCalls = 0
+    private var holdDiscover = false
+    private var heldDiscoverContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(
+        discovery: CmxIrohDiscoveryResponse,
+        pairGrantResponses: [CmxIrohPairGrantResponse]
+    ) {
+        discoveryResponse = discovery
+        self.pairGrantResponses = pairGrantResponses
+    }
+
+    func discover() async throws -> CmxIrohDiscoveryResponse {
+        if holdDiscover {
+            await withCheckedContinuation { continuation in
+                heldDiscoverContinuations.append(continuation)
+            }
+        }
+        completedDiscoverCalls += 1
+        if let discoverError { throw discoverError }
+        return discoveryResponse
+    }
+
+    func issuePairGrant(
+        initiatorBindingID _: String,
+        acceptorBindingID _: String
+    ) throws -> CmxIrohPairGrantResponse {
+        guard !pairGrantResponses.isEmpty else {
+            throw TestRegistryError.noGrantResponse
+        }
+        return pairGrantResponses.removeFirst()
+    }
+
+    func setDiscovery(_ discovery: CmxIrohDiscoveryResponse) {
+        discoveryResponse = discovery
+    }
+
+    func setDiscoverError(_ error: (any Error)?) {
+        discoverError = error
+    }
+
+    func holdDiscoverCalls() {
+        holdDiscover = true
+    }
+
+    func releaseHeldDiscoverCalls() {
+        holdDiscover = false
+        let continuations = heldDiscoverContinuations
+        heldDiscoverContinuations = []
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+
+    func heldDiscoverCallCount() -> Int {
+        heldDiscoverContinuations.count
+    }
+
+    func discoveryRequestCount() -> Int {
+        completedDiscoverCalls
+    }
+}

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohClientContextProvider.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/TestIrohClientContextProvider.swift
@@ -2,11 +2,18 @@ import CMUXMobileCore
 @testable import CmuxIrohTransport
 
 actor TestIrohClientContextProvider: CmxIrohClientContextProvider {
+    struct ObservedDialFailure: Sendable {
+        let request: CmxByteTransportRequest
+        let dialPlan: CmxIrohDialPlan
+        let failure: DiagnosticFailureKind
+    }
+
     private let clientContext: CmxIrohClientContext
     private let fallbackContext: CmxIrohClientContext?
     private var observedRequests: [CmxByteTransportRequest] = []
     private var fallbackRequestCount = 0
     private var authorizations: [CmxIrohPrivateFallbackAuthorization] = []
+    private var dialFailures: [ObservedDialFailure] = []
 
     init(
         context: CmxIrohClientContext,
@@ -39,6 +46,22 @@ actor TestIrohClientContextProvider: CmxIrohClientContextProvider {
         authorizations.append(authorization)
     }
 
+    // Declared `async` to match the protocol requirement exactly: an async
+    // caller would otherwise prefer the protocol-extension no-op over a
+    // synchronous member (SE-0296 overload ranking).
+    func noteDialFailure(
+        for request: CmxByteTransportRequest,
+        dialPlan: CmxIrohDialPlan,
+        failure: DiagnosticFailureKind
+    ) async {
+        dialFailures.append(ObservedDialFailure(
+            request: request,
+            dialPlan: dialPlan,
+            failure: failure
+        ))
+    }
+
     func observedFallbackRequestCount() -> Int { fallbackRequestCount }
     func observedAuthorizations() -> [CmxIrohPrivateFallbackAuthorization] { authorizations }
+    func observedDialFailures() -> [ObservedDialFailure] { dialFailures }
 }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
@@ -44,6 +44,9 @@ public protocol MobileSyncRuntime: Sendable {
     var terminalLaneProvider: MobileTerminalLaneProvider? { get }
     /// Optional source for low-priority raw artifact bytes on an admitted Iroh peer.
     var artifactLaneProvider: MobileArtifactLaneProvider? { get }
+    /// Optional credential-free path-health source for the live connection.
+    /// A nil provider keeps legacy escalation behavior (health `unknown`).
+    var transportPathHealthProvider: MobileTransportPathHealthProvider? { get }
     /// Bounded deadline, in nanoseconds, for the render-grid liveness
     /// watchdog's subscription probe (an idempotent `mobile.events.subscribe`
     /// re-assert). A healthy idle terminal legitimately pushes no events, so

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileTransportPathHealth.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileTransportPathHealth.swift
@@ -1,0 +1,29 @@
+/// Credential-free health classification of the live connection's selected
+/// transport path (docs/transport-plane.md, D3).
+///
+/// `unknown` means the active transport exposes no path observation (raw
+/// TCP, loopback, scripted test transports); callers must preserve their
+/// pre-gate behavior for it.
+public enum MobileTransportPathHealth: Equatable, Sendable {
+    /// The transport reports a usable selected path (direct, private
+    /// network, or relay) for the live session.
+    case healthy
+    /// The transport reports no usable path for the live session.
+    case noPath
+    /// No path information is available for the active transport.
+    case unknown
+}
+
+/// Async source for the live connection's current path health.
+///
+/// Implementations must never mutate connection state and must answer from
+/// already-observed state (no network round trips): the value gates
+/// escalation decisions on hot recovery paths.
+public typealias MobileTransportPathHealthProvider =
+    @Sendable () async -> MobileTransportPathHealth
+
+public extension MobileSyncRuntime {
+    /// Optional credential-free path-health source for the live connection.
+    /// A nil provider keeps legacy escalation behavior (health `unknown`).
+    var transportPathHealthProvider: MobileTransportPathHealthProvider? { nil }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionPolicy.swift
@@ -1,0 +1,159 @@
+internal import CmuxMobileRPC
+
+/// Connection evidence taxonomy (docs/transport-plane.md, D2).
+///
+/// Every signal that historically triggered recovery is one of these cases.
+/// Producers report what they observed; only ``MobileConnectionPolicy``
+/// decides what happens, and only the recovery owner executes it.
+enum MobileConnectionEvidence: Equatable, Sendable, CaseIterable {
+    // Health-fatal: the transport itself reported the session dead.
+    case transportClosed
+    case allPathsUnavailable
+    // Authorization: the peer or broker rejected our authority.
+    case authorizationLost
+    // Health-suspect: app-level silence or stream failure on a session the
+    // transport has not declared dead.
+    case livenessSilence
+    case eventStreamEnded
+    case subscriptionStartFailed
+    case rpcWriteTimedOut
+    // Opportunity: a moment when reconciling desired state is cheap or
+    // user-requested. Never death evidence by itself.
+    case foreground
+    case networkPathChanged
+    case presenceRoutePush
+    case manualRetry
+    case backoffExpired
+}
+
+/// What the policy tells the recovery owner to do (docs/transport-plane.md,
+/// D3, D11). Mechanics (generation guards, task ownership, deadlines) stay
+/// in the owner; this type is pure decision.
+enum MobileConnectionPolicyAction: Equatable, Sendable {
+    /// No action; the connection is fine or the evidence is moot.
+    case none
+    /// Repair subscriptions/streams on the live session without touching
+    /// the connection (resync: re-subscribe events, replay from cursors).
+    case resubscribe
+    /// Claim the owner for a probe on the live session; a healthy probe
+    /// resyncs, a failed probe escalates to one stored-Mac redial.
+    case probeThenEscalate
+    /// Claim the owner for a teardown-and-redial.
+    case redial
+    /// Tear down and stay down until authorization is repaired (sign-in,
+    /// re-pair). Automatic dials must not restart on health evidence.
+    case stopUntilAuthorizationRepaired
+}
+
+/// Inputs the policy needs beyond the evidence itself.
+struct MobileConnectionPolicyContext: Equatable, Sendable {
+    /// Whether the shell currently holds a live connection to the Mac.
+    var isConnected: Bool
+    /// Credential-free transport-path health for the live session.
+    /// `.unknown` preserves pre-gate behavior (legacy transports, tests).
+    var pathHealth: MobileTransportPathHealth
+    /// Whether automatic (non-manual) dials are currently blocked by the
+    /// account backoff ladder or a broker cooldown.
+    var automaticReconnectBlocked: Bool
+    /// Consecutive lightweight repairs (``MobileConnectionPolicyAction/resubscribe``)
+    /// already attempted on this connection generation without the data
+    /// plane recovering. Bounds the resubscribe ladder so repeated suspect
+    /// evidence escalates instead of looping (D2's "redial ONLY if ...
+    /// probe proves the session dead" ladder).
+    var consecutiveRepairAttempts: Int = 0
+
+    init(
+        isConnected: Bool,
+        pathHealth: MobileTransportPathHealth,
+        automaticReconnectBlocked: Bool,
+        consecutiveRepairAttempts: Int = 0
+    ) {
+        self.isConnected = isConnected
+        self.pathHealth = pathHealth
+        self.automaticReconnectBlocked = automaticReconnectBlocked
+        self.consecutiveRepairAttempts = consecutiveRepairAttempts
+    }
+}
+
+/// Pure escalation policy for one Mac connection (docs/transport-plane.md,
+/// invariant I1): app-level evidence never tears down a session the
+/// transport reports healthy; transport-health failure, authorization
+/// change, supersede, and user action remain the only close reasons.
+enum MobileConnectionPolicy {
+    static func action(
+        for evidence: MobileConnectionEvidence,
+        in context: MobileConnectionPolicyContext
+    ) -> MobileConnectionPolicyAction {
+        switch evidence {
+        case .authorizationLost:
+            return .stopUntilAuthorizationRepaired
+
+        case .transportClosed, .allPathsUnavailable:
+            // The transport declared the session dead. Disconnected shells
+            // have nothing to redial here; the next opportunity or the
+            // backoff timer owns the retry.
+            return context.isConnected ? .redial : .none
+
+        case .livenessSilence, .eventStreamEnded:
+            guard context.isConnected else { return .none }
+            switch context.pathHealth {
+            case .healthy:
+                // The path is usable, so the silence is a stream/subscription
+                // problem: repair in place. After a bounded number of
+                // fruitless repairs, escalate through a probe (which proves
+                // the session dead or alive) instead of looping.
+                return context.consecutiveRepairAttempts < 1
+                    ? .resubscribe
+                    : .probeThenEscalate
+            case .noPath:
+                return .redial
+            case .unknown:
+                // Pre-gate behavior: liveness silence probes first;
+                // a definitively ended event stream redials.
+                return evidence == .livenessSilence ? .probeThenEscalate : .redial
+            }
+
+        case .subscriptionStartFailed, .rpcWriteTimedOut:
+            guard context.isConnected else { return .none }
+            switch context.pathHealth {
+            case .healthy:
+                // The path works but a control-plane operation failed.
+                // A probe round-trip decides between resync and redial;
+                // blind resubscribe would retry the exact failed operation.
+                return .probeThenEscalate
+            case .noPath:
+                return .redial
+            case .unknown:
+                return .redial
+            }
+
+        case .foreground, .networkPathChanged:
+            if context.isConnected {
+                // Cheap revalidation of a connection we believe is live;
+                // fgrc rules make probes invisible and suspension-safe.
+                return .probeThenEscalate
+            }
+            return context.automaticReconnectBlocked ? .none : .redial
+
+        case .presenceRoutePush:
+            if context.isConnected {
+                switch context.pathHealth {
+                case .healthy: return .none
+                case .noPath: return .redial
+                case .unknown: return .probeThenEscalate
+                }
+            }
+            return context.automaticReconnectBlocked ? .none : .redial
+
+        case .manualRetry:
+            // The user asked: always act. Callers clear transient backoff
+            // before consulting the policy; broker cooldowns still apply at
+            // the dial layer.
+            return context.isConnected ? .probeThenEscalate : .redial
+
+        case .backoffExpired:
+            guard !context.isConnected else { return .none }
+            return context.automaticReconnectBlocked ? .none : .redial
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileIrohMacDiscovering.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileIrohMacDiscovering.swift
@@ -7,4 +7,12 @@
 public protocol MobileIrohMacDiscovering: Sendable {
     /// Refreshes broker state and returns the current live Mac candidates.
     func discoverLiveMacs() async -> [MobileDiscoveredIrohMac]
+
+    /// Invalidates reusable transport discovery state for one Mac.
+    ///
+    /// Called when a presence route push proves the Mac's endpoint state
+    /// changed (relaunch, re-registration): any discovery snapshot captured
+    /// before the push is stale, so the next dial to that Mac must rebuild
+    /// its plan from a fresh broker fetch instead of reusing it.
+    func invalidateDiscovery(forMacDeviceID deviceID: String) async
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionDiagnostics.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionDiagnostics.swift
@@ -44,6 +44,30 @@ extension MobileShellComposite {
         return DiagnosticFailureKind.classify(error)
     }
 
+    /// Failure classes that mean the dialed peer endpoint, not our request,
+    /// was bad: the Mac could not be reached on the plan we used. Mirrors the
+    /// transport provider's unreachable classification
+    /// (`CmxIrohRegistryContextProvider`), because an RPC deadline cancels the
+    /// underlying dial before the session pool can classify it, so this owner
+    /// must report equivalent staleness evidence itself. Auth, admission,
+    /// policy, and cancellation failures stay out: refetching discovery cannot
+    /// repair those.
+    static func routeFailureIndicatesStaleDiscovery(
+        _ failure: DiagnosticFailureKind
+    ) -> Bool {
+        switch failure {
+        case .timedOut,
+             .hostUnreachable,
+             .connectionRefused,
+             .connectionClosed,
+             .noRoute,
+             .transportIdleTimedOut:
+            return true
+        default:
+            return false
+        }
+    }
+
     func recordHostAuthenticationFailure(
         route: CmxAttachRoute,
         failure: DiagnosticFailureKind

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -81,23 +81,137 @@ extension MobileShellComposite {
                 break
             }
         }
+        if multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
+            scheduleSecondaryAggregation()
+        }
+        if let provider = transportPathHealthGate() {
+            applyPolicyGatedRecovery(
+                trigger: trigger,
+                expectedClient: nil,
+                provider: provider
+            )
+            return
+        }
         beginConnectionRecovery(
             trigger: trigger,
             expectedClient: remoteClient,
             probeCurrentConnection: connectionState == .connected && remoteClient != nil,
             resyncAfterHealthy: true
         )
-        if multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
-            scheduleSecondaryAggregation()
+    }
+
+    /// The D3 transport-health gate is armed only when the composition wired
+    /// a provider AND the live route is iroh; every other configuration
+    /// (legacy TCP, loopback, scripted tests) keeps pre-gate behavior.
+    private func transportPathHealthGate() -> MobileTransportPathHealthProvider? {
+        guard activeRoute?.kind == .iroh else { return nil }
+        return runtime?.transportPathHealthProvider
+    }
+
+    /// Consults ``MobileConnectionPolicy`` with observed transport health
+    /// before any escalation (docs/transport-plane.md D2/D3). The health
+    /// read is async but answers from already-observed state; the dispatch
+    /// re-validates connection identity after the hop.
+    private func applyPolicyGatedRecovery(
+        trigger: RecoveryTrigger,
+        expectedClient: MobileCoreRPCClient?,
+        provider: @escaping MobileTransportPathHealthProvider
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let health = await provider()
+            if let expectedClient {
+                guard self.remoteClient === expectedClient,
+                      self.connectionState == .connected else { return }
+            }
+            let blocked = self.identityProvider?.currentUserID.map {
+                self.automaticIrohReconnectIsBlocked(accountID: $0)
+            } ?? false
+            let context = MobileConnectionPolicyContext(
+                isConnected: self.connectionState == .connected && self.remoteClient != nil,
+                pathHealth: health,
+                automaticReconnectBlocked: blocked,
+                consecutiveRepairAttempts: self.connectionRepairAttemptCount
+            )
+            let action = MobileConnectionPolicy.action(
+                for: trigger.connectionEvidence,
+                in: context
+            )
+            MobileDebugLog.anchormux(
+                "connection.policy trigger=\(trigger.description) health=\(health) repairs=\(context.consecutiveRepairAttempts) action=\(action)"
+            )
+            self.dispatchPolicyAction(action, trigger: trigger, expectedClient: expectedClient)
         }
     }
 
-    /// A definitive event-stream failure bypasses same-client resubscription.
-    /// Once the exact session is proven dead, rebuilding its listener only hides
-    /// the failure behind the transport's reconnect behavior and leaves the
-    /// shell owner stale. Instead, transition the one lifecycle owner to a fresh
-    /// authenticated stored-Mac dial.
+    private func dispatchPolicyAction(
+        _ action: MobileConnectionPolicyAction,
+        trigger: RecoveryTrigger,
+        expectedClient: MobileCoreRPCClient?
+    ) {
+        switch action {
+        case .none:
+            return
+        case .resubscribe:
+            connectionRepairAttemptCount += 1
+            resyncTerminalOutput(
+                reason: "policy.resubscribe.\(trigger.description)",
+                restartEventStream: true
+            )
+        case .probeThenEscalate:
+            beginConnectionRecovery(
+                trigger: trigger,
+                expectedClient: remoteClient,
+                probeCurrentConnection: connectionState == .connected && remoteClient != nil,
+                resyncAfterHealthy: true
+            )
+        case .redial:
+            if let expectedClient, connectionState == .connected {
+                legacyRecoverDeadConnection(trigger: trigger, expectedClient: expectedClient)
+            } else {
+                beginConnectionRecovery(
+                    trigger: trigger,
+                    expectedClient: remoteClient,
+                    probeCurrentConnection: false,
+                    resyncAfterHealthy: true
+                )
+            }
+        case .stopUntilAuthorizationRepaired:
+            // Trigger-mapped evidence never produces this action; the
+            // authorization teardown path owns it directly.
+            return
+        }
+    }
+
+    /// Entry for evidence that historically proved the exact session dead
+    /// (ended event stream, failed subscribe, timed-out write). With a
+    /// path-health provider wired (D3), the policy decides whether the
+    /// evidence really warrants teardown: a healthy transport path means the
+    /// failure is a stream/control problem repaired in place, and only a
+    /// probe-proven-dead or path-dead session escalates to a redial.
     func recoverDeadConnection(
+        trigger: RecoveryTrigger,
+        expectedClient: MobileCoreRPCClient
+    ) {
+        guard remoteClient === expectedClient, connectionState == .connected else { return }
+        if let provider = transportPathHealthGate() {
+            applyPolicyGatedRecovery(
+                trigger: trigger,
+                expectedClient: expectedClient,
+                provider: provider
+            )
+            return
+        }
+        legacyRecoverDeadConnection(trigger: trigger, expectedClient: expectedClient)
+    }
+
+    /// Pre-gate behavior: a definitive event-stream failure bypasses
+    /// same-client resubscription. Once the exact session is proven dead,
+    /// rebuilding its listener only hides the failure behind the transport's
+    /// reconnect behavior and leaves the shell owner stale. Instead,
+    /// transition the one lifecycle owner to a fresh authenticated
+    /// stored-Mac dial.
+    private func legacyRecoverDeadConnection(
         trigger: RecoveryTrigger,
         expectedClient: MobileCoreRPCClient
     ) {
@@ -362,6 +476,7 @@ extension MobileShellComposite {
 
     func recordSuccessfulTerminalSubscription() {
         lastSuccessfulTerminalSubscriptionGeneration = connectionGeneration
+        connectionRepairAttemptCount = 0
         if connectionRecoveryOwner.completeValidation(connectionGeneration: connectionGeneration) {
             recordConnectionRecoverySucceeded()
             applyConnectionRecoveryOwnerState()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
@@ -146,6 +146,23 @@ extension MobileShellComposite {
         _ hostInstances: [PresenceInstance],
         scope: MobileShellScopeSnapshot
     ) async {
+        // A route push is broker-grade evidence that the Mac's endpoint state
+        // changed (relaunch, re-registration). Drop any reusable transport
+        // discovery snapshot for those Macs before recovery dials, so the
+        // next dial rebuilds its plan from a fresh broker fetch instead of
+        // redialing corpse route state (docs/transport-plane.md, D5).
+        if let personalIrohDiscovery {
+            var invalidatedDeviceIDs = Set<String>()
+            for instance in hostInstances where instance.routes?.isEmpty == false {
+                let deviceID = cmxCanonicalDeviceID(instance.deviceId)
+                guard invalidatedDeviceIDs.insert(deviceID).inserted else {
+                    continue
+                }
+                await personalIrohDiscovery.invalidateDiscovery(
+                    forMacDeviceID: instance.deviceId
+                )
+            }
+        }
         await performSerializedPairedMacWrite(ifStillCurrent: nil) { [weak self] in
             guard let self, await self.isScopeCurrent(scope) else { return }
             // Presence can arrive after another path paired or restored a Mac

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -8223,6 +8223,21 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         || failure == .accountMismatch {
                         recordHostAuthenticationFailure(route: route, failure: failure)
                     }
+                    // An unreachable-class iroh route failure is staleness
+                    // evidence: drop any reusable discovery snapshot for this
+                    // Mac so the NEXT attempt rebuilds its dial plan from a
+                    // fresh broker fetch instead of redialing a corpse route.
+                    // The transport pool reports most dial failures itself,
+                    // but this request deadline cancels an in-flight dial (the
+                    // pool then sees only a cancellation), so the owner that
+                    // classified the outcome reports it too.
+                    if route.kind == .iroh,
+                       !ticket.macDeviceID.isEmpty,
+                       Self.routeFailureIndicatesStaleDiscovery(failure) {
+                        await personalIrohDiscovery?.invalidateDiscovery(
+                            forMacDeviceID: ticket.macDeviceID
+                        )
+                    }
                 }
             }
             // This route exhausted every workspace-list request without being

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1954,6 +1954,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     var networkPathObservationStarted = false
     var networkPathObservationTask: Task<Void, Never>?
     let connectionRecoveryOwner = MobileConnectionRecoveryOwner()
+
+    /// Consecutive in-place stream repairs (policy ``MobileConnectionPolicyAction/resubscribe``)
+    /// on the current connection without the data plane proving healthy
+    /// again. Bounds the D2 repair ladder so repeated suspect evidence
+    /// escalates to a probe instead of looping; reset by
+    /// ``markMacConnectionHealthy()`` and
+    /// ``recordSuccessfulTerminalSubscription()``.
+    var connectionRepairAttemptCount = 0
     var lastReconnectStackUserID: String?
 
     enum RecoveryTrigger: CustomStringConvertible {
@@ -1997,6 +2005,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             case .subscriptionStartFailed: return "subscriptionStartFailed"
             case .transportWriteTimedOut: return "transportWriteTimedOut"
             case .automaticBackoffExpired: return "automaticBackoffExpired"
+            }
+        }
+
+        /// The trigger's place in the transport-plane evidence taxonomy
+        /// (docs/transport-plane.md D2), consumed by
+        /// ``MobileConnectionPolicy`` when a path-health provider is wired.
+        var connectionEvidence: MobileConnectionEvidence {
+            switch self {
+            case .networkChange: return .networkPathChanged
+            case .manual: return .manualRetry
+            case .presencePush: return .presenceRoutePush
+            case .foreground: return .foreground
+            case .liveness: return .livenessSilence
+            case .eventStreamEnded: return .eventStreamEnded
+            case .subscriptionStartFailed: return .subscriptionStartFailed
+            case .transportWriteTimedOut: return .rpcWriteTimedOut
+            case .automaticBackoffExpired: return .backoffExpired
             }
         }
     }
@@ -9116,6 +9141,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         isRecoveringConnection = false
         connectionRecoveryFailed = false
         connectionRequiresReauth = false
+        connectionRepairAttemptCount = 0
     }
 
     func markMacConnectionReconnecting() {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohConnectionRecoveryOwnerTests.swift
@@ -488,7 +488,8 @@ extension ReconnectRouteSelectionTests {
 
     private func makeRecoveryOwnerFixture(
         backup: (any PairedMacBackingUp)? = nil,
-        heldConnectAttempts: Set<Int> = []
+        heldConnectAttempts: Set<Int> = [],
+        pathHealth: MobileTransportPathHealthProvider? = nil
     ) async throws -> RecoveryOwnerFixture {
         let clock = TestClock()
         let router = LivenessHostRouter()
@@ -519,7 +520,8 @@ extension ReconnectRouteSelectionTests {
             runtime: LivenessTestRuntime(
                 transportFactory: factory,
                 now: { clock.now },
-                supportedRouteKinds: [.iroh, .tailscale]
+                supportedRouteKinds: [.iroh, .tailscale],
+                transportPathHealthProvider: pathHealth
             ),
             isSignedIn: true,
             pairedMacStore: pairedStore,
@@ -724,5 +726,75 @@ private actor BlockingSecondFetchBackup: PairedMacBackingUp {
         let waiters = releaseWaiters
         releaseWaiters = []
         for waiter in waiters { waiter.resume() }
+    }
+}
+
+// MARK: - Transport-health gate (docs/transport-plane.md D2/D3)
+
+@MainActor
+extension ReconnectRouteSelectionTests {
+    /// I1: dead-stream evidence on a session whose transport path is healthy
+    /// repairs the stream in place instead of tearing down the connection.
+    @Test func eventStreamEndedOnHealthyIrohPathRepairsInPlace() async throws {
+        let fixture = try await makeRecoveryOwnerFixture(pathHealth: { .healthy })
+        defer { fixture.release() }
+
+        #expect(await fixture.store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(await fixture.router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
+        let firstClient = try #require(fixture.store.remoteClient)
+
+        fixture.store.recoverDeadConnection(trigger: .eventStreamEnded, expectedClient: firstClient)
+
+        // The repair re-asserts the event subscription on the SAME client.
+        #expect(await fixture.router.waitForCount(of: "mobile.events.subscribe", atLeast: 2))
+        let settled = try await pollUntil {
+            fixture.store.connectionState == .connected
+                && fixture.store.remoteClient === firstClient
+        }
+        #expect(settled)
+        // Exactly one dial ever happened: the original connect, no redial.
+        #expect(fixture.factory.attemptedKinds() == [.iroh])
+    }
+
+    /// A dead transport path escalates the same evidence to a real redial.
+    @Test func eventStreamEndedOnDeadIrohPathRedials() async throws {
+        let fixture = try await makeRecoveryOwnerFixture(pathHealth: { .noPath })
+        defer { fixture.release() }
+
+        #expect(await fixture.store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(await fixture.router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
+        let firstClient = try #require(fixture.store.remoteClient)
+
+        fixture.store.recoverDeadConnection(trigger: .eventStreamEnded, expectedClient: firstClient)
+
+        let recovered = try await pollUntil {
+            guard let replacement = fixture.store.remoteClient else { return false }
+            return replacement !== firstClient && fixture.store.connectionState == .connected
+        }
+        #expect(recovered)
+        #expect(fixture.factory.attemptedKinds() == [.iroh, .iroh])
+    }
+
+    /// D2: a presence push while the connection is healthy reconciles to
+    /// nothing; it must not probe, dial, or restart anything.
+    @Test func presencePushOnHealthyPathIsANoOp() async throws {
+        let fixture = try await makeRecoveryOwnerFixture(pathHealth: { .healthy })
+        defer { fixture.release() }
+
+        #expect(await fixture.store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+        #expect(await fixture.router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
+        let firstClient = try #require(fixture.store.remoteClient)
+        let subscribesBefore = await fixture.router.count(of: "mobile.events.subscribe")
+
+        fixture.store.recoverMobileConnection(trigger: .presencePush)
+
+        // Bounded settle for the async policy hop; deterministic sleep is
+        // fine in tests.
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(fixture.store.remoteClient === firstClient)
+        #expect(fixture.store.connectionState == .connected)
+        #expect(fixture.factory.attemptedKinds() == [.iroh])
+        #expect(await fixture.router.count(of: "mobile.events.subscribe") == subscribesBefore)
+        #expect(!fixture.store.isRecoveringConnection)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohZeroTouchDiscoveryTests.swift
@@ -370,6 +370,8 @@ private final class ScriptedIrohDiscovery: MobileIrohMacDiscovering {
         return snapshots.isEmpty ? [] : snapshots[index]
     }
 
+    func invalidateDiscovery(forMacDeviceID _: String) async {}
+
     func callCount() -> Int { calls }
 }
 
@@ -397,6 +399,8 @@ private final class SuspendedIrohDiscovery: MobileIrohMacDiscovering {
         }
         return candidates
     }
+
+    func invalidateDiscovery(forMacDeviceID _: String) async {}
 
     func waitUntilRequested() async {
         guard !wasRequested else { return }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileConnectionPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileConnectionPolicyTests.swift
@@ -1,0 +1,221 @@
+import CmuxMobileRPC
+import Testing
+@testable import CmuxMobileShell
+
+/// Exhaustive table for docs/transport-plane.md D2/D3: app-level evidence
+/// never tears down a session the transport reports healthy.
+struct MobileConnectionPolicyTests {
+    private func context(
+        connected: Bool = true,
+        health: MobileTransportPathHealth = .unknown,
+        blocked: Bool = false,
+        repairs: Int = 0
+    ) -> MobileConnectionPolicyContext {
+        MobileConnectionPolicyContext(
+            isConnected: connected,
+            pathHealth: health,
+            automaticReconnectBlocked: blocked,
+            consecutiveRepairAttempts: repairs
+        )
+    }
+
+    // MARK: Invariant I1 — healthy path is never torn down by suspect evidence
+
+    @Test func healthyPathSuspectEvidenceNeverRedials() {
+        let suspect: [MobileConnectionEvidence] = [
+            .livenessSilence, .eventStreamEnded,
+            .subscriptionStartFailed, .rpcWriteTimedOut,
+        ]
+        for evidence in suspect {
+            for repairs in 0...3 {
+                let action = MobileConnectionPolicy.action(
+                    for: evidence,
+                    in: context(health: .healthy, repairs: repairs)
+                )
+                #expect(action != .redial, "\(evidence) repairs=\(repairs)")
+                #expect(
+                    action != .stopUntilAuthorizationRepaired,
+                    "\(evidence) repairs=\(repairs)"
+                )
+            }
+        }
+    }
+
+    @Test func healthyPathOpportunityEvidenceNeverRedials() {
+        let opportunity: [MobileConnectionEvidence] = [
+            .foreground, .networkPathChanged, .presenceRoutePush,
+            .manualRetry, .backoffExpired,
+        ]
+        for evidence in opportunity {
+            let action = MobileConnectionPolicy.action(
+                for: evidence,
+                in: context(health: .healthy)
+            )
+            #expect(action != .redial, "\(evidence)")
+        }
+    }
+
+    // MARK: Suspect-evidence ladder
+
+    @Test func livenessSilenceOnHealthyPathRepairsInPlaceFirst() {
+        #expect(MobileConnectionPolicy.action(
+            for: .livenessSilence, in: context(health: .healthy)
+        ) == .resubscribe)
+        #expect(MobileConnectionPolicy.action(
+            for: .eventStreamEnded, in: context(health: .healthy)
+        ) == .resubscribe)
+    }
+
+    @Test func repeatedRepairsEscalateToProbeNotRedial() {
+        #expect(MobileConnectionPolicy.action(
+            for: .livenessSilence, in: context(health: .healthy, repairs: 1)
+        ) == .probeThenEscalate)
+        #expect(MobileConnectionPolicy.action(
+            for: .eventStreamEnded, in: context(health: .healthy, repairs: 2)
+        ) == .probeThenEscalate)
+    }
+
+    @Test func controlPlaneFailuresOnHealthyPathProbeInsteadOfBlindRetry() {
+        #expect(MobileConnectionPolicy.action(
+            for: .subscriptionStartFailed, in: context(health: .healthy)
+        ) == .probeThenEscalate)
+        #expect(MobileConnectionPolicy.action(
+            for: .rpcWriteTimedOut, in: context(health: .healthy)
+        ) == .probeThenEscalate)
+    }
+
+    @Test func deadPathEscalatesSuspectEvidenceToRedial() {
+        let suspect: [MobileConnectionEvidence] = [
+            .livenessSilence, .eventStreamEnded,
+            .subscriptionStartFailed, .rpcWriteTimedOut,
+        ]
+        for evidence in suspect {
+            #expect(MobileConnectionPolicy.action(
+                for: evidence, in: context(health: .noPath)
+            ) == .redial, "\(evidence)")
+        }
+    }
+
+    // MARK: Unknown health preserves pre-gate behavior
+
+    @Test func unknownHealthKeepsLegacyEscalation() {
+        #expect(MobileConnectionPolicy.action(
+            for: .livenessSilence, in: context(health: .unknown)
+        ) == .probeThenEscalate)
+        #expect(MobileConnectionPolicy.action(
+            for: .eventStreamEnded, in: context(health: .unknown)
+        ) == .redial)
+        #expect(MobileConnectionPolicy.action(
+            for: .subscriptionStartFailed, in: context(health: .unknown)
+        ) == .redial)
+        #expect(MobileConnectionPolicy.action(
+            for: .rpcWriteTimedOut, in: context(health: .unknown)
+        ) == .redial)
+    }
+
+    // MARK: Health-fatal and authorization evidence
+
+    @Test func transportClosedRedialsWhileConnectedOnly() {
+        #expect(MobileConnectionPolicy.action(
+            for: .transportClosed, in: context(connected: true, health: .healthy)
+        ) == .redial)
+        #expect(MobileConnectionPolicy.action(
+            for: .allPathsUnavailable, in: context(connected: true)
+        ) == .redial)
+        #expect(MobileConnectionPolicy.action(
+            for: .transportClosed, in: context(connected: false)
+        ) == .none)
+    }
+
+    @Test func authorizationLossStopsRegardlessOfHealth() {
+        for health in [MobileTransportPathHealth.healthy, .noPath, .unknown] {
+            for connected in [true, false] {
+                #expect(MobileConnectionPolicy.action(
+                    for: .authorizationLost,
+                    in: context(connected: connected, health: health)
+                ) == .stopUntilAuthorizationRepaired)
+            }
+        }
+    }
+
+    // MARK: Opportunity evidence while disconnected
+
+    @Test func opportunityEvidenceDialsWhenUnblocked() {
+        let automatic: [MobileConnectionEvidence] = [
+            .foreground, .networkPathChanged, .presenceRoutePush, .backoffExpired,
+        ]
+        for evidence in automatic {
+            #expect(MobileConnectionPolicy.action(
+                for: evidence, in: context(connected: false)
+            ) == .redial, "\(evidence)")
+            #expect(MobileConnectionPolicy.action(
+                for: evidence, in: context(connected: false, blocked: true)
+            ) == .none, "\(evidence)")
+        }
+    }
+
+    @Test func manualRetryIgnoresAutomaticBackoff() {
+        #expect(MobileConnectionPolicy.action(
+            for: .manualRetry, in: context(connected: false, blocked: true)
+        ) == .redial)
+        #expect(MobileConnectionPolicy.action(
+            for: .manualRetry, in: context(connected: true, blocked: true)
+        ) == .probeThenEscalate)
+    }
+
+    @Test func connectedOpportunitiesProbeOrNoop() {
+        #expect(MobileConnectionPolicy.action(
+            for: .foreground, in: context(health: .unknown)
+        ) == .probeThenEscalate)
+        #expect(MobileConnectionPolicy.action(
+            for: .networkPathChanged, in: context(health: .healthy)
+        ) == .probeThenEscalate)
+        #expect(MobileConnectionPolicy.action(
+            for: .presenceRoutePush, in: context(health: .healthy)
+        ) == .none)
+        #expect(MobileConnectionPolicy.action(
+            for: .presenceRoutePush, in: context(health: .noPath)
+        ) == .redial)
+        #expect(MobileConnectionPolicy.action(
+            for: .backoffExpired, in: context(connected: true)
+        ) == .none)
+    }
+
+    // MARK: Suspect evidence while disconnected is moot
+
+    @Test func suspectEvidenceWhileDisconnectedIsIgnored() {
+        let suspect: [MobileConnectionEvidence] = [
+            .livenessSilence, .eventStreamEnded,
+            .subscriptionStartFailed, .rpcWriteTimedOut,
+        ]
+        for evidence in suspect {
+            #expect(MobileConnectionPolicy.action(
+                for: evidence, in: context(connected: false)
+            ) == .none, "\(evidence)")
+        }
+    }
+
+    // MARK: Totality — every evidence/context combination has a decision
+
+    @Test func policyIsTotal() {
+        for evidence in MobileConnectionEvidence.allCases {
+            for connected in [true, false] {
+                for health in [MobileTransportPathHealth.healthy, .noPath, .unknown] {
+                    for blocked in [true, false] {
+                        for repairs in [0, 1, 5] {
+                            _ = MobileConnectionPolicy.action(
+                                for: evidence,
+                                in: context(
+                                    connected: connected,
+                                    health: health,
+                                    blocked: blocked,
+                                    repairs: repairs
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessRuntimeSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessRuntimeSupport.swift
@@ -28,4 +28,5 @@ struct LivenessTestRuntime: MobileSyncRuntime {
     var supportsServerPushEvents: Bool = true
     var livenessProbeTimeoutNanoseconds: UInt64 = 200_000_000
     var reconnectAttemptDeadlineNanoseconds: UInt64 = 30 * 1_000_000_000
+    var transportPathHealthProvider: MobileTransportPathHealthProvider? = nil
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PresenceDiscoveryInvalidationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PresenceDiscoveryInvalidationTests.swift
@@ -1,0 +1,171 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileRPC
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// A presence route push proves the Mac's endpoint re-registered, so the shell
+/// must invalidate that Mac's reusable transport discovery snapshot before any
+/// `.presencePush` recovery dial (docs/transport-plane.md, D5). Without this,
+/// the next dial can rebuild its plan from a pre-relaunch snapshot and burn a
+/// full timeout against a corpse route.
+@MainActor
+@Suite struct PresenceDiscoveryInvalidationTests {
+    @Test func pushedRoutesInvalidateThatMacsDiscoverySnapshotOnce() async throws {
+        let discovery = RecordingIrohDiscovery()
+        let shell = MobileShellComposite(
+            isSignedIn: true,
+            personalIrohDiscovery: discovery,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+        let scope = MobileShellScopeSnapshot(
+            userID: "user-1",
+            teamID: "team-a",
+            generation: 0
+        )
+        let route = try CmxAttachRoute(
+            id: "pushed",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.1", port: 51_001)
+        )
+        // Two instances (tags) on the same physical Mac in one delivery.
+        let task = shell.syncPushedRoutes(
+            from: [
+                PresenceInstance(
+                    deviceId: "shared-mac",
+                    tag: "feature-a",
+                    platform: "mac",
+                    online: true,
+                    lastSeenAt: 1_000,
+                    routes: [route]
+                ),
+                PresenceInstance(
+                    deviceId: "shared-mac",
+                    tag: "feature-b",
+                    platform: "mac",
+                    online: true,
+                    lastSeenAt: 1_000,
+                    routes: [route]
+                ),
+            ],
+            scope: scope
+        )
+        await task?.value
+
+        #expect(discovery.invalidatedDeviceIDs == ["shared-mac"])
+    }
+
+    @Test func presenceWithoutRoutesDoesNotInvalidateDiscovery() async {
+        let discovery = RecordingIrohDiscovery()
+        let shell = MobileShellComposite(
+            isSignedIn: true,
+            personalIrohDiscovery: discovery,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-a" }
+        )
+        let scope = MobileShellScopeSnapshot(
+            userID: "user-1",
+            teamID: "team-a",
+            generation: 0
+        )
+        // Presence-only update: no route payload, so no new endpoint evidence.
+        let task = shell.syncPushedRoutes(
+            from: [PresenceInstance(
+                deviceId: "shared-mac",
+                tag: "feature-a",
+                platform: "mac",
+                online: true,
+                lastSeenAt: 1_000
+            )],
+            scope: scope
+        )
+        await task?.value
+
+        #expect(discovery.invalidatedDeviceIDs.isEmpty)
+    }
+}
+
+/// The RPC pairing deadline cancels a wedged in-flight iroh dial, so the
+/// transport pool observes only a cancellation and cannot classify the route
+/// failure. The shell owner that classified the timeout must therefore report
+/// the staleness itself, so the NEXT reconnect attempt rebuilds its dial plan
+/// from a fresh broker snapshot instead of burning backoff on a corpse route.
+@MainActor
+@Suite struct RouteFailureDiscoveryInvalidationTests {
+    @Test func timedOutIrohRouteDialInvalidatesDiscoveryForNextAttempt() async throws {
+        let discovery = RecordingIrohDiscovery()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let pairedStore = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+        )
+        let irohRoute = try CmxAttachRoute(
+            id: "iroh-personal",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(
+                    endpointID: String(repeating: "a", count: 64)
+                ),
+                pathHints: []
+            ),
+            priority: -10_000
+        )
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [irohRoute],
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: Date()
+        )
+        let router = LivenessHostRouter()
+        let box = TransportBox()
+        let factory = KindRecordingTransportFactory(router: router, box: box)
+        // An iroh dial that neither completes nor fails: the pairing request
+        // deadline is the only thing that can settle this attempt.
+        factory.setHangingKinds([.iroh])
+        let store = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { Date() },
+                supportedRouteKinds: [.iroh],
+                pairingRequestTimeoutNanoseconds: 50_000_000,
+                pairingAttemptTimeoutNanoseconds: 200_000_000
+            ),
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            personalIrohDiscovery: discovery,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "route-failure-invalidation-\(UUID().uuidString)"
+            )!,
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+        await store.loadPairedMacs()
+
+        #expect(!(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1")))
+
+        #expect(discovery.invalidatedDeviceIDs.contains("test-mac"))
+        await factory.releaseHangingTransports()
+    }
+}
+
+@MainActor
+private final class RecordingIrohDiscovery: MobileIrohMacDiscovering {
+    private(set) var invalidatedDeviceIDs: [String] = []
+
+    func discoverLiveMacs() async -> [MobileDiscoveredIrohMac] { [] }
+
+    func invalidateDiscovery(forMacDeviceID deviceID: String) async {
+        invalidatedDeviceIDs.append(deviceID)
+    }
+}

--- a/Sources/Mobile/MobileHostConnectionEventQueue.swift
+++ b/Sources/Mobile/MobileHostConnectionEventQueue.swift
@@ -3,8 +3,8 @@ import Foundation
 
 /// Per-topic shedding policy for server-pushed mobile events.
 ///
-/// "Droppable" topics are the refresh-class streams a client can always
-/// recover without the host replaying the exact dropped payload:
+/// "Droppable" topics are the streams a client can always recover without the
+/// host replaying the exact dropped payload:
 /// - `terminal.render_grid`: the producer is asked to re-emit a full frame for
 ///   every surface whose queued frame was shed
 ///   (``MobileTerminalRenderObserver/requestRenderGridFullResync(surfaceIDStrings:)``),
@@ -13,14 +13,26 @@ import Foundation
 ///   silently dropped delta would corrupt its grid invisibly; the
 ///   poison-until-full rule makes a shed unobservable beyond one stale paint.
 /// - `terminal.bytes`: chunks carry a byte-offset `seq`; the client detects the
-///   gap and requests a replay on its own.
-/// - `terminal.updated` / `workspace.updated`: level-triggered pings; the newer
-///   occurrence that forced the shed supersedes the shed one.
+///   gap on the next delivered chunk and requests a replay on its own.
+/// - `terminal.updated` / `workspace.updated`: level-triggered pings. A newer
+///   queued occurrence supersedes a shed one; when the shed ping was the LAST
+///   one, the drain-repair signal re-emits it once the queue drains.
+/// - `mobile.sync.delta`: revision-cursor stream (state sync v2). The client
+///   already treats `from_rev` past its cursor as a gap and repairs with a
+///   `mobile.sync.fetch`; after a shed, the drain-repair signal emits a
+///   zero-record head marker so a gap is detected even when the shed delta was
+///   the last one (see ``MobileHostShedRepairPlanner``).
+/// - `notification.feed.changed`: revision-carrying invalidation ping; the
+///   drain-repair signal re-emits the newest revision, and the client refetches
+///   iff it missed one.
 ///
 /// Every other topic keeps the close-on-overflow contract: those payloads
 /// cannot be re-derived by the client, so tearing the connection down (the
 /// client reconnects and re-syncs from authoritative state) is the only
-/// lossless bound.
+/// lossless bound. Backpressure on a recoverable topic must NEVER close the
+/// connection: the 2026-07 field incident showed a few seconds of QUIC write
+/// stall filling this queue and killing a healthy session every ~2s
+/// (`sendQueueOverflow`), forcing full phone redials mid path-flap.
 enum MobileHostEventTopicPolicy {
     static let renderGridTopic = "terminal.render_grid"
 
@@ -30,12 +42,45 @@ enum MobileHostEventTopicPolicy {
             // A render-grid event without a surface key cannot be resynced
             // per-surface, so it keeps the lossless close-on-overflow path.
             return coalesceKey != nil
-        case "terminal.bytes", "terminal.updated", "workspace.updated":
+        case "terminal.bytes", "terminal.updated", "workspace.updated",
+             "mobile.sync.delta", "notification.feed.changed":
             return true
         default:
             return false
         }
     }
+
+    /// Whether a shed on `topic` must be followed by one coalesced repair
+    /// signal once the queue drains (``MobileHostConnectionEventQueue/takeShedRepairs()``).
+    ///
+    /// These are the level-triggered invalidations and cursor streams where
+    /// the shed event may have been the last one: without a host-side repair
+    /// the client would stay silently stale until an unrelated future event.
+    /// `terminal.render_grid` repairs through the immediate
+    /// poison-plus-full-resync path and `terminal.bytes` through the client's
+    /// byte-offset gap detection, so neither needs a drain signal.
+    static func needsDrainRepairSignal(topic: String) -> Bool {
+        switch topic {
+        case "terminal.updated", "workspace.updated",
+             "mobile.sync.delta", "notification.feed.changed":
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+/// The coalesced backpressure outcome one drain cycle repairs: every topic
+/// that lost at least one repair-signaled event since the last take, plus the
+/// total number of events shed (all topics) for the diagnostic ring.
+struct MobileHostEventQueueShedRepair: Equatable, Sendable {
+    /// Topics that shed at least one event and need a repair signal
+    /// (``MobileHostEventTopicPolicy/needsDrainRepairSignal(topic:)``).
+    let topics: Set<String>
+    /// Every event dropped under backpressure since the last take, including
+    /// topics that repair through their own mechanism (render-grid resync,
+    /// byte-gap replay).
+    let shedEventCount: Int
 }
 
 /// Outcome of one synchronous admission attempt on a connection's event queue.
@@ -103,13 +148,26 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
     /// (queue full of non-droppable events). Re-requested once the drain frees
     /// room, so a fully stalled connection cannot spin the producer.
     private var resyncAfterDrainSurfaceIDs: Set<String> = []
+    /// Queue depth at or below which pending shed repairs are released to the
+    /// drain, so repair events land only once the transport is genuinely
+    /// flowing again and are not immediately shed themselves.
+    private let shedRepairLowWaterMark: Int
+    /// Topics that shed at least one repair-signaled event since the last
+    /// ``takeShedRepairs()``. Coalesced by construction: a topic appears once
+    /// no matter how many of its events were dropped.
+    private var shedRepairPendingTopics: Set<String> = []
+    /// Every event dropped under backpressure since the last
+    /// ``takeShedRepairs()`` (all topics), for the diagnostic ring.
+    private var shedEventCountSinceRepairTake = 0
 
     init(
         maximumEventCount: Int = MobileHostConnectionEventQueue.defaultMaximumEventCount,
-        maximumByteCount: Int = MobileHostConnectionEventQueue.defaultMaximumByteCount
+        maximumByteCount: Int = MobileHostConnectionEventQueue.defaultMaximumByteCount,
+        shedRepairLowWaterMark: Int? = nil
     ) {
         self.maximumEventCount = maximumEventCount
         self.maximumByteCount = maximumByteCount
+        self.shedRepairLowWaterMark = shedRepairLowWaterMark ?? max(1, maximumEventCount / 4)
     }
 
     var count: Int {
@@ -192,6 +250,9 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
                     depthAfterEnqueue: nil
                 )
             }
+            // The incoming droppable event itself is being dropped: it is a
+            // shed like any other and joins the coalesced repair cycle.
+            noteShedLocked(topic: topic)
             if isRenderGrid, let coalesceKey {
                 if poisonedRenderGridSurfaceIDs.insert(coalesceKey).inserted {
                     resyncSurfaceIDs.insert(coalesceKey)
@@ -289,6 +350,26 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
         return requests
     }
 
+    /// Pending shed repairs, released only once the drain has pulled the
+    /// queue down to the low-water mark so the repair events are not shed in
+    /// turn. Taking resets the pending set and the shed count; a repair event
+    /// that is itself shed later re-marks its topic, so the cycle self-heals.
+    /// Returns `nil` while the queue is still congested or nothing was shed.
+    func takeShedRepairs() -> MobileHostEventQueueShedRepair? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isClosed,
+              queuedEvents.count <= shedRepairLowWaterMark,
+              shedEventCountSinceRepairTake > 0 else { return nil }
+        let repairs = MobileHostEventQueueShedRepair(
+            topics: shedRepairPendingTopics,
+            shedEventCount: shedEventCountSinceRepairTake
+        )
+        shedRepairPendingTopics.removeAll()
+        shedEventCountSinceRepairTake = 0
+        return repairs
+    }
+
     /// Rejects all future admissions and releases every queued payload.
     func close() {
         lock.lock()
@@ -297,6 +378,8 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
         queuedByteCount = 0
         poisonedRenderGridSurfaceIDs.removeAll()
         resyncAfterDrainSurfaceIDs.removeAll()
+        shedRepairPendingTopics.removeAll()
+        shedEventCountSinceRepairTake = 0
         subscribedTopics.removeAll()
         lock.unlock()
     }
@@ -304,6 +387,17 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
     private func hasRoomLocked(for frame: Data) -> Bool {
         queuedEvents.count < maximumEventCount
             && queuedByteCount + frame.count <= maximumByteCount
+    }
+
+    /// Records one backpressure drop for the repair cycle and the diagnostic
+    /// shed count. Not called for poison-chain suppression (a refused
+    /// render-grid delta whose surface is already awaiting its full frame):
+    /// that drop was accounted for when the chain first broke.
+    private func noteShedLocked(topic: String) {
+        shedEventCountSinceRepairTake += 1
+        if MobileHostEventTopicPolicy.needsDrainRepairSignal(topic: topic) {
+            shedRepairPendingTopics.insert(topic)
+        }
     }
 
     private func shedDroppableEventsLocked(
@@ -322,6 +416,7 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
             }
             queuedEvents.remove(at: index)
             queuedByteCount -= event.frame.count
+            noteShedLocked(topic: event.topic)
             if event.topic == MobileHostEventTopicPolicy.renderGridTopic,
                let surfaceID = event.coalesceKey,
                poisonedRenderGridSurfaceIDs.insert(surfaceID).inserted {
@@ -334,6 +429,7 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
         // chain for the whole connection.
         guard !resyncSurfaceIDs.isEmpty else { return }
         var freedByteCount = 0
+        var purgedEventCount = 0
         let brokenSurfaceIDs = resyncSurfaceIDs
         queuedEvents.removeAll { event in
             guard event.topic == MobileHostEventTopicPolicy.renderGridTopic,
@@ -342,8 +438,10 @@ final class MobileHostConnectionEventQueue: @unchecked Sendable {
                 return false
             }
             freedByteCount += event.frame.count
+            purgedEventCount += 1
             return true
         }
         queuedByteCount -= freedByteCount
+        shedEventCountSinceRepairTake += purgedEventCount
     }
 }

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1817,6 +1817,37 @@ extension MobileHostService {
 }
 #endif
 
+/// Builds the per-topic payloads a connection emits after its bounded event
+/// queue shed events on that topic
+/// (``MobileHostEventTopicPolicy/needsDrainRepairSignal(topic:)``). Every
+/// repair rides a mechanism today's clients already implement — no new client
+/// behavior is required:
+/// - `workspace.updated` / `terminal.updated` are level-triggered empty-payload
+///   pings, so re-emitting the ping is the repair (legacy clients refetch).
+/// - `mobile.sync.delta` gets zero-record markers at each collection's current
+///   head: a client that missed a shed delta observes `from_rev` past its
+///   cursor, reports a gap, and repairs with its normal `mobile.sync.fetch`; a
+///   current client ignores the marker as stale.
+/// - `notification.feed.changed` re-carries the newest feed revision; the
+///   client refetches iff that revision is newer than the one it applied.
+@MainActor
+enum MobileHostShedRepairPlanner {
+    static func repairPayloads(topic: String) -> [[String: Any]] {
+        switch topic {
+        case "workspace.updated", "terminal.updated":
+            return [[:]]
+        case MobileStateSyncHost.deltaTopic:
+            return MobileStateSyncHost.shared.shedRepairMarkerPayloads()
+        case TerminalNotificationStore.feedChangedEventTopic:
+            return [[
+                "revision": TerminalNotificationStore.shared.notificationFeedHistory.revision,
+            ]]
+        default:
+            return []
+        }
+    }
+}
+
 actor MobileHostConnection {
     private static let maximumReceiveBufferByteCount = MobileSyncFrameCodec.defaultMaximumFrameByteCount + MobileSyncFrameCodec.headerByteCount
     private static let defaultFirstFrameTimeoutNanoseconds: UInt64 = 15 * 1_000_000_000
@@ -2523,11 +2554,13 @@ actor MobileHostConnection {
             Task { await self.drainQueuedEvents() }
         }
         if result.shouldClose {
-            // The bounded queue fills when the control stream stops draining
-            // (e.g. the peer's network path died mid-write) while terminal
-            // events keep arriving. The peer violated nothing; field host
-            // rings (2026-07-23 WiFi path flap) showed this close mislabeled
-            // protocolViolation seconds after admission.
+            // Only a NON-recoverable topic overflowing still closes: those
+            // payloads cannot be re-derived by the client, so teardown is the
+            // only lossless bound. Recoverable topics shed and repair instead
+            // (the 2026-07 field incident showed queue-depth closes killing
+            // healthy sessions every ~2s during a path flap). The peer
+            // violated nothing; field host rings (2026-07-23 WiFi path flap)
+            // also showed this close mislabeled protocolViolation.
             await close(
                 reason: "event queue exceeded bounded capacity",
                 exit: CmxIrohAdmittedConnectionExit(
@@ -2607,6 +2640,14 @@ actor MobileHostConnection {
                 return
             }
             guard let event = eventQueue.dequeue() else {
+                // The queue emptied without a delivered event releasing the
+                // pending repairs (every remaining event was skipped as
+                // unsubscribed): emit them now so a shed can never strand a
+                // stale client until unrelated future traffic.
+                if let shedRepairs = eventQueue.takeShedRepairs() {
+                    await emitShedRepairs(shedRepairs)
+                    continue
+                }
                 if eventQueue.finishDrain() { continue }
                 return
             }
@@ -2636,6 +2677,32 @@ actor MobileHostConnection {
                 MobileTerminalRenderObserver.requestRenderGridFullResync(
                     surfaceIDStrings: resyncSurfaceIDs
                 )
+            }
+            // Backpressure repairs are released only once the queue is back
+            // under its low-water mark, i.e. the transport is draining again.
+            if let shedRepairs = eventQueue.takeShedRepairs() {
+                await emitShedRepairs(shedRepairs)
+            }
+        }
+    }
+
+    /// Emits the coalesced repair signals for topics whose events were shed
+    /// under backpressure, and records one host-ring row per repair cycle so
+    /// field exports show backpressure episodes without connection deaths.
+    /// Repair events flow through the same bounded admission as every other
+    /// event; one that is shed in turn re-marks its topic and retries on the
+    /// next drain cycle.
+    private func emitShedRepairs(_ repairs: MobileHostEventQueueShedRepair) async {
+        MobileHostIrohRuntime.hostDiagnosticLog.record(DiagnosticEvent(
+            .hostEventQueueShed,
+            a: repairs.shedEventCount,
+            b: repairs.topics.count
+        ))
+        for topic in repairs.topics.sorted() {
+            guard eventQueue.isSubscribed(topic: topic) else { continue }
+            let payloads = await MobileHostShedRepairPlanner.repairPayloads(topic: topic)
+            for payload in payloads {
+                await sendEvent(topic: topic, payload: payload)
             }
         }
     }

--- a/Sources/Mobile/MobileStateSync.swift
+++ b/Sources/Mobile/MobileStateSync.swift
@@ -84,6 +84,42 @@ final class MobileStateSyncHost {
         }
     }
 
+    /// Zero-record delta markers at each collection's current head, emitted to
+    /// ONE connection after its queue shed `mobile.sync.delta` events under
+    /// backpressure (``MobileHostShedRepairPlanner``). `from_rev == to_rev ==
+    /// headRev`, so a client that missed nothing ignores the marker as stale,
+    /// while one whose cursor is behind sees `from_rev` past it, reports a
+    /// gap, and repairs with its normal cursor fetch. No rows travel; the
+    /// collection that shed is unknown at this layer, so both markers go (the
+    /// spare one is a few bytes and a guaranteed no-op).
+    func shedRepairMarkerPayloads() -> [[String: Any]] {
+        let coder = MobileSyncFrameCoder()
+        let workspacesMarker = MobileSyncDeltaEvent<WorkspaceSyncRecord>(
+            epoch: store.epoch,
+            collection: .workspaces,
+            fromRev: store.workspaces.headRev,
+            toRev: store.workspaces.headRev,
+            records: [],
+            removedIDs: []
+        )
+        let groupsMarker = MobileSyncDeltaEvent<GroupSyncRecord>(
+            epoch: store.epoch,
+            collection: .groups,
+            fromRev: store.groups.headRev,
+            toRev: store.groups.headRev,
+            records: [],
+            removedIDs: []
+        )
+        var payloads: [[String: Any]] = []
+        if let workspaces = try? coder.jsonObject(from: workspacesMarker) {
+            payloads.append(workspaces)
+        }
+        if let groups = try? coder.jsonObject(from: groupsMarker) {
+            payloads.append(groups)
+        }
+        return payloads
+    }
+
     private func emit<Record: MobileSyncRecord>(
         collection: MobileSyncCollectionID,
         change: MobileSyncCollectionChange<Record>

--- a/cmuxTests/MobileHostConnectionEventLaneTests.swift
+++ b/cmuxTests/MobileHostConnectionEventLaneTests.swift
@@ -198,17 +198,18 @@ extension MobileHostAuthorizationTests {
             handleRequest: { _ in .ok([:]) },
             onClose: { _ in }
         )
-        // A non-droppable topic (state-sync deltas cannot be re-derived by the
-        // client) keeps the close-on-overflow contract; recoverable topics like
-        // terminal.render_grid are shed instead — see
-        // testStalledRenderGridSubscriberStaysOpenWithBoundedEventQueue.
+        // A non-droppable topic (chat transcripts cannot be re-derived by the
+        // client) keeps the close-on-overflow contract; recoverable topics
+        // like terminal.render_grid and mobile.sync.delta are shed instead —
+        // see testStalledRenderGridSubscriberStaysOpenWithBoundedEventQueue
+        // and testSyncDeltaFloodDuringWriteStallShedsInsteadOfClosing.
         _ = await session.debugHandleSubscriptionRPCForTesting(
             MobileHostRPCRequest(
                 id: "subscribe",
                 method: "mobile.events.subscribe",
                 params: [
                     "stream_id": "events",
-                    "topics": ["mobile.sync.delta"],
+                    "topics": ["chat.message"],
                     "event_transport": "iroh_server_events_v1",
                 ],
                 auth: nil
@@ -217,7 +218,7 @@ extension MobileHostAuthorizationTests {
 
         #expect(
             await session.sendEvent(
-                topic: "mobile.sync.delta",
+                topic: "chat.message",
                 payload: ["seq": 0]
             )
         )
@@ -226,14 +227,14 @@ extension MobileHostAuthorizationTests {
         for sequence in 1...256 {
             #expect(
                 await session.sendEvent(
-                    topic: "mobile.sync.delta",
+                    topic: "chat.message",
                     payload: ["seq": sequence]
                 )
             )
         }
         #expect(
             !(await session.sendEvent(
-                topic: "mobile.sync.delta",
+                topic: "chat.message",
                 payload: ["seq": 257]
             ))
         )
@@ -333,7 +334,7 @@ extension MobileHostAuthorizationTests {
         #expect(await transport.observedCloseCount() == 1)
     }
 
-    /// Events that cannot be re-derived by the client (state-sync deltas and
+    /// Events that cannot be re-derived by the client (chat transcripts and
     /// other non-refresh topics) must keep the close-on-overflow contract: the
     /// host may never silently drop them, so a subscriber that stops draining
     /// is torn down at the bounded capacity instead of growing without bound.
@@ -347,13 +348,13 @@ extension MobileHostAuthorizationTests {
             handleRequest: { _ in .ok([:]) },
             onClose: { _ in }
         )
-        await session.subscribe(streamID: "events", topics: ["mobile.sync.delta"])
+        await session.subscribe(streamID: "events", topics: ["chat.message"])
 
         var admitted = 0
         for sequence in 0..<300 {
             if await session.sendEvent(
-                topic: "mobile.sync.delta",
-                payload: ["revision": sequence]
+                topic: "chat.message",
+                payload: ["seq": sequence]
             ) {
                 admitted += 1
             }
@@ -362,6 +363,55 @@ extension MobileHostAuthorizationTests {
         #expect(await transport.observedCloseCount() == 1)
         #expect(admitted <= 258)
         #expect(await session.debugQueuedEventCountForTesting() == 0)
+    }
+
+    /// Regression for the field "2s metronome" (reconnect loop): a QUIC write
+    /// stall of a few seconds used to fill the bounded queue and close the
+    /// whole connection with `sendQueueOverflow`, forcing a full phone redial
+    /// while the path flapped. State-sync deltas are client-repairable via
+    /// cursor fetch, so backpressure must shed them and keep the connection —
+    /// only the event-send stall deadline (a truly wedged transport) may
+    /// close it.
+    @Test func testSyncDeltaFloodDuringWriteStallShedsInsteadOfClosing() async throws {
+        let transport = StalledSendMobileHostByteTransport()
+        let session = MobileHostConnection(
+            id: UUID(),
+            transport: transport,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { _ in }
+        )
+        await session.subscribe(
+            streamID: "events",
+            topics: ["mobile.sync.delta", "workspace.updated", "notification.feed.changed"]
+        )
+
+        for revision in 0..<600 {
+            _ = await session.sendEvent(
+                topic: "mobile.sync.delta",
+                payload: [
+                    "epoch": "epoch-metronome",
+                    "collection": "workspaces",
+                    "from_rev": revision,
+                    "to_rev": revision + 1,
+                    "records": [],
+                    "removed_ids": [],
+                ]
+            )
+        }
+        _ = await session.sendEvent(topic: "workspace.updated", payload: [:])
+        _ = await session.sendEvent(
+            topic: "notification.feed.changed",
+            payload: ["revision": 7]
+        )
+
+        #expect(await transport.observedCloseCount() == 0)
+        #expect(await session.debugQueuedEventCountForTesting() <= 256)
+        #expect(await session.isSubscribed(to: "mobile.sync.delta"))
+
+        await session.close(reason: "test cleanup")
+        #expect(await transport.observedCloseCount() == 1)
     }
 
     /// End-to-end fan-out proof for issue #8842: sustained emission through the
@@ -495,18 +545,154 @@ extension MobileHostAuthorizationTests {
             maximumEventCount: 1,
             maximumByteCount: 1_000_000
         )
-        queue.updateSubscribedTopics(["mobile.sync.delta"])
+        queue.updateSubscribedTopics(["chat.message"])
         let frame = Data(repeating: 0x61, count: 16)
         #expect(queue.enqueue(
-            topic: "mobile.sync.delta", coalesceKey: nil,
+            topic: "chat.message", coalesceKey: nil,
             isFullRenderGridFrame: false, frame: frame
         ).admitted)
         let overflow = queue.enqueue(
-            topic: "mobile.sync.delta", coalesceKey: nil,
+            topic: "chat.message", coalesceKey: nil,
             isFullRenderGridFrame: false, frame: frame
         )
         #expect(!overflow.admitted)
         #expect(overflow.shouldClose)
+    }
+
+    /// A sync-delta overflow sheds the oldest delta instead of closing, and
+    /// the repair signal is withheld until the drain pulls the queue to the
+    /// low-water mark so the repair cannot be shed in turn.
+    @Test func testEventQueueShedsSyncDeltaAndReleasesRepairAtLowWaterMark() {
+        let queue = MobileHostConnectionEventQueue(
+            maximumEventCount: 2,
+            maximumByteCount: 1_000_000,
+            shedRepairLowWaterMark: 1
+        )
+        queue.updateSubscribedTopics(["mobile.sync.delta"])
+        let frame = Data(repeating: 0x61, count: 16)
+        for _ in 0..<2 {
+            #expect(queue.enqueue(
+                topic: "mobile.sync.delta", coalesceKey: nil,
+                isFullRenderGridFrame: false, frame: frame
+            ).admitted)
+        }
+        let overflow = queue.enqueue(
+            topic: "mobile.sync.delta", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        )
+        #expect(overflow.admitted)
+        #expect(!overflow.shouldClose)
+        // Still at capacity: the repair stays pending.
+        #expect(queue.takeShedRepairs() == nil)
+        _ = queue.dequeue()
+        let repairs = queue.takeShedRepairs()
+        #expect(repairs?.topics == ["mobile.sync.delta"])
+        #expect(repairs?.shedEventCount == 1)
+        // Taking resets the cycle: nothing further is pending.
+        #expect(queue.takeShedRepairs() == nil)
+    }
+
+    /// An incoming droppable event refused admission (queue full of
+    /// non-droppable frames) is itself a shed and must join the repair cycle
+    /// without requesting a close.
+    @Test func testEventQueueRefusedIncomingDroppableEventMarksRepair() {
+        let queue = MobileHostConnectionEventQueue(
+            maximumEventCount: 1,
+            maximumByteCount: 1_000_000,
+            shedRepairLowWaterMark: 1
+        )
+        queue.updateSubscribedTopics(["chat.message", "notification.feed.changed"])
+        let frame = Data(repeating: 0x61, count: 16)
+        #expect(queue.enqueue(
+            topic: "chat.message", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        let refused = queue.enqueue(
+            topic: "notification.feed.changed", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        )
+        #expect(!refused.admitted)
+        #expect(!refused.shouldClose)
+        _ = queue.dequeue()
+        let repairs = queue.takeShedRepairs()
+        #expect(repairs?.topics == ["notification.feed.changed"])
+        #expect(repairs?.shedEventCount == 1)
+    }
+
+    /// A level-triggered ping shed to make room for ANOTHER topic's event has
+    /// no newer occurrence superseding it, so the drain repair must re-emit
+    /// it; sheds also coalesce per topic across the cycle.
+    @Test func testEventQueueCrossTopicShedCoalescesLevelTriggeredPingRepair() {
+        let queue = MobileHostConnectionEventQueue(
+            maximumEventCount: 1,
+            maximumByteCount: 1_000_000,
+            shedRepairLowWaterMark: 1
+        )
+        queue.updateSubscribedTopics(["workspace.updated", "terminal.render_grid"])
+        let frame = Data(repeating: 0x61, count: 16)
+        #expect(queue.enqueue(
+            topic: "workspace.updated", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        // A render-grid full frame sheds the queued ping to make room.
+        let grid = queue.enqueue(
+            topic: MobileHostEventTopicPolicy.renderGridTopic, coalesceKey: "s1",
+            isFullRenderGridFrame: true, frame: frame
+        )
+        #expect(grid.admitted)
+        // A second ping is admitted (room after dequeue) and shed again by the
+        // next full frame: the repair still surfaces the topic exactly once.
+        _ = queue.dequeue()
+        #expect(queue.enqueue(
+            topic: "workspace.updated", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: frame
+        ).admitted)
+        #expect(queue.enqueue(
+            topic: MobileHostEventTopicPolicy.renderGridTopic, coalesceKey: "s1",
+            isFullRenderGridFrame: true, frame: frame
+        ).admitted)
+        _ = queue.dequeue()
+        let repairs = queue.takeShedRepairs()
+        #expect(repairs?.topics == ["workspace.updated"])
+        #expect(repairs?.shedEventCount == 2)
+    }
+
+    /// Render-grid sheds repair through poison-plus-full-resync, not the
+    /// drain repair signal, but still count toward the diagnostic shed total;
+    /// close() drops any pending repair state with the queue.
+    @Test func testEventQueueRenderGridShedCountsWithoutRepairTopicAndCloseClears() {
+        let queue = MobileHostConnectionEventQueue(
+            maximumEventCount: 2,
+            maximumByteCount: 1_000_000,
+            shedRepairLowWaterMark: 2
+        )
+        queue.updateSubscribedTopics(["terminal.render_grid", "workspace.updated"])
+        let frame = Data(repeating: 0x61, count: 16)
+        for _ in 0..<2 {
+            #expect(queue.enqueue(
+                topic: MobileHostEventTopicPolicy.renderGridTopic, coalesceKey: "s1",
+                isFullRenderGridFrame: false, frame: frame
+            ).admitted)
+        }
+        // Overflow sheds s1's queued deltas; the arriving delta is refused
+        // too (post-gap delta). No drain-repair topic is marked, but the
+        // diagnostic count reflects every dropped event.
+        let overflow = queue.enqueue(
+            topic: MobileHostEventTopicPolicy.renderGridTopic, coalesceKey: "s1",
+            isFullRenderGridFrame: false, frame: frame
+        )
+        #expect(!overflow.admitted)
+        #expect(overflow.renderGridResyncSurfaceIDs == ["s1"])
+        let repairs = queue.takeShedRepairs()
+        #expect(repairs?.topics.isEmpty == true)
+        #expect(repairs?.shedEventCount == 2)
+        // Pending state dies with the queue.
+        #expect(queue.enqueue(
+            topic: "workspace.updated", coalesceKey: nil,
+            isFullRenderGridFrame: false, frame: Data(repeating: 0x61, count: 2_000_000)
+        ).admitted == false)
+        queue.close()
+        #expect(queue.takeShedRepairs() == nil)
     }
 
     @Test func testEventQueueEnforcesByteBudgetBySheddingOldestDroppable() {

--- a/docs/transport-plane.md
+++ b/docs/transport-plane.md
@@ -1,0 +1,125 @@
+# Transport plane: connection policy contract
+
+Status: draft for the transport rewrite program, July 2026. This document is
+the contract for connection lifecycle behavior across iOS client, Mac host,
+and backend. It complements `docs/iroh-app-transport-architecture.md` (the
+transport floor: endpoints, relays, admission, security), which this document
+does not change. Where code and this document disagree, this document wins;
+change the code.
+
+## Goals as testable invariants
+
+- **I1 (no needless reconnects).** An established, admitted session closes
+  only for: transport-health failure (QUIC close, all paths dead, keepalive
+  timeout), authorization change (revoke, grant expiry, sign-out), explicit
+  supersede (a newer session for the same peer), or user action. App
+  lifecycle events (foreground/background, tab switches, pull-to-refresh,
+  presence pushes, watchdog probes) never close a session the transport
+  reports healthy. Measured by the transport-lab `soak` and `bgfg`
+  scenarios: involuntary-close count must be 0.
+- **I2 (fast discovery).** A phone reconnects to a relaunched, reachable Mac
+  in under 5 seconds when foregrounded. A revoked binding reaches affected
+  devices in under 10 seconds while they hold a presence connection.
+  Measured by the `mac-relaunch` scenario.
+- **I3 (latency).** Typing echo p50 stays within the PR 9146 baseline
+  (~15 ms sim loopback); reconnect resumes streams from cursors without a
+  full refetch. Measured by the latency-trace probe.
+
+## Decisions
+
+**D1. One dial/close owner per Mac.** All connect, redial, and teardown
+decisions for a given (account, MacPairingKey) flow through one main-actor
+owner (today: `MobileConnectionRecoveryOwner` + the composite's recovery
+entry points; end state: `MobileConnectionSupervisor`). No other code may
+call `connect`/`disconnect`/`session.close` for that pair. Side systems
+(terminal lanes, replay retries, browser streams, RPC session recycling)
+may repair their own *streams/subscriptions* on the live session but may
+never tear down or replace the session itself.
+
+**D2. Evidence, not triggers.** Every signal that today triggers recovery is
+reclassified as evidence fed to the owner:
+
+| Evidence | Class | Allowed effect |
+| --- | --- | --- |
+| QUIC close / connection error from transport | health-fatal | redial |
+| All-paths-unavailable (observed path status, sustained) | health-fatal | redial |
+| Grant/lease revoked, auth failure | authz | close, no auto-redial until authz repaired |
+| Host supersede close | coordination | adopt replacement, no backoff |
+| Liveness silence (render-grid, event stream, RPC timeout) | health-suspect | probe, then resync; redial ONLY if transport also unhealthy or probe proves the session dead |
+| Foreground, network path change, presence push, manual retry | opportunity | reconcile: dial if disconnected, probe if suspect, otherwise nothing |
+| Pull-to-refresh, tab switch, view appearance | UI refresh | data refetch only; never a dial, never a teardown |
+
+**D3. Transport-health gate.** Before any app-level evidence (health-suspect
+class) escalates to a redial, the owner consults transport health for that
+session (selected-path status from the session pool). A session with a
+usable path gets resync (resubscribe + replay-from-cursor), not teardown.
+This is the single rule that implements I1.
+
+**D4. One backoff.** Exactly one backoff ladder per (account, Mac),
+owned by the dial owner (today `MobileAutomaticReconnectBackoffOwner`).
+Server Retry-After floors are respected. Opportunity evidence (manual,
+foreground, network change) clears transient backoff; it never bypasses
+broker cooldowns. No other layer keeps retry counters that can refuse a
+dial the owner requested (pool corpse-retries and RPC connect gates are
+mechanics below the owner, not competing policy).
+
+**D5. Discovery freshness.** A dial plan is stale when it has no routes, or
+its last dial failed with an unreachable/no-route class. A stale plan forces
+a fresh broker discovery fetch (single-flight per peer, cooldown-respecting)
+before the next dial. A presence route push or nudge for a Mac invalidates
+that Mac's cached discovery snapshot. Discovery reuse windows apply only to
+healthy-plan dials.
+
+**D6. Broker pushes on binding change.** Binding replacement, revocation,
+and reaper revocation fire a presence nudge to the affected device. Plain
+refresh heartbeats do not. Nudge delivery is best-effort and never blocks
+or fails the broker operation.
+
+**D7. Host backpressure sheds, never kills.** The Mac host never closes a
+connection because of event-queue depth on recoverable topics. Overflow
+sheds per-topic with a coalesced repair signal once the queue drains;
+clients repair via cursor fetch/replay/refetch. Queue-depth close remains
+only for a wedged transport (write stall past deadline), classified as such.
+
+**D8. Reconnect resumes, never rebuilds.** After redial, every stream
+resumes from its cursor (state-sync v2 cursor fetch, render-grid replay
+cursor, terminal byte offsets, feed refetch). Full refetch is the repair of
+last resort, not the reconnect path. Remaining invalidate+refetch paths
+(notification feed, secondary-Mac aggregation) migrate to cursors.
+
+**D9. Background/foreground preserves sessions.** Backgrounding stops
+nonessential work but never closes a healthy endpoint or session (already
+per architecture doc). Foregrounding revalidates via probe with a fresh
+deadline; deadlines burned during suspension are not death evidence
+(existing `foregroundResumeEpoch` rule is the contract).
+
+**D10. Every involuntary close is attributed.** Any session close not
+requested by the user carries a named reason in the diagnostic ring on both
+roles (already largely true post-8716/8834/9192). The transport-lab
+scorecard treats an unattributed involuntary close as a defect.
+
+**D11. Policy is a pure function.** The escalation decision (evidence x
+connection state x transport health x backoff state -> action) lives in one
+pure, exhaustively-tested type (`MobileConnectionPolicy`), not inline in the
+composite. Mechanics (task management, generation guards) stay in the owner;
+policy changes become one-file diffs with table-driven tests.
+
+## Deletion targets
+
+Once D1-D5 hold and the scorecard is clean, these band-aids are deleted or
+demoted to mechanics, each removal proven by the scorecard staying clean:
+ACK-driven resubscribe side channel, missed-event-window repair special
+case, per-surface replay retry double-counters, foreground dual-gate
+(probe + disconnected-redial as separate entry points), pull-to-refresh
+cooldown bypasses, and the RPC-layer abandoned-connect registries where the
+fork's dial cancellation makes them redundant.
+
+## Verification
+
+`transport-lab` (cmuxterm-hq `scripts/transport-lab/`) runs topology
+scenarios against tagged dev builds and emits a scorecard from diagnostic
+rings and container logs: involuntary-close count (gate: 0), recovery
+trigger histogram, discovery convergence seconds (gate: <5 s), echo
+latency p50/p95. Scenarios: `soak`, `mac-relaunch`, `bgfg`, plus the
+in-app iroh release gate where applicable. The scorecard gates every
+change to this plane.

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -84,6 +84,9 @@ struct cmuxApp: App {
                     resourceID: resourceID,
                     offset: offset
                 )
+            },
+            transportPathHealthProvider: {
+                await iroh.selectedPathHealth()
             }
         )
 

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRuntime.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRuntime.swift
@@ -33,6 +33,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
     public var independentEventByteStreamProvider: CmxIndependentEventByteStreamProvider?
     public var terminalLaneProvider: MobileTerminalLaneProvider?
     public var artifactLaneProvider: MobileArtifactLaneProvider?
+    public var transportPathHealthProvider: MobileTransportPathHealthProvider?
 
     /// Builds the production access-token provider over an injected
     /// ``TokenProviding`` (the app-root ``AuthCoordinator``), honoring the DEBUG
@@ -142,7 +143,8 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         supportsServerPushEvents: Bool = true,
         independentEventByteStreamProvider: CmxIndependentEventByteStreamProvider? = nil,
         terminalLaneProvider: MobileTerminalLaneProvider? = nil,
-        artifactLaneProvider: MobileArtifactLaneProvider? = nil
+        artifactLaneProvider: MobileArtifactLaneProvider? = nil,
+        transportPathHealthProvider: MobileTransportPathHealthProvider? = nil
     ) {
         self.supportedRouteKinds = supportedRouteKinds
         self.transportFactory = transportFactory
@@ -157,6 +159,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         self.independentEventByteStreamProvider = independentEventByteStreamProvider
         self.terminalLaneProvider = terminalLaneProvider
         self.artifactLaneProvider = artifactLaneProvider
+        self.transportPathHealthProvider = transportPathHealthProvider
     }
 
     public init(
@@ -171,7 +174,8 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         supportsServerPushEvents: Bool = true,
         independentEventByteStreamProvider: CmxIndependentEventByteStreamProvider? = nil,
         terminalLaneProvider: MobileTerminalLaneProvider? = nil,
-        artifactLaneProvider: MobileArtifactLaneProvider? = nil
+        artifactLaneProvider: MobileArtifactLaneProvider? = nil,
+        transportPathHealthProvider: MobileTransportPathHealthProvider? = nil
     ) {
         self.supportedRouteKinds = transportFactory.supportedKinds
         self.transportFactory = transportFactory
@@ -185,6 +189,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         self.independentEventByteStreamProvider = independentEventByteStreamProvider
         self.terminalLaneProvider = terminalLaneProvider
         self.artifactLaneProvider = artifactLaneProvider
+        self.transportPathHealthProvider = transportPathHealthProvider
         self.now = now
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -573,6 +573,13 @@ public final class MobileIrohRuntimeComposition:
         return candidates
     }
 
+    /// Drops reusable broker discovery state for one Mac after a presence
+    /// route push, so the next dial rebuilds its plan from a fresh snapshot
+    /// instead of redialing the Mac's pre-relaunch route state.
+    public func invalidateDiscovery(forMacDeviceID deviceID: String) async {
+        await runtime?.invalidateDiscoverySnapshot(forMacDeviceID: deviceID)
+    }
+
     private func recordDiscoveryOutcome(candidateCount: Int) {
         if candidateCount > 0 {
             diagnosticLog?.record(DiagnosticEvent(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -1,7 +1,7 @@
 import CMUXMobileCore
 import CmuxAuthRuntime
 public import CmuxIrohTransport
-import CmuxMobileRPC
+public import CmuxMobileRPC
 import CmuxMobileShell
 import CmuxMobileTransport
 import CryptoKit
@@ -686,6 +686,16 @@ public final class MobileIrohRuntimeComposition:
         await prepareForConnection()
         let runtime = try await runtimeForDial()
         return try await runtime.serverEventByteStream(for: request)
+    }
+
+    /// Credential-free path health for the live iroh session
+    /// (docs/transport-plane.md D3). Never dials or activates: an inactive
+    /// or absent runtime answers `.unknown` so the shell keeps legacy
+    /// escalation behavior instead of misreading "not activated yet" as a
+    /// dead path.
+    public func selectedPathHealth() async -> MobileTransportPathHealth {
+        guard let runtime else { return .unknown }
+        return await runtime.hasUsableSelectedPath() ? .healthy : .noPath
     }
 
     private func runtimeForDial() async throws -> CmxIrohClientRuntime {

--- a/web/app/api/internal/iroh/retention/route.ts
+++ b/web/app/api/internal/iroh/retention/route.ts
@@ -1,11 +1,10 @@
 import { timingSafeEqual } from "node:crypto";
 import * as Effect from "effect/Effect";
 import {
-  IROH_RETENTION_MAX_DURATION_MS,
-  IROH_RETENTION_MAX_ROWS,
   IrohRepository,
   IrohRepositoryLive,
 } from "../../../../../services/iroh/repository";
+import { runIrohRetention } from "../../../../../services/iroh/retention";
 import { jsonResponse } from "../../../../../services/vms/routeHelpers";
 
 export const runtime = "nodejs";
@@ -34,25 +33,22 @@ async function handle(request: Request): Promise<Response> {
 
   try {
     const startedAt = Date.now();
-    const retention = await Effect.runPromise(
+    const summary = await Effect.runPromise(
       Effect.gen(function* () {
         const repository = yield* IrohRepository;
-        return yield* repository.pruneExpiredStateGlobally({
-          now: new Date(),
-          maxRows: IROH_RETENTION_MAX_ROWS,
-          maxDurationMs: IROH_RETENTION_MAX_DURATION_MS,
-        });
+        return yield* runIrohRetention({ repository });
       }).pipe(Effect.provide(IrohRepositoryLive)),
     );
     console.info("iroh retention cleanup completed", {
-      rows_processed: retention.rowsProcessed,
-      batches: retention.batches,
-      backlog: retention.backlog,
-      budget_exhausted: retention.budgetExhausted,
-      by_category: retention.byCategory,
+      rows_processed: summary.retention.rowsProcessed,
+      batches: summary.retention.batches,
+      backlog: summary.retention.backlog,
+      budget_exhausted: summary.retention.budgetExhausted,
+      by_category: summary.retention.byCategory,
+      reap: summary.reap,
       duration_ms: Date.now() - startedAt,
     });
-    return jsonResponse({ ok: true, retention });
+    return jsonResponse({ ok: true, retention: summary.retention, reap: summary.reap });
   } catch {
     console.error("iroh retention cleanup failed", { failure: "database" });
     return jsonResponse({ error: "iroh_retention_failed" }, 500);

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -252,6 +252,17 @@ export const env = createEnv({
     CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS: z.string().max(256).optional(),
     CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT: irohBindingLimit.optional(),
     CMUX_IROH_DEV_BINDING_DEVICE_LIMIT: irohBindingLimit.optional(),
+    // Stale-binding reaper TTLs (whole hours) for the hourly retention cron.
+    // Unset uses the defaults (72h for dev-style tagged builds, 1080h = 45
+    // days for release-channel bindings); see services/iroh/retention.ts.
+    CMUX_IROH_STALE_DEV_BINDING_TTL_HOURS: z.string().regex(/^[1-9][0-9]{0,4}$/).optional(),
+    CMUX_IROH_STALE_RELEASE_BINDING_TTL_HOURS: z.string().regex(/^[1-9][0-9]{0,4}$/).optional(),
+    // Broker -> presence-worker nudge fan-out (services/iroh/presenceNudge.ts).
+    // Both must be set for nudges to fire; leaving either unset disables the
+    // hook entirely (fail-open, never blocks broker operations). The secret is
+    // mirrored on the worker as the NUDGE_SERVER_SECRET Worker secret.
+    CMUX_PRESENCE_NUDGE_URL: z.string().url().max(512).optional(),
+    CMUX_PRESENCE_NUDGE_SECRET: z.string().min(16).max(512).optional(),
     // Self-hosted relay fleet. Preview and local builds remain credential-free,
     // while every deployed non-preview runtime must be able to mint endpoint-
     // bound credentials, sign the fleet policy, and enforce its account limit.
@@ -334,6 +345,10 @@ export const env = createEnv({
     CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS: trimEnv(process.env.CMUX_IROH_DEV_BINDING_OVERRIDE_ENVIRONMENTS),
     CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT: trimEnv(process.env.CMUX_IROH_DEV_BINDING_ACCOUNT_LIMIT),
     CMUX_IROH_DEV_BINDING_DEVICE_LIMIT: trimEnv(process.env.CMUX_IROH_DEV_BINDING_DEVICE_LIMIT),
+    CMUX_IROH_STALE_DEV_BINDING_TTL_HOURS: trimEnv(process.env.CMUX_IROH_STALE_DEV_BINDING_TTL_HOURS),
+    CMUX_IROH_STALE_RELEASE_BINDING_TTL_HOURS: trimEnv(process.env.CMUX_IROH_STALE_RELEASE_BINDING_TTL_HOURS),
+    CMUX_PRESENCE_NUDGE_URL: trimEnv(process.env.CMUX_PRESENCE_NUDGE_URL),
+    CMUX_PRESENCE_NUDGE_SECRET: trimEnv(process.env.CMUX_PRESENCE_NUDGE_SECRET),
     CMUX_RELAY_JWT_PRIVATE_KEY_PEM: trimEnv(process.env.CMUX_RELAY_JWT_PRIVATE_KEY_PEM),
     CMUX_RELAY_POLICY_KEY_ID: trimEnv(process.env.CMUX_RELAY_POLICY_KEY_ID),
     CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: trimEnv(process.env.CMUX_RELAY_POLICY_PRIVATE_KEY_PEM),

--- a/web/services/iroh/README.md
+++ b/web/services/iroh/README.md
@@ -32,6 +32,49 @@ display name. The hourly `/api/internal/iroh/retention` cron applies the same
 policy across inactive accounts; responses also filter expired hints
 defensively.
 
+Binding lifecycle changes additionally fire a best-effort `iroh-binding-changed`
+nudge at the presence worker (`POST /v1/presence/nudge`, shared-secret header
+`x-cmux-nudge-secret`), targeted at the AFFECTED binding's device id and tag, so
+a subscribed device re-checks broker state within seconds instead of on its next
+poll. Exactly three paths nudge: user revocation, slot reincarnation (a signed
+registration that re-keys an existing (user, device, tag) slot to a new binding
+id), and the stale-binding reaper below. Plain signed refresh heartbeats and
+genuinely new slots never nudge, so refresh cadence cannot become nudge churn.
+The hook is env-gated by `CMUX_PRESENCE_NUDGE_URL` plus
+`CMUX_PRESENCE_NUDGE_SECRET` (either absent disables it entirely) and strictly
+fail-open: delivery has a ~2s budget, errors are swallowed and logged as counts,
+and a presence-worker outage can never fail or block a broker mutation. Because
+the presence worker shards Durable Objects by team, the nudge fans out to the
+device's registry teams (`devices.team_id`, capped at three) plus the user id as
+the solo-account fallback; a wrong-team candidate 404s harmlessly. The worker
+verifies the shared secret, then still enforces the device's presence owner pin
+against the asserted user id.
+
+The retention cron also REAPS stale active bindings. Each dev build occupies its
+own (user, device, tag) slot, and the shared dev account once accumulated 250+
+of them, hit the 256 active-binding sanity cap (pinned to the iOS discovery wire
+limit, never to be raised), and 409'd every new registration. The reaper
+soft-revokes (sets `revoked_at`, through the exact same helper as user
+revocation: hints and direct ports cleared, live pair grants revoked, LAN
+rendezvous generation rotated) any active binding whose `registered_at`
+high-water mark AND `last_seen_at` are BOTH older than its shape's TTL.
+Shape rule: a binding whose tag exactly matches a release-channel tag
+(`default`, `stable`, `rc`, `nightly`, `staging` — stable builds register
+`default` on both platforms) gets the long TTL,
+`CMUX_IROH_STALE_RELEASE_BINDING_TTL_HOURS` (default 1080h = 45 days); every
+other tag is a dev-style tagged build and gets the short TTL,
+`CMUX_IROH_STALE_DEV_BINDING_TTL_HOURS` (default 72h). Slugged channel builds
+(a slugged rc/nightly/staging registers its bare slug) intentionally land in
+the dev bucket: they are transient dogfood installs, indistinguishable from dev
+tags on the wire, and the conservative failure mode is reaping a dogfood build
+early, never a stable one. Reaping is safe even if it misfires: newest-wins
+slot re-key semantics let a reaped device re-register IN PLACE on its next
+launch or signed refresh, and a still-running instance receives the reaper's
+nudge and re-registers within seconds. Reap batches are bounded (500 rows per
+run by default), re-check staleness under `FOR UPDATE SKIP LOCKED` inside the
+per-user binding advisory lock and account-deletion fence, and record
+`revoked_reason` as `stale_development_binding` or `stale_binding_retention`.
+
 The LAN rendezvous key is HMAC-derived from an independent random server secret,
 the exact Stack user id, and an account generation. Discovery reads active
 bindings and that generation in one transaction under the same account lock as

--- a/web/services/iroh/presenceNudge.ts
+++ b/web/services/iroh/presenceNudge.ts
@@ -1,0 +1,183 @@
+// Broker -> presence-worker wake-up hook.
+//
+// When a binding's lifecycle changes server-side (user revoke, slot
+// reincarnation, stale-binding reap) the affected device would otherwise learn
+// only on its next scheduled broker round trip (minutes, worst-case tens of
+// minutes). The presence worker already carries a directed, device-scoped
+// nudge channel (`POST /v1/presence/nudge`, kind `iroh-binding-changed`) that
+// the Mac subscribes to; this module lets the broker fire that nudge.
+//
+// Delivery contract: STRICTLY best-effort acceleration. Absent configuration
+// (`CMUX_PRESENCE_NUDGE_URL` + `CMUX_PRESENCE_NUDGE_SECRET`) it is a no-op;
+// lookup or fetch failures are swallowed after a bounded (~2s) budget and
+// logged as counts only. `bindingChanged` NEVER fails, so a presence-worker
+// outage can never fail or delay a broker mutation beyond the budget.
+//
+// Team fan-out: the presence worker shards its Durable Objects by team id, and
+// a Mac's directed socket lives in the DO of the team its auth session
+// resolved (selected team, else sole team, else the solo-account user id).
+// The broker only knows the Stack user id, so candidate team ids come from the
+// device registry (`devices.team_id` rows the same physical device registered,
+// which use the identical client-side team resolution) plus the user id as the
+// solo-account fallback. Wrong-team candidates 404 in the worker (no owner pin
+// in that DO), which is expected and not an error.
+
+import * as Effect from "effect/Effect";
+import { desc, inArray } from "drizzle-orm";
+import { env } from "../../app/env";
+import { cloudDb } from "../../db/client";
+import { devices } from "../../db/schema";
+
+export const IROH_PRESENCE_NUDGE_KIND = "iroh-binding-changed";
+export const IROH_PRESENCE_NUDGE_TIMEOUT_MS = 2_000;
+/** Upper bound on events per call (the reaper can revoke hundreds in one cron
+ * run). Excess events are dropped with a log line; the dropped devices still
+ * converge on their normal cadence. */
+export const IROH_PRESENCE_NUDGE_MAX_EVENTS = 128;
+/** Candidate team DOs tried per event, beyond the user-id fallback. */
+export const IROH_PRESENCE_NUDGE_MAX_TEAMS_PER_EVENT = 3;
+const CANDIDATE_TEAM_ROW_LIMIT = 256;
+
+export type IrohBindingNudgeEvent = {
+  readonly userId: string;
+  readonly deviceUuid: string;
+  readonly tag: string;
+};
+
+export type IrohPresenceNudgeShape = {
+  /** Fire-and-forget wake-up for each affected device. Never fails. */
+  readonly bindingChanged: (
+    events: readonly IrohBindingNudgeEvent[],
+  ) => Effect.Effect<void>;
+};
+
+export type IrohPresenceNudgeCandidateTeamLookup = (
+  events: readonly IrohBindingNudgeEvent[],
+) => Promise<ReadonlyMap<string, readonly string[]>>;
+
+export type IrohPresenceNudgeConfig = {
+  /** Presence service origin, e.g. https://presence.cmux.dev. Defaults to
+   * CMUX_PRESENCE_NUDGE_URL; absent = the whole hook is a no-op. */
+  readonly baseUrl?: string;
+  /** Shared server secret; sent as `x-cmux-nudge-secret`. Defaults to
+   * CMUX_PRESENCE_NUDGE_SECRET; absent = no-op. */
+  readonly secret?: string;
+  readonly timeoutMs?: number;
+  readonly fetchImpl?: typeof fetch;
+  readonly lookupCandidateTeamIds?: IrohPresenceNudgeCandidateTeamLookup;
+};
+
+/** Map key for candidate-team lookup results. */
+export function irohNudgeEventKey(event: Pick<IrohBindingNudgeEvent, "userId" | "deviceUuid">): string {
+  return `${event.userId}\n${event.deviceUuid}`;
+}
+
+export function makeIrohPresenceNudge(
+  config: IrohPresenceNudgeConfig = {},
+): IrohPresenceNudgeShape {
+  return {
+    bindingChanged: (events) => Effect.promise(() =>
+      deliverBindingChanged(config, events).catch(() => {
+        // deliverBindingChanged already contains all expected failure handling;
+        // this guard only catches programming defects so the contract holds.
+        console.warn("iroh presence nudge failed", { failure: "unexpected" });
+      })),
+  };
+}
+
+export const irohPresenceNudgeLive: IrohPresenceNudgeShape = makeIrohPresenceNudge();
+
+async function deliverBindingChanged(
+  config: IrohPresenceNudgeConfig,
+  events: readonly IrohBindingNudgeEvent[],
+): Promise<void> {
+  const baseUrl = (config.baseUrl ?? env.CMUX_PRESENCE_NUDGE_URL)?.trim().replace(/\/+$/, "");
+  const secret = (config.secret ?? env.CMUX_PRESENCE_NUDGE_SECRET)?.trim();
+  if (!baseUrl || !secret || events.length === 0) return;
+
+  const bounded = events.slice(0, IROH_PRESENCE_NUDGE_MAX_EVENTS);
+  if (bounded.length < events.length) {
+    console.warn("iroh presence nudge events truncated", {
+      dropped: events.length - bounded.length,
+    });
+  }
+
+  let candidateTeams: ReadonlyMap<string, readonly string[]>;
+  try {
+    candidateTeams = await (config.lookupCandidateTeamIds ?? registryCandidateTeamIds)(bounded);
+  } catch {
+    // Registry lookup is itself best-effort; the solo-account fallback below
+    // still covers teamless users.
+    candidateTeams = new Map();
+  }
+
+  const doFetch = config.fetchImpl ?? fetch;
+  const signal = AbortSignal.timeout(config.timeoutMs ?? IROH_PRESENCE_NUDGE_TIMEOUT_MS);
+  const posts: Promise<Response>[] = [];
+  for (const event of bounded) {
+    const teamIds = new Set([
+      ...(candidateTeams.get(irohNudgeEventKey(event)) ?? [])
+        .slice(0, IROH_PRESENCE_NUDGE_MAX_TEAMS_PER_EVENT),
+      event.userId,
+    ]);
+    for (const teamId of teamIds) {
+      posts.push(doFetch(`${baseUrl}/v1/presence/nudge`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-cmux-nudge-secret": secret,
+        },
+        body: JSON.stringify({
+          deviceId: event.deviceUuid,
+          tag: event.tag,
+          kind: IROH_PRESENCE_NUDGE_KIND,
+          userId: event.userId,
+          teamId,
+        }),
+        signal,
+      }));
+    }
+  }
+
+  const settled = await Promise.allSettled(posts);
+  // 404 = no owner pin in that candidate team's DO — expected for every
+  // wrong-team candidate and for devices that never heartbeated presence.
+  const failed = settled.filter((result) =>
+    result.status === "rejected" ||
+    (!result.value.ok && result.value.status !== 404)).length;
+  if (failed > 0) {
+    console.warn("iroh presence nudge delivery incomplete", {
+      attempted: settled.length,
+      failed,
+    });
+  }
+}
+
+async function registryCandidateTeamIds(
+  events: readonly IrohBindingNudgeEvent[],
+): Promise<ReadonlyMap<string, readonly string[]>> {
+  const deviceUuids = [...new Set(events.map((event) => event.deviceUuid))];
+  if (deviceUuids.length === 0) return new Map();
+  const rows = await cloudDb()
+    .select({
+      deviceUuid: devices.deviceUuid,
+      userId: devices.userId,
+      teamId: devices.teamId,
+    })
+    .from(devices)
+    .where(inArray(devices.deviceUuid, deviceUuids))
+    .orderBy(desc(devices.lastSeenAt))
+    .limit(CANDIDATE_TEAM_ROW_LIMIT);
+  const byEvent = new Map<string, string[]>();
+  for (const row of rows) {
+    // Registered-by-user must match: another account's registration of the
+    // same physical device id must not steer this account's nudges.
+    const key = irohNudgeEventKey({ userId: row.userId, deviceUuid: row.deviceUuid });
+    const teams = byEvent.get(key) ?? [];
+    if (teams.length < IROH_PRESENCE_NUDGE_MAX_TEAMS_PER_EVENT && !teams.includes(row.teamId)) {
+      teams.push(row.teamId);
+      byEvent.set(key, teams);
+    }
+  }
+  return byEvent;
+}

--- a/web/services/iroh/repository.ts
+++ b/web/services/iroh/repository.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, gt, inArray, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { and, asc, count, desc, eq, gt, inArray, isNull, lt, lte, ne, notInArray, or, sql } from "drizzle-orm";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -54,6 +54,64 @@ export const IROH_RELAY_RESERVATION_LEASE_MS = 60 * 1_000;
 // count while catching a runaway registration loop, which blows past it at once.
 export const IROH_ACTIVE_BINDING_SANITY_CAP = 256;
 
+// ---- Stale-binding reaper -------------------------------------------------
+//
+// Each dev build registers its own (user, device, tag) binding slot, and the
+// shared dev account accumulated 250+ of them, hit the sanity cap above, and
+// 409'd every NEW registration — bricking all dogfood phones at once. The
+// hourly retention cron therefore soft-revokes bindings whose registration
+// activity has gone stale, with a short TTL for dev-style tagged builds and a
+// long TTL for release-channel bindings.
+//
+// Shape rule (conservative by construction): a binding is RELEASE-shaped only
+// when its tag exactly matches a known release-channel tag. Stable builds
+// register "default" on both platforms (macOS `MobileHostIdentity.instanceTag`
+// and iOS `MobileIOSBuildScope`), and the unslugged mac channels register
+// "rc" / "nightly" / "staging". "stable" is included defensively for
+// historical rows. Slugged channel builds return their bare slug, which is
+// indistinguishable from a dev tag on the wire — they intentionally fall into
+// the dev bucket, since they are transient dogfood installs anyway. Everything
+// non-release is a dev-style tagged build and gets the short TTL.
+//
+// Staleness uses the slot's registration high-water mark (`registered_at`,
+// stamped by every applied signed registration — insert, reincarnation, and
+// heartbeat refresh alike) AND `last_seen_at` (also advanced by relay-token
+// renewal), so a binding with ANY recent authenticated activity is never
+// reaped. Reaping is safe for genuinely live-but-idle devices too: the revoke
+// is the same soft-revoke as a user revocation, and the newest-wins slot
+// re-key semantics let the device re-register IN PLACE on its next launch or
+// refresh, so a reaped Mac reappears with a normal registration round trip.
+export const IROH_RELEASE_CHANNEL_TAGS: readonly string[] = [
+  "default",
+  "stable",
+  "rc",
+  "nightly",
+  "staging",
+];
+
+export function isIrohReleaseChannelTag(tag: string): boolean {
+  return IROH_RELEASE_CHANNEL_TAGS.includes(tag);
+}
+
+export const IROH_STALE_BINDING_REAP_MAX_ROWS = 500;
+
+export type IrohReapedBinding = {
+  readonly userId: string;
+  readonly deviceUuid: string;
+  readonly tag: string;
+  readonly platform: string;
+};
+
+export type IrohStaleBindingReapResult = {
+  readonly revoked: readonly IrohReapedBinding[];
+  /** Rows the candidate scan selected for this run (before locking rechecks). */
+  readonly candidates: number;
+  /** Users skipped because account deletion holds their mutation fence. */
+  readonly skippedUsers: number;
+  /** More past-threshold rows remained beyond this run's budget. */
+  readonly backlog: boolean;
+};
+
 export type IrohRetentionCategory =
   | "revokedHints"
   | "expiredHints"
@@ -76,6 +134,11 @@ export type IrohChallengeRecord = typeof irohRegistrationChallenges.$inferSelect
 export type IrohRegistrationCommit = {
   readonly binding: IrohBindingRecord;
   readonly created: boolean;
+  /** True when this registration re-keyed an EXISTING slot to a new binding id
+   * (reincarnation): the old incarnation was revoked in the same transaction.
+   * Always false for a plain in-place heartbeat refresh and for a genuinely
+   * new slot, so callers can nudge exactly the binding-changed cases. */
+  readonly replaced: boolean;
 };
 type CloudDbTransaction = Parameters<Parameters<ReturnType<typeof cloudDb>["transaction"]>[0]>[0];
 
@@ -141,6 +204,17 @@ export type IrohRepositoryShape = {
     readonly maxRows?: number;
     readonly maxDurationMs?: number;
   }) => Effect.Effect<IrohRetentionResult, RepositoryError>;
+  /** Soft-revoke active bindings whose registration activity is past their
+   * shape's cutoff (see IROH_RELEASE_CHANNEL_TAGS). Mirrors the revoke path's
+   * semantics exactly via the shared revokeActiveBindings helper. */
+  readonly reapStaleBindings: (input: {
+    readonly now: Date;
+    /** Dev-style tagged bindings staler than this are revoked. */
+    readonly devCutoff: Date;
+    /** Release-channel bindings staler than this are revoked. */
+    readonly releaseCutoff: Date;
+    readonly maxBindings?: number;
+  }) => Effect.Effect<IrohStaleBindingReapResult, RepositoryError>;
   readonly finalizeEndpointAttestation: (input: {
     readonly userId: string;
     readonly bindingId: string;
@@ -416,7 +490,7 @@ function makeLiveRepository(): IrohRepositoryShape {
             .set({ consumedAt: input.now })
             .where(eq(irohRegistrationChallenges.id, challenge.id));
           if (!updated) throw new Error("binding update returned no row");
-          return { binding: updated, created: false };
+          return { binding: updated, created: false, replaced: false };
         }
 
         // A NEW incarnation on an existing slot: the endpoint key rotated (a
@@ -500,7 +574,7 @@ function makeLiveRepository(): IrohRepositoryShape {
             eq(irohRegistrationChallenges.id, challenge.id),
             isNull(irohRegistrationChallenges.consumedAt),
           ));
-        return { binding, created: true };
+        return { binding, created: true, replaced: existingSlot !== undefined };
       });
     }),
 
@@ -707,6 +781,112 @@ function makeLiveRepository(): IrohRepositoryShape {
       "prune_expired_state_globally",
       () => drainIrohRetention(input),
     ),
+
+    reapStaleBindings: (input) => repositoryEffect("reap_stale_bindings", async () => {
+      const maxBindings = retentionBudget(
+        input.maxBindings,
+        IROH_STALE_BINDING_REAP_MAX_ROWS,
+        10_000,
+        "maxBindings",
+      );
+      if (input.devCutoff > input.now || input.releaseCutoff > input.now) {
+        throw new Error("invalid Iroh reap cutoffs");
+      }
+      const db = cloudDb();
+      const staleness = staleBindingCondition(input.devCutoff, input.releaseCutoff);
+
+      // Phase 1: lock-free candidate scan. One extra row detects backlog.
+      const candidates = await db
+        .select({
+          id: irohEndpointBindings.id,
+          userId: irohEndpointBindings.userId,
+        })
+        .from(irohEndpointBindings)
+        .where(and(isNull(irohEndpointBindings.revokedAt), staleness))
+        .orderBy(asc(irohEndpointBindings.registeredAt), asc(irohEndpointBindings.id))
+        .limit(maxBindings + 1);
+      const backlog = candidates.length > maxBindings;
+      const work = candidates.slice(0, maxBindings);
+      const byUser = new Map<string, string[]>();
+      for (const row of work) {
+        const ids = byUser.get(row.userId);
+        if (ids) ids.push(row.id);
+        else byUser.set(row.userId, [row.id]);
+      }
+
+      // Phase 2: per-user transactions under the SAME fences the revoke path
+      // uses (account-deletion fence, then the per-user binding advisory lock),
+      // re-checking liveness and staleness under FOR UPDATE SKIP LOCKED so a
+      // binding a concurrent registration is refreshing is skipped, never
+      // clobbered.
+      const revoked: IrohReapedBinding[] = [];
+      let skippedUsers = 0;
+      for (const [userId, bindingIds] of byUser) {
+        try {
+          const reaped = await db.transaction(async (tx) => {
+            await assertIrohUserMutationAllowed(tx, userId);
+            await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${`iroh:binding:${userId}`}, 0))`);
+            const rows = await tx
+              .select({
+                id: irohEndpointBindings.id,
+                deviceUuid: irohEndpointBindings.deviceUuid,
+                tag: irohEndpointBindings.tag,
+                platform: irohEndpointBindings.platform,
+              })
+              .from(irohEndpointBindings)
+              .where(and(
+                eq(irohEndpointBindings.userId, userId),
+                inArray(irohEndpointBindings.id, bindingIds),
+                isNull(irohEndpointBindings.revokedAt),
+                staleness,
+              ))
+              .for("update", { skipLocked: true });
+            if (rows.length === 0) return [];
+            const revokedIds = new Set<string>();
+            for (const [reason, ids] of [
+              [
+                "stale_development_binding",
+                rows.filter((row) => !isIrohReleaseChannelTag(row.tag)).map((row) => row.id),
+              ],
+              [
+                "stale_binding_retention",
+                rows.filter((row) => isIrohReleaseChannelTag(row.tag)).map((row) => row.id),
+              ],
+            ] as const) {
+              for (const id of await revokeActiveBindings(tx, {
+                userId,
+                bindingIds: ids,
+                now: input.now,
+                reason,
+              })) {
+                revokedIds.add(id);
+              }
+            }
+            return rows
+              .filter((row) => revokedIds.has(row.id))
+              .map((row): IrohReapedBinding => ({
+                userId,
+                deviceUuid: row.deviceUuid,
+                tag: row.tag,
+                platform: row.platform,
+              }));
+          });
+          revoked.push(...reaped);
+        } catch (error) {
+          // Account deletion holds this user's fence; deletion removes the
+          // rows anyway, so skip the user rather than failing the whole run.
+          if (
+            (error as { _tag?: unknown } | null)?._tag === "IrohConflictError" &&
+            (error as { code?: unknown }).code === "account_deletion_in_progress"
+          ) {
+            skippedUsers += 1;
+            continue;
+          }
+          throw error;
+        }
+      }
+      return { revoked, candidates: work.length, skippedUsers, backlog };
+    }),
 
     finalizeEndpointAttestation: (input) => repositoryEffect("finalize_endpoint_attestation", async () => {
       await cloudDb().transaction(async (tx) => {
@@ -965,6 +1145,7 @@ async function revokeActiveBindings(
     readonly reason:
       | "user_requested"
       | "stale_development_binding"
+      | "stale_binding_retention"
       | "slot_reincarnated";
   },
 ): Promise<readonly string[]> {
@@ -1038,6 +1219,27 @@ async function enforceActiveBindingSanityCap(
   const active = row?.total ?? 0;
   if (active < IROH_ACTIVE_BINDING_SANITY_CAP) return;
   throw new IrohConflictError({ code: "active_binding_limit" });
+}
+
+// A binding is stale for reaping only when BOTH its registration high-water
+// mark and its last authenticated activity precede its shape's cutoff. Tag
+// shape picks the cutoff: exact release-channel tags get the (long)
+// releaseCutoff, every other tag is treated as a dev-style tagged build and
+// gets the (short) devCutoff.
+function staleBindingCondition(devCutoff: Date, releaseCutoff: Date) {
+  const releaseTags = [...IROH_RELEASE_CHANNEL_TAGS];
+  return or(
+    and(
+      inArray(irohEndpointBindings.tag, releaseTags),
+      lt(irohEndpointBindings.registeredAt, releaseCutoff),
+      lt(irohEndpointBindings.lastSeenAt, releaseCutoff),
+    ),
+    and(
+      notInArray(irohEndpointBindings.tag, releaseTags),
+      lt(irohEndpointBindings.registeredAt, devCutoff),
+      lt(irohEndpointBindings.lastSeenAt, devCutoff),
+    ),
+  );
 }
 
 type RetentionBatchOperation = {

--- a/web/services/iroh/retention.ts
+++ b/web/services/iroh/retention.ts
@@ -1,0 +1,112 @@
+// Hourly Iroh retention cron orchestration: the existing global retention
+// drain, then the stale-binding reaper, then a best-effort presence nudge for
+// every reaped binding (same wake-up hook the user revoke and reincarnation
+// paths fire). Lives outside the Next.js route file so it can be unit-tested
+// with stub repositories; the route stays a thin auth wrapper.
+
+import * as Effect from "effect/Effect";
+import { env } from "../../app/env";
+import {
+  IROH_RETENTION_MAX_DURATION_MS,
+  IROH_RETENTION_MAX_ROWS,
+  type IrohRepositoryShape,
+  type IrohRetentionResult,
+} from "./repository";
+import { irohPresenceNudgeLive, type IrohPresenceNudgeShape } from "./presenceNudge";
+
+export const IROH_STALE_DEV_BINDING_TTL_HOURS_DEFAULT = 72;
+export const IROH_STALE_RELEASE_BINDING_TTL_HOURS_DEFAULT = 45 * 24;
+const MAX_STALE_BINDING_TTL_HOURS = 24 * 366;
+
+export type IrohStaleBindingTtls = {
+  readonly devHours: number;
+  readonly releaseHours: number;
+};
+
+/** Env-tunable reap TTLs with safe defaults. Invalid or out-of-range values
+ * fall back to the defaults rather than failing the cron. Pure for tests. */
+export function irohStaleBindingTtlHours(
+  raw: { readonly dev?: string; readonly release?: string } = {
+    dev: env.CMUX_IROH_STALE_DEV_BINDING_TTL_HOURS,
+    release: env.CMUX_IROH_STALE_RELEASE_BINDING_TTL_HOURS,
+  },
+): IrohStaleBindingTtls {
+  return {
+    devHours: boundedTtlHours(raw.dev, IROH_STALE_DEV_BINDING_TTL_HOURS_DEFAULT),
+    releaseHours: boundedTtlHours(raw.release, IROH_STALE_RELEASE_BINDING_TTL_HOURS_DEFAULT),
+  };
+}
+
+function boundedTtlHours(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 1 && parsed <= MAX_STALE_BINDING_TTL_HOURS
+    ? parsed
+    : fallback;
+}
+
+export type IrohRetentionRunSummary = {
+  readonly retention: IrohRetentionResult;
+  readonly reap: {
+    readonly revoked: number;
+    readonly candidates: number;
+    readonly skippedUsers: number;
+    readonly backlog: boolean;
+    readonly devCutoff: string;
+    readonly releaseCutoff: string;
+  };
+};
+
+export function runIrohRetention(input: {
+  readonly repository: IrohRepositoryShape;
+  readonly now?: Date;
+  readonly presenceNudge?: IrohPresenceNudgeShape;
+  readonly ttlHours?: IrohStaleBindingTtls;
+}) {
+  return Effect.gen(function* () {
+    const now = input.now ?? new Date();
+    const presenceNudge = input.presenceNudge ?? irohPresenceNudgeLive;
+    const { devHours, releaseHours } = input.ttlHours ?? irohStaleBindingTtlHours();
+
+    const retention = yield* input.repository.pruneExpiredStateGlobally({
+      now,
+      maxRows: IROH_RETENTION_MAX_ROWS,
+      maxDurationMs: IROH_RETENTION_MAX_DURATION_MS,
+    });
+
+    const devCutoff = new Date(now.getTime() - devHours * 60 * 60 * 1_000);
+    const releaseCutoff = new Date(now.getTime() - releaseHours * 60 * 60 * 1_000);
+    const reap = yield* input.repository.reapStaleBindings({
+      now,
+      devCutoff,
+      releaseCutoff,
+    });
+
+    if (reap.revoked.length > 0) {
+      // Reaped devices re-register in place on next launch (newest-wins slot
+      // re-key); a still-running instance learns within seconds through its
+      // directed nudge channel instead of at its next poll. Best-effort and
+      // defect-guarded: nudge delivery can never fail the cron.
+      yield* Effect.suspend(() => presenceNudge.bindingChanged(
+        reap.revoked.map((binding) => ({
+          userId: binding.userId,
+          deviceUuid: binding.deviceUuid,
+          tag: binding.tag,
+        })),
+      )).pipe(Effect.catchAllCause(() => Effect.void));
+    }
+
+    const summary: IrohRetentionRunSummary = {
+      retention,
+      reap: {
+        revoked: reap.revoked.length,
+        candidates: reap.candidates,
+        skippedUsers: reap.skippedUsers,
+        backlog: reap.backlog,
+        devCutoff: devCutoff.toISOString(),
+        releaseCutoff: releaseCutoff.toISOString(),
+      },
+    };
+    return summary;
+  });
+}

--- a/web/services/iroh/trustBroker.ts
+++ b/web/services/iroh/trustBroker.ts
@@ -77,6 +77,11 @@ import {
   MANAGED_RELAY_URLS,
   accountPrivateIrohPathHints,
 } from "./publicationPolicy";
+import {
+  irohPresenceNudgeLive,
+  type IrohBindingNudgeEvent,
+  type IrohPresenceNudgeShape,
+} from "./presenceNudge";
 
 export type IrohTrustBrokerShape = {
   readonly issueChallenge: (
@@ -130,7 +135,18 @@ export function makeIrohTrustBroker(
       revision: 0,
     }),
   },
+  presenceNudge: IrohPresenceNudgeShape = irohPresenceNudgeLive,
 ): IrohTrustBrokerShape {
+  // Wake the affected device's presence nudge channel after a binding
+  // lifecycle change so it re-checks broker state within seconds instead of on
+  // its next scheduled round trip. Strictly best-effort: the nudge contract is
+  // never-failing, and this guard also swallows defects from injected
+  // implementations, so the broker mutation's outcome can never depend on the
+  // presence worker.
+  const nudgeBindingChanged = (
+    events: readonly IrohBindingNudgeEvent[],
+  ): Effect.Effect<void> => Effect.suspend(() => presenceNudge.bindingChanged(events))
+    .pipe(Effect.catchAllCause(() => Effect.void));
   const accountRelayPreference = (
     userId: string,
   ): Effect.Effect<RelayPreference, IrohExpectedError> => relayPreferences
@@ -248,6 +264,18 @@ export function makeIrohTrustBroker(
         now,
       });
 
+      // A reincarnation revoked the slot's previous incarnation in the same
+      // transaction: the device's other subscribers (old app instance, stale
+      // sockets) should re-check now. Plain heartbeats and genuinely new slots
+      // are deliberately silent — refresh cadence must not become nudge churn.
+      if (registration.replaced) {
+        yield* nudgeBindingChanged([{
+          userId,
+          deviceUuid: registration.binding.deviceUuid,
+          tag: registration.binding.tag,
+        }]);
+      }
+
       // New registration is already committed before relay minting starts.
       // Refreshes keep their existing credential and use the dedicated relay
       // route when it expires, so path-hint churn cannot consume mint quotas.
@@ -292,8 +320,21 @@ export function makeIrohTrustBroker(
 
     revoke: (userId, raw, now = new Date()) => Effect.gen(function* () {
       const { bindingId } = yield* parseEffect(() => parseBindingIdBody(raw));
+      // Capture the slot identity BEFORE revoking: revokeBinding reports only
+      // a boolean (true covers already-revoked retries too), and a retry of an
+      // already-revoked binding reads back nothing here, so it does not
+      // re-nudge.
+      const activeBindings = yield* repository.findActiveBindings(userId, [bindingId]);
+      const active = activeBindings.length === 1 ? activeBindings[0] : undefined;
       const revoked = yield* repository.revokeBinding({ userId, bindingId, now });
       if (!revoked) return yield* Effect.fail(new IrohNotFoundError({ resource: "binding" }));
+      if (active) {
+        yield* nudgeBindingChanged([{
+          userId,
+          deviceUuid: active.deviceUuid,
+          tag: active.tag,
+        }]);
+      }
       return { revoked: true, lan_rendezvous_rotated: true };
     }),
 

--- a/web/tests/iroh-db-behavior.test.ts
+++ b/web/tests/iroh-db-behavior.test.ts
@@ -883,6 +883,7 @@ describe("Iroh trust broker database behavior", () => {
       now: NOW,
     });
     expect(first.created).toBe(true);
+    expect(first.replaced).toBe(false);
 
     // Reinstall: fresh app instance, rotated endpoint, generation reset to 1.
     // The rotated key is a new incarnation, so the slot is re-keyed onto a BRAND
@@ -900,6 +901,9 @@ describe("Iroh trust broker database behavior", () => {
       now: new Date(NOW.getTime() + 1_000),
     });
     expect(reinstalled.created).toBe(true);
+    // The re-key retired a live incarnation of the same slot: exactly the
+    // binding-changed case the presence nudge hook keys off.
+    expect(reinstalled.replaced).toBe(true);
     expect(reinstalled.binding.id).not.toBe(first.binding.id);
     expect(reinstalled.binding.endpointId).toBe(rotatedEndpoint);
     expect(reinstalled.binding.appInstanceId).toBe(reinstallApp);
@@ -915,6 +919,7 @@ describe("Iroh trust broker database behavior", () => {
       now: NOW,
     });
     expect(secondTag.created).toBe(true);
+    expect(secondTag.replaced).toBe(false);
     expect(secondTag.binding.id).not.toBe(first.binding.id);
 
     const [state] = await requiredSql()<Array<{
@@ -1012,9 +1017,11 @@ describe("Iroh trust broker database behavior", () => {
     const older = await prepare({ appInstanceId: olderApp, suffix: "2", now: new Date(NOW.getTime() + 1_000) });
     const newer = await prepare({ appInstanceId: newerApp, suffix: "3", now: new Date(NOW.getTime() + 2_000) });
 
-    // The NEWER challenge lands first and refreshes the slot.
+    // The NEWER challenge lands first and refreshes the slot. A plain in-place
+    // heartbeat is neither a creation nor a replacement (so it never nudges).
     const newerResult = await Effect.runPromise(register(newer, new Date(NOW.getTime() + 2_500)));
     expect(newerResult.created).toBe(false);
+    expect(newerResult.replaced).toBe(false);
     expect(newerResult.binding.appInstanceId).toBe(newerApp);
 
     // The OLDER challenge, delayed, completes second. It was minted before the
@@ -2087,6 +2094,182 @@ describe("Iroh trust broker database behavior", () => {
       where user_id = 'user-retention-budget'
     `;
     expect(remaining).toBe("1");
+  });
+
+  dbTest("stale-binding reaper revokes only past-threshold rows by tag shape", async () => {
+    const repo = requiredRepository();
+    const userId = "user-reap";
+    const devCutoff = new Date(NOW.getTime() - 72 * 60 * 60 * 1_000);
+    const releaseCutoff = new Date(NOW.getTime() - 45 * 24 * 60 * 60 * 1_000);
+    const setActivity = async (id: string, at: Date, lastSeenAt: Date = at) => {
+      await requiredSql()`
+        update iroh_endpoint_bindings
+        set registered_at = ${at}, last_seen_at = ${lastSeenAt}
+        where id = ${id}
+      `;
+    };
+
+    // Dev-style tagged build, idle four days: reaped on the short threshold.
+    const staleDevId = await insertBinding({
+      userId,
+      tag: "wsid",
+      endpointId: "a0".repeat(32),
+      pathHints: [storedLanHint("10.0.0.9:4433", "2026-07-09T19:55:00.000Z", "2026-07-09T20:30:00.000Z")],
+    });
+    await setActivity(staleDevId, new Date(NOW.getTime() - 4 * 24 * 60 * 60 * 1_000));
+    // Dev-style but refreshed yesterday: inside the short threshold.
+    const freshDevId = await insertBinding({ userId, tag: "iq1", endpointId: "a1".repeat(32) });
+    await setActivity(freshDevId, new Date(NOW.getTime() - 24 * 60 * 60 * 1_000));
+    // Dev-style with an old registration but RECENT authenticated activity
+    // (relay renewal advances last_seen_at): must not be reaped.
+    const activeDevId = await insertBinding({ userId, tag: "pullr", endpointId: "a2".repeat(32) });
+    await setActivity(
+      activeDevId,
+      new Date(NOW.getTime() - 4 * 24 * 60 * 60 * 1_000),
+      new Date(NOW.getTime() - 60 * 60 * 1_000),
+    );
+    // Release-channel binding idle four days: far inside the long threshold.
+    const idleDefaultId = await insertBinding({ userId, tag: "default", endpointId: "a3".repeat(32) });
+    await setActivity(idleDefaultId, new Date(NOW.getTime() - 4 * 24 * 60 * 60 * 1_000));
+    // Release-channel binding idle 46 days: past the long threshold.
+    const staleDefaultId = await insertBinding({
+      userId,
+      tag: "default",
+      platform: "ios",
+      endpointId: "a4".repeat(32),
+    });
+    await setActivity(staleDefaultId, new Date(NOW.getTime() - 46 * 24 * 60 * 60 * 1_000));
+    // Already revoked long ago: the reaper never touches it again.
+    const alreadyRevokedId = await insertBinding({ userId, tag: "wsold", endpointId: "a5".repeat(32) });
+    await setActivity(alreadyRevokedId, new Date(NOW.getTime() - 20 * 24 * 60 * 60 * 1_000));
+    const priorRevokedAt = new Date(NOW.getTime() - 10 * 24 * 60 * 60 * 1_000);
+    await requiredSql()`
+      update iroh_endpoint_bindings
+      set revoked_at = ${priorRevokedAt}, revoked_reason = 'user_requested'
+      where id = ${alreadyRevokedId}
+    `;
+    // A live pair grant naming the stale dev binding: revoked with it, exactly
+    // like the user revoke path.
+    await requiredSql()`
+      insert into iroh_pair_grant_issuances (
+        user_id, jti, initiator_binding_id, acceptor_binding_id, signing_key_id,
+        alpn, scope, issued_at, not_before, expires_at
+      ) values (
+        ${userId}, ${randomUUID()}, ${freshDevId}, ${staleDevId}, 'current',
+        'cmux/mobile/1', 'cmux.mobile.attach', ${NOW}, ${NOW},
+        ${new Date(NOW.getTime() + 7 * 24 * 60 * 60 * 1_000)}
+      )
+    `;
+    const generationBefore = (await Effect.runPromise(
+      repo.discoverySnapshot({ userId, now: NOW }),
+    )).lanDiscoveryGeneration;
+
+    const result = await Effect.runPromise(repo.reapStaleBindings({
+      now: NOW,
+      devCutoff,
+      releaseCutoff,
+    }));
+
+    expect(result.backlog).toBe(false);
+    expect(result.skippedUsers).toBe(0);
+    expect(result.revoked.map((binding) => binding.tag).sort()).toEqual(["default", "wsid"]);
+    const reapedDev = result.revoked.find((binding) => binding.tag === "wsid");
+    expect(reapedDev).toMatchObject({ userId, platform: "mac" });
+
+    const rows = await requiredSql()<Array<{
+      id: string;
+      revoked: boolean;
+      reason: string | null;
+      hints: number;
+    }>>`
+      select
+        id::text,
+        revoked_at is not null as revoked,
+        revoked_reason as reason,
+        jsonb_array_length(path_hints)::int as hints
+      from iroh_endpoint_bindings
+      where user_id = ${userId}
+    `;
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    expect(byId.get(staleDevId)).toMatchObject({
+      revoked: true,
+      reason: "stale_development_binding",
+      hints: 0,
+    });
+    expect(byId.get(staleDefaultId)).toMatchObject({
+      revoked: true,
+      reason: "stale_binding_retention",
+    });
+    expect(byId.get(freshDevId)).toMatchObject({ revoked: false });
+    expect(byId.get(activeDevId)).toMatchObject({ revoked: false });
+    expect(byId.get(idleDefaultId)).toMatchObject({ revoked: false });
+    expect(byId.get(alreadyRevokedId)).toMatchObject({ revoked: true, reason: "user_requested" });
+    const [alreadyRevoked] = await requiredSql()<Array<{ revokedAt: Date }>>`
+      select revoked_at as "revokedAt" from iroh_endpoint_bindings where id = ${alreadyRevokedId}
+    `;
+    expect(alreadyRevoked?.revokedAt).toEqual(priorRevokedAt);
+
+    const [grant] = await requiredSql()<Array<{ revokedAt: Date | null }>>`
+      select revoked_at as "revokedAt"
+      from iroh_pair_grant_issuances
+      where acceptor_binding_id = ${staleDevId}
+    `;
+    expect(grant?.revokedAt).not.toBeNull();
+    // Reaping rotates the LAN rendezvous generation like every revocation.
+    const generationAfter = (await Effect.runPromise(
+      repo.discoverySnapshot({ userId, now: NOW }),
+    )).lanDiscoveryGeneration;
+    expect(generationAfter).toBeGreaterThan(generationBefore);
+
+    // Idempotent: a second run finds nothing left to reap.
+    const rerun = await Effect.runPromise(repo.reapStaleBindings({
+      now: NOW,
+      devCutoff,
+      releaseCutoff,
+    }));
+    expect(rerun.revoked).toEqual([]);
+  });
+
+  dbTest("stale-binding reaper honors its row budget and reports backlog", async () => {
+    const repo = requiredRepository();
+    const userId = "user-reap-budget";
+    const staleAt = new Date(NOW.getTime() - 5 * 24 * 60 * 60 * 1_000);
+    for (let index = 0; index < 3; index += 1) {
+      const id = await insertBinding({
+        userId,
+        tag: `dev${index}`,
+        endpointId: `b${index}`.repeat(32),
+      });
+      await requiredSql()`
+        update iroh_endpoint_bindings
+        set registered_at = ${staleAt}, last_seen_at = ${staleAt}
+        where id = ${id}
+      `;
+    }
+
+    const first = await Effect.runPromise(repo.reapStaleBindings({
+      now: NOW,
+      devCutoff: new Date(NOW.getTime() - 72 * 60 * 60 * 1_000),
+      releaseCutoff: new Date(NOW.getTime() - 45 * 24 * 60 * 60 * 1_000),
+      maxBindings: 2,
+    }));
+    expect(first.revoked).toHaveLength(2);
+    expect(first.backlog).toBe(true);
+
+    const second = await Effect.runPromise(repo.reapStaleBindings({
+      now: NOW,
+      devCutoff: new Date(NOW.getTime() - 72 * 60 * 60 * 1_000),
+      releaseCutoff: new Date(NOW.getTime() - 45 * 24 * 60 * 60 * 1_000),
+      maxBindings: 2,
+    }));
+    expect(second.revoked).toHaveLength(1);
+    expect(second.backlog).toBe(false);
+    const [{ active }] = await requiredSql()<Array<{ active: string }>>`
+      select count(*)::text as active
+      from iroh_endpoint_bindings
+      where user_id = ${userId} and revoked_at is null
+    `;
+    expect(active).toBe("0");
   });
 
   dbTest("retention and cascade lookups use their dedicated indexes", async () => {

--- a/web/tests/iroh-presence-nudge.test.ts
+++ b/web/tests/iroh-presence-nudge.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import {
+  IROH_PRESENCE_NUDGE_KIND,
+  IROH_PRESENCE_NUDGE_MAX_EVENTS,
+  irohNudgeEventKey,
+  makeIrohPresenceNudge,
+  type IrohBindingNudgeEvent,
+} from "../services/iroh/presenceNudge";
+
+const EVENT: IrohBindingNudgeEvent = {
+  userId: "user-owner",
+  deviceUuid: "11111111-2222-4333-8444-555555555555",
+  tag: "wsid",
+};
+
+type RecordedPost = {
+  readonly url: string;
+  readonly secret: string | null;
+  readonly body: Record<string, unknown>;
+};
+
+function recordingFetch(record: RecordedPost[], respond: () => Response | Promise<Response>) {
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    record.push({
+      url: String(input),
+      secret: new Headers(init?.headers).get("x-cmux-nudge-secret"),
+      body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+    });
+    return respond();
+  }) as typeof fetch;
+}
+
+describe("iroh presence nudge client", () => {
+  test("posts one server nudge per candidate team plus the solo fallback", async () => {
+    const posts: RecordedPost[] = [];
+    const nudge = makeIrohPresenceNudge({
+      baseUrl: "https://presence.example.test/",
+      secret: "0123456789abcdef",
+      fetchImpl: recordingFetch(posts, () => new Response("{}", { status: 200 })),
+      lookupCandidateTeamIds: async (events) => new Map([
+        [irohNudgeEventKey(events[0]!), ["team-1", "user-owner"]],
+      ]),
+    });
+
+    await Effect.runPromise(nudge.bindingChanged([EVENT]));
+
+    // "user-owner" appears both as a registry candidate and as the solo
+    // fallback; it must be posted once, so exactly two DO targets are hit.
+    expect(posts).toHaveLength(2);
+    expect(new Set(posts.map((post) => post.body.teamId))).toEqual(new Set(["team-1", "user-owner"]));
+    for (const post of posts) {
+      expect(post.url).toBe("https://presence.example.test/v1/presence/nudge");
+      expect(post.secret).toBe("0123456789abcdef");
+      expect(post.body).toMatchObject({
+        deviceId: EVENT.deviceUuid,
+        tag: EVENT.tag,
+        kind: IROH_PRESENCE_NUDGE_KIND,
+        userId: EVENT.userId,
+      });
+    }
+  });
+
+  test("is a no-op without configuration", async () => {
+    const posts: RecordedPost[] = [];
+    const fetchImpl = recordingFetch(posts, () => new Response("{}", { status: 200 }));
+    const noUrl = makeIrohPresenceNudge({ secret: "0123456789abcdef", fetchImpl });
+    const noSecret = makeIrohPresenceNudge({ baseUrl: "https://presence.example.test", fetchImpl });
+
+    await Effect.runPromise(noUrl.bindingChanged([EVENT]));
+    await Effect.runPromise(noSecret.bindingChanged([EVENT]));
+
+    expect(posts).toEqual([]);
+  });
+
+  test("never fails on rejected fetches, non-2xx responses, or lookup errors", async () => {
+    const rejecting = makeIrohPresenceNudge({
+      baseUrl: "https://presence.example.test",
+      secret: "0123456789abcdef",
+      fetchImpl: (() => Promise.reject(new Error("connect timeout"))) as typeof fetch,
+      lookupCandidateTeamIds: async () => {
+        throw new Error("database unavailable");
+      },
+    });
+    await Effect.runPromise(rejecting.bindingChanged([EVENT]));
+
+    const failing = makeIrohPresenceNudge({
+      baseUrl: "https://presence.example.test",
+      secret: "0123456789abcdef",
+      fetchImpl: (async () => new Response("{}", { status: 500 })) as typeof fetch,
+    });
+    await Effect.runPromise(failing.bindingChanged([EVENT]));
+  });
+
+  test("bounds the number of events posted per call", async () => {
+    const posts: RecordedPost[] = [];
+    const nudge = makeIrohPresenceNudge({
+      baseUrl: "https://presence.example.test",
+      secret: "0123456789abcdef",
+      fetchImpl: recordingFetch(posts, () => new Response("{}", { status: 200 })),
+      lookupCandidateTeamIds: async () => new Map(),
+    });
+    const events = Array.from({ length: IROH_PRESENCE_NUDGE_MAX_EVENTS + 10 }, (_, index): IrohBindingNudgeEvent => ({
+      userId: "user-owner",
+      deviceUuid: `11111111-2222-4333-8444-${String(index).padStart(12, "0")}`,
+      tag: "wsid",
+    }));
+
+    await Effect.runPromise(nudge.bindingChanged(events));
+
+    expect(posts).toHaveLength(IROH_PRESENCE_NUDGE_MAX_EVENTS);
+  });
+});

--- a/web/tests/iroh-retention-runner.test.ts
+++ b/web/tests/iroh-retention-runner.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import type {
+  IrohRepositoryShape,
+  IrohRetentionResult,
+  IrohStaleBindingReapResult,
+} from "../services/iroh/repository";
+import {
+  IROH_STALE_DEV_BINDING_TTL_HOURS_DEFAULT,
+  IROH_STALE_RELEASE_BINDING_TTL_HOURS_DEFAULT,
+  irohStaleBindingTtlHours,
+  runIrohRetention,
+} from "../services/iroh/retention";
+import type { IrohBindingNudgeEvent } from "../services/iroh/presenceNudge";
+
+const NOW = new Date("2026-07-30T12:00:00.000Z");
+
+const EMPTY_RETENTION: IrohRetentionResult = {
+  rowsProcessed: 0,
+  batches: 0,
+  backlog: false,
+  budgetExhausted: null,
+  byCategory: {
+    revokedHints: 0,
+    expiredHints: 0,
+    expiredChallenges: 0,
+    consumedChallenges: 0,
+    relayAudits: 0,
+    pairGrantAudits: 0,
+    revokedBindings: 0,
+  },
+};
+
+function stubRepository(reap: IrohStaleBindingReapResult) {
+  const calls: Array<{ devCutoff: Date; releaseCutoff: Date; now: Date }> = [];
+  const repository = {
+    pruneExpiredStateGlobally: () => Effect.succeed(EMPTY_RETENTION),
+    reapStaleBindings: (input: { now: Date; devCutoff: Date; releaseCutoff: Date }) => {
+      calls.push({ devCutoff: input.devCutoff, releaseCutoff: input.releaseCutoff, now: input.now });
+      return Effect.succeed(reap);
+    },
+  } as unknown as IrohRepositoryShape;
+  return { repository, calls };
+}
+
+describe("iroh stale-binding TTL configuration", () => {
+  test("defaults to 72h for dev tags and 45 days for release channels", () => {
+    expect(irohStaleBindingTtlHours({})).toEqual({
+      devHours: IROH_STALE_DEV_BINDING_TTL_HOURS_DEFAULT,
+      releaseHours: IROH_STALE_RELEASE_BINDING_TTL_HOURS_DEFAULT,
+    });
+    expect(IROH_STALE_DEV_BINDING_TTL_HOURS_DEFAULT).toBe(72);
+    expect(IROH_STALE_RELEASE_BINDING_TTL_HOURS_DEFAULT).toBe(45 * 24);
+  });
+
+  test("accepts bounded overrides and falls back on garbage", () => {
+    expect(irohStaleBindingTtlHours({ dev: "24", release: "2160" })).toEqual({
+      devHours: 24,
+      releaseHours: 2_160,
+    });
+    expect(irohStaleBindingTtlHours({ dev: "zero", release: "-4" })).toEqual({
+      devHours: IROH_STALE_DEV_BINDING_TTL_HOURS_DEFAULT,
+      releaseHours: IROH_STALE_RELEASE_BINDING_TTL_HOURS_DEFAULT,
+    });
+    expect(irohStaleBindingTtlHours({ dev: "0" }).devHours)
+      .toBe(IROH_STALE_DEV_BINDING_TTL_HOURS_DEFAULT);
+  });
+});
+
+describe("iroh retention run", () => {
+  test("reaps with shape-specific cutoffs and nudges every reaped binding", async () => {
+    const reaped: IrohStaleBindingReapResult = {
+      revoked: [
+        { userId: "user-a", deviceUuid: "device-1", tag: "wsid", platform: "mac" },
+        { userId: "user-b", deviceUuid: "device-2", tag: "default", platform: "ios" },
+      ],
+      candidates: 2,
+      skippedUsers: 0,
+      backlog: false,
+    };
+    const { repository, calls } = stubRepository(reaped);
+    const nudged: IrohBindingNudgeEvent[][] = [];
+
+    const summary = await Effect.runPromise(runIrohRetention({
+      repository,
+      now: NOW,
+      ttlHours: { devHours: 72, releaseHours: 1_080 },
+      presenceNudge: {
+        bindingChanged: (events) => Effect.sync(() => {
+          nudged.push([...events]);
+        }),
+      },
+    }));
+
+    expect(calls).toEqual([{
+      now: NOW,
+      devCutoff: new Date(NOW.getTime() - 72 * 60 * 60 * 1_000),
+      releaseCutoff: new Date(NOW.getTime() - 1_080 * 60 * 60 * 1_000),
+    }]);
+    expect(nudged).toEqual([[
+      { userId: "user-a", deviceUuid: "device-1", tag: "wsid" },
+      { userId: "user-b", deviceUuid: "device-2", tag: "default" },
+    ]]);
+    expect(summary.reap).toMatchObject({ revoked: 2, candidates: 2, backlog: false });
+  });
+
+  test("does not nudge when nothing was reaped, and a nudge defect cannot fail the run", async () => {
+    const quiet = stubRepository({ revoked: [], candidates: 0, skippedUsers: 0, backlog: false });
+    let nudges = 0;
+    const summaryQuiet = await Effect.runPromise(runIrohRetention({
+      repository: quiet.repository,
+      now: NOW,
+      ttlHours: { devHours: 72, releaseHours: 1_080 },
+      presenceNudge: {
+        bindingChanged: () => Effect.sync(() => {
+          nudges += 1;
+        }),
+      },
+    }));
+    expect(nudges).toBe(0);
+    expect(summaryQuiet.reap.revoked).toBe(0);
+
+    const reaping = stubRepository({
+      revoked: [{ userId: "user-a", deviceUuid: "device-1", tag: "wsid", platform: "mac" }],
+      candidates: 1,
+      skippedUsers: 0,
+      backlog: true,
+    });
+    const summary = await Effect.runPromise(runIrohRetention({
+      repository: reaping.repository,
+      now: NOW,
+      ttlHours: { devHours: 72, releaseHours: 1_080 },
+      presenceNudge: {
+        bindingChanged: () => Effect.sync(() => {
+          throw new Error("presence worker unreachable");
+        }),
+      },
+    }));
+    expect(summary.reap).toMatchObject({ revoked: 1, backlog: true });
+  });
+});

--- a/web/tests/iroh-trust-broker.test.ts
+++ b/web/tests/iroh-trust-broker.test.ts
@@ -26,12 +26,18 @@ import {
 } from "../services/iroh/model";
 import {
   IROH_ACTIVE_BINDING_SANITY_CAP,
+  isIrohReleaseChannelTag,
   type IrohBindingRecord,
   type IrohChallengeRecord,
+  type IrohReapedBinding,
   type IrohRepositoryShape,
 } from "../services/iroh/repository";
 import type { IrohRelayMinterShape } from "../services/iroh/relayMinter";
 import { makeIrohTrustBroker } from "../services/iroh/trustBroker";
+import type {
+  IrohBindingNudgeEvent,
+  IrohPresenceNudgeShape,
+} from "../services/iroh/presenceNudge";
 import type { RelayPreference } from "../services/relay/model";
 
 const NOW = new Date("2026-07-09T20:00:00.000Z");
@@ -268,6 +274,104 @@ describe("Iroh trust broker registration", () => {
     const retired = fixture.repository.bindings.find((row) => row.id === slotId);
     expect(retired?.revokedAt).toEqual(NOW);
     expect(retired?.revokedReason).toBe("slot_reincarnated");
+  });
+});
+
+// The presence nudge is a best-effort wake-up for the AFFECTED device: it must
+// fire exactly on binding-lifecycle changes (revocation, slot re-key) and stay
+// silent on refresh heartbeats, and its failure can never fail the broker op.
+describe("Iroh binding-changed presence nudges", () => {
+  test("revocation nudges the revoked binding's device once, not on retries", async () => {
+    const nudge = new RecordingPresenceNudge();
+    const fixture = makeFixture({ presenceNudge: nudge });
+    const active = binding({ userId: USER_A, tag: "wsid" });
+    fixture.repository.bindings.push(active);
+
+    await Effect.runPromise(fixture.broker.revoke(USER_A, { bindingId: active.id }, NOW));
+    expect(nudge.calls).toEqual([[{
+      userId: USER_A,
+      deviceUuid: active.deviceUuid,
+      tag: "wsid",
+    }]]);
+
+    // Retry of an already-revoked binding still succeeds but nudges nothing new.
+    await Effect.runPromise(fixture.broker.revoke(
+      USER_A,
+      { bindingId: active.id },
+      new Date(NOW.getTime() + 1_000),
+    ));
+    expect(nudge.calls).toHaveLength(1);
+  });
+
+  test("a plain signed refresh heartbeat never nudges", async () => {
+    const nudge = new RecordingPresenceNudge();
+    const fixture = makeFixture({ presenceNudge: nudge });
+    await Effect.runPromise(fixture.broker.register(USER_A, await fixture.signedRegistration(), NOW));
+    // A genuinely new slot is the registrant itself; nothing to wake.
+    expect(nudge.calls).toEqual([]);
+
+    await Effect.runPromise(fixture.broker.register(
+      USER_A,
+      await fixture.signedRegistration(),
+      new Date(NOW.getTime() + 1_000),
+    ));
+    expect(nudge.calls).toEqual([]);
+  });
+
+  test("a slot re-key (replacement registration) nudges the affected device", async () => {
+    const nudge = new RecordingPresenceNudge();
+    const fixture = makeFixture({ presenceNudge: nudge });
+    await Effect.runPromise(fixture.broker.register(USER_A, await fixture.signedRegistration(), NOW));
+
+    const replacement = makeFixture({
+      repository: fixture.repository,
+      appInstanceId: fixture.appInstanceId,
+      deviceId: fixture.deviceId,
+      identityGeneration: 2,
+      presenceNudge: nudge,
+    });
+    await Effect.runPromise(replacement.broker.register(
+      USER_A,
+      await replacement.signedRegistration(),
+      NOW,
+    ));
+    expect(nudge.calls).toEqual([[{
+      userId: USER_A,
+      deviceUuid: fixture.deviceId,
+      tag: "stable",
+    }]]);
+  });
+
+  test("a defective nudge implementation cannot fail revoke or registration", async () => {
+    const nudge = new RecordingPresenceNudge();
+    nudge.failWith = new Error("presence worker unreachable");
+    const fixture = makeFixture({ presenceNudge: nudge });
+    const active = binding({ userId: USER_A });
+    fixture.repository.bindings.push(active);
+
+    const revoked = await Effect.runPromise(fixture.broker.revoke(
+      USER_A,
+      { bindingId: active.id },
+      NOW,
+    ));
+    expect(revoked).toEqual({ revoked: true, lan_rendezvous_rotated: true });
+    expect(active.revokedAt).toEqual(NOW);
+
+    // A slot re-key (the other nudging path) must also survive the defect.
+    await Effect.runPromise(fixture.broker.register(USER_A, await fixture.signedRegistration(), NOW));
+    const replacement = makeFixture({
+      repository: fixture.repository,
+      appInstanceId: fixture.appInstanceId,
+      deviceId: fixture.deviceId,
+      identityGeneration: 2,
+      presenceNudge: nudge,
+    });
+    const registered = await Effect.runPromise(replacement.broker.register(
+      USER_A,
+      await replacement.signedRegistration(),
+      NOW,
+    )) as { binding: { endpoint_id: string } };
+    expect(registered.binding.endpoint_id).toBe(replacement.endpointId);
   });
 });
 
@@ -791,7 +895,7 @@ class MemoryRepository implements IrohRepositoryShape {
       existing.lastSeenAt = input.now;
       existing.registeredAt = challenge.createdAt;
       existing.updatedAt = input.now;
-      return Effect.succeed({ binding: existing, created: false });
+      return Effect.succeed({ binding: existing, created: false, replaced: false });
     }
     // A new incarnation (rotated endpoint, or any changed signed identity field):
     // retire the old row (soft-revoke, never delete) and mint a fresh binding id so
@@ -831,7 +935,7 @@ class MemoryRepository implements IrohRepositoryShape {
     });
     challenge.consumedAt = input.now;
     this.bindings.push(inserted);
-    return Effect.succeed({ binding: inserted, created: true });
+    return Effect.succeed({ binding: inserted, created: true, replaced: existing !== undefined });
   }
 
   discoverySnapshot(input: Parameters<IrohRepositoryShape["discoverySnapshot"]>[0]) {
@@ -898,6 +1002,32 @@ class MemoryRepository implements IrohRepositoryShape {
         pairGrantAudits: 0,
         revokedBindings: 0,
       },
+    });
+  }
+
+  reapStaleBindings(input: Parameters<IrohRepositoryShape["reapStaleBindings"]>[0]) {
+    const revoked: IrohReapedBinding[] = [];
+    for (const row of this.bindings) {
+      if (row.revokedAt) continue;
+      const cutoff = isIrohReleaseChannelTag(row.tag) ? input.releaseCutoff : input.devCutoff;
+      if (row.registeredAt >= cutoff || row.lastSeenAt >= cutoff) continue;
+      row.revokedAt = input.now;
+      row.revokedReason = isIrohReleaseChannelTag(row.tag)
+        ? "stale_binding_retention"
+        : "stale_development_binding";
+      this.lanGenerations.set(row.userId, (this.lanGenerations.get(row.userId) ?? 1) + 1);
+      revoked.push({
+        userId: row.userId,
+        deviceUuid: row.deviceUuid,
+        tag: row.tag,
+        platform: row.platform,
+      });
+    }
+    return Effect.succeed({
+      revoked,
+      candidates: revoked.length,
+      skippedUsers: 0,
+      backlog: false,
     });
   }
 
@@ -995,6 +1125,18 @@ class FakeMinter implements IrohRelayMinterShape {
   }
 }
 
+class RecordingPresenceNudge implements IrohPresenceNudgeShape {
+  readonly calls: IrohBindingNudgeEvent[][] = [];
+  failWith: Error | undefined;
+
+  bindingChanged(events: readonly IrohBindingNudgeEvent[]) {
+    return Effect.sync(() => {
+      if (this.failWith) throw this.failWith;
+      this.calls.push([...events]);
+    });
+  }
+}
+
 function makeFixture(options: {
   repository?: MemoryRepository;
   minterFailure?: boolean;
@@ -1004,6 +1146,7 @@ function makeFixture(options: {
   relayPreference?: RelayPreference;
   registrationPathHints?: IrohRegistrationPayload["pathHints"];
   registrationDirectPorts?: TestDirectPorts;
+  presenceNudge?: IrohPresenceNudgeShape;
   developmentBindingLimits?: {
     account: number;
     device: number;
@@ -1054,15 +1197,17 @@ function makeFixture(options: {
     selectedManagedRelayIds: [],
     customRelays: [],
   };
+  const presenceNudge = options.presenceNudge ?? new RecordingPresenceNudge();
   const broker = makeIrohTrustBroker(repository, minter, config, {
     getPreference: () => Effect.succeed({ preference: relayPreference, revision: 0 }),
-  });
+  }, presenceNudge);
 
   return {
     repository,
     minter,
     broker,
     config,
+    presenceNudge,
     endpointId,
     appInstanceId,
     deviceId,

--- a/workers/presence/README.md
+++ b/workers/presence/README.md
@@ -18,7 +18,7 @@ solo-account user id).
 | `/v1/presence/heartbeat` | POST | announce an app instance; `{deviceId, platform, tag?, displayName?, capabilities?, stopping?}`; `stopping: true` is a clean-shutdown goodbye |
 | `/v1/presence/snapshot` | GET | one-shot presence map |
 | `/v1/presence/subscribe` | GET | WebSocket upgrade or SSE stream: `snapshot` first, then `online` / `offline` / `seen` events. With `?deviceScope=<deviceId>` it is instead a directed nudge channel: WebSocket-only, no snapshot, only `nudge` frames for that device |
-| `/v1/presence/nudge` | POST | directed wake-up `{deviceId, tag?, kind}` delivered to that device's `deviceScope` subscribers; caller must be the device's pinned owner |
+| `/v1/presence/nudge` | POST | directed wake-up `{deviceId, tag?, kind}` delivered to that device's `deviceScope` subscribers; caller must be the device's pinned owner. With the `x-cmux-nudge-secret` header it is instead the server-to-server path: `{deviceId, tag?, kind, userId, teamId?}` |
 
 The heartbeat response returns `heartbeatIntervalMs` (15s) and
 `offlineTimeoutMs` (45s); hosts should follow the returned cadence rather than
@@ -61,6 +61,22 @@ cadence, never to a correctness failure. Registry-anchored device credentials
 (the planned key-pinning phase) replace the pin for both heartbeats and
 nudges when they land.
 
+The server-to-server nudge path exists for the web iroh trust broker, which
+holds no Stack user token when it revokes, re-keys, or reaps a binding. A
+request carrying `x-cmux-nudge-secret` never falls back to bearer auth: the
+header must match the `NUDGE_SERVER_SECRET` Worker secret (constant-time,
+provisioned with `wrangler secret put NUDGE_SERVER_SECRET`; unset rejects the
+whole path), and the body then asserts the device owner's `userId` and the
+target `teamId` (default: the user id, the solo-account team resolution). The
+asserted user id is still checked against the device's pinned owner in the DO,
+so even the trusted server cannot wake a device pinned by a different user.
+The web side fans one nudge out to the device's few candidate team DOs; a
+wrong-team candidate answers `404 device_unknown`, which callers treat as
+expected. Phones could reuse this exact `nudge` frame later by subscribing
+`deviceScope=<their paired Mac's deviceId>` (the owner pin already admits
+same-user subscribers); that needs no new frame type, so legacy presence
+decoders stay safe.
+
 ## Develop
 
 ```bash
@@ -95,9 +111,14 @@ One-time Worker secrets (survive deploys; production Stack project values):
 ```bash
 bunx wrangler secret put STACK_PROJECT_ID
 bunx wrangler secret put STACK_PUBLISHABLE_CLIENT_KEY
+bunx wrangler secret put NUDGE_SERVER_SECRET   # optional: server nudge path
 ```
 
 Optional plain var `STACK_API_URL` defaults to `https://api.stack-auth.com`.
+`NUDGE_SERVER_SECRET` (min 16 chars) enables the server-authenticated nudge
+path; mirror the same value into the web deployment's
+`CMUX_PRESENCE_NUDGE_SECRET` (with `CMUX_PRESENCE_NUDGE_URL` pointing at this
+worker). Leaving it unset keeps the path rejected.
 
 ### Dev/staging instance
 

--- a/workers/presence/src/auth.ts
+++ b/workers/presence/src/auth.ts
@@ -138,6 +138,34 @@ async function sha256Hex(value: string): Promise<string> {
   return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+/** Minimum configured length for the server nudge secret; anything shorter is
+ * treated as not configured so a weak or placeholder deploy fails closed. */
+export const MIN_NUDGE_SERVER_SECRET_LENGTH = 16;
+
+/** Constant-time shared-secret check for the server-authenticated nudge path
+ * (`x-cmux-nudge-secret`). Both sides are SHA-256 hashed first, so the byte
+ * comparison length is fixed and independent of either input; an unset,
+ * empty, or too-short configured secret always fails. Pure for tests. */
+export async function nudgeServerSecretMatches(
+  provided: string | null,
+  configured: string | undefined,
+): Promise<boolean> {
+  const secret = configured?.trim() ?? "";
+  const candidate = provided?.trim() ?? "";
+  if (secret.length < MIN_NUDGE_SERVER_SECRET_LENGTH || !candidate) return false;
+  const [candidateDigest, secretDigest] = await Promise.all([
+    crypto.subtle.digest("SHA-256", new TextEncoder().encode(candidate)),
+    crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret)),
+  ]);
+  const candidateBytes = new Uint8Array(candidateDigest);
+  const secretBytes = new Uint8Array(secretDigest);
+  let difference = 0;
+  for (let index = 0; index < candidateBytes.length; index += 1) {
+    difference |= (candidateBytes[index] ?? 0) ^ (secretBytes[index] ?? 0);
+  }
+  return difference === 0;
+}
+
 function stackHeaders(env: AuthEnv, accessToken: string): Record<string, string> {
   return {
     "x-stack-access-type": "client",

--- a/workers/presence/src/index.ts
+++ b/workers/presence/src/index.ts
@@ -21,6 +21,7 @@
 import {
   bearerToken,
   cacheDeadline,
+  nudgeServerSecretMatches,
   requestedTeamIdFromRequest,
   resolveTeamId,
   tokenExpiryMs,
@@ -29,13 +30,18 @@ import {
   type AuthEnv,
 } from "./auth";
 import { MAX_SUBSCRIBE_AGE_MS, TeamPresence } from "./do";
-import { parseHeartbeat, parseNudge, readBoundedJson } from "./validate";
+import { parseHeartbeat, parseNudge, parseServerNudge, readBoundedJson } from "./validate";
 import { MAX_PAIRED_MAC_BACKUP_BYTES, normalizeClientScope, parsePairedMacBackup } from "./syncPairedMacs";
 
 export { TeamPresence };
 
 export interface Env extends AuthEnv {
   TEAM_PRESENCE: DurableObjectNamespace<TeamPresence>;
+  /** Shared secret for the server-authenticated nudge path (the web trust
+   * broker fires binding-changed nudges with `x-cmux-nudge-secret`). Worker
+   * secret, provisioned once via `wrangler secret put NUDGE_SERVER_SECRET`;
+   * unset disables that path (requests carrying the header are rejected). */
+  NUDGE_SERVER_SECRET?: string;
 }
 
 function json(body: unknown, status = 200): Response {
@@ -94,6 +100,30 @@ export default {
       // caller must be the device's pinned owner, enforced in the DO exactly
       // like heartbeat ownership.
       if (request.method !== "POST") return json({ error: "method_not_allowed" }, 405);
+
+      // Server-to-server path: the web trust broker (revoke, slot
+      // reincarnation, stale-binding reap) holds no Stack user token, so it
+      // authenticates with a shared Worker secret and asserts the device
+      // owner's user id and target team itself. The DO's owner-pin check
+      // still runs against that asserted user id, so even the trusted server
+      // cannot deliver a nudge to a device pinned by a different user. A
+      // request CARRYING the header never falls back to bearer auth: with the
+      // secret unset or wrong it is rejected outright.
+      const serverSecret = request.headers.get("x-cmux-nudge-secret");
+      if (serverSecret !== null) {
+        if (!(await nudgeServerSecretMatches(serverSecret, env.NUDGE_SERVER_SECRET))) {
+          return unauthorized();
+        }
+        const body = await readBoundedJson(request);
+        if (!body.ok) return json({ error: "invalid_request" }, body.status);
+        const parsed = parseServerNudge(body.value);
+        if (!parsed.ok) return json({ error: parsed.error }, 400);
+        const stub = env.TEAM_PRESENCE.get(env.TEAM_PRESENCE.idFromName(parsed.server.teamId));
+        const result = await stub.nudge(parsed.server.teamId, parsed.server.userId, parsed.server.nudge);
+        if (!result.ok) return json({ error: result.error }, result.status);
+        return json(result);
+      }
+
       const team = await resolveTeamOr403(request, env);
       if (!team.ok) return team.response;
       const body = await readBoundedJson(request);

--- a/workers/presence/src/validate.ts
+++ b/workers/presence/src/validate.ts
@@ -158,6 +158,49 @@ export function parseNudge(body: Record<string, unknown>): NudgeParse {
   return { ok: true, nudge: { deviceId, tag: tag || undefined, kind } };
 }
 
+/** Bound on the server-asserted principal fields of a server nudge. Stack user
+ * ids and team ids are short opaque tokens; this only stops garbage. */
+export const MAX_NUDGE_PRINCIPAL_LENGTH = 256;
+
+export interface ServerNudgeInput {
+  nudge: NudgeInput;
+  /** The device owner's Stack user id, asserted by the trusted server caller.
+   * The DO still enforces it against the device's pinned owner. */
+  userId: string;
+  /** Team whose Durable Object should deliver the nudge. Defaults to the
+   * user id (the solo-account team resolution). */
+  teamId: string;
+}
+
+export type ServerNudgeParse =
+  | { ok: true; server: ServerNudgeInput }
+  | { ok: false; error: string };
+
+/** Parse a server-authenticated nudge body (shared-secret path): the normal
+ * nudge fields plus the server-asserted owner and target team. Pure for
+ * tests. */
+export function parseServerNudge(body: Record<string, unknown>): ServerNudgeParse {
+  const base = parseNudge(body);
+  if (!base.ok) return base;
+  const userId = trimmedString(body.userId);
+  if (!validNudgePrincipal(userId)) return { ok: false, error: "invalid_user_id" };
+  const teamId = trimmedString(body.teamId) || userId;
+  if (!validNudgePrincipal(teamId)) return { ok: false, error: "invalid_team_id" };
+  return { ok: true, server: { nudge: base.nudge, userId, teamId } };
+}
+
+function validNudgePrincipal(value: string): boolean {
+  if (!value || value.length > MAX_NUDGE_PRINCIPAL_LENGTH) return false;
+  // No whitespace or control characters: these values name a Durable Object
+  // and are compared against stored owner pins; real Stack ids are opaque
+  // tokens without either.
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code <= 0x20 || code === 0x7f) return false;
+  }
+  return true;
+}
+
 export type DeviceScopeParse =
   | { scope: "none" }
   | { scope: "invalid" }

--- a/workers/presence/test/nudge.test.ts
+++ b/workers/presence/test/nudge.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { MIN_NUDGE_SERVER_SECRET_LENGTH, nudgeServerSecretMatches } from "../src/auth";
 import {
   checkDeviceOwner,
   checkSubscriberAdmission,
@@ -8,7 +9,13 @@ import {
   shouldDeliverNudge,
   type NudgeSocketView,
 } from "../src/core";
-import { MAX_TAG_LENGTH, parseDeviceScope, parseNudge } from "../src/validate";
+import {
+  MAX_NUDGE_PRINCIPAL_LENGTH,
+  MAX_TAG_LENGTH,
+  parseDeviceScope,
+  parseNudge,
+  parseServerNudge,
+} from "../src/validate";
 
 const DEVICE_ID = "11111111-2222-4333-8444-555555555555";
 const OTHER_DEVICE_ID = "99999999-8888-4777-8666-555555555555";
@@ -59,6 +66,97 @@ describe("parseNudge", () => {
       kind: "iroh-binding-changed",
     });
     expect(parsed).toEqual({ ok: false, error: "invalid_tag" });
+  });
+});
+
+// The server-authenticated nudge path: the web trust broker asserts the owner
+// and target team itself after shared-secret auth. Parsing must bound those
+// server-asserted principals and reuse the exact user-path nudge validation.
+describe("parseServerNudge", () => {
+  it("accepts a server nudge and defaults the team to the user id", () => {
+    const parsed = parseServerNudge({
+      deviceId: DEVICE_ID,
+      tag: "rekey",
+      kind: "iroh-binding-changed",
+      userId: " user-owner ",
+    });
+    expect(parsed).toEqual({
+      ok: true,
+      server: {
+        nudge: { deviceId: DEVICE_ID, tag: "rekey", kind: "iroh-binding-changed" },
+        userId: "user-owner",
+        teamId: "user-owner",
+      },
+    });
+  });
+
+  it("keeps an explicit team id", () => {
+    const parsed = parseServerNudge({
+      deviceId: DEVICE_ID,
+      kind: "iroh-binding-changed",
+      userId: "user-owner",
+      teamId: "team-1",
+    });
+    expect(parsed).toEqual({
+      ok: true,
+      server: {
+        nudge: { deviceId: DEVICE_ID, tag: undefined, kind: "iroh-binding-changed" },
+        userId: "user-owner",
+        teamId: "team-1",
+      },
+    });
+  });
+
+  it("rejects a missing, overlong, or control-character principal", () => {
+    expect(parseServerNudge({ deviceId: DEVICE_ID, kind: "iroh-binding-changed" })).toEqual({
+      ok: false,
+      error: "invalid_user_id",
+    });
+    expect(parseServerNudge({
+      deviceId: DEVICE_ID,
+      kind: "iroh-binding-changed",
+      userId: "u".repeat(MAX_NUDGE_PRINCIPAL_LENGTH + 1),
+    })).toEqual({ ok: false, error: "invalid_user_id" });
+    expect(parseServerNudge({
+      deviceId: DEVICE_ID,
+      kind: "iroh-binding-changed",
+      userId: "user-owner",
+      teamId: "team evil",
+    })).toEqual({ ok: false, error: "invalid_team_id" });
+  });
+
+  it("propagates the base nudge validation", () => {
+    expect(parseServerNudge({
+      deviceId: "not-a-uuid",
+      kind: "iroh-binding-changed",
+      userId: "user-owner",
+    })).toEqual({ ok: false, error: "invalid_device_id" });
+    expect(parseServerNudge({
+      deviceId: DEVICE_ID,
+      kind: "drop-all-tables",
+      userId: "user-owner",
+    })).toEqual({ ok: false, error: "invalid_kind" });
+  });
+});
+
+describe("nudgeServerSecretMatches", () => {
+  const secret = "0123456789abcdef-nudge";
+
+  it("accepts the exact configured secret", async () => {
+    expect(await nudgeServerSecretMatches(secret, secret)).toBe(true);
+    expect(await nudgeServerSecretMatches(`  ${secret}  `, secret)).toBe(true);
+  });
+
+  it("rejects a mismatch, including same-length ones", async () => {
+    expect(await nudgeServerSecretMatches("0123456789abcdef-nudgf", secret)).toBe(false);
+    expect(await nudgeServerSecretMatches("wrong", secret)).toBe(false);
+  });
+
+  it("fails closed when the secret is unset, empty, or too short to be real", async () => {
+    expect(await nudgeServerSecretMatches(secret, undefined)).toBe(false);
+    expect(await nudgeServerSecretMatches("", secret)).toBe(false);
+    const short = "s".repeat(MIN_NUDGE_SERVER_SECRET_LENGTH - 1);
+    expect(await nudgeServerSecretMatches(short, short)).toBe(false);
   });
 });
 

--- a/workers/presence/wrangler.toml
+++ b/workers/presence/wrangler.toml
@@ -17,6 +17,7 @@
 # Worker secrets (see README.md) and survive deploys:
 #   wrangler secret put STACK_PROJECT_ID
 #   wrangler secret put STACK_PUBLISHABLE_CLIENT_KEY
+#   wrangler secret put NUDGE_SERVER_SECRET   # optional server nudge path
 # Optional plain var STACK_API_URL defaults to https://api.stack-auth.com.
 
 name = "cmux-presence"


### PR DESCRIPTION
First round of the transport rewrite program. Contract: `docs/transport-plane.md` (invariants I1-I3, decisions D1-D11).

**iOS: no reconnections unless network health requires it (I1/D2/D3).** `MobileConnectionPolicy` is a pure escalation decider; recovery entry points consult it with observed transport-path health (pool → `CmxIrohClientRuntime.hasUsableSelectedPath()` → composition provider). Suspect evidence (liveness silence, ended event stream, failed subscribe, timed-out write) on a healthy-path session repairs the stream in place with a bounded ladder instead of tearing down the connection; dead paths and probe-proven-dead sessions still redial. Nil provider or non-iroh route = exact pre-gate behavior (978-test shell suite unchanged; the 5 failures are pre-existing on main, verified side by side).

**iOS: fast discovery (I2/D5).** Failed dials feed back into discovery: unreachable-class outcomes and empty dial plans mark that peer's snapshot stale, the next dial bypasses the 30s reuse window with a single-flight fresh fetch (broker cooldowns honored), and presence route pushes invalidate the pushed Mac's snapshot. Kills the 2-4 minute Mac-relaunch convergence (`peer:no-relays:no-direct-addrs` dials).

**Mac host: backpressure sheds, never kills (D7).** Recoverable topics (`mobile.sync.delta`, `notification.feed.changed`, `workspace.updated`, `terminal.updated`) shed under the existing oldest-droppable policy and emit one coalesced repair signal per topic when the queue drains (sync head-marker gaps stale mirrors into a cursor fetch; feed/workspace pings trigger refetch). Close-on-queue-depth remains only for topics whose loss is silent corruption today; the 30s write-stall deadline still closes wedged transports. This removes the host half of the 2s-metronome kill loop (256-event overflow close during path flaps). New `hostEventQueueShed=56` ring code.

**Backend: binding-change push + reaper (D6).** Revocation and slot re-key fire a best-effort presence nudge through a new server-authenticated worker path (env-gated, 2s budget, never fails the broker op). The hourly retention cron reaps stale bindings (dev-style tags 72h, release-shaped 45d, both clocks required) under the exact revoke fences, preventing the staging 256-cap wedge. Nothing is deployed; env vars documented in `web/services/iroh/README.md`.

Verification: CmuxIrohTransport 508/508, CmuxMobileRPC 170/170, CmuxMobileShell 978 (zero new failures), presence worker 202/202, web iroh suites 150/150 incl. DB behavior, macOS app compile green, cmuxPackage iOS-sim triple green. A multi-device verification rig (`transport-lab` in cmuxterm-hq) gates this and future rounds: soak / mac-relaunch / bgfg scenarios scored from diagnostic rings (involuntary closes, discovery convergence, echo latency).

Dictionary: *shed* = dropping queued events for a topic the client can rebuild via refetch or cursors instead of killing the connection; *reaper* = scheduled job revoking bindings with no authenticated activity past a TTL; *nudge* = a payload-free presence WebSocket frame telling a device to refresh broker state now; *reuse window* = the 30s period a verified discovery snapshot serves dials without refetching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/9250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788053213&installation_model_id=21920&pr_number=9250&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F9250&signature=7b38b86eab26adf565599375cf09f4bb61538dbde4de5202f3336fcac6688d99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Transport plane round 1: iOS recovery now gates on path health, discovery refreshes on stale/empty plans, the Mac host sheds recoverable queues under backpressure, and the backend nudges devices on binding changes and reaps stale bindings. Contract lives in `docs/transport-plane.md` (I1–I3, D1–D11).

- **New Features**
  - iOS: Pure `MobileConnectionPolicy` decider; healthy-path sessions repair in place and only escalate if the path dies.
  - iOS: `MobileTransportPathHealthProvider` seam and `hasUsableSelectedPath()`; nil provider keeps legacy behavior.
  - iOS: Discovery freshness — `noteDialFailure(...)`, per-peer/device staleness markers, single-flight fresh fetch, presence push invalidation.
  - Mac: Event queue shedding for recoverable topics with coalesced repair signals; new ring code `hostEventQueueShed=56`.
  - Backend: Server-auth presence nudge on binding changes (revoke, slot re-key, reaper), fail-open with ~2s budget.
  - Backend: Hourly stale-binding reaper (dev 72h, release 45d) to avoid the 256-cap wedge.

- **Migration**
  - To enable health-gated recovery, inject `transportPathHealthProvider` into `CMUXMobileRuntime` (e.g., from `CmxIrohClientRuntime.selectedPathHealth()`).
  - Presence nudge: set `CMUX_PRESENCE_NUDGE_URL` and `CMUX_PRESENCE_NUDGE_SECRET` (web), plus `NUDGE_SERVER_SECRET` (workers/presence).
  - Optional TTLs: `CMUX_IROH_STALE_DEV_BINDING_TTL_HOURS`, `CMUX_IROH_STALE_RELEASE_BINDING_TTL_HOURS`.

<sup>Written for commit 3f2f38a437ad342aa1754b72e145302f42f06396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/9250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile connection recovery using live transport health, smarter escalation, and refreshed discovery after endpoint or dial failures.
  * Added automatic repair signals when recoverable sync and notification events are dropped during queue congestion.
  * Added presence updates for device binding changes and stale-connection cleanup.
  * Added secure server-to-server presence notifications with validation.

* **Bug Fixes**
  * Reduced unnecessary reconnects when an existing connection remains healthy.
  * Improved recovery after stale or unreachable connection paths.

* **Documentation**
  * Documented connection recovery, backpressure handling, retention, and presence notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->